### PR TITLE
execution path propagation for better execution errors

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,4 @@ org.gradle.daemon=true
 
 bintray.user=DUMMY_USER
 bintray.key=DUMMY_KEY
+

--- a/src/main/java/graphql/ExceptionWhileDataFetching.java
+++ b/src/main/java/graphql/ExceptionWhileDataFetching.java
@@ -1,15 +1,22 @@
 package graphql;
 
 
+import graphql.execution.Path;
 import graphql.language.SourceLocation;
 
 import java.util.List;
 
 public class ExceptionWhileDataFetching implements GraphQLError {
 
+    private final Path path;
     private final Throwable exception;
 
     public ExceptionWhileDataFetching(Throwable exception) {
+        this(null, exception);
+    }
+
+    public ExceptionWhileDataFetching(Path path, Throwable exception) {
+        this.path = path;
         this.exception = exception;
     }
 
@@ -26,6 +33,10 @@ public class ExceptionWhileDataFetching implements GraphQLError {
     @Override
     public List<SourceLocation> getLocations() {
         return null;
+    }
+
+    public String getPath() {
+        return path == null ? null : path.toString();
     }
 
     @Override

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -55,9 +55,9 @@ public class Execution {
         fieldCollector.collectFields(executionContext, operationRootType, operationDefinition.getSelectionSet(), new ArrayList<String>(), fields);
 
         if (operationDefinition.getOperation() == OperationDefinition.Operation.MUTATION) {
-            return mutationStrategy.execute(executionContext, operationRootType, root, fields);
+            return mutationStrategy.execute(executionContext, Path.root, operationRootType, root, fields);
         } else {
-            return queryStrategy.execute(executionContext, operationRootType, root, fields);
+            return queryStrategy.execute(executionContext, Path.root, operationRootType, root, fields);
         }
     }
 }

--- a/src/main/java/graphql/execution/ExecutorServiceExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutorServiceExecutionStrategy.java
@@ -17,7 +17,7 @@ import java.util.concurrent.Future;
 /**
  * <p>ExecutorServiceExecutionStrategy uses an {@link ExecutorService} to parallelize the resolve.</p>
  * 
- * Due to the nature of {@link #execute(ExecutionContext, GraphQLObjectType, Object, Map)} implementation, {@link ExecutorService}
+ * Due to the nature of {@link #execute(ExecutionContext, Path, GraphQLObjectType, Object, Map)} implementation, {@link ExecutorService}
  * MUST have the following 2 characteristics:
  * <ul>
  * <li>1. The underlying {@link java.util.concurrent.ThreadPoolExecutor} MUST have a reasonable {@code maximumPoolSize}
@@ -37,17 +37,17 @@ public class ExecutorServiceExecutionStrategy extends ExecutionStrategy {
     }
 
     @Override
-    public ExecutionResult execute(final ExecutionContext executionContext, final GraphQLObjectType parentType, final Object source, final Map<String, List<Field>> fields) {
+    public ExecutionResult execute(final ExecutionContext executionContext, final Path currentPath, final GraphQLObjectType parentType, final Object source, final Map<String, List<Field>> fields) {
         if (executorService == null)
-            return new SimpleExecutionStrategy().execute(executionContext, parentType, source, fields);
+            return new SimpleExecutionStrategy().execute(executionContext, currentPath, parentType, source, fields);
 
         Map<String, Future<ExecutionResult>> futures = new LinkedHashMap<String, Future<ExecutionResult>>();
-        for (String fieldName : fields.keySet()) {
+        for (final String fieldName : fields.keySet()) {
             final List<Field> fieldList = fields.get(fieldName);
             Callable<ExecutionResult> resolveField = new Callable<ExecutionResult>() {
                 @Override
                 public ExecutionResult call() throws Exception {
-                    return resolveField(executionContext, parentType, source, fieldList);
+                    return resolveField(executionContext, currentPath.withTrailing(fieldName), parentType, source, fieldList);
 
                 }
             };

--- a/src/main/java/graphql/execution/Path.java
+++ b/src/main/java/graphql/execution/Path.java
@@ -1,0 +1,71 @@
+package graphql.execution;
+
+public class Path {
+    private final Path parent;
+    private PathComponent tail;
+
+    public static Path root= new Path();
+
+    private Path() {
+        parent = null;
+        tail = null;
+    }
+
+    public Path(String topLevelField) {
+        this(null, new StringPathComponent(topLevelField));
+    }
+
+    private Path(Path parent, PathComponent tail) {
+        this.parent = parent;
+        this.tail = tail;
+    }
+
+    public Path withTrailing(String trailing) {
+        return new Path(this, new StringPathComponent(trailing));
+    }
+
+    public Path withTrailing(int index) {
+        return new Path(this, new IntPathComponent(index));
+    }
+
+    @Override
+    public String toString() {
+        if (tail == null) {
+            return "";
+        }
+
+        if (parent == root) {
+            return tail.toString().substring(1);
+        }
+
+        return parent.toString() + tail.toString();
+    }
+
+    private interface PathComponent {
+    }
+
+    private static class StringPathComponent implements PathComponent {
+        private final String value;
+        public StringPathComponent(String value) {
+            if (value == null || value.isEmpty()) {
+                throw new IllegalArgumentException("empty path component");
+            }
+            this.value = value;
+        }
+        @Override
+        public String toString() {
+            return '/' + value;
+        }
+    }
+
+    private static class IntPathComponent implements PathComponent {
+        private final int value;
+        public IntPathComponent(int value) {
+            this.value = value;
+        }
+        @Override
+        public String toString() {
+            return "[" + value + ']';
+        }
+    }
+}

--- a/src/main/java/graphql/execution/SimpleExecutionStrategy.java
+++ b/src/main/java/graphql/execution/SimpleExecutionStrategy.java
@@ -11,11 +11,11 @@ import java.util.Map;
 
 public class SimpleExecutionStrategy extends ExecutionStrategy {
     @Override
-    public ExecutionResult execute(ExecutionContext executionContext, GraphQLObjectType parentType, Object source, Map<String, List<Field>> fields) {
+    public ExecutionResult execute(ExecutionContext executionContext, Path currentPath, GraphQLObjectType parentType, Object source, Map<String, List<Field>> fields) {
         Map<String, Object> results = new LinkedHashMap<String, Object>();
         for (String fieldName : fields.keySet()) {
             List<Field> fieldList = fields.get(fieldName);
-            ExecutionResult resolvedResult = resolveField(executionContext, parentType, source, fieldList);
+            ExecutionResult resolvedResult = resolveField(executionContext, currentPath.withTrailing(fieldName), parentType, source, fieldList);
 
             results.put(fieldName, resolvedResult != null ? resolvedResult.getData() : null);
         }

--- a/src/test/groovy/graphql/ErrorPathTest.java
+++ b/src/test/groovy/graphql/ErrorPathTest.java
@@ -1,0 +1,83 @@
+package graphql;
+
+import static graphql.Scalars.GraphQLString;
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
+import static graphql.schema.GraphQLObjectType.newObject;
+import static org.junit.Assert.assertEquals;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLList;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLSchema;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+public class ErrorPathTest {
+    @Test
+    public void testErrorPath() {
+        GraphQLObjectType queryType = newObject()
+            .name("errorPathQuery")
+            .field(newFieldDefinition()
+                .name("f1")
+                .type(GraphQLString)
+                .dataFetcher(new DataFetcher(){
+                    @Override
+                    public Object get(DataFetchingEnvironment environment) {
+                        throw new RuntimeException("error.");
+                    }
+                })
+                .build())
+            .field(newFieldDefinition()
+                .name("f2")
+                .type(new GraphQLList(newObject()
+                    .name("Test")
+                    .field(newFieldDefinition()
+                        .name("sub1")
+                        .type(GraphQLString)
+                        .staticValue("test")
+                        .build()
+                    )
+                    .field(newFieldDefinition()
+                        .name("sub2")
+                        .type(GraphQLString)
+                        .dataFetcher(new DataFetcher(){
+                            @Override
+                            public Object get(DataFetchingEnvironment environment) {
+                                boolean willThrow = (Boolean) environment.getSource();
+                                if (willThrow) {
+                                    throw new RuntimeException("error.");
+                                }
+                                return "no error";
+                            }
+                        })
+                        .build()
+                    )
+                    .build()
+                ))
+                .dataFetcher(new DataFetcher() {
+                    @Override
+                    public Object get(DataFetchingEnvironment environment) {
+                        return new Boolean[] { false, true, false};
+                    }
+                })
+                .build()
+            )
+            .build();
+
+        GraphQLSchema schema = GraphQLSchema.newSchema()
+            .query(queryType)
+            .build();
+
+        GraphQL graphQL = GraphQL.newGraphQL(schema).build();
+
+        List<GraphQLError> errors = graphQL.execute("{f1 f2{sub1 sub2}}").getErrors();
+
+        ExceptionWhileDataFetching error = (ExceptionWhileDataFetching) errors.get(0);
+        assertEquals("f1", error.getPath());
+
+        error = (ExceptionWhileDataFetching) errors.get(1);
+        assertEquals("f2[1]/sub2", error.getPath());
+    }
+}

--- a/src/test/groovy/graphql/execution/ExecutionIdTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionIdTest.groovy
@@ -13,9 +13,9 @@ class ExecutionIdTest extends Specification {
         ExecutionId executionId = null
 
         @Override
-        ExecutionResult execute(ExecutionContext executionContext, GraphQLObjectType parentType, Object source, Map<String, List<Field>> fields) {
+        ExecutionResult execute(ExecutionContext executionContext, Path currentPath, GraphQLObjectType parentType, Object source, Map<String, List<Field>> fields) {
             executionId = executionContext.executionId
-            return super.execute(executionContext, parentType, source, fields)
+            return super.execute(executionContext, currentPath, parentType, source, fields)
         }
     }
 

--- a/src/test/groovy/graphql/execution/ExecutionStrategySpec.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategySpec.groovy
@@ -14,7 +14,7 @@ class ExecutionStrategySpec extends Specification {
     def setup() {
         executionStrategy = new ExecutionStrategy() {
             @Override
-            ExecutionResult execute(ExecutionContext executionContext, GraphQLObjectType parentType, Object source, Map<String, List<Field>> fields) {
+            ExecutionResult execute(ExecutionContext executionContext, Path currentPath, GraphQLObjectType parentType, Object source, Map<String, List<Field>> fields) {
                 return null
             }
         }
@@ -31,7 +31,7 @@ class ExecutionStrategySpec extends Specification {
         def fieldType = new GraphQLList(Scalars.GraphQLString)
         def result = Arrays.asList("test")
         when:
-        def executionResult = executionStrategy.completeValue(executionContext, fieldType, [field], result)
+        def executionResult = executionStrategy.completeValue(executionContext, Path.root, fieldType, [field], result)
 
         then:
         executionResult.data == ["test"]
@@ -44,7 +44,7 @@ class ExecutionStrategySpec extends Specification {
         def fieldType = new GraphQLList(Scalars.GraphQLString)
         String[] result = ["test"]
         when:
-        def executionResult = executionStrategy.completeValue(executionContext, fieldType, [field], result)
+        def executionResult = executionStrategy.completeValue(executionContext, Path.root, fieldType, [field], result)
 
         then:
         executionResult.data == ["test"]


### PR DESCRIPTION
This patch adds execution path information to the ExceptionWhileDataFetching errors in the GraphQL result.

During execution, the path of the currently resolved/processed field is remembered and put into the ExceptionWhileDataFetching exception when an error occurs. When examining the ExecutionResult after execution is finished, each execution error can then much better be associated to the result field (which was nulled) where the error happened.

The path is in hierarchical form, with / as object field separator and with list index in square brackets, for example: `field/subField[2]/subSubField`

The path information is an additional field in ExceptionWhileDataFetching which can be ignored if not used. So, this patch should be backward compatible.

*Note:* I don't understand the Batched execution strategy, so I'm not sure if I implemented it correctly there, but I think the Simple and Executor strategy are ok.