### PR TITLE
Fix for #130 - Adds support for Boolean property accessors with 'get' prefix in PropertyDataFetcher

### DIFF
--- a/src/main/java/graphql/schema/PropertyDataFetcher.java
+++ b/src/main/java/graphql/schema/PropertyDataFetcher.java
@@ -30,19 +30,19 @@ public class PropertyDataFetcher implements DataFetcher {
         try {
             if (isBooleanProperty(outputType)) {
                 try {
-                    return getPropertyViaGetterUsingPrefix(object, outputType, "is");
+                    return getPropertyViaGetterUsingPrefix(object, "is");
                 } catch (NoSuchMethodException e) {
-                    return getPropertyViaGetterUsingPrefix(object, outputType, "get");
+                    return getPropertyViaGetterUsingPrefix(object, "get");
                 }
             } else {
-                return getPropertyViaGetterUsingPrefix(object, outputType, "get");
+                return getPropertyViaGetterUsingPrefix(object, "get");
             }
         } catch (NoSuchMethodException e1) {
-            return getPropertyViaFieldAccess(object, outputType);
+            return getPropertyViaFieldAccess(object);
         }
     }
 
-    private Object getPropertyViaGetterUsingPrefix(Object object, GraphQLOutputType outputType, String prefix) throws NoSuchMethodException {
+    private Object getPropertyViaGetterUsingPrefix(Object object, String prefix) throws NoSuchMethodException {
         String getterName = prefix + propertyName.substring(0, 1).toUpperCase() + propertyName.substring(1);
         try {
             Method method = object.getClass().getMethod(getterName);
@@ -63,7 +63,7 @@ public class PropertyDataFetcher implements DataFetcher {
         return false;
     }
 
-    private Object getPropertyViaFieldAccess(Object object, GraphQLOutputType outputType) {
+    private Object getPropertyViaFieldAccess(Object object) {
         try {
             Field field = object.getClass().getField(propertyName);
             return field.get(object);

--- a/src/main/java/graphql/schema/PropertyDataFetcher.java
+++ b/src/main/java/graphql/schema/PropertyDataFetcher.java
@@ -27,20 +27,18 @@ public class PropertyDataFetcher implements DataFetcher {
     }
 
     private Object getPropertyViaGetter(Object object, GraphQLOutputType outputType) {
-        boolean isBooleanProperty = isBooleanProperty(outputType);
-        String prefix = isBooleanProperty ? "is" : "get";
         try {
-            return getPropertyViaGetterUsingPrefix(object, outputType, prefix);
-        } catch (NoSuchMethodException e) {
-            if (isBooleanProperty){
+            if (isBooleanProperty(outputType)) {
                 try {
+                    return getPropertyViaGetterUsingPrefix(object, outputType, "is");
+                } catch (NoSuchMethodException e) {
                     return getPropertyViaGetterUsingPrefix(object, outputType, "get");
-                } catch (NoSuchMethodException e1) {
-                    return getPropertyViaFieldAccess(object, outputType);
                 }
-            }else{
-                return getPropertyViaFieldAccess(object, outputType);
+            } else {
+                return getPropertyViaGetterUsingPrefix(object, outputType, "get");
             }
+        } catch (NoSuchMethodException e1) {
+            return getPropertyViaFieldAccess(object, outputType);
         }
     }
 

--- a/src/main/java/graphql/schema/PropertyDataFetcher.java
+++ b/src/main/java/graphql/schema/PropertyDataFetcher.java
@@ -48,8 +48,6 @@ public class PropertyDataFetcher implements DataFetcher {
             Method method = object.getClass().getMethod(getterName);
             return method.invoke(object);
 
-        } catch (NoSuchMethodException e) {
-            throw e;
         } catch (IllegalAccessException e) {
             throw new RuntimeException(e);
         } catch (InvocationTargetException e) {

--- a/src/test/groovy/graphql/DataFetcherTest.groovy
+++ b/src/test/groovy/graphql/DataFetcherTest.groovy
@@ -5,6 +5,7 @@ import graphql.schema.FieldDataFetcher
 import graphql.schema.PropertyDataFetcher
 import spock.lang.Specification
 
+import static graphql.Scalars.GraphQLBoolean
 import static graphql.Scalars.GraphQLString
 
 class DataFetcherTest extends Specification {
@@ -13,6 +14,8 @@ class DataFetcherTest extends Specification {
 
         private String privateField
         public String publicField
+        private Boolean booleanField
+        private Boolean booleanFieldWithGet
 
         public String getProperty() {
             return privateField
@@ -21,6 +24,22 @@ class DataFetcherTest extends Specification {
         public void setProperty(String value) {
             privateField = value
         }
+
+        public Boolean isBooleanField() {
+            return booleanField;
+        }
+
+        public void setBooleanField(Boolean value) {
+            booleanField = value
+        }
+
+        public Boolean getBooleanFieldWithGet() {
+            return booleanFieldWithGet
+        }
+
+        public Boolean setBooleanFieldWithGet(Boolean value) {
+            booleanFieldWithGet = value
+        }
     }
     def DataHolder dataHolder
 
@@ -28,6 +47,8 @@ class DataFetcherTest extends Specification {
         dataHolder = new DataHolder();
         dataHolder.publicField = "publicValue"
         dataHolder.setProperty("propertyValue")
+        dataHolder.setBooleanField(true)
+        dataHolder.setBooleanFieldWithGet(false)
     }
 
     def "get field value"() {
@@ -46,6 +67,24 @@ class DataFetcherTest extends Specification {
         def result = new PropertyDataFetcher("property").get(environment)
         then:
         result == "propertyValue"
+    }
+
+    def "get Boolean property value"() {
+        given:
+        def environment = new DataFetchingEnvironment(dataHolder, null, null, null, GraphQLBoolean, null, null)
+        when:
+        def result = new PropertyDataFetcher("booleanField").get(environment)
+        then:
+        result == true
+    }
+
+    def "get Boolean property value with get"() {
+        given:
+        def environment = new DataFetchingEnvironment(dataHolder, null, null, null, GraphQLBoolean, null, null)
+        when:
+        def result = new PropertyDataFetcher("booleanFieldWithGet").get(environment)
+        then:
+        result == false
     }
 
     def "get field value as property"() {


### PR DESCRIPTION
As mentioned in #130 some languages and frameworks uses "get" prefix for `Boolean `types. This was also the case for me. I use Lombok for generating accessors which also uses this convention. Even IDE's generate getters for `Boolean` with "get"

The prefix 'is' generally used for primitive `boolean`, Lombok has a option to disable this but not for `Boolean`. So I think this functionality should be a part of `PropertyDataFetcher`. Otherwise it will be error prone or some unnecessary configuration/code for these fields.