### PR TITLE
Add methods to field and argument builders that set the types using a builder method syntax

### DIFF
--- a/src/main/java/graphql/schema/GraphQLArgument.java
+++ b/src/main/java/graphql/schema/GraphQLArgument.java
@@ -1,6 +1,7 @@
 package graphql.schema;
 
 
+import graphql.Scalars;
 import static graphql.Assert.assertNotNull;
 
 public class GraphQLArgument {
@@ -65,6 +66,51 @@ public class GraphQLArgument {
 
         public Builder type(GraphQLInputType type) {
             this.type = type;
+            return this;
+        }
+
+        public Builder stringType() {
+            this.type = Scalars.GraphQLString;
+            return this;
+        }
+
+        public Builder integerType() {
+            this.type = Scalars.GraphQLInt;
+            return this;
+        }
+
+        public Builder floatType() {
+            this.type = Scalars.GraphQLFloat;
+            return this;
+        }
+
+        public Builder booleanType() {
+            this.type = Scalars.GraphQLBoolean;
+            return this;
+        }
+
+        public Builder longType() {
+            this.type = Scalars.GraphQLLong;
+            return this;
+        }
+
+        public Builder notNullType(GraphQLType type) {
+            this.type = new GraphQLNonNull(type);
+            return this;
+        }
+
+        public Builder listType(GraphQLType type) {
+            this.type = new GraphQLList(type);
+            return this;
+        }
+
+        public Builder notNull() {
+            this.type = new GraphQLNonNull(this.type);
+            return this;
+        }
+
+        public Builder list() {
+            this.type = new GraphQLList(this.type);
             return this;
         }
 

--- a/src/main/java/graphql/schema/GraphQLFieldDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLFieldDefinition.java
@@ -1,6 +1,6 @@
 package graphql.schema;
 
-
+import graphql.Scalars;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -98,6 +98,56 @@ public class GraphQLFieldDefinition {
 
         public Builder type(GraphQLOutputType type) {
             this.type = type;
+            return this;
+        }
+
+        public Builder stringType() {
+            this.type = Scalars.GraphQLString;
+            return this;
+        }
+
+        public Builder integerType() {
+            this.type = Scalars.GraphQLInt;
+            return this;
+        }
+
+        public Builder floatType() {
+            this.type = Scalars.GraphQLFloat;
+            return this;
+        }
+
+        public Builder booleanType() {
+            this.type = Scalars.GraphQLBoolean;
+            return this;
+        }
+
+        public Builder longType() {
+            this.type = Scalars.GraphQLLong;
+            return this;
+        }
+
+        public Builder notNullType(GraphQLType type) {
+            this.type = new GraphQLNonNull(type);
+            return this;
+        }
+
+        public Builder listType(GraphQLType type) {
+            this.type = new GraphQLList(type);
+            return this;
+        }
+
+        public Builder notNull() {
+            this.type = new GraphQLNonNull(this.type);
+            return this;
+        }
+
+        public Builder list() {
+            this.type = new GraphQLList(this.type);
+            return this;
+        }
+
+        public Builder refType(String typeRefName) {
+            this.type = new GraphQLTypeReference(typeRefName);
             return this;
         }
 

--- a/src/main/java/graphql/schema/GraphQLInputObjectField.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectField.java
@@ -1,6 +1,7 @@
 package graphql.schema;
 
 
+import graphql.Scalars;
 import static graphql.Assert.assertNotNull;
 
 public class GraphQLInputObjectField {
@@ -67,6 +68,51 @@ public class GraphQLInputObjectField {
 
         public Builder defaultValue(Object defaultValue) {
             this.defaultValue = defaultValue;
+            return this;
+        }
+
+        public Builder stringType() {
+            this.type = Scalars.GraphQLString;
+            return this;
+        }
+
+        public Builder integerType() {
+            this.type = Scalars.GraphQLInt;
+            return this;
+        }
+
+        public Builder floatType() {
+            this.type = Scalars.GraphQLFloat;
+            return this;
+        }
+
+        public Builder booleanType() {
+            this.type = Scalars.GraphQLBoolean;
+            return this;
+        }
+
+        public Builder longType() {
+            this.type = Scalars.GraphQLLong;
+            return this;
+        }
+
+        public Builder notNullType(GraphQLType type) {
+            this.type = new GraphQLNonNull(type);
+            return this;
+        }
+
+        public Builder listType(GraphQLType type) {
+            this.type = new GraphQLList(type);
+            return this;
+        }
+
+        public Builder notNull() {
+            this.type = new GraphQLNonNull(this.type);
+            return this;
+        }
+
+        public Builder list() {
+            this.type = new GraphQLList(this.type);
             return this;
         }
 

--- a/src/test/groovy/graphql/execution/ValuesResolverTest.groovy
+++ b/src/test/groovy/graphql/execution/ValuesResolverTest.groovy
@@ -246,7 +246,8 @@ class ValuesResolverTest extends Specification {
                 .build())
                 .field(newInputObjectField()
                 .name("requiredField")
-                .type(new GraphQLNonNull(GraphQLString))
+                .stringType()
+                .notNull()
                 .build())
                 .build()
         def inputValue = [intKey: 10]


### PR DESCRIPTION
It'd be nice to set the type also using a builder syntax
Instead of doing this:
`field.type(new GraphQLNonNull(GraphQLString))`
do this:
`field.stringType().notNull()`

Originally proposed by @Underzenith85