### PR TITLE
#345 - mutations are optional and errors should come back if they are missing

### DIFF
--- a/src/main/java/graphql/ErrorType.java
+++ b/src/main/java/graphql/ErrorType.java
@@ -6,6 +6,6 @@ public enum ErrorType {
     InvalidSyntax,
     ValidationError,
     DataFetchingException,
-    MutationsNoSupported
+    MutationNotSupported
 
 }

--- a/src/main/java/graphql/ErrorType.java
+++ b/src/main/java/graphql/ErrorType.java
@@ -5,6 +5,7 @@ public enum ErrorType {
 
     InvalidSyntax,
     ValidationError,
-    DataFetchingException
+    DataFetchingException,
+    MutationsNoSupported
 
 }

--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -87,9 +87,9 @@ public class GraphQL {
 
     private GraphQL(GraphQLSchema graphQLSchema, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy, ExecutionIdProvider idProvider, Instrumentation instrumentation) {
         this.graphQLSchema = assertNotNull(graphQLSchema,"queryStrategy must be non null");
-        this.queryStrategy = assertNotNull(queryStrategy, "queryStrategy must be non null");
+        this.queryStrategy = queryStrategy != null ? queryStrategy : new SimpleExecutionStrategy();
+        this.mutationStrategy = mutationStrategy != null ? mutationStrategy : new SimpleExecutionStrategy();
         this.idProvider = assertNotNull(idProvider, "idProvider must be non null");
-        this.mutationStrategy = mutationStrategy;
         this.instrumentation = instrumentation;
     }
 
@@ -143,6 +143,9 @@ public class GraphQL {
         }
 
         public GraphQL build() {
+            assertNotNull(graphQLSchema,"queryStrategy must be non null");
+            assertNotNull(queryExecutionStrategy, "queryStrategy must be non null");
+            assertNotNull(idProvider, "idProvider must be non null");
             return new GraphQL(graphQLSchema, queryExecutionStrategy, mutationExecutionStrategy, idProvider, instrumentation);
         }
     }

--- a/src/main/java/graphql/GraphQLError.java
+++ b/src/main/java/graphql/GraphQLError.java
@@ -28,10 +28,14 @@ public interface GraphQLError {
             return result;
         }
 
-        public static boolean equals(GraphQLError dis, GraphQLError dat) {
-            if (dis == dat) {
+        public static boolean equals(GraphQLError dis, Object o) {
+            if (dis == o) {
                 return true;
             }
+            if (o == null || dis.getClass() != o.getClass()) return false;
+
+            GraphQLError dat = (GraphQLError) o;
+
             if (dis.getMessage() != null ? !dis.getMessage().equals(dat.getMessage()) : dat.getMessage() != null)
                 return false;
             if (dis.getLocations() != null ? !dis.getLocations().equals(dat.getLocations()) : dat.getLocations() != null)

--- a/src/main/java/graphql/InvalidSyntaxError.java
+++ b/src/main/java/graphql/InvalidSyntaxError.java
@@ -46,12 +46,7 @@ public class InvalidSyntaxError implements GraphQLError {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        InvalidSyntaxError that = (InvalidSyntaxError) o;
-
-        return Helper.equals(this,that);
+        return Helper.equals(this, o);
     }
 
     @Override

--- a/src/main/java/graphql/MutationNotSupportedError.java
+++ b/src/main/java/graphql/MutationNotSupportedError.java
@@ -25,7 +25,7 @@ public class MutationNotSupportedError implements GraphQLError {
 
     @Override
     public ErrorType getErrorType() {
-        return ErrorType.MutationsNoSupported;
+        return ErrorType.MutationNotSupported;
     }
 
     @Override

--- a/src/main/java/graphql/MutationNotSupportedError.java
+++ b/src/main/java/graphql/MutationNotSupportedError.java
@@ -5,22 +5,17 @@ import graphql.language.SourceLocation;
 
 import java.util.List;
 
-public class ExceptionWhileDataFetching implements GraphQLError {
-
-    private final Throwable exception;
-
-    public ExceptionWhileDataFetching(Throwable exception) {
-        this.exception = exception;
-    }
-
-    public Throwable getException() {
-        return exception;
-    }
-
+/**
+ * The graphql spec says that mutations are optional but it does not specify how to respond
+ * when it is not supported.  This error is returned in this case.
+ *
+ * http://facebook.github.io/graphql/#sec-Initial-types
+ */
+public class MutationNotSupportedError implements GraphQLError {
 
     @Override
     public String getMessage() {
-        return "Exception while fetching data: " + exception.toString();
+        return "Mutations are not supported onm this schema";
     }
 
     @Override
@@ -30,14 +25,12 @@ public class ExceptionWhileDataFetching implements GraphQLError {
 
     @Override
     public ErrorType getErrorType() {
-        return ErrorType.DataFetchingException;
+        return ErrorType.MutationsNoSupported;
     }
 
     @Override
     public String toString() {
-        return "ExceptionWhileDataFetching{" +
-                "exception=" + exception +
-                '}';
+        return "MutationNotSupportedError";
     }
 
     @Override

--- a/src/main/java/graphql/schema/validation/InvalidSchemaException.java
+++ b/src/main/java/graphql/schema/validation/InvalidSchemaException.java
@@ -1,23 +1,20 @@
 package graphql.schema.validation;
 
-import java.util.Collection;
-
 import graphql.GraphQLException;
 
+import java.util.Collection;
+
 public class InvalidSchemaException extends GraphQLException {
-    
-    private final String message;
-    
+
     public InvalidSchemaException(Collection<ValidationError> errors) {
+        super(buildErrorMsg(errors));
+    }
+
+    private static String buildErrorMsg(Collection<ValidationError> errors) {
         StringBuilder message = new StringBuilder("invalid schema:");
         for (ValidationError error : errors) {
             message.append("\n").append(error.getDescription());
         }
-        this.message = message.toString();
-    }
-
-    @Override
-    public String getMessage() {
-        return message;
+        return message.toString();
     }
 }

--- a/src/main/java/graphql/validation/ValidationError.java
+++ b/src/main/java/graphql/validation/ValidationError.java
@@ -64,12 +64,7 @@ public class ValidationError implements GraphQLError {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        ValidationError that = (ValidationError) o;
-
-        return Helper.equals(this, that);
+        return Helper.equals(this, o);
     }
 
     @Override

--- a/src/test/groovy/graphql/GraphQLTest.groovy
+++ b/src/test/groovy/graphql/GraphQLTest.groovy
@@ -154,13 +154,13 @@ class GraphQLTest extends Specification {
         set.add("Two")
 
         def schema = GraphQLSchema.newSchema()
-          .query(GraphQLObjectType.newObject()
-            .name("QueryType")
-            .field(GraphQLFieldDefinition.newFieldDefinition()
-              .name("set")
-              .type(new GraphQLList(GraphQLString))
-              .dataFetcher({ set })))
-          .build()
+                .query(GraphQLObjectType.newObject()
+                .name("QueryType")
+                .field(GraphQLFieldDefinition.newFieldDefinition()
+                .name("set")
+                .type(new GraphQLList(GraphQLString))
+                .dataFetcher({ set })))
+                .build()
 
         when:
         def data = GraphQL.newGraphQL(schema).build().execute("query { set }").data
@@ -203,7 +203,7 @@ class GraphQLTest extends Specification {
                         .name("RootQueryType")
                         .field(newFieldDefinition().name("name").type(GraphQLString))
         )
-        .build()
+                .build()
 
         def query = """
         query Query1 { name }
@@ -215,5 +215,22 @@ class GraphQLTest extends Specification {
 
         then:
         thrown(GraphQLException)
+    }
+
+    def "null mutation type does not throw an npe re: #345 but returns and error"() {
+        given:
+
+        GraphQLSchema schema = newSchema().query(
+                newObject()
+                        .name("Query")
+        )
+                .build()
+
+        when:
+        def result = new GraphQL(schema).execute("mutation { doesNotExist }");
+
+        then:
+        result.errors.size() == 1
+        result.errors[0].class == MutationNotSupportedError
     }
 }


### PR DESCRIPTION
#345 outlined that NPEs can happen when mutation strategies are missing

But in fixing that I noticed that we blow up when there is no mutation root type

This is actually valid to NOT have a mutation root type but the spec is unclear on what should happen when "mutation is not allowed".

I am pretty sure that NullPointerException is not the desired response ;)

So I have made it return a new MutationNotSupportedError instead