### PR TITLE
Offer a method to specify field name of the target

### DIFF
--- a/src/main/java/graphql/schema/AbstractReflectionDataFetcher.java
+++ b/src/main/java/graphql/schema/AbstractReflectionDataFetcher.java
@@ -1,0 +1,34 @@
+package graphql.schema;
+
+import java.util.Map;
+
+public abstract class AbstractReflectionDataFetcher
+    implements DataFetcher {
+
+    protected final String name;
+
+    protected AbstractReflectionDataFetcher(
+        String name) {
+
+        this.name = name;
+
+    }
+
+    @Override
+    public final Object get(
+        DataFetchingEnvironment environment) {
+
+        Object source = environment.getSource();
+        if (source == null)
+            return null;
+        if (source instanceof Map) {
+            return ((Map<?, ?>) source).get(name);
+        }
+        return getValue(source, environment.getFieldType());
+    }
+
+    protected abstract Object getValue(
+        Object target,
+        GraphQLOutputType outputType);
+
+}

--- a/src/main/java/graphql/schema/FieldDataFetcher.java
+++ b/src/main/java/graphql/schema/FieldDataFetcher.java
@@ -1,39 +1,22 @@
 package graphql.schema;
 
-
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Map;
-
-import static graphql.Scalars.GraphQLBoolean;
 
 /**
  * Fetches data directly from a field.
  */
-public class FieldDataFetcher implements DataFetcher {
-
-    /**
-     * The name of the field.
-     */
-    private final String fieldName;
+public class FieldDataFetcher
+    extends AbstractReflectionDataFetcher
+    implements DataFetcher {
 
     /**
      * Ctor.
      * @param fieldName The name of the field.
      */
-    public FieldDataFetcher(String fieldName) {
-        this.fieldName = fieldName;
-    }
+    public FieldDataFetcher(
+        String fieldName) {
 
-    @Override
-    public Object get(DataFetchingEnvironment environment) {
-        Object source = environment.getSource();
-        if (source == null) return null;
-        if (source instanceof Map) {
-            return ((Map<?, ?>) source).get(fieldName);
-        }
-        return getFieldValue(source, environment.getFieldType());
+        super(fieldName);
     }
 
     /**
@@ -42,10 +25,13 @@ public class FieldDataFetcher implements DataFetcher {
      * @param outputType The output type; ignored in this case.
      * @return An object, or null.
      */
-    private Object getFieldValue(Object object, GraphQLOutputType outputType) {
+    protected Object getValue(
+        Object target,
+        GraphQLOutputType outputType) {
+
         try {
-            Field field = object.getClass().getField(fieldName);
-            return field.get(object);
+            Field field = target.getClass().getField(name);
+            return field.get(target);
         } catch (NoSuchFieldException e) {
             return null;
         } catch (IllegalAccessException e) {

--- a/src/main/java/graphql/schema/GraphQLFieldDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLFieldDefinition.java
@@ -1,10 +1,11 @@
 package graphql.schema;
 
-import static graphql.Assert.assertNotNull;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
+import static graphql.Assert.assertNotNull;
 
 public class GraphQLFieldDefinition {
 
@@ -15,14 +16,8 @@ public class GraphQLFieldDefinition {
     private final String deprecationReason;
     private final List<GraphQLArgument> arguments = new ArrayList<>();
 
-    public GraphQLFieldDefinition(
-        String name,
-        String description,
-        GraphQLOutputType type,
-        DataFetcher dataFetcher,
-        List<GraphQLArgument> arguments,
-        String deprecationReason) {
 
+    public GraphQLFieldDefinition(String name, String description, GraphQLOutputType type, DataFetcher dataFetcher, List<GraphQLArgument> arguments, String deprecationReason) {
         assertNotNull(name, "name can't be null");
         assertNotNull(dataFetcher, "dataFetcher can't be null");
         assertNotNull(type, "type can't be null");
@@ -35,59 +30,48 @@ public class GraphQLFieldDefinition {
         this.deprecationReason = deprecationReason;
     }
 
-    void replaceTypeReferences(
-        Map<String, GraphQLType> typeMap) {
 
+    void replaceTypeReferences(Map<String, GraphQLType> typeMap) {
         type = (GraphQLOutputType) new SchemaUtil().resolveTypeReference(type, typeMap);
     }
 
     public String getName() {
-
         return name;
     }
 
-    public GraphQLOutputType getType() {
 
+    public GraphQLOutputType getType() {
         return type;
     }
 
     public DataFetcher getDataFetcher() {
-
         return dataFetcher;
     }
 
-    public GraphQLArgument getArgument(
-        String name) {
-
+    public GraphQLArgument getArgument(String name) {
         for (GraphQLArgument argument : arguments) {
-            if (argument.getName().equals(name))
-                return argument;
+            if (argument.getName().equals(name)) return argument;
         }
         return null;
     }
 
     public List<GraphQLArgument> getArguments() {
-
         return new ArrayList<>(arguments);
     }
 
     public String getDescription() {
-
         return description;
     }
 
     public String getDeprecationReason() {
-
         return deprecationReason;
     }
 
     public boolean isDeprecated() {
-
         return deprecationReason != null;
     }
 
     public static Builder newFieldDefinition() {
-
         return new Builder();
     }
 
@@ -102,53 +86,38 @@ public class GraphQLFieldDefinition {
         private boolean isField;
         private String fieldName;
 
-        public Builder name(
-            String name) {
 
+        public Builder name(String name) {
             this.name = name;
             this.fieldName = name;
             return this;
         }
-
-        public Builder nameAndFieldName(
-            String name,
-            String fieldName) {
-
+        
+        public Builder nameAndFieldName(String name,String fieldName) {
             this.name = name;
             this.fieldName = fieldName;
             return this;
         }
 
-        public Builder description(
-            String description) {
-
+        public Builder description(String description) {
             this.description = description;
             return this;
         }
 
-        public Builder type(
-            GraphQLOutputType type) {
-
+        public Builder type(GraphQLOutputType type) {
             this.type = type;
             return this;
         }
 
-        public Builder dataFetcher(
-            DataFetcher dataFetcher) {
-
+        public Builder dataFetcher(DataFetcher dataFetcher) {
             this.dataFetcher = dataFetcher;
             return this;
         }
 
-        public Builder staticValue(
-            final Object value) {
-
+        public Builder staticValue(final Object value) {
             this.dataFetcher = new DataFetcher() {
-
                 @Override
-                public Object get(
-                    DataFetchingEnvironment environment) {
-
+                public Object get(DataFetchingEnvironment environment) {
                     return value;
                 }
             };
@@ -160,34 +129,26 @@ public class GraphQLFieldDefinition {
          * @return
          */
         public Builder fetchField() {
-
             this.isField = true;
             return this;
         }
 
-        public Builder argument(
-            GraphQLArgument argument) {
-
+        public Builder argument(GraphQLArgument argument) {
             this.arguments.add(argument);
             return this;
         }
 
-        public Builder argument(
-            List<GraphQLArgument> arguments) {
-
+        public Builder argument(List<GraphQLArgument> arguments) {
             this.arguments.addAll(arguments);
             return this;
         }
 
-        public Builder deprecate(
-            String deprecationReason) {
-
+        public Builder deprecate(String deprecationReason) {
             this.deprecationReason = deprecationReason;
             return this;
         }
 
         public GraphQLFieldDefinition build() {
-
             if (dataFetcher == null) {
                 if (isField) {
                     dataFetcher = new FieldDataFetcher(fieldName);
@@ -197,6 +158,7 @@ public class GraphQLFieldDefinition {
             }
             return new GraphQLFieldDefinition(name, description, type, dataFetcher, arguments, deprecationReason);
         }
+
 
     }
 }

--- a/src/main/java/graphql/schema/GraphQLFieldDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLFieldDefinition.java
@@ -1,11 +1,10 @@
 package graphql.schema;
 
+import static graphql.Assert.assertNotNull;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
-import static graphql.Assert.assertNotNull;
 
 public class GraphQLFieldDefinition {
 
@@ -16,8 +15,14 @@ public class GraphQLFieldDefinition {
     private final String deprecationReason;
     private final List<GraphQLArgument> arguments = new ArrayList<>();
 
+    public GraphQLFieldDefinition(
+        String name,
+        String description,
+        GraphQLOutputType type,
+        DataFetcher dataFetcher,
+        List<GraphQLArgument> arguments,
+        String deprecationReason) {
 
-    public GraphQLFieldDefinition(String name, String description, GraphQLOutputType type, DataFetcher dataFetcher, List<GraphQLArgument> arguments, String deprecationReason) {
         assertNotNull(name, "name can't be null");
         assertNotNull(dataFetcher, "dataFetcher can't be null");
         assertNotNull(type, "type can't be null");
@@ -30,48 +35,59 @@ public class GraphQLFieldDefinition {
         this.deprecationReason = deprecationReason;
     }
 
+    void replaceTypeReferences(
+        Map<String, GraphQLType> typeMap) {
 
-    void replaceTypeReferences(Map<String, GraphQLType> typeMap) {
         type = (GraphQLOutputType) new SchemaUtil().resolveTypeReference(type, typeMap);
     }
 
     public String getName() {
+
         return name;
     }
 
-
     public GraphQLOutputType getType() {
+
         return type;
     }
 
     public DataFetcher getDataFetcher() {
+
         return dataFetcher;
     }
 
-    public GraphQLArgument getArgument(String name) {
+    public GraphQLArgument getArgument(
+        String name) {
+
         for (GraphQLArgument argument : arguments) {
-            if (argument.getName().equals(name)) return argument;
+            if (argument.getName().equals(name))
+                return argument;
         }
         return null;
     }
 
     public List<GraphQLArgument> getArguments() {
+
         return new ArrayList<>(arguments);
     }
 
     public String getDescription() {
+
         return description;
     }
 
     public String getDeprecationReason() {
+
         return deprecationReason;
     }
 
     public boolean isDeprecated() {
+
         return deprecationReason != null;
     }
 
     public static Builder newFieldDefinition() {
+
         return new Builder();
     }
 
@@ -84,32 +100,55 @@ public class GraphQLFieldDefinition {
         private List<GraphQLArgument> arguments = new ArrayList<>();
         private String deprecationReason;
         private boolean isField;
+        private String fieldName;
 
+        public Builder name(
+            String name) {
 
-        public Builder name(String name) {
             this.name = name;
+            this.fieldName = name;
             return this;
         }
 
-        public Builder description(String description) {
+        public Builder nameAndFieldName(
+            String name,
+            String fieldName) {
+
+            this.name = name;
+            this.fieldName = fieldName;
+            return this;
+        }
+
+        public Builder description(
+            String description) {
+
             this.description = description;
             return this;
         }
 
-        public Builder type(GraphQLOutputType type) {
+        public Builder type(
+            GraphQLOutputType type) {
+
             this.type = type;
             return this;
         }
 
-        public Builder dataFetcher(DataFetcher dataFetcher) {
+        public Builder dataFetcher(
+            DataFetcher dataFetcher) {
+
             this.dataFetcher = dataFetcher;
             return this;
         }
 
-        public Builder staticValue(final Object value) {
+        public Builder staticValue(
+            final Object value) {
+
             this.dataFetcher = new DataFetcher() {
+
                 @Override
-                public Object get(DataFetchingEnvironment environment) {
+                public Object get(
+                    DataFetchingEnvironment environment) {
+
                     return value;
                 }
             };
@@ -121,36 +160,43 @@ public class GraphQLFieldDefinition {
          * @return
          */
         public Builder fetchField() {
+
             this.isField = true;
             return this;
         }
 
-        public Builder argument(GraphQLArgument argument) {
+        public Builder argument(
+            GraphQLArgument argument) {
+
             this.arguments.add(argument);
             return this;
         }
 
-        public Builder argument(List<GraphQLArgument> arguments) {
+        public Builder argument(
+            List<GraphQLArgument> arguments) {
+
             this.arguments.addAll(arguments);
             return this;
         }
 
-        public Builder deprecate(String deprecationReason) {
+        public Builder deprecate(
+            String deprecationReason) {
+
             this.deprecationReason = deprecationReason;
             return this;
         }
 
         public GraphQLFieldDefinition build() {
+
             if (dataFetcher == null) {
                 if (isField) {
-                    dataFetcher = new FieldDataFetcher(name);
+                    dataFetcher = new FieldDataFetcher(fieldName);
                 } else {
-                    dataFetcher = new PropertyDataFetcher(name);
+                    dataFetcher = new PropertyDataFetcher(fieldName);
                 }
             }
             return new GraphQLFieldDefinition(name, description, type, dataFetcher, arguments, deprecationReason);
         }
-
 
     }
 }

--- a/src/main/java/graphql/schema/PropertyDataFetcher.java
+++ b/src/main/java/graphql/schema/PropertyDataFetcher.java
@@ -1,49 +1,45 @@
 package graphql.schema;
 
+import static graphql.Scalars.GraphQLBoolean;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.Map;
 
-import static graphql.Scalars.GraphQLBoolean;
+public class PropertyDataFetcher
+    extends AbstractReflectionDataFetcher {
 
-public class PropertyDataFetcher implements DataFetcher {
+    public PropertyDataFetcher(
+        String propertyName) {
 
-    private final String propertyName;
+        super(propertyName);
+    }
 
-    public PropertyDataFetcher(String propertyName) {
-        this.propertyName = propertyName;
+    private boolean isBooleanProperty(
+        GraphQLOutputType outputType) {
+
+        if (outputType == GraphQLBoolean)
+            return true;
+        if (outputType instanceof GraphQLNonNull) {
+            return ((GraphQLNonNull) outputType).getWrappedType() == GraphQLBoolean;
+        }
+        return false;
     }
 
     @Override
-    public Object get(DataFetchingEnvironment environment) {
-        Object source = environment.getSource();
-        if (source == null) return null;
-        if (source instanceof Map) {
-            return ((Map<?, ?>) source).get(propertyName);
-        }
-        return getPropertyViaGetter(source, environment.getFieldType());
-    }
+    protected Object getValue(
+        Object target,
+        GraphQLOutputType outputType) {
 
-    private Object getPropertyViaGetter(Object object, GraphQLOutputType outputType) {
         String prefix = isBooleanProperty(outputType) ? "is" : "get";
-        String getterName = prefix + propertyName.substring(0, 1).toUpperCase() + propertyName.substring(1);
+        String getterName = prefix + name.substring(0, 1).toUpperCase() + name.substring(1);
         try {
-            Method method = object.getClass().getMethod(getterName);
-            return method.invoke(object);
+            Method method = target.getClass().getMethod(getterName);
+            return method.invoke(target);
 
         } catch (NoSuchMethodException e) {
             return null;
         } catch (IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    private boolean isBooleanProperty(GraphQLOutputType outputType) {
-        if (outputType == GraphQLBoolean) return true;
-        if (outputType instanceof GraphQLNonNull) {
-            return ((GraphQLNonNull) outputType).getWrappedType() == GraphQLBoolean;
-        }
-        return false;
     }
 }

--- a/src/test/groovy/graphql/schema/ReflectionDataFetcherTest.groovy
+++ b/src/test/groovy/graphql/schema/ReflectionDataFetcherTest.groovy
@@ -7,9 +7,13 @@ class ReflectionDataFetcherTest extends Specification {
 
     static final EXPECTED = "expected"
 
-    static final String SOME_SUPER_FIELD = "someSuperField";
+    static final String SOME_SUPER_FIELD = "someSuperField"
+
+    private static final String SOME_SUPER_FIELD_SNAKE_CASE = "some_super_field";
 
     def environment = Mock(DataFetchingEnvironment);
+
+    def fieldDefinition
 
     def "setup"(){
         environment.getSource() >> new TestObject(EXPECTED);
@@ -25,8 +29,10 @@ class ReflectionDataFetcherTest extends Specification {
 
         where:
         dataFetcher << [
-            new PropertyDataFetcher(SOME_SUPER_FIELD),
-            new FieldDataFetcher(SOME_SUPER_FIELD)
+            GraphQLFieldDefinition.newFieldDefinition().nameAndFieldName(SOME_SUPER_FIELD_SNAKE_CASE,SOME_SUPER_FIELD).type(GraphQLString).build().getDataFetcher(),
+            GraphQLFieldDefinition.newFieldDefinition().nameAndFieldName(SOME_SUPER_FIELD_SNAKE_CASE,SOME_SUPER_FIELD).type(GraphQLString).fetchField().build().getDataFetcher(),
+            GraphQLFieldDefinition.newFieldDefinition().name(SOME_SUPER_FIELD).type(GraphQLString).build().getDataFetcher(),
+            GraphQLFieldDefinition.newFieldDefinition().name(SOME_SUPER_FIELD).type(GraphQLString).fetchField().build().getDataFetcher()
         ]
     }
 }

--- a/src/test/groovy/graphql/schema/ReflectionDataFetcherTest.groovy
+++ b/src/test/groovy/graphql/schema/ReflectionDataFetcherTest.groovy
@@ -1,0 +1,32 @@
+package graphql.schema
+
+import static graphql.Scalars.GraphQLString
+import spock.lang.Specification
+
+class ReflectionDataFetcherTest extends Specification {
+
+    static final EXPECTED = "expected"
+
+    static final String SOME_SUPER_FIELD = "someSuperField";
+
+    def environment = Mock(DataFetchingEnvironment);
+
+    def "setup"(){
+        environment.getSource() >> new TestObject(EXPECTED);
+    }
+
+    def "testVariousImplementations"(DataFetcher dataFetcher) {
+
+        when:
+        String actual=dataFetcher.get(environment);
+
+        then:
+        EXPECTED==actual;
+
+        where:
+        dataFetcher << [
+            new PropertyDataFetcher(SOME_SUPER_FIELD),
+            new FieldDataFetcher(SOME_SUPER_FIELD)
+        ]
+    }
+}

--- a/src/test/groovy/graphql/schema/TestObject.java
+++ b/src/test/groovy/graphql/schema/TestObject.java
@@ -1,0 +1,18 @@
+package graphql.schema;
+
+public class TestObject {
+
+    public final String someSuperField;
+
+    public TestObject(
+        String someSuperField) {
+
+        this.someSuperField = someSuperField;
+
+    }
+
+    public String getSomeSuperField() {
+
+        return someSuperField;
+    }
+}


### PR DESCRIPTION
Currently, if a POJO has a field firstName for instance and you want to query with "first_name" instead of "firstName", you need to provide explicitly a data fetcher to do the map. That could be not quite cool to explicitly define a data fetcher for each field just to do this kind of map.

I am just proposing a new method on the builder to specify a field name to map with the name of the field in the schema. No big deal ;)