### PR TITLE
lenient scalar support

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,35 @@ GraphQLObjectType queryType = newObject()
                 .build();
 ```
 
+#### Numerical Scalar Support
+
+By default the numerical scalar types in graphql-java are strict.  So for example given a field declared like this :
+ 
+```java
+    newFieldDefinition()
+                 .name("strict")
+                 .type(Scalars.GraphQLInt);
+     
+```
+
+it will only accept Strings and Numbers that can be strictly coerced into `java.lang.Integer` values.  
+
+If it did not then an input value such as "42.3" woul result in a loss of precision if it was coerced into an Integer as "42.0".     
+
+Some JSON frameworks, such as GSON, (by default) turn JSON input such as `{ value : 42 }` into `java.lang.Double` values such as "42.0" and hence will not be accepted by the strict
+scalar types and will be mapped to `null`.  
+
+You can opt for lenient coercion by using the `LenientNumericalScalars` types
+ 
+
+```java
+      newFieldDefinition()
+                      .name("lenient")
+                      .type(LenientNumericalScalars.GraphQLInt);
+```
+
+This will use `java.lang.Number` conversion to turn input values into the target scalar type in a more lenient fashion.
+
 #### Logging
 
 Logging is done with [SLF4J](http://www.slf4j.org/). Please have a look at the [Manual](http://www.slf4j.org/manual.html) for details.

--- a/src/main/java/graphql/LenientNumericalScalars.java
+++ b/src/main/java/graphql/LenientNumericalScalars.java
@@ -1,0 +1,141 @@
+package graphql;
+
+
+import graphql.schema.GraphQLScalarType;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+/**
+ * The standard numerical scalars in {@link Scalars} are strict in implementation and hence a Double
+ * passed into a Integer type will not be coerced into that type, whereas these implementations are more lenient
+ * and will coerce {@link Number}s into the corresponding scalar values.
+ */
+@SuppressWarnings("Duplicates")
+public class LenientNumericalScalars {
+
+    public static GraphQLScalarType GraphQLInt = new GraphQLScalarType("Int", "Built-in Int", new Scalars.IntegerCoercing() {
+        @Override
+        public Integer serialize(Object input) {
+            if (input instanceof String) {
+                return Integer.parseInt((String) input);
+            } else if (input instanceof Integer) {
+                return (Integer) input;
+            } else if (input instanceof Number) {
+                return ((Number) input).intValue();
+            } else {
+                return null;
+            }
+        }
+    });
+
+
+    public static GraphQLScalarType GraphQLLong = new GraphQLScalarType("Long", "Long type", new Scalars.LongCoercing() {
+        @Override
+        public Long serialize(Object input) {
+            if (input instanceof String) {
+                return Long.parseLong((String) input);
+            } else if (input instanceof Long) {
+                return (Long) input;
+            } else if (input instanceof Integer) {
+                return ((Integer) input).longValue();
+            } else if (input instanceof Number) {
+                return ((Number) input).longValue();
+            } else {
+                return null;
+            }
+        }
+    });
+
+    public static GraphQLScalarType GraphQLFloat = new GraphQLScalarType("Float", "Built-in Float", new Scalars.DoubleCoercing() {
+        @Override
+        public Double serialize(Object input) {
+            if (input instanceof String) {
+                return Double.parseDouble((String) input);
+            } else if (input instanceof Double) {
+                return (Double) input;
+            } else if (input instanceof Float) {
+                return (double) (Float) input;
+            } else if (input instanceof Integer) {
+                return (double) (Integer) input;
+            } else if (input instanceof Number) {
+                return ((Number) input).doubleValue();
+            } else {
+                return null;
+            }
+        }
+    });
+
+
+    public static GraphQLScalarType GraphQLBigInteger = new GraphQLScalarType("BigInteger", "Built-in java.math.BigInteger", new Scalars.BigIntegerCoercing() {
+        @Override
+        public BigInteger serialize(Object input) {
+            if (input instanceof BigInteger) {
+                return (BigInteger) input;
+            } else if (input instanceof String) {
+                return new BigInteger((String) input);
+            } else if (input instanceof Integer) {
+                return BigInteger.valueOf((Integer) input);
+            } else if (input instanceof Long) {
+                return BigInteger.valueOf((Long) input);
+            } else if (input instanceof Number) {
+                return BigInteger.valueOf(((Number) input).longValue());
+            } else {
+                return null;
+            }
+        }
+    });
+
+    public static GraphQLScalarType GraphQLBigDecimal = new GraphQLScalarType("BigDecimal", "Built-in java.math.BigDecimal", new Scalars.BigDecimalCoercing() {
+        @Override
+        public BigDecimal serialize(Object input) {
+            if (input instanceof BigDecimal) {
+                return (BigDecimal) input;
+            } else if (input instanceof String) {
+                return new BigDecimal((String) input);
+            } else if (input instanceof Float) {
+                return BigDecimal.valueOf((Float) input);
+            } else if (input instanceof Double) {
+                return BigDecimal.valueOf((Double) input);
+            } else if (input instanceof Integer) {
+                return BigDecimal.valueOf((Integer) input);
+            } else if (input instanceof Long) {
+                return BigDecimal.valueOf((Long) input);
+            } else if (input instanceof Number) {
+                return BigDecimal.valueOf(((Number) input).longValue());
+            } else {
+                return null;
+            }
+        }
+    });
+
+    public static GraphQLScalarType GraphQLByte = new GraphQLScalarType("Byte", "Built-in Byte as Int", new Scalars.ByteCoercing() {
+        @Override
+        public Byte serialize(Object input) {
+            if (input instanceof String) {
+                return Byte.parseByte((String) input);
+            } else if (input instanceof Byte) {
+                return (Byte) input;
+            } else if (input instanceof Number) {
+                return ((Number) input).byteValue();
+            } else {
+                return null;
+            }
+        }
+    });
+
+    public static GraphQLScalarType GraphQLShort = new GraphQLScalarType("Short", "Built-in Short as Int", new Scalars.ShortCoercing() {
+        @Override
+        public Short serialize(Object input) {
+            if (input instanceof String) {
+                return Short.parseShort((String) input);
+            } else if (input instanceof Short) {
+                return (Short) input;
+            } else if (input instanceof Number) {
+                return ((Number) input).shortValue();
+            } else {
+                return null;
+            }
+        }
+    });
+}

--- a/src/main/java/graphql/Scalars.java
+++ b/src/main/java/graphql/Scalars.java
@@ -11,18 +11,19 @@ import graphql.schema.GraphQLScalarType;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
+@SuppressWarnings("Duplicates")
 public class Scalars {
 
-    private static final BigInteger LONG_MAX = BigInteger.valueOf(Long.MAX_VALUE);
-    private static final BigInteger LONG_MIN = BigInteger.valueOf(Long.MIN_VALUE);
-    private static final BigInteger INT_MAX = BigInteger.valueOf(Integer.MAX_VALUE);
-    private static final BigInteger INT_MIN = BigInteger.valueOf(Integer.MIN_VALUE);
-    private static final BigInteger BYTE_MAX = BigInteger.valueOf(Byte.MAX_VALUE);
-    private static final BigInteger BYTE_MIN = BigInteger.valueOf(Byte.MIN_VALUE);
-    private static final BigInteger SHORT_MAX = BigInteger.valueOf(Short.MAX_VALUE);
-    private static final BigInteger SHORT_MIN = BigInteger.valueOf(Short.MIN_VALUE);
+    static final BigInteger LONG_MAX = BigInteger.valueOf(Long.MAX_VALUE);
+    static final BigInteger LONG_MIN = BigInteger.valueOf(Long.MIN_VALUE);
+    static final BigInteger INT_MAX = BigInteger.valueOf(Integer.MAX_VALUE);
+    static final BigInteger INT_MIN = BigInteger.valueOf(Integer.MIN_VALUE);
+    static final BigInteger BYTE_MAX = BigInteger.valueOf(Byte.MAX_VALUE);
+    static final BigInteger BYTE_MIN = BigInteger.valueOf(Byte.MIN_VALUE);
+    static final BigInteger SHORT_MAX = BigInteger.valueOf(Short.MAX_VALUE);
+    static final BigInteger SHORT_MIN = BigInteger.valueOf(Short.MIN_VALUE);
 
-    public static GraphQLScalarType GraphQLInt = new GraphQLScalarType("Int", "Built-in Int", new Coercing<Integer>() {
+    static class IntegerCoercing implements Coercing<Integer> {
         @Override
         public Integer serialize(Object input) {
             if (input instanceof String) {
@@ -48,10 +49,11 @@ public class Scalars {
             }
             return value.intValue();
         }
-    });
+    }
 
+    public static GraphQLScalarType GraphQLInt = new GraphQLScalarType("Int", "Built-in Int", new IntegerCoercing());
 
-    public static GraphQLScalarType GraphQLLong = new GraphQLScalarType("Long", "Long type", new Coercing<Long>() {
+    static class LongCoercing implements Coercing<Long> {
         @Override
         public Long serialize(Object input) {
             if (input instanceof String) {
@@ -84,9 +86,11 @@ public class Scalars {
             }
             return null;
         }
-    });
+    }
 
-    public static GraphQLScalarType GraphQLFloat = new GraphQLScalarType("Float", "Built-in Float", new Coercing<Double>() {
+    public static GraphQLScalarType GraphQLLong = new GraphQLScalarType("Long", "Long type", new LongCoercing());
+
+    static class DoubleCoercing implements Coercing<Double> {
         @Override
         public Double serialize(Object input) {
             if (input instanceof String) {
@@ -117,7 +121,9 @@ public class Scalars {
                 return null;
             }
         }
-    });
+    }
+
+    public static GraphQLScalarType GraphQLFloat = new GraphQLScalarType("Float", "Built-in Float", new DoubleCoercing());
 
     public static GraphQLScalarType GraphQLString = new GraphQLScalarType("String", "Built-in String", new Coercing<String>() {
         @Override
@@ -195,7 +201,7 @@ public class Scalars {
         }
     });
 
-    public static GraphQLScalarType GraphQLBigInteger = new GraphQLScalarType("BigInteger", "Built-in java.math.BigInteger", new Coercing<BigInteger>() {
+    static class BigIntegerCoercing implements Coercing<BigInteger> {
         @Override
         public BigInteger serialize(Object input) {
             if (input instanceof BigInteger) {
@@ -225,9 +231,11 @@ public class Scalars {
             }
             return null;
         }
-    });
+    }
 
-    public static GraphQLScalarType GraphQLBigDecimal = new GraphQLScalarType("BigDecimal", "Built-in java.math.BigDecimal", new Coercing<BigDecimal>() {
+    public static GraphQLScalarType GraphQLBigInteger = new GraphQLScalarType("BigInteger", "Built-in java.math.BigInteger", new BigIntegerCoercing());
+
+    static class BigDecimalCoercing implements Coercing<BigDecimal> {
         @Override
         public BigDecimal serialize(Object input) {
             if (input instanceof BigDecimal) {
@@ -263,9 +271,11 @@ public class Scalars {
             }
             return null;
         }
-    });
+    }
 
-    public static GraphQLScalarType GraphQLByte = new GraphQLScalarType("Byte", "Built-in Byte as Int", new Coercing<Byte>() {
+    public static GraphQLScalarType GraphQLBigDecimal = new GraphQLScalarType("BigDecimal", "Built-in java.math.BigDecimal", new BigDecimalCoercing());
+
+    static class ByteCoercing implements Coercing<Byte> {
         @Override
         public Byte serialize(Object input) {
             if (input instanceof String) {
@@ -291,9 +301,11 @@ public class Scalars {
             }
             return value.byteValue();
         }
-    });
+    }
 
-    public static GraphQLScalarType GraphQLShort = new GraphQLScalarType("Short", "Built-in Short as Int", new Coercing<Short>() {
+    public static GraphQLScalarType GraphQLByte = new GraphQLScalarType("Byte", "Built-in Byte as Int", new ByteCoercing());
+
+    static class ShortCoercing implements Coercing<Short> {
         @Override
         public Short serialize(Object input) {
             if (input instanceof String) {
@@ -319,7 +331,9 @@ public class Scalars {
             }
             return value.shortValue();
         }
-    });
+    }
+
+    public static GraphQLScalarType GraphQLShort = new GraphQLScalarType("Short", "Built-in Short as Int", new ShortCoercing());
 
     public static GraphQLScalarType GraphQLChar = new GraphQLScalarType("Char", "Built-in Char as Character", new Coercing<Character>() {
         @Override

--- a/src/test/groovy/graphql/LenientNumericalScalarsTest.groovy
+++ b/src/test/groovy/graphql/LenientNumericalScalarsTest.groovy
@@ -1,0 +1,128 @@
+package graphql
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class LenientNumericalScalarsTest extends Specification {
+
+    // we don't test parseLiteral since its covered by the parent class tests
+
+    @Unroll
+    def "Long serialize/parseValue #value into #result"() {
+        expect:
+        LenientNumericalScalars.GraphQLLong.getCoercing().serialize(value) == result
+        LenientNumericalScalars.GraphQLLong.getCoercing().parseValue(value) == result
+
+        where:
+        value                        | result
+        "42"                         | 42
+        new Long(42345784398534785l) | 42345784398534785l
+        new Integer(42)              | 42
+        "-1"                         | -1
+        new Double(42.5)             | 42 // lenient scalar correctness
+        null                         | null
+    }
+
+    @Unroll
+    def "Int serialize/parseValue #value into #result"() {
+        expect:
+        LenientNumericalScalars.GraphQLInt.getCoercing().serialize(value) == result
+        LenientNumericalScalars.GraphQLInt.getCoercing().parseValue(value) == result
+
+        where:
+        value            | result
+        "42"             | 42
+        new Integer(42)  | 42
+        "-1"             | -1
+        new Double(42.5) | 42 // lenient scalar correctness
+        new Long(42)     | 42 // lenient scalar correctness
+        null             | null
+    }
+
+    @Unroll
+    def "Short serialize/parseValue #value into #result"() {
+        expect:
+        LenientNumericalScalars.GraphQLShort.getCoercing().serialize(value) == result
+        LenientNumericalScalars.GraphQLShort.getCoercing().parseValue(value) == result
+
+        where:
+        value               | result
+        "42"                | 42
+        Short.valueOf("42") | 42
+        "-1"                | -1
+        new Integer(42)     | 42 // lenient scalar correctness
+        new Double(42.5)    | 42 // lenient scalar correctness
+        new Long(42)        | 42 // lenient scalar correctness
+        null                | null
+    }
+
+    @Unroll
+    def "Byte serialize/parseValue #value into #result"() {
+        expect:
+        LenientNumericalScalars.GraphQLByte.getCoercing().serialize(value) == result
+        LenientNumericalScalars.GraphQLByte.getCoercing().parseValue(value) == result
+
+        where:
+        value               | result
+        "42"                | 42
+        Byte.valueOf("42")  | 42
+        "-1"                | -1
+        Short.valueOf("42") | 42 // lenient scalar correctness
+        new Integer(42)     | 42 // lenient scalar correctness
+        new Double(42.5)    | 42 // lenient scalar correctness
+        new Float(42.5)     | 42 // lenient scalar correctness
+        new Long(42)        | 42 // lenient scalar correctness
+        null                | null
+    }
+
+    @Unroll
+    def "Float serialize/parseValue #value into #result"() {
+        expect:
+        LenientNumericalScalars.GraphQLFloat.getCoercing().serialize(value) == result
+        LenientNumericalScalars.GraphQLFloat.getCoercing().parseValue(value) == result
+
+        where:
+        value      | result
+        "11.3"     | 11.3d
+        "24.0"     | 24.0d
+        42.3f      | 42.3f
+        10         | 10.0d
+        90.000004d | 90.000004d
+        null       | null
+    }
+
+    @Unroll
+    def "BigInteger serialize/parseValue #value into #result"() {
+        expect:
+        LenientNumericalScalars.GraphQLBigInteger.getCoercing().serialize(value) == result
+        LenientNumericalScalars.GraphQLBigInteger.getCoercing().parseValue(value) == result
+
+        where:
+        value                                                 | result
+        "42"                                                  | 42
+        new Long(42345784398534785l)                          | 42345784398534785l
+        new Integer(42)                                       | 42
+        "-1"                                                  | -1
+        new Double(42.5)                                      | 42 // lenient scalar correctness
+        new Float(42)                                         | 42 // lenient scalar correctness
+        null                                                  | null
+        "423457843985347854234578439853478542345784398534785" | new BigInteger("423457843985347854234578439853478542345784398534785")
+    }
+
+    @Unroll
+    def "BigDecimal serialize/parseValue #value into #result"() {
+        expect:
+        LenientNumericalScalars.GraphQLBigDecimal.getCoercing().serialize(value) == result
+        LenientNumericalScalars.GraphQLBigDecimal.getCoercing().parseValue(value) == result
+
+        where:
+        value      | result
+        "11.3"     | 11.3d
+        "24.0"     | 24.0d
+        42.3f      | 42.3f
+        10         | 10.0d
+        90.000004d | 90.000004d
+        null       | null
+    }
+
+}

--- a/src/test/groovy/graphql/ScalarsTest.groovy
+++ b/src/test/groovy/graphql/ScalarsTest.groovy
@@ -86,6 +86,7 @@ class ScalarsTest extends Specification {
         new Long(42345784398534785l) | 42345784398534785l
         new Integer(42)              | 42
         "-1"                         | -1
+        new Double(42.5)             | null // strict scalar correctness
         null                         | null
     }
 
@@ -96,11 +97,10 @@ class ScalarsTest extends Specification {
         Scalars.GraphQLInt.getCoercing().parseLiteral(literal) == result
 
         where:
-        literal          | result
-        new IntValue(42) | 42
+        literal               | result
+        new IntValue(42)      | 42
         new StringValue("-1") | null
         new FloatValue(42.3)  | null
-        
     }
 
     @Unroll
@@ -110,12 +110,74 @@ class ScalarsTest extends Specification {
         Scalars.GraphQLInt.getCoercing().parseValue(value) == result
 
         where:
-        value           | result
-        "42"            | 42
-        new Integer(42) | 42
-        "-1"            | -1
-        null            | null
+        value               | result
+        "42"                | 42
+        new Integer(42)     | 42
+        "-1"                | -1
+        new Double(42.5)    | null // strict scalar correctness
+        new Long(42)        | null // strict scalar correctness
+        null                | null
     }
+
+    @Unroll
+    def "Short parse literal #literal.value as #result"() {
+        expect:
+        Scalars.GraphQLShort.getCoercing().parseLiteral(literal) == result
+
+        where:
+        literal               | result
+        new IntValue(42)      | 42
+        new StringValue("-1") | null
+        new FloatValue(42.3)  | null
+    }
+
+    @Unroll
+    def "Short serialize/parseValue #value into #result"() {
+        expect:
+        Scalars.GraphQLShort.getCoercing().serialize(value) == result
+        Scalars.GraphQLShort.getCoercing().parseValue(value) == result
+
+        where:
+        value               | result
+        "42"                | 42
+        Short.valueOf("42") | 42
+        "-1"                | -1
+        new Integer(42)     | null // strict scalar correctness
+        new Double(42.5)    | null // strict scalar correctness
+        new Long(42)        | null // strict scalar correctness
+        null                | null
+    }
+    @Unroll
+    def "Byte parse literal #literal.value as #result"() {
+        expect:
+        Scalars.GraphQLByte.getCoercing().parseLiteral(literal) == result
+
+        where:
+        literal               | result
+        new IntValue(42)      | 42
+        new StringValue("-1") | null
+        new FloatValue(42.3)  | null
+    }
+
+    @Unroll
+    def "Byte serialize/parseValue #value into #result"() {
+        expect:
+        Scalars.GraphQLByte.getCoercing().serialize(value) == result
+        Scalars.GraphQLByte.getCoercing().parseValue(value) == result
+
+        where:
+        value               | result
+        "42"                | 42
+        Byte.valueOf("42")  | 42
+        "-1"                | -1
+        Short.valueOf("42") | null // strict scalar correctness
+        new Integer(42)     | null // strict scalar correctness
+        new Double(42.5)    | null // strict scalar correctness
+        new Float(42.5)     | null // strict scalar correctness
+        new Long(42)        | null // strict scalar correctness
+        null                | null
+    }
+
 
     @Unroll
     def "#scalar.name parse error for too big/small literal"() {
@@ -240,6 +302,8 @@ class ScalarsTest extends Specification {
         new Long(42345784398534785l) | 42345784398534785l
         new Integer(42)              | 42
         "-1"                         | -1
+        new Double(42.5)             | null // strict scalar correctness
+        new Float(42)                | null // strict scalar correctness
         null                         | null
         "423457843985347854234578439853478542345784398534785" | new BigInteger("423457843985347854234578439853478542345784398534785")
     }
@@ -265,13 +329,13 @@ class ScalarsTest extends Specification {
         Scalars.GraphQLBigDecimal.getCoercing().parseValue(value) == result
 
         where:
-        value      | result
-        "11.3"     | 11.3d
-        "24.0"     | 24.0d
-        42.3f      | 42.3f
-        10         | 10.0d
-        90.000004d | 90.000004d
-        null       | null
+        value               | result
+        "11.3"              | 11.3d
+        "24.0"              | 24.0d
+        42.3f               | 42.3f
+        10                  | 10.0d
+        90.000004d          | 90.000004d
+        null                | null
     }
 
     @Unroll

--- a/src/test/groovy/readme/ReadmeExamples.java
+++ b/src/test/groovy/readme/ReadmeExamples.java
@@ -2,6 +2,8 @@ package readme;
 
 import graphql.GarfieldSchema;
 import graphql.GraphQL;
+import graphql.LenientNumericalScalars;
+import graphql.Scalars;
 import graphql.StarWarsSchema;
 import graphql.execution.ExecutorServiceExecutionStrategy;
 import graphql.execution.SimpleExecutionStrategy;
@@ -169,6 +171,17 @@ public class ReadmeExamples {
                         .type(GraphQLString)
                         .dataFetcher(fooDataFetcher))
                 .build();
+
+    }
+
+    void lenientScalarSupport() {
+        newFieldDefinition()
+                        .name("strict")
+                        .type(Scalars.GraphQLInt);
+
+        newFieldDefinition()
+                        .name("lenient")
+                        .type(LenientNumericalScalars.GraphQLInt);
 
     }
 


### PR DESCRIPTION
#105 - support for lenient scalar numerical types

I am still not sure whether the default in the library should be "strict" or "lenient" by default.

I personally prefer "lenient" by default since a number of people have reported that 42.3 as input becomes null as surprising (as I did)

But I cant understand being strict as well.

This code could be reversed and the tests switch if it is decided to be lenient by default say