### PR TITLE
Union types must have at least 1 member, and members can be only of O…

### DIFF
--- a/src/main/java/graphql/Assert.java
+++ b/src/main/java/graphql/Assert.java
@@ -1,5 +1,6 @@
 package graphql;
 
+import java.util.Collection;
 
 public class Assert {
 
@@ -7,6 +8,11 @@ public class Assert {
     public static void assertNotNull(Object object, String errorMessage) {
         if (object != null) return;
         throw new AssertException(errorMessage);
+    }
+
+    public static void assertNotEmpty(Collection<?> c, String errorMessage) {
+        if (c == null || c.isEmpty()) throw new AssertException(errorMessage);
+        return;
     }
 
 }

--- a/src/main/java/graphql/schema/GraphQLUnionType.java
+++ b/src/main/java/graphql/schema/GraphQLUnionType.java
@@ -4,19 +4,20 @@ package graphql.schema;
 import java.util.ArrayList;
 import java.util.List;
 
-import static graphql.Assert.assertNotNull;
+import static graphql.Assert.*;
 
 public class GraphQLUnionType implements GraphQLType, GraphQLOutputType, GraphQLCompositeType, GraphQLUnmodifiedType, GraphQLNullableType {
 
     private final String name;
     private final String description;
-    private List<GraphQLType> types = new ArrayList<GraphQLType>();
+    private List<GraphQLObjectType> types = new ArrayList<GraphQLObjectType>();
     private final TypeResolver typeResolver;
 
 
-    public GraphQLUnionType(String name, String description, List<GraphQLType> types, TypeResolver typeResolver) {
+    public GraphQLUnionType(String name, String description, List<GraphQLObjectType> types, TypeResolver typeResolver) {
         assertNotNull(name, "name can't be null");
         assertNotNull(types, "types can't be null");
+        assertNotEmpty(types, "A Union type must define one or more member types.");
         assertNotNull(typeResolver, "typeResolver can't be null");
         this.name = name;
         this.description = description;
@@ -25,8 +26,8 @@ public class GraphQLUnionType implements GraphQLType, GraphQLOutputType, GraphQL
     }
 
 
-    public List<GraphQLType> getTypes() {
-        return new ArrayList<GraphQLType>(types);
+    public List<GraphQLObjectType> getTypes() {
+        return new ArrayList<GraphQLObjectType>(types);
     }
 
     public TypeResolver getTypeResolver() {
@@ -49,7 +50,7 @@ public class GraphQLUnionType implements GraphQLType, GraphQLOutputType, GraphQL
     public static class Builder {
         private String name;
         private String description;
-        private List<GraphQLType> types = new ArrayList<GraphQLType>();
+        private List<GraphQLObjectType> types = new ArrayList<GraphQLObjectType>();
         private TypeResolver typeResolver;
 
         public Builder name(String name) {
@@ -69,14 +70,14 @@ public class GraphQLUnionType implements GraphQLType, GraphQLOutputType, GraphQL
         }
 
 
-        public Builder possibleType(GraphQLType type) {
+        public Builder possibleType(GraphQLObjectType type) {
             assertNotNull(type, "possible type can't be null");
             types.add(type);
             return this;
         }
 
-        public Builder possibleTypes(GraphQLType... type) {
-            for (GraphQLType graphQLType : type) {
+        public Builder possibleTypes(GraphQLObjectType... type) {
+            for (GraphQLObjectType graphQLType : type) {
                 possibleType(graphQLType);
             }
             return this;

--- a/src/test/groovy/graphql/schema/GraphQLUnionTypeTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLUnionTypeTest.groovy
@@ -1,0 +1,24 @@
+package graphql.schema
+
+import spock.lang.Specification
+
+import graphql.AssertException
+import graphql.schema.TypeResolverProxy
+
+import static graphql.schema.GraphQLUnionType.newUnionType
+
+import static graphql.Scalars.GraphQLString
+
+
+class GraphQLUnionTypeTest extends Specification {
+
+    def "no possible types in union fails"() {
+        when:
+        newUnionType()
+                .name("TestUnionType")
+                .typeResolver(new TypeResolverProxy())
+                .build();
+        then:
+        thrown(AssertException)
+    }
+}


### PR DESCRIPTION
…bject types, not scalars etc.

References #128  Union types may not have Scalars, Interfaces, or Unions as member types.  From spec.

This PR changes member types to GraphQLObjectType, creates a test case and some validation.