### PR TITLE
Added public "addField" to GraphQLObjectType

### DIFF
--- a/src/main/java/graphql/schema/GraphQLObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLObjectType.java
@@ -28,11 +28,18 @@ public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQ
 
     private void buildDefinitionMap(List<GraphQLFieldDefinition> fieldDefinitions) {
         for (GraphQLFieldDefinition fieldDefinition : fieldDefinitions) {
-            String name = fieldDefinition.getName();
-            if (fieldDefinitionsByName.containsKey(name))
-                throw new AssertException("field " + name + " redefined");
-            fieldDefinitionsByName.put(name, fieldDefinition);
+            addField(fieldDefinition);
         }
+    }
+
+
+    public void addField(GraphQLFieldDefinition fieldDefinition) {
+        String name = fieldDefinition.getName();
+
+        if (fieldDefinitionsByName.containsKey(name))
+            throw new AssertException("field " + name + " redefined");
+
+        fieldDefinitionsByName.put(name, fieldDefinition);
     }
 
 


### PR DESCRIPTION
Now it's possibly to make cross-references from type to type.

Example:

```
GraphQLObjectType testObject = GraphQLAnnotations.object(Test.class);
GraphQLObjectType testParentObject = GraphQLAnnotations.object(TestParent.class);

testObject.addField(GraphQLFieldDefinition.newFieldDefinition()
    .name("testParent")
    .description("The testParent of the testobject.")
    .type(testParentObject)
    .build());

testParentObject.addField(GraphQLFieldDefinition.newFieldDefinition()
    .name("tests")
    .description("Testparents testobjects")
    .type(new GraphQLList(testObject))
    .build());
```