### PR TITLE
Update ExecutionContextBuilder.java

### DIFF
--- a/src/main/java/graphql/execution/ExecutionContextBuilder.java
+++ b/src/main/java/graphql/execution/ExecutionContextBuilder.java
@@ -32,7 +32,7 @@ public class ExecutionContextBuilder {
                 fragmentsByName.put(fragmentDefinition.getName(), fragmentDefinition);
             }
         }
-        if (operationName != null && operationsByName.size() > 1) {
+        if (operationName == null && operationsByName.size() > 1) {
             throw new GraphQLException("missing operation name");
         }
         OperationDefinition operation;


### PR DESCRIPTION
From [2.2](http://facebook.github.io/graphql/#sec-Language.Query-Document)

> if a GraphQL query document contains multiple operations, each operation must be named. When submitting a query document with multiple operations to a GraphQL service, the name of the desired operation to be executed must also be provided.