### PR TITLE
Fixed grammar: type conditions in inline fragments are optional

### DIFF
--- a/src/main/antlr/Graphql.g4
+++ b/src/main/antlr/Graphql.g4
@@ -49,13 +49,13 @@ argument : name ':' valueWithVariable;
 
 fragmentSpread : '...' fragmentName directives?;
 
-inlineFragment : '...' 'on' typeCondition directives? selectionSet;
+inlineFragment : '...' typeCondition? directives? selectionSet;
 
-fragmentDefinition : 'fragment' fragmentName 'on' typeCondition directives? selectionSet;
+fragmentDefinition : 'fragment' fragmentName typeCondition directives? selectionSet;
 
 fragmentName :  name;
 
-typeCondition : typeName;
+typeCondition : 'on' typeName;
 
 // Value
 

--- a/src/main/java/graphql/execution/FieldCollector.java
+++ b/src/main/java/graphql/execution/FieldCollector.java
@@ -79,6 +79,9 @@ public class FieldCollector {
 
 
     private boolean doesFragmentConditionMatch(ExecutionContext executionContext, InlineFragment inlineFragment, GraphQLObjectType type) {
+        if (inlineFragment.getTypeCondition() == null) {
+            return true;
+        }
         GraphQLType conditionType;
         conditionType = getTypeFromAST(executionContext.getGraphQLSchema(), inlineFragment.getTypeCondition());
         return checkTypeCondition(executionContext, type, conditionType);

--- a/src/main/java/graphql/language/InlineFragment.java
+++ b/src/main/java/graphql/language/InlineFragment.java
@@ -56,7 +56,9 @@ public class InlineFragment extends AbstractNode implements Selection {
     @Override
     public List<Node> getChildren() {
         List<Node> result = new ArrayList<Node>();
-        result.add(typeCondition);
+        if (typeCondition != null) {
+            result.add(typeCondition);
+        }
         result.addAll(directives);
         result.add(selectionSet);
         return result;

--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -182,7 +182,7 @@ public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
         FragmentDefinition fragmentDefinition = new FragmentDefinition();
         newNode(fragmentDefinition, ctx);
         fragmentDefinition.setName(ctx.fragmentName().getText());
-        fragmentDefinition.setTypeCondition(new TypeName(ctx.typeCondition().getText()));
+        fragmentDefinition.setTypeCondition(new TypeName(ctx.typeCondition().typeName().getText()));
         addContextProperty(ContextProperty.FragmentDefinition, fragmentDefinition);
         result.getDefinitions().add(fragmentDefinition);
         super.visitFragmentDefinition(ctx);
@@ -332,7 +332,8 @@ public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
 
     @Override
     public Void visitInlineFragment(GraphqlParser.InlineFragmentContext ctx) {
-        InlineFragment inlineFragment = new InlineFragment(new TypeName(ctx.typeCondition().getText()));
+        TypeName typeName = ctx.typeCondition() != null ? new TypeName(ctx.typeCondition().typeName().getText()) : null;
+        InlineFragment inlineFragment = new InlineFragment(typeName);
         newNode(inlineFragment, ctx);
         ((SelectionSet) getFromContextStack(ContextProperty.SelectionSet)).getSelections().add(inlineFragment);
         addContextProperty(ContextProperty.InlineFragment, inlineFragment);

--- a/src/main/java/graphql/validation/TraversalContext.java
+++ b/src/main/java/graphql/validation/TraversalContext.java
@@ -87,8 +87,14 @@ public class TraversalContext implements QueryLanguageVisitor {
     }
 
     private void enterImpl(InlineFragment inlineFragment) {
-        GraphQLType type = schema.getType(inlineFragment.getTypeCondition().getName());
-        addType((GraphQLOutputType) type);
+        TypeName typeCondition = inlineFragment.getTypeCondition();
+        GraphQLOutputType type;
+        if (typeCondition != null) {
+            type = (GraphQLOutputType) schema.getType(typeCondition.getName());
+        } else {
+            type = (GraphQLOutputType) getParentType();
+        }
+        addType(type);
     }
 
     private void enterImpl(FragmentDefinition fragmentDefinition) {

--- a/src/main/java/graphql/validation/rules/FragmentsOnCompositeType.java
+++ b/src/main/java/graphql/validation/rules/FragmentsOnCompositeType.java
@@ -16,6 +16,9 @@ public class FragmentsOnCompositeType extends AbstractRule {
 
     @Override
     public void checkInlineFragment(InlineFragment inlineFragment) {
+        if (inlineFragment.getTypeCondition() == null) {
+            return;
+        }
         GraphQLType type = getValidationContext().getSchema().getType(inlineFragment.getTypeCondition().getName());
         if (type == null) return;
         if (!(type instanceof GraphQLCompositeType)) {

--- a/src/main/java/graphql/validation/rules/OverlappingFieldsCanBeMerged.java
+++ b/src/main/java/graphql/validation/rules/OverlappingFieldsCanBeMerged.java
@@ -215,7 +215,7 @@ public class OverlappingFieldsCanBeMerged extends AbstractRule {
                 collectFieldsForField(fieldMap, parentType, (Field) selection);
 
             } else if (selection instanceof InlineFragment) {
-                collectFieldsForInlineFragment(fieldMap, visitedFragmentSpreads, (InlineFragment) selection);
+                collectFieldsForInlineFragment(fieldMap, visitedFragmentSpreads, parentType, (InlineFragment) selection);
 
             } else if (selection instanceof FragmentSpread) {
                 collectFieldsForFragmentSpread(fieldMap, visitedFragmentSpreads, (FragmentSpread) selection);
@@ -237,10 +237,11 @@ public class OverlappingFieldsCanBeMerged extends AbstractRule {
         collectFields(fieldMap, fragment.getSelectionSet(), graphQLType, visitedFragmentSpreads);
     }
 
-    private void collectFieldsForInlineFragment(Map<String, List<FieldAndType>> fieldMap, Set<String> visitedFragmentSpreads, InlineFragment selection) {
+    private void collectFieldsForInlineFragment(Map<String, List<FieldAndType>> fieldMap, Set<String> visitedFragmentSpreads, GraphQLType parentType, InlineFragment selection) {
         InlineFragment inlineFragment = selection;
-        GraphQLOutputType graphQLType = (GraphQLOutputType) TypeFromAST.getTypeFromAST(getValidationContext().getSchema(),
-                inlineFragment.getTypeCondition());
+        GraphQLType graphQLType = inlineFragment.getTypeCondition() != null
+                ? (GraphQLOutputType) TypeFromAST.getTypeFromAST(getValidationContext().getSchema(), inlineFragment.getTypeCondition())
+                : parentType;
         collectFields(fieldMap, inlineFragment.getSelectionSet(), graphQLType, visitedFragmentSpreads);
     }
 

--- a/src/test/groovy/graphql/StarWarsValidationTest.groovy
+++ b/src/test/groovy/graphql/StarWarsValidationTest.groovy
@@ -138,4 +138,42 @@ class StarWarsValidationTest extends Specification {
         validationErrors.isEmpty()
     }
 
+    def 'Allows object fields in inline fragments on with no type'() {
+        def query = """
+        query InlineFragmentWithNoType {
+            hero {
+                name
+                ... @include(if: true) {
+                    appearsIn
+                }
+            }
+        }
+        """
+        when:
+        def validationErrors = validate(query)
+
+        then:
+        validationErrors.isEmpty()
+    }
+
+    def 'Allows object fields in inline fragments with no type in array context'() {
+        def query = """
+        query InlineFragmentWithNoType {
+            hero {
+                name
+                friends {
+                    ... @include(if: true) {
+                        name
+                    }
+                }
+            }
+        }
+        """
+        when:
+        def validationErrors = validate(query)
+
+        then:
+        validationErrors.isEmpty()
+    }
+
 }

--- a/src/test/groovy/graphql/validation/SpecValidation282Test.groovy
+++ b/src/test/groovy/graphql/validation/SpecValidation282Test.groovy
@@ -1,0 +1,30 @@
+package graphql.validation
+
+/**
+ * validation examples used in the spec in given section
+ * http://facebook.github.io/graphql/#sec-Validation
+ *
+ * This test checks that an inline fragment containing just a directive
+ * is parsed correctly
+ */
+class SpecValidation282Test extends SpecValidationBase {
+
+    def 'Inline fragment can omit type condition'() {
+        def query = """
+query {
+  dog {
+    name
+    ... @skip(if: true) {
+      barkVolume
+    }
+  }
+}
+"""
+        when:
+        def validationErrors = validate(query)
+
+        then:
+        validationErrors.empty
+    }
+    
+}


### PR DESCRIPTION
From #175:

> * Fix a problem with the Antlr grammar for inline fragments. It had this:
`inlineFragment : '...' 'on' typeCondition directives? selectionSet;`
That is the "type condition" (on TypeName) was required. Changed it to be optional, which involved changing the grammar, the way we construct the parse tree and then a bunch of new null checks to deal with the case where the type condition is null.