### PR TITLE
Add environment to field instrumentation.

### DIFF
--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -78,7 +78,7 @@ public abstract class ExecutionStrategy {
 
         Instrumentation instrumentation = executionContext.getInstrumentation();
 
-        InstrumentationContext<ExecutionResult> fieldCtx = instrumentation.beginField(new FieldParameters(executionContext, fieldDef));
+        InstrumentationContext<ExecutionResult> fieldCtx = instrumentation.beginField(new FieldParameters(executionContext, fieldDef, environment));
 
         InstrumentationContext<Object> fetchCtx = instrumentation.beginFieldFetch(new FieldFetchParameters(executionContext, fieldDef, environment));
         Object resolvedValue = null;

--- a/src/main/java/graphql/execution/instrumentation/parameters/FieldFetchParameters.java
+++ b/src/main/java/graphql/execution/instrumentation/parameters/FieldFetchParameters.java
@@ -12,7 +12,7 @@ public class FieldFetchParameters extends FieldParameters {
     private final DataFetchingEnvironment environment;
 
     public FieldFetchParameters(ExecutionContext getExecutionContext, GraphQLFieldDefinition fieldDef, DataFetchingEnvironment environment) {
-        super(getExecutionContext, fieldDef);
+        super(getExecutionContext, fieldDef, environment);
         this.environment = environment;
     }
 

--- a/src/main/java/graphql/execution/instrumentation/parameters/FieldParameters.java
+++ b/src/main/java/graphql/execution/instrumentation/parameters/FieldParameters.java
@@ -2,6 +2,7 @@ package graphql.execution.instrumentation.parameters;
 
 import graphql.execution.ExecutionContext;
 import graphql.execution.instrumentation.Instrumentation;
+import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.GraphQLFieldDefinition;
 
 /**
@@ -10,10 +11,12 @@ import graphql.schema.GraphQLFieldDefinition;
 public class FieldParameters {
     private final ExecutionContext executionContext;
     private final graphql.schema.GraphQLFieldDefinition fieldDef;
+    private final DataFetchingEnvironment environment;
 
-    public FieldParameters(ExecutionContext executionContext, GraphQLFieldDefinition fieldDef) {
+    public FieldParameters(ExecutionContext executionContext, GraphQLFieldDefinition fieldDef, DataFetchingEnvironment environment) {
         this.executionContext = executionContext;
         this.fieldDef = fieldDef;
+        this.environment = environment;
     }
 
     public ExecutionContext getExecutionContext() {
@@ -22,5 +25,9 @@ public class FieldParameters {
 
     public GraphQLFieldDefinition getField() {
         return fieldDef;
+    }
+
+    public DataFetchingEnvironment getEnvironment() {
+        return environment;
     }
 }


### PR DESCRIPTION
It looks like this is an oversight - the environment isn't passed to `beginField` but is passed to `beginFieldFetch` on the next line.

Without the environment, it's impossible to know the type that the current field is on in `beginField`.