### PR TITLE
PropertyDataFetcherTest throwing exception

### DIFF
--- a/src/test/groovy/graphql/schema/PropertyDataFetcherTest.groovy
+++ b/src/test/groovy/graphql/schema/PropertyDataFetcherTest.groovy
@@ -7,7 +7,7 @@ import spock.lang.Specification
 class PropertyDataFetcherTest extends Specification {
 
     def env(obj) {
-        return new DataFetchingEnvironment(obj,
+        return new DataFetchingEnvironmentImpl(obj,
                 Collections.emptyMap(),
                 null,
                 Collections.emptyList(),


### PR DESCRIPTION
It was throwing an exception while trying to instantiate the interface under test and not an impl of the interface.  Here is what I am seeing:

> gradlew clean build

`PropertyDataFetcherTest.groovy: 10: You cannot create an instance from the abstract interface 'graphql.schema.DataFetchingEnvironment'.
 @ line 10, column 16.
           return new DataFetchingEnvironment(obj,
                  ^

1 error`