### PR TITLE
Fix #225: remove ANTLR compile dep from published POM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,9 @@ allprojects {
 }
 
 publishing {
+
     publications {
+
         graphqlJava(MavenPublication) {
             version version
             from components.java
@@ -89,7 +91,13 @@ publishing {
                 classifier "javadoc"
             }
             pom.withXml {
-                asNode().children().last() + {
+                Node pomNode = asNode()
+                pomNode.dependencies.'*'.findAll() {
+                    it.artifactId.text() == 'antlr4'
+                }.each() {
+                    it.parent().remove(it)
+                }
+                pomNode.children().last() + {
                     resolveStrategy = Closure.DELEGATE_FIRST
                     name 'graphql-java'
                     description 'GraphqL Java'

--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,9 @@ publishing {
                 classifier "javadoc"
             }
             pom.withXml {
+                // The ANTLR-related code below--introdcued in `1ac98bf`--addresses an issue with
+                // the Gradle ANTLR plugin. `1ac98bf` can be reverted and this comment removed once
+                // that issue is fixed and Gradle upgraded. See https://goo.gl/L92KiF and https://goo.gl/FY0PVR.
                 Node pomNode = asNode()
                 pomNode.dependencies.'*'.findAll() {
                     it.artifactId.text() == 'antlr4'


### PR DESCRIPTION
This PR is a patch from @IamCornholio. Thank you @IamCornholio.