### PR TITLE
Add fragment definitions and execution id to DataFetchingEnvironment

### DIFF
--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -69,11 +69,10 @@ public abstract class ExecutionStrategy {
         DataFetchingEnvironment environment = new DataFetchingEnvironmentImpl(
                 parameters.source(),
                 argumentValues,
-                executionContext.getRoot(),
                 fields,
                 fieldDef.getType(),
                 type,
-                executionContext.getGraphQLSchema()
+                executionContext
         );
 
         Instrumentation instrumentation = executionContext.getInstrumentation();

--- a/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
+++ b/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
@@ -255,11 +255,10 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
         DataFetchingEnvironment environment = new DataFetchingEnvironmentImpl(
                 sources,
                 argumentValues,
-                executionContext.getRoot(),
                 fields,
                 fieldDef.getType(),
                 parentType,
-                executionContext.getGraphQLSchema()
+                executionContext
         );
 
         List<Object> values;

--- a/src/main/java/graphql/execution/batched/UnbatchedDataFetcher.java
+++ b/src/main/java/graphql/execution/batched/UnbatchedDataFetcher.java
@@ -35,7 +35,9 @@ public class UnbatchedDataFetcher implements BatchedDataFetcher {
                     environment.getFields(),
                     environment.getFieldType(),
                     environment.getParentType(),
-                    environment.getGraphQLSchema());
+                    environment.getGraphQLSchema(),
+                    environment.getFragmentsByName(),
+                    environment.getExecutionId());
             results.add(delegate.get(singleEnv));
         }
         return results;

--- a/src/main/java/graphql/schema/DataFetchingEnvironment.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironment.java
@@ -1,6 +1,8 @@
 package graphql.schema;
 
+import graphql.execution.ExecutionId;
 import graphql.language.Field;
+import graphql.language.FragmentDefinition;
 
 import java.util.List;
 import java.util.Map;
@@ -69,4 +71,14 @@ public interface DataFetchingEnvironment {
      * @return the underlying graphql schema
      */
     GraphQLSchema getGraphQLSchema();
+
+    /**
+     * @return the {@link FragmentDefinition} map for the current operation
+     */
+    Map<String, FragmentDefinition> getFragmentsByName();
+
+    /**
+     * @return the {@link ExecutionId} for the current operation
+     */
+    ExecutionId getExecutionId();
 }

--- a/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
@@ -1,7 +1,10 @@
 package graphql.schema;
 
 
+import graphql.execution.ExecutionContext;
+import graphql.execution.ExecutionId;
 import graphql.language.Field;
+import graphql.language.FragmentDefinition;
 
 import java.util.List;
 import java.util.Map;
@@ -15,8 +18,14 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
     private final GraphQLOutputType fieldType;
     private final GraphQLType parentType;
     private final GraphQLSchema graphQLSchema;
+    private Map<String, FragmentDefinition> fragmentsByName;
+    private ExecutionId executionId;
 
-    public DataFetchingEnvironmentImpl(Object source, Map<String, Object> arguments, Object context, List<Field> fields, GraphQLOutputType fieldType, GraphQLType parentType, GraphQLSchema graphQLSchema) {
+    public DataFetchingEnvironmentImpl(Object source, Map<String, Object> arguments, List<Field> fields, GraphQLOutputType fieldType, GraphQLType parentType, ExecutionContext executionContext) {
+        this(source, arguments, executionContext.getRoot(), fields, fieldType, parentType, executionContext.getGraphQLSchema(), executionContext.getFragmentsByName(), executionContext.getExecutionId());
+    }
+
+    public DataFetchingEnvironmentImpl(Object source, Map<String, Object> arguments, Object context, List<Field> fields, GraphQLOutputType fieldType, GraphQLType parentType, GraphQLSchema graphQLSchema, Map<String, FragmentDefinition> fragmentsByName, ExecutionId executionId) {
         this.source = source;
         this.arguments = arguments;
         this.context = context;
@@ -24,6 +33,8 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
         this.fieldType = fieldType;
         this.parentType = parentType;
         this.graphQLSchema = graphQLSchema;
+        this.fragmentsByName = fragmentsByName;
+        this.executionId = executionId;
     }
 
     @Override
@@ -69,5 +80,15 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
     @Override
     public GraphQLSchema getGraphQLSchema() {
         return graphQLSchema;
+    }
+
+    @Override
+    public Map<String, FragmentDefinition> getFragmentsByName() {
+        return fragmentsByName;
+    }
+
+    @Override
+    public ExecutionId getExecutionId() {
+        return executionId;
     }
 }

--- a/src/test/groovy/graphql/DataFetcherTest.groovy
+++ b/src/test/groovy/graphql/DataFetcherTest.groovy
@@ -2,6 +2,8 @@ package graphql
 
 import graphql.schema.DataFetchingEnvironmentImpl
 import graphql.schema.FieldDataFetcher
+import graphql.schema.GraphQLOutputType
+import graphql.schema.GraphQLScalarType
 import graphql.schema.PropertyDataFetcher
 import spock.lang.Specification
 
@@ -53,9 +55,13 @@ class DataFetcherTest extends Specification {
         dataHolder.setBooleanFieldWithGet(false)
     }
 
+    private def env(GraphQLOutputType type) {
+        new DataFetchingEnvironmentImpl(dataHolder, null, null, null, type, null, null, null, null)
+    }
+
     def "get field value"() {
         given:
-        def environment = new DataFetchingEnvironmentImpl(dataHolder, null, null, null, GraphQLString, null, null)
+        def environment = env(GraphQLString)
         when:
         def result = new FieldDataFetcher("publicField").get(environment)
         then:
@@ -64,7 +70,7 @@ class DataFetcherTest extends Specification {
 
     def "get property value"() {
         given:
-        def environment = new DataFetchingEnvironmentImpl(dataHolder, null, null, null, GraphQLString, null, null)
+        def environment = env(GraphQLString)
         when:
         def result = new PropertyDataFetcher("property").get(environment)
         then:
@@ -73,7 +79,7 @@ class DataFetcherTest extends Specification {
 
     def "get Boolean property value"() {
         given:
-        def environment = new DataFetchingEnvironmentImpl(dataHolder, null, null, null, GraphQLBoolean, null, null)
+        def environment = env(GraphQLBoolean)
         when:
         def result = new PropertyDataFetcher("booleanField").get(environment)
         then:
@@ -82,7 +88,7 @@ class DataFetcherTest extends Specification {
 
     def "get Boolean property value with get"() {
         given:
-        def environment = new DataFetchingEnvironmentImpl(dataHolder, null, null, null, GraphQLBoolean, null, null)
+        def environment = env(GraphQLBoolean)
         when:
         def result = new PropertyDataFetcher("booleanFieldWithGet").get(environment)
         then:
@@ -91,7 +97,7 @@ class DataFetcherTest extends Specification {
 
     def "get field value as property"() {
         given:
-        def environment = new DataFetchingEnvironmentImpl(dataHolder, null, null, null, GraphQLString, null, null)
+        def environment = env(GraphQLString)
         when:
         def result = new PropertyDataFetcher("publicField").get(environment)
         then:

--- a/src/test/groovy/graphql/schema/PropertyDataFetcherTest.groovy
+++ b/src/test/groovy/graphql/schema/PropertyDataFetcherTest.groovy
@@ -7,10 +7,13 @@ import spock.lang.Specification
 class PropertyDataFetcherTest extends Specification {
 
     def env(obj) {
-        return new DataFetchingEnvironmentImpl(obj,
+        return new DataFetchingEnvironmentImpl(
+                obj,
                 Collections.emptyMap(),
                 null,
                 Collections.emptyList(),
+                null,
+                null,
                 null,
                 null,
                 null


### PR DESCRIPTION
Fix for #303, but also exposes the `ExecutionId` - it seemed like the only other thing on the `ExecutionContext` that could be useful to know in a `DataFetcher`.