### PR TITLE
Renaming dictionary argument

### DIFF
--- a/src/main/java/graphql/schema/GraphQLSchema.java
+++ b/src/main/java/graphql/schema/GraphQLSchema.java
@@ -1,19 +1,12 @@
 package graphql.schema;
 
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import graphql.Assert;
 import graphql.Directives;
 import graphql.schema.validation.InvalidSchemaException;
 import graphql.schema.validation.ValidationError;
 import graphql.schema.validation.Validator;
+
+import java.util.*;
 
 import static graphql.Assert.assertNotNull;
 
@@ -22,23 +15,23 @@ public class GraphQLSchema {
     private final GraphQLObjectType queryType;
     private final GraphQLObjectType mutationType;
     private final Map<String, GraphQLType> typeMap;
-    private Set<GraphQLType> dictionary;
+    private Set<GraphQLType> additionalTypes;
 
     public GraphQLSchema(GraphQLObjectType queryType) {
-        this(queryType, null, Collections.<GraphQLType>emptySet());
+        this(queryType, null, Collections.emptySet());
     }
 
-    public Set<GraphQLType> getDictionary() {
-        return dictionary;
+    public Set<GraphQLType> getAdditionalTypes() {
+        return additionalTypes;
     }
 
-    public GraphQLSchema(GraphQLObjectType queryType, GraphQLObjectType mutationType, Set<GraphQLType> dictionary) {
-        assertNotNull(dictionary, "dictionary can't be null");
+    public GraphQLSchema(GraphQLObjectType queryType, GraphQLObjectType mutationType, Set<GraphQLType> additionalTypes) {
+        assertNotNull(additionalTypes, "additionalTypes can't be null");
         assertNotNull(queryType, "queryType can't be null");
         this.queryType = queryType;
         this.mutationType = mutationType;
-        this.dictionary = dictionary;
-        typeMap = new SchemaUtil().allTypes(this, dictionary);
+        this.additionalTypes = additionalTypes;
+        typeMap = new SchemaUtil().allTypes(this, additionalTypes);
     }
 
     public GraphQLType getType(String typeName) {
@@ -101,12 +94,12 @@ public class GraphQLSchema {
         }
 
         public GraphQLSchema build() {
-            return build(Collections.<GraphQLType>emptySet());
+            return build(Collections.emptySet());
         }
 
-        public GraphQLSchema build(Set<GraphQLType> dictionary) {
-            Assert.assertNotNull(dictionary, "dictionary can't be null");
-            GraphQLSchema graphQLSchema = new GraphQLSchema(queryType, mutationType, dictionary);
+        public GraphQLSchema build(Set<GraphQLType> additionalTypes) {
+            assertNotNull(additionalTypes, "additionalTypes can't be null");
+            GraphQLSchema graphQLSchema = new GraphQLSchema(queryType, mutationType, additionalTypes);
             new SchemaUtil().replaceTypeReferences(graphQLSchema);
             Collection<ValidationError> errors = new Validator().validateSchema(graphQLSchema);
             if (errors.size() > 0) {

--- a/src/main/java/graphql/schema/SchemaUtil.java
+++ b/src/main/java/graphql/schema/SchemaUtil.java
@@ -1,14 +1,10 @@
 package graphql.schema;
 
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import graphql.GraphQLException;
 import graphql.introspection.Introspection;
+
+import java.util.*;
 
 public class SchemaUtil {
 
@@ -105,14 +101,14 @@ public class SchemaUtil {
     }
 
 
-    public Map<String, GraphQLType> allTypes(GraphQLSchema schema, Set<GraphQLType> dictionary) {
+    public Map<String, GraphQLType> allTypes(GraphQLSchema schema, Set<GraphQLType> additionalTypes) {
         Map<String, GraphQLType> typesByName = new LinkedHashMap<>();
         collectTypes(schema.getQueryType(), typesByName);
         if (schema.isSupportingMutations()) {
             collectTypes(schema.getMutationType(), typesByName);
         }
-        if (dictionary != null) {
-            for (GraphQLType type : dictionary) {
+        if (additionalTypes != null) {
+            for (GraphQLType type : additionalTypes) {
                 collectTypes(type, typesByName);
             }
         }
@@ -121,7 +117,7 @@ public class SchemaUtil {
     }
 
     public List<GraphQLObjectType> findImplementations(GraphQLSchema schema, GraphQLInterfaceType interfaceType) {
-        Map<String, GraphQLType> allTypes = allTypes(schema, schema.getDictionary());
+        Map<String, GraphQLType> allTypes = allTypes(schema, schema.getAdditionalTypes());
         List<GraphQLObjectType> result = new ArrayList<>();
         for (GraphQLType type : allTypes.values()) {
             if (!(type instanceof GraphQLObjectType)) {
@@ -135,7 +131,7 @@ public class SchemaUtil {
 
 
     void replaceTypeReferences(GraphQLSchema schema) {
-        Map<String, GraphQLType> typeMap = allTypes(schema, schema.getDictionary());
+        Map<String, GraphQLType> typeMap = allTypes(schema, schema.getAdditionalTypes());
         for (GraphQLType type : typeMap.values()) {
             if (type instanceof GraphQLFieldsContainer) {
                 resolveTypeReferencesForFieldsContainer((GraphQLFieldsContainer) type, typeMap);


### PR DESCRIPTION
Renaming the map with extra types for the schema from `dictionary` to `additionalTypes` to make it more clear.

This is a breaking change if somebody is using `GraphQLSchema.getDictionary`, which is normally not the case.