### PR TITLE
Fix validation stack overflow errors

### DIFF
--- a/src/main/java/graphql/validation/LanguageTraversal.java
+++ b/src/main/java/graphql/validation/LanguageTraversal.java
@@ -8,9 +8,21 @@ import java.util.List;
 
 public class LanguageTraversal {
 
+    private final List<Node> path;
+
+    public LanguageTraversal() {
+        path = new ArrayList<Node>();
+    }
+
+    public LanguageTraversal(List<Node> basePath) {
+        if (basePath != null) {
+            path = basePath;
+        } else {
+            path = new ArrayList<Node>();
+        }
+    }
 
     public void traverse(Node root, QueryLanguageVisitor queryLanguageVisitor) {
-        List<Node> path = new ArrayList<Node>();
         traverseImpl(root, queryLanguageVisitor, path);
     }
 
@@ -23,7 +35,5 @@ public class LanguageTraversal {
         }
         path.remove(path.size() - 1);
         queryLanguageVisitor.leave(root, path);
-
-
     }
 }

--- a/src/main/java/graphql/validation/RulesVisitor.java
+++ b/src/main/java/graphql/validation/RulesVisitor.java
@@ -54,7 +54,7 @@ public class RulesVisitor implements QueryLanguageVisitor {
         } else if (node instanceof Directive) {
             checkDirective((Directive) node, ancestors, rulesToConsider);
         } else if (node instanceof FragmentSpread) {
-            checkFragmentSpread((FragmentSpread) node, rulesToConsider);
+            checkFragmentSpread((FragmentSpread) node, rulesToConsider, ancestors);
         } else if (node instanceof FragmentDefinition) {
             checkFragmentDefinition((FragmentDefinition) node, rulesToConsider);
         } else if (node instanceof OperationDefinition) {
@@ -105,14 +105,16 @@ public class RulesVisitor implements QueryLanguageVisitor {
         }
     }
 
-    private void checkFragmentSpread(FragmentSpread fragmentSpread, List<AbstractRule> rules) {
+    private void checkFragmentSpread(FragmentSpread fragmentSpread, List<AbstractRule> rules, List<Node> ancestors) {
         for (AbstractRule rule : rules) {
             rule.checkFragmentSpread(fragmentSpread);
         }
         List<AbstractRule> rulesVisitingFragmentSpreads = getRulesVisitingFragmentSpreads(rules);
         if (rulesVisitingFragmentSpreads.size() > 0) {
             FragmentDefinition fragment = validationContext.getFragment(fragmentSpread.getName());
-            new LanguageTraversal().traverse(fragment, new RulesVisitor(validationContext, rulesVisitingFragmentSpreads, true));
+            if(!ancestors.contains(fragment)){
+                new LanguageTraversal(ancestors).traverse(fragment, new RulesVisitor(validationContext, rulesVisitingFragmentSpreads, true));
+            }
         }
     }
 

--- a/src/test/groovy/graphql/validation/RulesVisitorTest.groovy
+++ b/src/test/groovy/graphql/validation/RulesVisitorTest.groovy
@@ -1,0 +1,75 @@
+package graphql.validation
+
+import graphql.TestUtil
+import graphql.language.Document
+import graphql.parser.Parser
+import graphql.validation.rules.NoFragmentCycles
+import graphql.validation.rules.NoUnusedVariables
+import spock.lang.Specification
+
+public class RulesVisitorTest extends Specification {
+    ValidationErrorCollector errorCollector = new ValidationErrorCollector()
+
+    def traverse(String query){
+        Document document = new Parser().parseDocument(query)
+        ValidationContext validationContext = new ValidationContext(TestUtil.dummySchema, document)
+        LanguageTraversal languageTraversal = new LanguageTraversal()
+        // this is one of the rules which checks inside fragment spreads, so it's needed to test this
+        NoUnusedVariables noUnusedVariables = new NoUnusedVariables(validationContext, errorCollector)
+
+        languageTraversal.traverse(document, new RulesVisitor(validationContext, [noUnusedVariables]))
+    }
+
+    def "RulesVisitor does not repeatedly spread directly recursive fragments leading to a stackoverflow"() {
+        given:
+        def query = """
+        query directFragmentRecursion {
+            __schema {
+                queryType {
+                    ...Recursive
+                }
+            }
+        }
+
+        fragment Recursive on __Type {
+            ofType {
+              ...Recursive
+             }
+        }
+        """
+        when:
+        traverse(query)
+        then:
+        notThrown(StackOverflowError)
+    }
+
+    def "RulesVisitor does not repeatedly spread indirectly recursive fragments leading to a stackoverflow"() {
+        given:
+        def query = """
+        query directFragmentRecursion {
+            __schema {
+                queryType {
+                    ...CycleA
+                }
+            }
+        }
+
+        fragment CycleA on __Type {
+            ofType {
+                ...CycleB
+            }
+        }
+
+        fragment CycleB on __Type {
+            ofType{
+                ...CycleA
+            }
+        }
+        """
+        when:
+        traverse(query)
+        then:
+        notThrown(StackOverflowError)
+    }
+
+}


### PR DESCRIPTION
### Summary
Stackoverflow errors happen if you run a query with recursive fragments. While the library has a rule which (correctly) identify recursive fragments when this rule is used in isolation, there are other rules which need to look inside fragment spreads, such as `NoUnusedVariables`. This causes the RulesVisitor itself to go into a loop spreading these fragments and produces a StackOverflow error.

The fix is to add the path history to any new LanguageTraversals which are made, so that before it dives into another fragment it can check if it has opened this fragment in its history already. I've added some tests as well, let me know if the fix / tests are reasonable!

### Steps to reproduce
Create any schema and run a query with a recursive fragment against it. For example this introspection query: 
```graphql
{
  __schema{
    queryType{
      ...RecursiveFragment
    }
  }
}

fragment RecursiveFragment on __Type{
  ofType{
    ...RecursiveFragment
  }
}
```
you should see:
```
Expected no exception of type 'java.lang.StackOverflowError' to be thrown, but got it nevertheless
Caused by: java.lang.StackOverflowError
	at java.util.HashMap.hash(HashMap.java:338)
	at java.util.LinkedHashMap.get(LinkedHashMap.java:440)
	at graphql.schema.GraphQLSchema.getType(GraphQLSchema.java:36)
	at graphql.validation.TraversalContext.enterImpl(TraversalContext.java:95)
	at graphql.validation.TraversalContext.enter(TraversalContext.java:43)
	at graphql.validation.RulesVisitor.enter(RulesVisitor.java:40)
	at graphql.validation.LanguageTraversal.traverseImpl(LanguageTraversal.java:19)
	at graphql.validation.LanguageTraversal.traverse(LanguageTraversal.java:14)
	at graphql.validation.RulesVisitor.checkFragmentSpread(RulesVisitor.java:115)
	at graphql.validation.RulesVisitor.enter(RulesVisitor.java:57)
```