### PR TITLE
Allows a ExecutionProvider to be provided by the caller

### DIFF
--- a/src/test/groovy/graphql/execution/ExecutionIdTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionIdTest.groovy
@@ -19,9 +19,7 @@ class ExecutionIdTest extends Specification {
         }
     }
 
-    def 'Ensures that an execution identifier is present'() {
-        given:
-        def query = """
+    def query = """
         query HeroNameAndFriendsQuery {
             hero {
                 id
@@ -29,14 +27,50 @@ class ExecutionIdTest extends Specification {
         }
         """
 
+
+    def 'Ensures that an execution identifier is present by default'() {
+
         when:
 
         CaptureIdStrategy idStrategy = new CaptureIdStrategy()
 
-        new GraphQL(StarWarsSchema.starWarsSchema, idStrategy).execute(query).data
+        GraphQL.newGraphQL(StarWarsSchema.starWarsSchema).queryExecutionStrategy(idStrategy).build().execute(query)
 
         then:
 
         idStrategy.executionId != null
+    }
+
+    def 'Ensures that an execution identifier provider is able to be specified'() {
+
+        when:
+
+        CaptureIdStrategy idStrategy = new CaptureIdStrategy()
+
+        def specificProvider = new ExecutionIdProvider() {
+            long count = 0
+
+            @Override
+            ExecutionId provide(String query, String operationName, Object context) {
+                count++
+                return ExecutionId.from(count.toString())
+            }
+        }
+        def graphQL = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema)
+                .executionIdProvider(specificProvider)
+                .queryExecutionStrategy(idStrategy)
+                .build()
+
+        // execute multiple times to ensure its called multiple times
+        graphQL.execute(query)
+        def id1 = idStrategy.executionId.toString()
+
+        graphQL.execute(query)
+        def id2 = idStrategy.executionId.toString()
+
+        then:
+
+        id1 == "1"
+        id2 == "2"
     }
 }


### PR DESCRIPTION
#278  - This now allows the caller to provider their own ExecutionId into the mix.  There is a good default however