### PR TITLE
Java Generics for clarity

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,8 @@ apply plugin: 'maven-publish'
 sourceCompatibility = 1.6
 targetCompatibility = 1.6
 def releaseVersion = System.properties.RELEASE_VERSION
-version = releaseVersion ? releaseVersion : new SimpleDateFormat('yyyy-MM-dd\'T\'HH-mm-ss').format(new Date())
+//version = releaseVersion ? releaseVersion : new SimpleDateFormat('yyyy-MM-dd\'T\'HH-mm-ss').format(new Date())
+version = releaseVersion ? releaseVersion : '2.0.0-SNAPSHOT'
 group = 'com.graphql-java'
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -115,3 +115,11 @@ task wrapper(type: Wrapper) {
     gradleVersion = '2.11'
     distributionUrl = "http://services.gradle.org/distributions/gradle-${gradleVersion}-all.zip"
 }
+
+if (JavaVersion.current().isJava8Compatible()) {
+    allprojects {
+        tasks.withType(Javadoc) {
+            options.addStringOption('Xdoclint:none', '-quiet')
+        }
+    }
+}

--- a/src/main/java/graphql/Scalars.java
+++ b/src/main/java/graphql/Scalars.java
@@ -11,38 +11,38 @@ import graphql.schema.GraphQLScalarType;
 public class Scalars {
 
 
-    public static GraphQLScalarType GraphQLInt = new GraphQLScalarType("Int", "Built-in Int", new Coercing() {
+    public static GraphQLScalarType GraphQLInt = new GraphQLScalarType("Int", "Built-in Int", new Coercing<Integer>() {
         @Override
-        public Object serialize(Object input) {
+        public Integer serialize(Object input) {
             if (input instanceof String) {
                 return Integer.parseInt((String) input);
             } else if (input instanceof Integer) {
-                return input;
+                return (Integer) input;
             } else {
                 return null;
             }
         }
 
         @Override
-        public Object parseValue(Object input) {
+        public Integer parseValue(Object input) {
             return serialize(input);
         }
 
         @Override
-        public Object parseLiteral(Object input) {
+        public Integer parseLiteral(Object input) {
             if (!(input instanceof IntValue)) return null;
             return ((IntValue) input).getValue();
         }
     });
 
 
-    public static GraphQLScalarType GraphQLLong = new GraphQLScalarType("Long", "Long type", new Coercing() {
+    public static GraphQLScalarType GraphQLLong = new GraphQLScalarType("Long", "Long type", new Coercing<Long>() {
         @Override
-        public Object serialize(Object input) {
+        public Long serialize(Object input) {
             if (input instanceof String) {
                 return Long.parseLong((String) input);
             } else if (input instanceof Long) {
-                return input;
+                return (Long) input;
             } else if (input instanceof Integer) {
                 return ((Integer) input).longValue();
             } else {
@@ -51,22 +51,22 @@ public class Scalars {
         }
 
         @Override
-        public Object parseValue(Object input) {
+        public Long parseValue(Object input) {
             return serialize(input);
         }
 
         @Override
-        public Object parseLiteral(Object input) {
+        public Long parseLiteral(Object input) {
             if (input instanceof StringValue) {
                 return Long.parseLong(((StringValue) input).getValue());
             } else if (input instanceof IntValue) {
-                return ((IntValue) input).getValue();
+                return Long.valueOf(((IntValue) input).getValue());
             }
             return null;
         }
     });
 
-    public static GraphQLScalarType GraphQLFloat = new GraphQLScalarType("Float", "Built-in Float", new Coercing() {
+    public static GraphQLScalarType GraphQLFloat = new GraphQLScalarType("Float", "Built-in Float", new Coercing<Double>() {
         @Override
         public Double serialize(Object input) {
             if (input instanceof String) {
@@ -83,40 +83,40 @@ public class Scalars {
         }
 
         @Override
-        public Object parseValue(Object input) {
+        public Double parseValue(Object input) {
             return serialize(input);
         }
 
         @Override
-        public Object parseLiteral(Object input) {
+        public Double parseLiteral(Object input) {
             return ((FloatValue) input).getValue().doubleValue();
         }
     });
 
-    public static GraphQLScalarType GraphQLString = new GraphQLScalarType("String", "Built-in String", new Coercing() {
+    public static GraphQLScalarType GraphQLString = new GraphQLScalarType("String", "Built-in String", new Coercing<String>() {
         @Override
-        public Object serialize(Object input) {
+        public String serialize(Object input) {
             return input == null ? null : input.toString();
         }
 
         @Override
-        public Object parseValue(Object input) {
+        public String parseValue(Object input) {
             return serialize(input);
         }
 
         @Override
-        public Object parseLiteral(Object input) {
+        public String parseLiteral(Object input) {
             if (!(input instanceof StringValue)) return null;
             return ((StringValue) input).getValue();
         }
     });
 
 
-    public static GraphQLScalarType GraphQLBoolean = new GraphQLScalarType("Boolean", "Built-in Boolean", new Coercing() {
+    public static GraphQLScalarType GraphQLBoolean = new GraphQLScalarType("Boolean", "Built-in Boolean", new Coercing<Boolean>() {
         @Override
-        public Object serialize(Object input) {
+        public Boolean serialize(Object input) {
             if (input instanceof Boolean) {
-                return input;
+                return (Boolean) input;
             } else if (input instanceof Integer) {
                 return (Integer) input > 0;
             } else if (input instanceof String) {
@@ -127,12 +127,12 @@ public class Scalars {
         }
 
         @Override
-        public Object parseValue(Object input) {
+        public Boolean parseValue(Object input) {
             return serialize(input);
         }
 
         @Override
-        public Object parseLiteral(Object input) {
+        public Boolean parseLiteral(Object input) {
             if (!(input instanceof BooleanValue)) return null;
             return ((BooleanValue) input).isValue();
         }

--- a/src/main/java/graphql/schema/Coercing.java
+++ b/src/main/java/graphql/schema/Coercing.java
@@ -1,7 +1,7 @@
 package graphql.schema;
 
 
-public interface Coercing {
+public interface Coercing <T2> {
 
 
     /**
@@ -10,7 +10,7 @@ public interface Coercing {
      * @param input is never null
      * @return null if not possible/invalid
      */
-    Object serialize(Object input);
+    T2 serialize(Object input);
 
     /**
      * Called to resolve a input from a variable.
@@ -19,7 +19,7 @@ public interface Coercing {
      * @param input is never null
      * @return null if not possible/invalid
      */
-    Object parseValue(Object input);
+    T2 parseValue(Object input);
 
     /**
      * Called to convert a AST node
@@ -27,5 +27,5 @@ public interface Coercing {
      * @param input is never null
      * @return null if not possible/invalid
      */
-    Object parseLiteral(Object input);
+    T2 parseLiteral(Object input);
 }

--- a/src/main/java/graphql/schema/DataFetcher.java
+++ b/src/main/java/graphql/schema/DataFetcher.java
@@ -1,7 +1,7 @@
 package graphql.schema;
 
 
-public interface DataFetcher {
+public interface DataFetcher <T> {
 
-    Object get(DataFetchingEnvironment environment);
+    T get(DataFetchingEnvironment environment);
 }


### PR DESCRIPTION
By using generics it is easier to understand how to use the API. It also helps with finding type errors.

I also changed the versioning in the build file to fit the SNAPSHOT strategy from Maven. 
Minor change to disable doclint for java 1.8 builds
