### PR TITLE
Provide more information to TypeResolver

### DIFF
--- a/src/main/java/graphql/TypeResolutionEnvironment.java
+++ b/src/main/java/graphql/TypeResolutionEnvironment.java
@@ -1,0 +1,44 @@
+package graphql;
+
+import java.util.Map;
+
+import graphql.language.Field;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLType;
+
+public class TypeResolutionEnvironment {
+
+    private final Object object;
+    private final Map<String, Object> arguments;
+    private final Field field;
+    private final GraphQLType fieldType;
+    private final GraphQLSchema schema;
+
+    public TypeResolutionEnvironment(Object object, Map<String, Object> arguments, Field field, GraphQLType fieldType, GraphQLSchema schema) {
+        this.object = object;
+        this.arguments = arguments;
+        this.field = field;
+        this.fieldType = fieldType;
+        this.schema = schema;
+    }
+
+    public Object getObject() {
+        return object;
+    }
+
+    public Map<String, Object> getArguments() {
+        return arguments;
+    }
+
+    public Field getField() {
+        return field;
+    }
+
+    public GraphQLType getFieldType() {
+        return fieldType;
+    }
+
+    public GraphQLSchema getSchema() {
+        return schema;
+    }
+}

--- a/src/main/java/graphql/execution/TypeResolutionParameters.java
+++ b/src/main/java/graphql/execution/TypeResolutionParameters.java
@@ -1,0 +1,100 @@
+package graphql.execution;
+
+import java.util.Map;
+
+import graphql.language.Field;
+import graphql.schema.GraphQLInterfaceType;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLUnionType;
+
+public class TypeResolutionParameters {
+
+    private final GraphQLInterfaceType graphQLInterfaceType;
+    private final GraphQLUnionType graphQLUnionType;
+    private final Field field;
+    private final Object value;
+    private final Map<String, Object> argumentValues;
+    private final GraphQLSchema schema;
+
+    private TypeResolutionParameters(GraphQLInterfaceType graphQLInterfaceType, GraphQLUnionType graphQLUnionType,
+                                     Field field, Object value, Map<String, Object> argumentValues, GraphQLSchema schema) {
+        this.graphQLInterfaceType = graphQLInterfaceType;
+        this.graphQLUnionType = graphQLUnionType;
+        this.field = field;
+        this.value = value;
+        this.argumentValues = argumentValues;
+        this.schema = schema;
+    }
+
+    public GraphQLInterfaceType getGraphQLInterfaceType() {
+        return graphQLInterfaceType;
+    }
+
+    public GraphQLUnionType getGraphQLUnionType() {
+        return graphQLUnionType;
+    }
+
+    public Field getField() {
+        return field;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+
+    public Map<String, Object> getArgumentValues() {
+        return argumentValues;
+    }
+
+    public GraphQLSchema getSchema() {
+        return schema;
+    }
+
+    public static Builder newParameters() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private Field field;
+        private GraphQLInterfaceType graphQLInterfaceType;
+        private GraphQLUnionType graphQLUnionType;
+        private Object value;
+        private Map<String, Object> argumentValues;
+        private GraphQLSchema schema;
+
+        public Builder field(Field field) {
+            this.field = field;
+            return this;
+        }
+
+        public Builder graphQLInterfaceType(GraphQLInterfaceType graphQLInterfaceType) {
+            this.graphQLInterfaceType = graphQLInterfaceType;
+            return this;
+        }
+
+        public Builder graphQLUnionType(GraphQLUnionType graphQLUnionType) {
+            this.graphQLUnionType = graphQLUnionType;
+            return this;
+        }
+
+        public Builder value(Object value) {
+            this.value = value;
+            return this;
+        }
+
+        public Builder argumentValues(Map<String, Object> argumentValues) {
+            this.argumentValues = argumentValues;
+            return this;
+        }
+
+        public Builder schema(GraphQLSchema schema) {
+            this.schema = schema;
+            return this;
+        }
+
+        public TypeResolutionParameters build() {
+            return new TypeResolutionParameters(graphQLInterfaceType, graphQLUnionType, field, value, argumentValues, schema);
+        }
+    }
+}

--- a/src/main/java/graphql/execution/ValueCompletionParameters.java
+++ b/src/main/java/graphql/execution/ValueCompletionParameters.java
@@ -1,0 +1,90 @@
+package graphql.execution;
+
+import java.util.List;
+import java.util.Map;
+
+import graphql.language.Field;
+import graphql.schema.GraphQLType;
+
+class ValueCompletionParameters {
+
+    private final ExecutionContext executionContext;
+    private final GraphQLType fieldType;
+    private final List<Field> fields;
+    private final Object result;
+    private final Map<String, Object> argumentValues;
+
+    private ValueCompletionParameters(ExecutionContext executionContext, GraphQLType fieldType,
+                                      List<Field> fields, Object result, Map<String, Object> argumentValues) {
+
+        this.executionContext = executionContext;
+        this.fieldType = fieldType;
+        this.fields = fields;
+        this.result = result;
+        this.argumentValues = argumentValues;
+    }
+
+    public ExecutionContext getExecutionContext() {
+        return executionContext;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T extends GraphQLType> T getFieldType() {
+        return (T) fieldType;
+    }
+
+    public List<Field> getFields() {
+        return fields;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> T getResult() {
+        return (T) result;
+    }
+
+    public Map<String, Object> getArgumentValues() {
+        return argumentValues;
+    }
+
+    public static Builder newParameters() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private ExecutionContext executionContext;
+        private GraphQLType fieldType;
+        private List<Field> fields;
+        private Object result;
+        private Map<String, Object> argumentValues;
+
+        public Builder executionContext(ExecutionContext executionContext) {
+            this.executionContext = executionContext;
+            return this;
+        }
+
+        public Builder fieldType(GraphQLType fieldType) {
+            this.fieldType = fieldType;
+            return this;
+        }
+
+        public Builder fields(List<Field> fields) {
+            this.fields = fields;
+            return this;
+        }
+
+        public Builder result(Object result) {
+            this.result = result;
+            return this;
+        }
+
+        public Builder argumentValues(Map<String, Object> argumentValues) {
+            this.argumentValues = argumentValues;
+            return this;
+        }
+
+        public ValueCompletionParameters build() {
+            return new ValueCompletionParameters(executionContext, fieldType, fields, result, argumentValues);
+        }
+    }
+}

--- a/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
+++ b/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
@@ -6,6 +6,7 @@ import graphql.ExecutionResultImpl;
 import graphql.GraphQLException;
 import graphql.execution.ExecutionContext;
 import graphql.execution.ExecutionStrategy;
+import graphql.execution.TypeResolutionParameters;
 import graphql.language.Field;
 import graphql.schema.*;
 import org.slf4j.Logger;
@@ -75,7 +76,9 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
         }
         List<GraphQLExecutionNodeValue> values = fetchData(executionContext, parentType, nodeData, fields, fieldDef);
 
-        return completeValues(executionContext, parentType, values, fieldName, fields, fieldDef.getType());
+        Map<String, Object> argumentValues = valuesResolver.getArgumentValues(
+                fieldDef.getArguments(), fields.get(0).getArguments(), executionContext.getVariables());
+        return completeValues(executionContext, parentType, values, fieldName, fields, fieldDef.getType(), argumentValues);
     }
 
     /**
@@ -83,7 +86,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
      */
     private List<GraphQLExecutionNode> completeValues(ExecutionContext executionContext, GraphQLObjectType parentType,
                                                       List<GraphQLExecutionNodeValue> values, String fieldName, List<Field> fields,
-                                                      GraphQLOutputType outputType) {
+                                                      GraphQLOutputType outputType, Map<String, Object> argumentValues) {
 
         GraphQLType fieldType = handleNonNullType(outputType, values, parentType, fields);
 
@@ -91,16 +94,16 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
             handlePrimitives(values, fieldName, fieldType);
             return Collections.emptyList();
         } else if (isObject(fieldType)) {
-            return handleObject(executionContext, values, fieldName, fields, fieldType);
+            return handleObject(executionContext, argumentValues, values, fieldName, fields, fieldType);
         } else if (isList(fieldType)) {
-            return handleList(executionContext, values, fieldName, fields, parentType, (GraphQLList) fieldType);
+            return handleList(executionContext, argumentValues, values, fieldName, fields, parentType, (GraphQLList) fieldType);
         } else {
             throw new IllegalArgumentException("Unrecognized type: " + fieldType);
         }
     }
 
     @SuppressWarnings("unchecked")
-    private List<GraphQLExecutionNode> handleList(ExecutionContext executionContext,
+    private List<GraphQLExecutionNode> handleList(ExecutionContext executionContext, Map<String, Object> argumentValues,
                                                   List<GraphQLExecutionNodeValue> values, String fieldName, List<Field> fields,
                                                   GraphQLObjectType parentType, GraphQLList listType) {
 
@@ -119,15 +122,15 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
         }
 
         GraphQLOutputType subType = (GraphQLOutputType) listType.getWrappedType();
-        return completeValues(executionContext, parentType, flattenedNodeValues, fieldName, fields, subType);
+        return completeValues(executionContext, parentType, flattenedNodeValues, fieldName, fields, subType, argumentValues);
 
     }
 
     @SuppressWarnings("UnnecessaryLocalVariable")
-    private List<GraphQLExecutionNode> handleObject(ExecutionContext executionContext,
+    private List<GraphQLExecutionNode> handleObject(ExecutionContext executionContext, Map<String, Object> argumentValues,
                                                     List<GraphQLExecutionNodeValue> values, String fieldName, List<Field> fields, GraphQLType fieldType) {
 
-        ChildDataCollector collector = createAndPopulateChildData(values, fieldName, fieldType);
+        ChildDataCollector collector = createAndPopulateChildData(executionContext, fields.get(0), values, fieldName, fieldType, argumentValues);
 
         List<GraphQLExecutionNode> childNodes =
                 createChildNodes(executionContext, fields, collector);
@@ -147,8 +150,8 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
         return childNodes;
     }
 
-    private ChildDataCollector createAndPopulateChildData(List<GraphQLExecutionNodeValue> values, String fieldName,
-                                                          GraphQLType fieldType) {
+    private ChildDataCollector createAndPopulateChildData(ExecutionContext executionContext, Field field, List<GraphQLExecutionNodeValue> values, String fieldName,
+                                                          GraphQLType fieldType, Map<String, Object> argumentValues) {
         ChildDataCollector collector = new ChildDataCollector();
         for (GraphQLExecutionNodeValue value : values) {
             if (value.getValue() == null) {
@@ -156,7 +159,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
                 value.getResultContainer().putResult(fieldName, null);
             } else {
                 GraphQLExecutionNodeDatum childDatum = value.getResultContainer().createAndPutChildDatum(fieldName, value.getValue());
-                GraphQLObjectType graphQLObjectType = getGraphQLObjectType(fieldType, value.getValue());
+                GraphQLObjectType graphQLObjectType = getGraphQLObjectType(executionContext, field, fieldType, value.getValue(), argumentValues);
                 collector.putChildData(graphQLObjectType, childDatum);
             }
         }
@@ -195,12 +198,24 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
         return subFields;
     }
 
-    private GraphQLObjectType getGraphQLObjectType(GraphQLType fieldType, Object value) {
+    private GraphQLObjectType getGraphQLObjectType(ExecutionContext executionContext, Field field, GraphQLType fieldType, Object value, Map<String, Object> argumentValues) {
         GraphQLObjectType resolvedType = null;
         if (fieldType instanceof GraphQLInterfaceType) {
-            resolvedType = resolveType((GraphQLInterfaceType) fieldType, value);
+            resolvedType = resolveTypeForInterface(TypeResolutionParameters.newParameters()
+                    .graphQLInterfaceType((GraphQLInterfaceType) fieldType)
+                    .field(field)
+                    .value(value)
+                    .argumentValues(argumentValues)
+                    .schema(executionContext.getGraphQLSchema())
+                    .build());
         } else if (fieldType instanceof GraphQLUnionType) {
-            resolvedType = resolveType((GraphQLUnionType) fieldType, value);
+            resolvedType = resolveTypeForUnion(TypeResolutionParameters.newParameters()
+                    .graphQLUnionType((GraphQLUnionType) fieldType)
+                    .field(field)
+                    .value(value)
+                    .argumentValues(argumentValues)
+                    .schema(executionContext.getGraphQLSchema())
+                    .build());
         } else if (fieldType instanceof GraphQLObjectType) {
             resolvedType = (GraphQLObjectType) fieldType;
         }

--- a/src/main/java/graphql/schema/TypeResolver.java
+++ b/src/main/java/graphql/schema/TypeResolver.java
@@ -1,9 +1,10 @@
 package graphql.schema;
 
 
+import graphql.TypeResolutionEnvironment;
+
 public interface TypeResolver {
 
-
-    GraphQLObjectType getType(Object object);
+    GraphQLObjectType getType(TypeResolutionEnvironment env);
 
 }

--- a/src/main/java/graphql/schema/TypeResolverProxy.java
+++ b/src/main/java/graphql/schema/TypeResolverProxy.java
@@ -1,6 +1,8 @@
 package graphql.schema;
 
 
+import graphql.TypeResolutionEnvironment;
+
 public class TypeResolverProxy implements TypeResolver {
 
     private TypeResolver typeResolver;
@@ -14,7 +16,7 @@ public class TypeResolverProxy implements TypeResolver {
     }
 
     @Override
-    public GraphQLObjectType getType(Object object) {
-        return typeResolver != null ? typeResolver.getType(object) : null;
+    public GraphQLObjectType getType(TypeResolutionEnvironment env) {
+        return typeResolver != null ? typeResolver.getType(env) : null;
     }
 }

--- a/src/test/groovy/graphql/GarfieldSchema.java
+++ b/src/test/groovy/graphql/GarfieldSchema.java
@@ -80,7 +80,7 @@ public class GarfieldSchema {
         }
 
         public List<Object> getPets() {
-            List<Object> pets = new ArrayList<Object>();
+            List<Object> pets = new ArrayList<>();
             pets.addAll(cats);
             pets.addAll(dogs);
             return pets;
@@ -108,14 +108,14 @@ public class GarfieldSchema {
                     .type(GraphQLString))
             .typeResolver(new TypeResolver() {
                 @Override
-                public GraphQLObjectType getType(Object object) {
-                    if (object instanceof Dog) {
+                public GraphQLObjectType getType(TypeResolutionEnvironment env) {
+                    if (env.getObject() instanceof Dog) {
                         return DogType;
                     }
-                    if (object instanceof Person) {
+                    if (env.getObject() instanceof Person) {
                         return PersonType;
                     }
-                    if (object instanceof Cat) {
+                    if (env.getObject() instanceof Cat) {
                         return CatType;
                     }
                     return null;
@@ -151,11 +151,11 @@ public class GarfieldSchema {
             .possibleType(DogType)
             .typeResolver(new TypeResolver() {
                 @Override
-                public GraphQLObjectType getType(Object object) {
-                    if (object instanceof Cat) {
+                public GraphQLObjectType getType(TypeResolutionEnvironment env) {
+                    if (env.getObject() instanceof Cat) {
                         return CatType;
                     }
-                    if (object instanceof Dog) {
+                    if (env.getObject() instanceof Dog) {
                         return DogType;
                     }
                     return null;

--- a/src/test/groovy/graphql/RelaySchema.java
+++ b/src/test/groovy/graphql/RelaySchema.java
@@ -23,16 +23,16 @@ public class RelaySchema {
 
     public static GraphQLInterfaceType NodeInterface = relay.nodeInterface(new TypeResolver() {
         @Override
-        public GraphQLObjectType getType(Object object) {
-            Relay.ResolvedGlobalId resolvedGlobalId = relay.fromGlobalId((String) object);
+        public GraphQLObjectType getType(TypeResolutionEnvironment env) {
+            Relay.ResolvedGlobalId resolvedGlobalId = relay.fromGlobalId((String) env.getObject());
             //TODO: implement
             return null;
         }
     });
 
-    public static GraphQLObjectType StuffEdgeType = relay.edgeType("Stuff", StuffType, NodeInterface, new ArrayList<GraphQLFieldDefinition>());
+    public static GraphQLObjectType StuffEdgeType = relay.edgeType("Stuff", StuffType, NodeInterface, new ArrayList<>());
 
-    public static GraphQLObjectType StuffConnectionType = relay.connectionType("Stuff", StuffEdgeType, new ArrayList<GraphQLFieldDefinition>());
+    public static GraphQLObjectType StuffConnectionType = relay.connectionType("Stuff", StuffEdgeType, new ArrayList<>());
 
     public static GraphQLObjectType ThingType = newObject()
             .name("Thing")

--- a/src/test/groovy/graphql/StarWarsData.groovy
+++ b/src/test/groovy/graphql/StarWarsData.groovy
@@ -100,8 +100,8 @@ class StarWarsData {
 
     static TypeResolver characterTypeResolver = new TypeResolver() {
         @Override
-        GraphQLObjectType getType(Object object) {
-            def id = object.id
+        GraphQLObjectType getType(TypeResolutionEnvironment env) {
+            def id = env.getObject().id
             if (humanData[id] != null)
                 return StarWarsSchema.humanType
             if (droidData[id] != null)

--- a/src/test/groovy/graphql/validation/SpecValidationSchema.java
+++ b/src/test/groovy/graphql/validation/SpecValidationSchema.java
@@ -6,6 +6,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import graphql.Scalars;
+import graphql.TypeResolutionEnvironment;
 import graphql.schema.FieldDataFetcher;
 import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLEnumType;
@@ -26,7 +27,7 @@ import graphql.validation.SpecValidationSchemaPojos.Human;
  * Sample schema used in the spec for validation examples
  * http://facebook.github.io/graphql/#sec-Validation
  * @author dwinsor
- *        
+ *
  */
 public class SpecValidationSchema {
     public static final GraphQLEnumType dogCommand = GraphQLEnumType.newEnum()
@@ -35,45 +36,45 @@ public class SpecValidationSchema {
             .value("DOWN")
             .value("HEEL")
             .build();
-            
+
     public static final GraphQLEnumType catCommand = GraphQLEnumType.newEnum()
             .name("CatCommand")
             .value("JUMP")
             .build();
-            
+
     public static final GraphQLInterfaceType sentient = GraphQLInterfaceType.newInterface()
             .name("Sentient")
             .field(new GraphQLFieldDefinition(
                     "name", null, new GraphQLNonNull(Scalars.GraphQLString), new FieldDataFetcher("name"), Collections.<GraphQLArgument>emptyList(), null))
             .typeResolver(new TypeResolver() {
-            @Override
-            public GraphQLObjectType getType(Object object) {
-                if (object instanceof Human) return human;
-                if (object instanceof Alien) return alien;
-                return null;
-            }})
+                @Override
+                public GraphQLObjectType getType(TypeResolutionEnvironment env) {
+                    if (env.getObject() instanceof Human) return human;
+                    if (env.getObject() instanceof Alien) return alien;
+                    return null;
+                }})
             .build();
-            
+
     public static final GraphQLInterfaceType pet = GraphQLInterfaceType.newInterface()
             .name("Pet")
             .field(new GraphQLFieldDefinition(
                     "name", null, new GraphQLNonNull(Scalars.GraphQLString), new FieldDataFetcher("name"), Collections.<GraphQLArgument>emptyList(), null))
             .typeResolver(new TypeResolver() {
-            @Override
-            public GraphQLObjectType getType(Object object) {
-                if (object instanceof Dog) return dog;
-                if (object instanceof Cat) return cat;
-                return null;
-            }})
+                @Override
+                public GraphQLObjectType getType(TypeResolutionEnvironment env) {
+                    if (env.getObject() instanceof Dog) return dog;
+                    if (env.getObject() instanceof Cat) return cat;
+                    return null;
+                }})
             .build();
-            
+
     public static final GraphQLObjectType human = GraphQLObjectType.newObject()
             .name("Human")
             .field(new GraphQLFieldDefinition(
                     "name", null, new GraphQLNonNull(Scalars.GraphQLString), new FieldDataFetcher("name"), Collections.<GraphQLArgument>emptyList(), null))
             .withInterface(SpecValidationSchema.sentient)
             .build();
-            
+
     public static final GraphQLObjectType alien = GraphQLObjectType.newObject()
             .name("Alien")
             .field(new GraphQLFieldDefinition(
@@ -82,22 +83,22 @@ public class SpecValidationSchema {
                     "homePlanet", null, Scalars.GraphQLString, new FieldDataFetcher("homePlanet"), Collections.<GraphQLArgument>emptyList(), null))
             .withInterface(SpecValidationSchema.sentient)
             .build();
-            
+
     public static final GraphQLArgument dogCommandArg = GraphQLArgument.newArgument()
             .name("dogCommand")
             .type(new GraphQLNonNull(dogCommand))
             .build();
-            
+
     public static final GraphQLArgument atOtherHomesArg = GraphQLArgument.newArgument()
             .name("atOtherHomes")
             .type(Scalars.GraphQLBoolean)
             .build();
-            
+
     public static final GraphQLArgument catCommandArg = GraphQLArgument.newArgument()
             .name("catCommand")
             .type(new GraphQLNonNull(catCommand))
             .build();
-            
+
     public static final GraphQLObjectType dog = GraphQLObjectType.newObject()
             .name("Dog")
             .field(new GraphQLFieldDefinition(
@@ -116,7 +117,7 @@ public class SpecValidationSchema {
                     "owner", null, human, new FieldDataFetcher("owner"), Collections.<GraphQLArgument>emptyList(), null))
             .withInterface(SpecValidationSchema.pet)
             .build();
-            
+
     public static final GraphQLObjectType cat = GraphQLObjectType.newObject()
             .name("Cat")
             .field(new GraphQLFieldDefinition(
@@ -130,49 +131,49 @@ public class SpecValidationSchema {
                     Arrays.asList(catCommandArg), null))
             .withInterface(SpecValidationSchema.pet)
             .build();
-            
+
     public static final GraphQLUnionType catOrDog = GraphQLUnionType.newUnionType()
             .name("CatOrDog")
             .possibleTypes(cat, dog)
             .typeResolver(new TypeResolver() {
-            @Override
-            public GraphQLObjectType getType(Object object) {
-                if (object instanceof Cat) return cat;
-                if (object instanceof Dog) return dog;
-                return null;
-            }})
+                @Override
+                public GraphQLObjectType getType(TypeResolutionEnvironment env) {
+                    if (env.getObject() instanceof Cat) return cat;
+                    if (env.getObject() instanceof Dog) return dog;
+                    return null;
+                }})
             .build();
-            
+
     public static final GraphQLUnionType dogOrHuman = GraphQLUnionType.newUnionType()
             .name("DogOrHuman")
             .possibleTypes(dog, human)
             .typeResolver(new TypeResolver() {
-            @Override
-            public GraphQLObjectType getType(Object object) {
-                if (object instanceof Human) return human;
-                if (object instanceof Dog) return dog;
-                return null;
-            }})
+                @Override
+                public GraphQLObjectType getType(TypeResolutionEnvironment env) {
+                    if (env.getObject() instanceof Human) return human;
+                    if (env.getObject() instanceof Dog) return dog;
+                    return null;
+                }})
             .build();
-            
+
     public static final GraphQLUnionType humanOrAlien = GraphQLUnionType.newUnionType()
             .name("HumanOrAlien")
             .possibleTypes(human, alien)
             .typeResolver(new TypeResolver() {
-            @Override
-            public GraphQLObjectType getType(Object object) {
-                if (object instanceof Human) return human;
-                if (object instanceof Alien) return alien;
-                return null;
-            }})
+                @Override
+                public GraphQLObjectType getType(TypeResolutionEnvironment env) {
+                    if (env.getObject() instanceof Human) return human;
+                    if (env.getObject() instanceof Alien) return alien;
+                    return null;
+                }})
             .build();
-    
+
     public static final GraphQLObjectType queryRoot = GraphQLObjectType.newObject()
             .name("QueryRoot")
             .field(new GraphQLFieldDefinition(
                     "dog", null, dog, new FieldDataFetcher("dog"), Collections.<GraphQLArgument>emptyList(), null))
             .build();
-            
+
     @SuppressWarnings("serial")
     public static final Set<GraphQLType> specValidationDictionary = new HashSet<GraphQLType>() {{
         add(dogCommand);
@@ -190,6 +191,6 @@ public class SpecValidationSchema {
     public static final GraphQLSchema specValidationSchema = GraphQLSchema.newSchema()
             .query(queryRoot)
             .build(specValidationDictionary);
-    
-    
+
+
 }

--- a/src/test/groovy/graphql/validation/rules/Harness.java
+++ b/src/test/groovy/graphql/validation/rules/Harness.java
@@ -1,5 +1,6 @@
 package graphql.validation.rules;
 
+import graphql.TypeResolutionEnvironment;
 import graphql.schema.*;
 
 import static graphql.Scalars.*;
@@ -16,7 +17,7 @@ public class Harness {
 
     private static TypeResolver dummyTypeResolve = new TypeResolver() {
         @Override
-        public GraphQLObjectType getType(Object object) {
+        public GraphQLObjectType getType(TypeResolutionEnvironment env) {
             return null;
         }
     };
@@ -119,7 +120,7 @@ public class Harness {
             .possibleTypes(Dog, Cat)
             .typeResolver(new TypeResolver() {
                 @Override
-                public GraphQLObjectType getType(Object object) {
+                public GraphQLObjectType getType(TypeResolutionEnvironment env) {
                     return null;
                 }
             })

--- a/src/test/groovy/graphql/validation/rules/OverlappingFieldsCanBeMergedTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/OverlappingFieldsCanBeMergedTest.groovy
@@ -1,5 +1,6 @@
 package graphql.validation.rules
 
+import graphql.TypeResolutionEnvironment
 import graphql.language.Document
 import graphql.language.SourceLocation
 import graphql.parser.Parser
@@ -95,7 +96,7 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
                 .possibleTypes(StringBox, IntBox, NonNullStringBox1, NonNullStringBox2)
                 .typeResolver(new TypeResolver() {
             @Override
-            GraphQLObjectType getType(Object object) {
+            GraphQLObjectType getType(TypeResolutionEnvironment env) {
                 return null
             }
         })

--- a/src/test/groovy/readme/ReadmeExamples.java
+++ b/src/test/groovy/readme/ReadmeExamples.java
@@ -3,6 +3,7 @@ package readme;
 import graphql.GarfieldSchema;
 import graphql.GraphQL;
 import graphql.StarWarsSchema;
+import graphql.TypeResolutionEnvironment;
 import graphql.execution.ExecutorServiceExecutionStrategy;
 import graphql.execution.SimpleExecutionStrategy;
 import graphql.schema.DataFetcher;
@@ -118,11 +119,11 @@ public class ReadmeExamples {
                 .possibleType(DogType)
                 .typeResolver(new TypeResolver() {
                     @Override
-                    public GraphQLObjectType getType(Object object) {
-                        if (object instanceof GarfieldSchema.Cat) {
+                    public GraphQLObjectType getType(TypeResolutionEnvironment env) {
+                        if (env.getObject() instanceof GarfieldSchema.Cat) {
                             return CatType;
                         }
-                        if (object instanceof GarfieldSchema.Dog) {
+                        if (env.getObject() instanceof GarfieldSchema.Dog) {
                             return DogType;
                         }
                         return null;
@@ -148,7 +149,7 @@ public class ReadmeExamples {
                 2, /* core pool size 2 thread */
                 2, /* max pool size 2 thread */
                 30, TimeUnit.SECONDS,
-                new LinkedBlockingQueue<Runnable>(),
+                new LinkedBlockingQueue<>(),
                 new ThreadPoolExecutor.CallerRunsPolicy());
 
         GraphQL graphQL = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema)


### PR DESCRIPTION
closes #122 

(I closed my original PR #343 because I managed to get myself in a Git situation that was easier for me to resolve by recreating the branch, thus opening a new PR)

I've reimplemented the changes to the `ExecutionStrategy` in a way that allows easier future modifications, and made overloads and deprecations for backward-compatibility.

**Implementation notes:**
- I've only introduced the `...Parameters` classes where I needed them for this change, not everywhere where they should arguably go. Tell me If you want me refactor more places.
- I made the `...Parameters` constructors private to avoid implementors relying on them and ending up in this same situation. I wanted them package private so that they can be used internally, but `BatchedExecutionStrategy` is in a different package so there wasn't much point.
- I added Javadoc to the `@Deprecated` methods only to link to the new options, but since this is not a full Javadoc, a lot of lint warnings are generated during the build. Would you rather have the incomplete docs removed or maybe provide the text you'd like in the Javadoc, or would you like me to add my own?

Now, the question comes back to the `TypeResolver`:
* should I re-introduce the Java 8 dependent `default` for backwards compatibility 
* should I leave as a breaking change, since it seems more breaking changes have been planned
* should I implement it in a different, backwards-compatible way (described below)?

One idea I have is to introduce a new interface, e.g. `TypeDecider`, that would provide the new functionality: `GraphQLObjectType getType(TypeResolutionEnvironment env)`, and then change the builders that accept `TypeResolver`s in a fashion similar to this:

```
//wrap the given TypeResolver in a simple TypeDecider that just delegates to it
public Builder typeResolver(TypeResolver typeResolver) {
    this.typeDecider = new SimpleTypeDecider(typeResolver);
    return this;
 }

//add a new method that accepts TypeDecider directly
public Builder typeDecider(TypeDecider typeDecider) {
    this.typeDecider = typeDecider;
    return this;
 }
```

With both approaches, backwards-compatibility would be, I think, complete.

I've already implemented the `TypeDecider` approach, so if you like that option I can push it for review.