### PR TITLE
Validate name field matches current spec's conventions

### DIFF
--- a/src/main/java/graphql/Assert.java
+++ b/src/main/java/graphql/Assert.java
@@ -15,4 +15,18 @@ public class Assert {
         return c;
     }
 
+    private static final String invalidNameErrorMessage = "Name must be non-null, non-empty and match [_A-Za-z][_0-9A-Za-z]*";
+    /**
+     * Validates that the Lexical token name matches the current spec.
+     * currently non null, non empty, 
+     * @param name - the name to be validated.
+     * @return the name if valid, or AssertException if invalid. 
+     */
+	public static String assertValidName(String name) {
+		if (name != null && !name.isEmpty() && name.matches("[_A-Za-z][_0-9A-Za-z]*")) {
+			return name;
+		}
+		throw new AssertException(invalidNameErrorMessage);
+	}
+
 }

--- a/src/main/java/graphql/schema/GraphQLArgument.java
+++ b/src/main/java/graphql/schema/GraphQLArgument.java
@@ -4,6 +4,7 @@ package graphql.schema;
 import java.util.Map;
 
 import static graphql.Assert.assertNotNull;
+import static graphql.Assert.assertValidName;
 
 public class GraphQLArgument {
 
@@ -13,7 +14,7 @@ public class GraphQLArgument {
     private final Object defaultValue;
 
     public GraphQLArgument(String name, String description, GraphQLInputType type, Object defaultValue) {
-        assertNotNull(name, "name can't be null");
+    	assertValidName(name);
         assertNotNull(type, "type can't be null");
         this.name = name;
         this.description = description;

--- a/src/main/java/graphql/schema/GraphQLDirective.java
+++ b/src/main/java/graphql/schema/GraphQLDirective.java
@@ -6,6 +6,7 @@ import java.util.EnumSet;
 import java.util.List;
 
 import static graphql.Assert.assertNotNull;
+import static graphql.Assert.assertValidName;
 import static graphql.introspection.Introspection.DirectiveLocation;
 
 public class GraphQLDirective {
@@ -20,7 +21,7 @@ public class GraphQLDirective {
 
     public GraphQLDirective(String name, String description, EnumSet<DirectiveLocation> locations,
                             List<GraphQLArgument> arguments, boolean onOperation, boolean onFragment, boolean onField) {
-        assertNotNull(name, "name can't be null");
+    	assertValidName(name);
         assertNotNull(arguments, "arguments can't be null");
         this.name = name;
         this.description = description;

--- a/src/main/java/graphql/schema/GraphQLEnumType.java
+++ b/src/main/java/graphql/schema/GraphQLEnumType.java
@@ -9,7 +9,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import static graphql.Assert.assertNotNull;
+import static graphql.Assert.assertValidName;
 
 public class GraphQLEnumType implements GraphQLType, GraphQLInputType, GraphQLOutputType, GraphQLUnmodifiedType {
 
@@ -63,7 +63,7 @@ public class GraphQLEnumType implements GraphQLType, GraphQLInputType, GraphQLOu
 
 
     public GraphQLEnumType(String name, String description, List<GraphQLEnumValueDefinition> values) {
-        assertNotNull(name, "name can't be null");
+    	assertValidName(name);
         this.name = name;
         this.description = description;
         buildMap(values);

--- a/src/main/java/graphql/schema/GraphQLEnumValueDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLEnumValueDefinition.java
@@ -2,6 +2,7 @@ package graphql.schema;
 
 
 import static graphql.Assert.assertNotNull;
+import static graphql.Assert.assertValidName;
 
 public class GraphQLEnumValueDefinition {
 
@@ -11,7 +12,7 @@ public class GraphQLEnumValueDefinition {
     private final String deprecationReason;
 
     public GraphQLEnumValueDefinition(String name, String description, Object value, String deprecationReason) {
-        assertNotNull(name, "name can't be null");
+    	assertValidName(name);
         this.name = name;
         this.description = description;
         this.value = value;

--- a/src/main/java/graphql/schema/GraphQLFieldDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLFieldDefinition.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 
 import static graphql.Assert.assertNotNull;
+import static graphql.Assert.assertValidName;
 
 public class GraphQLFieldDefinition {
 
@@ -18,7 +19,7 @@ public class GraphQLFieldDefinition {
 
 
     public GraphQLFieldDefinition(String name, String description, GraphQLOutputType type, DataFetcher dataFetcher, List<GraphQLArgument> arguments, String deprecationReason) {
-        assertNotNull(name, "name can't be null");
+    	assertValidName(name);
         assertNotNull(dataFetcher, "dataFetcher can't be null");
         assertNotNull(type, "type can't be null");
         assertNotNull(arguments, "arguments can't be null");

--- a/src/main/java/graphql/schema/GraphQLInputObjectField.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectField.java
@@ -4,6 +4,7 @@ package graphql.schema;
 import java.util.Map;
 
 import static graphql.Assert.assertNotNull;
+import static graphql.Assert.assertValidName;
 
 public class GraphQLInputObjectField {
 
@@ -17,7 +18,7 @@ public class GraphQLInputObjectField {
     }
 
     public GraphQLInputObjectField(String name, String description, GraphQLInputType type, Object defaultValue) {
-        assertNotNull(name, "name can't be null");
+    	assertValidName(name);
         assertNotNull(type, "type can't be null");
         this.name = name;
         this.type = type;

--- a/src/main/java/graphql/schema/GraphQLInputObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectType.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import graphql.AssertException;
 
 import static graphql.Assert.assertNotNull;
+import static graphql.Assert.assertValidName;
 
 public class GraphQLInputObjectType implements GraphQLType, GraphQLInputType, GraphQLUnmodifiedType, GraphQLNullableType, GraphQLInputFieldsContainer {
 
@@ -19,7 +20,7 @@ public class GraphQLInputObjectType implements GraphQLType, GraphQLInputType, Gr
     private final Map<String, GraphQLInputObjectField> fieldMap = new LinkedHashMap<String, GraphQLInputObjectField>();
 
     public GraphQLInputObjectType(String name, String description, List<GraphQLInputObjectField> fields) {
-        assertNotNull(name, "name can't be null");
+    	assertValidName(name);
         assertNotNull(fields, "fields can't be null");
         this.name = name;
         this.description = description;

--- a/src/main/java/graphql/schema/GraphQLInterfaceType.java
+++ b/src/main/java/graphql/schema/GraphQLInterfaceType.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import graphql.AssertException;
 
 import static graphql.Assert.assertNotNull;
+import static graphql.Assert.assertValidName;
 
 public class GraphQLInterfaceType implements GraphQLType, GraphQLOutputType, GraphQLFieldsContainer, GraphQLCompositeType, GraphQLUnmodifiedType, GraphQLNullableType {
 
@@ -18,7 +19,7 @@ public class GraphQLInterfaceType implements GraphQLType, GraphQLOutputType, Gra
     private final TypeResolver typeResolver;
 
     public GraphQLInterfaceType(String name, String description, List<GraphQLFieldDefinition> fieldDefinitions, TypeResolver typeResolver) {
-        assertNotNull(name, "name can't null");
+    	assertValidName(name);
         assertNotNull(typeResolver, "typeResolver can't null");
         assertNotNull(fieldDefinitions, "fieldDefinitions can't null");
         this.name = name;

--- a/src/main/java/graphql/schema/GraphQLObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLObjectType.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import graphql.AssertException;
 
 import static graphql.Assert.assertNotNull;
+import static graphql.Assert.assertValidName;
 
 public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQLFieldsContainer, GraphQLCompositeType, GraphQLUnmodifiedType, GraphQLNullableType {
 
@@ -19,7 +20,7 @@ public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQ
 
     public GraphQLObjectType(String name, String description, List<GraphQLFieldDefinition> fieldDefinitions,
                              List<GraphQLInterfaceType> interfaces) {
-        assertNotNull(name, "name can't be null");
+    	assertValidName(name);
         assertNotNull(fieldDefinitions, "fieldDefinitions can't be null");
         assertNotNull(interfaces, "interfaces can't be null");
         assertNotNull(interfaces, "unresolvedInterfaces can't be null");

--- a/src/main/java/graphql/schema/GraphQLScalarType.java
+++ b/src/main/java/graphql/schema/GraphQLScalarType.java
@@ -2,6 +2,7 @@ package graphql.schema;
 
 
 import static graphql.Assert.assertNotNull;
+import static graphql.Assert.assertValidName;
 
 public class GraphQLScalarType implements GraphQLType, GraphQLInputType, GraphQLOutputType, GraphQLUnmodifiedType, GraphQLNullableType {
 
@@ -11,7 +12,7 @@ public class GraphQLScalarType implements GraphQLType, GraphQLInputType, GraphQL
 
 
     public GraphQLScalarType(String name, String description, Coercing coercing) {
-        assertNotNull(name, "name can't be null");
+    	assertValidName(name);
         assertNotNull(coercing, "coercing can't be null");
         this.name = name;
         this.description = description;

--- a/src/main/java/graphql/schema/GraphQLTypeReference.java
+++ b/src/main/java/graphql/schema/GraphQLTypeReference.java
@@ -2,6 +2,7 @@ package graphql.schema;
 
 
 import static graphql.Assert.assertNotNull;
+import static graphql.Assert.assertValidName;
 
 /**
  * A special type to allow a object/interface types to reference itself. It's replaced with the real type
@@ -12,7 +13,7 @@ public class GraphQLTypeReference implements GraphQLType, GraphQLOutputType, Gra
     private final String name;
 
     public GraphQLTypeReference(String name) {
-        assertNotNull(name, "name can't be null");
+    	assertValidName(name);
         this.name = name;
     }
 

--- a/src/main/java/graphql/schema/GraphQLUnionType.java
+++ b/src/main/java/graphql/schema/GraphQLUnionType.java
@@ -16,7 +16,7 @@ public class GraphQLUnionType implements GraphQLType, GraphQLOutputType, GraphQL
 
 
     public GraphQLUnionType(String name, String description, List<GraphQLObjectType> types, TypeResolver typeResolver) {
-        assertNotNull(name, "name can't be null");
+    	assertValidName(name);
         assertNotNull(types, "types can't be null");
         assertNotEmpty(types, "A Union type must define one or more member types.");
         assertNotNull(typeResolver, "typeResolver can't be null");


### PR DESCRIPTION
Validation of schema names on the server side (not in the query document)  