### PR TITLE
278 unique query idenitifer

### DIFF
--- a/src/main/java/graphql/Assert.java
+++ b/src/main/java/graphql/Assert.java
@@ -5,14 +5,14 @@ import java.util.Collection;
 public class Assert {
 
 
-    public static void assertNotNull(Object object, String errorMessage) {
-        if (object != null) return;
+    public static <T> T assertNotNull(T object, String errorMessage) {
+        if (object != null) return object;
         throw new AssertException(errorMessage);
     }
 
-    public static void assertNotEmpty(Collection<?> c, String errorMessage) {
+    public static <T> Collection<T> assertNotEmpty(Collection<T> c, String errorMessage) {
         if (c == null || c.isEmpty()) throw new AssertException(errorMessage);
-        return;
+        return c;
     }
 
 }

--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -16,7 +16,6 @@ import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -33,7 +32,7 @@ public class GraphQL {
     // later PR changes will allow api consumers to provide their own id provider
     //
     // see https://github.com/graphql-java/graphql-java/pull/276 for the builder pattern
-    // needed to make this sustainable.  But for now we will use hard coded approach.
+    // needed to make this sustainable.  But for now we will use a hard coded approach.
     //
     private final ExecutionIdProvider idProvider = new ExecutionIdProvider() {
         @Override

--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -36,7 +36,7 @@ public class GraphQL {
     //
     private final ExecutionIdProvider idProvider = new ExecutionIdProvider() {
         @Override
-        public ExecutionId generate(String query, String operationName, Object context) {
+        public ExecutionId provide(String query, String operationName, Object context) {
             return ExecutionId.generate();
         }
     };
@@ -93,7 +93,7 @@ public class GraphQL {
         if (validationErrors.size() > 0) {
             return new ExecutionResultImpl(validationErrors);
         }
-        ExecutionId executionId = idProvider.generate(requestString, operationName, context);
+        ExecutionId executionId = idProvider.provide(requestString, operationName, context);
 
         Execution execution = new Execution(queryStrategy, mutationStrategy);
         return execution.execute(executionId, graphQLSchema, context, document, operationName, arguments);

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -16,20 +16,19 @@ import java.util.Map;
 
 public class Execution {
 
-    private FieldCollector fieldCollector = new FieldCollector();
-    private ExecutionStrategy strategy;
+    private final FieldCollector fieldCollector = new FieldCollector();
+    private final ExecutionStrategy strategy;
 
-    public Execution(ExecutionStrategy strategy) {
-        this.strategy = strategy;
-
-        if (this.strategy == null) {
-            this.strategy = new SimpleExecutionStrategy();
-        }
+    public Execution(ExecutionStrategy executionStrategy) {
+        this.strategy = executionStrategy == null ? new SimpleExecutionStrategy() : executionStrategy;
     }
 
-    public ExecutionResult execute(GraphQLSchema graphQLSchema, Object root, Document document, String operationName, Map<String, Object> args) {
+    public ExecutionResult execute(ExecutionId executionId, GraphQLSchema graphQLSchema, Object root, Document document, String operationName, Map<String, Object> args) {
         ExecutionContextBuilder executionContextBuilder = new ExecutionContextBuilder(new ValuesResolver());
-        ExecutionContext executionContext = executionContextBuilder.build(graphQLSchema, strategy, root, document, operationName, args);
+        ExecutionContext executionContext = executionContextBuilder
+                .executionId(executionId)
+                .build(graphQLSchema, strategy, root, document, operationName, args);
+
         return executeOperation(executionContext, root, executionContext.getOperationDefinition());
     }
 

--- a/src/main/java/graphql/execution/ExecutionContext.java
+++ b/src/main/java/graphql/execution/ExecutionContext.java
@@ -22,7 +22,7 @@ public class ExecutionContext {
     private final Object root;
     private final List<GraphQLError> errors = new CopyOnWriteArrayList<GraphQLError>();
 
-    public ExecutionContext(GraphQLSchema graphQLSchema, ExecutionId executionId, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy, Map<String, FragmentDefinition> fragmentsByName, OperationDefinition operationDefinition, Map<String, Object> variables, Object root) {
+    public ExecutionContext(ExecutionId executionId, GraphQLSchema graphQLSchema, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy, Map<String, FragmentDefinition> fragmentsByName, OperationDefinition operationDefinition, Map<String, Object> variables, Object root) {
         this.graphQLSchema = graphQLSchema;
         this.executionId = executionId;
         this.queryStrategy = queryStrategy;
@@ -33,12 +33,12 @@ public class ExecutionContext {
         this.root = root;
     }
 
-    public GraphQLSchema getGraphQLSchema() {
-        return graphQLSchema;
-    }
-
     public ExecutionId getExecutionId() {
         return executionId;
+    }
+
+    public GraphQLSchema getGraphQLSchema() {
+        return graphQLSchema;
     }
 
     public Map<String, FragmentDefinition> getFragmentsByName() {

--- a/src/main/java/graphql/execution/ExecutionContext.java
+++ b/src/main/java/graphql/execution/ExecutionContext.java
@@ -6,7 +6,6 @@ import graphql.language.FragmentDefinition;
 import graphql.language.OperationDefinition;
 import graphql.schema.GraphQLSchema;
 
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -14,6 +13,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public class ExecutionContext {
 
     private final GraphQLSchema graphQLSchema;
+    private final ExecutionId executionId;
     private final ExecutionStrategy executionStrategy;
     private final Map<String, FragmentDefinition> fragmentsByName;
     private final OperationDefinition operationDefinition;
@@ -21,8 +21,9 @@ public class ExecutionContext {
     private final Object root;
     private final List<GraphQLError> errors = new CopyOnWriteArrayList<GraphQLError>();
 
-    public ExecutionContext(GraphQLSchema graphQLSchema, ExecutionStrategy executionStrategy, Map<String, FragmentDefinition> fragmentsByName, OperationDefinition operationDefinition, Map<String, Object> variables, Object root) {
+    public ExecutionContext(GraphQLSchema graphQLSchema, ExecutionId executionId, ExecutionStrategy executionStrategy, Map<String, FragmentDefinition> fragmentsByName, OperationDefinition operationDefinition, Map<String, Object> variables, Object root) {
         this.graphQLSchema = graphQLSchema;
+        this.executionId = executionId;
         this.executionStrategy = executionStrategy;
         this.fragmentsByName = fragmentsByName;
         this.operationDefinition = operationDefinition;
@@ -32,6 +33,10 @@ public class ExecutionContext {
 
     public GraphQLSchema getGraphQLSchema() {
         return graphQLSchema;
+    }
+
+    public ExecutionId getExecutionId() {
+        return executionId;
     }
 
     public Map<String, FragmentDefinition> getFragmentsByName() {

--- a/src/main/java/graphql/execution/ExecutionContextBuilder.java
+++ b/src/main/java/graphql/execution/ExecutionContextBuilder.java
@@ -1,6 +1,5 @@
 package graphql.execution;
 
-import graphql.Assert;
 import graphql.GraphQLException;
 import graphql.language.Definition;
 import graphql.language.Document;
@@ -61,8 +60,8 @@ public class ExecutionContextBuilder {
         Map<String, Object> variableValues = valuesResolver.getVariableValues(graphQLSchema, operation.getVariableDefinitions(), args);
 
         return new ExecutionContext(
-                graphQLSchema,
                 executionId,
+                graphQLSchema,
                 queryStrategy,
                 mutationStrategy,
                 fragmentsByName,

--- a/src/main/java/graphql/execution/ExecutionContextBuilder.java
+++ b/src/main/java/graphql/execution/ExecutionContextBuilder.java
@@ -1,5 +1,6 @@
 package graphql.execution;
 
+import graphql.Assert;
 import graphql.GraphQLException;
 import graphql.language.Definition;
 import graphql.language.Document;
@@ -10,15 +11,27 @@ import graphql.schema.GraphQLSchema;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import static graphql.Assert.assertNotNull;
+
 public class ExecutionContextBuilder {
 
     private ValuesResolver valuesResolver;
+
+    private ExecutionId executionId;
 
     public ExecutionContextBuilder(ValuesResolver valuesResolver) {
         this.valuesResolver = valuesResolver;
     }
 
+    public ExecutionContextBuilder executionId(ExecutionId executionId) {
+        this.executionId = executionId;
+        return this;
+    }
+
     public ExecutionContext build(GraphQLSchema graphQLSchema, ExecutionStrategy executionStrategy, Object root, Document document, String operationName, Map<String, Object> args) {
+        // preconditions
+        assertNotNull(executionId,"You must provide a query identifier");
+
         Map<String, FragmentDefinition> fragmentsByName = new LinkedHashMap<String, FragmentDefinition>();
         Map<String, OperationDefinition> operationsByName = new LinkedHashMap<String, OperationDefinition>();
 
@@ -50,6 +63,7 @@ public class ExecutionContextBuilder {
 
         return new ExecutionContext(
                 graphQLSchema,
+                executionId,
                 executionStrategy,
                 fragmentsByName,
                 operation,

--- a/src/main/java/graphql/execution/ExecutionContextBuilder.java
+++ b/src/main/java/graphql/execution/ExecutionContextBuilder.java
@@ -31,6 +31,7 @@ public class ExecutionContextBuilder {
     public ExecutionContext build(GraphQLSchema graphQLSchema, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy, Object root, Document document, String operationName, Map<String, Object> args) {
         // preconditions
         assertNotNull(executionId,"You must provide a query identifier");
+
         Map<String, FragmentDefinition> fragmentsByName = new LinkedHashMap<String, FragmentDefinition>();
         Map<String, OperationDefinition> operationsByName = new LinkedHashMap<String, OperationDefinition>();
 

--- a/src/main/java/graphql/execution/ExecutionId.java
+++ b/src/main/java/graphql/execution/ExecutionId.java
@@ -10,8 +10,8 @@ import java.util.UUID;
 public class ExecutionId {
 
     /**
-     * Create an identifier from the given string
-     * @return a query identifier
+     * Create an unique identifier from the given string
+     * @return a query execution identifier
      */
     public static ExecutionId generate() {
         return new ExecutionId(UUID.randomUUID().toString());
@@ -22,7 +22,7 @@ public class ExecutionId {
      * @param id the string to wrap
      * @return a query identifier
      */
-    public static ExecutionId generateFrom(String id) {
+    public static ExecutionId from(String id) {
         return new ExecutionId(id);
     }
 

--- a/src/main/java/graphql/execution/ExecutionId.java
+++ b/src/main/java/graphql/execution/ExecutionId.java
@@ -1,0 +1,55 @@
+package graphql.execution;
+
+import graphql.Assert;
+
+import java.util.UUID;
+
+/**
+ * This opaque identifier is used to identify a unique query execution
+ */
+public class ExecutionId {
+
+    /**
+     * Create an identifier from the given string
+     * @return a query identifier
+     */
+    public static ExecutionId generate() {
+        return new ExecutionId(UUID.randomUUID().toString());
+    }
+
+    /**
+     * Create an identifier from the given string
+     * @param id the string to wrap
+     * @return a query identifier
+     */
+    public static ExecutionId generateFrom(String id) {
+        return new ExecutionId(id);
+    }
+
+    private final String id;
+
+    private ExecutionId(String id) {
+        Assert.assertNotNull(id, "You must provided a non null id");
+        this.id = id;
+    }
+
+    @Override
+    public String toString() {
+        return id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ExecutionId that = (ExecutionId) o;
+
+        return id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+}

--- a/src/main/java/graphql/execution/ExecutionIdProvider.java
+++ b/src/main/java/graphql/execution/ExecutionIdProvider.java
@@ -11,6 +11,7 @@ public interface ExecutionIdProvider {
      * @param query         the query to be executed
      * @param operationName thr name of the operation
      * @param context       the context object passed to the query
+     *
      * @return a non null {@link ExecutionId}
      */
     ExecutionId provide(String query, String operationName, Object context);

--- a/src/main/java/graphql/execution/ExecutionIdProvider.java
+++ b/src/main/java/graphql/execution/ExecutionIdProvider.java
@@ -6,12 +6,12 @@ package graphql.execution;
 public interface ExecutionIdProvider {
 
     /**
-     * Allows generation of a unique identifier per query execution
+     * Allows provision of a unique identifier per query execution.
      *
      * @param query         the query to be executed
      * @param operationName thr name of the operation
      * @param context       the context object passed to the query
      * @return a non null {@link ExecutionId}
      */
-    ExecutionId generate(String query, String operationName, Object context);
+    ExecutionId provide(String query, String operationName, Object context);
 }

--- a/src/main/java/graphql/execution/ExecutionIdProvider.java
+++ b/src/main/java/graphql/execution/ExecutionIdProvider.java
@@ -1,0 +1,17 @@
+package graphql.execution;
+
+/**
+ * A provider of {@link ExecutionId}s
+ */
+public interface ExecutionIdProvider {
+
+    /**
+     * Allows generation of a unique identifier per query execution
+     *
+     * @param query         the query to be executed
+     * @param operationName thr name of the operation
+     * @param context       the context object passed to the query
+     * @return a non null {@link ExecutionId}
+     */
+    ExecutionId generate(String query, String operationName, Object context);
+}

--- a/src/test/groovy/graphql/execution/ExecutionIdTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionIdTest.groovy
@@ -1,0 +1,42 @@
+package graphql.execution
+
+import graphql.ExecutionResult
+import graphql.GraphQL
+import graphql.StarWarsSchema
+import graphql.language.Field
+import graphql.schema.GraphQLObjectType
+import spock.lang.Specification
+
+class ExecutionIdTest extends Specification {
+
+    class CaptureIdStrategy extends SimpleExecutionStrategy {
+        ExecutionId executionId = null
+
+        @Override
+        ExecutionResult execute(ExecutionContext executionContext, GraphQLObjectType parentType, Object source, Map<String, List<Field>> fields) {
+            executionId = executionContext.executionId
+            return super.execute(executionContext, parentType, source, fields)
+        }
+    }
+
+    def 'Ensures that an execution identifier is present'() {
+        given:
+        def query = """
+        query HeroNameAndFriendsQuery {
+            hero {
+                id
+            }
+        }
+        """
+
+        when:
+
+        CaptureIdStrategy idStrategy = new CaptureIdStrategy()
+
+        new GraphQL(StarWarsSchema.starWarsSchema, idStrategy).execute(query).data
+
+        then:
+
+        idStrategy.executionId != null
+    }
+}

--- a/src/test/groovy/graphql/execution/ExecutionStrategySpec.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategySpec.groovy
@@ -21,7 +21,7 @@ class ExecutionStrategySpec extends Specification {
     }
 
     def buildContext() {
-        new ExecutionContext(null,executionStrategy,null,null,null,null)
+        new ExecutionContext(null, null, executionStrategy, null, null, null, null)
     }
 
     def "completes value for a java.util.List"() {

--- a/src/test/groovy/graphql/execution/ExecutionStrategySpec.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategySpec.groovy
@@ -21,7 +21,7 @@ class ExecutionStrategySpec extends Specification {
     }
 
     def buildContext() {
-        new ExecutionContext(null,null, executionStrategy,executionStrategy,null,null,null,null)
+        new ExecutionContext(null, null, executionStrategy, executionStrategy, null, null, null, null)
     }
 
     def "completes value for a java.util.List"() {

--- a/src/test/groovy/graphql/execution/ExecutionTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionTest.groovy
@@ -28,7 +28,7 @@ class ExecutionTest extends Specification {
         def document = parser.parseDocument(query)
 
         when:
-        execution.execute(MutationSchema.schema, null, document, null, null)
+        execution.execute(ExecutionId.generate(), MutationSchema.schema, null, document, null, null)
 
         then:
         1 * queryStrategy.execute(*_)
@@ -47,7 +47,7 @@ class ExecutionTest extends Specification {
         def document = parser.parseDocument(query)
 
         when:
-        execution.execute(MutationSchema.schema, null, document, null, null)
+        execution.execute(ExecutionId.generate(), MutationSchema.schema, null, document, null, null)
 
         then:
         0 * queryStrategy.execute(*_)


### PR DESCRIPTION
As per #278  - This provides a unique id in the execution of a graphql query.  A later PR will provide the ability for api consumers to provide their own ExecutionIds but this gets you 90% on the way