### PR TITLE
Allow serialization of any Iterable collection as a list

### DIFF
--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -93,7 +93,7 @@ public abstract class ExecutionStrategy {
             result = Arrays.asList((Object[]) result);
         }
 
-        return completeValueForList(executionContext, fieldType, fields, (List<Object>) result);
+        return completeValueForList(executionContext, fieldType, fields, (Iterable<Object>) result);
     }
 
     protected GraphQLObjectType resolveType(GraphQLInterfaceType graphQLInterfaceType, Object value) {
@@ -126,7 +126,8 @@ public abstract class ExecutionStrategy {
         return new ExecutionResultImpl(serialized, null);
     }
 
-    protected ExecutionResult completeValueForList(ExecutionContext executionContext, GraphQLList fieldType, List<Field> fields, List<Object> result) {
+    protected ExecutionResult completeValueForList(ExecutionContext executionContext, GraphQLList fieldType, List<Field>
+            fields, Iterable<Object> result) {
         List<Object> completedResults = new ArrayList<Object>();
         for (Object item : result) {
             ExecutionResult completedValue = completeValue(executionContext, fieldType.getWrappedType(), fields, item);

--- a/src/test/groovy/graphql/SetAsListTest.java
+++ b/src/test/groovy/graphql/SetAsListTest.java
@@ -1,0 +1,57 @@
+package graphql;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import graphql.language.SourceLocation;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLList;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLSchema;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ *
+ */
+public class SetAsListTest {
+    private void printErrors(ExecutionResult result) {
+        for(GraphQLError error : result.getErrors()) {
+            System.out.println(error.getErrorType() +": "+error.getMessage());
+            for(SourceLocation location : error.getLocations()) {
+                System.out.println("on line " + location.getLine() + ", column "+ location.getColumn());
+            }
+        }
+    }
+
+    @Test
+    public void test() {
+
+        GraphQLObjectType queryType = GraphQLObjectType.newObject()
+                .name("QueryType")
+                .field(GraphQLFieldDefinition.newFieldDefinition()
+                    .name("set")
+                    .type(new GraphQLList(Scalars.GraphQLString))
+                        .dataFetcher(new DataFetcher() {
+                            @Override
+                            public Object get(DataFetchingEnvironment environment) {
+                                Set<String> set = new HashSet<String>();
+                                set.add("One");
+                                set.add("Two");
+                                return set;
+                            }
+                        }))
+                .build();
+
+        GraphQLSchema schema = GraphQLSchema.newSchema()
+                .query(queryType)
+                .build();
+        ExecutionResult result = new GraphQL(schema).execute(
+                "query { set }");
+        printErrors(result);
+        assertEquals(result.getData().toString(), "{set=[One, Two]}");
+    }
+}


### PR DESCRIPTION
Removes the need to write a custom `DataFetcher` when serializing a `Set` to a `GraphQLList`.

