### PR TITLE
#263 - make execution context thread safe 

### DIFF
--- a/src/main/java/graphql/execution/ExecutionContext.java
+++ b/src/main/java/graphql/execution/ExecutionContext.java
@@ -6,59 +6,48 @@ import graphql.language.FragmentDefinition;
 import graphql.language.OperationDefinition;
 import graphql.schema.GraphQLSchema;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 public class ExecutionContext {
 
-    private GraphQLSchema graphQLSchema;
-    private ExecutionStrategy executionStrategy;
-    private Map<String, FragmentDefinition> fragmentsByName = new LinkedHashMap<String, FragmentDefinition>();
-    private OperationDefinition operationDefinition;
-    private Map<String, Object> variables = new LinkedHashMap<String, Object>();
-    private Object root;
-    private List<GraphQLError> errors = new ArrayList<GraphQLError>();
+    private final GraphQLSchema graphQLSchema;
+    private final ExecutionStrategy executionStrategy;
+    private final Map<String, FragmentDefinition> fragmentsByName;
+    private final OperationDefinition operationDefinition;
+    private final Map<String, Object> variables;
+    private final Object root;
+    private final List<GraphQLError> errors = new CopyOnWriteArrayList<GraphQLError>();
+
+    public ExecutionContext(GraphQLSchema graphQLSchema, ExecutionStrategy executionStrategy, Map<String, FragmentDefinition> fragmentsByName, OperationDefinition operationDefinition, Map<String, Object> variables, Object root) {
+        this.graphQLSchema = graphQLSchema;
+        this.executionStrategy = executionStrategy;
+        this.fragmentsByName = fragmentsByName;
+        this.operationDefinition = operationDefinition;
+        this.variables = variables;
+        this.root = root;
+    }
 
     public GraphQLSchema getGraphQLSchema() {
         return graphQLSchema;
-    }
-
-    public void setGraphQLSchema(GraphQLSchema graphQLSchema) {
-        this.graphQLSchema = graphQLSchema;
     }
 
     public Map<String, FragmentDefinition> getFragmentsByName() {
         return fragmentsByName;
     }
 
-    public void setFragmentsByName(Map<String, FragmentDefinition> fragmentsByName) {
-        this.fragmentsByName = fragmentsByName;
-    }
-
     public OperationDefinition getOperationDefinition() {
         return operationDefinition;
-    }
-
-    public void setOperationDefinition(OperationDefinition operationDefinition) {
-        this.operationDefinition = operationDefinition;
     }
 
     public Map<String, Object> getVariables() {
         return variables;
     }
 
-    public void setVariables(Map<String, Object> variables) {
-        this.variables = variables;
-    }
-
     public Object getRoot() {
         return root;
-    }
-
-    public void setRoot(Object root) {
-        this.root = root;
     }
 
     public FragmentDefinition getFragment(String name) {
@@ -77,7 +66,4 @@ public class ExecutionContext {
         return executionStrategy;
     }
 
-    public void setExecutionStrategy(ExecutionStrategy executionStrategy) {
-        this.executionStrategy = executionStrategy;
-    }
 }

--- a/src/main/java/graphql/execution/ExecutionContextBuilder.java
+++ b/src/main/java/graphql/execution/ExecutionContextBuilder.java
@@ -46,14 +46,14 @@ public class ExecutionContextBuilder {
             throw new GraphQLException();
         }
 
-        ExecutionContext executionContext = new ExecutionContext();
-        executionContext.setGraphQLSchema(graphQLSchema);
-        executionContext.setExecutionStrategy(executionStrategy);
-        executionContext.setOperationDefinition(operation);
-        executionContext.setRoot(root);
-        executionContext.setFragmentsByName(fragmentsByName);
         Map<String, Object> variableValues = valuesResolver.getVariableValues(graphQLSchema, operation.getVariableDefinitions(), args);
-        executionContext.setVariables(variableValues);
-        return executionContext;
+
+        return new ExecutionContext(
+                graphQLSchema,
+                executionStrategy,
+                fragmentsByName,
+                operation,
+                variableValues,
+                root);
     }
 }

--- a/src/test/groovy/graphql/execution/ExecutionStrategySpec.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategySpec.groovy
@@ -20,9 +20,13 @@ class ExecutionStrategySpec extends Specification {
         }
     }
 
+    def buildContext() {
+        new ExecutionContext(null,executionStrategy,null,null,null,null)
+    }
+
     def "completes value for a java.util.List"() {
         given:
-        ExecutionContext executionContext = new ExecutionContext();
+        ExecutionContext executionContext = buildContext()
         Field field = new Field()
         def fieldType = new GraphQLList(Scalars.GraphQLString)
         def result = Arrays.asList("test")
@@ -33,10 +37,9 @@ class ExecutionStrategySpec extends Specification {
         executionResult.data == ["test"]
     }
 
-
     def "completes value for an array"() {
         given:
-        ExecutionContext executionContext = new ExecutionContext();
+        ExecutionContext executionContext = buildContext()
         Field field = new Field()
         def fieldType = new GraphQLList(Scalars.GraphQLString)
         String[] result = ["test"]


### PR DESCRIPTION
mostly immutable and otherwise thread safe

Without this a multi threaded execution strategy will not be able to safely update errors.  