### PR TITLE
Asynchronous execution strategy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-import java.text.SimpleDateFormat
-
 plugins {
     id "com.jfrog.bintray" version "1.2"
 }
@@ -10,10 +8,11 @@ apply plugin: 'maven-publish'
 apply plugin: 'antlr'
 apply plugin: 'jacoco'
 
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 def releaseVersion = System.properties.RELEASE_VERSION
-version = releaseVersion ? releaseVersion : new SimpleDateFormat('yyyy-MM-dd\'T\'HH-mm-ss').format(new Date())
+version = "3.0.0-SNAPSHOT"
+//version = releaseVersion ? releaseVersion : new SimpleDateFormat('yyyy-MM-dd\'T\'HH-mm-ss').format(new Date())
 group = 'com.graphql-java'
 
 
@@ -30,12 +29,14 @@ jar {
 dependencies {
     compile 'org.antlr:antlr4-runtime:4.5.1'
     compile 'org.slf4j:slf4j-api:1.7.12'
+    compile 'com.spotify:completable-futures:0.3.0'
     antlr "org.antlr:antlr4:4.5.1"
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'
     testCompile 'org.codehaus.groovy:groovy-all:2.4.4'
     testCompile 'cglib:cglib-nodep:3.1'
     testCompile 'org.objenesis:objenesis:2.1'
+    testCompile 'org.slf4j:slf4j-log4j12:1.7.21'
 }
 
 compileJava.source file("build/generated-src"), sourceSets.main.java

--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletionStage;
 
 import static graphql.Assert.assertNotNull;
 
@@ -34,11 +35,10 @@ public class GraphQL {
         }
     };
 
-    private final GraphQLSchema graphQLSchema;
-    private final ExecutionStrategy queryStrategy;
-    private final ExecutionStrategy mutationStrategy;
-    private final ExecutionIdProvider idProvider;
-
+    protected final GraphQLSchema graphQLSchema;
+    protected final ExecutionStrategy queryStrategy;
+    protected final ExecutionStrategy mutationStrategy;
+    protected final ExecutionIdProvider idProvider;
 
     /**
      * A GraphQL object ready to execute queries

--- a/src/main/java/graphql/GraphQLAsync.java
+++ b/src/main/java/graphql/GraphQLAsync.java
@@ -1,0 +1,86 @@
+package graphql;
+
+import graphql.execution.AsyncExecution;
+import graphql.execution.Execution;
+import graphql.execution.ExecutionStrategy;
+import graphql.language.Document;
+import graphql.language.SourceLocation;
+import graphql.parser.Parser;
+import graphql.schema.GraphQLSchema;
+import graphql.validation.ValidationError;
+import graphql.validation.Validator;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.misc.ParseCancellationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+
+import static graphql.Assert.assertNotNull;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+public class GraphQLAsync extends GraphQL {
+
+    private static Logger log = LoggerFactory.getLogger(GraphQLAsync.class);
+
+    public GraphQLAsync(GraphQLSchema graphQLSchema) {
+        super(graphQLSchema);
+    }
+
+    public GraphQLAsync(GraphQLSchema graphQLSchema, ExecutionStrategy queryStrategy) {
+        super(graphQLSchema, queryStrategy);
+    }
+
+    public GraphQLAsync(GraphQLSchema graphQLSchema, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy) {
+        super(graphQLSchema, queryStrategy, mutationStrategy);
+    }
+
+    public CompletionStage<ExecutionResult> executeAsync(String requestString) {
+        return executeAsync(requestString, null);
+
+    }
+
+    public CompletionStage<ExecutionResult> executeAsync(String requestString, Object context) {
+        return executeAsync(requestString, context, Collections.emptyMap());
+
+    }
+
+    public CompletionStage<ExecutionResult> executeAsync(String requestString, String operationName, Object context) {
+        return executeAsync(requestString, operationName, context, Collections.emptyMap());
+
+    }
+
+    public CompletionStage<ExecutionResult> executeAsync(String requestString, Object context, Map<String, Object> arguments) {
+        return executeAsync(requestString, null, context, arguments);
+
+    }
+
+    @SuppressWarnings("unchecked")
+    public CompletionStage<ExecutionResult> executeAsync(String requestString, String operationName, Object context, Map<String, Object> arguments) {
+
+        assertNotNull(arguments, "arguments can't be null");
+        log.debug("Executing request. operation name: {}. Request: {} ", operationName, requestString);
+        Parser parser = new Parser();
+        Document document;
+        try {
+            document = parser.parseDocument(requestString);
+        } catch (ParseCancellationException e) {
+            RecognitionException recognitionException = (RecognitionException) e.getCause();
+            SourceLocation sourceLocation = new SourceLocation(recognitionException.getOffendingToken().getLine(), recognitionException.getOffendingToken().getCharPositionInLine());
+            InvalidSyntaxError invalidSyntaxError = new InvalidSyntaxError(sourceLocation);
+            return completedFuture(new ExecutionResultImpl(Arrays.asList(invalidSyntaxError)));
+        }
+
+        Validator validator = new Validator();
+        List<ValidationError> validationErrors = validator.validateDocument(graphQLSchema, document);
+        if (validationErrors.size() > 0) {
+            return completedFuture(new ExecutionResultImpl(validationErrors));
+        }
+        AsyncExecution execution = new AsyncExecution(queryStrategy, mutationStrategy);
+        return execution.executeAsync(graphQLSchema, context, document, operationName, arguments);
+    }
+}

--- a/src/main/java/graphql/NonNullException.java
+++ b/src/main/java/graphql/NonNullException.java
@@ -1,0 +1,8 @@
+package graphql;
+
+public class NonNullException extends GraphQLException {
+
+    public NonNullException(String s) {
+        super(s);
+    }
+}

--- a/src/main/java/graphql/execution/AsyncExecution.java
+++ b/src/main/java/graphql/execution/AsyncExecution.java
@@ -1,0 +1,44 @@
+package graphql.execution;
+
+import graphql.ExecutionResult;
+import graphql.execution.async.AsyncExecutionStrategy;
+import graphql.language.Document;
+import graphql.language.Field;
+import graphql.language.OperationDefinition;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLSchema;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+
+public class AsyncExecution extends Execution {
+
+    public AsyncExecution(ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy) {
+        super(queryStrategy, mutationStrategy);
+    }
+
+    public CompletionStage<ExecutionResult> executeAsync(GraphQLSchema graphQLSchema, Object root, Document document, String operationName, Map<String, Object> args) {
+        ExecutionContextBuilder executionContextBuilder = new ExecutionContextBuilder(new ValuesResolver());
+        ExecutionContext executionContext = executionContextBuilder.build(graphQLSchema, queryStrategy, mutationStrategy, root, document, operationName, args);
+        return executeOperationAsync(executionContext, root, executionContext.getOperationDefinition());
+    }
+
+    private CompletionStage<ExecutionResult> executeOperationAsync(
+      ExecutionContext executionContext,
+      Object root,
+      OperationDefinition operationDefinition) {
+        GraphQLObjectType operationRootType = getOperationRootType(executionContext.getGraphQLSchema(), operationDefinition);
+
+        Map<String, List<Field>> fields = new LinkedHashMap<String, List<Field>>();
+        fieldCollector.collectFields(executionContext, operationRootType, operationDefinition.getSelectionSet(), new ArrayList<String>(), fields);
+
+        if (operationDefinition.getOperation() == OperationDefinition.Operation.MUTATION) {
+            return ((AsyncExecutionStrategy) mutationStrategy).executeAsync(executionContext, operationRootType, root, fields);
+        } else {
+            return ((AsyncExecutionStrategy) queryStrategy).executeAsync(executionContext, operationRootType, root, fields);
+        }
+    }
+}

--- a/src/main/java/graphql/execution/AsyncExecution.java
+++ b/src/main/java/graphql/execution/AsyncExecution.java
@@ -22,7 +22,9 @@ public class AsyncExecution extends Execution {
 
     public CompletionStage<ExecutionResult> executeAsync(GraphQLSchema graphQLSchema, Object root, Document document, String operationName, Map<String, Object> args) {
         ExecutionContextBuilder executionContextBuilder = new ExecutionContextBuilder(new ValuesResolver());
-        ExecutionContext executionContext = executionContextBuilder.build(graphQLSchema, queryStrategy, mutationStrategy, root, document, operationName, args);
+        ExecutionContext executionContext = executionContextBuilder
+          .executionId(ExecutionId.generate())
+          .build(graphQLSchema, queryStrategy, mutationStrategy, root, document, operationName, args);
         return executeOperationAsync(executionContext, root, executionContext.getOperationDefinition());
     }
 

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -3,6 +3,7 @@ package graphql.execution;
 
 import graphql.ExecutionResult;
 import graphql.GraphQLException;
+import graphql.execution.async.AsyncExecutionStrategy;
 import graphql.language.Document;
 import graphql.language.Field;
 import graphql.language.OperationDefinition;
@@ -13,12 +14,14 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Stream;
 
 public class Execution {
 
-    private FieldCollector fieldCollector = new FieldCollector();
-    private ExecutionStrategy queryStrategy;
-    private ExecutionStrategy mutationStrategy;
+    protected FieldCollector fieldCollector = new FieldCollector();
+    protected ExecutionStrategy queryStrategy;
+    protected ExecutionStrategy mutationStrategy;
 
     public Execution(ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy) {
         this.queryStrategy = queryStrategy != null ? queryStrategy : new SimpleExecutionStrategy();
@@ -33,7 +36,7 @@ public class Execution {
         return executeOperation(executionContext, root, executionContext.getOperationDefinition());
     }
 
-    private GraphQLObjectType getOperationRootType(GraphQLSchema graphQLSchema, OperationDefinition operationDefinition) {
+    protected GraphQLObjectType getOperationRootType(GraphQLSchema graphQLSchema, OperationDefinition operationDefinition) {
         if (operationDefinition.getOperation() == OperationDefinition.Operation.MUTATION) {
             return graphQLSchema.getMutationType();
 

--- a/src/main/java/graphql/execution/async/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/async/AsyncExecutionStrategy.java
@@ -199,6 +199,9 @@ public final class AsyncExecutionStrategy extends ExecutionStrategy {
         Map<K, V> results = new ConcurrentHashMap<>();
         resolvers.entrySet().forEach(entry -> {
             entry.getValue().get().thenAccept(result -> {
+                if (future.isCompletedExceptionally()) {
+                    return;
+                }
                 K key = entry.getKey();
                 if (!isNull(result)) {
                     results.put(key, result);
@@ -209,6 +212,9 @@ public final class AsyncExecutionStrategy extends ExecutionStrategy {
                     resolvers.keySet().forEach(key1 -> map.put(key1, results.get(key1)));
                     future.complete(map);
                 }
+            }).exceptionally(e -> {
+                future.completeExceptionally(e);
+                return null;
             });
         });
         return future;

--- a/src/main/java/graphql/execution/async/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/async/AsyncExecutionStrategy.java
@@ -1,0 +1,207 @@
+package graphql.execution.async;
+
+import com.spotify.futures.CompletableFutures;
+import graphql.ExceptionWhileDataFetching;
+import graphql.ExecutionResult;
+import graphql.ExecutionResultImpl;
+import graphql.GraphQLException;
+import graphql.execution.ExecutionContext;
+import graphql.execution.ExecutionStrategy;
+import graphql.language.Field;
+import graphql.schema.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.stream.Collectors.toList;
+
+
+public final class AsyncExecutionStrategy extends ExecutionStrategy {
+
+    public static AsyncExecutionStrategy serial() {
+        return new AsyncExecutionStrategy(true);
+    }
+
+    public static AsyncExecutionStrategy parallel() {
+        return new AsyncExecutionStrategy(false);
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(AsyncExecutionStrategy.class);
+
+    private final boolean serial;
+
+    private AsyncExecutionStrategy(boolean serial) {
+        this.serial = serial;
+    }
+
+    @Override
+    public ExecutionResult execute(ExecutionContext executionContext, GraphQLObjectType parentType, Object source, Map<String, List<Field>> fields) {
+        try {
+            return executeAsync(executionContext, parentType, source, fields).toCompletableFuture().get();
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public CompletionStage<ExecutionResult> executeAsync(ExecutionContext executionContext, GraphQLObjectType parentType, Object source, Map<String, List<Field>> fields) {
+
+        Map<String, Supplier<CompletionStage<ExecutionResult>>> fieldsToExecute = fields.keySet()
+          .stream()
+          .collect(Collectors.toMap(
+            Function.identity(),
+            field -> () -> resolveFieldAsync(executionContext, parentType, source, fields.get(field)),
+            (a, b) -> a,
+            LinkedHashMap::new
+          ));
+
+        return executeFields(fieldsToExecute).thenApply(resultMap -> {
+            Map<String, Object> dataMap = new HashMap<>();
+            resultMap.forEach((key, result) -> {
+                dataMap.put(key, result.getData());
+            });
+            return new ExecutionResultImpl(dataMap, executionContext.getErrors());
+        });
+    }
+
+    protected CompletionStage<ExecutionResult> resolveFieldAsync(ExecutionContext executionContext, GraphQLObjectType parentType, Object source, List<Field> fields) {
+        GraphQLFieldDefinition fieldDef = getFieldDef(executionContext.getGraphQLSchema(), parentType, fields.get(0));
+
+        Map<String, Object> argumentValues = valuesResolver.getArgumentValues(fieldDef.getArguments(), fields.get(0).getArguments(), executionContext.getVariables());
+        DataFetchingEnvironment environment = new DataFetchingEnvironment(
+          source,
+          argumentValues,
+          executionContext.getRoot(),
+          fields,
+          fieldDef.getType(),
+          parentType,
+          executionContext.getGraphQLSchema()
+        );
+
+        CompletionStage<?> stage;
+        try {
+            Object resolvedValue = fieldDef.getDataFetcher().get(environment);
+            stage = resolvedValue instanceof CompletionStage ? (CompletionStage<?>) resolvedValue : completedFuture(resolvedValue);
+        } catch (Exception e) {
+            log.warn("Exception while fetching data", e);
+            executionContext.addError(new ExceptionWhileDataFetching(e));
+            stage = completedFuture(null);
+        }
+
+        return stage.exceptionally(e -> {
+            log.warn("Exception while fetching data", e);
+            executionContext.addError(new ExceptionWhileDataFetching(e));
+            return null;
+        }).thenCompose(o -> completeValueAsync(executionContext, fieldDef.getType(), fields, o));
+    }
+
+    protected CompletionStage<ExecutionResult> completeValueAsync(ExecutionContext executionContext, GraphQLType fieldType, List<Field> fields, Object result) {
+        if (fieldType instanceof GraphQLNonNull) {
+            return completeValueAsync(executionContext, ((GraphQLNonNull) fieldType).getWrappedType(), fields, result).thenApply(result1 -> {
+                if (result1.getData() == null) {
+                    throw new GraphQLException("Cannot return null for non-nullable type: " + fields);
+                }
+                return result1;
+            });
+        } else if (result == null) {
+            return completedFuture(new ExecutionResultImpl(null, null));
+        } else if (fieldType instanceof GraphQLList) {
+            if (result.getClass().isArray()) {
+                result = Arrays.asList((Object[]) result);
+            }
+            return completeValueForListAsync(executionContext, (GraphQLList) fieldType, fields, (Iterable<Object>) result);
+        } else if (fieldType instanceof GraphQLScalarType) {
+            return completedFuture(completeValueForScalar((GraphQLScalarType) fieldType, result));
+        } else if (fieldType instanceof GraphQLEnumType) {
+            return completedFuture(completeValueForEnum((GraphQLEnumType) fieldType, result));
+        }
+
+        GraphQLObjectType resolvedType;
+        if (fieldType instanceof GraphQLInterfaceType) {
+            resolvedType = resolveType((GraphQLInterfaceType) fieldType, result);
+        } else if (fieldType instanceof GraphQLUnionType) {
+            resolvedType = resolveType((GraphQLUnionType) fieldType, result);
+        } else {
+            resolvedType = (GraphQLObjectType) fieldType;
+        }
+
+        Map<String, List<Field>> subFields = new LinkedHashMap<>();
+        List<String> visitedFragments = new ArrayList<>();
+        for (Field field : fields) {
+            if (field.getSelectionSet() == null) continue;
+            fieldCollector.collectFields(executionContext, resolvedType, field.getSelectionSet(), visitedFragments, subFields);
+        }
+
+        // Calling this from the executionContext to ensure we shift back from mutation strategy to the query strategy.
+        AsyncExecutionStrategy queryStrategy = (AsyncExecutionStrategy) executionContext.getQueryStrategy();
+        return queryStrategy.executeAsync(executionContext, resolvedType, result, subFields);
+    }
+
+    protected CompletionStage<ExecutionResult> completeValueForListAsync(ExecutionContext executionContext, GraphQLList fieldType, List<Field> fields, Iterable<Object> result) {
+        List<CompletionStage<ExecutionResult>> completedResults = new ArrayList<>();
+        for (Object item : result) {
+            CompletionStage<ExecutionResult> completedValue = completeValueAsync(executionContext, fieldType.getWrappedType(), fields, item);
+            completedResults.add(completedValue);
+        }
+        return CompletableFutures.allAsList(completedResults).thenApply(results -> {
+            List<Object> items = results.stream().map(ExecutionResult::getData).collect(toList());
+            return new ExecutionResultImpl(items, null);
+        });
+    }
+
+    private <K, V> CompletionStage<Map<K, V>> executeFields(Map<K, Supplier<CompletionStage<V>>> map) {
+       if (serial) {
+            List<Map.Entry<K, Supplier<CompletionStage<V>>>> resolvers = new ArrayList<>(map.entrySet());
+            LinkedHashMap<K, V> results = new LinkedHashMap<>();
+            return executeInSerial(resolvers, results, 0);
+        } else {
+            return executeInParallel(map);
+        }
+    }
+
+    private <K, V> CompletionStage<Map<K, V>> executeInSerial(List<Map.Entry<K, Supplier<CompletionStage<V>>>> resolvers, Map<K, V> results, int i) {
+        return resolvers.get(i).getValue().get().thenCompose(result -> {
+            results.put(resolvers.get(i).getKey(), result);
+            if (i == resolvers.size() - 1) {
+                return completedFuture(results);
+            } else {
+                return executeInSerial(resolvers, results, i + 1);
+            }
+        });
+    }
+
+    /**
+     * `ConcurrentHashMap`, used by `executeInParallel()`, does not allow null keys or values
+     */
+    private static final Object NULL = new Object();
+
+    private <K, V> CompletionStage<Map<K, V>> executeInParallel(Map<K, Supplier<CompletionStage<V>>> resolvers) {
+        CompletableFuture<Map<K, V>> future = new CompletableFuture<>();
+        Set<K> awaiting = new ConcurrentHashMap<>(new HashMap<>(resolvers)).keySet();  // `keySet()` is a view and will be modified, so copy first
+        Map<K, V> results = new ConcurrentHashMap<>();
+        resolvers.entrySet().forEach(entry -> {
+            entry.getValue().get().thenAccept(result -> {
+                K key = entry.getKey();
+                results.put(key, result);
+                awaiting.remove(key);
+                if (awaiting.isEmpty()) {
+                    Map<K, V> map = new LinkedHashMap<>();
+                    resolvers.keySet().forEach(key1 -> {
+                        V value = results.get(key1);
+                        map.put(key1, value == NULL ? null : value);
+                    });
+                    future.complete(map);
+                }
+            });
+        });
+        return future;
+    }
+}

--- a/src/main/java/graphql/execution/async/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/async/AsyncExecutionStrategy.java
@@ -20,6 +20,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static java.util.Arrays.asList;
 import static java.util.Objects.isNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.stream.Collectors.toList;
@@ -130,7 +131,7 @@ public final class AsyncExecutionStrategy extends ExecutionStrategy {
             return completedFuture(new ExecutionResultImpl(null, null));
         } else if (fieldType instanceof GraphQLList) {
             if (result.getClass().isArray()) {
-                result = Arrays.asList((Object[]) result);
+                result = asList((Object[]) result);
             }
             return completeValueForListAsync(executionContext, (GraphQLList) fieldType, fields, (Iterable<Object>) result);
         } else if (fieldType instanceof GraphQLScalarType) {

--- a/src/main/java/graphql/execution/async/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/async/AsyncExecutionStrategy.java
@@ -121,12 +121,12 @@ public final class AsyncExecutionStrategy extends ExecutionStrategy {
     protected CompletionStage<ExecutionResult> completeValueAsync(ExecutionContext executionContext, GraphQLType fieldType, List<Field> fields, Object result) {
         if (fieldType instanceof GraphQLNonNull) {
             return completeValueAsync(executionContext, ((GraphQLNonNull) fieldType).getWrappedType(), fields, result).thenApply(result1 -> {
-                if (result1.getData() == null) {
+                if (isNull(result1.getData())) {
                     throw new GraphQLException("Cannot return null for non-nullable type: " + fields);
                 }
                 return result1;
             });
-        } else if (result == null) {
+        } else if (isNull(result)) {
             return completedFuture(new ExecutionResultImpl(null, null));
         } else if (fieldType instanceof GraphQLList) {
             if (result.getClass().isArray()) {
@@ -151,7 +151,7 @@ public final class AsyncExecutionStrategy extends ExecutionStrategy {
         Map<String, List<Field>> subFields = new LinkedHashMap<>();
         List<String> visitedFragments = new ArrayList<>();
         for (Field field : fields) {
-            if (field.getSelectionSet() == null) continue;
+            if (isNull(field.getSelectionSet())) continue;
             fieldCollector.collectFields(executionContext, resolvedType, field.getSelectionSet(), visitedFragments, subFields);
         }
 

--- a/src/main/java/graphql/execution/async/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/async/AsyncExecutionStrategy.java
@@ -93,7 +93,7 @@ public final class AsyncExecutionStrategy extends ExecutionStrategy {
         GraphQLFieldDefinition fieldDef = getFieldDef(executionContext.getGraphQLSchema(), parentType, fields.get(0));
 
         Map<String, Object> argumentValues = valuesResolver.getArgumentValues(fieldDef.getArguments(), fields.get(0).getArguments(), executionContext.getVariables());
-        DataFetchingEnvironment environment = new DataFetchingEnvironment(
+        DataFetchingEnvironment environment = new DataFetchingEnvironmentImpl(
           source,
           argumentValues,
           executionContext.getRoot(),

--- a/src/main/java/graphql/execution/async/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/async/AsyncExecutionStrategy.java
@@ -195,7 +195,7 @@ public final class AsyncExecutionStrategy extends ExecutionStrategy {
 
     private <K, V> CompletionStage<Map<K, V>> executeInParallel(Map<K, Supplier<CompletionStage<V>>> resolvers) {
         CompletableFuture<Map<K, V>> future = completableFutureFactory.future();
-        Set<K> awaiting = new ConcurrentHashMap<>(new HashMap<>(resolvers)).keySet();  // `keySet()` is a view and will be modified, so copy first
+        Set<K> awaiting = new ConcurrentHashMap<>(resolvers).keySet();
         Map<K, V> results = new ConcurrentHashMap<>();
         resolvers.entrySet().forEach(entry -> {
             entry.getValue().get().thenAccept(result -> {

--- a/src/main/java/graphql/execution/async/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/async/AsyncExecutionStrategy.java
@@ -67,7 +67,6 @@ public final class AsyncExecutionStrategy extends ExecutionStrategy {
         }
     }
 
-    @SuppressWarnings("unchecked")
     public CompletionStage<ExecutionResult> executeAsync(ExecutionContext executionContext, GraphQLObjectType parentType, Object source, Map<String, List<Field>> fields) {
 
         Map<String, Supplier<CompletionStage<ExecutionResult>>> fieldsToExecute = fields.keySet()

--- a/src/main/java/graphql/execution/async/CompletableFutureFactory.java
+++ b/src/main/java/graphql/execution/async/CompletableFutureFactory.java
@@ -1,0 +1,7 @@
+package graphql.execution.async;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface CompletableFutureFactory {
+  <T> CompletableFuture<T> future();
+}

--- a/src/main/java/graphql/execution/async/DefaultCompletableFutureFactory.java
+++ b/src/main/java/graphql/execution/async/DefaultCompletableFutureFactory.java
@@ -1,0 +1,15 @@
+package graphql.execution.async;
+
+import java.util.concurrent.CompletableFuture;
+
+public class DefaultCompletableFutureFactory implements CompletableFutureFactory {
+
+  public static CompletableFutureFactory defaultFactory() {
+    return new DefaultCompletableFutureFactory();
+  }
+
+  @Override
+  public <T> CompletableFuture<T> future() {
+    return new CompletableFuture<>();
+  }
+}

--- a/src/test/groovy/graphql/execution/async/AsyncExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/async/AsyncExecutionStrategyTest.groovy
@@ -18,19 +18,18 @@ import static java.util.concurrent.CompletableFuture.completedFuture
 
 class AsyncExecutionStrategyTest extends Specification {
 
-    def strategy = AsyncExecutionStrategy.serial()
-    def fields = [field: [new Field('field')]]
-
-    def parentType, executionContext, result, actual
-
     @Unroll
     def "async field"() {
         given:
-        parentType = buildParentType(type, fetcher)
-        executionContext = buildExecutionContext(strategy, parentType)
-        actual = strategy.execute(executionContext, parentType, null, fields);
+        def strategy = AsyncExecutionStrategy.serial()
+        def parentType = buildParentType(type, fetcher)
+        def executionContext = buildExecutionContext(strategy, parentType)
+        def fields = [field: [new Field('field')]]
 
-        expect:
+        when:
+        def actual = strategy.execute(executionContext, parentType, null, fields);
+
+        then:
         actual.data.field == expected
 
         where:
@@ -51,16 +50,16 @@ class AsyncExecutionStrategyTest extends Specification {
     def "async obj"() {
         given:
         def type = new GraphQLList(newObject()
-          .name('composite')
+          .name('Composite')
           .field(field('field', GraphQLString, { 'value' }))
           .build())
-        strategy = AsyncExecutionStrategy.serial()
-        parentType = buildParentType(type, { completedFuture([[field: 'value']]) })
-        executionContext = buildExecutionContext(strategy, parentType)
-        fields = [field: [new Field('field', new SelectionSet([new Field('field')]))]]
+        def strategy = AsyncExecutionStrategy.serial()
+        def parentType = buildParentType(type, { completedFuture([[field: 'value']]) })
+        def executionContext = buildExecutionContext(strategy, parentType)
+        def fields = [field: [new Field('field', new SelectionSet([new Field('field')]))]]
 
         when:
-        actual = strategy.execute(executionContext, parentType, null, fields);
+        def actual = strategy.execute(executionContext, parentType, null, fields);
 
         then:
         actual.data == [field: [[field: 'value']]]
@@ -87,7 +86,7 @@ class AsyncExecutionStrategyTest extends Specification {
         def fields = [field: [new Field('field')]]
 
         when:
-        actual = strategy.execute(executionContext, type, [:], fields)
+        def actual = strategy.execute(executionContext, type, [:], fields)
 
         then:
         actual.data == null
@@ -115,7 +114,7 @@ class AsyncExecutionStrategyTest extends Specification {
         def fields = [nullableField: [new Field('nullableField', new SelectionSet([new Field('nonNullField', new SelectionSet([new Field('nonNullField')]))]))]]
 
         when:
-        actual = strategy.execute(executionContext, type, [:], fields)
+        def actual = strategy.execute(executionContext, type, [:], fields)
 
         then:
         actual.data == [nullableField: null]

--- a/src/test/groovy/graphql/execution/async/AsyncExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/async/AsyncExecutionStrategyTest.groovy
@@ -142,6 +142,7 @@ class AsyncExecutionStrategyTest extends Specification {
 
     ExecutionContext buildExecutionContext(ExecutionStrategy strategy, GraphQLObjectType parentType) {
         def executionContext = new ExecutionContext(
+          null,
           newSchema().query(parentType).build(),
           strategy,
           null,

--- a/src/test/groovy/graphql/execution/async/AsyncExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/async/AsyncExecutionStrategyTest.groovy
@@ -1,0 +1,101 @@
+package graphql.execution.async
+
+import graphql.execution.ExecutionContext
+import graphql.execution.ExecutionStrategy
+import graphql.language.Field
+import graphql.language.SelectionSet
+import graphql.schema.*
+import spock.lang.Ignore
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static com.spotify.futures.CompletableFutures.exceptionallyCompletedFuture
+import static graphql.Scalars.GraphQLString
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
+import static graphql.schema.GraphQLObjectType.newObject
+import static graphql.schema.GraphQLSchema.newSchema
+import static java.util.concurrent.CompletableFuture.completedFuture
+
+class AsyncExecutionStrategyTest extends Specification {
+
+    def strategy = AsyncExecutionStrategy.serial()
+    def fields = [field: [new Field('field')]]
+
+    def parentType, executionContext, result, actual
+
+    @Unroll
+    def "async field"() {
+        given:
+        parentType = buildParentType(type, fetcher)
+        executionContext = buildExecutionContext(strategy, parentType)
+        actual = strategy.execute(executionContext, parentType, null, fields);
+
+        expect:
+        actual.data.field == expected
+
+        where:
+        fetcher                                                           | type                                                    || expected
+        { it -> null }                                                    | GraphQLString                                           || null
+        { it -> 'a' }                                                     | GraphQLString                                           || 'a'
+        { it -> 'a' }                                                     | new GraphQLNonNull(GraphQLString)                       || 'a'
+        { it -> ['a'] }                                                   | new GraphQLList(GraphQLString)                          || ['a']
+        { it -> ['a'] }                                                   | new GraphQLList(new GraphQLNonNull(GraphQLString))      || ['a']
+        { it -> completedFuture(null) }                                   | GraphQLString                                           || null
+        { it -> completedFuture('value') }                                | GraphQLString                                           || 'value'
+        { it -> completedFuture('value') }                                | new GraphQLNonNull(GraphQLString)                       || 'value'
+        { it -> completedFuture(['value']) }                              | new GraphQLList(new GraphQLNonNull(GraphQLString))      || ['value']
+        { it -> throw new RuntimeException() }                            | GraphQLString                                           || null
+        { it -> exceptionallyCompletedFuture(new RuntimeException()) }    | GraphQLString                                           || null
+    }
+
+    def "async obj"() {
+        given:
+        def type = new GraphQLList(newObject()
+          .name('composite')
+          .field(field('field', GraphQLString, { 'value' }))
+          .build())
+        strategy = AsyncExecutionStrategy.serial()
+        parentType = buildParentType(type, { completedFuture([[field: 'value']]) })
+        executionContext = buildExecutionContext(strategy, parentType)
+        fields = [field: [new Field('field', new SelectionSet([new Field('field')]))]]
+
+        when:
+        actual = strategy.execute(executionContext, parentType, null, fields);
+
+        then:
+        actual.data == [field: [[field: 'value']]]
+
+    }
+
+    @Ignore
+    def "fields execute in the correct order"() {
+
+    }
+
+    GraphQLFieldDefinition field(String name, GraphQLOutputType type, DataFetcher fetcher) {
+        newFieldDefinition()
+          .name(name)
+          .type(type)
+          .dataFetcher(fetcher)
+          .build()
+    }
+
+    GraphQLObjectType buildParentType(GraphQLOutputType type, DataFetcher fetcher) {
+        newObject()
+          .name('object')
+          .field(field('field', type, fetcher))
+          .build()
+    }
+
+    ExecutionContext buildExecutionContext(ExecutionStrategy strategy, GraphQLObjectType parentType) {
+        def executionContext = new ExecutionContext(
+          newSchema().query(parentType).build(),
+          strategy,
+          null,
+          null,
+          null,
+          null,
+          null
+        )
+    }
+}


### PR DESCRIPTION
Following up with #242 and #202, this is a working asynchronous execution strategy:

```
GraphQLAsync graphql = new GraphQLAsync(
  schema,
  AsyncExecutionStrategy.serial(),
  AsyncExecutionStrategy.parallel()
);

String query = "{ name }";
CompletionStage<ExecutionResult> result = graphql.executeAsync(query);
result.thenAccept(executionResult -> {
  // use result //
})
```

Calls are made through `GraphQLAsync`, which extends `GraphQL` and provides an `executeAsync` method that returns `CompletionStage<ExecutionResult>`.

