### PR TITLE
Allow specification of mutation strategy

### DIFF
--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -25,18 +25,24 @@ public class GraphQL {
 
 
     private final GraphQLSchema graphQLSchema;
-    private final ExecutionStrategy executionStrategy;
+    private final ExecutionStrategy queryStrategy;
+    private final ExecutionStrategy mutationStrategy;
 
     private static final Logger log = LoggerFactory.getLogger(GraphQL.class);
 
     public GraphQL(GraphQLSchema graphQLSchema) {
-        this(graphQLSchema, null);
+        this(graphQLSchema, null, null);
     }
 
 
-    public GraphQL(GraphQLSchema graphQLSchema, ExecutionStrategy executionStrategy) {
+    public GraphQL(GraphQLSchema graphQLSchema, ExecutionStrategy queryStrategy) {
+        this(graphQLSchema, queryStrategy, null);
+    }
+
+    public GraphQL(GraphQLSchema graphQLSchema, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy) {
         this.graphQLSchema = graphQLSchema;
-        this.executionStrategy = executionStrategy;
+        this.queryStrategy = queryStrategy;
+        this.mutationStrategy = mutationStrategy;
     }
 
     public ExecutionResult execute(String requestString) {
@@ -74,7 +80,7 @@ public class GraphQL {
         if (validationErrors.size() > 0) {
             return new ExecutionResultImpl(validationErrors);
         }
-        Execution execution = new Execution(executionStrategy);
+        Execution execution = new Execution(queryStrategy, mutationStrategy);
         return execution.execute(graphQLSchema, context, document, operationName, arguments);
     }
 

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -17,19 +17,17 @@ import java.util.Map;
 public class Execution {
 
     private FieldCollector fieldCollector = new FieldCollector();
-    private ExecutionStrategy strategy;
+    private ExecutionStrategy queryStrategy;
+    private ExecutionStrategy mutationStrategy;
 
-    public Execution(ExecutionStrategy strategy) {
-        this.strategy = strategy;
-
-        if (this.strategy == null) {
-            this.strategy = new SimpleExecutionStrategy();
-        }
+    public Execution(ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy) {
+        this.queryStrategy = queryStrategy != null ? queryStrategy : new SimpleExecutionStrategy();
+        this.mutationStrategy = mutationStrategy != null ? mutationStrategy : new SimpleExecutionStrategy();
     }
 
     public ExecutionResult execute(GraphQLSchema graphQLSchema, Object root, Document document, String operationName, Map<String, Object> args) {
         ExecutionContextBuilder executionContextBuilder = new ExecutionContextBuilder(new ValuesResolver());
-        ExecutionContext executionContext = executionContextBuilder.build(graphQLSchema, strategy, root, document, operationName, args);
+        ExecutionContext executionContext = executionContextBuilder.build(graphQLSchema, queryStrategy, mutationStrategy, root, document, operationName, args);
         return executeOperation(executionContext, root, executionContext.getOperationDefinition());
     }
 
@@ -55,9 +53,9 @@ public class Execution {
         fieldCollector.collectFields(executionContext, operationRootType, operationDefinition.getSelectionSet(), new ArrayList<String>(), fields);
 
         if (operationDefinition.getOperation() == OperationDefinition.Operation.MUTATION) {
-            return new SimpleExecutionStrategy().execute(executionContext, operationRootType, root, fields);
+            return mutationStrategy.execute(executionContext, operationRootType, root, fields);
         } else {
-            return strategy.execute(executionContext, operationRootType, root, fields);
+            return queryStrategy.execute(executionContext, operationRootType, root, fields);
         }
     }
 }

--- a/src/main/java/graphql/execution/ExecutionContext.java
+++ b/src/main/java/graphql/execution/ExecutionContext.java
@@ -6,7 +6,6 @@ import graphql.language.FragmentDefinition;
 import graphql.language.OperationDefinition;
 import graphql.schema.GraphQLSchema;
 
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -14,16 +13,18 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public class ExecutionContext {
 
     private final GraphQLSchema graphQLSchema;
-    private final ExecutionStrategy executionStrategy;
+    private final ExecutionStrategy queryStrategy;
+    private final ExecutionStrategy mutationStrategy;
     private final Map<String, FragmentDefinition> fragmentsByName;
     private final OperationDefinition operationDefinition;
     private final Map<String, Object> variables;
     private final Object root;
     private final List<GraphQLError> errors = new CopyOnWriteArrayList<GraphQLError>();
 
-    public ExecutionContext(GraphQLSchema graphQLSchema, ExecutionStrategy executionStrategy, Map<String, FragmentDefinition> fragmentsByName, OperationDefinition operationDefinition, Map<String, Object> variables, Object root) {
+    public ExecutionContext(GraphQLSchema graphQLSchema, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy, Map<String, FragmentDefinition> fragmentsByName, OperationDefinition operationDefinition, Map<String, Object> variables, Object root) {
         this.graphQLSchema = graphQLSchema;
-        this.executionStrategy = executionStrategy;
+        this.queryStrategy = queryStrategy;
+        this.mutationStrategy = mutationStrategy;
         this.fragmentsByName = fragmentsByName;
         this.operationDefinition = operationDefinition;
         this.variables = variables;
@@ -62,8 +63,11 @@ public class ExecutionContext {
         return errors;
     }
 
-    public ExecutionStrategy getExecutionStrategy() {
-        return executionStrategy;
+    public ExecutionStrategy getQueryStrategy() {
+        return queryStrategy;
     }
 
+    public ExecutionStrategy getMutationStrategy() {
+        return mutationStrategy;
+    }
 }

--- a/src/main/java/graphql/execution/ExecutionContextBuilder.java
+++ b/src/main/java/graphql/execution/ExecutionContextBuilder.java
@@ -18,7 +18,7 @@ public class ExecutionContextBuilder {
         this.valuesResolver = valuesResolver;
     }
 
-    public ExecutionContext build(GraphQLSchema graphQLSchema, ExecutionStrategy executionStrategy, Object root, Document document, String operationName, Map<String, Object> args) {
+    public ExecutionContext build(GraphQLSchema graphQLSchema, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy, Object root, Document document, String operationName, Map<String, Object> args) {
         Map<String, FragmentDefinition> fragmentsByName = new LinkedHashMap<String, FragmentDefinition>();
         Map<String, OperationDefinition> operationsByName = new LinkedHashMap<String, OperationDefinition>();
 
@@ -45,12 +45,12 @@ public class ExecutionContextBuilder {
         if (operation == null) {
             throw new GraphQLException();
         }
-
         Map<String, Object> variableValues = valuesResolver.getVariableValues(graphQLSchema, operation.getVariableDefinitions(), args);
 
         return new ExecutionContext(
                 graphQLSchema,
-                executionStrategy,
+                queryStrategy,
+                mutationStrategy,
                 fragmentsByName,
                 operation,
                 variableValues,

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -82,10 +82,9 @@ public abstract class ExecutionStrategy {
             fieldCollector.collectFields(executionContext, resolvedType, field.getSelectionSet(), visitedFragments, subFields);
         }
 
-        // Calling this from the executionContext so that you can shift from the simple execution strategy for mutations
-        // back to the desired strategy.
+        // Calling this from the executionContext to ensure we shift back from mutation strategy to the query strategy.
 
-        return executionContext.getExecutionStrategy().execute(executionContext, resolvedType, result, subFields);
+        return executionContext.getQueryStrategy().execute(executionContext, resolvedType, result, subFields);
     }
 
     private ExecutionResult completeValueForList(ExecutionContext executionContext, GraphQLList fieldType, List<Field> fields, Object result) {

--- a/src/test/groovy/graphql/execution/ExecutionStrategySpec.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategySpec.groovy
@@ -21,7 +21,7 @@ class ExecutionStrategySpec extends Specification {
     }
 
     def buildContext() {
-        new ExecutionContext(null,executionStrategy,null,null,null,null)
+        new ExecutionContext(null,executionStrategy,executionStrategy,null,null,null,null)
     }
 
     def "completes value for a java.util.List"() {

--- a/src/test/groovy/graphql/execution/ExecutionTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionTest.groovy
@@ -1,0 +1,56 @@
+package graphql.execution
+
+import graphql.MutationSchema
+import graphql.parser.Parser
+import spock.lang.Specification
+
+class ExecutionTest extends Specification {
+
+    def parser = new Parser()
+    def mutationStrategy = Mock(ExecutionStrategy)
+    def queryStrategy = Mock(ExecutionStrategy)
+    def execution = new Execution(queryStrategy, mutationStrategy)
+
+    def "query strategy is used for query requests"() {
+        given:
+        def mutationStrategy = Mock(ExecutionStrategy)
+
+        def queryStrategy = Mock(ExecutionStrategy)
+        def execution = new Execution(queryStrategy, mutationStrategy)
+
+        def query = '''
+            query {
+                numberHolder {
+                    theNumber
+                }
+            }
+        '''
+        def document = parser.parseDocument(query)
+
+        when:
+        execution.execute(MutationSchema.schema, null, document, null, null)
+
+        then:
+        1 * queryStrategy.execute(*_)
+        0 * mutationStrategy.execute(*_)
+    }
+
+    def "mutation strategy is used for mutation requests"() {
+        given:
+        def query = '''
+            mutation {
+                changeTheNumber(newNumber: 1) {
+                    theNumber
+                }
+            }
+        '''
+        def document = parser.parseDocument(query)
+
+        when:
+        execution.execute(MutationSchema.schema, null, document, null, null)
+
+        then:
+        0 * queryStrategy.execute(*_)
+        1 * mutationStrategy.execute(*_)
+    }
+}


### PR DESCRIPTION
Fixes #208 and #97. Use case for me is writing an async execution strategy. A custom mutation strategy is needed to not block on mutation results, even while they are executed serially. 