### PR TITLE
Fix handling of UnknownFragment 

### DIFF
--- a/src/main/java/graphql/validation/RulesVisitor.java
+++ b/src/main/java/graphql/validation/RulesVisitor.java
@@ -112,7 +112,7 @@ public class RulesVisitor implements QueryLanguageVisitor {
         List<AbstractRule> rulesVisitingFragmentSpreads = getRulesVisitingFragmentSpreads(rules);
         if (rulesVisitingFragmentSpreads.size() > 0) {
             FragmentDefinition fragment = validationContext.getFragment(fragmentSpread.getName());
-            if(!ancestors.contains(fragment)){
+            if (fragment != null && !ancestors.contains(fragment)) {
                 new LanguageTraversal(ancestors).traverse(fragment, new RulesVisitor(validationContext, rulesVisitingFragmentSpreads, true));
             }
         }

--- a/src/main/java/graphql/validation/rules/NoUnusedFragments.java
+++ b/src/main/java/graphql/validation/rules/NoUnusedFragments.java
@@ -67,6 +67,9 @@ public class NoUnusedFragments extends AbstractRule {
         if (result.contains(fragmentName)) return;
         result.add(fragmentName);
         List<String> spreadList = spreadsInDefinition.get(fragmentName);
+        if (spreadList == null) {
+            return;
+        }
         for (String fragment : spreadList) {
             collectUsedFragmentsInDefinition(result, fragment);
         }

--- a/src/test/groovy/graphql/validation/RulesVisitorTest.groovy
+++ b/src/test/groovy/graphql/validation/RulesVisitorTest.groovy
@@ -3,7 +3,6 @@ package graphql.validation
 import graphql.TestUtil
 import graphql.language.Document
 import graphql.parser.Parser
-import graphql.validation.rules.NoFragmentCycles
 import graphql.validation.rules.NoUnusedVariables
 import spock.lang.Specification
 

--- a/src/test/groovy/graphql/validation/SpecValidation5421Test.groovy
+++ b/src/test/groovy/graphql/validation/SpecValidation5421Test.groovy
@@ -1,0 +1,26 @@
+package graphql.validation
+/**
+ * validation examples used in the spec in given section
+ * http://facebook.github.io/graphql/#sec-Validation
+ * @author dwinsor
+ *        
+ */
+class SpecValidation5421Test extends SpecValidationBase {
+
+    def '5.4.2.1 Fragment spread target defined '() {
+        def query = """
+            query getDogName {
+              dog {
+                ... FragmentDoesNotExist
+              }           
+            }
+        """
+        when:
+        def validationErrors = validate(query)
+
+        then:
+        !validationErrors.empty
+        validationErrors.size() == 1
+        validationErrors.get(0).getValidationErrorType() == ValidationErrorType.UndefinedFragment
+    }
+}


### PR DESCRIPTION
The KnownFragment rule does not seem to be applying properly, instead a nullpointer is thrown. 

Even if `validationContext.getFragment` returns null, it still descends into that node and then throws. 
https://github.com/graphql-java/graphql-java/blob/master/src/main/java/graphql/validation/RulesVisitor.java#L115