### PR TITLE
ValuesResolver fixes for input object literals and variable values

### DIFF
--- a/src/test/groovy/graphql/execution/ValuesResolverTest.groovy
+++ b/src/test/groovy/graphql/execution/ValuesResolverTest.groovy
@@ -55,9 +55,14 @@ class ValuesResolverTest extends Specification {
         VariableDefinition variableDefinition = new VariableDefinition("variable", new TypeName("Person"))
 
         when:
-        def resolvedValues = resolver.getVariableValues(schema, [variableDefinition], [variable: [name: 'a', id: 123]])
+        def resolvedValues = resolver.getVariableValues(schema, [variableDefinition], [variable: inputValue])
         then:
-        resolvedValues['variable'] == [name: 'a', id: 123]
+        resolvedValues['variable'] == outputValue
+        where:
+        inputValue              || outputValue
+        [name: 'a', id: 123]    || [name: 'a', id: 123]
+        [id: 123]               || [id: 123]
+        [name: 'x']             || [name: 'x']
     }
 
     def "getVariableValues: simple value gets resolved to a list when the type is a List"() {
@@ -87,16 +92,7 @@ class ValuesResolverTest extends Specification {
     }
 
     def "getArgumentValues: resolves object literal"() {
-        given: "complex object value"
-        def complexObjectValue = new ObjectValue()
-        complexObjectValue.getObjectFields().add(new ObjectField("intKey", new IntValue(1)))
-        complexObjectValue.getObjectFields().add(new ObjectField("stringKey", new StringValue("world")))
-        def subObject = new ObjectValue()
-        subObject.getObjectFields().add(new ObjectField("subKey", new BooleanValue(true)))
-        complexObjectValue.getObjectFields().add(new ObjectField("subObject", subObject))
-        def argument = new Argument("arg", complexObjectValue)
-
-        and: "schema defining input object"
+        given: "schema defining input object"
         def subObjectType = newInputObject()
                 .name("SubType")
                 .field(newInputObjectField()
@@ -118,10 +114,104 @@ class ValuesResolverTest extends Specification {
         def fieldArgument = new GraphQLArgument("arg", inputObjectType)
 
         when:
+        def argument = new Argument("arg", inputValue)
         def values = resolver.getArgumentValues([fieldArgument], [argument], [:])
 
         then:
-        values['arg'] == [intKey: 1, stringKey: 'world', subObject: [subKey: true]]
+        values['arg'] == outputValue
+
+        where:
+        inputValue << [
+                buildObjectLiteral([
+                        intKey: new IntValue(BigInteger.ONE),
+                        stringKey: new StringValue("world"),
+                        subObject: [
+                                subKey: new BooleanValue(true)
+                        ]
+                ]),
+                buildObjectLiteral([
+                        intKey: new IntValue(BigInteger.ONE),
+                        stringKey: new StringValue("world")
+                ]),
+                buildObjectLiteral([
+                        intKey: new IntValue(BigInteger.ONE)
+                ])
+        ]
+        outputValue << [
+                [intKey: 1, stringKey: 'world', subObject: [subKey: true]],
+                [intKey: 1, stringKey: 'world'],
+                [intKey: 1]
+        ]
+    }
+
+    def "getArgumentValues: uses default value if object literal omits field"() {
+        given: "schema defining input object"
+        def inputObjectType = newInputObject()
+                .name("inputObject")
+                .field(newInputObjectField()
+                .name("intKey")
+                .type(new GraphQLNonNull(GraphQLInt))
+                .defaultValue(3)
+                .build())
+                .field(newInputObjectField()
+                .name("stringKey")
+                .type(GraphQLString)
+                .defaultValue("defaultString")
+                .build())
+                .build()
+        def fieldArgument = new GraphQLArgument("arg", inputObjectType)
+
+        when:
+        def argument = new Argument("arg", inputValue)
+        def values = resolver.getArgumentValues([fieldArgument], [argument], [:])
+
+        then:
+        values['arg'] == outputValue
+
+        where:
+        inputValue << [
+                buildObjectLiteral([
+                        intKey: new IntValue(BigInteger.ONE),
+                        stringKey: new StringValue("world")
+                ]),
+                buildObjectLiteral([
+                        intKey: new IntValue(BigInteger.ONE)
+                ]),
+                buildObjectLiteral([:])
+        ]
+        outputValue << [
+                [intKey: 1, stringKey: 'world'],
+                [intKey: 1, stringKey: 'defaultString'],
+                [intKey: 3, stringKey: 'defaultString']
+        ]
+    }
+
+    def "getArgumentValues: missing InputObject fields which are non-null cause error"() {
+        given: "schema defining input object"
+        def inputObjectType = newInputObject()
+                .name("inputObject")
+                .field(newInputObjectField()
+                .name("intKey")
+                .type(new GraphQLNonNull(GraphQLInt))
+                .build())
+                .build()
+        def fieldArgument = new GraphQLArgument("arg", inputObjectType)
+
+        when:
+        def argument = new Argument("arg", new ObjectValue())
+        resolver.getArgumentValues([fieldArgument], [argument], [:])
+
+        then:
+        thrown(GraphQLException)
+    }
+
+    ObjectValue buildObjectLiteral(Map<String, Object> contents) {
+        def object = new ObjectValue()
+        contents.each { key, value ->
+            def transformedValue = value instanceof Map ? buildObjectLiteral(value) : (Value) value
+            object.getObjectFields().add(new ObjectField(key, transformedValue))
+        }
+        return object
     }
 
     def "getArgumentValues: resolves enum literals"() {
@@ -214,7 +304,6 @@ class ValuesResolverTest extends Specification {
                 .type(GraphQLString)
                 .defaultValue("defaultString"))
                 .build()
-        def inputValue = [intKey: 10]
 
         def schema = TestUtil.schemaWithInputType(inputObjectType)
         VariableDefinition variableDefinition = new VariableDefinition("variable", new TypeName("InputObject"))
@@ -223,8 +312,13 @@ class ValuesResolverTest extends Specification {
         def resolvedValues = resolver.getVariableValues(schema, [variableDefinition], [variable: inputValue])
 
         then:
-        resolvedValues['variable'].stringKey == 'defaultString'
-        resolvedValues['variable'].intKey == 10
+        resolvedValues['variable'] == outputValue
+
+        where:
+        inputValue                    || outputValue
+        [intKey: 10]                  || [intKey: 10, stringKey: 'defaultString']
+        [intKey: 10, stringKey: null] || [intKey: 10, stringKey: 'defaultString']
+
     }
 
     def "getVariableInput: Missing InputObject fields which are non-null cause error"() {
@@ -239,15 +333,19 @@ class ValuesResolverTest extends Specification {
                 .name("requiredField")
                 .type(new GraphQLNonNull(GraphQLString)))
                 .build()
-        def inputValue = [intKey: 10]
 
         def schema = TestUtil.schemaWithInputType(inputObjectType)
         VariableDefinition variableDefinition = new VariableDefinition("variable", new TypeName("InputObject"))
 
         when:
-        def resolvedValues = resolver.getVariableValues(schema, [variableDefinition], [variable: inputValue])
+        resolver.getVariableValues(schema, [variableDefinition], [variable: inputValue])
 
         then:
         thrown(GraphQLException)
+
+        where:
+        inputValue                        | _
+        [intKey: 10]                      | _
+        [intKey: 10, requiredField: null] | _
     }
 }


### PR DESCRIPTION
Addresses #152 and #106

When resolving an object literal check for any fields which are omitted from
the literal but have a default value. In that case copy the default value to
the result. This fixes #152 (InputObjectType defaultValue is not getting used)

When resolving a variable value that corresponds to an input object type omit
any fields that are not present in the value, unless those fields have a
default value (in which case use the default value) or non null (which should
force an error). This fixes at least one part of #106, Unspecified fields in
Input object are set to null
