### PR TITLE
4. parses as FloatValue

### DIFF
--- a/src/main/antlr/Graphql.g4
+++ b/src/main/antlr/Graphql.g4
@@ -118,7 +118,7 @@ NAME: [_A-Za-z][_0-9A-Za-z]* ;
 
 IntValue : Sign? IntegerPart;
 
-FloatValue : Sign? IntegerPart ('.' Digit+)? ExponentPart?;
+FloatValue : Sign? IntegerPart ('.' Digit*)? ExponentPart?;
 
 Sign : '-';
 

--- a/src/test/groovy/graphql/parser/ParserTest.groovy
+++ b/src/test/groovy/graphql/parser/ParserTest.groovy
@@ -275,13 +275,14 @@ class ParserTest extends Specification {
         given:
         def input = """
             query myQuery {
-              hello(arg: {intKey:1, stringKey: \"world\", subObject: {subKey:true} } ) }
+              hello(arg: {intKey:1, floatKey: 4., stringKey: \"world\", subObject: {subKey:true} } ) }
             """
 
         and: "expected query"
 
         def objectValue = new ObjectValue()
         objectValue.getObjectFields().add(new ObjectField("intKey", new IntValue(1)))
+        objectValue.getObjectFields().add(new ObjectField("floatKey", new FloatValue(4)))
         objectValue.getObjectFields().add(new ObjectField("stringKey", new StringValue("world")))
         def subObject = new ObjectValue()
         subObject.getObjectFields().add(new ObjectField("subKey", new BooleanValue(true)))


### PR DESCRIPTION
2.9.2 seems somewhat ambiguous as it indicates a list of digits in fractional part but doesn't specify whether it can be empty or not. `graphql-js` has:

```
if (code === 46) { // .
    isFloat = true;

    code = charCodeAt.call(body, ++position);
    position = readDigits(source, position, code);
    code = charCodeAt.call(body, position);
  }
```