### PR TITLE
Download gradle over https

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -146,5 +146,5 @@ tasks.withType(PublishToMavenRepository) {
 
 task wrapper(type: Wrapper) {
     gradleVersion = '3.4'
-    distributionUrl = "http://services.gradle.org/distributions/gradle-${gradleVersion}-all.zip"
+    distributionUrl = "https://services.gradle.org/distributions/gradle-${gradleVersion}-all.zip"
 }


### PR DESCRIPTION
It's always safest to download software over https