### PR TITLE
#325 - retain comments in the parsed document

### DIFF
--- a/src/main/antlr/Graphql.g4
+++ b/src/main/antlr/Graphql.g4
@@ -209,13 +209,13 @@ Digit : '0'..'9';
 
 StringValue: '"' (~(["\\\n\r\u2028\u2029])|EscapedChar)* '"';
 
+Comment: '#' ~[\n\r\u2028\u2029]* -> channel(2);
+
+Ignored: (Whitespace|Comma|LineTerminator) -> skip;
+
 fragment EscapedChar :   '\\' (["\\/bfnrt] | Unicode) ;
 fragment Unicode : 'u' Hex Hex Hex Hex ;
 fragment Hex : [0-9a-fA-F] ;
-
-Ignored: (Whitespace|Comma|LineTerminator|Comment) -> skip;
-
-fragment Comment: '#' ~[\n\r\u2028\u2029]*;
 
 fragment LineTerminator: [\n\r\u2028\u2029];
 

--- a/src/main/java/graphql/language/AbstractNode.java
+++ b/src/main/java/graphql/language/AbstractNode.java
@@ -4,6 +4,8 @@ package graphql.language;
 import java.util.Collections;
 import java.util.List;
 
+import static graphql.Assert.assertNotNull;
+
 public abstract class AbstractNode implements Node {
 
     private SourceLocation sourceLocation;
@@ -24,6 +26,7 @@ public abstract class AbstractNode implements Node {
     }
 
     public void setComments(List<String> comments) {
-        this.comments = comments == null ? Collections.emptyList() : comments;
+        assertNotNull(comments, "You must provide non null comments");
+        this.comments = comments;
     }
 }

--- a/src/main/java/graphql/language/AbstractNode.java
+++ b/src/main/java/graphql/language/AbstractNode.java
@@ -1,9 +1,13 @@
 package graphql.language;
 
 
+import java.util.Collections;
+import java.util.List;
+
 public abstract class AbstractNode implements Node {
 
     private SourceLocation sourceLocation;
+    private List<String> comments = Collections.emptyList();
 
 
     public void setSourceLocation(SourceLocation sourceLocation) {
@@ -13,5 +17,13 @@ public abstract class AbstractNode implements Node {
     @Override
     public SourceLocation getSourceLocation() {
         return sourceLocation;
+    }
+
+    public List<String> getComments() {
+        return comments;
+    }
+
+    public void setComments(List<String> comments) {
+        this.comments = comments == null ? Collections.emptyList() : comments;
     }
 }

--- a/src/main/java/graphql/language/AbstractNode.java
+++ b/src/main/java/graphql/language/AbstractNode.java
@@ -9,7 +9,7 @@ import static graphql.Assert.assertNotNull;
 public abstract class AbstractNode implements Node {
 
     private SourceLocation sourceLocation;
-    private List<String> comments = Collections.emptyList();
+    private List<Comment> comments = Collections.emptyList();
 
 
     public void setSourceLocation(SourceLocation sourceLocation) {
@@ -21,11 +21,11 @@ public abstract class AbstractNode implements Node {
         return sourceLocation;
     }
 
-    public List<String> getComments() {
+    public List<Comment> getComments() {
         return comments;
     }
 
-    public void setComments(List<String> comments) {
+    public void setComments(List<Comment> comments) {
         assertNotNull(comments, "You must provide non null comments");
         this.comments = comments;
     }

--- a/src/main/java/graphql/language/Comment.java
+++ b/src/main/java/graphql/language/Comment.java
@@ -1,0 +1,19 @@
+package graphql.language;
+
+public class Comment {
+    public final String content;
+    public final SourceLocation sourceLocation;
+
+    public Comment(String content, SourceLocation sourceLocation) {
+        this.content = content;
+        this.sourceLocation = sourceLocation;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public SourceLocation getSourceLocation() {
+        return sourceLocation;
+    }
+}

--- a/src/main/java/graphql/language/Node.java
+++ b/src/main/java/graphql/language/Node.java
@@ -10,7 +10,7 @@ public interface Node {
     SourceLocation getSourceLocation();
 
     /**
-     * Nodes can have comments made on them
+     * Nodes can have comments made on them, the following is one comment per line before a node.
      *
      * @return the list of comments or an empty list of there are none
      */

--- a/src/main/java/graphql/language/Node.java
+++ b/src/main/java/graphql/language/Node.java
@@ -14,7 +14,7 @@ public interface Node {
      *
      * @return the list of comments or an empty list of there are none
      */
-    List<String> getComments();
+    List<Comment> getComments();
 
     /**
      * Compares just the content and not the children.

--- a/src/main/java/graphql/language/Node.java
+++ b/src/main/java/graphql/language/Node.java
@@ -10,6 +10,13 @@ public interface Node {
     SourceLocation getSourceLocation();
 
     /**
+     * Nodes can have comments made on them
+     *
+     * @return the list of comments or an empty list of there are none
+     */
+    List<String> getComments();
+
+    /**
      * Compares just the content and not the children.
      *
      * @param node the other node to compare to

--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -2,20 +2,68 @@ package graphql.parser;
 
 
 import graphql.ShouldNotHappenException;
-import graphql.language.*;
+import graphql.language.AbstractNode;
+import graphql.language.Argument;
+import graphql.language.ArrayValue;
+import graphql.language.BooleanValue;
+import graphql.language.Directive;
+import graphql.language.DirectiveDefinition;
+import graphql.language.DirectiveLocation;
+import graphql.language.Document;
+import graphql.language.EnumTypeDefinition;
+import graphql.language.EnumValue;
+import graphql.language.EnumValueDefinition;
+import graphql.language.Field;
+import graphql.language.FieldDefinition;
+import graphql.language.FloatValue;
+import graphql.language.FragmentDefinition;
+import graphql.language.FragmentSpread;
+import graphql.language.InlineFragment;
+import graphql.language.InputObjectTypeDefinition;
+import graphql.language.InputValueDefinition;
+import graphql.language.IntValue;
+import graphql.language.InterfaceTypeDefinition;
+import graphql.language.ListType;
+import graphql.language.NonNullType;
+import graphql.language.ObjectField;
+import graphql.language.ObjectTypeDefinition;
+import graphql.language.ObjectValue;
+import graphql.language.OperationDefinition;
+import graphql.language.OperationTypeDefinition;
+import graphql.language.ScalarTypeDefinition;
+import graphql.language.SchemaDefinition;
+import graphql.language.SelectionSet;
+import graphql.language.SourceLocation;
+import graphql.language.StringValue;
+import graphql.language.TypeExtensionDefinition;
+import graphql.language.TypeName;
+import graphql.language.UnionTypeDefinition;
+import graphql.language.Value;
+import graphql.language.VariableDefinition;
+import graphql.language.VariableReference;
 import graphql.parser.antlr.GraphqlBaseVisitor;
 import graphql.parser.antlr.GraphqlParser;
+import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.Token;
 
 import java.io.StringWriter;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Deque;
+import java.util.List;
 
 public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
 
+    private final CommonTokenStream tokens;
     Document result;
+
+    GraphqlAntlrToLanguage(CommonTokenStream tokens) {
+        this.tokens = tokens;
+    }
 
     private enum ContextProperty {
         OperationDefinition,
@@ -144,7 +192,7 @@ public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
         } else if (operationTypeContext.getText().equals("mutation")) {
             return OperationDefinition.Operation.MUTATION;
         } else {
-            throw new RuntimeException("InternalError: unknown operationTypeContext="+operationTypeContext.getText());
+            throw new RuntimeException("InternalError: unknown operationTypeContext=" + operationTypeContext.getText());
         }
     }
 
@@ -444,7 +492,7 @@ public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
         for (ContextEntry contextEntry : contextStack) {
             if (contextEntry.contextProperty == ContextProperty.TypeExtensionDefinition) {
                 ((TypeExtensionDefinition) contextEntry.value).setName(ctx.name().getText());
-                def = (ObjectTypeDefinition)contextEntry.value;
+                def = (ObjectTypeDefinition) contextEntry.value;
                 break;
             }
         }
@@ -737,6 +785,11 @@ public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
     }
 
     private void newNode(AbstractNode abstractNode, ParserRuleContext parserRuleContext) {
+        List<String> comments = getComments(parserRuleContext);
+        if (!comments.isEmpty()) {
+            abstractNode.setComments(comments);
+        }
+
         abstractNode.setSourceLocation(getSourceLocation(parserRuleContext));
     }
 
@@ -744,4 +797,32 @@ public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
         return new SourceLocation(parserRuleContext.getStart().getLine(), parserRuleContext.getStart().getCharPositionInLine() + 1);
     }
 
+    private List<String> getComments(ParserRuleContext ctx) {
+        Token start = ctx.getStart();
+        if (start != null) {
+            int tokPos = start.getTokenIndex();
+            List<Token> refChannel = tokens.getHiddenTokensToLeft(tokPos, 2);
+            if (refChannel != null) {
+                return getCommentOnChannel(refChannel);
+            }
+        }
+        return Collections.emptyList();
+    }
+
+
+    private List<String> getCommentOnChannel(List<Token> refChannel) {
+        List<String> comments = new ArrayList<>();
+        for (Token refTok : refChannel) {
+            String text = refTok.getText();
+            // we strip the leading hash # character but we don't trim because we don't
+            // know the "comment markup".  Maybe its space sensitive, maybe its not.  So
+            // consumers can decide that
+            text = (text == null) ? "" : text;
+            text = text.replaceFirst("^#", "");
+            if (text.length() > 0) {
+                comments.add(text);
+            }
+        }
+        return comments;
+    }
 }

--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -6,6 +6,7 @@ import graphql.language.AbstractNode;
 import graphql.language.Argument;
 import graphql.language.ArrayValue;
 import graphql.language.BooleanValue;
+import graphql.language.Comment;
 import graphql.language.Directive;
 import graphql.language.DirectiveDefinition;
 import graphql.language.DirectiveLocation;
@@ -785,7 +786,7 @@ public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
     }
 
     private void newNode(AbstractNode abstractNode, ParserRuleContext parserRuleContext) {
-        List<String> comments = getComments(parserRuleContext);
+        List<Comment> comments = getComments(parserRuleContext);
         if (!comments.isEmpty()) {
             abstractNode.setComments(comments);
         }
@@ -797,7 +798,7 @@ public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
         return new SourceLocation(parserRuleContext.getStart().getLine(), parserRuleContext.getStart().getCharPositionInLine() + 1);
     }
 
-    private List<String> getComments(ParserRuleContext ctx) {
+    private List<Comment> getComments(ParserRuleContext ctx) {
         Token start = ctx.getStart();
         if (start != null) {
             int tokPos = start.getTokenIndex();
@@ -810,8 +811,8 @@ public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
     }
 
 
-    private List<String> getCommentOnChannel(List<Token> refChannel) {
-        List<String> comments = new ArrayList<>();
+    private List<Comment> getCommentOnChannel(List<Token> refChannel) {
+        List<Comment> comments = new ArrayList<>();
         for (Token refTok : refChannel) {
             String text = refTok.getText();
             // we strip the leading hash # character but we don't trim because we don't
@@ -820,7 +821,7 @@ public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
             text = (text == null) ? "" : text;
             text = text.replaceFirst("^#", "");
             if (text.length() > 0) {
-                comments.add(text);
+                comments.add(new Comment(text, new SourceLocation(refTok.getLine(), refTok.getCharPositionInLine())));
             }
         }
         return comments;

--- a/src/main/java/graphql/parser/Parser.java
+++ b/src/main/java/graphql/parser/Parser.java
@@ -7,8 +7,6 @@ import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.BailErrorStrategy;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.atn.PredictionMode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class Parser {
 
@@ -25,7 +23,7 @@ public class Parser {
         GraphqlParser.DocumentContext document = parser.document();
 
 
-        GraphqlAntlrToLanguage antlrToLanguage = new GraphqlAntlrToLanguage();
+        GraphqlAntlrToLanguage antlrToLanguage = new GraphqlAntlrToLanguage(tokens);
         antlrToLanguage.visitDocument(document);
         return antlrToLanguage.result;
     }

--- a/src/test/groovy/graphql/parser/IDLParserTest.groovy
+++ b/src/test/groovy/graphql/parser/IDLParserTest.groovy
@@ -3,6 +3,8 @@ package graphql.parser
 import graphql.language.*
 import spock.lang.Specification
 
+import java.util.stream.Collectors
+
 class IDLParserTest extends Specification {
 
     boolean isEqual(Node node1, Node node2) {
@@ -365,7 +367,14 @@ directive @DirectiveName(arg1:String arg2:Int=23) on FIELD | QUERY
         isEqual(document.definitions[0], schema)
     }
 
+
+    List<String> commentContent(List<Comment> comments) {
+        comments.stream().map {c -> c.content}.collect(Collectors.toList())
+    }
+
     def "comment support on definitions"() {
+
+
         given:
         def input = """
 
@@ -432,32 +441,32 @@ input Gun {
 
         then:
         SchemaDefinition schemaDef = document.definitions[0] as SchemaDefinition
-        schemaDef.comments == ["schema comment 1", "       schema comment 2 with leading spaces"]
-        schemaDef.operationTypeDefinitions[0].comments == [" schema operation comment query"]
-        schemaDef.operationTypeDefinitions[1].comments == [" schema operation comment mutation"]
+        commentContent(schemaDef.comments) == ["schema comment 1", "       schema comment 2 with leading spaces"]
+        commentContent(schemaDef.operationTypeDefinitions[0].comments) == [" schema operation comment query"]
+        commentContent(schemaDef.operationTypeDefinitions[1].comments) == [" schema operation comment mutation"]
 
         ObjectTypeDefinition typeDef = document.definitions[1] as ObjectTypeDefinition
-        typeDef.comments == [" type query comment 1", " type query comment 2"]
-        typeDef.fieldDefinitions[0].comments == [" query field 'hero' comment"]
-        typeDef.fieldDefinitions[1].comments == [" query field 'droid' comment"]
+        commentContent(typeDef.comments) == [" type query comment 1", " type query comment 2"]
+        commentContent(typeDef.fieldDefinitions[0].comments) == [" query field 'hero' comment"]
+        commentContent(typeDef.fieldDefinitions[1].comments) == [" query field 'droid' comment"]
 
         EnumTypeDefinition enumTypeDef = document.definitions[2] as EnumTypeDefinition
-        enumTypeDef.comments == [" enum Episode comment 1", " enum Episode comment 2"]
+        commentContent(enumTypeDef.comments) == [" enum Episode comment 1", " enum Episode comment 2"]
 
         InterfaceTypeDefinition interfaceTypeDef = document.definitions[3] as InterfaceTypeDefinition
-        interfaceTypeDef.comments == [" interface Character comment 1", " interface Character comment 2"]
+        commentContent(interfaceTypeDef.comments) == [" interface Character comment 1", " interface Character comment 2"]
 
         UnionTypeDefinition unionTypeDef = document.definitions[4] as UnionTypeDefinition
-        unionTypeDef.comments == [" union type Humanoid comment 1"]
+        commentContent(unionTypeDef.comments) == [" union type Humanoid comment 1"]
 
         ObjectTypeDefinition mutationTypeDef = document.definitions[5] as ObjectTypeDefinition
-        mutationTypeDef.fieldDefinitions[0].inputValueDefinitions[0].comments == [" arg 'id'"]
-        mutationTypeDef.fieldDefinitions[0].inputValueDefinitions[1].comments == [" arg 'with'"]
+        commentContent(mutationTypeDef.fieldDefinitions[0].inputValueDefinitions[0].comments) == [" arg 'id'"]
+        commentContent(mutationTypeDef.fieldDefinitions[0].inputValueDefinitions[1].comments) == [" arg 'with'"]
 
         InputObjectTypeDefinition inputTypeDef = document.definitions[6] as InputObjectTypeDefinition
-        inputTypeDef.comments == [" input type Gun comment 1"]
-        inputTypeDef.inputValueDefinitions[0].comments == [" gun 'name' input value comment"]
-        inputTypeDef.inputValueDefinitions[1].comments == [" gun 'caliber' input value comment"]
+        commentContent(inputTypeDef.comments) == [" input type Gun comment 1"]
+        commentContent(inputTypeDef.inputValueDefinitions[0].comments) == [" gun 'name' input value comment"]
+        commentContent(inputTypeDef.inputValueDefinitions[1].comments) == [" gun 'caliber' input value comment"]
 
     }
 

--- a/src/test/groovy/graphql/parser/ParserTest.groovy
+++ b/src/test/groovy/graphql/parser/ParserTest.groovy
@@ -317,7 +317,7 @@ class ParserTest extends Specification {
 
         then:
         isEqual(helloField, new Field("hello", [new Argument("arg", new StringValue("hello, world"))]))
-        helloField.comments == [" this is some comment, which should be captured"]
+        helloField.comments.collect { c-> c.content } == [" this is some comment, which should be captured"]
     }
 
     @Unroll

--- a/src/test/groovy/graphql/parser/ParserTest.groovy
+++ b/src/test/groovy/graphql/parser/ParserTest.groovy
@@ -307,7 +307,7 @@ class ParserTest extends Specification {
     def "parse complex string value and comment"() {
         given:
         def input = """
-            { # this is some comment, which should be igored
+            { # this is some comment, which should be captured
                hello(arg: "hello, world" ) }
             """
 
@@ -317,6 +317,7 @@ class ParserTest extends Specification {
 
         then:
         isEqual(helloField, new Field("hello", [new Argument("arg", new StringValue("hello, world"))]))
+        helloField.comments == [" this is some comment, which should be captured"]
     }
 
     @Unroll


### PR DESCRIPTION
This retains the comments in the grammar and makes the available on nodes.

This is the first step in allowing a schema generator to turn language defs into descriptions etc...