### PR TITLE
#417 do not overwrite top level schema definition during type registry merge

### DIFF
--- a/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java
+++ b/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java
@@ -60,8 +60,12 @@ public class TypeDefinitionRegistry {
             throw new SchemaProblem(errors);
         }
 
+        if (this.schema == null) {
+            // ensure schema is not overwritten by merge
+            this.schema = typeRegistry.schema;
+        }
+
         // ok commit to the merge
-        this.schema = typeRegistry.schema;
         this.types.putAll(tempTypes);
         this.typeExtensions.putAll(tempTypeExtensions);
         this.scalarTypes.putAll(tempScalarTypes);

--- a/src/test/groovy/graphql/schema/idl/TypeDefinitionRegistryTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/TypeDefinitionRegistryTest.groovy
@@ -45,6 +45,29 @@ class TypeDefinitionRegistryTest extends Specification {
     }
 
 
+    def "merging multiple type registries does not overwrite schema definition"() {
+
+        def spec1 = """ 
+            schema {
+                query: Query
+            }
+        """
+
+        def spec2 = """ 
+            type Post { id: Int! }
+        """
+
+        def result1 = compile(spec1)
+        def result2 = compile(spec2)
+
+        def registry = result1.merge(result2)
+
+        expect:
+        result1.schemaDefinition().isPresent()
+        registry.schemaDefinition().get().isEqualTo(result1.schemaDefinition().get())
+
+    }
+
     def "test merge of schema types"() {
 
         def spec1 = """ 


### PR DESCRIPTION
Fixes #417 