### PR TITLE
273 - use builder pattern in GraphQL top level object

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,11 +229,11 @@ Example:
 
 ```java
 GraphQLInputObjectType inputObjectType = newInputObject()
-    .name("inputObjectType")
-    .field(newInputObjectField()
-        .name("field")
-        .type(GraphQLString))
-    .build()
+        .name("inputObjectType")
+        .field(newInputObjectField()
+                .name("field")
+                .type(GraphQLString))
+        .build();
 
 ```
 
@@ -309,27 +309,27 @@ Example of configuring a custom `DataFetcher`:
 
 DataFetcher<Foo> fooDataFetcher = new DataFetcher<Foo>() {
     @Override
-    Foo get(DataFetchingEnvironment environment) {
+    public Foo get(DataFetchingEnvironment environment) {
         // environment.getSource() is the value of the surrounding
         // object. In this case described by objectType
-        Foo value = ... // Perhaps getting from a DB or whatever 
+        Foo value = perhapsFromDatabase(); // Perhaps getting from a DB or whatever 
         return value;
     }
 };
 
 GraphQLObjectType objectType = newObject()
-    .name("ObjectType")
-    .field(newFieldDefinition()
-            .name("foo")
-            .type(GraphQLString)
-            .dataFetcher(fooDataFetcher))
-    .build();
+        .name("ObjectType")
+        .field(newFieldDefinition()
+                .name("foo")
+                .type(GraphQLString)
+                .dataFetcher(fooDataFetcher))
+        .build();
 
 ```
 
 #### Executing 
 
-To execute a Query/Mutation against a Schema instantiate a new `GraphQL` Object with the appropriate arguments and then call `execute()`.
+To execute a Query/Mutation against a Schema build a new `GraphQL` Object with the appropriate arguments and then call `execute()`.
  
 The result of a Query is a `ExecutionResult` Object with the result and/or a list of Errors.
 
@@ -340,14 +340,31 @@ More complex examples: [StarWars query tests](src/test/groovy/graphql/StarWarsQu
 
 #### Execution strategies
 
-All fields in a SelectionSet are executed serially per default. 
+All fields in a SelectionSet are executed serially per default.
+ 
+You can however provide your own execution strategies, one to use while querying data and one
+to use when mutating data.
 
-`GraphQL` takes as second constructor argument an optional [ExecutorService](http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ExecutorService.html).
+```java
+
+ThreadPoolExecutor threadPoolExecutor = new ThreadPoolExecutor(
+        2, /* core pool size 2 thread */
+        2, /* max pool size 2 thread */
+        30, TimeUnit.SECONDS,
+        new LinkedBlockingQueue<Runnable>(),
+        new ThreadPoolExecutor.CallerRunsPolicy());
+
+GraphQL graphQL = GraphQL.newObject(StarWarsSchema.starWarsSchema)
+        .queryExecutionStrategy(new ExecutorServiceExecutionStrategy(threadPoolExecutor))
+        .mutationExecutionStrategy(new SimpleExecutionStrategy())
+        .build();
+
+
+```
+
 When provided fields will be executed parallel, except the first level of a mutation operation.
 
 See [specification](http://facebook.github.io/graphql/#sec-Normal-evaluation) for details.
-
-It's recommended to use a `ExecutorService` to speed up execution.
 
 Alternatively, schemas with nested lists may benefit from using a BatchedExecutionStrategy and creating batched DataFetchers with get() methods annotated @Batched.
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ This is the famous "hello world" in graphql-java:
 ```java
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
+import java.util.Map;
 
 import static graphql.Scalars.GraphQLString;
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
@@ -82,20 +83,21 @@ import static graphql.schema.GraphQLObjectType.newObject;
 public class HelloWorld {
 
     public static void main(String[] args) {
-    
         GraphQLObjectType queryType = newObject()
-                        .name("helloWorldQuery")
-                        .field(newFieldDefinition()
-                                .type(GraphQLString)
-                                .name("hello")
-                                .staticValue("world"))
-                        .build();
-        
-        GraphQLSchema schema = GraphQLSchema.newSchema()
-                        .query(queryType)
-                        .build();
-        Map<String, Object> result = new GraphQL(schema).execute("{hello}").getData();
+                .name("helloWorldQuery")
+                .field(newFieldDefinition()
+                        .type(GraphQLString)
+                        .name("hello")
+                        .staticValue("world"))
+                .build();
 
+        GraphQLSchema schema = GraphQLSchema.newSchema()
+                .query(queryType)
+                .build();
+
+        GraphQL graphQL = GraphQL.newObject(schema).build();
+
+        Map<String, Object> result = graphQL.execute("{hello}").getData();
         System.out.println(result);
         // Prints: {hello=world}
     }

--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ public class HelloWorld {
         GraphQLSchema schema = GraphQLSchema.newSchema()
                         .query(queryType)
                         .build();
-        Map<String, Object> result = (Map<String, Object>) new GraphQL(schema).execute("{hello}").getData();
+        
+        GraphQL graphQL = GraphQL.newObject(schema).build();
+        Map<String, Object> result = (Map<String, Object>) graphQL.execute("{hello}").getData();
 
         System.out.println(result);
         // Prints: {hello=world}

--- a/src/main/java/graphql/Assert.java
+++ b/src/main/java/graphql/Assert.java
@@ -5,14 +5,14 @@ import java.util.Collection;
 public class Assert {
 
 
-    public static void assertNotNull(Object object, String errorMessage) {
-        if (object != null) return;
+    public static <T> T assertNotNull(T object, String errorMessage) {
+        if (object != null) return object;
         throw new AssertException(errorMessage);
     }
 
-    public static void assertNotEmpty(Collection<?> c, String errorMessage) {
+    public static <T> Collection<T> assertNotEmpty(Collection<T> c, String errorMessage) {
         if (c == null || c.isEmpty()) throw new AssertException(errorMessage);
-        return;
+        return c;
     }
 
 }

--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -46,8 +46,8 @@ public class GraphQL {
     /**
      * A GraphQL object ready to execute queries
      *
-     * @param graphQLSchema     the schema to use
-     * @param queryStrategy the execution strategy to use
+     * @param graphQLSchema the schema to use
+     * @param queryStrategy the query execution strategy to use
      *
      * @deprecated use the {@link #newObject(GraphQLSchema)} builder instead.  This will be removed in a future version.
      */
@@ -59,11 +59,13 @@ public class GraphQL {
     /**
      * A GraphQL object ready to execute queries
      *
-     * @param graphQLSchema     the schema to use
-     * @param queryStrategy the execution strategy to use
+     * @param graphQLSchema    the schema to use
+     * @param queryStrategy    the query execution strategy to use
+     * @param mutationStrategy the mutation execution strategy to use
      *
      * @deprecated use the {@link #newObject(GraphQLSchema)} builder instead.  This will be removed in a future version.
      */
+    @SuppressWarnings("DeprecatedIsStillUsed")
     public GraphQL(GraphQLSchema graphQLSchema, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy) {
         this.graphQLSchema = graphQLSchema;
         this.queryStrategy = queryStrategy;
@@ -84,7 +86,8 @@ public class GraphQL {
 
     public static class Builder {
         private GraphQLSchema graphQLSchema;
-        private ExecutionStrategy executionStrategy = new SimpleExecutionStrategy();
+        private ExecutionStrategy queryExecutionStrategy = new SimpleExecutionStrategy();
+        private ExecutionStrategy mutationExecutionStrategy = null;
 
         public Builder(GraphQLSchema graphQLSchema) {
             this.graphQLSchema = graphQLSchema;
@@ -95,14 +98,19 @@ public class GraphQL {
             return this;
         }
 
-        public Builder executionStrategy(ExecutionStrategy executionStrategy) {
-            this.executionStrategy = assertNotNull(executionStrategy, "ExecutionStrategy must be non null");
+        public Builder queryExecutionStrategy(ExecutionStrategy executionStrategy) {
+            this.queryExecutionStrategy = assertNotNull(executionStrategy, "Query ExecutionStrategy must be non null");
+            return this;
+        }
+
+        public Builder mutationExecutionStrategy(ExecutionStrategy executionStrategy) {
+            this.mutationExecutionStrategy = assertNotNull(executionStrategy, "Mutation ExecutionStrategy must be non null");
             return this;
         }
 
         public GraphQL build() {
             //noinspection deprecation
-            return new GraphQL(graphQLSchema, executionStrategy);
+            return new GraphQL(graphQLSchema, queryExecutionStrategy, mutationExecutionStrategy);
         }
     }
 

--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -49,7 +49,7 @@ public class GraphQL {
      *
      * @param graphQLSchema the schema to use
      *
-     * @deprecated use the {@link #newObject(GraphQLSchema)} builder instead.  This will be removed in a future version.
+     * @deprecated use the {@link #newGraphQL(GraphQLSchema)} builder instead.  This will be removed in a future version.
      */
     public GraphQL(GraphQLSchema graphQLSchema) {
         //noinspection deprecation
@@ -63,7 +63,7 @@ public class GraphQL {
      * @param graphQLSchema the schema to use
      * @param queryStrategy the query execution strategy to use
      *
-     * @deprecated use the {@link #newObject(GraphQLSchema)} builder instead.  This will be removed in a future version.
+     * @deprecated use the {@link #newGraphQL(GraphQLSchema)} builder instead.  This will be removed in a future version.
      */
     public GraphQL(GraphQLSchema graphQLSchema, ExecutionStrategy queryStrategy) {
         //noinspection deprecation
@@ -77,7 +77,7 @@ public class GraphQL {
      * @param queryStrategy    the query execution strategy to use
      * @param mutationStrategy the mutation execution strategy to use
      *
-     * @deprecated use the {@link #newObject(GraphQLSchema)} builder instead.  This will be removed in a future version.
+     * @deprecated use the {@link #newGraphQL(GraphQLSchema)} builder instead.  This will be removed in a future version.
      */
     @SuppressWarnings("DeprecatedIsStillUsed")
     public GraphQL(GraphQLSchema graphQLSchema, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy) {
@@ -87,13 +87,13 @@ public class GraphQL {
     }
 
     /**
-     * Helps you build GraphQL object ready to execute queries
+     * Helps you build a GraphQL object ready to execute queries
      *
      * @param graphQLSchema the schema to use
      *
      * @return a builder of GraphQL objects
      */
-    public static Builder newObject(GraphQLSchema graphQLSchema) {
+    public static Builder newGraphQL(GraphQLSchema graphQLSchema) {
         return new Builder(graphQLSchema);
     }
 

--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -87,7 +87,7 @@ public class GraphQL {
     public static class Builder {
         private GraphQLSchema graphQLSchema;
         private ExecutionStrategy queryExecutionStrategy = new SimpleExecutionStrategy();
-        private ExecutionStrategy mutationExecutionStrategy = null;
+        private ExecutionStrategy mutationExecutionStrategy = new SimpleExecutionStrategy();
 
         public Builder(GraphQLSchema graphQLSchema) {
             this.graphQLSchema = graphQLSchema;

--- a/src/test/groovy/graphql/GraphQLTest.groovy
+++ b/src/test/groovy/graphql/GraphQLTest.groovy
@@ -28,7 +28,7 @@ class GraphQLTest extends Specification {
         ).build()
 
         when:
-        def result = new GraphQL(schema).execute('{ hello }').data
+        def result = GraphQL.newObject(schema).build().execute('{ hello }').data
 
         then:
         result == [hello: 'world']
@@ -59,10 +59,10 @@ class GraphQLTest extends Specification {
                         .name("RootQueryType")
                         .field(simpsonField)
                         .build()
-        ).build();
+        ).build()
 
         when:
-        def result = new GraphQL(graphQLSchema).execute('{ simpson { id, name } }').data
+        def result = GraphQL.newObject(graphQLSchema).build().execute('{ simpson { id, name } }').data
 
         then:
         result == [simpson: [id: '123', name: 'homer']]
@@ -83,7 +83,7 @@ class GraphQLTest extends Specification {
         ).build()
 
         when:
-        def errors = new GraphQL(schema).execute('{ hello(arg:11) }').errors
+        def errors = GraphQL.newObject(schema).build().execute('{ hello(arg:11) }').errors
 
         then:
         errors.size() == 1
@@ -98,7 +98,7 @@ class GraphQLTest extends Specification {
         ).build()
 
         when:
-        def errors = new GraphQL(schema).execute('{ hello(() }').errors
+        def errors = GraphQL.newObject(schema).build().execute('{ hello(() }').errors
 
         then:
         errors.size() == 1
@@ -115,7 +115,7 @@ class GraphQLTest extends Specification {
         ).build()
 
         when:
-        def errors = new GraphQL(schema).execute('{ hello[](() }').errors
+        def errors = GraphQL.newObject(schema).build().execute('{ hello[](() }').errors
 
         then:
         errors.size() == 1
@@ -138,7 +138,7 @@ class GraphQLTest extends Specification {
         ).build()
 
         when:
-        def errors = new GraphQL(schema).execute('{ field }').errors
+        def errors = GraphQL.newObject(schema).build().execute('{ field }').errors
 
         then:
         errors.size() == 1
@@ -163,7 +163,7 @@ class GraphQLTest extends Specification {
           .build()
 
         when:
-        def data = new GraphQL(schema).execute("query { set }").data
+        def data = GraphQL.newObject(schema).build().execute("query { set }").data
 
         then:
         data == [set: ['One', 'Two']]
@@ -188,7 +188,7 @@ class GraphQLTest extends Specification {
         def expected = [field2: 'value2']
 
         when:
-        def result = new GraphQL(schema).execute(query, 'Query2', null, [:])
+        def result = GraphQL.newObject(schema).build().execute(query, 'Query2', null, [:])
 
         then:
         result.data == expected
@@ -211,7 +211,7 @@ class GraphQLTest extends Specification {
         """
 
         when:
-        new GraphQL(schema).execute(query)
+        GraphQL.newObject(schema).build().execute(query)
 
         then:
         thrown(GraphQLException)

--- a/src/test/groovy/graphql/GraphQLTest.groovy
+++ b/src/test/groovy/graphql/GraphQLTest.groovy
@@ -28,7 +28,7 @@ class GraphQLTest extends Specification {
         ).build()
 
         when:
-        def result = GraphQL.newObject(schema).build().execute('{ hello }').data
+        def result = GraphQL.newGraphQL(schema).build().execute('{ hello }').data
 
         then:
         result == [hello: 'world']
@@ -62,7 +62,7 @@ class GraphQLTest extends Specification {
         ).build()
 
         when:
-        def result = GraphQL.newObject(graphQLSchema).build().execute('{ simpson { id, name } }').data
+        def result = GraphQL.newGraphQL(graphQLSchema).build().execute('{ simpson { id, name } }').data
 
         then:
         result == [simpson: [id: '123', name: 'homer']]
@@ -83,7 +83,7 @@ class GraphQLTest extends Specification {
         ).build()
 
         when:
-        def errors = GraphQL.newObject(schema).build().execute('{ hello(arg:11) }').errors
+        def errors = GraphQL.newGraphQL(schema).build().execute('{ hello(arg:11) }').errors
 
         then:
         errors.size() == 1
@@ -98,7 +98,7 @@ class GraphQLTest extends Specification {
         ).build()
 
         when:
-        def errors = GraphQL.newObject(schema).build().execute('{ hello(() }').errors
+        def errors = GraphQL.newGraphQL(schema).build().execute('{ hello(() }').errors
 
         then:
         errors.size() == 1
@@ -115,7 +115,7 @@ class GraphQLTest extends Specification {
         ).build()
 
         when:
-        def errors = GraphQL.newObject(schema).build().execute('{ hello[](() }').errors
+        def errors = GraphQL.newGraphQL(schema).build().execute('{ hello[](() }').errors
 
         then:
         errors.size() == 1
@@ -138,7 +138,7 @@ class GraphQLTest extends Specification {
         ).build()
 
         when:
-        def errors = GraphQL.newObject(schema).build().execute('{ field }').errors
+        def errors = GraphQL.newGraphQL(schema).build().execute('{ field }').errors
 
         then:
         errors.size() == 1
@@ -163,7 +163,7 @@ class GraphQLTest extends Specification {
           .build()
 
         when:
-        def data = GraphQL.newObject(schema).build().execute("query { set }").data
+        def data = GraphQL.newGraphQL(schema).build().execute("query { set }").data
 
         then:
         data == [set: ['One', 'Two']]
@@ -188,7 +188,7 @@ class GraphQLTest extends Specification {
         def expected = [field2: 'value2']
 
         when:
-        def result = GraphQL.newObject(schema).build().execute(query, 'Query2', null, [:])
+        def result = GraphQL.newGraphQL(schema).build().execute(query, 'Query2', null, [:])
 
         then:
         result.data == expected
@@ -211,7 +211,7 @@ class GraphQLTest extends Specification {
         """
 
         when:
-        GraphQL.newObject(schema).build().execute(query)
+        GraphQL.newGraphQL(schema).build().execute(query)
 
         then:
         thrown(GraphQLException)

--- a/src/test/groovy/graphql/HelloWorld.java
+++ b/src/test/groovy/graphql/HelloWorld.java
@@ -27,7 +27,7 @@ public class HelloWorld {
                 .query(queryType)
                 .build();
 
-        GraphQL graphQL = GraphQL.newObject(schema).build();
+        GraphQL graphQL = GraphQL.newGraphQL(schema).build();
 
         Map<String, Object> result = graphQL.execute("{hello}").getData();
         System.out.println(result);
@@ -47,7 +47,7 @@ public class HelloWorld {
         GraphQLSchema schema = GraphQLSchema.newSchema()
                 .query(queryType)
                 .build();
-        GraphQL graphQL = GraphQL.newObject(schema).build();
+        GraphQL graphQL = GraphQL.newGraphQL(schema).build();
         Map<String, Object> result = graphQL.execute("{hello}").getData();
         assertEquals("world", result.get("hello"));
     }

--- a/src/test/groovy/graphql/HelloWorld.java
+++ b/src/test/groovy/graphql/HelloWorld.java
@@ -26,9 +26,12 @@ public class HelloWorld {
         GraphQLSchema schema = GraphQLSchema.newSchema()
                 .query(queryType)
                 .build();
+
         GraphQL graphQL = GraphQL.newObject(schema).build();
-        Map<String, Object> result = (Map<String, Object>) graphQL.execute("{hello}").getData();
+
+        Map<String, Object> result = graphQL.execute("{hello}").getData();
         System.out.println(result);
+        // Prints: {hello=world}
     }
 
     @Test
@@ -45,7 +48,7 @@ public class HelloWorld {
                 .query(queryType)
                 .build();
         GraphQL graphQL = GraphQL.newObject(schema).build();
-        Map<String, Object> result = (Map<String, Object>) graphQL.execute("{hello}").getData();
+        Map<String, Object> result = graphQL.execute("{hello}").getData();
         assertEquals("world", result.get("hello"));
     }
 }

--- a/src/test/groovy/graphql/HelloWorld.java
+++ b/src/test/groovy/graphql/HelloWorld.java
@@ -26,7 +26,8 @@ public class HelloWorld {
         GraphQLSchema schema = GraphQLSchema.newSchema()
                 .query(queryType)
                 .build();
-        Map<String, Object> result = (Map<String, Object>)new GraphQL(schema).execute("{hello}").getData();
+        GraphQL graphQL = GraphQL.newObject(schema).build();
+        Map<String, Object> result = (Map<String, Object>) graphQL.execute("{hello}").getData();
         System.out.println(result);
     }
 
@@ -43,7 +44,8 @@ public class HelloWorld {
         GraphQLSchema schema = GraphQLSchema.newSchema()
                 .query(queryType)
                 .build();
-        Map<String, Object> result = (Map<String, Object>)new GraphQL(schema).execute("{hello}").getData();
+        GraphQL graphQL = GraphQL.newObject(schema).build();
+        Map<String, Object> result = (Map<String, Object>) graphQL.execute("{hello}").getData();
         assertEquals("world", result.get("hello"));
     }
 }

--- a/src/test/groovy/graphql/MutationTest.groovy
+++ b/src/test/groovy/graphql/MutationTest.groovy
@@ -47,7 +47,7 @@ class MutationTest extends Specification {
         ]
 
         when:
-        def executionResult = new GraphQL(MutationSchema.schema).execute(query, new MutationSchema.Root(6))
+        def executionResult = GraphQL.newObject(MutationSchema.schema).build().execute(query, new MutationSchema.Root(6))
 
 
         then:
@@ -93,7 +93,7 @@ class MutationTest extends Specification {
         ]
 
         when:
-        def executionResult = new GraphQL(MutationSchema.schema).execute(query, new MutationSchema.Root(6))
+        def executionResult = GraphQL.newObject(MutationSchema.schema).build().execute(query, new MutationSchema.Root(6))
 
 
         then:

--- a/src/test/groovy/graphql/MutationTest.groovy
+++ b/src/test/groovy/graphql/MutationTest.groovy
@@ -47,7 +47,7 @@ class MutationTest extends Specification {
         ]
 
         when:
-        def executionResult = GraphQL.newObject(MutationSchema.schema).build().execute(query, new MutationSchema.Root(6))
+        def executionResult = GraphQL.newGraphQL(MutationSchema.schema).build().execute(query, new MutationSchema.Root(6))
 
 
         then:
@@ -93,7 +93,7 @@ class MutationTest extends Specification {
         ]
 
         when:
-        def executionResult = GraphQL.newObject(MutationSchema.schema).build().execute(query, new MutationSchema.Root(6))
+        def executionResult = GraphQL.newGraphQL(MutationSchema.schema).build().execute(query, new MutationSchema.Root(6))
 
 
         then:

--- a/src/test/groovy/graphql/RelaySchemaTest.groovy
+++ b/src/test/groovy/graphql/RelaySchemaTest.groovy
@@ -32,7 +32,7 @@ class RelaySchemaTest extends Specification {
                     }
                     """
         when:
-        def result = new GraphQL(RelaySchema.Schema).execute(query);
+        def result = GraphQL.newObject(RelaySchema.Schema).build().execute(query);
 
         then:
         def nodeField = result.data["__schema"]["queryType"]["fields"][0];
@@ -59,7 +59,7 @@ class RelaySchemaTest extends Specification {
                           }
                         }"""
         when:
-        def result = new GraphQL(RelaySchema.Schema).execute(query);
+        def result = GraphQL.newObject(RelaySchema.Schema).build().execute(query);
 
         then:
         def fields = result.data["__type"]["fields"];
@@ -86,7 +86,7 @@ class RelaySchemaTest extends Specification {
                         }
                     """
         when:
-        def result = new GraphQL(RelaySchema.Schema).execute(query);
+        def result = GraphQL.newObject(RelaySchema.Schema).build().execute(query);
 
         then:
         def fields = result.data["__type"]["fields"];

--- a/src/test/groovy/graphql/RelaySchemaTest.groovy
+++ b/src/test/groovy/graphql/RelaySchemaTest.groovy
@@ -32,7 +32,7 @@ class RelaySchemaTest extends Specification {
                     }
                     """
         when:
-        def result = GraphQL.newObject(RelaySchema.Schema).build().execute(query);
+        def result = GraphQL.newGraphQL(RelaySchema.Schema).build().execute(query);
 
         then:
         def nodeField = result.data["__schema"]["queryType"]["fields"][0];
@@ -59,7 +59,7 @@ class RelaySchemaTest extends Specification {
                           }
                         }"""
         when:
-        def result = GraphQL.newObject(RelaySchema.Schema).build().execute(query);
+        def result = GraphQL.newGraphQL(RelaySchema.Schema).build().execute(query);
 
         then:
         def fields = result.data["__type"]["fields"];
@@ -86,7 +86,7 @@ class RelaySchemaTest extends Specification {
                         }
                     """
         when:
-        def result = GraphQL.newObject(RelaySchema.Schema).build().execute(query);
+        def result = GraphQL.newGraphQL(RelaySchema.Schema).build().execute(query);
 
         then:
         def fields = result.data["__type"]["fields"];

--- a/src/test/groovy/graphql/ScalarsQueryTest.groovy
+++ b/src/test/groovy/graphql/ScalarsQueryTest.groovy
@@ -71,7 +71,7 @@ class ScalarsQueryTest extends Specification {
         def result = GraphQL.newObject(ScalarsQuerySchema.scalarsQuerySchema)
                 .build().execute(query)
         def resultBatched = GraphQL.newObject(ScalarsQuerySchema.scalarsQuerySchema)
-                .executionStrategy(new BatchedExecutionStrategy())
+                .queryExecutionStrategy(new BatchedExecutionStrategy())
                 .build().execute(query)
 
         then:

--- a/src/test/groovy/graphql/ScalarsQueryTest.groovy
+++ b/src/test/groovy/graphql/ScalarsQueryTest.groovy
@@ -24,7 +24,7 @@ class ScalarsQueryTest extends Specification {
         ]
 
         when:
-        def result = GraphQL.newObject(ScalarsQuerySchema.scalarsQuerySchema).build().execute(query)
+        def result = GraphQL.newGraphQL(ScalarsQuerySchema.scalarsQuerySchema).build().execute(query)
 
         then:
         result.data == expected
@@ -49,7 +49,7 @@ class ScalarsQueryTest extends Specification {
         ]
 
         when:
-        def result = GraphQL.newObject(ScalarsQuerySchema.scalarsQuerySchema).build().execute(query)
+        def result = GraphQL.newGraphQL(ScalarsQuerySchema.scalarsQuerySchema).build().execute(query)
 
         then:
         result.data == expected
@@ -68,9 +68,9 @@ class ScalarsQueryTest extends Specification {
         ]
 
         when:
-        def result = GraphQL.newObject(ScalarsQuerySchema.scalarsQuerySchema)
+        def result = GraphQL.newGraphQL(ScalarsQuerySchema.scalarsQuerySchema)
                 .build().execute(query)
-        def resultBatched = GraphQL.newObject(ScalarsQuerySchema.scalarsQuerySchema)
+        def resultBatched = GraphQL.newGraphQL(ScalarsQuerySchema.scalarsQuerySchema)
                 .queryExecutionStrategy(new BatchedExecutionStrategy())
                 .build().execute(query)
 
@@ -93,7 +93,7 @@ class ScalarsQueryTest extends Specification {
         ]
 
         when:
-        def result = GraphQL.newObject(ScalarsQuerySchema.scalarsQuerySchema).build().execute(query)
+        def result = GraphQL.newGraphQL(ScalarsQuerySchema.scalarsQuerySchema).build().execute(query)
 
         then:
         result.data == expected
@@ -106,7 +106,7 @@ class ScalarsQueryTest extends Specification {
         def query = "{ " + number + "String(input: \"foobar\") }"
         
         when:
-        def result = GraphQL.newObject(ScalarsQuerySchema.scalarsQuerySchema).build().execute(query)
+        def result = GraphQL.newGraphQL(ScalarsQuerySchema.scalarsQuerySchema).build().execute(query)
         
         then:
         //FIXME do not propagate exception, but instead raise an error.

--- a/src/test/groovy/graphql/ScalarsQueryTest.groovy
+++ b/src/test/groovy/graphql/ScalarsQueryTest.groovy
@@ -24,7 +24,7 @@ class ScalarsQueryTest extends Specification {
         ]
 
         when:
-        def result = new GraphQL(ScalarsQuerySchema.scalarsQuerySchema).execute(query)
+        def result = GraphQL.newObject(ScalarsQuerySchema.scalarsQuerySchema).build().execute(query)
 
         then:
         result.data == expected
@@ -49,7 +49,7 @@ class ScalarsQueryTest extends Specification {
         ]
 
         when:
-        def result = new GraphQL(ScalarsQuerySchema.scalarsQuerySchema).execute(query)
+        def result = GraphQL.newObject(ScalarsQuerySchema.scalarsQuerySchema).build().execute(query)
 
         then:
         result.data == expected
@@ -68,8 +68,11 @@ class ScalarsQueryTest extends Specification {
         ]
 
         when:
-        def result = new GraphQL(ScalarsQuerySchema.scalarsQuerySchema).execute(query)
-        def resultBatched = new GraphQL(ScalarsQuerySchema.scalarsQuerySchema, new BatchedExecutionStrategy()).execute(query)
+        def result = GraphQL.newObject(ScalarsQuerySchema.scalarsQuerySchema)
+                .build().execute(query)
+        def resultBatched = GraphQL.newObject(ScalarsQuerySchema.scalarsQuerySchema)
+                .executionStrategy(new BatchedExecutionStrategy())
+                .build().execute(query)
 
         then:
         result.data == expected
@@ -90,7 +93,7 @@ class ScalarsQueryTest extends Specification {
         ]
 
         when:
-        def result = new GraphQL(ScalarsQuerySchema.scalarsQuerySchema).execute(query)
+        def result = GraphQL.newObject(ScalarsQuerySchema.scalarsQuerySchema).build().execute(query)
 
         then:
         result.data == expected
@@ -103,7 +106,7 @@ class ScalarsQueryTest extends Specification {
         def query = "{ " + number + "String(input: \"foobar\") }"
         
         when:
-        def result = new GraphQL(ScalarsQuerySchema.scalarsQuerySchema).execute(query)
+        def result = GraphQL.newObject(ScalarsQuerySchema.scalarsQuerySchema).build().execute(query)
         
         then:
         //FIXME do not propagate exception, but instead raise an error.

--- a/src/test/groovy/graphql/StarWarsIntrospectionTests.groovy
+++ b/src/test/groovy/graphql/StarWarsIntrospectionTests.groovy
@@ -39,7 +39,7 @@ class StarWarsIntrospectionTests extends Specification {
         ];
 
         when:
-        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query).data
+        def result = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema).build().execute(query).data
 
         then:
         result == expected
@@ -65,7 +65,7 @@ class StarWarsIntrospectionTests extends Specification {
                 ]
         ]
         when:
-        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query).data
+        def result = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema).build().execute(query).data
 
         then:
         result == expected
@@ -88,7 +88,7 @@ class StarWarsIntrospectionTests extends Specification {
         ]
 
         when:
-        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query).data
+        def result = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema).build().execute(query).data
 
         then:
         result == expected
@@ -111,7 +111,7 @@ class StarWarsIntrospectionTests extends Specification {
                 ]
         ];
         when:
-        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query).data
+        def result = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema).build().execute(query).data
 
         then:
         result == expected
@@ -134,7 +134,7 @@ class StarWarsIntrospectionTests extends Specification {
                 ]
         ];
         when:
-        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query).data
+        def result = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema).build().execute(query).data
 
         then:
         result == expected
@@ -200,7 +200,7 @@ class StarWarsIntrospectionTests extends Specification {
                 ]
         ];
         when:
-        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query).data
+        def result = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema).build().execute(query).data
 
         then:
         result == expected
@@ -283,7 +283,7 @@ class StarWarsIntrospectionTests extends Specification {
                 ]
         ]
         when:
-        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query)
+        def result = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema).build().execute(query)
 
         then:
         result.data == expected
@@ -380,7 +380,7 @@ class StarWarsIntrospectionTests extends Specification {
         ];
 
         when:
-        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query)
+        def result = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema).build().execute(query)
 
         then:
         result.data == expected
@@ -404,7 +404,7 @@ class StarWarsIntrospectionTests extends Specification {
         ];
 
         when:
-        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query)
+        def result = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema).build().execute(query)
 
         then:
         result.data == expected
@@ -415,7 +415,7 @@ class StarWarsIntrospectionTests extends Specification {
         def query = IntrospectionQuery.INTROSPECTION_QUERY
 
         when:
-        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query)
+        def result = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema).build().execute(query)
 
         then:
         Map<String, Object> schema = (Map<String, Object>) result.data

--- a/src/test/groovy/graphql/StarWarsIntrospectionTests.groovy
+++ b/src/test/groovy/graphql/StarWarsIntrospectionTests.groovy
@@ -39,7 +39,7 @@ class StarWarsIntrospectionTests extends Specification {
         ];
 
         when:
-        def result = new GraphQL(StarWarsSchema.starWarsSchema).execute(query).data
+        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query).data
 
         then:
         result == expected
@@ -65,7 +65,7 @@ class StarWarsIntrospectionTests extends Specification {
                 ]
         ]
         when:
-        def result = new GraphQL(StarWarsSchema.starWarsSchema).execute(query).data
+        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query).data
 
         then:
         result == expected
@@ -88,7 +88,7 @@ class StarWarsIntrospectionTests extends Specification {
         ]
 
         when:
-        def result = new GraphQL(StarWarsSchema.starWarsSchema).execute(query).data
+        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query).data
 
         then:
         result == expected
@@ -111,7 +111,7 @@ class StarWarsIntrospectionTests extends Specification {
                 ]
         ];
         when:
-        def result = new GraphQL(StarWarsSchema.starWarsSchema).execute(query).data
+        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query).data
 
         then:
         result == expected
@@ -134,7 +134,7 @@ class StarWarsIntrospectionTests extends Specification {
                 ]
         ];
         when:
-        def result = new GraphQL(StarWarsSchema.starWarsSchema).execute(query).data
+        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query).data
 
         then:
         result == expected
@@ -200,7 +200,7 @@ class StarWarsIntrospectionTests extends Specification {
                 ]
         ];
         when:
-        def result = new GraphQL(StarWarsSchema.starWarsSchema).execute(query).data
+        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query).data
 
         then:
         result == expected
@@ -283,7 +283,7 @@ class StarWarsIntrospectionTests extends Specification {
                 ]
         ]
         when:
-        def result = new GraphQL(StarWarsSchema.starWarsSchema).execute(query)
+        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query)
 
         then:
         result.data == expected
@@ -380,7 +380,7 @@ class StarWarsIntrospectionTests extends Specification {
         ];
 
         when:
-        def result = new GraphQL(StarWarsSchema.starWarsSchema).execute(query)
+        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query)
 
         then:
         result.data == expected
@@ -404,7 +404,7 @@ class StarWarsIntrospectionTests extends Specification {
         ];
 
         when:
-        def result = new GraphQL(StarWarsSchema.starWarsSchema).execute(query)
+        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query)
 
         then:
         result.data == expected
@@ -415,7 +415,7 @@ class StarWarsIntrospectionTests extends Specification {
         def query = IntrospectionQuery.INTROSPECTION_QUERY
 
         when:
-        def result = new GraphQL(StarWarsSchema.starWarsSchema).execute(query)
+        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query)
 
         then:
         Map<String, Object> schema = (Map<String, Object>) result.data

--- a/src/test/groovy/graphql/StarWarsQueryTest.groovy
+++ b/src/test/groovy/graphql/StarWarsQueryTest.groovy
@@ -20,7 +20,7 @@ class StarWarsQueryTest extends Specification {
         ]
 
         when:
-        def result = new GraphQL(StarWarsSchema.starWarsSchema).execute(query).data
+        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query).data
 
         then:
         result == expected
@@ -59,7 +59,7 @@ class StarWarsQueryTest extends Specification {
         ]
 
         when:
-        def result = new GraphQL(StarWarsSchema.starWarsSchema).execute(query).data
+        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query).data
 
         then:
         result == expected
@@ -142,7 +142,7 @@ class StarWarsQueryTest extends Specification {
         ]
 
         when:
-        def result = new GraphQL(StarWarsSchema.starWarsSchema).execute(query).data
+        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query).data
 
         then:
         result == expected
@@ -166,7 +166,7 @@ class StarWarsQueryTest extends Specification {
         ]
 
         when:
-        def result = new GraphQL(StarWarsSchema.starWarsSchema).execute(query).data
+        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query).data
 
         then:
         result == expected
@@ -190,7 +190,7 @@ class StarWarsQueryTest extends Specification {
                 ]
         ]
         when:
-        def result = new GraphQL(StarWarsSchema.starWarsSchema).execute(query, null, params).data
+        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query, null, params).data
 
         then:
         result == expected
@@ -212,7 +212,7 @@ class StarWarsQueryTest extends Specification {
                 human: null
         ]
         when:
-        def result = new GraphQL(StarWarsSchema.starWarsSchema).execute(query, null, params).data
+        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query, null, params).data
 
         then:
         result == expected
@@ -235,7 +235,7 @@ class StarWarsQueryTest extends Specification {
         ]
 
         when:
-        def result = new GraphQL(StarWarsSchema.starWarsSchema).execute(query).data
+        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query).data
 
         then:
         result == expected
@@ -268,7 +268,7 @@ class StarWarsQueryTest extends Specification {
         ]
 
         when:
-        def result = new GraphQL(StarWarsSchema.starWarsSchema).execute(query).data
+        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query).data
 
         then:
         result == expected
@@ -301,7 +301,7 @@ class StarWarsQueryTest extends Specification {
         ];
 
         when:
-        def result = new GraphQL(StarWarsSchema.starWarsSchema).execute(query).data
+        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query).data
 
         then:
         result == expected
@@ -335,7 +335,7 @@ class StarWarsQueryTest extends Specification {
                 ]
         ];
         when:
-        def result = new GraphQL(StarWarsSchema.starWarsSchema).execute(query).data
+        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query).data
 
         then:
         result == expected
@@ -358,7 +358,7 @@ class StarWarsQueryTest extends Specification {
                 ],
         ]
         when:
-        def result = new GraphQL(StarWarsSchema.starWarsSchema).execute(query).data
+        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query).data
 
         then:
         result == expected

--- a/src/test/groovy/graphql/StarWarsQueryTest.groovy
+++ b/src/test/groovy/graphql/StarWarsQueryTest.groovy
@@ -20,7 +20,7 @@ class StarWarsQueryTest extends Specification {
         ]
 
         when:
-        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query).data
+        def result = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema).build().execute(query).data
 
         then:
         result == expected
@@ -59,7 +59,7 @@ class StarWarsQueryTest extends Specification {
         ]
 
         when:
-        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query).data
+        def result = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema).build().execute(query).data
 
         then:
         result == expected
@@ -142,7 +142,7 @@ class StarWarsQueryTest extends Specification {
         ]
 
         when:
-        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query).data
+        def result = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema).build().execute(query).data
 
         then:
         result == expected
@@ -166,7 +166,7 @@ class StarWarsQueryTest extends Specification {
         ]
 
         when:
-        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query).data
+        def result = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema).build().execute(query).data
 
         then:
         result == expected
@@ -190,7 +190,7 @@ class StarWarsQueryTest extends Specification {
                 ]
         ]
         when:
-        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query, null, params).data
+        def result = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema).build().execute(query, null, params).data
 
         then:
         result == expected
@@ -212,7 +212,7 @@ class StarWarsQueryTest extends Specification {
                 human: null
         ]
         when:
-        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query, null, params).data
+        def result = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema).build().execute(query, null, params).data
 
         then:
         result == expected
@@ -235,7 +235,7 @@ class StarWarsQueryTest extends Specification {
         ]
 
         when:
-        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query).data
+        def result = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema).build().execute(query).data
 
         then:
         result == expected
@@ -268,7 +268,7 @@ class StarWarsQueryTest extends Specification {
         ]
 
         when:
-        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query).data
+        def result = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema).build().execute(query).data
 
         then:
         result == expected
@@ -301,7 +301,7 @@ class StarWarsQueryTest extends Specification {
         ];
 
         when:
-        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query).data
+        def result = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema).build().execute(query).data
 
         then:
         result == expected
@@ -335,7 +335,7 @@ class StarWarsQueryTest extends Specification {
                 ]
         ];
         when:
-        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query).data
+        def result = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema).build().execute(query).data
 
         then:
         result == expected
@@ -358,7 +358,7 @@ class StarWarsQueryTest extends Specification {
                 ],
         ]
         when:
-        def result = GraphQL.newObject(StarWarsSchema.starWarsSchema).build().execute(query).data
+        def result = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema).build().execute(query).data
 
         then:
         result == expected

--- a/src/test/groovy/graphql/UnionTest.groovy
+++ b/src/test/groovy/graphql/UnionTest.groovy
@@ -58,7 +58,7 @@ class UnionTest extends Specification {
                               ]
         ]
         when:
-        def executionResult = new GraphQL(GarfieldSchema.GarfieldSchema).execute(query)
+        def executionResult = GraphQL.newObject(GarfieldSchema.GarfieldSchema).build().execute(query)
 
         then:
         executionResult.data == expectedResult
@@ -96,7 +96,7 @@ class UnionTest extends Specification {
         ]
 
         when:
-        def executionResult = new GraphQL(GarfieldSchema.GarfieldSchema).execute(query, GarfieldSchema.john)
+        def executionResult = GraphQL.newObject(GarfieldSchema.GarfieldSchema).build().execute(query, GarfieldSchema.john)
 
         then:
         executionResult.data == expectedResult
@@ -148,7 +148,7 @@ class UnionTest extends Specification {
                 ]
         ]
         when:
-        def executionResult = new GraphQL(GarfieldSchema.GarfieldSchema).execute(query, GarfieldSchema.john)
+        def executionResult = GraphQL.newObject(GarfieldSchema.GarfieldSchema).build().execute(query, GarfieldSchema.john)
 
         then:
         executionResult.data == expectedResult

--- a/src/test/groovy/graphql/UnionTest.groovy
+++ b/src/test/groovy/graphql/UnionTest.groovy
@@ -58,7 +58,7 @@ class UnionTest extends Specification {
                               ]
         ]
         when:
-        def executionResult = GraphQL.newObject(GarfieldSchema.GarfieldSchema).build().execute(query)
+        def executionResult = GraphQL.newGraphQL(GarfieldSchema.GarfieldSchema).build().execute(query)
 
         then:
         executionResult.data == expectedResult
@@ -96,7 +96,7 @@ class UnionTest extends Specification {
         ]
 
         when:
-        def executionResult = GraphQL.newObject(GarfieldSchema.GarfieldSchema).build().execute(query, GarfieldSchema.john)
+        def executionResult = GraphQL.newGraphQL(GarfieldSchema.GarfieldSchema).build().execute(query, GarfieldSchema.john)
 
         then:
         executionResult.data == expectedResult
@@ -148,7 +148,7 @@ class UnionTest extends Specification {
                 ]
         ]
         when:
-        def executionResult = GraphQL.newObject(GarfieldSchema.GarfieldSchema).build().execute(query, GarfieldSchema.john)
+        def executionResult = GraphQL.newGraphQL(GarfieldSchema.GarfieldSchema).build().execute(query, GarfieldSchema.john)
 
         then:
         executionResult.data == expectedResult

--- a/src/test/groovy/graphql/execution/ExecutorServiceExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutorServiceExecutionStrategyTest.groovy
@@ -63,7 +63,10 @@ class ExecutorServiceExecutionStrategyTest extends Specification {
                  */
                 new ThreadPoolExecutor.CallerRunsPolicy());
 
-        def result = new GraphQL(StarWarsSchema.starWarsSchema, new ExecutorServiceExecutionStrategy(threadPoolExecutor)).execute(query).data
+        def graphQL = GraphQL.newObject(StarWarsSchema.starWarsSchema)
+                .executionStrategy(new ExecutorServiceExecutionStrategy(threadPoolExecutor))
+                .build()
+        def result = graphQL.execute(query).data
 
         then:
         result == expected

--- a/src/test/groovy/graphql/execution/ExecutorServiceExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutorServiceExecutionStrategyTest.groovy
@@ -63,7 +63,7 @@ class ExecutorServiceExecutionStrategyTest extends Specification {
                  */
                 new ThreadPoolExecutor.CallerRunsPolicy());
 
-        def graphQL = GraphQL.newObject(StarWarsSchema.starWarsSchema)
+        def graphQL = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema)
                 .queryExecutionStrategy(new ExecutorServiceExecutionStrategy(threadPoolExecutor))
                 .build()
         def result = graphQL.execute(query).data

--- a/src/test/groovy/graphql/execution/ExecutorServiceExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutorServiceExecutionStrategyTest.groovy
@@ -64,7 +64,7 @@ class ExecutorServiceExecutionStrategyTest extends Specification {
                 new ThreadPoolExecutor.CallerRunsPolicy());
 
         def graphQL = GraphQL.newObject(StarWarsSchema.starWarsSchema)
-                .executionStrategy(new ExecutorServiceExecutionStrategy(threadPoolExecutor))
+                .queryExecutionStrategy(new ExecutorServiceExecutionStrategy(threadPoolExecutor))
                 .build()
         def result = graphQL.execute(query).data
 

--- a/src/test/groovy/graphql/execution/batched/GraphqlExecutionSpec.groovy
+++ b/src/test/groovy/graphql/execution/batched/GraphqlExecutionSpec.groovy
@@ -18,10 +18,19 @@ import java.util.concurrent.atomic.AtomicInteger
 class GraphqlExecutionSpec extends Specification {
 
     private GraphQLSchema schema = new FunWithStringsSchemaFactory().createSchema();
-    private GraphQL graphQLSimple = new GraphQL(this.schema, new SimpleExecutionStrategy());
-    private GraphQL graphQLBatchedButUnbatched = new GraphQL(this.schema, new BatchedExecutionStrategy());
+
+    private GraphQL graphQLSimple = GraphQL.newObject(schema)
+            .executionStrategy(new SimpleExecutionStrategy())
+            .build()
+
+    private GraphQL graphQLBatchedButUnbatched = GraphQL.newObject(this.schema)
+            .executionStrategy(new BatchedExecutionStrategy())
+            .build()
+
     private Map<FunWithStringsSchemaFactory.CallType, AtomicInteger> countMap = new HashMap<>();
-    private GraphQL graphQLBatchedValue = new GraphQL(FunWithStringsSchemaFactory.createBatched(countMap).createSchema(), new BatchedExecutionStrategy());
+    private GraphQL graphQLBatchedValue = GraphQL.newObject(FunWithStringsSchemaFactory.createBatched(countMap).createSchema())
+            .executionStrategy(new BatchedExecutionStrategy())
+            .build()
 
     private Map<String, Object> nullValueMap = new HashMap<>();
 
@@ -415,7 +424,7 @@ class GraphqlExecutionSpec extends Specification {
                 }"""
 
         expect:
-        Arrays.asList(this.graphQLSimple, this.graphQLBatchedButUnbatched,this.graphQLBatchedValue).each { GraphQL graphQL ->
+        Arrays.asList(this.graphQLSimple, this.graphQLBatchedButUnbatched, this.graphQLBatchedValue).each { GraphQL graphQL ->
             Map<String, Object> response = graphQL.execute(query).getData() as Map<String, Object>;
             Map<String, Object> values = (response.get("string") as Map<String, Object>).get("append") as Map<String, Object>;
             assert Arrays.asList("v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9") == values.keySet().toList();

--- a/src/test/groovy/graphql/execution/batched/GraphqlExecutionSpec.groovy
+++ b/src/test/groovy/graphql/execution/batched/GraphqlExecutionSpec.groovy
@@ -20,16 +20,16 @@ class GraphqlExecutionSpec extends Specification {
     private GraphQLSchema schema = new FunWithStringsSchemaFactory().createSchema();
 
     private GraphQL graphQLSimple = GraphQL.newObject(schema)
-            .executionStrategy(new SimpleExecutionStrategy())
+            .queryExecutionStrategy(new SimpleExecutionStrategy())
             .build()
 
     private GraphQL graphQLBatchedButUnbatched = GraphQL.newObject(this.schema)
-            .executionStrategy(new BatchedExecutionStrategy())
+            .queryExecutionStrategy(new BatchedExecutionStrategy())
             .build()
 
     private Map<FunWithStringsSchemaFactory.CallType, AtomicInteger> countMap = new HashMap<>();
     private GraphQL graphQLBatchedValue = GraphQL.newObject(FunWithStringsSchemaFactory.createBatched(countMap).createSchema())
-            .executionStrategy(new BatchedExecutionStrategy())
+            .queryExecutionStrategy(new BatchedExecutionStrategy())
             .build()
 
     private Map<String, Object> nullValueMap = new HashMap<>();

--- a/src/test/groovy/graphql/execution/batched/GraphqlExecutionSpec.groovy
+++ b/src/test/groovy/graphql/execution/batched/GraphqlExecutionSpec.groovy
@@ -19,16 +19,16 @@ class GraphqlExecutionSpec extends Specification {
 
     private GraphQLSchema schema = new FunWithStringsSchemaFactory().createSchema();
 
-    private GraphQL graphQLSimple = GraphQL.newObject(schema)
+    private GraphQL graphQLSimple = GraphQL.newGraphQL(schema)
             .queryExecutionStrategy(new SimpleExecutionStrategy())
             .build()
 
-    private GraphQL graphQLBatchedButUnbatched = GraphQL.newObject(this.schema)
+    private GraphQL graphQLBatchedButUnbatched = GraphQL.newGraphQL(this.schema)
             .queryExecutionStrategy(new BatchedExecutionStrategy())
             .build()
 
     private Map<FunWithStringsSchemaFactory.CallType, AtomicInteger> countMap = new HashMap<>();
-    private GraphQL graphQLBatchedValue = GraphQL.newObject(FunWithStringsSchemaFactory.createBatched(countMap).createSchema())
+    private GraphQL graphQLBatchedValue = GraphQL.newGraphQL(FunWithStringsSchemaFactory.createBatched(countMap).createSchema())
             .queryExecutionStrategy(new BatchedExecutionStrategy())
             .build()
 

--- a/src/test/groovy/readme/ReadmeExamples.java
+++ b/src/test/groovy/readme/ReadmeExamples.java
@@ -1,0 +1,179 @@
+package readme;
+
+import graphql.GarfieldSchema;
+import graphql.GraphQL;
+import graphql.StarWarsSchema;
+import graphql.execution.ExecutorServiceExecutionStrategy;
+import graphql.execution.SimpleExecutionStrategy;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLEnumType;
+import graphql.schema.GraphQLInputObjectType;
+import graphql.schema.GraphQLInterfaceType;
+import graphql.schema.GraphQLList;
+import graphql.schema.GraphQLNonNull;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLTypeReference;
+import graphql.schema.GraphQLUnionType;
+import graphql.schema.TypeResolver;
+
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import static graphql.GarfieldSchema.CatType;
+import static graphql.GarfieldSchema.DogType;
+import static graphql.MutationSchema.mutationType;
+import static graphql.Scalars.GraphQLBoolean;
+import static graphql.Scalars.GraphQLString;
+import static graphql.StarWarsSchema.queryType;
+import static graphql.schema.GraphQLEnumType.newEnum;
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
+import static graphql.schema.GraphQLInputObjectField.newInputObjectField;
+import static graphql.schema.GraphQLInputObjectType.newInputObject;
+import static graphql.schema.GraphQLInterfaceType.newInterface;
+import static graphql.schema.GraphQLObjectType.newObject;
+import static graphql.schema.GraphQLUnionType.newUnionType;
+
+/**
+ * This class holds readme examples so they stay correct and can be compiled.  If this
+ * does not compile, chances are the readme examples are now wrong.
+ */
+public class ReadmeExamples {
+
+    class Foo {
+    }
+
+    void creatingASchema() {
+        GraphQLSchema schema = GraphQLSchema.newSchema()
+                .query(queryType) // must be provided
+                .mutation(mutationType) // is optional
+                .build();
+    }
+
+    void listsAndNonNullLists() {
+        new GraphQLList(GraphQLString); // a list of Strings
+
+        new GraphQLNonNull(GraphQLString); // a non null String
+    }
+
+    void newType() {
+        GraphQLObjectType simpsonCharacter = newObject()
+                .name("SimpsonCharacter")
+                .description("A Simpson character")
+                .field(newFieldDefinition()
+                        .name("name")
+                        .description("The name of the character.")
+                        .type(GraphQLString))
+                .field(newFieldDefinition()
+                        .name("mainCharacter")
+                        .description("One of the main Simpson characters?")
+                        .type(GraphQLBoolean))
+                .build();
+    }
+
+    void interfaceType() {
+        GraphQLInterfaceType comicCharacter = newInterface()
+                .name("ComicCharacter")
+                .description("A abstract comic character.")
+                .field(newFieldDefinition()
+                        .name("name")
+                        .description("The name of the character.")
+                        .type(GraphQLString))
+                .build();
+    }
+
+    void inputTypes() {
+        GraphQLInputObjectType inputObjectType = newInputObject()
+                .name("inputObjectType")
+                .field(newInputObjectField()
+                        .name("field")
+                        .type(GraphQLString))
+                .build();
+    }
+
+    void enumTypes() {
+        GraphQLEnumType colorEnum = newEnum()
+                .name("Color")
+                .description("Supported colors.")
+                .value("RED")
+                .value("GREEN")
+                .value("BLUE")
+                .build();
+    }
+
+    void unionType() {
+        GraphQLUnionType PetType = newUnionType()
+                .name("Pet")
+                .possibleType(CatType)
+                .possibleType(DogType)
+                .typeResolver(new TypeResolver() {
+                    @Override
+                    public GraphQLObjectType getType(Object object) {
+                        if (object instanceof GarfieldSchema.Cat) {
+                            return CatType;
+                        }
+                        if (object instanceof GarfieldSchema.Dog) {
+                            return DogType;
+                        }
+                        return null;
+                    }
+                })
+                .build();
+    }
+
+
+    void recursiveTypes() {
+
+        GraphQLObjectType person = newObject()
+                .name("Person")
+                .field(newFieldDefinition()
+                        .name("friends")
+                        .type(new GraphQLList(new GraphQLTypeReference("Person"))))
+                .build();
+    }
+
+    void executionStrategies() {
+
+        ThreadPoolExecutor threadPoolExecutor = new ThreadPoolExecutor(
+                2, /* core pool size 2 thread */
+                2, /* max pool size 2 thread */
+                30, TimeUnit.SECONDS,
+                new LinkedBlockingQueue<Runnable>(),
+                new ThreadPoolExecutor.CallerRunsPolicy());
+
+        GraphQL graphQL = GraphQL.newObject(StarWarsSchema.starWarsSchema)
+                .queryExecutionStrategy(new ExecutorServiceExecutionStrategy(threadPoolExecutor))
+                .mutationExecutionStrategy(new SimpleExecutionStrategy())
+                .build();
+
+    }
+
+    void dataFetching() {
+
+        DataFetcher<Foo> fooDataFetcher = new DataFetcher<Foo>() {
+            @Override
+            public Foo get(DataFetchingEnvironment environment) {
+                // environment.getSource() is the value of the surrounding
+                // object. In this case described by objectType
+                Foo value = perhapsFromDatabase(); // Perhaps getting from a DB or whatever
+                return value;
+            }
+        };
+
+        GraphQLObjectType objectType = newObject()
+                .name("ObjectType")
+                .field(newFieldDefinition()
+                        .name("foo")
+                        .type(GraphQLString)
+                        .dataFetcher(fooDataFetcher))
+                .build();
+
+    }
+
+    private Foo perhapsFromDatabase() {
+        return new Foo();
+    }
+
+}

--- a/src/test/groovy/readme/ReadmeExamples.java
+++ b/src/test/groovy/readme/ReadmeExamples.java
@@ -143,7 +143,7 @@ public class ReadmeExamples {
                 new LinkedBlockingQueue<Runnable>(),
                 new ThreadPoolExecutor.CallerRunsPolicy());
 
-        GraphQL graphQL = GraphQL.newObject(StarWarsSchema.starWarsSchema)
+        GraphQL graphQL = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema)
                 .queryExecutionStrategy(new ExecutorServiceExecutionStrategy(threadPoolExecutor))
                 .mutationExecutionStrategy(new SimpleExecutionStrategy())
                 .build();


### PR DESCRIPTION
#273 - to allow consistency with other parts of the API and extensibility in the future, the builder pattern should be used on the GraphQL object