### PR TITLE
Problem: passing input object as a resolved class doesn't work

### DIFF
--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -80,8 +80,10 @@ public class ValuesResolver {
             return coerceValueForEnum((GraphQLEnumType) graphQLType, value);
         } else if (graphQLType instanceof GraphQLList) {
             return coerceValueForList((GraphQLList) graphQLType, value);
-        } else if (graphQLType instanceof GraphQLInputObjectType) {
+        } else if (graphQLType instanceof GraphQLInputObjectType && value instanceof Map) {
             return coerceValueForInputObjectType((GraphQLInputObjectType) graphQLType, (Map<String, Object>) value);
+        } else if (graphQLType instanceof GraphQLInputObjectType) {
+            return value;
         } else {
             throw new GraphQLException("unknown type " + graphQLType);
         }

--- a/src/test/groovy/graphql/execution/ValuesResolverTest.groovy
+++ b/src/test/groovy/graphql/execution/ValuesResolverTest.groovy
@@ -38,7 +38,7 @@ class ValuesResolverTest extends Specification {
 
     }
 
-    def "getVariableValues: object as variable input"() {
+    def "getVariableValues: map object as variable input"() {
         given:
         def nameField = newInputObjectField()
                 .name("name")
@@ -58,6 +58,41 @@ class ValuesResolverTest extends Specification {
         def resolvedValues = resolver.getVariableValues(schema, [variableDefinition], [variable: [name: 'a', id: 123]])
         then:
         resolvedValues['variable'] == [name: 'a', id: 123]
+    }
+
+
+    class Person {
+        def name = ""
+        def id = 0
+
+        Person(name, id) {
+            this.name = name
+            this.id = id
+        }
+
+    }
+    
+    def "getVariableValues: object as variable input"() {
+        given:
+        def nameField = newInputObjectField()
+                .name("name")
+                .type(GraphQLString)
+        def idField = newInputObjectField()
+                .name("id")
+                .type(GraphQLInt)
+        def inputType = newInputObject()
+                .name("Person")
+                .field(nameField)
+                .field(idField)
+                .build()
+        def schema = TestUtil.schemaWithInputType(inputType)
+        VariableDefinition variableDefinition = new VariableDefinition("variable", new TypeName("Person"))
+
+        when:
+        def obj = new Person('a', 123)
+        def resolvedValues = resolver.getVariableValues(schema, [variableDefinition], [variable: obj])
+        then:
+        resolvedValues['variable'] == obj
     }
 
     def "getVariableValues: simple value gets resolved to a list when the type is a List"() {


### PR DESCRIPTION
ValueResolver makes an assumption that an object passed through
is always going to be a map.

However, when using graphql-java with graphql-java-annotations and
graphql-java-servlet (GraphQLVariables), the inputs passed through
are already resolved.

Solution: this patch allows to pass such objects through the resolver
unmodified, without throwing an exception.