### PR TITLE
Add jacoco plugin. It generates test coverage.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'maven-publish'
 apply plugin: 'antlr'
+apply plugin: 'jacoco'
 
 sourceCompatibility = 1.6
 targetCompatibility = 1.6


### PR DESCRIPTION
Plugin [page](https://docs.gradle.org/current/userguide/jacoco_plugin.html) on gradle site.
Coverage report for this pr: [graphql-java](http://exbe.info/projects/graphql-java/)

Do it yourself: 
```
gradle clean test jacocoTestReport
```
Jacoco plugin add yourself after test tasks and one need to call **jacocoTestReport** to generate actual report from collected metrics. Multiple formats are supported and configurable.

The reason why report generation is a manual step is to avoid impact on build time for developers.