### PR TITLE
add public/internal/spi annotations

### DIFF
--- a/src/main/java/graphql/Assert.java
+++ b/src/main/java/graphql/Assert.java
@@ -2,6 +2,7 @@ package graphql;
 
 import java.util.Collection;
 
+@Internal
 public class Assert {
 
     public static <T> T assertNotNull(T object, String errorMessage) {

--- a/src/main/java/graphql/AssertException.java
+++ b/src/main/java/graphql/AssertException.java
@@ -1,6 +1,7 @@
 package graphql;
 
 
+@PublicApi
 public class AssertException extends GraphQLException {
 
     public AssertException(String message) {

--- a/src/main/java/graphql/ExceptionWhileDataFetching.java
+++ b/src/main/java/graphql/ExceptionWhileDataFetching.java
@@ -5,6 +5,7 @@ import graphql.language.SourceLocation;
 
 import java.util.List;
 
+@PublicApi
 public class ExceptionWhileDataFetching implements GraphQLError {
 
     private final Throwable exception;

--- a/src/main/java/graphql/ExecutionResult.java
+++ b/src/main/java/graphql/ExecutionResult.java
@@ -4,6 +4,7 @@ package graphql;
 import java.util.List;
 import java.util.Map;
 
+@PublicApi
 public interface ExecutionResult {
 
     <T> T getData();

--- a/src/main/java/graphql/ExecutionResultImpl.java
+++ b/src/main/java/graphql/ExecutionResultImpl.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+@Internal
 public class ExecutionResultImpl implements ExecutionResult {
 
     private final List<GraphQLError> errors = new ArrayList<>();

--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import static graphql.Assert.assertNotNull;
 
+@PublicApi
 public class GraphQL {
 
     private static final Logger log = LoggerFactory.getLogger(GraphQL.class);
@@ -48,6 +49,7 @@ public class GraphQL {
      *
      * @deprecated use the {@link #newGraphQL(GraphQLSchema)} builder instead.  This will be removed in a future version.
      */
+    @Internal
     public GraphQL(GraphQLSchema graphQLSchema) {
         //noinspection deprecation
         this(graphQLSchema, null, null);
@@ -61,6 +63,7 @@ public class GraphQL {
      *
      * @deprecated use the {@link #newGraphQL(GraphQLSchema)} builder instead.  This will be removed in a future version.
      */
+    @Internal
     public GraphQL(GraphQLSchema graphQLSchema, ExecutionStrategy queryStrategy) {
         //noinspection deprecation
         this(graphQLSchema, queryStrategy, null);
@@ -75,6 +78,7 @@ public class GraphQL {
      *
      * @deprecated use the {@link #newGraphQL(GraphQLSchema)} builder instead.  This will be removed in a future version.
      */
+    @Internal
     public GraphQL(GraphQLSchema graphQLSchema, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy) {
         this(graphQLSchema, queryStrategy, mutationStrategy, null, DEFAULT_EXECUTION_ID_PROVIDER, NoOpInstrumentation.INSTANCE);
     }
@@ -89,6 +93,7 @@ public class GraphQL {
      *
      * @deprecated use the {@link #newGraphQL(GraphQLSchema)} builder instead.  This will be removed in a future version.
      */
+    @Internal
     public GraphQL(GraphQLSchema graphQLSchema, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy, ExecutionStrategy subscriptionStrategy) {
         this(graphQLSchema, queryStrategy, mutationStrategy, subscriptionStrategy, DEFAULT_EXECUTION_ID_PROVIDER, NoOpInstrumentation.INSTANCE);
     }
@@ -114,6 +119,7 @@ public class GraphQL {
     }
 
 
+    @PublicApi
     public static class Builder {
         private GraphQLSchema graphQLSchema;
         private ExecutionStrategy queryExecutionStrategy = new SimpleExecutionStrategy();

--- a/src/main/java/graphql/GraphQLError.java
+++ b/src/main/java/graphql/GraphQLError.java
@@ -5,6 +5,7 @@ import graphql.language.SourceLocation;
 
 import java.util.List;
 
+@PublicApi
 public interface GraphQLError {
 
     String getMessage();

--- a/src/main/java/graphql/Internal.java
+++ b/src/main/java/graphql/Internal.java
@@ -1,0 +1,14 @@
+package graphql;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = {CONSTRUCTOR, METHOD, TYPE})
+public @interface Internal {
+}

--- a/src/main/java/graphql/PublicApi.java
+++ b/src/main/java/graphql/PublicApi.java
@@ -1,5 +1,6 @@
 package graphql;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -10,5 +11,6 @@ import static java.lang.annotation.ElementType.TYPE;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(value = {CONSTRUCTOR, METHOD, TYPE})
+@Documented
 public @interface PublicApi {
 }

--- a/src/main/java/graphql/PublicApi.java
+++ b/src/main/java/graphql/PublicApi.java
@@ -1,0 +1,14 @@
+package graphql;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = {CONSTRUCTOR, METHOD, TYPE})
+public @interface PublicApi {
+}

--- a/src/main/java/graphql/PublicSpi.java
+++ b/src/main/java/graphql/PublicSpi.java
@@ -1,5 +1,6 @@
 package graphql;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -10,5 +11,6 @@ import static java.lang.annotation.ElementType.TYPE;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(value = {CONSTRUCTOR, METHOD, TYPE})
+@Documented
 public @interface PublicSpi {
 }

--- a/src/main/java/graphql/PublicSpi.java
+++ b/src/main/java/graphql/PublicSpi.java
@@ -1,0 +1,14 @@
+package graphql;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = {CONSTRUCTOR, METHOD, TYPE})
+public @interface PublicSpi {
+}

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -4,6 +4,7 @@ package graphql.execution;
 import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.GraphQLException;
+import graphql.Internal;
 import graphql.MutationNotSupportedError;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationContext;
@@ -26,6 +27,7 @@ import static graphql.language.OperationDefinition.Operation.MUTATION;
 import static graphql.language.OperationDefinition.Operation.QUERY;
 import static graphql.language.OperationDefinition.Operation.SUBSCRIPTION;
 
+@Internal
 public class Execution {
 
     private final FieldCollector fieldCollector = new FieldCollector();

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -4,6 +4,7 @@ import graphql.ExceptionWhileDataFetching;
 import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.GraphQLException;
+import graphql.PublicSpi;
 import graphql.TypeResolutionEnvironment;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationContext;
@@ -35,6 +36,7 @@ import static graphql.introspection.Introspection.SchemaMetaFieldDef;
 import static graphql.introspection.Introspection.TypeMetaFieldDef;
 import static graphql.introspection.Introspection.TypeNameMetaFieldDef;
 
+@PublicSpi
 public abstract class ExecutionStrategy {
 
     private static final Logger log = LoggerFactory.getLogger(ExecutionStrategy.class);

--- a/src/main/java/graphql/execution/ExecutorServiceExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutorServiceExecutionStrategy.java
@@ -3,6 +3,7 @@ package graphql.execution;
 import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.GraphQLException;
+import graphql.PublicApi;
 import graphql.language.Field;
 
 import java.util.LinkedHashMap;
@@ -27,6 +28,7 @@ import java.util.concurrent.Future;
  * 
  * See {@code graphql.execution.ExecutorServiceExecutionStrategyTest} for example usage.
  */
+@PublicApi
 public class ExecutorServiceExecutionStrategy extends ExecutionStrategy {
 
     ExecutorService executorService;

--- a/src/main/java/graphql/execution/FieldCollector.java
+++ b/src/main/java/graphql/execution/FieldCollector.java
@@ -1,6 +1,7 @@
 package graphql.execution;
 
 
+import graphql.Internal;
 import graphql.language.Field;
 import graphql.language.FragmentDefinition;
 import graphql.language.FragmentSpread;
@@ -19,6 +20,7 @@ import java.util.Map;
 
 import static graphql.execution.TypeFromAST.getTypeFromAST;
 
+@Internal
 public class FieldCollector {
 
     private ConditionalNodes conditionalNodes;

--- a/src/main/java/graphql/execution/TypeFromAST.java
+++ b/src/main/java/graphql/execution/TypeFromAST.java
@@ -1,6 +1,7 @@
 package graphql.execution;
 
 
+import graphql.Internal;
 import graphql.language.ListType;
 import graphql.language.NonNullType;
 import graphql.language.Type;
@@ -10,6 +11,7 @@ import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
 
+@Internal
 public class TypeFromAST {
 
 

--- a/src/main/java/graphql/schema/DataFetcher.java
+++ b/src/main/java/graphql/schema/DataFetcher.java
@@ -1,6 +1,9 @@
 package graphql.schema;
 
 
+import graphql.PublicSpi;
+
+@PublicSpi
 public interface DataFetcher<T> {
 
     T get(DataFetchingEnvironment environment);

--- a/src/main/java/graphql/schema/GraphQLFieldDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLFieldDefinition.java
@@ -1,6 +1,8 @@
 package graphql.schema;
 
 
+import graphql.Internal;
+import graphql.PublicApi;
 import graphql.language.FieldDefinition;
 
 import java.util.ArrayList;
@@ -11,6 +13,7 @@ import java.util.function.UnaryOperator;
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
 
+@PublicApi
 public class GraphQLFieldDefinition {
 
     private final String name;
@@ -22,10 +25,12 @@ public class GraphQLFieldDefinition {
     private final FieldDefinition definition;
 
 
+    @Internal
     public GraphQLFieldDefinition(String name, String description, GraphQLOutputType type, DataFetcher dataFetcher, List<GraphQLArgument> arguments, String deprecationReason) {
         this(name,description,type, dataFetcher,arguments,deprecationReason,null);
     }
 
+    @Internal
     public GraphQLFieldDefinition(String name, String description, GraphQLOutputType type, DataFetcher dataFetcher, List<GraphQLArgument> arguments, String deprecationReason, FieldDefinition definition) {
         assertValidName(name);
         assertNotNull(dataFetcher, "dataFetcher can't be null");
@@ -89,6 +94,7 @@ public class GraphQLFieldDefinition {
         return new Builder();
     }
 
+    @PublicApi
     public static class Builder {
 
         private String name;

--- a/src/main/java/graphql/schema/GraphQLInputObjectField.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectField.java
@@ -1,6 +1,8 @@
 package graphql.schema;
 
 
+import graphql.Internal;
+import graphql.PublicApi;
 import graphql.language.InputValueDefinition;
 
 import java.util.Map;
@@ -8,6 +10,7 @@ import java.util.Map;
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
 
+@PublicApi
 public class GraphQLInputObjectField {
 
     private final String name;
@@ -16,14 +19,17 @@ public class GraphQLInputObjectField {
     private final Object defaultValue;
     private final InputValueDefinition definition;
 
+    @Internal
     public GraphQLInputObjectField(String name, GraphQLInputType type) {
         this(name, null, type, null, null);
     }
 
+    @Internal
     public GraphQLInputObjectField(String name, String description, GraphQLInputType type, Object defaultValue) {
         this(name,description,type,defaultValue,null);
     }
 
+    @Internal
     public GraphQLInputObjectField(String name, String description, GraphQLInputType type, Object defaultValue, InputValueDefinition definition) {
         assertValidName(name);
         assertNotNull(type, "type can't be null");
@@ -42,8 +48,7 @@ public class GraphQLInputObjectField {
         return name;
     }
 
-    public GraphQLInputType getType() {
-        return type;
+    public GraphQLInputType getType() { return type;
     }
 
     public Object getDefaultValue() {
@@ -62,6 +67,7 @@ public class GraphQLInputObjectField {
         return new Builder();
     }
 
+    @PublicApi
     public static class Builder {
         private String name;
         private String description;

--- a/src/main/java/graphql/schema/GraphQLInputObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectType.java
@@ -1,6 +1,8 @@
 package graphql.schema;
 
 import graphql.AssertException;
+import graphql.Internal;
+import graphql.PublicApi;
 import graphql.language.InputObjectTypeDefinition;
 
 import java.util.ArrayList;
@@ -12,6 +14,7 @@ import java.util.function.UnaryOperator;
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
 
+@PublicApi
 public class GraphQLInputObjectType implements GraphQLType, GraphQLInputType, GraphQLUnmodifiedType, GraphQLNullableType, GraphQLInputFieldsContainer {
 
     private final String name;
@@ -19,9 +22,12 @@ public class GraphQLInputObjectType implements GraphQLType, GraphQLInputType, Gr
     private final Map<String, GraphQLInputObjectField> fieldMap = new LinkedHashMap<>();
     private final InputObjectTypeDefinition definition;
 
+    @Internal
     public GraphQLInputObjectType(String name, String description, List<GraphQLInputObjectField> fields) {
         this(name,description,fields,null);
     }
+
+    @Internal
     public GraphQLInputObjectType(String name, String description, List<GraphQLInputObjectField> fields, InputObjectTypeDefinition definition) {
         assertValidName(name);
         assertNotNull(fields, "fields can't be null");
@@ -75,6 +81,7 @@ public class GraphQLInputObjectType implements GraphQLType, GraphQLInputType, Gr
         return definition;
     }
 
+    @PublicApi
     public static class Builder {
         private String name;
         private String description;

--- a/src/main/java/graphql/schema/GraphQLInterfaceType.java
+++ b/src/main/java/graphql/schema/GraphQLInterfaceType.java
@@ -1,6 +1,8 @@
 package graphql.schema;
 
 import graphql.AssertException;
+import graphql.Internal;
+import graphql.PublicApi;
 import graphql.language.InterfaceTypeDefinition;
 
 import java.util.ArrayList;
@@ -12,6 +14,7 @@ import java.util.function.UnaryOperator;
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
 
+@PublicApi
 public class GraphQLInterfaceType implements GraphQLType, GraphQLOutputType, GraphQLFieldsContainer, GraphQLCompositeType, GraphQLUnmodifiedType, GraphQLNullableType {
 
     private final String name;
@@ -20,10 +23,12 @@ public class GraphQLInterfaceType implements GraphQLType, GraphQLOutputType, Gra
     private final TypeResolver typeResolver;
     private final InterfaceTypeDefinition definition;
 
+    @Internal
     public GraphQLInterfaceType(String name, String description, List<GraphQLFieldDefinition> fieldDefinitions, TypeResolver typeResolver) {
         this(name, description, fieldDefinitions, typeResolver, null);
     }
 
+    @Internal
     public GraphQLInterfaceType(String name, String description, List<GraphQLFieldDefinition> fieldDefinitions, TypeResolver typeResolver, InterfaceTypeDefinition definition) {
         assertValidName(name);
         assertNotNull(typeResolver, "typeResolver can't null");
@@ -84,6 +89,7 @@ public class GraphQLInterfaceType implements GraphQLType, GraphQLOutputType, Gra
     }
 
 
+    @PublicApi
     public static class Builder {
         private String name;
         private String description;

--- a/src/main/java/graphql/schema/GraphQLList.java
+++ b/src/main/java/graphql/schema/GraphQLList.java
@@ -1,10 +1,13 @@
 package graphql.schema;
 
 
+import graphql.PublicApi;
+
 import java.util.Map;
 
 import static graphql.Assert.assertNotNull;
 
+@PublicApi
 public class GraphQLList implements GraphQLType, GraphQLInputType, GraphQLOutputType, GraphQLModifiedType, GraphQLNullableType {
 
     /**

--- a/src/main/java/graphql/schema/GraphQLNonNull.java
+++ b/src/main/java/graphql/schema/GraphQLNonNull.java
@@ -1,10 +1,13 @@
 package graphql.schema;
 
 
+import graphql.PublicApi;
+
 import java.util.Map;
 
 import static graphql.Assert.assertNotNull;
 
+@PublicApi
 public class GraphQLNonNull implements GraphQLType, GraphQLInputType, GraphQLOutputType, GraphQLModifiedType {
 
     /**

--- a/src/main/java/graphql/schema/GraphQLObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLObjectType.java
@@ -1,6 +1,8 @@
 package graphql.schema;
 
 import graphql.AssertException;
+import graphql.Internal;
+import graphql.PublicApi;
 import graphql.language.ObjectTypeDefinition;
 
 import java.util.ArrayList;
@@ -14,6 +16,7 @@ import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
 
 
+@PublicApi
 public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQLFieldsContainer, GraphQLCompositeType, GraphQLUnmodifiedType, GraphQLNullableType {
 
 
@@ -23,11 +26,13 @@ public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQ
     private List<GraphQLOutputType> interfaces = new ArrayList<>();
     private final ObjectTypeDefinition definition;
 
+    @Internal
     public GraphQLObjectType(String name, String description, List<GraphQLFieldDefinition> fieldDefinitions,
                              List<GraphQLOutputType> interfaces) {
         this(name, description, fieldDefinitions, interfaces, null);
     }
 
+    @Internal
     public GraphQLObjectType(String name, String description, List<GraphQLFieldDefinition> fieldDefinitions,
                              List<GraphQLOutputType> interfaces, ObjectTypeDefinition definition) {
         assertValidName(name);
@@ -101,6 +106,7 @@ public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQ
         return new Builder();
     }
 
+    @PublicApi
     public static class Builder {
         private String name;
         private String description;

--- a/src/main/java/graphql/schema/GraphQLUnionType.java
+++ b/src/main/java/graphql/schema/GraphQLUnionType.java
@@ -1,6 +1,8 @@
 package graphql.schema;
 
 
+import graphql.Internal;
+import graphql.PublicApi;
 import graphql.language.UnionTypeDefinition;
 
 import java.util.ArrayList;
@@ -12,6 +14,7 @@ import static graphql.Assert.assertNotEmpty;
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
 
+@PublicApi
 public class GraphQLUnionType implements GraphQLType, GraphQLOutputType, GraphQLCompositeType, GraphQLUnmodifiedType, GraphQLNullableType {
 
     private final String name;
@@ -21,10 +24,12 @@ public class GraphQLUnionType implements GraphQLType, GraphQLOutputType, GraphQL
     private final UnionTypeDefinition definition;
 
 
+    @Internal
     public GraphQLUnionType(String name, String description, List<GraphQLOutputType> types, TypeResolver typeResolver) {
         this(name, description, types, typeResolver, null);
     }
 
+    @Internal
     public GraphQLUnionType(String name, String description, List<GraphQLOutputType> types, TypeResolver typeResolver, UnionTypeDefinition definition) {
         assertValidName(name);
         assertNotNull(types, "types can't be null");
@@ -73,6 +78,7 @@ public class GraphQLUnionType implements GraphQLType, GraphQLOutputType, GraphQL
         return new Builder();
     }
 
+    @PublicApi
     public static class Builder {
         private String name;
         private String description;

--- a/src/main/java/graphql/schema/SchemaUtil.java
+++ b/src/main/java/graphql/schema/SchemaUtil.java
@@ -3,6 +3,7 @@ package graphql.schema;
 
 import graphql.AssertException;
 import graphql.GraphQLException;
+import graphql.Internal;
 import graphql.introspection.Introspection;
 
 import java.util.ArrayList;
@@ -13,6 +14,7 @@ import java.util.Set;
 
 import static java.lang.String.format;
 
+@Internal
 public class SchemaUtil {
 
     public boolean isLeafType(GraphQLType type) {

--- a/src/main/java/graphql/schema/TypeResolver.java
+++ b/src/main/java/graphql/schema/TypeResolver.java
@@ -1,12 +1,14 @@
 package graphql.schema;
 
 
+import graphql.PublicSpi;
 import graphql.TypeResolutionEnvironment;
 
 /**
  * This is called during type resolution to work out what graphql type should be used
  * dynamically during runtime for {@link GraphQLInterfaceType}s and {@link GraphQLUnionType}s
  */
+@PublicSpi
 public interface TypeResolver {
 
     /**

--- a/src/main/java/graphql/schema/idl/RuntimeWiring.java
+++ b/src/main/java/graphql/schema/idl/RuntimeWiring.java
@@ -1,5 +1,6 @@
 package graphql.schema.idl;
 
+import graphql.PublicApi;
 import graphql.schema.DataFetcher;
 import graphql.schema.GraphQLScalarType;
 import graphql.schema.GraphQLSchema;
@@ -13,6 +14,7 @@ import java.util.function.UnaryOperator;
  * A runtime wiring is a specification of data fetchers, type resolves and custom scalars that are needed
  * to wire together a functional {@link GraphQLSchema}
  */
+@PublicApi
 public class RuntimeWiring {
 
     private final Map<String, Map<String, DataFetcher>> dataFetchers;
@@ -48,6 +50,7 @@ public class RuntimeWiring {
         return new Builder();
     }
 
+    @PublicApi
     public static class Builder {
         private final Map<String, Map<String, DataFetcher>> dataFetchers = new LinkedHashMap<>();
         private final Map<String, GraphQLScalarType> scalars = new LinkedHashMap<>();


### PR DESCRIPTION
This is a first idea how we could handle #284:

There are three different Annotations: 
-`@PublicApi` for public classes/methods/interfaces.
- `@PrivateApi` for private stuff
- `@PublicSpi` for public interfaces/abstract classes which users are expected to implement.
