### PR TITLE
Build with java6 runtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
-language: java
-jdk:
-  - oraclejdk7
-after_success:
-  - ./gradlew bintrayUpload -x check --info
+sudo: required
+services:
+  - docker
+script:
+  - docker create -v /usr/lib/jvm/java-6-openjdk-amd64/jre/lib --name java6-rt java:6 /bin/true
+  - docker run -it --rm --volumes-from java6-rt -v `pwd .`:/build -e JDK6_HOME=/usr/lib/jvm/java-6-openjdk-amd64 -e BINTRAY_USER=$BINTRAY_USER -e BINTRAY_API_KEY=$BINTRAY_API_KEY -w /build java:8 bash -c "./gradlew assemble && ./gradlew check && ./gradlew bintrayUpload -x check --info"
+
+

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,15 @@ allprojects {
     tasks.withType(Javadoc) {
         exclude('**/antlr/**')
     }
+
+    tasks.withType(JavaCompile) {
+        doFirst {
+            if (sourceCompatibility == '1.6' && System.env.JDK6_HOME != null) {
+                options.bootClasspath = "$System.env.JDK6_HOME/jre/lib/rt.jar"
+            }
+        }
+    }
+
 }
 
 publishing {


### PR DESCRIPTION
This ensures that only java6 functionality can be used, while compiling with the java8 compiler. source and target versions remain unchanged to 1.6

