### PR TITLE
Check for invalid SimpleListConnection list indices on client-provided cursor

### DIFF
--- a/src/main/java/graphql/relay/SimpleListConnection.java
+++ b/src/main/java/graphql/relay/SimpleListConnection.java
@@ -1,6 +1,5 @@
 package graphql.relay;
 
-
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 
@@ -38,6 +37,8 @@ public class SimpleListConnection implements DataFetcher {
         int begin = Math.max(afterOffset, -1) + 1;
         int beforeOffset = getOffsetFromCursor(environment.<String>getArgument("before"), edges.size());
         int end = Math.min(beforeOffset, edges.size());
+
+        if (begin > end) begin = end;
 
         edges = edges.subList(begin, end);
         if (edges.size() == 0) {

--- a/src/main/java/graphql/relay/SimpleListConnection.java
+++ b/src/main/java/graphql/relay/SimpleListConnection.java
@@ -1,5 +1,6 @@
 package graphql.relay;
 
+
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 

--- a/src/test/groovy/graphql/relay/SimpleListConnectionTest.groovy
+++ b/src/test/groovy/graphql/relay/SimpleListConnectionTest.groovy
@@ -1,0 +1,31 @@
+package graphql.relay
+
+import graphql.language.BooleanValue
+import graphql.language.FloatValue
+import graphql.language.IntValue
+import graphql.language.StringValue
+import graphql.relay.SimpleListConnection
+import graphql.schema.DataFetchingEnvironment
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class SimpleListConnectionTest extends Specification {
+    def "invalid list indices handled"() {
+        given:
+        def testList = ["a", "b"]
+        def listConnection = new SimpleListConnection(testList)
+        def env = new DataFetchingEnvironment(null, ["after":createCursor(3)], null, null, null, null, null);
+
+        when:
+        Object item = listConnection.get(env);
+
+        then:
+        item instanceof graphql.relay.Connection
+    }
+
+    private static final String DUMMY_CURSOR_PREFIX = "simple-cursor";
+    private String createCursor(int offset) {
+        String string = graphql.relay.Base64.toBase64(DUMMY_CURSOR_PREFIX + Integer.toString(offset));
+        return string;
+    }
+}


### PR DESCRIPTION
Scenario to reproduce:
Client requests first 3 edges of relay list of list total length 4 at time t.

At time t+1, 
underlying list is mutated at data source, list becomes 2 items shorter.
Length of edge list is now 2, but GraphQL client thinks list is length 4.

At time t+2, 
Client requests some more edges specifying parameter `after` as 3

```
java.lang.IllegalArgumentException: fromIndex(3) > toIndex(2)
        at java.util.ArrayList.subListRangeCheck(ArrayList.java:1006)
        at java.util.ArrayList.subList(ArrayList.java:996)
        at graphql.relay.SimpleListConnection.get(SimpleListConnection.java:42)
        at GraphQL.DataFetchers.lambda$getPlaylistGroupVideosDataFetcher$20(DataFetchers.java:365)
        at graphql.execution.ExecutionStrategy.resolveField(ExecutionStrategy.java:46)
        at graphql.execution.SimpleExecutionStrategy.execute(SimpleExecutionStrategy.java:18)
        at graphql.execution.ExecutionStrategy.completeValue(ExecutionStrategy.java:92)
        at graphql.execution.ExecutionStrategy.resolveField(ExecutionStrategy.java:52)
        at graphql.execution.SimpleExecutionStrategy.execute(SimpleExecutionStrategy.java:18)
        at graphql.execution.Execution.executeOperation(Execution.java:69)
        at graphql.execution.Execution.execute(Execution.java:42)
        at graphql.GraphQL.execute(GraphQL.java:78)
        at graphql.GraphQL.execute(GraphQL.java:55)

```
