### PR TITLE
#406 added extend type XXX {} support

### DIFF
--- a/src/main/java/graphql/schema/idl/errors/MissingInterfaceTypeError.java
+++ b/src/main/java/graphql/schema/idl/errors/MissingInterfaceTypeError.java
@@ -1,0 +1,14 @@
+package graphql.schema.idl.errors;
+
+import graphql.language.TypeDefinition;
+import graphql.language.TypeName;
+
+import static java.lang.String.format;
+
+public class MissingInterfaceTypeError extends BaseError {
+
+    public MissingInterfaceTypeError(String typeOfType, TypeDefinition typeDefinition, TypeName typeName) {
+        super(typeDefinition, format("The %s type '%s' is not present when resolving type '%s' %s",
+                typeOfType, typeName.getName(), typeDefinition.getName(), lineCol(typeDefinition)));
+    }
+}

--- a/src/main/java/graphql/schema/idl/errors/SchemaMissingError.java
+++ b/src/main/java/graphql/schema/idl/errors/SchemaMissingError.java
@@ -3,6 +3,6 @@ package graphql.schema.idl.errors;
 public class SchemaMissingError extends BaseError {
 
     public SchemaMissingError() {
-        super(null, "There is no ttop level schema object defined");
+        super(null, "There is no top level schema object defined");
     }
 }

--- a/src/main/java/graphql/schema/idl/errors/SchemaProblem.java
+++ b/src/main/java/graphql/schema/idl/errors/SchemaProblem.java
@@ -1,9 +1,9 @@
 package graphql.schema.idl.errors;
 
 import graphql.GraphQLError;
+import graphql.GraphQLException;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -11,7 +11,7 @@ import java.util.List;
  * or {@link graphql.schema.idl.SchemaGenerator} classes and they are reported via this
  * exception as a list of {@link GraphQLError}s
  */
-public class SchemaProblem extends RuntimeException {
+public class SchemaProblem extends GraphQLException {
 
     private final List<GraphQLError> errors;
 
@@ -21,5 +21,12 @@ public class SchemaProblem extends RuntimeException {
 
     public List<GraphQLError> getErrors() {
         return errors;
+    }
+
+    @Override
+    public String toString() {
+        return "SchemaProblem{" +
+                "errors=" + errors +
+                '}';
     }
 }

--- a/src/main/java/graphql/schema/idl/errors/TypeExtensionFieldRedefinitionError.java
+++ b/src/main/java/graphql/schema/idl/errors/TypeExtensionFieldRedefinitionError.java
@@ -1,0 +1,16 @@
+package graphql.schema.idl.errors;
+
+import graphql.language.FieldDefinition;
+import graphql.language.TypeDefinition;
+
+import static java.lang.String.format;
+
+public class TypeExtensionFieldRedefinitionError extends BaseError {
+
+    public TypeExtensionFieldRedefinitionError(TypeDefinition typeDefinition, FieldDefinition fieldDefinition) {
+        super(typeDefinition,
+                format("'%s' extension type %s tried to redefine field '%s' %s",
+                        typeDefinition.getName(), BaseError.lineCol(typeDefinition), fieldDefinition.getName(), BaseError.lineCol(fieldDefinition)
+                ));
+    }
+}

--- a/src/main/java/graphql/schema/idl/errors/TypeExtensionMissingBaseTypeError.java
+++ b/src/main/java/graphql/schema/idl/errors/TypeExtensionMissingBaseTypeError.java
@@ -1,0 +1,15 @@
+package graphql.schema.idl.errors;
+
+import graphql.language.TypeExtensionDefinition;
+
+import static java.lang.String.format;
+
+public class TypeExtensionMissingBaseTypeError extends BaseError {
+
+    public TypeExtensionMissingBaseTypeError(TypeExtensionDefinition typeExtensionDefinition) {
+        super(typeExtensionDefinition,
+                format("The extension '%s' type %s is missing its base object type",
+                        typeExtensionDefinition.getName(), BaseError.lineCol(typeExtensionDefinition)
+                ));
+    }
+}

--- a/src/test/groovy/graphql/schema/idl/SchemaCompilerTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaCompilerTest.groovy
@@ -4,6 +4,7 @@ import graphql.language.EnumTypeDefinition
 import graphql.language.InterfaceTypeDefinition
 import graphql.language.ObjectTypeDefinition
 import graphql.language.ScalarTypeDefinition
+import graphql.language.TypeExtensionDefinition
 import graphql.schema.idl.errors.SchemaProblem
 import spock.lang.Specification
 
@@ -76,6 +77,10 @@ class SchemaCompilerTest extends Specification {
               ): Post
             }
             
+            extend type Query {
+                occurredWhen : String
+            }
+            
             # we need to tell the server which types represent the root query
             # and root mutation types. We call them RootQuery and RootMutation by convention.
             schema @java(package:"com.company.package", directive2:123) {
@@ -95,6 +100,7 @@ class SchemaCompilerTest extends Specification {
         def parsedTypes = typeRegistry.types()
         def scalarTypes = typeRegistry.scalars()
         def schemaDef = typeRegistry.schemaDefinition()
+        def typeExtensions = typeRegistry.typeExtensions()
 
         expect:
 
@@ -104,6 +110,9 @@ class SchemaCompilerTest extends Specification {
         parsedTypes.get("Query") instanceof ObjectTypeDefinition
         parsedTypes.get("Foo") instanceof InterfaceTypeDefinition
         parsedTypes.get("USER_STATE") instanceof EnumTypeDefinition
+
+        typeExtensions.size() == 1
+        typeExtensions.get("Query") != null
 
         scalarTypes.size() == 11 // includes standard scalars
         scalarTypes.get("Url") instanceof ScalarTypeDefinition

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -4,7 +4,21 @@ import graphql.TypeResolutionEnvironment
 import graphql.schema.*
 import spock.lang.Specification
 
+import java.util.function.UnaryOperator
+
 class SchemaGeneratorTest extends Specification {
+
+    def resolver = new TypeResolver() {
+
+        @Override
+        GraphQLObjectType getType(TypeResolutionEnvironment env) {
+            throw new UnsupportedOperationException("Not implemented")
+        }
+    }
+
+    private UnaryOperator<TypeRuntimeWiring.Builder> buildResolver() {
+        { builder -> builder.typeResolver(resolver) } as UnaryOperator<TypeRuntimeWiring.Builder>
+    }
 
 
     GraphQLSchema generateSchema(String schemaSpec, RuntimeWiring wiring) {
@@ -298,16 +312,9 @@ class SchemaGeneratorTest extends Specification {
 
         """
 
-        def resolver = new TypeResolver() {
-
-            @Override
-            GraphQLObjectType getType(TypeResolutionEnvironment env) {
-                throw new UnsupportedOperationException("Not implemented")
-            }
-        }
         def wiring = RuntimeWiring.newRuntimeWiring()
-                .type("Foo",{ type -> type.typeResolver(resolver) })
-                .type("Goo", { type -> type.typeResolver(resolver) })
+                .type("Foo", buildResolver())
+                .type("Goo", buildResolver())
                 .build()
 
         def schema = generateSchema(spec, wiring)
@@ -319,6 +326,103 @@ class SchemaGeneratorTest extends Specification {
         schema.queryType.fieldDefinitions[0].type.name == "Boolean"
         schema.queryType.fieldDefinitions[1].name == "is_bar"
         schema.queryType.fieldDefinitions[1].type.name == "Boolean"
+
+    }
+
+    def "type extensions can be specified multiple times #406"() {
+
+        def spec = """
+
+            interface Interface1 {
+               baseField : String
+            }     
+
+            interface Interface2 {
+               extraField1 : String
+               extraField2 : ID
+            }     
+
+            interface Interface3 {
+               extraField1 : String
+               extraField3 : ID
+            }     
+
+            type BaseType {
+               baseField : String
+            }
+            
+            extend type BaseType implements Interface1 {
+               extraField1 : String
+            }
+
+            extend type BaseType implements Interface2 {
+               extraField2 : Int
+            }
+
+            extend type BaseType implements Interface3 {
+               extraField3 : ID
+            }
+
+            extend type BaseType {
+               extraField4 : Boolean
+            }
+
+            extend type BaseType {
+               extraField5 : Boolean!
+            }
+
+            #
+            # if we repeat a definition, that's ok as long as its the same types as before
+            # they will be de-duped since the effect is the same
+            #
+            extend type BaseType implements Interface1 {
+               baseField : String
+            }
+            
+            schema {
+              query: BaseType
+            }
+
+        """
+
+        def wiring = RuntimeWiring.newRuntimeWiring()
+                .type("Interface1", buildResolver())
+                .type("Interface2", buildResolver())
+                .type("Interface3", buildResolver())
+                .build()
+
+        def schema = generateSchema(spec, wiring)
+
+        expect:
+
+        GraphQLObjectType type = schema.getType("BaseType") as GraphQLObjectType
+
+        type.fieldDefinitions.size() == 6
+
+        type.fieldDefinitions[0].name == "baseField"
+        type.fieldDefinitions[0].type.name == "String"
+
+        type.fieldDefinitions[1].name == "extraField1"
+        type.fieldDefinitions[1].type.name == "String"
+
+        type.fieldDefinitions[2].name == "extraField2"
+        type.fieldDefinitions[2].type.name == "Int"
+
+        type.fieldDefinitions[3].name == "extraField3"
+        type.fieldDefinitions[3].type.name == "ID"
+
+        type.fieldDefinitions[4].name == "extraField4"
+        type.fieldDefinitions[4].type.name == "Boolean"
+
+        type.fieldDefinitions[5].name == "extraField5"
+        type.fieldDefinitions[5].type instanceof GraphQLNonNull
+
+        def interfaces = type.getInterfaces()
+
+        interfaces.size() == 3
+        interfaces[0].name == "Interface1"
+        interfaces[1].name == "Interface2"
+        interfaces[2].name == "Interface3"
 
     }
 

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -426,4 +426,58 @@ class SchemaGeneratorTest extends Specification {
 
     }
 
+    def "read me type example makes sense"() {
+
+        def spec = """             
+
+            schema {
+              query: Human
+            }
+
+            type Episode {
+                name : String
+            }
+            
+            interface Character {
+                name: String!
+            }
+                
+            type Human {
+                id: ID!
+                name: String!
+            }
+
+            extend type Human implements Character {
+                friends: [Character]
+            }
+
+            extend type Human {
+                appearsIn: [Episode]!
+                homePlanet: String
+            }
+        """
+
+        def wiring = RuntimeWiring.newRuntimeWiring()
+                .type("Character", buildResolver())
+                .build()
+
+        def schema = generateSchema(spec, wiring)
+
+        expect:
+
+        GraphQLObjectType type = schema.getQueryType()
+
+        type.name == "Human"
+        type.fieldDefinitions[0].name == "id"
+        type.fieldDefinitions[1].name == "name"
+        type.fieldDefinitions[2].name == "friends"
+        type.fieldDefinitions[3].name == "appearsIn"
+        type.fieldDefinitions[4].name == "homePlanet"
+
+        type.interfaces.size() == 1
+        type.interfaces[0].name == "Character"
+
+
+
+    }
 }

--- a/src/test/groovy/graphql/schema/idl/TypeDefinitionRegistryTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/TypeDefinitionRegistryTest.groovy
@@ -65,7 +65,7 @@ class TypeDefinitionRegistryTest extends Specification {
         def result2 = compile(spec2)
 
         when:
-            result1.merge(result2)
+        result1.merge(result2)
 
         then:
         SchemaProblem e = thrown(SchemaProblem)
@@ -146,6 +146,10 @@ class TypeDefinitionRegistryTest extends Specification {
               votes: Int
             }
 
+            extend type Post {
+                placeOfPost : String
+            }
+
         """
 
         def spec2 = """ 
@@ -155,6 +159,10 @@ class TypeDefinitionRegistryTest extends Specification {
               title : String
               posts : [Post]
             }
+            
+            extend type Post {
+                timeOfPost : Int
+            }
 
         """
 
@@ -162,6 +170,7 @@ class TypeDefinitionRegistryTest extends Specification {
         def result2 = compile(spec2)
 
         when:
+
         result1.merge(result2)
 
         then:
@@ -176,7 +185,8 @@ class TypeDefinitionRegistryTest extends Specification {
 
         author.name == "Author"
         author.getChildren().size() == 4
+
+        def typeExtensions = result1.typeExtensions().get("Post")
+        typeExtensions.size() == 2
     }
-
-
 }

--- a/src/test/groovy/readme/README.next.md
+++ b/src/test/groovy/readme/README.next.md
@@ -627,8 +627,106 @@ You wire this together using this builder pattern
 
 NOTE: IDL is not currently part of the [formal graphql spec](https://facebook.github.io/graphql/#sec-Appendix-Grammar-Summary.Query-Document).  
 The implementation in this library is based off the [reference implementation](https://github.com/graphql/graphql-js).  However plenty of 
-code out there is based on this IDL syntax and hence you can be fairly confident that you are building on solid technology ground.   
+code out there is based on this IDL syntax and hence you can be fairly confident that you are building on solid technology ground.
+   
+# Modularising the Schema IDL
 
+Having one one large schema file is not always viable.  You can modularise you schema using two techniques.
+
+The first technique is to merge multiple Schema IDL files into one logic unit.  In the case below the schema as 
+been split into multiple files and merged all together just before schema generation.
+
+   ```java
+        SchemaCompiler schemaCompiler = new SchemaCompiler();
+        SchemaGenerator schemaGenerator = new SchemaGenerator();
+
+        File schemaFile1 = loadSchema("starWarsSchemaPart1.graphqls");
+        File schemaFile2 = loadSchema("starWarsSchemaPart2.graphqls");
+        File schemaFile3 = loadSchema("starWarsSchemaPart3.graphqls");
+
+        TypeDefinitionRegistry typeRegistry = new TypeDefinitionRegistry();
+
+        // each compiled registry is merged into the main registry
+        typeRegistry.merge(schemaCompiler.compile(schemaFile1));
+        typeRegistry.merge(schemaCompiler.compile(schemaFile2));
+        typeRegistry.merge(schemaCompiler.compile(schemaFile3));
+
+        GraphQLSchema graphQLSchema = schemaGenerator.makeExecutableSchema(typeRegistry, buildRuntimeWiring());
+   ```
+
+The Graphql IDL type system has another construct for modularising your schema.  You can use `type extensions` to add
+extra fields and interfaces to a type.
+
+Imagine you start with a type like this in one schema file.
+
+```graphql
+type Human {
+    id: ID!
+    name: String!
+}
+```
+
+Another part of your system can extend this type to add more shape to it. 
+
+```graphql
+extend type Human implements Character {
+    friends: [Character]
+}
+```
+
+You can have as many extensions as you think sensible.  They will be combined in the order
+in which they are encountered.
+
+```graphql
+extend type Human {
+    appearsIn: [Episode]!
+    homePlanet: String
+}
+```
+
+
+With all these type extensions in place the `Human` type now looks like this at runtime.
+
+```graphql
+type Human implements Character {
+    id: ID!
+    name: String!
+    friends: [Character]
+    appearsIn: [Episode]!
+    homePlanet: String
+}
+```
+
+This is especially useful at the top level.  You can use extension types to add new fields to the
+top level schema "query".  Teams could contribute "sections" on what is being offered as the total
+graphql query.
+
+
+```graphql
+schema {
+  query: CombinedQueryFromMultipleTeams
+}
+
+type CombinedQueryFromMultipleTeams {
+    createdTimestamp : String
+}
+
+# maybe the invoicing system team puts in this set of attributes
+extend type CombinedQueryFromMultipleTeams {
+    invoicing : Invoicing
+}
+
+# and the billing system team puts in this set of attributes
+extend type CombinedQueryFromMultipleTeams {
+    billing : Billing
+}
+
+# and so and so forth
+extend type CombinedQueryFromMultipleTeams {
+    auditing : Auditing
+}
+
+```
 
 #### Contributions
 

--- a/src/test/groovy/readme/ReadmeExamples.java
+++ b/src/test/groovy/readme/ReadmeExamples.java
@@ -61,7 +61,7 @@ import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring;
  * You should place these examples into the README.next.md and NOT the main README.md.  This allows
  * 'master' to progress yet shows consumers the released information about the project.
  */
-@SuppressWarnings({"unused", "Convert2Lambda", "UnnecessaryLocalVariable"})
+@SuppressWarnings({"unused", "Convert2Lambda", "UnnecessaryLocalVariable", "ConstantConditions"})
 public class ReadmeExamples {
 
 
@@ -312,6 +312,26 @@ public class ReadmeExamples {
         RuntimeWiring wiring = buildRuntimeWiring();
         GraphQLSchema graphQLSchema = schemaGenerator.makeExecutableSchema(typeRegistry, wiring);
     }
+
+    void compiledSplitSchemaExample() {
+
+        SchemaCompiler schemaCompiler = new SchemaCompiler();
+        SchemaGenerator schemaGenerator = new SchemaGenerator();
+
+        File schemaFile1 = loadSchema("starWarsSchemaPart1.graphqls");
+        File schemaFile2 = loadSchema("starWarsSchemaPart2.graphqls");
+        File schemaFile3 = loadSchema("starWarsSchemaPart3.graphqls");
+
+        TypeDefinitionRegistry typeRegistry = new TypeDefinitionRegistry();
+
+        // each compiled registry is merged into the main registry
+        typeRegistry.merge(schemaCompiler.compile(schemaFile1));
+        typeRegistry.merge(schemaCompiler.compile(schemaFile2));
+        typeRegistry.merge(schemaCompiler.compile(schemaFile3));
+
+        GraphQLSchema graphQLSchema = schemaGenerator.makeExecutableSchema(typeRegistry, buildRuntimeWiring());
+    }
+
 
     RuntimeWiring buildRuntimeWiring() {
         return RuntimeWiring.newRuntimeWiring()


### PR DESCRIPTION
#406 added extend type XXX {} support

this now allows the type extension syntax

            type BaseType {
                fieldA : Int
            }

            extend type BaseType {
                fieldB : Int
            }

This could be in multiple files say to modularize the schema files.

The schema grammar always had these...we just didnt apply them in the generator

I think this should be in 3.x because it fits the "add IDL support" them in 3.x