### PR TITLE
PropertyDataFetcher supports AutoValue style classes

### DIFF
--- a/src/main/java/graphql/schema/PropertyDataFetcher.java
+++ b/src/main/java/graphql/schema/PropertyDataFetcher.java
@@ -4,6 +4,7 @@ package graphql.schema;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.Map;
 
 import static graphql.Scalars.GraphQLBoolean;
@@ -26,11 +27,33 @@ public class PropertyDataFetcher implements DataFetcher {
         return getPropertyViaGetter(source, environment.getFieldType());
     }
 
+    /**
+     * Invoking public methods on package-protected classes via reflection
+     * causes exceptions. This method searches a class's hierarchy for
+     * public visibility parent classes with the desired getter. This
+     * particular case is required to support AutoValue style data classes,
+     * which have abstract public interfaces implemented by package-protected
+     * (generated) subclasses.
+     */
+    private Method findAccessibleMethod(Class root, String methodName) throws NoSuchMethodException {
+        Class cur = root;
+        while(cur != null) {
+            if(Modifier.isPublic(cur.getModifiers())){
+                Method m = cur.getMethod(methodName);
+                if (Modifier.isPublic(m.getModifiers())) {
+                    return m;
+                }
+            }
+            cur = cur.getSuperclass();
+        }
+        return root.getMethod(methodName);
+    }
+
     private Object getPropertyViaGetter(Object object, GraphQLOutputType outputType) {
         String prefix = isBooleanProperty(outputType) ? "is" : "get";
         String getterName = prefix + propertyName.substring(0, 1).toUpperCase() + propertyName.substring(1);
         try {
-            Method method = object.getClass().getMethod(getterName);
+            Method method = findAccessibleMethod(object.getClass(), getterName);
             return method.invoke(object);
 
         } catch (NoSuchMethodException e) {

--- a/src/test/groovy/graphql/schema/PropertyDataFetcherTest.groovy
+++ b/src/test/groovy/graphql/schema/PropertyDataFetcherTest.groovy
@@ -1,0 +1,66 @@
+package graphql.schema
+
+import graphql.schema.somepackage.TestClass
+import graphql.schema.somepackage.TwoClassesDown
+import spock.lang.Specification
+
+class PropertyDataFetcherTest extends Specification {
+
+    def env(obj) {
+        return new DataFetchingEnvironment(obj,
+                Collections.emptyMap(),
+                null,
+                Collections.emptyList(),
+                null,
+                null,
+                null
+        )
+    }
+
+    def "fetch via public getter with private subclass"() {
+        def environment = env(TestClass.createPackageProtectedImpl("aValue"))
+        def fetcher = new PropertyDataFetcher("packageProtectedProperty")
+        expect:
+        fetcher.get(environment) == "aValue"
+    }
+
+    def "fetch via method that isn't present"() {
+        def environment = env(new TestClass())
+        def fetcher = new PropertyDataFetcher("valueNotPresent")
+        def result = fetcher.get(environment)
+        expect:
+        result == null
+    }
+
+    def "fetch via method that is private"() {
+        def environment = env(new TestClass())
+        def fetcher = new PropertyDataFetcher("privateProperty")
+        def result = fetcher.get(environment)
+        expect:
+        result == null
+    }
+
+    def "fetch via public method"() {
+        def environment = env(new TestClass())
+        def fetcher = new PropertyDataFetcher("publicProperty")
+        def result = fetcher.get(environment)
+        expect:
+        result == "publicValue"
+    }
+
+    def "fetch via public method declared two classes up"() {
+        def environment = env(new TwoClassesDown("aValue"))
+        def fetcher = new PropertyDataFetcher("publicProperty")
+        def result = fetcher.get(environment)
+        expect:
+        result == "publicValue"
+    }
+
+    def "fetch via property only defined on package protected impl"() {
+        def environment = env(TestClass.createPackageProtectedImpl("aValue"))
+        def fetcher = new PropertyDataFetcher("propertyOnlyDefinedOnPackageProtectedImpl")
+        def result = fetcher.get(environment)
+        expect:
+        result == null
+    }
+}

--- a/src/test/groovy/graphql/schema/somepackage/PackageProtectedImpl.java
+++ b/src/test/groovy/graphql/schema/somepackage/PackageProtectedImpl.java
@@ -1,0 +1,20 @@
+package graphql.schema.somepackage;
+
+class PackageProtectedImpl extends TestClass {
+
+    private final String aValue;
+
+    PackageProtectedImpl(String aValue) {
+        this.aValue = aValue;
+    }
+
+    @Override
+    public String getPackageProtectedProperty() {
+        return aValue;
+    }
+
+    public String getPropertyOnlyDefinedOnPackageProtectedImpl() {
+        return "valueOnlyDefinedOnPackageProtectedIpl";
+    }
+
+}

--- a/src/test/groovy/graphql/schema/somepackage/TestClass.java
+++ b/src/test/groovy/graphql/schema/somepackage/TestClass.java
@@ -1,0 +1,24 @@
+package graphql.schema.somepackage;
+
+public class TestClass {
+
+    private String privateProperty = "privateValue";
+
+    private String publicProperty = "publicValue";
+
+    public static TestClass createPackageProtectedImpl(String value) {
+        return new PackageProtectedImpl(value);
+    }
+
+    public String getPackageProtectedProperty() {
+        return "parentProperty";
+    }
+
+    private String getPrivateProperty() {
+        return privateProperty;
+    }
+
+    public String getPublicProperty() {
+        return publicProperty;
+    }
+}

--- a/src/test/groovy/graphql/schema/somepackage/TwoClassesDown.java
+++ b/src/test/groovy/graphql/schema/somepackage/TwoClassesDown.java
@@ -1,0 +1,8 @@
+package graphql.schema.somepackage;
+
+public class TwoClassesDown extends PackageProtectedImpl {
+
+    public TwoClassesDown(String aValue) {
+        super(aValue);
+    }
+}


### PR DESCRIPTION
 Google's AutoValue library (https://github.com/google/auto/)
 generates package-protected implementations of abstract
 data classes with abstract public getters. These classes
 weren't supported by the PropertyDataFetcher, since invoking
 the public method on a package-protected class causes
 InvocationTargetException. However, invoking the method
 on the public parent class works fine.

 These changes look for a public parent class with the applicable
 getter method. Behavior with normal style classes should not be
 affected.
