### PR TITLE
#269 - this adds instrumentation to the execution of the graphql query

### DIFF
--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -119,7 +119,7 @@ public class GraphQL {
         ExecutionId executionId = idProvider.provide(requestString, operationName, context);
 
         Execution execution = new Execution(queryStrategy, mutationStrategy, instrumentation);
-        ExecutionResult result = execution.execute(graphQLSchema, context, document, operationName, arguments);
+        ExecutionResult result = execution.execute(executionId, graphQLSchema, context, document, operationName, arguments);
 
         executionCtx.onEnd(result);
 

--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -6,6 +6,8 @@ import graphql.execution.ExecutionStrategy;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.NoOpInstrumentation;
+import graphql.execution.instrumentation.parameters.ExecutionParameters;
+import graphql.execution.instrumentation.parameters.ValidationParameters;
 import graphql.language.Document;
 import graphql.language.SourceLocation;
 import graphql.parser.Parser;
@@ -64,12 +66,12 @@ public class GraphQL {
     }
 
     public ExecutionResult execute(String requestString, String operationName, Object context, Map<String, Object> arguments) {
-        InstrumentationContext<ExecutionResult> executionCtx = instrumentation.beginExecution(requestString, operationName, context, arguments);
+        InstrumentationContext<ExecutionResult> executionCtx = instrumentation.beginExecution(new ExecutionParameters(requestString, operationName, context, arguments));
 
         assertNotNull(arguments, "arguments can't be null");
         log.debug("Executing request. operation name: {}. Request: {} ", operationName, requestString);
 
-        InstrumentationContext<Document> parseCtx = instrumentation.beginParse(requestString, operationName, context, arguments);
+        InstrumentationContext<Document> parseCtx = instrumentation.beginParse(new ExecutionParameters(requestString, operationName, context, arguments));
 
         Parser parser = new Parser();
         Document document;
@@ -87,7 +89,7 @@ public class GraphQL {
             return new ExecutionResultImpl(Collections.singletonList(invalidSyntaxError));
         }
 
-        InstrumentationContext<List<ValidationError>> validationCtx = instrumentation.beginValidation(document);
+        InstrumentationContext<List<ValidationError>> validationCtx = instrumentation.beginValidation(new ValidationParameters(requestString,operationName,context,arguments,document));
 
         Validator validator = new Validator();
         List<ValidationError> validationErrors = validator.validateDocument(graphQLSchema, document);
@@ -105,6 +107,4 @@ public class GraphQL {
 
         return result;
     }
-
-
 }

--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -90,17 +90,7 @@ public class GraphQL {
         this(graphQLSchema,queryStrategy,mutationStrategy,NoOpInstrumentation.INSTANCE);
     }
 
-    /**
-     * A GraphQL object ready to execute queries
-     *
-     * @param graphQLSchema    the schema to use
-     * @param queryStrategy    the query execution strategy to use
-     * @param mutationStrategy the mutation execution strategy to use
-     *
-     * @deprecated use the {@link #newGraphQL(GraphQLSchema)} builder instead.  This will be removed in a future version.
-     */
-    @SuppressWarnings("DeprecatedIsStillUsed")
-    public GraphQL(GraphQLSchema graphQLSchema, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy, Instrumentation instrumentation) {
+    private GraphQL(GraphQLSchema graphQLSchema, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy, Instrumentation instrumentation) {
         this.graphQLSchema = graphQLSchema;
         this.queryStrategy = queryStrategy;
         this.mutationStrategy = mutationStrategy;
@@ -123,6 +113,7 @@ public class GraphQL {
         private GraphQLSchema graphQLSchema;
         private ExecutionStrategy queryExecutionStrategy = new SimpleExecutionStrategy();
         private ExecutionStrategy mutationExecutionStrategy = new SimpleExecutionStrategy();
+        private Instrumentation instrumentation = NoOpInstrumentation.INSTANCE;
 
         public Builder(GraphQLSchema graphQLSchema) {
             this.graphQLSchema = graphQLSchema;
@@ -143,9 +134,14 @@ public class GraphQL {
             return this;
         }
 
+        public Builder instrumentation(Instrumentation instrumentation) {
+            this.instrumentation = assertNotNull(instrumentation, "Instrumentation must be non null");
+            return this;
+        }
+
         public GraphQL build() {
             //noinspection deprecation
-            return new GraphQL(graphQLSchema, queryExecutionStrategy, mutationExecutionStrategy);
+            return new GraphQL(graphQLSchema, queryExecutionStrategy, mutationExecutionStrategy, instrumentation);
         }
     }
 
@@ -170,7 +166,6 @@ public class GraphQL {
 
         assertNotNull(arguments, "arguments can't be null");
         log.debug("Executing request. operation name: {}. Request: {} ", operationName, requestString);
-
 
         InstrumentationContext<Document> parseCtx = instrumentation.beginParse(new ExecutionParameters(requestString, operationName, context, arguments));
         Parser parser = new Parser();

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -3,6 +3,7 @@ package graphql.execution;
 
 import graphql.ExecutionResult;
 import graphql.GraphQLException;
+import graphql.execution.instrumentation.Instrumentation;
 import graphql.language.Document;
 import graphql.language.Field;
 import graphql.language.OperationDefinition;
@@ -16,19 +17,18 @@ import java.util.Map;
 
 public class Execution {
 
-    private FieldCollector fieldCollector = new FieldCollector();
-    private ExecutionStrategy strategy;
+    private final FieldCollector fieldCollector = new FieldCollector();
+    private final ExecutionStrategy strategy;
+    private final Instrumentation instrumentation;
 
-    public Execution(ExecutionStrategy strategy) {
-        this.strategy = strategy;
+    public Execution(ExecutionStrategy strategy, Instrumentation instrumentation) {
+        this.strategy = strategy == null ? new SimpleExecutionStrategy() : strategy;
+        this.instrumentation = instrumentation;
 
-        if (this.strategy == null) {
-            this.strategy = new SimpleExecutionStrategy();
-        }
     }
 
     public ExecutionResult execute(GraphQLSchema graphQLSchema, Object root, Document document, String operationName, Map<String, Object> args) {
-        ExecutionContextBuilder executionContextBuilder = new ExecutionContextBuilder(new ValuesResolver());
+        ExecutionContextBuilder executionContextBuilder = new ExecutionContextBuilder(new ValuesResolver(),instrumentation);
         ExecutionContext executionContext = executionContextBuilder.build(graphQLSchema, strategy, root, document, operationName, args);
         return executeOperation(executionContext, root, executionContext.getOperationDefinition());
     }

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -28,7 +28,7 @@ public class Execution {
         this.instrumentation = instrumentation;
     }
 
-    public ExecutionResult execute(GraphQLSchema graphQLSchema, Object root, Document document, String operationName, Map<String, Object> args) {
+    public ExecutionResult execute(ExecutionId executionId, GraphQLSchema graphQLSchema, Object root, Document document, String operationName, Map<String, Object> args) {
         ExecutionContextBuilder executionContextBuilder = new ExecutionContextBuilder(new ValuesResolver(),instrumentation);
         ExecutionContext executionContext = executionContextBuilder
                 .executionId(executionId)

--- a/src/main/java/graphql/execution/ExecutionContext.java
+++ b/src/main/java/graphql/execution/ExecutionContext.java
@@ -42,10 +42,6 @@ public class ExecutionContext {
         return executionId;
     }
 
-    public ExecutionContext(Instrumentation instrumentation) {
-        this.instrumentation = instrumentation;
-    }
-
     public Instrumentation getInstrumentation() {
         return instrumentation;
     }

--- a/src/main/java/graphql/execution/ExecutionContext.java
+++ b/src/main/java/graphql/execution/ExecutionContext.java
@@ -2,6 +2,8 @@ package graphql.execution;
 
 
 import graphql.GraphQLError;
+import graphql.execution.instrumentation.Instrumentation;
+import graphql.execution.instrumentation.NoOpInstrumentation;
 import graphql.language.FragmentDefinition;
 import graphql.language.OperationDefinition;
 import graphql.schema.GraphQLSchema;
@@ -13,6 +15,7 @@ import java.util.Map;
 
 public class ExecutionContext {
 
+    private final Instrumentation instrumentation;
     private GraphQLSchema graphQLSchema;
     private ExecutionStrategy executionStrategy;
     private Map<String, FragmentDefinition> fragmentsByName = new LinkedHashMap<String, FragmentDefinition>();
@@ -20,6 +23,18 @@ public class ExecutionContext {
     private Map<String, Object> variables = new LinkedHashMap<String, Object>();
     private Object root;
     private List<GraphQLError> errors = new ArrayList<GraphQLError>();
+
+    public ExecutionContext() {
+        this(NoOpInstrumentation.INSTANCE);
+    }
+
+    public ExecutionContext(Instrumentation instrumentation) {
+        this.instrumentation = instrumentation;
+    }
+
+    public Instrumentation getInstrumentation() {
+        return instrumentation;
+    }
 
     public GraphQLSchema getGraphQLSchema() {
         return graphQLSchema;

--- a/src/main/java/graphql/execution/ExecutionContextBuilder.java
+++ b/src/main/java/graphql/execution/ExecutionContextBuilder.java
@@ -1,6 +1,7 @@
 package graphql.execution;
 
 import graphql.GraphQLException;
+import graphql.execution.instrumentation.Instrumentation;
 import graphql.language.Definition;
 import graphql.language.Document;
 import graphql.language.FragmentDefinition;
@@ -13,10 +14,13 @@ import java.util.Map;
 public class ExecutionContextBuilder {
 
     private ValuesResolver valuesResolver;
+    private Instrumentation instrumentation;
 
-    public ExecutionContextBuilder(ValuesResolver valuesResolver) {
+    public ExecutionContextBuilder(ValuesResolver valuesResolver, Instrumentation instrumentation) {
         this.valuesResolver = valuesResolver;
+        this.instrumentation = instrumentation;
     }
+
 
     public ExecutionContext build(GraphQLSchema graphQLSchema, ExecutionStrategy executionStrategy, Object root, Document document, String operationName, Map<String, Object> args) {
         Map<String, FragmentDefinition> fragmentsByName = new LinkedHashMap<String, FragmentDefinition>();
@@ -46,7 +50,7 @@ public class ExecutionContextBuilder {
             throw new GraphQLException();
         }
 
-        ExecutionContext executionContext = new ExecutionContext();
+        ExecutionContext executionContext = new ExecutionContext(instrumentation);
         executionContext.setGraphQLSchema(graphQLSchema);
         executionContext.setExecutionStrategy(executionStrategy);
         executionContext.setOperationDefinition(operation);

--- a/src/main/java/graphql/execution/ExecutionContextBuilder.java
+++ b/src/main/java/graphql/execution/ExecutionContextBuilder.java
@@ -19,7 +19,7 @@ public class ExecutionContextBuilder {
     private Instrumentation instrumentation;
     private ExecutionId executionId;
 
-    public ExecutionContextBuilder(ValuesResolver valuesResolver, , Instrumentation instrumentation) {
+    public ExecutionContextBuilder(ValuesResolver valuesResolver, Instrumentation instrumentation) {
         this.valuesResolver = valuesResolver;
         this.instrumentation = instrumentation;
     }
@@ -32,7 +32,7 @@ public class ExecutionContextBuilder {
 
     public ExecutionContext build(GraphQLSchema graphQLSchema, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy, Object root, Document document, String operationName, Map<String, Object> args) {
         // preconditions
-        assertNotNull(executionId,"You must provide a query identifier");
+        assertNotNull(executionId, "You must provide a query identifier");
 
         Map<String, FragmentDefinition> fragmentsByName = new LinkedHashMap<String, FragmentDefinition>();
         Map<String, OperationDefinition> operationsByName = new LinkedHashMap<String, OperationDefinition>();

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -4,14 +4,32 @@ import graphql.ExceptionWhileDataFetching;
 import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.GraphQLException;
+import graphql.execution.instrumentation.Instrumentation;
+import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.language.Field;
-import graphql.schema.*;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLEnumType;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLInterfaceType;
+import graphql.schema.GraphQLList;
+import graphql.schema.GraphQLNonNull;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLScalarType;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLType;
+import graphql.schema.GraphQLUnionType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
-import static graphql.introspection.Introspection.*;
+import static graphql.introspection.Introspection.SchemaMetaFieldDef;
+import static graphql.introspection.Introspection.TypeMetaFieldDef;
+import static graphql.introspection.Introspection.TypeNameMetaFieldDef;
 
 public abstract class ExecutionStrategy {
     private static final Logger log = LoggerFactory.getLogger(ExecutionStrategy.class);
@@ -35,15 +53,27 @@ public abstract class ExecutionStrategy {
                 executionContext.getGraphQLSchema()
         );
 
+        Instrumentation instrumentation = executionContext.getInstrumentation();
+
+        InstrumentationContext<ExecutionResult> fieldCtx = instrumentation.beginField(executionContext, fieldDef);
+
+        InstrumentationContext<Object> fetchCtx = instrumentation.beginDataFetch(executionContext, fieldDef, environment);
         Object resolvedValue = null;
         try {
             resolvedValue = fieldDef.getDataFetcher().get(environment);
+
+            fetchCtx.onEnd(resolvedValue);
         } catch (Exception e) {
             log.warn("Exception while fetching data", e);
             executionContext.addError(new ExceptionWhileDataFetching(e));
+
+            fetchCtx.onEnd(e);
         }
 
-        return completeValue(executionContext, fieldDef.getType(), fields, resolvedValue);
+        ExecutionResult result = completeValue(executionContext, fieldDef.getType(), fields, resolvedValue);
+
+        fieldCtx.onEnd(result);
+        return result;
     }
 
     protected ExecutionResult completeValue(ExecutionContext executionContext, GraphQLType fieldType, List<Field> fields, Object result) {

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -6,6 +6,8 @@ import graphql.ExecutionResultImpl;
 import graphql.GraphQLException;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationContext;
+import graphql.execution.instrumentation.parameters.FieldFetchParameters;
+import graphql.execution.instrumentation.parameters.FieldParameters;
 import graphql.language.Field;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.GraphQLEnumType;
@@ -55,9 +57,9 @@ public abstract class ExecutionStrategy {
 
         Instrumentation instrumentation = executionContext.getInstrumentation();
 
-        InstrumentationContext<ExecutionResult> fieldCtx = instrumentation.beginField(executionContext, fieldDef);
+        InstrumentationContext<ExecutionResult> fieldCtx = instrumentation.beginField(new FieldParameters(executionContext, fieldDef));
 
-        InstrumentationContext<Object> fetchCtx = instrumentation.beginDataFetch(executionContext, fieldDef, environment);
+        InstrumentationContext<Object> fetchCtx = instrumentation.beginFieldFetch(new FieldFetchParameters(executionContext, fieldDef, environment));
         Object resolvedValue = null;
         try {
             resolvedValue = fieldDef.getDataFetcher().get(environment);

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -10,6 +10,7 @@ import graphql.execution.instrumentation.parameters.FieldFetchParameters;
 import graphql.execution.instrumentation.parameters.FieldParameters;
 import graphql.language.Field;
 import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingEnvironmentImpl;
 import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLInterfaceType;

--- a/src/main/java/graphql/execution/instrumentation/Instrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/Instrumentation.java
@@ -1,15 +1,15 @@
 package graphql.execution.instrumentation;
 
 import graphql.ExecutionResult;
-import graphql.execution.ExecutionContext;
+import graphql.execution.instrumentation.parameters.ExecutionParameters;
+import graphql.execution.instrumentation.parameters.FieldFetchParameters;
+import graphql.execution.instrumentation.parameters.FieldParameters;
+import graphql.execution.instrumentation.parameters.ValidationParameters;
 import graphql.language.Document;
 import graphql.schema.DataFetcher;
-import graphql.schema.DataFetchingEnvironment;
-import graphql.schema.GraphQLFieldDefinition;
 import graphql.validation.ValidationError;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * Provides the capability to instrument the execution steps of a GraphQL query.
@@ -23,55 +23,49 @@ public interface Instrumentation {
      * This is called just before a query is executed and when this step finishes the {@link InstrumentationContext#onEnd(Object)}
      * will be called indicating that the step has finished.
      *
-     * @param requestString the GraphQL query string
-     * @param operationName the GraphQL operation name
-     * @param context the context object in play
-     * @param arguments the arguments in play
+     * @param parameters the parameters to this step
+     *
      * @return a non null {@link InstrumentationContext} object that will be called back when the step ends
      */
-    InstrumentationContext<ExecutionResult> beginExecution(String requestString, String operationName, Object context, Map<String, Object> arguments);
+    InstrumentationContext<ExecutionResult> beginExecution(ExecutionParameters parameters);
 
     /**
      * This is called just before a query is parsed and when this step finishes the {@link InstrumentationContext#onEnd(Object)}
      * will be called indicating that the step has finished.
      *
-     * @param requestString the GraphQL query string
-     * @param operationName the GraphQL operation name
-     * @param context the context object in play
-     * @param arguments the arguments in play
+     * @param parameters the parameters to this step
+     *
      * @return a non null {@link InstrumentationContext} object that will be called back when the step ends
      */
-    InstrumentationContext<Document> beginParse(String requestString, String operationName, Object context, Map<String, Object> arguments);
+    InstrumentationContext<Document> beginParse(ExecutionParameters parameters);
 
     /**
      * This is called just before the parsed query Document is validated and when this step finishes the {@link InstrumentationContext#onEnd(Object)}
      * will be called indicating that the step has finished.
      *
-     * @param document the GraphQL query string
+     * @param parameters the parameters to this step
+     *
      * @return a non null {@link InstrumentationContext} object that will be called back when the step ends
      */
-    InstrumentationContext<List<ValidationError>> beginValidation(Document document);
+    InstrumentationContext<List<ValidationError>> beginValidation(ValidationParameters parameters);
 
     /**
      * This is called just before a field is resolved and when this step finishes the {@link InstrumentationContext#onEnd(Object)}
      * will be called indicating that the step has finished.
      *
-     * @param executionContext the {@link ExecutionContext} in play
-     * @param fieldDef the current {@link GraphQLFieldDefinition} that is about to be resolved
+     * @param parameters the parameters to this step
      *
      * @return a non null {@link InstrumentationContext} object that will be called back when the step ends
      */
-    InstrumentationContext<ExecutionResult> beginField(ExecutionContext executionContext, GraphQLFieldDefinition fieldDef);
+    InstrumentationContext<ExecutionResult> beginField(FieldParameters parameters);
 
     /**
      * This is called just before a field {@link DataFetcher} is invoked and when this step finishes the {@link InstrumentationContext#onEnd(Object)}
      * will be called indicating that the step has finished.
      *
-     * @param executionContext the {@link ExecutionContext} in play
-     * @param fieldDef the current {@link GraphQLFieldDefinition} that is about to be resolved
-     * @param environment the current {@link DataFetchingEnvironment} that will be passed to the data fetcher
+     * @param parameters the parameters to this step
      *
      * @return a non null {@link InstrumentationContext} object that will be called back when the step ends
      */
-    InstrumentationContext<Object> beginDataFetch(ExecutionContext executionContext, GraphQLFieldDefinition fieldDef, DataFetchingEnvironment environment);
+    InstrumentationContext<Object> beginFieldFetch(FieldFetchParameters parameters);
 }

--- a/src/main/java/graphql/execution/instrumentation/Instrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/Instrumentation.java
@@ -1,6 +1,7 @@
 package graphql.execution.instrumentation;
 
 import graphql.ExecutionResult;
+import graphql.execution.instrumentation.parameters.DataFetchParameters;
 import graphql.execution.instrumentation.parameters.ExecutionParameters;
 import graphql.execution.instrumentation.parameters.FieldFetchParameters;
 import graphql.execution.instrumentation.parameters.FieldParameters;
@@ -48,6 +49,16 @@ public interface Instrumentation {
      * @return a non null {@link InstrumentationContext} object that will be called back when the step ends
      */
     InstrumentationContext<List<ValidationError>> beginValidation(ValidationParameters parameters);
+
+    /**
+     * This is called just before the data fetch is started and when this step finishes the {@link InstrumentationContext#onEnd(Object)}
+     * will be called indicating that the step has finished.
+     *
+     * @param parameters the parameters to this step
+     *
+     * @return a non null {@link InstrumentationContext} object that will be called back when the step ends
+     */
+    InstrumentationContext<ExecutionResult> beginDataFetch(DataFetchParameters parameters);
 
     /**
      * This is called just before a field is resolved and when this step finishes the {@link InstrumentationContext#onEnd(Object)}

--- a/src/main/java/graphql/execution/instrumentation/Instrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/Instrumentation.java
@@ -1,0 +1,77 @@
+package graphql.execution.instrumentation;
+
+import graphql.ExecutionResult;
+import graphql.execution.ExecutionContext;
+import graphql.language.Document;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.validation.ValidationError;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Provides the capability to instrument the execution steps of a GraphQL query.
+ *
+ * For example you might want to track which fields are taking the most time to fetch from the backing database
+ * or log what fields are being asked for.
+ */
+public interface Instrumentation {
+
+    /**
+     * This is called just before a query is executed and when this step finishes the {@link InstrumentationContext#onEnd(Object)}
+     * will be called indicating that the step has finished.
+     *
+     * @param requestString the GraphQL query string
+     * @param operationName the GraphQL operation name
+     * @param context the context object in play
+     * @param arguments the arguments in play
+     * @return a non null {@link InstrumentationContext} object that will be called back when the step ends
+     */
+    InstrumentationContext<ExecutionResult> beginExecution(String requestString, String operationName, Object context, Map<String, Object> arguments);
+
+    /**
+     * This is called just before a query is parsed and when this step finishes the {@link InstrumentationContext#onEnd(Object)}
+     * will be called indicating that the step has finished.
+     *
+     * @param requestString the GraphQL query string
+     * @param operationName the GraphQL operation name
+     * @param context the context object in play
+     * @param arguments the arguments in play
+     * @return a non null {@link InstrumentationContext} object that will be called back when the step ends
+     */
+    InstrumentationContext<Document> beginParse(String requestString, String operationName, Object context, Map<String, Object> arguments);
+
+    /**
+     * This is called just before the parsed query Document is validated and when this step finishes the {@link InstrumentationContext#onEnd(Object)}
+     * will be called indicating that the step has finished.
+     *
+     * @param document the GraphQL query string
+     * @return a non null {@link InstrumentationContext} object that will be called back when the step ends
+     */
+    InstrumentationContext<List<ValidationError>> beginValidation(Document document);
+
+    /**
+     * This is called just before a field is resolved and when this step finishes the {@link InstrumentationContext#onEnd(Object)}
+     * will be called indicating that the step has finished.
+     *
+     * @param executionContext the {@link ExecutionContext} in play
+     * @param fieldDef the current {@link GraphQLFieldDefinition} that is about to be resolved
+     *
+     * @return a non null {@link InstrumentationContext} object that will be called back when the step ends
+     */
+    InstrumentationContext<ExecutionResult> beginField(ExecutionContext executionContext, GraphQLFieldDefinition fieldDef);
+
+    /**
+     * This is called just before a field {@link DataFetcher} is invoked and when this step finishes the {@link InstrumentationContext#onEnd(Object)}
+     * will be called indicating that the step has finished.
+     *
+     * @param executionContext the {@link ExecutionContext} in play
+     * @param fieldDef the current {@link GraphQLFieldDefinition} that is about to be resolved
+     * @param environment the current {@link DataFetchingEnvironment} that will be passed to the data fetcher
+     *
+     * @return a non null {@link InstrumentationContext} object that will be called back when the step ends
+     */
+    InstrumentationContext<Object> beginDataFetch(ExecutionContext executionContext, GraphQLFieldDefinition fieldDef, DataFetchingEnvironment environment);
+}

--- a/src/main/java/graphql/execution/instrumentation/InstrumentationContext.java
+++ b/src/main/java/graphql/execution/instrumentation/InstrumentationContext.java
@@ -1,0 +1,23 @@
+package graphql.execution.instrumentation;
+
+/**
+ * When a {@link Instrumentation}.'beginXXX' method is called then it must return a non null InstrumentationContext
+ * that will the be invoked as {@link #onEnd(Object)} or {@link #onEnd(Exception)} when the step completes.
+ *
+ * This pattern of construction of an object then call back is intended to allow "timers" to be created that can instrument what has
+ * just happened or "loggers" to be called to record what has happened.
+ */
+public interface InstrumentationContext<T> {
+
+    /**
+     * This is invoked when the execution step is completed successfully
+     * @param result the successful result of the step
+     */
+    void onEnd(T result);
+
+    /**
+     * This is invoked when the execution step is completed unsuccessfully
+     * @param e the exception that happened during the step
+     */
+    void onEnd(Exception e);
+}

--- a/src/main/java/graphql/execution/instrumentation/NoOpInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/NoOpInstrumentation.java
@@ -1,6 +1,7 @@
 package graphql.execution.instrumentation;
 
 import graphql.ExecutionResult;
+import graphql.execution.instrumentation.parameters.DataFetchParameters;
 import graphql.execution.instrumentation.parameters.ExecutionParameters;
 import graphql.execution.instrumentation.parameters.FieldFetchParameters;
 import graphql.execution.instrumentation.parameters.FieldParameters;
@@ -51,6 +52,19 @@ public final class NoOpInstrumentation implements Instrumentation {
         return new InstrumentationContext<List<ValidationError>>() {
             @Override
             public void onEnd(List<ValidationError> result) {
+            }
+
+            @Override
+            public void onEnd(Exception e) {
+            }
+        };
+    }
+
+    @Override
+    public InstrumentationContext<ExecutionResult> beginDataFetch(DataFetchParameters parameters) {
+        return new InstrumentationContext<ExecutionResult>() {
+            @Override
+            public void onEnd(ExecutionResult result) {
             }
 
             @Override

--- a/src/main/java/graphql/execution/instrumentation/NoOpInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/NoOpInstrumentation.java
@@ -1,0 +1,87 @@
+package graphql.execution.instrumentation;
+
+import graphql.ExecutionResult;
+import graphql.execution.ExecutionContext;
+import graphql.language.Document;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.validation.ValidationError;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Nothing to see here
+ */
+public final class NoOpInstrumentation implements Instrumentation {
+
+    public static NoOpInstrumentation INSTANCE = new NoOpInstrumentation();
+
+    private NoOpInstrumentation() {
+    }
+
+    @Override
+    public InstrumentationContext<ExecutionResult> beginExecution(String requestString, String operationName, Object context, Map<String, Object> arguments) {
+        return new InstrumentationContext<ExecutionResult>() {
+            @Override
+            public void onEnd(ExecutionResult result) {
+            }
+
+            @Override
+            public void onEnd(Exception e) {
+            }
+        };
+    }
+
+    @Override
+    public InstrumentationContext<Document> beginParse(String requestString, String operationName, Object context, Map<String, Object> arguments) {
+        return new InstrumentationContext<Document>() {
+            @Override
+            public void onEnd(Document result) {
+            }
+
+            @Override
+            public void onEnd(Exception e) {
+            }
+        };
+    }
+
+    @Override
+    public InstrumentationContext<List<ValidationError>> beginValidation(Document document) {
+        return new InstrumentationContext<List<ValidationError>>() {
+            @Override
+            public void onEnd(List<ValidationError> result) {
+            }
+
+            @Override
+            public void onEnd(Exception e) {
+            }
+        };
+    }
+
+    @Override
+    public InstrumentationContext<ExecutionResult> beginField(ExecutionContext executionContext, GraphQLFieldDefinition fieldDef) {
+        return new InstrumentationContext<ExecutionResult>() {
+            @Override
+            public void onEnd(ExecutionResult result) {
+            }
+
+            @Override
+            public void onEnd(Exception e) {
+            }
+        };
+    }
+
+    @Override
+    public InstrumentationContext<Object> beginDataFetch(ExecutionContext executionContext, GraphQLFieldDefinition fieldDef, DataFetchingEnvironment environment) {
+        return new InstrumentationContext<Object>() {
+            @Override
+            public void onEnd(Object result) {
+            }
+
+            @Override
+            public void onEnd(Exception e) {
+            }
+        };
+    }
+}

--- a/src/main/java/graphql/execution/instrumentation/NoOpInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/NoOpInstrumentation.java
@@ -1,17 +1,17 @@
 package graphql.execution.instrumentation;
 
 import graphql.ExecutionResult;
-import graphql.execution.ExecutionContext;
+import graphql.execution.instrumentation.parameters.ExecutionParameters;
+import graphql.execution.instrumentation.parameters.FieldFetchParameters;
+import graphql.execution.instrumentation.parameters.FieldParameters;
+import graphql.execution.instrumentation.parameters.ValidationParameters;
 import graphql.language.Document;
-import graphql.schema.DataFetchingEnvironment;
-import graphql.schema.GraphQLFieldDefinition;
 import graphql.validation.ValidationError;
 
 import java.util.List;
-import java.util.Map;
 
 /**
- * Nothing to see here
+ * Nothing to see or do here ;)
  */
 public final class NoOpInstrumentation implements Instrumentation {
 
@@ -21,7 +21,7 @@ public final class NoOpInstrumentation implements Instrumentation {
     }
 
     @Override
-    public InstrumentationContext<ExecutionResult> beginExecution(String requestString, String operationName, Object context, Map<String, Object> arguments) {
+    public InstrumentationContext<ExecutionResult> beginExecution(ExecutionParameters parameters) {
         return new InstrumentationContext<ExecutionResult>() {
             @Override
             public void onEnd(ExecutionResult result) {
@@ -34,7 +34,7 @@ public final class NoOpInstrumentation implements Instrumentation {
     }
 
     @Override
-    public InstrumentationContext<Document> beginParse(String requestString, String operationName, Object context, Map<String, Object> arguments) {
+    public InstrumentationContext<Document> beginParse(ExecutionParameters parameters) {
         return new InstrumentationContext<Document>() {
             @Override
             public void onEnd(Document result) {
@@ -47,7 +47,7 @@ public final class NoOpInstrumentation implements Instrumentation {
     }
 
     @Override
-    public InstrumentationContext<List<ValidationError>> beginValidation(Document document) {
+    public InstrumentationContext<List<ValidationError>> beginValidation(ValidationParameters parameters) {
         return new InstrumentationContext<List<ValidationError>>() {
             @Override
             public void onEnd(List<ValidationError> result) {
@@ -60,7 +60,7 @@ public final class NoOpInstrumentation implements Instrumentation {
     }
 
     @Override
-    public InstrumentationContext<ExecutionResult> beginField(ExecutionContext executionContext, GraphQLFieldDefinition fieldDef) {
+    public InstrumentationContext<ExecutionResult> beginField(FieldParameters parameters) {
         return new InstrumentationContext<ExecutionResult>() {
             @Override
             public void onEnd(ExecutionResult result) {
@@ -73,7 +73,7 @@ public final class NoOpInstrumentation implements Instrumentation {
     }
 
     @Override
-    public InstrumentationContext<Object> beginDataFetch(ExecutionContext executionContext, GraphQLFieldDefinition fieldDef, DataFetchingEnvironment environment) {
+    public InstrumentationContext<Object> beginFieldFetch(FieldFetchParameters parameters) {
         return new InstrumentationContext<Object>() {
             @Override
             public void onEnd(Object result) {

--- a/src/main/java/graphql/execution/instrumentation/parameters/DataFetchParameters.java
+++ b/src/main/java/graphql/execution/instrumentation/parameters/DataFetchParameters.java
@@ -1,0 +1,20 @@
+package graphql.execution.instrumentation.parameters;
+
+import graphql.execution.ExecutionContext;
+import graphql.execution.instrumentation.Instrumentation;
+
+/**
+ * Parameters sent to {@link Instrumentation} methods
+ */
+public class DataFetchParameters {
+    private final ExecutionContext executionContext;
+
+    public DataFetchParameters(ExecutionContext executionContext) {
+        this.executionContext = executionContext;
+    }
+
+    public ExecutionContext getExecutionContext() {
+        return executionContext;
+    }
+
+}

--- a/src/main/java/graphql/execution/instrumentation/parameters/ExecutionParameters.java
+++ b/src/main/java/graphql/execution/instrumentation/parameters/ExecutionParameters.java
@@ -1,0 +1,39 @@
+package graphql.execution.instrumentation.parameters;
+
+import graphql.execution.instrumentation.Instrumentation;
+
+import java.util.Map;
+
+/**
+ * Parameters sent to {@link Instrumentation} methods
+ */
+public class ExecutionParameters {
+    private final String query;
+    private final String operation;
+    private final Object context;
+    private final Map<String, Object> arguments;
+
+    public ExecutionParameters(String query, String operation, Object context, Map<String, Object> arguments) {
+        this.query = query;
+        this.operation = operation;
+        this.context = context;
+        this.arguments = arguments;
+    }
+
+    public String getQuery() {
+        return query;
+    }
+
+    public String getOperation() {
+        return operation;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> T getContext() {
+        return (T) context;
+    }
+
+    public Map<String, Object> getArguments() {
+        return arguments;
+    }
+}

--- a/src/main/java/graphql/execution/instrumentation/parameters/FieldFetchParameters.java
+++ b/src/main/java/graphql/execution/instrumentation/parameters/FieldFetchParameters.java
@@ -1,0 +1,22 @@
+package graphql.execution.instrumentation.parameters;
+
+import graphql.execution.ExecutionContext;
+import graphql.execution.instrumentation.Instrumentation;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLFieldDefinition;
+
+/**
+ * Parameters sent to {@link Instrumentation} methods
+ */
+public class FieldFetchParameters extends FieldParameters {
+    private final DataFetchingEnvironment environment;
+
+    public FieldFetchParameters(ExecutionContext getExecutionContext, GraphQLFieldDefinition fieldDef, DataFetchingEnvironment environment) {
+        super(getExecutionContext, fieldDef);
+        this.environment = environment;
+    }
+
+    public DataFetchingEnvironment getEnvironment() {
+        return environment;
+    }
+}

--- a/src/main/java/graphql/execution/instrumentation/parameters/FieldParameters.java
+++ b/src/main/java/graphql/execution/instrumentation/parameters/FieldParameters.java
@@ -1,0 +1,26 @@
+package graphql.execution.instrumentation.parameters;
+
+import graphql.execution.ExecutionContext;
+import graphql.execution.instrumentation.Instrumentation;
+import graphql.schema.GraphQLFieldDefinition;
+
+/**
+ * Parameters sent to {@link Instrumentation} methods
+ */
+public class FieldParameters {
+    private final ExecutionContext executionContext;
+    private final graphql.schema.GraphQLFieldDefinition fieldDef;
+
+    public FieldParameters(ExecutionContext executionContext, GraphQLFieldDefinition fieldDef) {
+        this.executionContext = executionContext;
+        this.fieldDef = fieldDef;
+    }
+
+    public ExecutionContext getExecutionContext() {
+        return executionContext;
+    }
+
+    public GraphQLFieldDefinition getField() {
+        return fieldDef;
+    }
+}

--- a/src/main/java/graphql/execution/instrumentation/parameters/ValidationParameters.java
+++ b/src/main/java/graphql/execution/instrumentation/parameters/ValidationParameters.java
@@ -1,0 +1,22 @@
+package graphql.execution.instrumentation.parameters;
+
+import graphql.execution.instrumentation.Instrumentation;
+import graphql.language.Document;
+
+import java.util.Map;
+
+/**
+ * Parameters sent to {@link Instrumentation} methods
+ */
+public class ValidationParameters extends ExecutionParameters {
+    private final Document document;
+
+    public ValidationParameters(String query, String operation, Object context, Map<String, Object> arguments, Document document) {
+        super(query, operation, context, arguments);
+        this.document = document;
+    }
+
+    public Document getDocument() {
+        return document;
+    }
+}

--- a/src/test/groovy/graphql/execution/ExecutionStrategySpec.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategySpec.groovy
@@ -21,7 +21,7 @@ class ExecutionStrategySpec extends Specification {
     }
 
     def buildContext() {
-        new ExecutionContext(null, null, executionStrategy, executionStrategy, null, null, null, null)
+        new ExecutionContext(null, null, null, executionStrategy, executionStrategy, null, null, null, null)
     }
 
     def "completes value for a java.util.List"() {

--- a/src/test/groovy/graphql/execution/ExecutionTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionTest.groovy
@@ -1,6 +1,7 @@
 package graphql.execution
 
 import graphql.MutationSchema
+import graphql.execution.instrumentation.NoOpInstrumentation
 import graphql.parser.Parser
 import spock.lang.Specification
 
@@ -9,14 +10,14 @@ class ExecutionTest extends Specification {
     def parser = new Parser()
     def mutationStrategy = Mock(ExecutionStrategy)
     def queryStrategy = Mock(ExecutionStrategy)
-    def execution = new Execution(queryStrategy, mutationStrategy)
+    def execution = new Execution(queryStrategy, mutationStrategy, NoOpInstrumentation.INSTANCE)
 
     def "query strategy is used for query requests"() {
         given:
         def mutationStrategy = Mock(ExecutionStrategy)
 
         def queryStrategy = Mock(ExecutionStrategy)
-        def execution = new Execution(queryStrategy, mutationStrategy)
+        def execution = new Execution(queryStrategy, mutationStrategy, NoOpInstrumentation.INSTANCE)
 
         def query = '''
             query {

--- a/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
@@ -1,12 +1,14 @@
 package graphql.execution.instrumentation
 
+import graphql.ExecutionResult
 import graphql.GraphQL
 import graphql.StarWarsSchema
-import graphql.execution.ExecutionContext
 import graphql.execution.SimpleExecutionStrategy
+import graphql.execution.instrumentation.parameters.ExecutionParameters
+import graphql.execution.instrumentation.parameters.FieldFetchParameters
+import graphql.execution.instrumentation.parameters.FieldParameters
+import graphql.execution.instrumentation.parameters.ValidationParameters
 import graphql.language.Document
-import graphql.schema.DataFetchingEnvironment
-import graphql.schema.GraphQLFieldDefinition
 import graphql.validation.ValidationError
 import spock.lang.Specification
 
@@ -87,28 +89,28 @@ class InstrumentationTest extends Specification {
             def executionList = []
 
             @Override
-            InstrumentationContext beginExecution(String requestString, String operationName, Object context, Map<String, Object> arguments) {
+            InstrumentationContext<ExecutionResult> beginExecution(ExecutionParameters parameters) {
                 new Timer("execution", executionList)
             }
 
             @Override
-            InstrumentationContext beginParse(String requestString, String operationName, Object context, Map<String, Object> arguments) {
+            InstrumentationContext<Document> beginParse(ExecutionParameters parameters) {
                 return new Timer("parse", executionList)
             }
 
             @Override
-            InstrumentationContext<List<ValidationError>> beginValidation(Document document) {
+            InstrumentationContext<List<ValidationError>> beginValidation(ValidationParameters parameters) {
                 return new Timer("validation", executionList)
             }
 
             @Override
-            InstrumentationContext beginField(ExecutionContext executionContext, GraphQLFieldDefinition fieldDef) {
-                return new Timer("field-$fieldDef.name", executionList)
+            InstrumentationContext<ExecutionResult> beginField(FieldParameters parameters) {
+                return new Timer("field-$parameters.field.name", executionList)
             }
 
             @Override
-            InstrumentationContext beginDataFetch(ExecutionContext executionContext, GraphQLFieldDefinition fieldDef, DataFetchingEnvironment environment) {
-                return new Timer("fetch-$fieldDef.name", executionList)
+            InstrumentationContext<Object> beginFieldFetch(FieldFetchParameters parameters) {
+                return new Timer("fetch-$parameters.field.name", executionList)
             }
         }
 

--- a/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
@@ -1,0 +1,125 @@
+package graphql.execution.instrumentation
+
+import graphql.GraphQL
+import graphql.StarWarsSchema
+import graphql.execution.ExecutionContext
+import graphql.execution.SimpleExecutionStrategy
+import graphql.language.Document
+import graphql.schema.DataFetchingEnvironment
+import graphql.schema.GraphQLFieldDefinition
+import graphql.validation.ValidationError
+import spock.lang.Specification
+
+class InstrumentationTest extends Specification {
+
+    class Timer<T> implements InstrumentationContext<T> {
+        def op
+        def start = System.currentTimeMillis()
+        def executionList = []
+
+        Timer(op, executionList) {
+            this.op = op
+            this.executionList = executionList
+            executionList << "start:$op"
+            println("Started $op...")
+        }
+
+        def end() {
+            this.executionList << "end:$op"
+            def ms = System.currentTimeMillis() - start
+            println("\tEnded $op in ${ms}ms")
+        }
+
+        @Override
+        void onEnd(T result) {
+            end()
+        }
+
+        @Override
+        void onEnd(Exception e) {
+            end()
+        }
+    }
+
+
+    def 'Instrumentation of simple serial execution'() {
+        given:
+
+        def query = """
+        query HeroNameAndFriendsQuery {
+            hero {
+                id
+            }
+        }
+        """
+
+        //
+        // for testing purposes we must use SimpleExecutionStrategy under the covers to get such
+        // serial behaviour.  The Instrumentation of a parallel strategy would be much different
+        // and certainly harder to test
+        def expected = [
+                "start:execution",
+
+                "start:parse",
+                "end:parse",
+
+                "start:validation",
+                "end:validation",
+
+                "start:field-hero",
+                "start:fetch-hero",
+                "end:fetch-hero",
+
+                "start:field-id",
+                "start:fetch-id",
+                "end:fetch-id",
+                "end:field-id",
+
+                "end:field-hero",
+
+                "end:execution",
+        ]
+
+        when:
+
+        def instrumentation = new Instrumentation() {
+
+            def executionList = []
+
+            @Override
+            InstrumentationContext beginExecution(String requestString, String operationName, Object context, Map<String, Object> arguments) {
+                new Timer("execution", executionList)
+            }
+
+            @Override
+            InstrumentationContext beginParse(String requestString, String operationName, Object context, Map<String, Object> arguments) {
+                return new Timer("parse", executionList)
+            }
+
+            @Override
+            InstrumentationContext<List<ValidationError>> beginValidation(Document document) {
+                return new Timer("validation", executionList)
+            }
+
+            @Override
+            InstrumentationContext beginField(ExecutionContext executionContext, GraphQLFieldDefinition fieldDef) {
+                return new Timer("field-$fieldDef.name", executionList)
+            }
+
+            @Override
+            InstrumentationContext beginDataFetch(ExecutionContext executionContext, GraphQLFieldDefinition fieldDef, DataFetchingEnvironment environment) {
+                return new Timer("fetch-$fieldDef.name", executionList)
+            }
+        }
+
+        def strategy = new SimpleExecutionStrategy()
+        def graphQL = new GraphQL(StarWarsSchema.starWarsSchema, strategy, instrumentation)
+
+        graphQL.execute(query).data
+
+        then:
+
+        instrumentation.executionList == expected
+    }
+
+}

--- a/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
@@ -115,7 +115,7 @@ class InstrumentationTest extends Specification {
         }
 
         def strategy = new SimpleExecutionStrategy()
-        def graphQL = new GraphQL(StarWarsSchema.starWarsSchema, strategy, instrumentation)
+        def graphQL = new GraphQL(StarWarsSchema.starWarsSchema, strategy, strategy, instrumentation)
 
         graphQL.execute(query).data
 


### PR DESCRIPTION
as per #269 the desire here is to be able to measure how long a graphql query is taken

This approach of "return call back " allows for a fairly stateless system if we have multi threaded execution.

So you can "create a timer and then have the end time - start time  be calculated via this created object.