### PR TITLE
Fix problem where unspecified fields in an object value for a variable are set to null

### DIFF
--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -90,11 +90,17 @@ public class ValuesResolver {
     private Object coerceValueForInputObjectField(GraphQLInputObjectType inputObjectType, Map<String, Object> input) {
         Map<String, Object> result = new LinkedHashMap<String, Object>();
         for (GraphQLInputObjectField inputField : inputObjectType.getFields()) {
-            Object value = coerceValue(inputField.getType(), input.get(inputField.getName()));
-            result.put(inputField.getName(), value == null ? inputField.getDefaultValue() : value);
-
+            if (input.containsKey(inputField.getName()) || alwaysHasValue(inputField)) {
+                Object value = coerceValue(inputField.getType(), input.get(inputField.getName()));
+                result.put(inputField.getName(), value == null ? inputField.getDefaultValue() : value);
+            }
         }
         return result;
+    }
+
+    private boolean alwaysHasValue(GraphQLInputObjectField inputField) {
+        return inputField.getDefaultValue() != null
+                || inputField.getType() instanceof GraphQLNonNull;
     }
 
     private Object coerceValueForScalar(GraphQLScalarType graphQLScalarType, Object value) {


### PR DESCRIPTION
Addresses #106

When copying a variable value that corresponds to an input object type omit
any fields that are not present in the value, unless those fields have a
default value (in which case use the default value) or non null (which should
force an error)

This fixes a problem where such omitted fields were being copied with a null
value, making it impossible to tell whether the original variable value
omitted the field or explicitly set it to null.