### PR TITLE
Makes type name specified to builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,19 +601,19 @@ You wire this together using this builder pattern
         return RuntimeWiring.newRuntimeWiring()
                 .scalar(CustomScalar)
                 // this uses builder function lambda syntax
-                .type(typeWiring -> typeWiring.typeName("QueryType")
+                .type("QueryType", typeWiring -> typeWiring
                         .dataFetcher("hero", new StaticDataFetcher(StarWarsData.getArtoo()))
                         .dataFetcher("human", StarWarsData.getHumanDataFetcher())
                         .dataFetcher("droid", StarWarsData.getDroidDataFetcher())
                 )
-                .type(typeWiring -> typeWiring.typeName("Human")
+                .type("Human", typeWiring -> typeWiring
                         .dataFetcher("friends", StarWarsData.getFriendsDataFetcher())
                 )
                 // you can use builder syntax if you don't like the lambda syntax
-                .type(typeWiring -> typeWiring.typeName("Droid")
+                .type(newTypeWiring("Droid")
                         .dataFetcher("friends", StarWarsData.getFriendsDataFetcher())
                 )
-                // or full builder syntax if that takes your fancy
+                // or full builder syntax if that takes your fancy where you call .build()
                 .type(
                         newTypeWiring("Character")
                                 .typeResolver(StarWarsData.getCharacterTypeResolver())

--- a/src/main/java/graphql/schema/idl/RuntimeWiring.java
+++ b/src/main/java/graphql/schema/idl/RuntimeWiring.java
@@ -83,12 +83,13 @@ public class RuntimeWiring {
         /**
          * This form allows a lambda to be used as the builder of a type wiring
          *
+         * @param typeName the name of the type to wire
          * @param builderFunction a function that will be given the builder to use
          *
          * @return the runtime wiring builder
          */
-        public Builder type(UnaryOperator<TypeRuntimeWiring.Builder> builderFunction) {
-            TypeRuntimeWiring.Builder builder = builderFunction.apply(TypeRuntimeWiring.newTypeWiring());
+        public Builder type(String typeName, UnaryOperator<TypeRuntimeWiring.Builder> builderFunction) {
+            TypeRuntimeWiring.Builder builder = builderFunction.apply(TypeRuntimeWiring.newTypeWiring(typeName));
             return type(builder.build());
         }
 

--- a/src/main/java/graphql/schema/idl/TypeRuntimeWiring.java
+++ b/src/main/java/graphql/schema/idl/TypeRuntimeWiring.java
@@ -1,6 +1,5 @@
 package graphql.schema.idl;
 
-import graphql.Assert;
 import graphql.schema.DataFetcher;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.TypeResolver;
@@ -8,6 +7,8 @@ import graphql.schema.TypeResolver;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.UnaryOperator;
+
+import static graphql.Assert.assertNotNull;
 
 /**
  * A type runtime wiring is a specification of the data fetchers and possible type resolver for a given type name.
@@ -45,27 +46,20 @@ public class TypeRuntimeWiring {
      * @return the builder
      */
     public static Builder newTypeWiring(String typeName) {
+        assertNotNull(typeName, "You must provide a type name");
         return new Builder().typeName(typeName);
-    }
-
-    /**
-     * Creates a new type wiring builder
-     *
-     * @return the builder
-     */
-    public static Builder newTypeWiring() {
-        return new Builder();
     }
 
     /**
      * This form allows a lambda to be used as the builder
      *
+     * @param typeName        the name of the type to wire
      * @param builderFunction a function that will be given the builder to use
      *
      * @return the same builder back please
      */
-    public static TypeRuntimeWiring newTypeWiring(UnaryOperator<Builder> builderFunction) {
-        return builderFunction.apply(newTypeWiring()).build();
+    public static TypeRuntimeWiring newTypeWiring(String typeName, UnaryOperator<Builder> builderFunction) {
+        return builderFunction.apply(newTypeWiring(typeName)).build();
     }
 
     public static class Builder {
@@ -94,8 +88,8 @@ public class TypeRuntimeWiring {
          * @return the current type wiring
          */
         public Builder dataFetcher(String fieldName, DataFetcher dataFetcher) {
-            Assert.assertNotNull(dataFetcher, "you must provide a data fetcher");
-            Assert.assertNotNull(fieldName, "you must tell us what field");
+            assertNotNull(dataFetcher, "you must provide a data fetcher");
+            assertNotNull(fieldName, "you must tell us what field");
             fieldDataFetchers.put(fieldName, dataFetcher);
             return this;
         }
@@ -108,7 +102,7 @@ public class TypeRuntimeWiring {
          * @return the current type wiring
          */
         public Builder dataFetchers(Map<String, DataFetcher> dataFetchersMap) {
-            Assert.assertNotNull(dataFetchersMap, "you must provide a data fetchers map");
+            assertNotNull(dataFetchersMap, "you must provide a data fetchers map");
             fieldDataFetchers.putAll(dataFetchersMap);
             return this;
         }
@@ -122,7 +116,7 @@ public class TypeRuntimeWiring {
          * @return the current type wiring
          */
         public Builder typeResolver(TypeResolver typeResolver) {
-            Assert.assertNotNull(typeResolver, "you must provide a type resolver");
+            assertNotNull(typeResolver, "you must provide a type resolver");
             this.typeResolver = typeResolver;
             return this;
         }
@@ -131,7 +125,7 @@ public class TypeRuntimeWiring {
          * @return the built type wiring
          */
         public TypeRuntimeWiring build() {
-            Assert.assertNotNull(typeName, "you must provide a type name");
+            assertNotNull(typeName, "you must provide a type name");
             return new TypeRuntimeWiring(typeName, fieldDataFetchers, typeResolver);
         }
     }

--- a/src/test/groovy/graphql/schema/idl/RuntimeWiringTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/RuntimeWiringTest.groovy
@@ -51,16 +51,14 @@ class RuntimeWiringTest extends Specification {
 
     def "basic call structure"() {
         def wiring = RuntimeWiring.newRuntimeWiring()
-                .type({ type ->
-            type.typeName("Query")
+                .type("Query",{ type -> type
                     .dataFetcher("fieldX", new NamedDF("fieldX"))
                     .dataFetcher("fieldY", new NamedDF("fieldY"))
                     .dataFetcher("fieldZ", new NamedDF("fieldZ"))
                     .typeResolver(new NamedTR("typeResolver4Query"))
         })
 
-                .type({ type ->
-            type.typeName("Mutation")
+                .type("Mutation",{ type -> type
                     .dataFetcher("fieldX", new NamedDF("mfieldX"))
                     .dataFetcher("fieldY", new NamedDF("mfieldY"))
                     .dataFetcher("fieldZ", new NamedDF("mfieldZ"))

--- a/src/test/groovy/graphql/schema/idl/SchemaDecompilerTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaDecompilerTest.groovy
@@ -17,7 +17,7 @@ class SchemaDecompilerTest extends Specification {
 
     GraphQLSchema starWarsSchema() {
         def wiring =  RuntimeWiring.newRuntimeWiring()
-                .type({ type -> type.typeName("Character").typeResolver(resolver)})
+                .type("Character", { type -> type.typeResolver(resolver)})
                 .scalar(ASTEROID)
                 .build()
         GraphQLSchema schema = load("starWarsSchemaExtended.graphqls", wiring)

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -306,8 +306,8 @@ class SchemaGeneratorTest extends Specification {
             }
         }
         def wiring = RuntimeWiring.newRuntimeWiring()
-                .type({ type -> type.typeName("Foo").typeResolver(resolver) })
-                .type({ type -> type.typeName("Goo").typeResolver(resolver) })
+                .type("Foo",{ type -> type.typeResolver(resolver) })
+                .type("Goo", { type -> type.typeResolver(resolver) })
                 .build()
 
         def schema = generateSchema(spec, wiring)

--- a/src/test/groovy/readme/ReadmeExamples.java
+++ b/src/test/groovy/readme/ReadmeExamples.java
@@ -1,9 +1,8 @@
 package readme;
 
-import graphql.GarfieldSchema;
 import graphql.GraphQL;
-import graphql.StarWarsData;
 import graphql.Scalars;
+import graphql.StarWarsData;
 import graphql.StarWarsSchema;
 import graphql.TypeResolutionEnvironment;
 import graphql.execution.ExecutorServiceExecutionStrategy;
@@ -35,8 +34,9 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
-import static graphql.GarfieldSchema.*;
+import static graphql.GarfieldSchema.Cat;
 import static graphql.GarfieldSchema.CatType;
+import static graphql.GarfieldSchema.Dog;
 import static graphql.GarfieldSchema.DogType;
 import static graphql.MutationSchema.mutationType;
 import static graphql.Scalars.GraphQLBoolean;
@@ -314,19 +314,19 @@ public class ReadmeExamples {
         return RuntimeWiring.newRuntimeWiring()
                 .scalar(CustomScalar)
                 // this uses builder function lambda syntax
-                .type(typeWiring -> typeWiring.typeName("QueryType")
+                .type("QueryType", typeWiring -> typeWiring
                         .dataFetcher("hero", new StaticDataFetcher(StarWarsData.getArtoo()))
                         .dataFetcher("human", StarWarsData.getHumanDataFetcher())
                         .dataFetcher("droid", StarWarsData.getDroidDataFetcher())
                 )
-                .type(typeWiring -> typeWiring.typeName("Human")
+                .type("Human", typeWiring -> typeWiring
                         .dataFetcher("friends", StarWarsData.getFriendsDataFetcher())
                 )
                 // you can use builder syntax if you don't like the lambda syntax
-                .type(typeWiring -> typeWiring.typeName("Droid")
+                .type(newTypeWiring("Droid")
                         .dataFetcher("friends", StarWarsData.getFriendsDataFetcher())
                 )
-                // or full builder syntax if that takes your fancy
+                // or full builder syntax if that takes your fancy where you call .build()
                 .type(
                         newTypeWiring("Character")
                                 .typeResolver(StarWarsData.getCharacterTypeResolver())


### PR DESCRIPTION
A type name is ALWAYS required when building runtime wiring of data fetchers.  This makes more DSL sense