### PR TITLE
bugfix: comments as descriptions

### DIFF
--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -822,11 +822,11 @@ public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
             // we strip the leading hash # character but we don't trim because we don't
             // know the "comment markup".  Maybe its space sensitive, maybe its not.  So
             // consumers can decide that
-            text = (text == null) ? "" : text;
-            text = text.replaceFirst("^#", "");
-            if (text.length() > 0) {
-                comments.add(new Comment(text, new SourceLocation(refTok.getLine(), refTok.getCharPositionInLine())));
+            if (text == null) {
+                continue;
             }
+            text = text.replaceFirst("^#", "");
+            comments.add(new Comment(text, new SourceLocation(refTok.getLine(), refTok.getCharPositionInLine())));
         }
         return comments;
     }

--- a/src/main/java/graphql/schema/GraphQLEnumType.java
+++ b/src/main/java/graphql/schema/GraphQLEnumType.java
@@ -1,9 +1,9 @@
 package graphql.schema;
 
 
+import graphql.AssertException;
 import graphql.language.EnumTypeDefinition;
 import graphql.language.EnumValue;
-import graphql.AssertException;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -40,6 +40,36 @@ public class GraphQLEnumType implements GraphQLType, GraphQLInputType, GraphQLOu
         }
     };
 
+
+    public GraphQLEnumType(String name, String description, List<GraphQLEnumValueDefinition> values) {
+        this(name, description, values, null);
+    }
+
+    public GraphQLEnumType(String name, String description, List<GraphQLEnumValueDefinition> values, EnumTypeDefinition definition) {
+        assertValidName(name);
+        this.name = name;
+        this.description = description;
+        this.definition = definition;
+        buildMap(values);
+    }
+
+    public List<GraphQLEnumValueDefinition> getValues() {
+        return new ArrayList<>(valueDefinitionMap.values());
+    }
+
+    public GraphQLEnumValueDefinition getValue(String name) {
+        return valueDefinitionMap.get(name);
+    }
+
+    private void buildMap(List<GraphQLEnumValueDefinition> values) {
+        for (GraphQLEnumValueDefinition valueDefinition : values) {
+            String name = valueDefinition.getName();
+            if (valueDefinitionMap.containsKey(name))
+                throw new AssertException("value " + name + " redefined");
+            valueDefinitionMap.put(name, valueDefinition);
+        }
+    }
+
     private Object getValueByName(Object value) {
         GraphQLEnumValueDefinition enumValueDefinition = valueDefinitionMap.get(value.toString());
         if (enumValueDefinition != null) return enumValueDefinition.getValue();
@@ -59,31 +89,6 @@ public class GraphQLEnumType implements GraphQLType, GraphQLInputType, GraphQLOu
         return null;
     }
 
-    public List<GraphQLEnumValueDefinition> getValues() {
-        return new ArrayList<>(valueDefinitionMap.values());
-    }
-
-
-    public GraphQLEnumType(String name, String description, List<GraphQLEnumValueDefinition> values) {
-        this(name,description,values,null);
-    }
-
-    public GraphQLEnumType(String name, String description, List<GraphQLEnumValueDefinition> values, EnumTypeDefinition definition) {
-        assertValidName(name);
-        this.name = name;
-        this.description = description;
-        this.definition = definition;
-        buildMap(values);
-    }
-
-    private void buildMap(List<GraphQLEnumValueDefinition> values) {
-        for (GraphQLEnumValueDefinition valueDefinition : values) {
-            String name = valueDefinition.getName();
-            if (valueDefinitionMap.containsKey(name))
-                throw new AssertException("value " + name + " redefined");
-            valueDefinitionMap.put(name, valueDefinition);
-        }
-    }
 
     public String getName() {
         return name;

--- a/src/main/java/graphql/schema/idl/SchemaGenerator.java
+++ b/src/main/java/graphql/schema/idl/SchemaGenerator.java
@@ -523,8 +523,8 @@ public class SchemaGenerator {
         List<Comment> comments = node.getComments();
         List<String> lines = new ArrayList<>();
         for (int i = 0; i < comments.size(); i++) {
-            String commentLine = comments.get(i).getContent().trim();
-            if (commentLine.isEmpty()) {
+            String commentLine = comments.get(i).getContent();
+            if (commentLine.trim().isEmpty()) {
                 lines.clear();
             } else {
                 lines.add(commentLine);

--- a/src/main/java/graphql/schema/idl/SchemaGenerator.java
+++ b/src/main/java/graphql/schema/idl/SchemaGenerator.java
@@ -45,6 +45,7 @@ import graphql.schema.idl.errors.NotAnInputTypeError;
 import graphql.schema.idl.errors.NotAnOutputTypeError;
 import graphql.schema.idl.errors.SchemaProblem;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -52,6 +53,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Stack;
+import java.util.stream.Collectors;
 
 import static graphql.Assert.assertNotNull;
 
@@ -366,7 +368,8 @@ public class SchemaGenerator {
         builder.name(typeDefinition.getName());
         builder.description(buildDescription(typeDefinition));
 
-        typeDefinition.getEnumValueDefinitions().forEach(evd -> builder.value(evd.getName()));
+        typeDefinition.getEnumValueDefinitions().forEach(evd -> builder.value(evd.getName(), evd.getName(), buildDescription(evd)));
+//        typeDefinition.getEnumValueDefinitions().forEach(evd -> builder.value(evd.getName()));
         return builder.build();
     }
 
@@ -517,14 +520,17 @@ public class SchemaGenerator {
 
 
     private String buildDescription(Node node) {
-        StringBuilder sb = new StringBuilder();
         List<Comment> comments = node.getComments();
+        List<String> lines = new ArrayList<>();
         for (int i = 0; i < comments.size(); i++) {
-            if (i > 0) {
-                sb.append("\n");
+            String commentLine = comments.get(i).getContent().trim();
+            if (commentLine.isEmpty()) {
+                lines.clear();
+            } else {
+                lines.add(commentLine);
             }
-            sb.append(comments.get(i).getContent().trim());
         }
-        return sb.toString();
+        if (lines.size() == 0) return null;
+        return lines.stream().collect(Collectors.joining("\n"));
     }
 }

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -67,7 +67,7 @@ class SchemaGeneratorTest extends Specification {
 
         def authorField = schema.getQueryType().getFieldDefinition("author")
         assert authorField.type.name == "Author"
-        assert authorField.description == "author query must receive an id as argument"
+        assert authorField.description == " author query must receive an id as argument"
         assert authorField.arguments.get(0).name == "id"
         assert authorField.arguments.get(0).type instanceof GraphQLNonNull
         assert unwrap(authorField.arguments.get(0).type).name == "Int"
@@ -125,7 +125,7 @@ class SchemaGeneratorTest extends Specification {
         assert (unwrap(upvotePostFieldArg.type) as GraphQLInputObjectType).getField("votes").type.name == "Int"
 
         def queryType = schema.getQueryType()
-        assert queryType.description == "the schema allows the following query\nto be made"
+        assert queryType.description == " the schema allows the following query\n to be made"
 
     }
 
@@ -702,7 +702,7 @@ class SchemaGeneratorTest extends Specification {
     def "comments are used as descriptions"() {
         given:
         def spec = """
-        # description 1
+        #description 1
         # description 2
         type Query {
             # description 3
@@ -741,18 +741,18 @@ class SchemaGeneratorTest extends Specification {
         def schema = generateSchema(spec, wiring)
 
         then:
-        schema.getQueryType().description == "description 1\ndescription 2"
-        schema.getQueryType().getFieldDefinition("foo").description == "description 3"
-        ((GraphQLUnionType) schema.getType("Union")).description == "description 4"
+        schema.getQueryType().description == "description 1\n description 2"
+        schema.getQueryType().getFieldDefinition("foo").description == " description 3"
+        ((GraphQLUnionType) schema.getType("Union")).description == " description 4"
 
-        ((GraphQLInterfaceType) schema.getType("Interface")).description == "description 5"
-        ((GraphQLInterfaceType) schema.getType("Interface")).getFieldDefinition("foo").description == "interface field"
+        ((GraphQLInterfaceType) schema.getType("Interface")).description == " description 5"
+        ((GraphQLInterfaceType) schema.getType("Interface")).getFieldDefinition("foo").description == " interface field"
 
-        ((GraphQLInputObjectType) schema.getType("Input")).description == "description 6"
-        ((GraphQLInputObjectType) schema.getType("Input")).getFieldDefinition("foo").description == "input field"
+        ((GraphQLInputObjectType) schema.getType("Input")).description == " description 6 "
+        ((GraphQLInputObjectType) schema.getType("Input")).getFieldDefinition("foo").description == " input field"
 
-        ((GraphQLEnumType) schema.getType("Enum")).description == "description 7"
-        ((GraphQLEnumType) schema.getType("Enum")).getValue("FOO").description == "enum value"
+        ((GraphQLEnumType) schema.getType("Enum")).description == " description 7"
+        ((GraphQLEnumType) schema.getType("Enum")).getValue("FOO").description == " enum value"
     }
 
     def "comments are separated from descriptions with empty lines"() {
@@ -788,7 +788,7 @@ class SchemaGeneratorTest extends Specification {
         def schema = generateSchema(spec, wiring)
 
         then:
-        schema.getQueryType().description == "description 1\ndescription 2"
-        schema.getQueryType().getFieldDefinition("foo").description == "description 3\ndescription 4"
+        schema.getQueryType().description == " description 1\n description 2"
+        schema.getQueryType().getFieldDefinition("foo").description == " description 3\n description 4"
     }
 }


### PR DESCRIPTION
this is a small bugfix for enum field descriptions and a change so that
an empty line in an comment separate a comment from a description (for the IDL)

also: empty lines are not skipped, but are valid comments