### PR TITLE
Fix #296: Introspection on default value for input object is not following GraphQL spec

### DIFF
--- a/src/test/groovy/graphql/Issue296.groovy
+++ b/src/test/groovy/graphql/Issue296.groovy
@@ -1,0 +1,41 @@
+package graphql
+
+import spock.lang.Specification
+
+import static graphql.Scalars.GraphQLString
+import static graphql.schema.GraphQLArgument.newArgument
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
+import static graphql.schema.GraphQLInputObjectField.newInputObjectField
+import static graphql.schema.GraphQLInputObjectType.newInputObject
+import static graphql.schema.GraphQLObjectType.newObject
+import static graphql.schema.GraphQLSchema.newSchema
+
+class Issue296 extends Specification {
+
+    def "test"() {
+
+        def graphql = GraphQL.newGraphQL(newSchema()
+            .query(newObject()
+                .name("Query")
+                .field(newFieldDefinition()
+                    .name("field")
+                    .type(GraphQLString)
+                    .argument(newArgument()
+                        .name("argument")
+                        .type(newInputObject()
+                            .name("InputObjectType")
+                            .field(newInputObjectField()
+                                .name("inputField")
+                                .type(GraphQLString))
+                            .build())
+                        .defaultValue([field1:'value1']))))
+            .build())
+        .build()
+
+        def query = '{ __type(name: "Query") { fields { args { defaultValue } } } }'
+
+        // Instead of `'{field: "value"}'` you get '{field1=value1}' (#toString())
+        expect:
+        graphql.execute(query).data == [ __type: [ fields: [ [ args: [ [ defaultValue: '{field: "value"}' ] ] ] ] ] ]
+    }
+}


### PR DESCRIPTION
Relevant lines: https://github.com/graphql-java/graphql-java/blob/6b94b458f6738bde331444d307d1081aecb6ab10/src/main/java/graphql/introspection/Introspection.java#L84-L89

I think this will require https://github.com/graphql-java/graphql-java/issues/126