### PR TITLE
#281: Spec allows for 'extensions' map in result but graphql-java does not

### DIFF
--- a/src/main/java/graphql/ExecutionResult.java
+++ b/src/main/java/graphql/ExecutionResult.java
@@ -2,10 +2,14 @@ package graphql;
 
 
 import java.util.List;
+import java.util.Map;
 
 public interface ExecutionResult {
 
     Object getData();
 
     List<GraphQLError> getErrors();
+
+    Map<Object,Object> getExtensions();
+
 }

--- a/src/main/java/graphql/ExecutionResultImpl.java
+++ b/src/main/java/graphql/ExecutionResultImpl.java
@@ -2,28 +2,44 @@ package graphql;
 
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class ExecutionResultImpl implements ExecutionResult {
 
     private final List<GraphQLError> errors = new ArrayList<GraphQLError>();
     private Object data;
+    private Map<Object,Object> extensions = null;
 
     public ExecutionResultImpl(List<? extends GraphQLError> errors) {
-        this.errors.addAll(errors);
+        this(null,errors,null);
     }
 
     public ExecutionResultImpl(Object data, List<? extends GraphQLError> errors) {
+        this(data,errors,null);
+    }
+
+    public ExecutionResultImpl(Object data, List<? extends GraphQLError> errors, Map<Object,Object> extensions) {
         this.data = data;
 
-        if (errors != null) {
+        if (errors != null && !errors.isEmpty()) {
             this.errors.addAll(errors);
+        }
+
+        if (extensions != null && !extensions.isEmpty()) {
+            this.extensions = new HashMap<Object,Object>(extensions);
         }
     }
 
     public void addErrors(List<? extends GraphQLError> errors) {
         this.errors.addAll(errors);
     }
+
+    public void addExtensions(Map<Object, Object> extensions) {
+        this.extensions.putAll(extensions);
+    }
+
 
     @Override
     public Object getData() {
@@ -39,5 +55,8 @@ public class ExecutionResultImpl implements ExecutionResult {
         return new ArrayList<GraphQLError>(errors);
     }
 
-
+    @Override
+    public Map<Object, Object> getExtensions() {
+        return extensions == null ? null : new HashMap<Object,Object>(extensions);
+    }
 }


### PR DESCRIPTION
Issue 281: Spec allows for 'extensions' map in result but graphql-java does not.

ExecutionResult changed to have an extensions Map<Object,Object> and
ExecutionResultImpl changed to support it, defaulting to null.