### PR TITLE
Support for directive.locations in introspection query

### DIFF
--- a/src/main/java/graphql/Directives.java
+++ b/src/main/java/graphql/Directives.java
@@ -5,6 +5,7 @@ import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLNonNull;
 
 import static graphql.Scalars.GraphQLBoolean;
+import static graphql.introspection.Introspection.DirectiveLocation.*;
 import static graphql.schema.GraphQLArgument.newArgument;
 
 public class Directives {
@@ -17,9 +18,7 @@ public class Directives {
                     .type(new GraphQLNonNull(GraphQLBoolean))
                     .description("Included when true.")
                     .build())
-            .onOperation(false)
-            .onFragment(true)
-            .onField(true)
+            .validLocations(FRAGMENT_DEFINITION, FRAGMENT_SPREAD, INLINE_FRAGMENT, FIELD)
             .build();
 
     public static GraphQLDirective SkipDirective = GraphQLDirective.newDirective()
@@ -30,9 +29,7 @@ public class Directives {
                     .type(new GraphQLNonNull(GraphQLBoolean))
                     .description("Skipped when true.")
                     .build())
-            .onOperation(false)
-            .onFragment(true)
-            .onField(true)
+            .validLocations(FRAGMENT_DEFINITION, FRAGMENT_SPREAD, INLINE_FRAGMENT, FIELD)
             .build();
 
 

--- a/src/main/java/graphql/introspection/Introspection.java
+++ b/src/main/java/graphql/introspection/Introspection.java
@@ -313,6 +313,26 @@ public class Introspection {
                     .build())
             .build();
 
+    public enum DirectiveLocation {
+        QUERY,
+        MUTATION,
+        FIELD,
+        FRAGMENT_DEFINITION,
+        FRAGMENT_SPREAD,
+        INLINE_FRAGMENT
+    }
+
+    public static GraphQLEnumType __DirectiveLocation = GraphQLEnumType.newEnum()
+            .name("__DirectiveLocation")
+            .description("An enum describing valid locations where a directive can be placed")
+            .value("QUERY", DirectiveLocation.QUERY, "Indicates the directive is valid on queries.")
+            .value("MUTATION", DirectiveLocation.MUTATION, "Indicates the directive is valid on mutations.")
+            .value("FIELD", DirectiveLocation.FIELD, "Indicates the directive is valid on fields.")
+            .value("FRAGMENT_DEFINITION", DirectiveLocation.FRAGMENT_DEFINITION, "Indicates the directive is valid on fragment definitions.")
+            .value("FRAGMENT_SPREAD", DirectiveLocation.FRAGMENT_SPREAD, "Indicates the directive is valid on fragment spreads.")
+            .value("INLINE_FRAGMENT", DirectiveLocation.INLINE_FRAGMENT, "Indicates the directive is valid on inline fragments.")
+            .build();
+
     public static GraphQLObjectType __Directive = newObject()
             .name("__Directive")
             .field(newFieldDefinition()
@@ -322,6 +342,10 @@ public class Introspection {
             .field(newFieldDefinition()
                     .name("description")
                     .type(GraphQLString)
+                    .build())
+            .field(newFieldDefinition()
+                    .name("locations")
+                    .type(new GraphQLList(new GraphQLNonNull(__DirectiveLocation)))
                     .build())
             .field(newFieldDefinition()
                     .name("args")
@@ -337,14 +361,17 @@ public class Introspection {
             .field(newFieldDefinition()
                     .name("onOperation")
                     .type(GraphQLBoolean)
+                    .deprecate("Use `locations`.")
                     .build())
             .field(newFieldDefinition()
                     .name("onFragment")
                     .type(GraphQLBoolean)
+                    .deprecate("Use `locations`.")
                     .build())
             .field(newFieldDefinition()
                     .name("onField")
                     .type(GraphQLBoolean)
+                    .deprecate("Use `locations`.")
                     .build())
             .build();
 

--- a/src/main/java/graphql/schema/GraphQLDirective.java
+++ b/src/main/java/graphql/schema/GraphQLDirective.java
@@ -2,24 +2,29 @@ package graphql.schema;
 
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 
 import static graphql.Assert.assertNotNull;
+import static graphql.introspection.Introspection.DirectiveLocation;
 
 public class GraphQLDirective {
 
     private final String name;
     private final String description;
+    private final EnumSet<DirectiveLocation> locations;
     private final List<GraphQLArgument> arguments = new ArrayList<GraphQLArgument>();
     private final boolean onOperation;
     private final boolean onFragment;
     private final boolean onField;
 
-    public GraphQLDirective(String name, String description, List<GraphQLArgument> arguments, boolean onOperation, boolean onFragment, boolean onField) {
+    public GraphQLDirective(String name, String description, EnumSet<DirectiveLocation> locations,
+                            List<GraphQLArgument> arguments, boolean onOperation, boolean onFragment, boolean onField) {
         assertNotNull(name, "name can't be null");
         assertNotNull(arguments, "arguments can't be null");
         this.name = name;
         this.description = description;
+        this.locations = locations;
         this.arguments.addAll(arguments);
         this.onOperation = onOperation;
         this.onFragment = onFragment;
@@ -41,14 +46,30 @@ public class GraphQLDirective {
         return null;
     }
 
+    public EnumSet<DirectiveLocation> validLocations() {
+        return locations;
+    }
+
+    /**
+     * @deprecated  Use {@link #validLocations()}
+     */
+    @Deprecated
     public boolean isOnOperation() {
         return onOperation;
     }
 
+    /**
+     * @deprecated  Use {@link #validLocations()}
+     */
+    @Deprecated
     public boolean isOnFragment() {
         return onFragment;
     }
 
+    /**
+     * @deprecated  Use {@link #validLocations()}
+     */
+    @Deprecated
     public boolean isOnField() {
         return onField;
     }
@@ -64,6 +85,7 @@ public class GraphQLDirective {
     public static class Builder {
 
         private String name;
+        private EnumSet<DirectiveLocation> locations = EnumSet.noneOf(DirectiveLocation.class);
         private final List<GraphQLArgument> arguments = new ArrayList<GraphQLArgument>();
         private String description;
         private boolean onOperation;
@@ -80,28 +102,47 @@ public class GraphQLDirective {
             return this;
         }
 
+        public Builder validLocations(DirectiveLocation ...validLocations) {
+            for (DirectiveLocation location : validLocations) {
+                locations.add(location);
+            }
+            return this;
+        }
+
         public Builder argument(GraphQLArgument fieldArgument) {
             arguments.add(fieldArgument);
             return this;
         }
 
+        /**
+         * @deprecated  Use {@link graphql.schema.GraphQLDirective.Builder#validLocations(DirectiveLocation...)}
+         */
+        @Deprecated
         public Builder onOperation(boolean onOperation) {
             this.onOperation = onOperation;
             return this;
         }
 
+        /**
+         * @deprecated  Use {@link graphql.schema.GraphQLDirective.Builder#validLocations(DirectiveLocation...)}
+         */
+        @Deprecated
         public Builder onFragment(boolean onFragment) {
             this.onFragment = onFragment;
             return this;
         }
 
+        /**
+         * @deprecated  Use {@link graphql.schema.GraphQLDirective.Builder#validLocations(DirectiveLocation...)}
+         */
+        @Deprecated
         public Builder onField(boolean onField) {
             this.onField = onField;
             return this;
         }
 
         public GraphQLDirective build() {
-            return new GraphQLDirective(name, description, arguments, onOperation, onFragment, onField);
+            return new GraphQLDirective(name, description, locations, arguments, onOperation, onFragment, onField);
         }
 
 

--- a/src/main/java/graphql/validation/rules/KnownDirectives.java
+++ b/src/main/java/graphql/validation/rules/KnownDirectives.java
@@ -36,16 +36,16 @@ public class KnownDirectives extends AbstractRule {
         if (ancestor instanceof OperationDefinition) {
             Operation operation = ((OperationDefinition) ancestor).getOperation();
             return Operation.QUERY.equals(operation) ?
-                    !directive.validLocations().contains(DirectiveLocation.QUERY) :
-                    !directive.validLocations().contains(DirectiveLocation.MUTATION);
+                    !(directive.validLocations().contains(DirectiveLocation.QUERY) || directive.isOnOperation()) :
+                    !(directive.validLocations().contains(DirectiveLocation.MUTATION) || directive.isOnOperation());
         } else if (ancestor instanceof Field) {
-            return !directive.validLocations().contains(DirectiveLocation.FIELD);
+            return !(directive.validLocations().contains(DirectiveLocation.FIELD) || directive.isOnField());
         } else if (ancestor instanceof FragmentSpread) {
-            return  !directive.validLocations().contains(DirectiveLocation.FRAGMENT_SPREAD);
+            return  !(directive.validLocations().contains(DirectiveLocation.FRAGMENT_SPREAD) || directive.isOnFragment());
         } else if (ancestor instanceof FragmentDefinition) {
-            return !directive.validLocations().contains(DirectiveLocation.FRAGMENT_DEFINITION);
+            return !(directive.validLocations().contains(DirectiveLocation.FRAGMENT_DEFINITION) || directive.isOnFragment());
         } else if (ancestor instanceof InlineFragment) {
-            return !directive.validLocations().contains(DirectiveLocation.INLINE_FRAGMENT);
+            return (!directive.validLocations().contains(DirectiveLocation.INLINE_FRAGMENT) || directive.isOnFragment());
         }
         return true;
     }

--- a/src/test/groovy/graphql/StarWarsIntrospectionTests.groovy
+++ b/src/test/groovy/graphql/StarWarsIntrospectionTests.groovy
@@ -31,7 +31,8 @@ class StarWarsIntrospectionTests extends Specification {
                                     [name: '__InputValue'],
                                     [name: 'Boolean'],
                                     [name: '__EnumValue'],
-                                    [name: '__Directive']]
+                                    [name: '__Directive'],
+                                    [name: '__DirectiveLocation']]
                 ]
 
         ];

--- a/src/test/groovy/graphql/schema/SchemaUtilTest.groovy
+++ b/src/test/groovy/graphql/schema/SchemaUtilTest.groovy
@@ -13,6 +13,7 @@ class SchemaUtilTest extends Specification {
         when:
         Map<String, GraphQLType> types = new SchemaUtil().allTypes(starWarsSchema, Collections.emptySet())
         then:
+        types.size() == 15
         types == [(droidType.name)                 : droidType,
                   (humanType.name)                 : humanType,
                   (queryType.name)                 : queryType,

--- a/src/test/groovy/graphql/schema/SchemaUtilTest.groovy
+++ b/src/test/groovy/graphql/schema/SchemaUtilTest.groovy
@@ -1,15 +1,10 @@
 package graphql.schema
 
 import graphql.NestedInputSchema
-import graphql.Scalars
 import graphql.introspection.Introspection
 import spock.lang.Specification
 
-import java.util.Collections;
-
-import static graphql.Scalars.GraphQLBoolean
-import static graphql.Scalars.GraphQLInt
-import static graphql.Scalars.GraphQLString
+import static graphql.Scalars.*
 import static graphql.StarWarsSchema.*
 
 class SchemaUtilTest extends Specification {
@@ -31,6 +26,7 @@ class SchemaUtilTest extends Specification {
                   (Introspection.__InputValue.name): Introspection.__InputValue,
                   (Introspection.__EnumValue.name) : Introspection.__EnumValue,
                   (Introspection.__Directive.name) : Introspection.__Directive,
+                  (Introspection.__DirectiveLocation.name) : Introspection.__DirectiveLocation,
                   (GraphQLBoolean.name)            : GraphQLBoolean]
     }
 
@@ -51,6 +47,7 @@ class SchemaUtilTest extends Specification {
                   (Introspection.__InputValue.name): Introspection.__InputValue,
                   (Introspection.__EnumValue.name) : Introspection.__EnumValue,
           (Introspection.__Directive.name) : Introspection.__Directive,
+          (Introspection.__DirectiveLocation.name) : Introspection.__DirectiveLocation,
           (GraphQLBoolean.name)            : GraphQLBoolean];
         then:
         types.keySet() == expected.keySet()


### PR DESCRIPTION
When using the introspection query that is supplied with the latest version of graphql npm package (currently 0.5.0) the query uses a `locations` key that is not supported in graphql-java 2.0.0.
See also: http://facebook.github.io/graphql/#sec-The-__Directive-Type

At the moment the compatibility level of graphql-java is not really clear as stated in #132 
This pull request does not solve that but ups the compatibility to the latest graphql spec, and its introspection query (see: https://github.com/graphql/graphql-js/blob/0b72e7038761bec9fb5319cc08ea93ff8b071a9c/src/utilities/introspectionQuery.js).