### PR TITLE
#172 Allow TypeReference as InputType

### DIFF
--- a/src/main/java/graphql/schema/GraphQLArgument.java
+++ b/src/main/java/graphql/schema/GraphQLArgument.java
@@ -1,6 +1,8 @@
 package graphql.schema;
 
 
+import java.util.Map;
+
 import static graphql.Assert.assertNotNull;
 
 public class GraphQLArgument {
@@ -23,6 +25,10 @@ public class GraphQLArgument {
         this(name, null, type, null);
     }
 
+
+    void replaceTypeReferences(Map<String, GraphQLType> typeMap) {
+        type = (GraphQLInputType) new SchemaUtil().resolveTypeReference(type, typeMap);
+    }
 
     public String getName() {
         return name;

--- a/src/main/java/graphql/schema/GraphQLInputFieldsContainer.java
+++ b/src/main/java/graphql/schema/GraphQLInputFieldsContainer.java
@@ -1,0 +1,10 @@
+package graphql.schema;
+
+import java.util.List;
+
+public interface GraphQLInputFieldsContainer extends GraphQLType {
+
+	GraphQLInputObjectField getFieldDefinition(String name);
+
+	List<GraphQLInputObjectField> getFieldDefinitions();
+}

--- a/src/main/java/graphql/schema/GraphQLInputObjectField.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectField.java
@@ -1,6 +1,8 @@
 package graphql.schema;
 
 
+import java.util.Map;
+
 import static graphql.Assert.assertNotNull;
 
 public class GraphQLInputObjectField {
@@ -23,6 +25,9 @@ public class GraphQLInputObjectField {
         this.description = description;
     }
 
+    void replaceTypeReferences(Map<String, GraphQLType> typeMap) {
+        type = (GraphQLInputType) new SchemaUtil().resolveTypeReference(type, typeMap);
+    }
 
     public String getName() {
         return name;

--- a/src/main/java/graphql/schema/GraphQLInputObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectType.java
@@ -1,6 +1,7 @@
 package graphql.schema;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -54,6 +55,10 @@ public class GraphQLInputObjectType implements GraphQLType, GraphQLInputType, Gr
         return new Builder();
     }
 
+    public static Reference reference(String name) {
+        return new Reference(name);
+    }
+    
     @Override
     public GraphQLInputObjectField getFieldDefinition(String name) {
         return fieldMap.get(name);
@@ -127,5 +132,11 @@ public class GraphQLInputObjectType implements GraphQLType, GraphQLInputType, Gr
             return new GraphQLInputObjectType(name, description, fields);
         }
 
+    }
+
+    private static class Reference extends GraphQLInputObjectType implements TypeReference {
+        private Reference(String name) {
+            super(name, "", Collections.<GraphQLInputObjectField>emptyList());
+        }
     }
 }

--- a/src/main/java/graphql/schema/GraphQLInputObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectType.java
@@ -1,15 +1,15 @@
 package graphql.schema;
 
-import graphql.AssertException;
-
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import graphql.AssertException;
+
 import static graphql.Assert.assertNotNull;
 
-public class GraphQLInputObjectType implements GraphQLType, GraphQLInputType, GraphQLUnmodifiedType, GraphQLNullableType {
+public class GraphQLInputObjectType implements GraphQLType, GraphQLInputType, GraphQLUnmodifiedType, GraphQLNullableType, GraphQLInputFieldsContainer {
 
     private final String name;
     private final String description;
@@ -52,6 +52,16 @@ public class GraphQLInputObjectType implements GraphQLType, GraphQLInputType, Gr
 
     public static Builder newInputObject() {
         return new Builder();
+    }
+
+    @Override
+    public GraphQLInputObjectField getFieldDefinition(String name) {
+        return fieldMap.get(name);
+    }
+
+    @Override
+    public List<GraphQLInputObjectField> getFieldDefinitions() {
+        return new ArrayList<GraphQLInputObjectField>(fieldMap.values());
     }
 
     public static class Builder {

--- a/src/main/java/graphql/schema/GraphQLInterfaceType.java
+++ b/src/main/java/graphql/schema/GraphQLInterfaceType.java
@@ -1,11 +1,12 @@
 package graphql.schema;
 
-import graphql.AssertException;
-
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+
+import graphql.AssertException;
 
 import static graphql.Assert.assertNotNull;
 
@@ -70,7 +71,10 @@ public class GraphQLInterfaceType implements GraphQLType, GraphQLOutputType, Gra
         return new Builder();
     }
 
-
+    public static Reference reference(String name) {
+        return new Reference(name);
+    }
+    
     public static class Builder {
         private String name;
         private String description;
@@ -142,5 +146,9 @@ public class GraphQLInterfaceType implements GraphQLType, GraphQLOutputType, Gra
 
     }
 
-
+    private static class Reference extends GraphQLInterfaceType implements TypeReference {
+        private Reference(String name) {
+            super(name, "", Collections.<GraphQLFieldDefinition>emptyList(), new TypeResolverProxy());
+        }
+    }
 }

--- a/src/main/java/graphql/schema/GraphQLSchema.java
+++ b/src/main/java/graphql/schema/GraphQLSchema.java
@@ -1,10 +1,19 @@
 package graphql.schema;
 
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import graphql.Assert;
 import graphql.Directives;
-
-import java.util.*;
+import graphql.schema.validation.InvalidSchemaException;
+import graphql.schema.validation.ValidationError;
+import graphql.schema.validation.Validator;
 
 import static graphql.Assert.assertNotNull;
 
@@ -99,10 +108,11 @@ public class GraphQLSchema {
             Assert.assertNotNull(dictionary, "dictionary can't be null");
             GraphQLSchema graphQLSchema = new GraphQLSchema(queryType, mutationType, dictionary);
             new SchemaUtil().replaceTypeReferences(graphQLSchema);
+            Collection<ValidationError> errors = new Validator().validateSchema(graphQLSchema);
+            if (errors.size() > 0) {
+                throw new InvalidSchemaException(errors);
+            }
             return graphQLSchema;
         }
-
-
     }
-
 }

--- a/src/main/java/graphql/schema/GraphQLTypeReference.java
+++ b/src/main/java/graphql/schema/GraphQLTypeReference.java
@@ -7,7 +7,7 @@ import static graphql.Assert.assertNotNull;
  * A special type to allow a object/interface types to reference itself. It's replaced with the real type
  * object when the schema is build.
  */
-public class GraphQLTypeReference implements GraphQLType, GraphQLOutputType {
+public class GraphQLTypeReference implements GraphQLType, GraphQLOutputType, GraphQLInputType {
 
     private final String name;
 

--- a/src/main/java/graphql/schema/GraphQLTypeReference.java
+++ b/src/main/java/graphql/schema/GraphQLTypeReference.java
@@ -7,7 +7,7 @@ import static graphql.Assert.assertNotNull;
  * A special type to allow a object/interface types to reference itself. It's replaced with the real type
  * object when the schema is build.
  */
-public class GraphQLTypeReference implements GraphQLType, GraphQLOutputType, GraphQLInputType {
+public class GraphQLTypeReference implements GraphQLType, GraphQLOutputType, GraphQLInputType, TypeReference {
 
     private final String name;
 

--- a/src/main/java/graphql/schema/GraphQLUnionType.java
+++ b/src/main/java/graphql/schema/GraphQLUnionType.java
@@ -3,6 +3,7 @@ package graphql.schema;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static graphql.Assert.*;
 
@@ -10,7 +11,7 @@ public class GraphQLUnionType implements GraphQLType, GraphQLOutputType, GraphQL
 
     private final String name;
     private final String description;
-    private List<GraphQLObjectType> types = new ArrayList<GraphQLObjectType>();
+    private final List<GraphQLObjectType> types = new ArrayList<GraphQLObjectType>();
     private final TypeResolver typeResolver;
 
 
@@ -25,6 +26,14 @@ public class GraphQLUnionType implements GraphQLType, GraphQLOutputType, GraphQL
         this.typeResolver = typeResolver;
     }
 
+    void replaceTypeReferences(Map<String, GraphQLType> typeMap) {
+        for (int i = 0; i < types.size(); i++) {
+            GraphQLObjectType type = types.get(i);
+            if (type instanceof TypeReference) {
+                this.types.set(i, (GraphQLObjectType) new SchemaUtil().resolveTypeReference(type, typeMap));
+            }
+        }
+    }
 
     public List<GraphQLObjectType> getTypes() {
         return new ArrayList<GraphQLObjectType>(types);
@@ -86,7 +95,5 @@ public class GraphQLUnionType implements GraphQLType, GraphQLOutputType, GraphQL
         public GraphQLUnionType build() {
             return new GraphQLUnionType(name, description, types, typeResolver);
         }
-
-
     }
 }

--- a/src/main/java/graphql/schema/SchemaUtil.java
+++ b/src/main/java/graphql/schema/SchemaUtil.java
@@ -1,10 +1,14 @@
 package graphql.schema;
 
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import graphql.GraphQLException;
 import graphql.introspection.Introspection;
-
-import java.util.*;
 
 public class SchemaUtil {
 
@@ -37,9 +41,9 @@ public class SchemaUtil {
         } else if (root instanceof GraphQLList) {
             collectTypes(((GraphQLList) root).getWrappedType(), result);
         } else if (root instanceof GraphQLEnumType) {
-            result.put(((GraphQLEnumType) root).getName(), root);
+            result.put(root.getName(), root);
         } else if (root instanceof GraphQLScalarType) {
-            result.put(((GraphQLScalarType) root).getName(), root);
+            result.put(root.getName(), root);
         } else if (root instanceof GraphQLObjectType) {
             collectTypesForObjects((GraphQLObjectType) root, result);
         } else if (root instanceof GraphQLInterfaceType) {
@@ -136,11 +140,23 @@ public class SchemaUtil {
             if (type instanceof GraphQLFieldsContainer) {
                 resolveTypeReferencesForFieldsContainer((GraphQLFieldsContainer) type, typeMap);
             }
+            if (type instanceof GraphQLInputFieldsContainer) {
+                resolveTypeReferencesForInputFieldsContainer((GraphQLInputFieldsContainer) type, typeMap);
+            }
         }
     }
 
     private void resolveTypeReferencesForFieldsContainer(GraphQLFieldsContainer fieldsContainer, Map<String, GraphQLType> typeMap) {
         for (GraphQLFieldDefinition fieldDefinition : fieldsContainer.getFieldDefinitions()) {
+            fieldDefinition.replaceTypeReferences(typeMap);
+            for (GraphQLArgument argument : fieldDefinition.getArguments()) {
+                argument.replaceTypeReferences(typeMap);
+            }
+        }
+    }
+
+    private void resolveTypeReferencesForInputFieldsContainer(GraphQLInputFieldsContainer fieldsContainer, Map<String, GraphQLType> typeMap) {
+        for (GraphQLInputObjectField fieldDefinition : fieldsContainer.getFieldDefinitions()) {
             fieldDefinition.replaceTypeReferences(typeMap);
         }
     }

--- a/src/main/java/graphql/schema/SchemaUtil.java
+++ b/src/main/java/graphql/schema/SchemaUtil.java
@@ -68,7 +68,7 @@ public class SchemaUtil {
     }
 
     private void collectTypesForInterfaces(GraphQLInterfaceType interfaceType, Map<String, GraphQLType> result) {
-        if (result.containsKey(interfaceType.getName())) return;
+        if (result.containsKey(interfaceType.getName()) && !(result.get(interfaceType.getName()) instanceof TypeReference)) return;
         result.put(interfaceType.getName(), interfaceType);
 
         for (GraphQLFieldDefinition fieldDefinition : interfaceType.getFieldDefinitions()) {
@@ -81,7 +81,7 @@ public class SchemaUtil {
 
 
     private void collectTypesForObjects(GraphQLObjectType objectType, Map<String, GraphQLType> result) {
-        if (result.containsKey(objectType.getName())) return;
+        if (result.containsKey(objectType.getName()) && !(result.get(objectType.getName()) instanceof TypeReference)) return;
         result.put(objectType.getName(), objectType);
 
         for (GraphQLFieldDefinition fieldDefinition : objectType.getFieldDefinitions()) {
@@ -96,7 +96,7 @@ public class SchemaUtil {
     }
 
     private void collectTypesForInputObjects(GraphQLInputObjectType objectType, Map<String, GraphQLType> result) {
-        if (result.containsKey(objectType.getName())) return;
+        if (result.containsKey(objectType.getName()) && !(result.get(objectType.getName()) instanceof TypeReference)) return;
         result.put(objectType.getName(), objectType);
 
         for (GraphQLInputObjectField fieldDefinition : objectType.getFields()) {

--- a/src/main/java/graphql/schema/TypeReference.java
+++ b/src/main/java/graphql/schema/TypeReference.java
@@ -1,0 +1,6 @@
+package graphql.schema;
+
+public interface TypeReference {
+
+    String getName();
+}

--- a/src/main/java/graphql/schema/validation/InvalidSchemaException.java
+++ b/src/main/java/graphql/schema/validation/InvalidSchemaException.java
@@ -1,0 +1,23 @@
+package graphql.schema.validation;
+
+import java.util.Collection;
+
+import graphql.GraphQLException;
+
+public class InvalidSchemaException extends GraphQLException {
+    
+    private final String message;
+    
+    public InvalidSchemaException(Collection<ValidationError> errors) {
+        StringBuilder message = new StringBuilder("invalid schema:");
+        for (ValidationError error : errors) {
+            message.append("\n").append(error.getDescription());
+        }
+        this.message = message.toString();
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/graphql/schema/validation/NoUnbrokenInputCycles.java
+++ b/src/main/java/graphql/schema/validation/NoUnbrokenInputCycles.java
@@ -1,0 +1,86 @@
+package graphql.schema.validation;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import graphql.schema.GraphQLArgument;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLInputObjectField;
+import graphql.schema.GraphQLInputObjectType;
+import graphql.schema.GraphQLInputType;
+import graphql.schema.GraphQLList;
+import graphql.schema.GraphQLModifiedType;
+import graphql.schema.GraphQLNonNull;
+import graphql.schema.GraphQLType;
+
+/**
+ * Schema validation rule ensuring no input type forms an unbroken non-nullable recursion,
+ * as such a type would be impossible to satisfy
+ */
+public class NoUnbrokenInputCycles implements ValidationRule {
+
+    public void check(GraphQLFieldDefinition fieldDef, ValidationErrorCollector validationErrorCollector) {
+        for (GraphQLArgument argument : fieldDef.getArguments()) {
+            GraphQLInputType argumentType = argument.getType();
+            if (argumentType instanceof GraphQLInputObjectType) {
+                List<String> path = new ArrayList<String>();
+                path.add(argumentType.getName());
+                check((GraphQLInputObjectType) argumentType, new HashSet<GraphQLType>(), path, validationErrorCollector);
+            }
+        }
+    }
+
+    private void check(GraphQLInputObjectType type, Set<GraphQLType> seen, List<String> path, ValidationErrorCollector validationErrorCollector) {
+        if (seen.contains(type)) {
+            validationErrorCollector.addError(new ValidationError(ValidationErrorType.UnbrokenInputCycle, getErrorMessage(path)));
+            return;
+        }
+        seen.add(type);
+
+        for (GraphQLInputObjectField field : type.getFieldDefinitions()) {
+            if (field.getType() instanceof GraphQLNonNull) {
+                GraphQLType unwrapped = unwrapNonNull((GraphQLNonNull) field.getType());
+                if (unwrapped instanceof GraphQLInputObjectType) {
+                    path = new ArrayList<String>(path);
+                    path.add(field.getName() + "!");
+                    check((GraphQLInputObjectType) unwrapped, new HashSet<GraphQLType>(seen), path, validationErrorCollector);
+                }
+            }
+        }
+    }
+
+    private GraphQLType unwrapNonNull(GraphQLNonNull type) {
+        if (type.getWrappedType() instanceof GraphQLList) {
+            //we only care about [type!]! i.e. non-null lists of non-nulls
+            if (((GraphQLList) type.getWrappedType()).getWrappedType() instanceof GraphQLNonNull) {
+                return unwrap(((GraphQLList) type.getWrappedType()).getWrappedType());
+            } else {
+                return type.getWrappedType();
+            }
+        } else {
+            return unwrap(type.getWrappedType());
+        }
+    }
+
+    private GraphQLType unwrap(GraphQLType type) {
+        if (type instanceof GraphQLModifiedType) {
+            return unwrap(((GraphQLModifiedType) type).getWrappedType());
+        }
+        return type;
+    }
+    
+    private String getErrorMessage(List<String> path) {
+        StringBuilder message = new StringBuilder();
+        message.append("[");
+        for (int i  = 0; i < path.size(); i++) {
+            if (i != 0) {
+                message.append(".");
+            }
+            message.append(path.get(i));
+        }
+        message.append("] forms an unsatisfiable cycle");
+        return message.toString();
+    }
+}

--- a/src/main/java/graphql/schema/validation/ValidationError.java
+++ b/src/main/java/graphql/schema/validation/ValidationError.java
@@ -1,0 +1,41 @@
+package graphql.schema.validation;
+
+import static graphql.Assert.assertNotNull;
+
+public class ValidationError {
+
+    private final ValidationErrorType errorType;
+    private final String description;
+
+    public ValidationError(ValidationErrorType errorType, String description) {
+        assertNotNull(errorType, "error type can not be null");
+        assertNotNull(description, "error description can not be null");
+        this.errorType = errorType;
+        this.description = description;
+    }
+
+    public ValidationErrorType getErrorType() {
+        return errorType;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public int hashCode() {
+        return errorType.hashCode() ^ description.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof ValidationError)) {
+            return false;
+        }
+        ValidationError that = (ValidationError) other;
+        return this.errorType.equals(that.errorType) && this.description.equals(that.description);
+    }
+}

--- a/src/main/java/graphql/schema/validation/ValidationErrorCollector.java
+++ b/src/main/java/graphql/schema/validation/ValidationErrorCollector.java
@@ -1,0 +1,24 @@
+package graphql.schema.validation;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public class ValidationErrorCollector {
+
+    private final LinkedHashSet<ValidationError> errors = new LinkedHashSet<ValidationError>();
+
+    public void addError(ValidationError validationError) {
+        this.errors.add(validationError);
+    }
+
+    public Set<ValidationError> getErrors() {
+        return errors;
+    }
+
+    public boolean containsValidationError(ValidationErrorType validationErrorType) {
+        for (ValidationError validationError : errors) {
+            if (validationError.getErrorType() == validationErrorType) return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/graphql/schema/validation/ValidationErrorType.java
+++ b/src/main/java/graphql/schema/validation/ValidationErrorType.java
@@ -1,0 +1,6 @@
+package graphql.schema.validation;
+
+public enum ValidationErrorType {
+    
+    UnbrokenInputCycle
+}

--- a/src/main/java/graphql/schema/validation/ValidationRule.java
+++ b/src/main/java/graphql/schema/validation/ValidationRule.java
@@ -1,0 +1,9 @@
+package graphql.schema.validation;
+
+import graphql.schema.GraphQLFieldDefinition;
+
+public interface ValidationRule {
+
+    void check(GraphQLFieldDefinition fieldDef, ValidationErrorCollector validationErrorCollector);
+    
+}

--- a/src/main/java/graphql/schema/validation/Validator.java
+++ b/src/main/java/graphql/schema/validation/Validator.java
@@ -1,0 +1,43 @@
+package graphql.schema.validation;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLFieldsContainer;
+import graphql.schema.GraphQLOutputType;
+import graphql.schema.GraphQLSchema;
+
+public class Validator {
+
+    private final Set<GraphQLOutputType> processed = new HashSet<GraphQLOutputType>();
+    
+    public Set<ValidationError> validateSchema(GraphQLSchema schema) {
+        ValidationErrorCollector validationErrorCollector = new ValidationErrorCollector();
+        List<ValidationRule> rules = new ArrayList<ValidationRule>();
+        rules.add(new NoUnbrokenInputCycles());
+        
+        traverse(schema.getQueryType(), rules, validationErrorCollector);
+        if (schema.isSupportingMutations()) {
+            traverse(schema.getMutationType(), rules, validationErrorCollector);
+        }
+        return validationErrorCollector.getErrors();
+    }
+    
+    private void traverse(GraphQLOutputType root, List<ValidationRule> rules, ValidationErrorCollector validationErrorCollector) {
+        if (processed.contains(root)) {
+            return;
+        }
+        processed.add(root);
+        if (root instanceof GraphQLFieldsContainer) {
+            for (GraphQLFieldDefinition fieldDefinition : ((GraphQLFieldsContainer) root).getFieldDefinitions()) {
+                for (ValidationRule rule : rules) {
+                    rule.check(fieldDefinition, validationErrorCollector);
+                }
+                traverse(fieldDefinition.getType(), rules, validationErrorCollector);
+            }
+        }
+    }
+}

--- a/src/test/groovy/graphql/TypeReferenceSchema.java
+++ b/src/test/groovy/graphql/TypeReferenceSchema.java
@@ -1,0 +1,79 @@
+package graphql;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import graphql.schema.GraphQLArgument;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLInputObjectType;
+import graphql.schema.GraphQLInterfaceType;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLType;
+import graphql.schema.GraphQLTypeReference;
+import graphql.schema.GraphQLUnionType;
+import graphql.schema.TypeResolverProxy;
+
+import static graphql.GarfieldSchema.CatType;
+import static graphql.GarfieldSchema.DogType;
+import static graphql.GarfieldSchema.NamedType;
+import static graphql.Scalars.GraphQLBoolean;
+import static graphql.Scalars.GraphQLString;
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
+import static graphql.schema.GraphQLInputObjectField.newInputObjectField;
+import static graphql.schema.GraphQLInputObjectType.newInputObject;
+import static graphql.schema.GraphQLObjectType.newObject;
+import static graphql.schema.GraphQLUnionType.newUnionType;
+
+public class TypeReferenceSchema {
+
+    public static GraphQLUnionType PetType = newUnionType()
+            .name("Pet")
+            .possibleType(GraphQLObjectType.reference(CatType.getName()))
+            .possibleType(GraphQLObjectType.reference(DogType.getName()))
+            .typeResolver(new TypeResolverProxy())
+            .build();
+    
+    public static GraphQLInputObjectType PersonInputType = newInputObject()
+            .name("Person_Input")
+            .field(newInputObjectField()
+                    .name("name")
+                    .type(GraphQLString))
+            .build();
+    
+    public static GraphQLObjectType PersonType = newObject()
+            .name("Person")
+            .field(newFieldDefinition()
+                    .name("name")
+                    .type(GraphQLString))
+            .field(newFieldDefinition()
+                    .name("pet")
+                    .type(new GraphQLTypeReference(PetType.getName())))
+            .withInterface(GraphQLInterfaceType.reference(NamedType.getName()))
+            .build();
+
+    public static GraphQLFieldDefinition exists = newFieldDefinition()
+            .name("exists")
+            .type(GraphQLBoolean)
+            .argument(GraphQLArgument.newArgument()
+                    .name("person")
+                    .type(new GraphQLTypeReference("Person_Input")))
+            .build();
+    
+    public static GraphQLFieldDefinition find = newFieldDefinition()
+            .name("find")
+            .type(new GraphQLTypeReference("Person"))
+            .argument(GraphQLArgument.newArgument()
+                    .name("name")
+                    .type(GraphQLString))
+            .build();
+
+    public static GraphQLObjectType PersonService = newObject()
+            .name("PersonService")
+            .field(exists)
+            .field(find)
+            .build();
+
+    public static GraphQLSchema SchemaWithReferences = new GraphQLSchema(PersonService, null, 
+            new HashSet<GraphQLType>(Arrays.asList(PersonType, PersonInputType, PetType, CatType, DogType, NamedType)));
+}

--- a/src/test/groovy/graphql/schema/validation/NoUnbrokenInputCyclesTest.groovy
+++ b/src/test/groovy/graphql/schema/validation/NoUnbrokenInputCyclesTest.groovy
@@ -1,0 +1,38 @@
+package graphql.schema.validation
+
+import graphql.schema.*
+import spock.lang.Specification
+
+import static graphql.Scalars.GraphQLBoolean
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
+import static graphql.schema.GraphQLInputObjectType.newInputObject
+
+class NoUnbrokenInputCyclesTest extends Specification {
+
+    ValidationErrorCollector errorCollector = new ValidationErrorCollector()
+
+    def "infinitely recursive input type results in error"() {
+        given:
+        GraphQLInputObjectType PersonInputType = newInputObject()
+                .name("Person")
+                .field(GraphQLInputObjectField.newInputObjectField()
+                .name("friend")
+                .type(new GraphQLTypeReference("Person"))
+                .build())
+                .build();
+
+        GraphQLFieldDefinition field = newFieldDefinition()
+                .name("exists")
+                .type(GraphQLBoolean)
+                .argument(GraphQLArgument.newArgument()
+                .name("person")
+                .type(PersonInputType))
+                .build();
+
+        PersonInputType.getFieldDefinition("friend").type = new GraphQLNonNull(PersonInputType);
+        when:
+        new NoUnbrokenInputCycles().check(field, errorCollector)
+        then:
+        errorCollector.containsValidationError(ValidationErrorType.UnbrokenInputCycle)
+    }
+}


### PR DESCRIPTION
As described in https://github.com/graphql-java/graphql-java/issues/172 this allows `TypeReference`s to be used as input types, making sure they're properly replaced, in both type and argument definitions.

Worth to note is that it does _not_ add validations that would disallow creating infinitely recursive types, as described in https://github.com/facebook/graphql/issues/189
I need some help/discussion for that. I see a few possible approaches here: add checks GraphQLInputObjectType.Builder#field, so they're ran as the fields are added (not really sure this is possible), add it to GraphQLFieldDefinition.Builder#argument (sounds like it's enough to just run this check for query & mutation roots?), or to GraphQLSchema.Builder#build so they're ran for the entire schema at the end.
