### PR TITLE
Async Execution Strategy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,12 +28,14 @@ jar {
 dependencies {
     compile 'org.antlr:antlr4-runtime:4.5.1'
     compile 'org.slf4j:slf4j-api:1.7.12'
+    compile 'com.spotify:completable-futures:0.3.0'
     antlr "org.antlr:antlr4:4.5.1"
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'
     testCompile 'org.codehaus.groovy:groovy-all:2.4.4'
     testCompile 'cglib:cglib-nodep:3.1'
     testCompile 'org.objenesis:objenesis:2.1'
+    testCompile 'org.slf4j:slf4j-log4j12:1.7.21'
 }
 
 compileJava.source file("build/generated-src"), sourceSets.main.java

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-import java.text.SimpleDateFormat
-
 plugins {
     id "com.jfrog.bintray" version "1.2"
 }
@@ -9,10 +7,11 @@ apply plugin: 'maven'
 apply plugin: 'maven-publish'
 apply plugin: 'antlr'
 
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 def releaseVersion = System.properties.RELEASE_VERSION
-version = releaseVersion ? releaseVersion : new SimpleDateFormat('yyyy-MM-dd\'T\'HH-mm-ss').format(new Date())
+version = "2.3.0-SNAPSHOT"
+//version = releaseVersion ? releaseVersion : new SimpleDateFormat('yyyy-MM-dd\'T\'HH-mm-ss').format(new Date())
 group = 'com.graphql-java'
 
 

--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -25,18 +25,24 @@ public class GraphQL {
 
 
     private final GraphQLSchema graphQLSchema;
-    private final ExecutionStrategy executionStrategy;
+    private final ExecutionStrategy queryStrategy;
+    private final ExecutionStrategy mutationStrategy;
 
     private static final Logger log = LoggerFactory.getLogger(GraphQL.class);
 
     public GraphQL(GraphQLSchema graphQLSchema) {
-        this(graphQLSchema, null);
+        this(graphQLSchema, null, null);
     }
 
 
-    public GraphQL(GraphQLSchema graphQLSchema, ExecutionStrategy executionStrategy) {
+    public GraphQL(GraphQLSchema graphQLSchema, ExecutionStrategy queryStrategy) {
+        this(graphQLSchema, queryStrategy, null);
+    }
+
+    public GraphQL(GraphQLSchema graphQLSchema, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy) {
         this.graphQLSchema = graphQLSchema;
-        this.executionStrategy = executionStrategy;
+        this.queryStrategy = queryStrategy;
+        this.mutationStrategy = mutationStrategy;
     }
 
     public ExecutionResult execute(String requestString) {
@@ -74,7 +80,7 @@ public class GraphQL {
         if (validationErrors.size() > 0) {
             return new ExecutionResultImpl(validationErrors);
         }
-        Execution execution = new Execution(executionStrategy);
+        Execution execution = new Execution(queryStrategy, mutationStrategy);
         return execution.execute(graphQLSchema, context, document, operationName, arguments);
     }
 

--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -18,6 +18,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletionStage;
 
 import static graphql.Assert.assertNotNull;
 

--- a/src/main/java/graphql/GraphQLAsync.java
+++ b/src/main/java/graphql/GraphQLAsync.java
@@ -7,6 +7,8 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
 
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
 public class GraphQLAsync extends GraphQL {
 
     public GraphQLAsync(GraphQLSchema graphQLSchema) {
@@ -44,7 +46,10 @@ public class GraphQLAsync extends GraphQL {
     @SuppressWarnings("unchecked")
     public CompletionStage<ExecutionResult> executeAsync(String requestString, String operationName, Object context, Map<String, Object> arguments) {
         ExecutionResult result = execute(requestString, operationName, context, arguments);
-        return ((CompletionStage<Map<String, Object>>) result.getData())
-          .thenApply(data -> new ExecutionResultImpl(data, result.getErrors()));
+        Object data1 = result.getData();
+        if (data1 instanceof CompletionStage) {
+            return ((CompletionStage<Map<String, Object>>) data1).thenApply(data -> new ExecutionResultImpl(data, result.getErrors()));
+        }
+        return completedFuture(result);
     }
 }

--- a/src/main/java/graphql/GraphQLAsync.java
+++ b/src/main/java/graphql/GraphQLAsync.java
@@ -1,0 +1,50 @@
+package graphql;
+
+import graphql.execution.ExecutionStrategy;
+import graphql.schema.GraphQLSchema;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+
+public class GraphQLAsync extends GraphQL {
+
+    public GraphQLAsync(GraphQLSchema graphQLSchema) {
+        super(graphQLSchema);
+    }
+
+    public GraphQLAsync(GraphQLSchema graphQLSchema, ExecutionStrategy queryStrategy) {
+        super(graphQLSchema, queryStrategy);
+    }
+
+    public GraphQLAsync(GraphQLSchema graphQLSchema, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy) {
+        super(graphQLSchema, queryStrategy, mutationStrategy);
+    }
+
+    public CompletionStage<ExecutionResult> executeAsync(String requestString) {
+        return executeAsync(requestString, null);
+
+    }
+
+    public CompletionStage<ExecutionResult> executeAsync(String requestString, Object context) {
+        return executeAsync(requestString, context, Collections.emptyMap());
+
+    }
+
+    public CompletionStage<ExecutionResult> executeAsync(String requestString, String operationName, Object context) {
+        return executeAsync(requestString, operationName, context, Collections.emptyMap());
+
+    }
+
+    public CompletionStage<ExecutionResult> executeAsync(String requestString, Object context, Map<String, Object> arguments) {
+        return executeAsync(requestString, null, context, arguments);
+
+    }
+
+    @SuppressWarnings("unchecked")
+    public CompletionStage<ExecutionResult> executeAsync(String requestString, String operationName, Object context, Map<String, Object> arguments) {
+        ExecutionResult result = execute(requestString, operationName, context, arguments);
+        return ((CompletionStage<Map<String, Object>>) result.getData())
+          .thenApply(data -> new ExecutionResultImpl(data, result.getErrors()));
+    }
+}

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -17,19 +17,17 @@ import java.util.Map;
 public class Execution {
 
     private FieldCollector fieldCollector = new FieldCollector();
-    private ExecutionStrategy strategy;
+    private ExecutionStrategy queryStrategy;
+    private ExecutionStrategy mutationStrategy;
 
-    public Execution(ExecutionStrategy strategy) {
-        this.strategy = strategy;
-
-        if (this.strategy == null) {
-            this.strategy = new SimpleExecutionStrategy();
-        }
+    public Execution(ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy) {
+        this.queryStrategy = queryStrategy != null ? queryStrategy : new SimpleExecutionStrategy();
+        this.mutationStrategy = mutationStrategy != null ? mutationStrategy : new SimpleExecutionStrategy();
     }
 
     public ExecutionResult execute(GraphQLSchema graphQLSchema, Object root, Document document, String operationName, Map<String, Object> args) {
         ExecutionContextBuilder executionContextBuilder = new ExecutionContextBuilder(new ValuesResolver());
-        ExecutionContext executionContext = executionContextBuilder.build(graphQLSchema, strategy, root, document, operationName, args);
+        ExecutionContext executionContext = executionContextBuilder.build(graphQLSchema, queryStrategy, mutationStrategy, root, document, operationName, args);
         return executeOperation(executionContext, root, executionContext.getOperationDefinition());
     }
 
@@ -55,9 +53,9 @@ public class Execution {
         fieldCollector.collectFields(executionContext, operationRootType, operationDefinition.getSelectionSet(), new ArrayList<String>(), fields);
 
         if (operationDefinition.getOperation() == OperationDefinition.Operation.MUTATION) {
-            return new SimpleExecutionStrategy().execute(executionContext, operationRootType, root, fields);
+            return mutationStrategy.execute(executionContext, operationRootType, root, fields);
         } else {
-            return strategy.execute(executionContext, operationRootType, root, fields);
+            return queryStrategy.execute(executionContext, operationRootType, root, fields);
         }
     }
 }

--- a/src/main/java/graphql/execution/ExecutionContext.java
+++ b/src/main/java/graphql/execution/ExecutionContext.java
@@ -6,10 +6,7 @@ import graphql.language.FragmentDefinition;
 import graphql.language.OperationDefinition;
 import graphql.schema.GraphQLSchema;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class ExecutionContext {
 
@@ -20,7 +17,7 @@ public class ExecutionContext {
     private OperationDefinition operationDefinition;
     private Map<String, Object> variables = new LinkedHashMap<String, Object>();
     private Object root;
-    private List<GraphQLError> errors = new ArrayList<GraphQLError>();
+    private List<GraphQLError> errors = Collections.synchronizedList(new ArrayList<GraphQLError>());
 
     public GraphQLSchema getGraphQLSchema() {
         return graphQLSchema;

--- a/src/main/java/graphql/execution/ExecutionContext.java
+++ b/src/main/java/graphql/execution/ExecutionContext.java
@@ -14,7 +14,8 @@ import java.util.Map;
 public class ExecutionContext {
 
     private GraphQLSchema graphQLSchema;
-    private ExecutionStrategy executionStrategy;
+    private ExecutionStrategy queryStrategy;
+    private ExecutionStrategy mutationStrategy;
     private Map<String, FragmentDefinition> fragmentsByName = new LinkedHashMap<String, FragmentDefinition>();
     private OperationDefinition operationDefinition;
     private Map<String, Object> variables = new LinkedHashMap<String, Object>();
@@ -73,11 +74,19 @@ public class ExecutionContext {
         return errors;
     }
 
-    public ExecutionStrategy getExecutionStrategy() {
-        return executionStrategy;
+    public ExecutionStrategy getQueryStrategy() {
+        return queryStrategy;
     }
 
-    public void setExecutionStrategy(ExecutionStrategy executionStrategy) {
-        this.executionStrategy = executionStrategy;
+    public void setQueryStrategy(ExecutionStrategy queryStrategy) {
+        this.queryStrategy = queryStrategy;
+    }
+
+    public ExecutionStrategy getMutationStrategy() {
+        return mutationStrategy;
+    }
+
+    public void setMutationStrategy(ExecutionStrategy mutationStrategy) {
+        this.mutationStrategy = mutationStrategy;
     }
 }

--- a/src/main/java/graphql/execution/ExecutionContextBuilder.java
+++ b/src/main/java/graphql/execution/ExecutionContextBuilder.java
@@ -18,7 +18,7 @@ public class ExecutionContextBuilder {
         this.valuesResolver = valuesResolver;
     }
 
-    public ExecutionContext build(GraphQLSchema graphQLSchema, ExecutionStrategy executionStrategy, Object root, Document document, String operationName, Map<String, Object> args) {
+    public ExecutionContext build(GraphQLSchema graphQLSchema, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy, Object root, Document document, String operationName, Map<String, Object> args) {
         Map<String, FragmentDefinition> fragmentsByName = new LinkedHashMap<String, FragmentDefinition>();
         Map<String, OperationDefinition> operationsByName = new LinkedHashMap<String, OperationDefinition>();
 
@@ -48,7 +48,8 @@ public class ExecutionContextBuilder {
 
         ExecutionContext executionContext = new ExecutionContext();
         executionContext.setGraphQLSchema(graphQLSchema);
-        executionContext.setExecutionStrategy(executionStrategy);
+        executionContext.setQueryStrategy(queryStrategy);
+        executionContext.setMutationStrategy(mutationStrategy);
         executionContext.setOperationDefinition(operation);
         executionContext.setRoot(root);
         executionContext.setFragmentsByName(fragmentsByName);

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -82,10 +82,9 @@ public abstract class ExecutionStrategy {
             fieldCollector.collectFields(executionContext, resolvedType, field.getSelectionSet(), visitedFragments, subFields);
         }
 
-        // Calling this from the executionContext so that you can shift from the simple execution strategy for mutations
-        // back to the desired strategy.
+        // Calling this from the executionContext to ensure we shift back from mutation strategy to the query strategy.
 
-        return executionContext.getExecutionStrategy().execute(executionContext, resolvedType, result, subFields);
+        return executionContext.getQueryStrategy().execute(executionContext, resolvedType, result, subFields);
     }
 
     private ExecutionResult completeValueForList(ExecutionContext executionContext, GraphQLList fieldType, List<Field> fields, Object result) {

--- a/src/main/java/graphql/execution/async/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/async/AsyncExecutionStrategy.java
@@ -1,0 +1,97 @@
+package graphql.execution.async;
+
+import graphql.ExceptionWhileDataFetching;
+import graphql.ExecutionResult;
+import graphql.execution.ExecutionContext;
+import graphql.execution.ExecutionStrategy;
+import graphql.language.Field;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLObjectType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.stream.Collectors.toMap;
+
+
+public final class AsyncExecutionStrategy extends ExecutionStrategy {
+
+    public static AsyncExecutionStrategy serial() {
+        return new AsyncExecutionStrategy(true);
+    }
+
+    public static AsyncExecutionStrategy parallel() {
+        return new AsyncExecutionStrategy(false);
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(AsyncExecutionStrategy.class);
+
+    private final boolean serial;
+
+    private AsyncExecutionStrategy(boolean serial) {
+        this.serial = serial;
+    }
+
+    @Override
+    public ExecutionResult execute(ExecutionContext executionContext, GraphQLObjectType parentType, Object source, Map<String, List<Field>> fields) {
+        Map<String, Supplier<CompletionStage<ExecutionResult>>> resolvers = fields.entrySet().stream()
+          .collect(toMap(Map.Entry::getKey, entry -> () -> resolveFieldAsync(executionContext, parentType, source, entry.getValue())));
+        AsyncFieldsCoordinator coordinator = new AsyncFieldsCoordinator(resolvers);
+        return new ExecutionResultImpl(serial ? coordinator.executeSerially() : coordinator.executeParallelly(), executionContext.getErrors());
+    }
+
+    private CompletionStage<ExecutionResult> resolveFieldAsync(ExecutionContext executionContext, GraphQLObjectType parentType, Object source, List<Field> fieldList) {
+        GraphQLFieldDefinition fieldDef = getFieldDef(executionContext.getGraphQLSchema(), parentType, fieldList.get(0));
+
+        DataFetchingEnvironment env = new DataFetchingEnvironment(
+          source,
+          valuesResolver.getArgumentValues(fieldDef.getArguments(), fieldList.get(0).getArguments(), executionContext.getVariables()),
+          executionContext.getRoot(),
+          fieldList,
+          fieldDef.getType(),
+          parentType,
+          executionContext.getGraphQLSchema()
+        );
+
+        try {
+            Object obj1 = fieldDef.getDataFetcher().get(env);
+            if (obj1 instanceof CompletionStage) {
+                return ((CompletionStage<?>) obj1)
+                  .exceptionally(e -> {
+                      logExceptionWhileFetching(e);
+                      executionContext.addError(new ExceptionWhileDataFetching(e));
+                      return null;
+                  })
+                  .thenCompose(obj2 -> completeValueAsync(executionContext, fieldDef, fieldList, obj2));
+            } else {
+                return completeValueAsync(executionContext, fieldDef, fieldList, obj1);
+            }
+        } catch (Exception e) {
+            logExceptionWhileFetching(e);
+            executionContext.addError(new ExceptionWhileDataFetching(e));
+            return completeValueAsync(executionContext, fieldDef, fieldList, null);
+        }
+    }
+
+    private CompletionStage<ExecutionResult> completeValueAsync(ExecutionContext executionContext, GraphQLFieldDefinition fieldDef, List<Field> fieldList, Object result) {
+        ExecutionResult completed = completeValue(executionContext, fieldDef.getType(), fieldList, result);
+        // Happens when the data fetcher returns null for nullable field
+        if (completed == null) {
+            return completedFuture(new ExecutionResultImpl(null, null));
+        }
+        if (!(completed.getData() instanceof CompletionStage)) {
+            return completedFuture(completed);
+        }
+        return ((CompletionStage<?>) completed.getData()).thenApply(data -> new ExecutionResultImpl(data, completed.getErrors()));
+    }
+
+    private void logExceptionWhileFetching(Throwable e) {
+        log.warn("Exception while fetching data", e.getMessage());
+    }
+
+}

--- a/src/main/java/graphql/execution/async/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/async/AsyncExecutionStrategy.java
@@ -74,7 +74,7 @@ public final class AsyncExecutionStrategy extends ExecutionStrategy {
         } catch (Exception e) {
             logExceptionWhileFetching(e, fieldList.get(0));
             executionContext.addError(new ExceptionWhileDataFetching(e));
-            return completeValueAsync(executionContext, fieldDef, fieldList, null);
+            return completedFuture(new ExecutionResultImpl(null, null));
         }
     }
 

--- a/src/main/java/graphql/execution/async/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/async/AsyncExecutionStrategy.java
@@ -63,7 +63,7 @@ public final class AsyncExecutionStrategy extends ExecutionStrategy {
             if (obj1 instanceof CompletionStage) {
                 return ((CompletionStage<?>) obj1)
                   .exceptionally(e -> {
-                      logExceptionWhileFetching(e);
+                      logExceptionWhileFetching(e, fieldList.get(0));
                       executionContext.addError(new ExceptionWhileDataFetching(e));
                       return null;
                   })
@@ -72,7 +72,7 @@ public final class AsyncExecutionStrategy extends ExecutionStrategy {
                 return completeValueAsync(executionContext, fieldDef, fieldList, obj1);
             }
         } catch (Exception e) {
-            logExceptionWhileFetching(e);
+            logExceptionWhileFetching(e, fieldList.get(0));
             executionContext.addError(new ExceptionWhileDataFetching(e));
             return completeValueAsync(executionContext, fieldDef, fieldList, null);
         }
@@ -90,8 +90,8 @@ public final class AsyncExecutionStrategy extends ExecutionStrategy {
         return ((CompletionStage<?>) completed.getData()).thenApply(data -> new ExecutionResultImpl(data, completed.getErrors()));
     }
 
-    private void logExceptionWhileFetching(Throwable e) {
-        log.warn("Exception while fetching data", e.getMessage());
+    private void logExceptionWhileFetching(Throwable e, Field field) {
+        log.debug("Exception while fetching data for field {}", field.getName(), e);
     }
 
 }

--- a/src/main/java/graphql/execution/async/AsyncFieldsCoordinator.java
+++ b/src/main/java/graphql/execution/async/AsyncFieldsCoordinator.java
@@ -1,0 +1,65 @@
+package graphql.execution.async;
+
+import graphql.ExecutionResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+class AsyncFieldsCoordinator {
+
+    private static final Logger log = LoggerFactory.getLogger(AsyncFieldsCoordinator.class);
+
+    private final Map<String, Supplier<CompletionStage<ExecutionResult>>> resolvers;
+
+    AsyncFieldsCoordinator(Map<String, Supplier<CompletionStage<ExecutionResult>>> resolvers) {
+        this.resolvers = resolvers;
+    }
+
+    public CompletionStage<Map<String, Object>> executeSerially() {
+        return executeSerially(new ArrayList<>(resolvers.entrySet()), new LinkedHashMap<>(), 0);
+    }
+
+    private CompletionStage<Map<String, Object>> executeSerially(List<Map.Entry<String, Supplier<CompletionStage<ExecutionResult>>>> resolvers, Map<String, Object> results, int i) {
+        return resolvers.get(i).getValue().get().thenCompose(result -> {
+            results.put(resolvers.get(i).getKey(), result.getData());
+            if (i == resolvers.size() - 1) {
+                return completedFuture(results);
+            } else {
+                return executeSerially(resolvers, results, i + 1);
+            }
+        });
+    }
+
+    private static final Object NULL = new Object();
+
+    public CompletionStage<Map<String, Object>> executeParallelly() {
+        CompletableFuture<Map<String, Object>> future = new CompletableFuture<>();
+        Set<String> awaiting = new ConcurrentHashMap<>(new HashMap<>(resolvers)).keySet();  // `keySet()` is a view and will be modified, so copy first
+        Map<String, Object> results = new ConcurrentHashMap<>();
+        resolvers.entrySet().forEach(entry -> {
+            entry.getValue().get().thenAccept(result -> {
+                String key = entry.getKey();
+                Object value1 = result.getData() != null ? result.getData() : NULL;
+                results.put(key, value1);
+                awaiting.remove(key);
+                if (awaiting.isEmpty()) {
+                    Map<String, Object> map = new LinkedHashMap<>();
+                    resolvers.keySet().forEach(fieldName -> {
+                        Object value = results.get(fieldName);
+                        map.put(fieldName, value == NULL ? null : value);
+                    });
+                    log.trace("completing");
+                    future.complete(map);
+                }
+            });
+        });
+        return future;
+    }
+}

--- a/src/main/java/graphql/execution/async/ExecutionResultImpl.java
+++ b/src/main/java/graphql/execution/async/ExecutionResultImpl.java
@@ -1,0 +1,32 @@
+package graphql.execution.async;
+
+import graphql.ExecutionResult;
+import graphql.GraphQLError;
+
+import java.util.List;
+
+/**
+ * `graphql.ExecutionResultImpl` shallow copies the list of passed-in errors before storing it,
+ * which prevents sharing the list of errors among threads. This implementation stores and encapsulates
+ * the errors list reference directly so that it may be shared among threads.
+ */
+class ExecutionResultImpl implements ExecutionResult {
+
+    private final Object data;
+    private final List<GraphQLError> errors;
+
+    ExecutionResultImpl(Object data, List<GraphQLError> errors) {
+        this.data = data;
+        this.errors = errors;
+    }
+
+    @Override
+    public Object getData() {
+        return data;
+    }
+
+    @Override
+    public List<GraphQLError> getErrors() {
+        return errors;
+    }
+}

--- a/src/main/java/graphql/validation/rules/KnownArgumentNames.java
+++ b/src/main/java/graphql/validation/rules/KnownArgumentNames.java
@@ -2,6 +2,7 @@ package graphql.validation.rules;
 
 import graphql.language.Argument;
 import graphql.schema.GraphQLArgument;
+import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.validation.*;
 
@@ -15,12 +16,23 @@ public class KnownArgumentNames extends AbstractRule {
 
     @Override
     public void checkArgument(Argument argument) {
+        GraphQLDirective directive = getValidationContext().getDirective();
+        if (directive != null) {
+            GraphQLArgument directiveArgument = directive.getArgument(argument.getName());
+            if (directiveArgument == null) {
+                String message = String.format("Unknown argument %s on directive %s", argument.getName(), directive.getName());
+                addError(new ValidationError(ValidationErrorType.UnknownArgument, argument.getSourceLocation(), message));
+            }
+            return;
+        }
         GraphQLFieldDefinition fieldDef = getValidationContext().getFieldDef();
-        if (fieldDef == null) return;
-        GraphQLArgument fieldArgument = fieldDef.getArgument(argument.getName());
-        if (fieldArgument == null) {
-            String message = String.format("Unknown argument %s", argument.getName());
-            addError(new ValidationError(ValidationErrorType.UnknownArgument, argument.getSourceLocation(), message));
+        if (fieldDef != null) {
+            GraphQLArgument fieldArgument = fieldDef.getArgument(argument.getName());
+            if (fieldArgument == null) {
+                String message = String.format("Unknown argument %s onf field %s", argument.getName(), fieldDef.getName());
+                addError(new ValidationError(ValidationErrorType.UnknownArgument, argument.getSourceLocation(), message));
+            }
+
         }
     }
 }

--- a/src/test/groovy/graphql/execution/async/AsyncExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/async/AsyncExecutionStrategyTest.groovy
@@ -1,0 +1,93 @@
+package graphql.execution.async
+
+import graphql.ExceptionWhileDataFetching
+import graphql.execution.ExecutionContext
+import graphql.execution.ExecutionStrategy
+import graphql.language.Field
+import graphql.schema.DataFetcher
+import graphql.schema.GraphQLFieldDefinition
+import graphql.schema.GraphQLObjectType
+import graphql.schema.GraphQLOutputType
+import spock.lang.Specification
+import spock.util.concurrent.AsyncConditions
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+
+import static graphql.Scalars.GraphQLString
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
+import static graphql.schema.GraphQLObjectType.newObject
+import static graphql.schema.GraphQLSchema.newSchema
+import static java.util.concurrent.CompletableFuture.completedFuture
+
+class AsyncExecutionStrategyTest extends Specification {
+
+    def exception = new RuntimeException();
+
+    def executionContext
+
+    def "executes"() {
+        given:
+        def strategy = AsyncExecutionStrategy.serial()
+
+        def parentType = newObject()
+          .name('object')
+          .field(field('field', GraphQLString, { completedFuture('string') }))
+          .field(field('completesExceptionally', GraphQLString, { exceptionally(exception) }))
+          .field(field('throwsException', GraphQLString, { throw exception }))
+          .build()
+
+        executionContext = buildExecutionContext(strategy, parentType)
+
+        def fields = [
+          field                 : [new Field('field')],
+          completesExceptionally: [new Field('completesExceptionally')],
+          throwsException       : [new Field('throwsException')]
+        ];
+
+
+        when:
+        def result = strategy.execute(executionContext, parentType, null, fields)
+
+        then:
+        def conds = new AsyncConditions(1)
+
+        result.getData().thenAccept({ data ->
+            conds.evaluate {
+                assert data == [
+                  field                 : 'string',
+                  completesExceptionally: null,
+                  throwsException       : null
+                ]
+                assert result.errors.size() == 2
+                (0..1).each {
+                    result.errors[it] instanceof ExceptionWhileDataFetching
+                    result.errors[it].exception == exception
+                }
+            }
+        })
+
+        conds.await()
+    }
+
+    public <T> CompletionStage<T> exceptionally(Throwable exception) {
+        def future = new CompletableFuture<>();
+        future.completeExceptionally(exception);
+        future;
+    }
+
+    GraphQLFieldDefinition field(String name, GraphQLOutputType type, DataFetcher fetcher) {
+        newFieldDefinition()
+          .name(name)
+          .type(type)
+          .dataFetcher(fetcher)
+          .build()
+    }
+
+    ExecutionContext buildExecutionContext(ExecutionStrategy strategy, GraphQLObjectType parentType) {
+        executionContext = new ExecutionContext()
+        executionContext.setGraphQLSchema(newSchema().query(parentType).build())
+        executionContext.setQueryStrategy(strategy)
+        executionContext
+    }
+}

--- a/src/test/groovy/graphql/validation/rules/KnownArgumentNamesTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/KnownArgumentNamesTest.groovy
@@ -1,6 +1,8 @@
 package graphql.validation.rules
 
+import graphql.Directives
 import graphql.language.Argument
+import graphql.language.BooleanValue
 import graphql.language.StringValue
 import graphql.schema.GraphQLFieldDefinition
 import graphql.validation.ValidationContext
@@ -9,6 +11,7 @@ import graphql.validation.ValidationErrorType
 import spock.lang.Specification
 
 import static graphql.Scalars.GraphQLString
+import static graphql.schema.GraphQLArgument.newArgument
 
 class KnownArgumentNamesTest extends Specification {
 
@@ -16,14 +19,29 @@ class KnownArgumentNamesTest extends Specification {
     ValidationErrorCollector errorCollector = new ValidationErrorCollector()
     KnownArgumentNames knownArgumentNames = new KnownArgumentNames(validationContext, errorCollector)
 
+
     def "unknown argument"(){
         given:
-        Argument argument = new Argument("unknownArg",new StringValue("value"))
         def fieldDefinition = GraphQLFieldDefinition.newFieldDefinition().name("field").type(GraphQLString).build();
+        Argument argument = new Argument("unknownArg",new StringValue("value"))
         validationContext.getFieldDef() >> fieldDefinition
         when:
         knownArgumentNames.checkArgument(argument)
         then:
         errorCollector.containsValidationError(ValidationErrorType.UnknownArgument)
+    }
+
+    def "directives"() {
+        given:
+        def fieldArg = newArgument().name("arg").type(GraphQLString)
+        def fieldDefinition = GraphQLFieldDefinition.newFieldDefinition().name("field").argument(fieldArg).type(GraphQLString).build();
+        def directive = Directives.IncludeDirective
+        validationContext.getFieldDef() >> fieldDefinition
+        validationContext.getDirective() >> directive
+        def argument = new Argument("if", new BooleanValue(true))
+        when:
+        knownArgumentNames.checkArgument(argument)
+        then:
+        !errorCollector.containsValidationError(ValidationErrorType.UnknownArgument)
     }
 }


### PR DESCRIPTION
A Java 8 `CompletableFuture`-based [async execution strategy](https://github.com/dminkovsky/graphql-java/blob/async/src/main/java/graphql/execution/AsyncExecutionStrategy.java).

The API is:

```
GraphQLSchema schema;

GraphQL graphql = new GraphQL(
  schema,
  AsyncExecutionStrategy.parallel(),
  AsyncExecutionStrategy.serial()
);

ExecutionResult result = graphql.execute("... some query ...");
        
CompletionStage<Map<String, Object>> data = (CompletionStage<Map<String, Object>>) result.getData();
        
data.thenAccept(data -> {

    // ... use `data`: a `Map<String, Object>` where the values are all complete results 

    List<GraphQLError> errors = result.getErrors();

    // ... use `errors`
});
```

Data fetchers can return synchronously or asynchronously (by returning a `CompletionState`).

This strategy requires Java 8, but uses the existing core graphql-java execution API without any changes. It will have to be broken out as a sub-module with its own artifact for Java 8 users wanting to use this strategy.

Still missing:

- [ ] timeout configuration
- [ ] executor service configuration

Still thinking about [the tests](https://github.com/dminkovsky/graphql-java/blob/async/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy).

Looking forward to your thoughts. Thank you.