### PR TITLE
Fixes for location and directives

### DIFF
--- a/src/main/antlr/Graphql.g4
+++ b/src/main/antlr/Graphql.g4
@@ -47,13 +47,13 @@ argument : NAME ':' valueWithVariable;
 
 fragmentSpread : '...' fragmentName directives?;
 
-inlineFragment : '...' 'on' typeCondition directives? selectionSet;
+inlineFragment : '...' typeCondition? directives? selectionSet;
 
-fragmentDefinition : 'fragment' fragmentName 'on' typeCondition directives? selectionSet;
+fragmentDefinition : 'fragment' fragmentName typeCondition directives? selectionSet;
 
 fragmentName :  NAME;
 
-typeCondition : typeName;
+typeCondition : 'on' typeName;
 
 // Value
 

--- a/src/main/java/graphql/execution/FieldCollector.java
+++ b/src/main/java/graphql/execution/FieldCollector.java
@@ -79,6 +79,9 @@ public class FieldCollector {
 
 
     private boolean doesFragmentConditionMatch(ExecutionContext executionContext, InlineFragment inlineFragment, GraphQLObjectType type) {
+        if (inlineFragment.getTypeCondition() == null) {
+            return true;
+        }
         GraphQLType conditionType;
         conditionType = getTypeFromAST(executionContext.getGraphQLSchema(), inlineFragment.getTypeCondition());
         return checkTypeCondition(executionContext, type, conditionType);

--- a/src/main/java/graphql/introspection/Introspection.java
+++ b/src/main/java/graphql/introspection/Introspection.java
@@ -318,7 +318,14 @@ public class Introspection {
                     .type(GraphQLString))
             .field(newFieldDefinition()
                     .name("locations")
-                    .type(new GraphQLList(new GraphQLNonNull(__DirectiveLocation))))
+                    .type(new GraphQLList(new GraphQLNonNull(__DirectiveLocation)))
+                    .dataFetcher(new DataFetcher() {
+                        @Override
+                        public Object get(DataFetchingEnvironment environment) {
+                            GraphQLDirective directive = (GraphQLDirective) environment.getSource();
+                            return new ArrayList<DirectiveLocation>(directive.validLocations());
+                        }
+                    }))
             .field(newFieldDefinition()
                     .name("args")
                     .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(__InputValue))))
@@ -332,15 +339,39 @@ public class Introspection {
             .field(newFieldDefinition()
                     .name("onOperation")
                     .type(GraphQLBoolean)
-                    .deprecate("Use `locations`."))
+                    .deprecate("Use `locations`.")
+                    .dataFetcher(new DataFetcher() {
+                        @Override
+                        public Object get(DataFetchingEnvironment environment) {
+                            GraphQLDirective directive = (GraphQLDirective) environment.getSource();
+                            return directive.isOnOperation();
+                        }
+                    }))
             .field(newFieldDefinition()
                     .name("onFragment")
                     .type(GraphQLBoolean)
-                    .deprecate("Use `locations`."))
+                    .deprecate("Use `locations`.")
+                    .dataFetcher(new DataFetcher() {
+                        @Override
+                        public Object get(DataFetchingEnvironment environment) {
+                            GraphQLDirective directive = (GraphQLDirective) environment.getSource();
+                            return directive.isOnFragment() ||
+                                    (directive.validLocations().contains(DirectiveLocation.INLINE_FRAGMENT)
+                                    && directive.validLocations().contains(DirectiveLocation.FRAGMENT_SPREAD));
+                        }
+                    }))
             .field(newFieldDefinition()
                     .name("onField")
                     .type(GraphQLBoolean)
-                    .deprecate("Use `locations`."))
+                    .deprecate("Use `locations`.")
+                    .dataFetcher(new DataFetcher() {
+                        @Override
+                        public Object get(DataFetchingEnvironment environment) {
+                            GraphQLDirective directive = (GraphQLDirective) environment.getSource();
+                            return directive.isOnField() ||
+                                    directive.validLocations().contains(DirectiveLocation.FIELD);
+                        }
+                    }))
             .build();
 
     public static GraphQLObjectType __Schema = newObject()

--- a/src/main/java/graphql/language/InlineFragment.java
+++ b/src/main/java/graphql/language/InlineFragment.java
@@ -56,7 +56,9 @@ public class InlineFragment extends AbstractNode implements Selection {
     @Override
     public List<Node> getChildren() {
         List<Node> result = new ArrayList<Node>();
-        result.add(typeCondition);
+        if (typeCondition != null) {
+            result.add(typeCondition);
+        }
         result.addAll(directives);
         result.add(selectionSet);
         return result;

--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -170,7 +170,7 @@ public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
         FragmentDefinition fragmentDefinition = new FragmentDefinition();
         newNode(fragmentDefinition, ctx);
         fragmentDefinition.setName(ctx.fragmentName().getText());
-        fragmentDefinition.setTypeCondition(new TypeName(ctx.typeCondition().getText()));
+        fragmentDefinition.setTypeCondition(new TypeName(ctx.typeCondition().typeName().getText()));
         addContextProperty(ContextProperty.FragmentDefinition, fragmentDefinition);
         result.getDefinitions().add(fragmentDefinition);
         super.visitFragmentDefinition(ctx);
@@ -284,7 +284,8 @@ public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
 
     @Override
     public Void visitInlineFragment(GraphqlParser.InlineFragmentContext ctx) {
-        InlineFragment inlineFragment = new InlineFragment(new TypeName(ctx.typeCondition().getText()));
+        TypeName typeName = ctx.typeCondition() != null ? new TypeName(ctx.typeCondition().typeName().getText()) : null;
+        InlineFragment inlineFragment = new InlineFragment(typeName);
         newNode(inlineFragment, ctx);
         ((SelectionSet) getFromContextStack(ContextProperty.SelectionSet)).getSelections().add(inlineFragment);
         addContextProperty(ContextProperty.InlineFragment, inlineFragment);

--- a/src/main/java/graphql/validation/TraversalContext.java
+++ b/src/main/java/graphql/validation/TraversalContext.java
@@ -87,11 +87,13 @@ public class TraversalContext implements QueryLanguageVisitor {
     }
 
     private void enterImpl(InlineFragment inlineFragment) {
-        if (inlineFragment.getTypeCondition() == null) {
-            return;
+        if (inlineFragment.getTypeCondition() != null) {
+            GraphQLType type = schema.getType(inlineFragment.getTypeCondition().getName());
+            addType((GraphQLOutputType) type);
+        } else {
+            // Inline fragment always embedded in a selection set
+            addType((GraphQLOutputType) getParentType());
         }
-        GraphQLType type = schema.getType(inlineFragment.getTypeCondition().getName());
-        addType((GraphQLOutputType) type);
     }
 
     private void enterImpl(FragmentDefinition fragmentDefinition) {
@@ -156,9 +158,7 @@ public class TraversalContext implements QueryLanguageVisitor {
         } else if (node instanceof Directive) {
             directive = null;
         } else if (node instanceof InlineFragment) {
-            if (((InlineFragment) node).getTypeCondition() != null) {
-                outputTypeStack.remove(outputTypeStack.size() - 1);
-            }
+            outputTypeStack.remove(outputTypeStack.size() - 1);
         } else if (node instanceof FragmentDefinition) {
             outputTypeStack.remove(outputTypeStack.size() - 1);
         } else if (node instanceof VariableDefinition) {

--- a/src/main/java/graphql/validation/TraversalContext.java
+++ b/src/main/java/graphql/validation/TraversalContext.java
@@ -87,6 +87,9 @@ public class TraversalContext implements QueryLanguageVisitor {
     }
 
     private void enterImpl(InlineFragment inlineFragment) {
+        if (inlineFragment.getTypeCondition() == null) {
+            return;
+        }
         GraphQLType type = schema.getType(inlineFragment.getTypeCondition().getName());
         addType((GraphQLOutputType) type);
     }
@@ -153,7 +156,9 @@ public class TraversalContext implements QueryLanguageVisitor {
         } else if (node instanceof Directive) {
             directive = null;
         } else if (node instanceof InlineFragment) {
-            outputTypeStack.remove(outputTypeStack.size() - 1);
+            if (((InlineFragment) node).getTypeCondition() != null) {
+                outputTypeStack.remove(outputTypeStack.size() - 1);
+            }
         } else if (node instanceof FragmentDefinition) {
             outputTypeStack.remove(outputTypeStack.size() - 1);
         } else if (node instanceof VariableDefinition) {

--- a/src/main/java/graphql/validation/rules/FragmentsOnCompositeType.java
+++ b/src/main/java/graphql/validation/rules/FragmentsOnCompositeType.java
@@ -16,6 +16,9 @@ public class FragmentsOnCompositeType extends AbstractRule {
 
     @Override
     public void checkInlineFragment(InlineFragment inlineFragment) {
+        if (inlineFragment.getTypeCondition() == null) {
+            return;
+        }
         GraphQLType type = getValidationContext().getSchema().getType(inlineFragment.getTypeCondition().getName());
         if (type == null) return;
         if (!(type instanceof GraphQLCompositeType)) {

--- a/src/main/java/graphql/validation/rules/KnownArgumentNames.java
+++ b/src/main/java/graphql/validation/rules/KnownArgumentNames.java
@@ -1,9 +1,21 @@
 package graphql.validation.rules;
 
 import graphql.language.Argument;
+import graphql.language.Directive;
+import graphql.language.Field;
+import graphql.language.Node;
 import graphql.schema.GraphQLArgument;
+import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLFieldDefinition;
-import graphql.validation.*;
+import graphql.validation.AbstractRule;
+import graphql.validation.ValidationContext;
+import graphql.validation.ValidationError;
+import graphql.validation.ValidationErrorCollector;
+import graphql.validation.ValidationErrorType;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 
 public class KnownArgumentNames extends AbstractRule {
@@ -12,15 +24,36 @@ public class KnownArgumentNames extends AbstractRule {
         super(validationContext, validationErrorCollector);
     }
 
-
     @Override
-    public void checkArgument(Argument argument) {
+    public void checkField(Field field) {
         GraphQLFieldDefinition fieldDef = getValidationContext().getFieldDef();
         if (fieldDef == null) return;
-        GraphQLArgument fieldArgument = fieldDef.getArgument(argument.getName());
-        if (fieldArgument == null) {
-            String message = String.format("Unknown argument %s", argument.getName());
-            addError(new ValidationError(ValidationErrorType.UnknownArgument, argument.getSourceLocation(), message));
+        checkForUnknownNames(fieldDef.getArguments(), field.getArguments());
+    }
+
+    @Override
+    public void checkDirective(Directive directive, List<Node> ancestors) {
+        GraphQLDirective graphQLDirective = getValidationContext().getDirective();
+        if (graphQLDirective == null) return;
+        checkForUnknownNames(graphQLDirective.getArguments(), directive.getArguments());
+    }
+
+    private void checkForUnknownNames(List<GraphQLArgument> argumentDefinitions, List<Argument> argumentValues) {
+        Set<String> knownNames = argumentNameSet(argumentDefinitions);
+        for (Argument argument : argumentValues) {
+            if (!knownNames.contains(argument.getName())) {
+                String message = String.format("Unknown argument %s", argument.getName());
+                addError(new ValidationError(ValidationErrorType.UnknownArgument, argument.getSourceLocation(), message));
+            }
         }
     }
+
+    private Set<String> argumentNameSet(List<GraphQLArgument> argumentDefinitions) {
+        Set<String> names = new HashSet<String>();
+        for (GraphQLArgument argument : argumentDefinitions) {
+            names.add(argument.getName());
+        }
+        return names;
+    }
+
 }

--- a/src/main/java/graphql/validation/rules/OverlappingFieldsCanBeMerged.java
+++ b/src/main/java/graphql/validation/rules/OverlappingFieldsCanBeMerged.java
@@ -215,7 +215,7 @@ public class OverlappingFieldsCanBeMerged extends AbstractRule {
                 collectFieldsForField(fieldMap, parentType, (Field) selection);
 
             } else if (selection instanceof InlineFragment) {
-                collectFieldsForInlineFragment(fieldMap, visitedFragmentSpreads, (InlineFragment) selection);
+                collectFieldsForInlineFragment(fieldMap, visitedFragmentSpreads, parentType, (InlineFragment) selection);
 
             } else if (selection instanceof FragmentSpread) {
                 collectFieldsForFragmentSpread(fieldMap, visitedFragmentSpreads, (FragmentSpread) selection);
@@ -237,10 +237,11 @@ public class OverlappingFieldsCanBeMerged extends AbstractRule {
         collectFields(fieldMap, fragment.getSelectionSet(), graphQLType, visitedFragmentSpreads);
     }
 
-    private void collectFieldsForInlineFragment(Map<String, List<FieldAndType>> fieldMap, Set<String> visitedFragmentSpreads, InlineFragment selection) {
+    private void collectFieldsForInlineFragment(Map<String, List<FieldAndType>> fieldMap, Set<String> visitedFragmentSpreads, GraphQLType parentType, InlineFragment selection) {
         InlineFragment inlineFragment = selection;
-        GraphQLOutputType graphQLType = (GraphQLOutputType) TypeFromAST.getTypeFromAST(getValidationContext().getSchema(),
-                inlineFragment.getTypeCondition());
+        GraphQLType graphQLType = inlineFragment.getTypeCondition() != null
+                ? (GraphQLOutputType) TypeFromAST.getTypeFromAST(getValidationContext().getSchema(), inlineFragment.getTypeCondition())
+                : parentType;
         collectFields(fieldMap, inlineFragment.getSelectionSet(), graphQLType, visitedFragmentSpreads);
     }
 

--- a/src/test/groovy/graphql/StarWarsValidationTest.groovy
+++ b/src/test/groovy/graphql/StarWarsValidationTest.groovy
@@ -138,4 +138,42 @@ class StarWarsValidationTest extends Specification {
         validationErrors.isEmpty()
     }
 
+    def 'Allows object fields in inline fragments on with no type'() {
+        def query = """
+        query InlineFragmentWithNoType {
+            hero {
+                name
+                ... @include(if: true) {
+                    appearsIn
+                }
+            }
+        }
+        """
+        when:
+        def validationErrors = validate(query)
+
+        then:
+        validationErrors.isEmpty()
+    }
+
+    def 'Allows object fields in inline fragments with no type in array context'() {
+        def query = """
+        query InlineFragmentWithNoType {
+            hero {
+                name
+                friends {
+                    ... @include(if: true) {
+                        name
+                    }
+                }
+            }
+        }
+        """
+        when:
+        def validationErrors = validate(query)
+
+        then:
+        validationErrors.isEmpty()
+    }
+
 }

--- a/src/test/groovy/graphql/validation/SpecValidation282Test.groovy
+++ b/src/test/groovy/graphql/validation/SpecValidation282Test.groovy
@@ -1,0 +1,30 @@
+package graphql.validation
+
+/**
+ * validation examples used in the spec in given section
+ * http://facebook.github.io/graphql/#sec-Validation
+ *
+ * This test checks that an inline fragment containing just a directive
+ * is parsed correctly
+ */
+class SpecValidation282Test extends SpecValidationBase {
+
+    def 'Inline fragment can omit type condition'() {
+        def query = """
+query {
+  dog {
+    name
+    ... @skip(if: true) {
+      barkVolume
+    }
+  }
+}
+"""
+        when:
+        def validationErrors = validate(query)
+
+        then:
+        validationErrors.empty
+    }
+    
+}

--- a/src/test/groovy/graphql/validation/rules/KnownArgumentNamesTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/KnownArgumentNamesTest.groovy
@@ -1,6 +1,7 @@
 package graphql.validation.rules
 
 import graphql.language.Argument
+import graphql.language.Field
 import graphql.language.StringValue
 import graphql.schema.GraphQLFieldDefinition
 import graphql.validation.ValidationContext
@@ -19,10 +20,11 @@ class KnownArgumentNamesTest extends Specification {
     def "unknown argument"(){
         given:
         Argument argument = new Argument("unknownArg",new StringValue("value"))
+        Field field = new Field("f", [argument])
         def fieldDefinition = GraphQLFieldDefinition.newFieldDefinition().name("field").type(GraphQLString).build();
         validationContext.getFieldDef() >> fieldDefinition
         when:
-        knownArgumentNames.checkArgument(argument)
+        knownArgumentNames.checkField(field)
         then:
         errorCollector.containsValidationError(ValidationErrorType.UnknownArgument)
     }


### PR DESCRIPTION
proposed by @trevor-morris
- Update introspection for directives. Return values for "locations" (the field used in the latest GraphQL spec) and also for "onOperation", "onFragment" and "onField" (the deprecated fields which our current GraphiQL expects in its schema query).
- Fix a problem with the KnownArgumentNames validation check. It was assuming all arguments belonged to a field, but they can also belong to directives. So changed the level of the check - we check fields and directives for unknown argument names, rather than looking at an argument and then assuming it must belong to a field.
- Fix a problem with the Antlr grammar for inline fragments. It had this:
  `inlineFragment : '...' 'on' typeCondition directives? selectionSet;`
  That is the "type condition" (on TypeName) was required. Changed it to be optional, which involved changing the grammar, the way we construct the parse tree and then a bunch of new null checks to deal with the case where the type condition is null.
