### PR TITLE
Fix Hello World example in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ There is a mailing list (Google Group) for graphql-java: [graphql-java group](ht
 This is the famous "hello world" in graphql-java: 
 
 ```java
+import java.util.Map;
+
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
 
@@ -88,13 +90,14 @@ public class HelloWorld {
                         .field(newFieldDefinition()
                                 .type(GraphQLString)
                                 .name("hello")
-                                .staticValue("world"))
+                                .staticValue("world")
+                                .build())
                         .build();
         
         GraphQLSchema schema = GraphQLSchema.newSchema()
                         .query(queryType)
                         .build();
-        Map<String, Object> result = new GraphQL(schema).execute("{hello}").getData();
+        Map<String, Object> result = (Map<String, Object>)new GraphQL(schema).execute("{hello}").getData();
         
         System.out.println(result);
         // Prints: {hello=world}


### PR DESCRIPTION
The existing Hello World example has a few compilation errors:

- java.util.Map is not imported.
- build is not called on the GraphQLFieldDefinition.Builder
- result is not cast into a Map<String,Object>

This PR addresses these issues.