### PR TITLE
Allow ExecutionStrategy to specify dataFetchingExceptionHandler

### DIFF
--- a/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
+++ b/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
@@ -1,6 +1,5 @@
 package graphql.execution.batched;
 
-import graphql.ExceptionWhileDataFetching;
 import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.GraphQLException;
@@ -267,12 +266,9 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
         try {
             values = (List<Object>) getDataFetcher(fieldDef).get(environment);
         } catch (Exception e) {
-            values = new ArrayList<>();
-            for (int i = 0; i < nodeData.size(); i++) {
-                values.add(null);
-            }
+            values = new ArrayList<>(nodeData.size());
             log.warn("Exception while fetching data", e);
-            executionContext.addError(new ExceptionWhileDataFetching(e));
+            handleDataFetchingException(executionContext, fieldDef, argumentValues, e);
         }
         assert nodeData.size() == values.size();
 


### PR DESCRIPTION
Allow ExecutionStrategies to specify a `handleDataFetchingException` to allow more customized error handling.

To solve the issue here: https://github.com/graphql-java/graphql-java/issues/282, my team also faced the same issue. 