### PR TITLE
A start to #324 that provides a promise interface to executing querie

### DIFF
--- a/src/main/java/graphql/execution/ExecutorServiceExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutorServiceExecutionStrategy.java
@@ -10,6 +10,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -44,7 +45,7 @@ public class ExecutorServiceExecutionStrategy extends ExecutionStrategy {
 
 
     @Override
-    public ExecutionResult execute(final ExecutionContext executionContext, final ExecutionStrategyParameters parameters) {
+    public CompletableFuture<ExecutionResult> execute(final ExecutionContext executionContext, final ExecutionStrategyParameters parameters) {
         if (executorService == null)
             return new SimpleExecutionStrategy().execute(executionContext, parameters);
 
@@ -56,7 +57,7 @@ public class ExecutorServiceExecutionStrategy extends ExecutionStrategy {
             ExecutionPath fieldPath = parameters.path().segment(fieldName);
             ExecutionStrategyParameters newParameters = parameters.transform(bldr -> bldr.path(fieldPath));
 
-            Callable<ExecutionResult> resolveField = () -> resolveField(executionContext, newParameters, fieldList);
+            Callable<ExecutionResult> resolveField = () -> resolveField(executionContext, newParameters, fieldList).join();
             futures.put(fieldName, executorService.submit(resolveField));
         }
         try {
@@ -66,7 +67,7 @@ public class ExecutorServiceExecutionStrategy extends ExecutionStrategy {
 
                 results.put(fieldName, executionResult != null ? executionResult.getData() : null);
             }
-            return new ExecutionResultImpl(results, executionContext.getErrors());
+            return CompletableFuture.completedFuture(new ExecutionResultImpl(results, executionContext.getErrors()));
         } catch (InterruptedException | ExecutionException e) {
             throw new GraphQLException(e);
         }

--- a/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
+++ b/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
@@ -37,10 +37,12 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
 
 import static graphql.execution.FieldCollectorParameters.newParameters;
 import static graphql.schema.DataFetchingEnvironmentBuilder.newDataFetchingEnvironment;
 import static java.util.Collections.singletonList;
+import static java.util.concurrent.CompletableFuture.completedFuture;
 
 /**
  * Execution Strategy that minimizes calls to the data fetcher when used in conjunction with {@link DataFetcher}s that have
@@ -67,11 +69,11 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
     }
 
     @Override
-    public ExecutionResult execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
+    public CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
         GraphQLExecutionNodeDatum data = new GraphQLExecutionNodeDatum(new LinkedHashMap<>(), parameters.source());
         GraphQLObjectType type = parameters.typeInfo().castType(GraphQLObjectType.class);
         GraphQLExecutionNode root = new GraphQLExecutionNode(type, parameters.fields(), singletonList(data));
-        return execute(executionContext, parameters, root);
+        return completedFuture(execute(executionContext, parameters, root));
     }
 
     private ExecutionResult execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters, GraphQLExecutionNode root) {

--- a/src/test/groovy/graphql/GraphQLTest.groovy
+++ b/src/test/groovy/graphql/GraphQLTest.groovy
@@ -1,7 +1,14 @@
 package graphql
 
 import graphql.language.SourceLocation
-import graphql.schema.*
+import graphql.schema.DataFetcher
+import graphql.schema.DataFetchingEnvironment
+import graphql.schema.GraphQLFieldDefinition
+import graphql.schema.GraphQLList
+import graphql.schema.GraphQLNonNull
+import graphql.schema.GraphQLObjectType
+import graphql.schema.GraphQLSchema
+import graphql.schema.StaticDataFetcher
 import graphql.validation.ValidationErrorType
 import spock.lang.Specification
 
@@ -11,7 +18,6 @@ import static graphql.schema.GraphQLArgument.newArgument
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
 import static graphql.schema.GraphQLInputObjectField.newInputObjectField
 import static graphql.schema.GraphQLInputObjectType.newInputObject
-import static graphql.schema.GraphQLNonNull.nonNull
 import static graphql.schema.GraphQLObjectType.newObject
 import static graphql.schema.GraphQLSchema.newSchema
 
@@ -238,100 +244,6 @@ class GraphQLTest extends Specification {
         result.errors[0].class == MutationNotSupportedError
     }
 
-
-    class ParentTypeImplementation {
-        String nullChild = null
-        String nonNullChild = "not null"
-    }
-
-    def "#268 - null child field values are allowed in nullable parent type"() {
-
-        // see https://github.com/graphql-java/graphql-java/issues/268
-
-        given:
-
-
-        GraphQLOutputType parentType = newObject()
-                .name("currentType")
-                .field(newFieldDefinition().name("nullChild")
-                .type(nonNull(GraphQLString)))
-                .field(newFieldDefinition().name("nonNullChild")
-                .type(nonNull(GraphQLString)))
-                .build()
-
-        GraphQLSchema schema = newSchema().query(
-                newObject()
-                        .name("RootQueryType")
-                        .field(newFieldDefinition()
-                        .name("parent")
-                        .type(parentType) // nullable parent
-                        .dataFetcher({ env -> new ParentTypeImplementation() })
-
-                ))
-                .build()
-
-        def query = """
-        query { 
-            parent {
-                nonNullChild
-                nullChild
-            }
-        }
-        """
-
-        when:
-        def result = GraphQL.newGraphQL(schema).build().execute(query)
-
-        then:
-
-        result.errors.size() == 1
-        result.data["parent"] == null
-    }
-
-    def "#268 - null child field values are NOT allowed in non nullable parent types"() {
-
-        // see https://github.com/graphql-java/graphql-java/issues/268
-
-        given:
-
-
-        GraphQLOutputType parentType = newObject()
-                .name("currentType")
-                .field(newFieldDefinition().name("nullChild")
-                .type(nonNull(GraphQLString)))
-                .field(newFieldDefinition().name("nonNullChild")
-                .type(nonNull(GraphQLString)))
-                .build()
-
-        GraphQLSchema schema = newSchema().query(
-                newObject()
-                        .name("RootQueryType")
-                        .field(
-                        newFieldDefinition()
-                                .name("parent")
-                                .type(nonNull(parentType)) // non nullable parent
-                                .dataFetcher({ env -> new ParentTypeImplementation() })
-
-                ))
-                .build()
-
-        def query = """
-        query { 
-            parent {
-                nonNullChild
-                nullChild
-            }
-        }
-        """
-
-        when:
-        def result = GraphQL.newGraphQL(schema).build().execute(query)
-
-        then:
-
-        result.errors.size() == 1
-        result.data == null
-    }
 
 
     def "query with int literal too large"() {

--- a/src/test/groovy/graphql/NonNullHandlingTest.groovy
+++ b/src/test/groovy/graphql/NonNullHandlingTest.groovy
@@ -1,0 +1,116 @@
+package graphql
+
+import graphql.schema.GraphQLOutputType
+import graphql.schema.GraphQLSchema
+import spock.lang.Specification
+
+import static graphql.Scalars.GraphQLString
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
+import static graphql.schema.GraphQLNonNull.nonNull
+import static graphql.schema.GraphQLObjectType.newObject
+import static graphql.schema.GraphQLSchema.newSchema
+
+/**
+ * A set of tests to show how non null field handling correctly bubble up or not
+ */
+class NonNullHandlingTest extends Specification {
+
+    @SuppressWarnings("GroovyUnusedDeclaration")
+    class ParentTypeImplementation {
+        String nullChild = null
+        String nonNullChild = "not null"
+    }
+
+    def executionInput(String query) {
+        ExecutionInput.newExecutionInput().query(query).build()
+    }
+
+    def "#268 - null child field values are allowed in nullable parent type"() {
+
+        // see https://github.com/graphql-java/graphql-java/issues/268
+
+        given:
+
+
+        GraphQLOutputType parentType = newObject()
+                .name("currentType")
+                .field(newFieldDefinition().name("nullChild")
+                .type(nonNull(GraphQLString)))
+                .field(newFieldDefinition().name("nonNullChild")
+                .type(nonNull(GraphQLString)))
+                .build()
+
+        GraphQLSchema schema = newSchema().query(
+                newObject()
+                        .name("RootQueryType")
+                        .field(newFieldDefinition()
+                        .name("parent")
+                        .type(parentType) // nullable parent
+                        .dataFetcher({ env -> new ParentTypeImplementation() })
+
+                ))
+                .build()
+
+        def query = """
+        query { 
+            parent {
+                nonNullChild
+                nullChild
+            }
+        }
+        """
+
+        when:
+        def result = GraphQL.newGraphQL(schema).build().execute(executionInput(query))
+
+        then:
+
+        result.errors.size() == 1
+        result.data["parent"] == null
+    }
+
+    def "#268 - null child field values are NOT allowed in non nullable parent types"() {
+
+        // see https://github.com/graphql-java/graphql-java/issues/268
+
+        given:
+
+
+        GraphQLOutputType parentType = newObject()
+                .name("currentType")
+                .field(newFieldDefinition().name("nullChild")
+                .type(nonNull(GraphQLString)))
+                .field(newFieldDefinition().name("nonNullChild")
+                .type(nonNull(GraphQLString)))
+                .build()
+
+        GraphQLSchema schema = newSchema().query(
+                newObject()
+                        .name("RootQueryType")
+                        .field(
+                        newFieldDefinition()
+                                .name("parent")
+                                .type(nonNull(parentType)) // non nullable parent
+                                .dataFetcher({ env -> new ParentTypeImplementation() })
+
+                ))
+                .build()
+
+        def query = """
+        query { 
+            parent {
+                nonNullChild
+                nullChild
+            }
+        }
+        """
+
+        when:
+        def result = GraphQL.newGraphQL(schema).build().execute(executionInput(query))
+
+        then:
+
+        result.errors.size() == 1
+        result.data == null
+    }
+}

--- a/src/test/groovy/graphql/execution/AsyncFetchThenCompleteExecutionTestStrategy.java
+++ b/src/test/groovy/graphql/execution/AsyncFetchThenCompleteExecutionTestStrategy.java
@@ -32,7 +32,7 @@ public class AsyncFetchThenCompleteExecutionTestStrategy extends ExecutionStrate
     }
 
     @Override
-    public ExecutionResult execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) throws NonNullableFieldWasNullException {
+    public CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) throws NonNullableFieldWasNullException {
 
         Map<String, Object> fetchedValues = fetchFields(executionContext, parameters);
 
@@ -63,7 +63,7 @@ public class AsyncFetchThenCompleteExecutionTestStrategy extends ExecutionStrate
         return fetchedValues;
     }
 
-    private ExecutionResult completeFields(ExecutionContext executionContext, ExecutionStrategyParameters parameters, Map<String, Object> fetchedValues) {
+    private CompletableFuture<ExecutionResult> completeFields(ExecutionContext executionContext, ExecutionStrategyParameters parameters, Map<String, Object> fetchedValues) {
         Map<String, List<Field>> fields = parameters.fields();
 
         // then for every fetched value, complete it, breath first
@@ -75,7 +75,7 @@ public class AsyncFetchThenCompleteExecutionTestStrategy extends ExecutionStrate
 
             Object fetchedValue = fetchedValues.get(fieldName);
             try {
-                ExecutionResult resolvedResult = completeField(executionContext, newParameters, fieldList, fetchedValue);
+                ExecutionResult resolvedResult = completeField(executionContext, newParameters, fieldList, fetchedValue).join();
                 results.put(fieldName, resolvedResult != null ? resolvedResult.getData() : null);
             } catch (NonNullableFieldWasNullException e) {
                 assertNonNullFieldPrecondition(e);
@@ -83,7 +83,7 @@ public class AsyncFetchThenCompleteExecutionTestStrategy extends ExecutionStrate
                 break;
             }
         }
-        return new ExecutionResultImpl(results, executionContext.getErrors());
+        return CompletableFuture.completedFuture(new ExecutionResultImpl(results, executionContext.getErrors()));
     }
 
     private ExecutionStrategyParameters newParameters(ExecutionStrategyParameters parameters, String fieldName) {

--- a/src/test/groovy/graphql/execution/BreadthFirstExecutionTestStrategy.java
+++ b/src/test/groovy/graphql/execution/BreadthFirstExecutionTestStrategy.java
@@ -8,6 +8,7 @@ import graphql.language.Field;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * To prove we can write other execution strategies this one does a breath first approach
@@ -20,7 +21,7 @@ public class BreadthFirstExecutionTestStrategy extends ExecutionStrategy {
     }
 
     @Override
-    public ExecutionResult execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) throws NonNullableFieldWasNullException {
+    public CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) throws NonNullableFieldWasNullException {
         Map<String, List<Field>> fields = parameters.fields();
 
         Map<String, Object> fetchedValues = new LinkedHashMap<>();
@@ -48,7 +49,7 @@ public class BreadthFirstExecutionTestStrategy extends ExecutionStrategy {
                 break;
             }
         }
-        return new ExecutionResultImpl(results, executionContext.getErrors());
+        return CompletableFuture.completedFuture(new ExecutionResultImpl(results, executionContext.getErrors()));
     }
 
     private Object fetchField(ExecutionContext executionContext, ExecutionStrategyParameters parameters, Map<String, List<Field>> fields, String fieldName) {
@@ -61,7 +62,7 @@ public class BreadthFirstExecutionTestStrategy extends ExecutionStrategy {
     }
 
     private void completeValue(ExecutionContext executionContext, Map<String, Object> results, String fieldName, List<Field> fieldList, Object fetchedValue, ExecutionStrategyParameters newParameters) {
-        ExecutionResult resolvedResult = completeField(executionContext, newParameters, fieldList, fetchedValue);
+        ExecutionResult resolvedResult = completeField(executionContext, newParameters, fieldList, fetchedValue).join();
         results.put(fieldName, resolvedResult != null ? resolvedResult.getData() : null);
     }
 

--- a/src/test/groovy/graphql/execution/ExecutionIdTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionIdTest.groovy
@@ -5,13 +5,15 @@ import graphql.GraphQL
 import graphql.StarWarsSchema
 import spock.lang.Specification
 
+import java.util.concurrent.CompletableFuture
+
 class ExecutionIdTest extends Specification {
 
     class CaptureIdStrategy extends SimpleExecutionStrategy {
         ExecutionId executionId = null
 
         @Override
-        ExecutionResult execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
+        CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
             executionId = executionContext.executionId
             return super.execute(executionContext, parameters)
         }

--- a/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
@@ -17,6 +17,8 @@ import graphql.schema.GraphQLScalarType
 import graphql.schema.GraphQLSchema
 import spock.lang.Specification
 
+import java.util.concurrent.CompletableFuture
+
 import static ExecutionStrategyParameters.newParameters
 import static graphql.Scalars.GraphQLString
 import static graphql.schema.GraphQLEnumType.newEnum
@@ -35,7 +37,7 @@ class ExecutionStrategyTest extends Specification {
         executionStrategy = new ExecutionStrategy(dataFetcherExceptionHandler) {
 
             @Override
-            ExecutionResult execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
+            CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
                 return null
             }
         }
@@ -51,7 +53,7 @@ class ExecutionStrategyTest extends Specification {
         ExecutionContext executionContext = buildContext()
         Field field = new Field()
         def fieldType = new GraphQLList(GraphQLString)
-        def result = Arrays.asList("test")
+        def result = ["test", "1", "2", "3"]
         def parameters = newParameters()
                 .typeInfo(TypeInfo.newTypeInfo().type(fieldType))
                 .source(result)
@@ -59,10 +61,10 @@ class ExecutionStrategyTest extends Specification {
                 .build()
 
         when:
-        def executionResult = executionStrategy.completeValue(executionContext, parameters, [field])
+        def executionResult = executionStrategy.completeValue(executionContext, parameters, [field]).join()
 
         then:
-        executionResult.data == ["test"]
+        executionResult.data == result
     }
 
     def "completes value for an array"() {
@@ -70,7 +72,7 @@ class ExecutionStrategyTest extends Specification {
         ExecutionContext executionContext = buildContext()
         Field field = new Field()
         def fieldType = new GraphQLList(GraphQLString)
-        String[] result = ["test"]
+        def result = ["test", "1", "2", "3"]
         def parameters = newParameters()
                 .typeInfo(TypeInfo.newTypeInfo().type(fieldType))
                 .source(result)
@@ -78,10 +80,10 @@ class ExecutionStrategyTest extends Specification {
                 .build()
 
         when:
-        def executionResult = executionStrategy.completeValue(executionContext, parameters, [field])
+        def executionResult = executionStrategy.completeValue(executionContext, parameters, [field]).join()
 
         then:
-        executionResult.data == ["test"]
+        executionResult.data == result
     }
 
     def "completing value with serializing throwing exception"() {
@@ -100,7 +102,7 @@ class ExecutionStrategyTest extends Specification {
                 .build()
 
         when:
-        def executionResult = executionStrategy.completeValue(executionContext, parameters, [new Field()])
+        def executionResult = executionStrategy.completeValue(executionContext, parameters, [new Field()]).join()
 
         then:
         executionResult.data == null
@@ -125,7 +127,7 @@ class ExecutionStrategyTest extends Specification {
                 .build()
 
         when:
-        def executionResult = executionStrategy.completeValue(executionContext, parameters, [new Field()])
+        def executionResult = executionStrategy.completeValue(executionContext, parameters, [new Field()]).join()
 
         then:
         executionResult.data == null
@@ -273,7 +275,7 @@ class ExecutionStrategyTest extends Specification {
         boolean handleDataFetchingExceptionCalled = false
         ExecutionStrategy overridingStrategy = new ExecutionStrategy() {
             @Override
-            ExecutionResult execute(ExecutionContext ec, ExecutionStrategyParameters p) throws NonNullableFieldWasNullException {
+            CompletableFuture<ExecutionResult> execute(ExecutionContext ec, ExecutionStrategyParameters p) throws NonNullableFieldWasNullException {
                 null
             }
 
@@ -319,7 +321,7 @@ class ExecutionStrategyTest extends Specification {
             }
         }) {
             @Override
-            ExecutionResult execute(ExecutionContext ec, ExecutionStrategyParameters p) throws NonNullableFieldWasNullException {
+            CompletableFuture<ExecutionResult> execute(ExecutionContext ec, ExecutionStrategyParameters p) throws NonNullableFieldWasNullException {
                 null
             }
 
@@ -350,7 +352,7 @@ class ExecutionStrategyTest extends Specification {
 
         ExecutionStrategy overridingStrategy = new ExecutionStrategy() {
             @Override
-            ExecutionResult execute(ExecutionContext ec, ExecutionStrategyParameters p) throws NonNullableFieldWasNullException {
+            CompletableFuture<ExecutionResult> execute(ExecutionContext ec, ExecutionStrategyParameters p) throws NonNullableFieldWasNullException {
                 null
             }
         }


### PR DESCRIPTION
Any serial execution is really an async one that is deemed complete so we are able to implement the existing via this pattern

This puts the structure in place to allow us to write truly asynchronous execution strategies where the consumer gets to decide when to consume the result.

As it turns out we can re-implement all the current serial execution strategies via the CompletableFuture pattern that have completed immediately.  And hence this calls the async versions of everything to get work done.