### PR TITLE
Remove prefix string from getMessage

### DIFF
--- a/src/main/java/graphql/ExceptionWhileDataFetching.java
+++ b/src/main/java/graphql/ExceptionWhileDataFetching.java
@@ -17,10 +17,9 @@ public class ExceptionWhileDataFetching implements GraphQLError {
         return exception;
     }
 
-
     @Override
     public String getMessage() {
-        return "Exception while fetching data: " + exception.toString();
+        return exception.getMessage();
     }
 
     @Override


### PR DESCRIPTION
Suggestion: Can we remove the prefix string from the getMessage method of this exception wrapper? It makes things a little tricky and can expose the toString implementation of an exception where it is not desired.