### PR TITLE
Parse escaped characters in strings

### DIFF
--- a/src/test/groovy/graphql/ScalarsQuerySchema.java
+++ b/src/test/groovy/graphql/ScalarsQuerySchema.java
@@ -69,6 +69,15 @@ public class ScalarsQuerySchema {
                             .build())
                     .dataFetcher(inputDF)
                     .build())
+            .field(newFieldDefinition()
+                    .name("stringInput")
+                    .type(Scalars.GraphQLString)
+                    .argument(newArgument()
+                            .name("input")
+                            .type(new GraphQLNonNull(Scalars.GraphQLString))
+                            .build())
+                    .dataFetcher(inputDF)
+                    .build())
             
             
             

--- a/src/test/groovy/graphql/ScalarsQueryTest.groovy
+++ b/src/test/groovy/graphql/ScalarsQueryTest.groovy
@@ -77,6 +77,25 @@ class ScalarsQueryTest extends Specification {
         resultBatched.data == expected
         resultBatched.errors.empty
     }
+
+    def 'Escaped characters are handled'() {
+        given:
+        def query = """
+        query {
+          stringInput(input: "test \\" \\/ \\b \\f \\n \\r \\t \\u12Aa")
+        }
+        """
+        def expected = [
+                stringInput: "test \" / \b \f \n \r \t \u12Aa",
+        ]
+
+        when:
+        def result = new GraphQL(ScalarsQuerySchema.scalarsQuerySchema).execute(query)
+
+        then:
+        result.data == expected
+        result.errors.empty == true
+    }
     
     @Unroll
     def "FooBar String cannot be cast to #number"() {


### PR DESCRIPTION
Escaped characters in string literals were not replaced with the correct character.

A ShouldNotHappenException is thrown on unknown escape codes because these should already be rejected during parsing.