### PR TITLE
add explicit root object

### DIFF
--- a/src/main/java/graphql/ExecutionInput.java
+++ b/src/main/java/graphql/ExecutionInput.java
@@ -1,0 +1,94 @@
+package graphql;
+
+import java.util.Map;
+
+@PublicApi
+public class ExecutionInput {
+    private final String requestString;
+    private final String operationName;
+    private final Object context;
+    private final Object root;
+    private final Map<String, Object> arguments;
+
+
+    public ExecutionInput(String requestString, String operationName, Object context, Object root, Map<String, Object> arguments) {
+        this.requestString = requestString;
+        this.operationName = operationName;
+        this.context = context;
+        this.root = root;
+        this.arguments = arguments;
+    }
+
+    public String getRequestString() {
+        return requestString;
+    }
+
+    public String getOperationName() {
+        return operationName;
+    }
+
+    public Object getContext() {
+        return context;
+    }
+
+    public Object getRoot() {
+        return root;
+    }
+
+    public Map<String, Object> getArguments() {
+        return arguments;
+    }
+
+    @Override
+    public String toString() {
+        return "ExecutionInput{" +
+                "requestString='" + requestString + '\'' +
+                ", operationName='" + operationName + '\'' +
+                ", context=" + context +
+                ", root=" + root +
+                ", arguments=" + arguments +
+                '}';
+    }
+
+    public static Builder newExecutionInput() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String requestString;
+        private String operationName;
+        private Object context;
+        private Object root;
+        private Map<String, Object> arguments;
+
+        public Builder requestString(String requestString) {
+            this.requestString = requestString;
+            return this;
+        }
+
+        public Builder operationName(String operationName) {
+            this.operationName = operationName;
+            return this;
+        }
+
+        public Builder context(Object context) {
+            this.context = context;
+            return this;
+        }
+
+        public Builder root(Object root) {
+            this.root = root;
+            return this;
+        }
+
+        public Builder arguments(Map<String, Object> arguments) {
+            this.arguments = arguments;
+            return this;
+        }
+
+        public ExecutionInput build() {
+            return new ExecutionInput(requestString, operationName, context, root, arguments);
+        }
+    }
+}

--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -204,12 +204,12 @@ public class GraphQL {
         String operationName = executionInput.getOperationName();
         Object context = executionInput.getContext();
         Object root = executionInput.getRoot();
-        Map<String, Object> arguments = executionInput.getArguments();
+        Map<String, Object> arguments = executionInput.getArguments() != null ? executionInput.getArguments() : Collections.emptyMap();
+
+        log.debug("Executing request. operation name: {}. Request: {} ", operationName, requestString);
 
         InstrumentationContext<ExecutionResult> executionCtx = instrumentation.beginExecution(new InstrumentationExecutionParameters(requestString, operationName, context, arguments));
 
-        assertNotNull(arguments, "arguments can't be null");
-        log.debug("Executing request. operation name: {}. Request: {} ", operationName, requestString);
 
         InstrumentationContext<Document> parseCtx = instrumentation.beginParse(new InstrumentationExecutionParameters(requestString, operationName, context, arguments));
         Parser parser = new Parser();

--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -167,8 +167,8 @@ public class GraphQL {
     }
 
     /**
-     * @param requestString
-     * @return
+     * @param requestString  the query/mutation/subscription
+     * @return result including errors
      * @deprecated Use {@link #execute(ExecutionInput)}
      */
     @Deprecated

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -8,7 +8,7 @@ import graphql.Internal;
 import graphql.MutationNotSupportedError;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationContext;
-import graphql.execution.instrumentation.parameters.DataFetchParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationDataFetchParameters;
 import graphql.language.Document;
 import graphql.language.Field;
 import graphql.language.OperationDefinition;
@@ -69,7 +69,7 @@ public class Execution {
             Object root,
             OperationDefinition operationDefinition) {
 
-        InstrumentationContext<ExecutionResult> dataFetchCtx = instrumentation.beginDataFetch(new DataFetchParameters(executionContext));
+        InstrumentationContext<ExecutionResult> dataFetchCtx = instrumentation.beginDataFetch(new InstrumentationDataFetchParameters(executionContext));
 
         OperationDefinition.Operation operation = operationDefinition.getOperation();
         GraphQLObjectType operationRootType = getOperationRootType(executionContext.getGraphQLSchema(), operation);

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -19,7 +19,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static graphql.execution.ExecutionParameters.newParameters;
+import static graphql.execution.ExecutionStrategyParameters.newParameters;
 import static graphql.execution.TypeInfo.newTypeInfo;
 import static graphql.language.OperationDefinition.Operation.MUTATION;
 import static graphql.language.OperationDefinition.Operation.QUERY;
@@ -41,11 +41,11 @@ public class Execution {
         this.instrumentation = instrumentation;
     }
 
-    public ExecutionResult execute(ExecutionId executionId, GraphQLSchema graphQLSchema, Object root, Document document, String operationName, Map<String, Object> args) {
+    public ExecutionResult execute(ExecutionId executionId, GraphQLSchema graphQLSchema, Object context, Object root, Document document, String operationName, Map<String, Object> args) {
         ExecutionContextBuilder executionContextBuilder = new ExecutionContextBuilder(new ValuesResolver(), instrumentation);
         ExecutionContext executionContext = executionContextBuilder
                 .executionId(executionId)
-                .build(graphQLSchema, queryStrategy, mutationStrategy, subscriptionStrategy, root, document, operationName, args);
+                .build(graphQLSchema, queryStrategy, mutationStrategy, subscriptionStrategy, context, root, document, operationName, args);
         return executeOperation(executionContext, root, executionContext.getOperationDefinition());
     }
 
@@ -93,7 +93,7 @@ public class Execution {
         TypeInfo typeInfo = newTypeInfo().type(operationRootType).build();
         NonNullableFieldValidator nonNullableFieldValidator = new NonNullableFieldValidator(executionContext, typeInfo);
 
-        ExecutionParameters parameters = newParameters()
+        ExecutionStrategyParameters parameters = newParameters()
                 .typeInfo(typeInfo)
                 .source(root)
                 .fields(fields)

--- a/src/main/java/graphql/execution/ExecutionContext.java
+++ b/src/main/java/graphql/execution/ExecutionContext.java
@@ -3,7 +3,6 @@ package graphql.execution;
 
 import graphql.GraphQLError;
 import graphql.execution.instrumentation.Instrumentation;
-import graphql.execution.instrumentation.NoOpInstrumentation;
 import graphql.language.FragmentDefinition;
 import graphql.language.OperationDefinition;
 import graphql.schema.GraphQLSchema;
@@ -23,10 +22,11 @@ public class ExecutionContext {
     private final OperationDefinition operationDefinition;
     private final Map<String, Object> variables;
     private final Object root;
+    private final Object context;
     private final List<GraphQLError> errors = new CopyOnWriteArrayList<>();
     private final Instrumentation instrumentation;
 
-    public ExecutionContext(Instrumentation instrumentation, ExecutionId executionId, GraphQLSchema graphQLSchema, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy, ExecutionStrategy subscriptionStrategy, Map<String, FragmentDefinition> fragmentsByName, OperationDefinition operationDefinition, Map<String, Object> variables, Object root) {
+    public ExecutionContext(Instrumentation instrumentation, ExecutionId executionId, GraphQLSchema graphQLSchema, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy, ExecutionStrategy subscriptionStrategy, Map<String, FragmentDefinition> fragmentsByName, OperationDefinition operationDefinition, Map<String, Object> variables, Object context, Object root) {
         this.graphQLSchema = graphQLSchema;
         this.executionId = executionId;
         this.queryStrategy = queryStrategy;
@@ -35,6 +35,7 @@ public class ExecutionContext {
         this.fragmentsByName = fragmentsByName;
         this.operationDefinition = operationDefinition;
         this.variables = variables;
+        this.context = context;
         this.root = root;
         this.instrumentation = instrumentation;
     }
@@ -62,6 +63,10 @@ public class ExecutionContext {
 
     public Map<String, Object> getVariables() {
         return variables;
+    }
+
+    public Object getContext() {
+        return context;
     }
 
     public <T> T getRoot() {

--- a/src/main/java/graphql/execution/ExecutionContextBuilder.java
+++ b/src/main/java/graphql/execution/ExecutionContextBuilder.java
@@ -30,7 +30,7 @@ public class ExecutionContextBuilder {
         return this;
     }
 
-    public ExecutionContext build(GraphQLSchema graphQLSchema, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy, ExecutionStrategy subscriptionStrategy, Object root, Document document, String operationName, Map<String, Object> args) {
+    public ExecutionContext build(GraphQLSchema graphQLSchema, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy, ExecutionStrategy subscriptionStrategy, Object context, Object root, Document document, String operationName, Map<String, Object> args) {
         // preconditions
         assertNotNull(executionId, "You must provide a query identifier");
 
@@ -72,6 +72,7 @@ public class ExecutionContextBuilder {
                 fragmentsByName,
                 operation,
                 variableValues,
-                root);
+                root,
+                context);
     }
 }

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -48,7 +48,7 @@ public abstract class ExecutionStrategy {
     protected final ValuesResolver valuesResolver = new ValuesResolver();
     protected final FieldCollector fieldCollector = new FieldCollector();
 
-    public abstract ExecutionResult execute(ExecutionContext executionContext, ExecutionParameters parameters) throws NonNullableFieldWasNullException;
+    public abstract ExecutionResult execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) throws NonNullableFieldWasNullException;
 
     /**
      * Handle exceptions which occur during data fetching. By default, add all exceptions to the execution context's
@@ -70,7 +70,7 @@ public abstract class ExecutionStrategy {
     }
 
 
-    protected ExecutionResult resolveField(ExecutionContext executionContext, ExecutionParameters parameters, List<Field> fields) {
+    protected ExecutionResult resolveField(ExecutionContext executionContext, ExecutionStrategyParameters parameters, List<Field> fields) {
         GraphQLObjectType type = parameters.typeInfo().castType(GraphQLObjectType.class);
         GraphQLFieldDefinition fieldDef = getFieldDef(executionContext.getGraphQLSchema(), type, fields.get(0));
 
@@ -82,6 +82,7 @@ public abstract class ExecutionStrategy {
         DataFetchingEnvironment environment = new DataFetchingEnvironmentImpl(
                 parameters.source(),
                 argumentValues,
+                executionContext.getContext(),
                 executionContext.getRoot(),
                 fields,
                 fieldType,
@@ -116,7 +117,7 @@ public abstract class ExecutionStrategy {
 
         NonNullableFieldValidator nonNullableFieldValidator = new NonNullableFieldValidator(executionContext, fieldTypeInfo);
 
-        ExecutionParameters newParameters = ExecutionParameters.newParameters()
+        ExecutionStrategyParameters newParameters = ExecutionStrategyParameters.newParameters()
                 .typeInfo(fieldTypeInfo)
                 .fields(parameters.fields())
                 .arguments(argumentValues)
@@ -130,7 +131,7 @@ public abstract class ExecutionStrategy {
         return result;
     }
 
-    protected ExecutionResult completeValue(ExecutionContext executionContext, ExecutionParameters parameters, List<Field> fields) {
+    protected ExecutionResult completeValue(ExecutionContext executionContext, ExecutionStrategyParameters parameters, List<Field> fields) {
         TypeInfo typeInfo = parameters.typeInfo();
         Object result = parameters.source();
         GraphQLType fieldType = parameters.typeInfo().type();
@@ -181,7 +182,7 @@ public abstract class ExecutionStrategy {
         TypeInfo newTypeInfo = typeInfo.asType(resolvedType);
         NonNullableFieldValidator nonNullableFieldValidator = new NonNullableFieldValidator(executionContext, newTypeInfo);
 
-        ExecutionParameters newParameters = ExecutionParameters.newParameters()
+        ExecutionStrategyParameters newParameters = ExecutionStrategyParameters.newParameters()
                 .typeInfo(newTypeInfo)
                 .fields(subFields)
                 .nonNullFieldValidator(nonNullableFieldValidator)
@@ -218,7 +219,7 @@ public abstract class ExecutionStrategy {
         return result;
     }
 
-    protected ExecutionResult completeValueForEnum(GraphQLEnumType enumType, ExecutionParameters parameters, Object result) {
+    protected ExecutionResult completeValueForEnum(GraphQLEnumType enumType, ExecutionSParameters parameters, Object result) {
         Object serialized = enumType.getCoercing().serialize(result);
         serialized = parameters.nonNullFieldValidator().validate(serialized);
         return new ExecutionResultImpl(serialized, null);
@@ -234,7 +235,7 @@ public abstract class ExecutionStrategy {
         return new ExecutionResultImpl(serialized, null);
     }
 
-    protected ExecutionResult completeValueForList(ExecutionContext executionContext, ExecutionParameters parameters, List<Field> fields, Iterable<Object> result) {
+    protected ExecutionResult completeValueForList(ExecutionContext executionContext, ExecutionStrategyParameters parameters, List<Field> fields, Iterable<Object> result) {
         List<Object> completedResults = new ArrayList<>();
         TypeInfo typeInfo = parameters.typeInfo();
         GraphQLList fieldType = typeInfo.castType(GraphQLList.class);
@@ -243,7 +244,7 @@ public abstract class ExecutionStrategy {
             TypeInfo wrappedTypeInfo = typeInfo.asType(fieldType.getWrappedType());
             NonNullableFieldValidator nonNullableFieldValidator = new NonNullableFieldValidator(executionContext, wrappedTypeInfo);
 
-            ExecutionParameters newParameters = ExecutionParameters.newParameters()
+            ExecutionStrategyParameters newParameters = ExecutionStrategyParameters.newParameters()
                     .typeInfo(wrappedTypeInfo)
                     .fields(parameters.fields())
                     .nonNullFieldValidator(nonNullableFieldValidator)

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -219,13 +219,13 @@ public abstract class ExecutionStrategy {
         return result;
     }
 
-    protected ExecutionResult completeValueForEnum(GraphQLEnumType enumType, ExecutionSParameters parameters, Object result) {
+    protected ExecutionResult completeValueForEnum(GraphQLEnumType enumType, ExecutionStrategyParameters parameters, Object result) {
         Object serialized = enumType.getCoercing().serialize(result);
         serialized = parameters.nonNullFieldValidator().validate(serialized);
         return new ExecutionResultImpl(serialized, null);
     }
 
-    protected ExecutionResult completeValueForScalar(GraphQLScalarType scalarType, ExecutionParameters parameters, Object result) {
+    protected ExecutionResult completeValueForScalar(GraphQLScalarType scalarType, ExecutionStrategyParameters parameters, Object result) {
         Object serialized = scalarType.getCoercing().serialize(result);
         //6.6.1 http://facebook.github.io/graphql/#sec-Field-entries
         if (serialized instanceof Double && ((Double) serialized).isNaN()) {

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -8,8 +8,8 @@ import graphql.PublicSpi;
 import graphql.TypeResolutionEnvironment;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationContext;
-import graphql.execution.instrumentation.parameters.FieldFetchParameters;
-import graphql.execution.instrumentation.parameters.FieldParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationFieldParameters;
 import graphql.language.Field;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
@@ -94,9 +94,9 @@ public abstract class ExecutionStrategy {
 
         Instrumentation instrumentation = executionContext.getInstrumentation();
 
-        InstrumentationContext<ExecutionResult> fieldCtx = instrumentation.beginField(new FieldParameters(executionContext, fieldDef, environment));
+        InstrumentationContext<ExecutionResult> fieldCtx = instrumentation.beginField(new InstrumentationFieldParameters(executionContext, fieldDef, environment));
 
-        InstrumentationContext<Object> fetchCtx = instrumentation.beginFieldFetch(new FieldFetchParameters(executionContext, fieldDef, environment));
+        InstrumentationContext<Object> fetchCtx = instrumentation.beginFieldFetch(new InstrumentationFieldFetchParameters(executionContext, fieldDef, environment));
         Object resolvedValue = null;
         try {
             DataFetcher dataFetcher = fieldDef.getDataFetcher();

--- a/src/main/java/graphql/execution/ExecutionStrategyParameters.java
+++ b/src/main/java/graphql/execution/ExecutionStrategyParameters.java
@@ -1,6 +1,7 @@
 package graphql.execution;
 
 import graphql.Assert;
+import graphql.PublicApi;
 import graphql.language.Field;
 
 import java.util.List;
@@ -11,14 +12,15 @@ import static graphql.Assert.assertNotNull;
 /**
  * The parameters that are passed to execution strategies
  */
-public class ExecutionParameters {
+@PublicApi
+public class ExecutionStrategyParameters {
     private final TypeInfo typeInfo;
     private final Object source;
     private final Map<String, Object> arguments;
     private final Map<String, List<Field>> fields;
     private final NonNullableFieldValidator nonNullableFieldValidator;
 
-    private ExecutionParameters(TypeInfo typeInfo, Object source, Map<String, List<Field>> fields, Map<String, Object> arguments, NonNullableFieldValidator nonNullableFieldValidator) {
+    private ExecutionStrategyParameters(TypeInfo typeInfo, Object source, Map<String, List<Field>> fields, Map<String, Object> arguments, NonNullableFieldValidator nonNullableFieldValidator) {
         this.typeInfo = assertNotNull(typeInfo, "typeInfo is null");
         this.fields = assertNotNull(fields, "fields is null");
         this.source = source;
@@ -52,7 +54,7 @@ public class ExecutionParameters {
 
     @Override
     public String toString() {
-        return String.format("ExecutionParameters { typeInfo=%s, source=%s, fields=%s }",
+        return String.format("ExecutionStrategyParameters { typeInfo=%s, source=%s, fields=%s }",
                 typeInfo, source, fields);
     }
 
@@ -93,8 +95,8 @@ public class ExecutionParameters {
             return this;
         }
 
-        public ExecutionParameters build() {
-            return new ExecutionParameters(typeInfo, source, fields, arguments, nonNullableFieldValidator);
+        public ExecutionStrategyParameters build() {
+            return new ExecutionStrategyParameters(typeInfo, source, fields, arguments, nonNullableFieldValidator);
         }
     }
 }

--- a/src/main/java/graphql/execution/ExecutorServiceExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutorServiceExecutionStrategy.java
@@ -16,8 +16,8 @@ import java.util.concurrent.Future;
 
 /**
  * <p>ExecutorServiceExecutionStrategy uses an {@link ExecutorService} to parallelize the resolve.</p>
- * 
- * Due to the nature of {@link #execute(ExecutionContext, ExecutionParameters)}  implementation, {@link ExecutorService}
+ *
+ * Due to the nature of {@link #execute(ExecutionContext, ExecutionStrategyParameters)}  implementation, {@link ExecutorService}
  * MUST have the following 2 characteristics:
  * <ul>
  * <li>1. The underlying {@link java.util.concurrent.ThreadPoolExecutor} MUST have a reasonable {@code maximumPoolSize}
@@ -38,7 +38,7 @@ public class ExecutorServiceExecutionStrategy extends ExecutionStrategy {
     }
 
     @Override
-    public ExecutionResult execute(final ExecutionContext executionContext, final ExecutionParameters parameters) {
+    public ExecutionResult execute(final ExecutionContext executionContext, final ExecutionStrategyParameters parameters) {
         if (executorService == null)
             return new SimpleExecutionStrategy().execute(executionContext,parameters);
 

--- a/src/main/java/graphql/execution/SimpleExecutionStrategy.java
+++ b/src/main/java/graphql/execution/SimpleExecutionStrategy.java
@@ -10,7 +10,7 @@ import java.util.Map;
 
 public class SimpleExecutionStrategy extends ExecutionStrategy {
     @Override
-    public ExecutionResult execute(ExecutionContext executionContext, ExecutionParameters parameters) throws NonNullableFieldWasNullException {
+    public ExecutionResult execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) throws NonNullableFieldWasNullException {
         Map<String, List<Field>> fields = parameters.fields();
         Map<String, Object> results = new LinkedHashMap<>();
         for (String fieldName : fields.keySet()) {

--- a/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
+++ b/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
@@ -4,8 +4,8 @@ import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.GraphQLException;
 import graphql.execution.ExecutionContext;
-import graphql.execution.ExecutionParameters;
 import graphql.execution.ExecutionStrategy;
+import graphql.execution.ExecutionStrategyParameters;
 import graphql.execution.FieldCollectorParameters;
 import graphql.execution.TypeResolutionParameters;
 import graphql.language.Field;
@@ -55,7 +55,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
     private final BatchedDataFetcherFactory batchingFactory = new BatchedDataFetcherFactory();
 
     @Override
-    public ExecutionResult execute(ExecutionContext executionContext, ExecutionParameters parameters) {
+    public ExecutionResult execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
         GraphQLExecutionNodeDatum data = new GraphQLExecutionNodeDatum(new LinkedHashMap<>(), parameters.source());
         GraphQLObjectType type = parameters.typeInfo().castType(GraphQLObjectType.class);
         GraphQLExecutionNode root = new GraphQLExecutionNode(type, parameters.fields(), singletonList(data));
@@ -296,6 +296,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
         DataFetchingEnvironment environment = new DataFetchingEnvironmentImpl(
                 sources,
                 argumentValues,
+                executionContext.getContext(),
                 executionContext.getRoot(),
                 fields,
                 fieldDef.getType(),

--- a/src/main/java/graphql/execution/batched/UnbatchedDataFetcher.java
+++ b/src/main/java/graphql/execution/batched/UnbatchedDataFetcher.java
@@ -31,6 +31,7 @@ public class UnbatchedDataFetcher implements BatchedDataFetcher {
                     source,
                     environment.getArguments(),
                     environment.getContext(),
+                    environment.getRoot(),
                     environment.getFields(),
                     environment.getFieldType(),
                     environment.getParentType(),

--- a/src/main/java/graphql/execution/instrumentation/Instrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/Instrumentation.java
@@ -2,10 +2,10 @@ package graphql.execution.instrumentation;
 
 import graphql.ExecutionResult;
 import graphql.execution.instrumentation.parameters.DataFetchParameters;
-import graphql.execution.instrumentation.parameters.ExecutionParameters;
 import graphql.execution.instrumentation.parameters.FieldFetchParameters;
 import graphql.execution.instrumentation.parameters.FieldParameters;
-import graphql.execution.instrumentation.parameters.ValidationParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationValidationParameters;
 import graphql.language.Document;
 import graphql.schema.DataFetcher;
 import graphql.validation.ValidationError;
@@ -28,7 +28,7 @@ public interface Instrumentation {
      *
      * @return a non null {@link InstrumentationContext} object that will be called back when the step ends
      */
-    InstrumentationContext<ExecutionResult> beginExecution(ExecutionParameters parameters);
+    InstrumentationContext<ExecutionResult> beginExecution(InstrumentationExecutionParameters parameters);
 
     /**
      * This is called just before a query is parsed and when this step finishes the {@link InstrumentationContext#onEnd(Object)}
@@ -38,7 +38,7 @@ public interface Instrumentation {
      *
      * @return a non null {@link InstrumentationContext} object that will be called back when the step ends
      */
-    InstrumentationContext<Document> beginParse(ExecutionParameters parameters);
+    InstrumentationContext<Document> beginParse(InstrumentationExecutionParameters parameters);
 
     /**
      * This is called just before the parsed query Document is validated and when this step finishes the {@link InstrumentationContext#onEnd(Object)}
@@ -48,7 +48,7 @@ public interface Instrumentation {
      *
      * @return a non null {@link InstrumentationContext} object that will be called back when the step ends
      */
-    InstrumentationContext<List<ValidationError>> beginValidation(ValidationParameters parameters);
+    InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters);
 
     /**
      * This is called just before the data fetch is started and when this step finishes the {@link InstrumentationContext#onEnd(Object)}

--- a/src/main/java/graphql/execution/instrumentation/Instrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/Instrumentation.java
@@ -1,10 +1,10 @@
 package graphql.execution.instrumentation;
 
 import graphql.ExecutionResult;
-import graphql.execution.instrumentation.parameters.DataFetchParameters;
-import graphql.execution.instrumentation.parameters.FieldFetchParameters;
-import graphql.execution.instrumentation.parameters.FieldParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationDataFetchParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationFieldParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationValidationParameters;
 import graphql.language.Document;
 import graphql.schema.DataFetcher;
@@ -58,7 +58,7 @@ public interface Instrumentation {
      *
      * @return a non null {@link InstrumentationContext} object that will be called back when the step ends
      */
-    InstrumentationContext<ExecutionResult> beginDataFetch(DataFetchParameters parameters);
+    InstrumentationContext<ExecutionResult> beginDataFetch(InstrumentationDataFetchParameters parameters);
 
     /**
      * This is called just before a field is resolved and when this step finishes the {@link InstrumentationContext#onEnd(Object)}
@@ -68,7 +68,7 @@ public interface Instrumentation {
      *
      * @return a non null {@link InstrumentationContext} object that will be called back when the step ends
      */
-    InstrumentationContext<ExecutionResult> beginField(FieldParameters parameters);
+    InstrumentationContext<ExecutionResult> beginField(InstrumentationFieldParameters parameters);
 
     /**
      * This is called just before a field {@link DataFetcher} is invoked and when this step finishes the {@link InstrumentationContext#onEnd(Object)}
@@ -78,5 +78,5 @@ public interface Instrumentation {
      *
      * @return a non null {@link InstrumentationContext} object that will be called back when the step ends
      */
-    InstrumentationContext<Object> beginFieldFetch(FieldFetchParameters parameters);
+    InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters);
 }

--- a/src/main/java/graphql/execution/instrumentation/NoOpInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/NoOpInstrumentation.java
@@ -1,10 +1,10 @@
 package graphql.execution.instrumentation;
 
 import graphql.ExecutionResult;
-import graphql.execution.instrumentation.parameters.DataFetchParameters;
-import graphql.execution.instrumentation.parameters.FieldFetchParameters;
-import graphql.execution.instrumentation.parameters.FieldParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationDataFetchParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationFieldParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationValidationParameters;
 import graphql.language.Document;
 import graphql.validation.ValidationError;
@@ -61,7 +61,7 @@ public final class NoOpInstrumentation implements Instrumentation {
     }
 
     @Override
-    public InstrumentationContext<ExecutionResult> beginDataFetch(DataFetchParameters parameters) {
+    public InstrumentationContext<ExecutionResult> beginDataFetch(InstrumentationDataFetchParameters parameters) {
         return new InstrumentationContext<ExecutionResult>() {
             @Override
             public void onEnd(ExecutionResult result) {
@@ -74,7 +74,7 @@ public final class NoOpInstrumentation implements Instrumentation {
     }
 
     @Override
-    public InstrumentationContext<ExecutionResult> beginField(FieldParameters parameters) {
+    public InstrumentationContext<ExecutionResult> beginField(InstrumentationFieldParameters parameters) {
         return new InstrumentationContext<ExecutionResult>() {
             @Override
             public void onEnd(ExecutionResult result) {
@@ -87,7 +87,7 @@ public final class NoOpInstrumentation implements Instrumentation {
     }
 
     @Override
-    public InstrumentationContext<Object> beginFieldFetch(FieldFetchParameters parameters) {
+    public InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters) {
         return new InstrumentationContext<Object>() {
             @Override
             public void onEnd(Object result) {

--- a/src/main/java/graphql/execution/instrumentation/NoOpInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/NoOpInstrumentation.java
@@ -2,10 +2,10 @@ package graphql.execution.instrumentation;
 
 import graphql.ExecutionResult;
 import graphql.execution.instrumentation.parameters.DataFetchParameters;
-import graphql.execution.instrumentation.parameters.ExecutionParameters;
 import graphql.execution.instrumentation.parameters.FieldFetchParameters;
 import graphql.execution.instrumentation.parameters.FieldParameters;
-import graphql.execution.instrumentation.parameters.ValidationParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationValidationParameters;
 import graphql.language.Document;
 import graphql.validation.ValidationError;
 
@@ -22,7 +22,7 @@ public final class NoOpInstrumentation implements Instrumentation {
     }
 
     @Override
-    public InstrumentationContext<ExecutionResult> beginExecution(ExecutionParameters parameters) {
+    public InstrumentationContext<ExecutionResult> beginExecution(InstrumentationExecutionParameters parameters) {
         return new InstrumentationContext<ExecutionResult>() {
             @Override
             public void onEnd(ExecutionResult result) {
@@ -35,7 +35,7 @@ public final class NoOpInstrumentation implements Instrumentation {
     }
 
     @Override
-    public InstrumentationContext<Document> beginParse(ExecutionParameters parameters) {
+    public InstrumentationContext<Document> beginParse(InstrumentationExecutionParameters parameters) {
         return new InstrumentationContext<Document>() {
             @Override
             public void onEnd(Document result) {
@@ -48,7 +48,7 @@ public final class NoOpInstrumentation implements Instrumentation {
     }
 
     @Override
-    public InstrumentationContext<List<ValidationError>> beginValidation(ValidationParameters parameters) {
+    public InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters) {
         return new InstrumentationContext<List<ValidationError>>() {
             @Override
             public void onEnd(List<ValidationError> result) {

--- a/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationDataFetchParameters.java
+++ b/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationDataFetchParameters.java
@@ -6,10 +6,10 @@ import graphql.execution.instrumentation.Instrumentation;
 /**
  * Parameters sent to {@link Instrumentation} methods
  */
-public class DataFetchParameters {
+public class InstrumentationDataFetchParameters {
     private final ExecutionContext executionContext;
 
-    public DataFetchParameters(ExecutionContext executionContext) {
+    public InstrumentationDataFetchParameters(ExecutionContext executionContext) {
         this.executionContext = executionContext;
     }
 

--- a/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationExecutionParameters.java
+++ b/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationExecutionParameters.java
@@ -1,5 +1,6 @@
 package graphql.execution.instrumentation.parameters;
 
+import graphql.PublicApi;
 import graphql.execution.instrumentation.Instrumentation;
 
 import java.util.Map;
@@ -7,13 +8,14 @@ import java.util.Map;
 /**
  * Parameters sent to {@link Instrumentation} methods
  */
-public class ExecutionParameters {
+@PublicApi
+public class InstrumentationExecutionParameters {
     private final String query;
     private final String operation;
     private final Object context;
     private final Map<String, Object> arguments;
 
-    public ExecutionParameters(String query, String operation, Object context, Map<String, Object> arguments) {
+    public InstrumentationExecutionParameters(String query, String operation, Object context, Map<String, Object> arguments) {
         this.query = query;
         this.operation = operation;
         this.context = context;

--- a/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationFieldFetchParameters.java
+++ b/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationFieldFetchParameters.java
@@ -8,10 +8,10 @@ import graphql.schema.GraphQLFieldDefinition;
 /**
  * Parameters sent to {@link Instrumentation} methods
  */
-public class FieldFetchParameters extends FieldParameters {
+public class InstrumentationFieldFetchParameters extends InstrumentationFieldParameters {
     private final DataFetchingEnvironment environment;
 
-    public FieldFetchParameters(ExecutionContext getExecutionContext, GraphQLFieldDefinition fieldDef, DataFetchingEnvironment environment) {
+    public InstrumentationFieldFetchParameters(ExecutionContext getExecutionContext, GraphQLFieldDefinition fieldDef, DataFetchingEnvironment environment) {
         super(getExecutionContext, fieldDef, environment);
         this.environment = environment;
     }

--- a/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationFieldParameters.java
+++ b/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationFieldParameters.java
@@ -8,12 +8,12 @@ import graphql.schema.GraphQLFieldDefinition;
 /**
  * Parameters sent to {@link Instrumentation} methods
  */
-public class FieldParameters {
+public class InstrumentationFieldParameters {
     private final ExecutionContext executionContext;
     private final graphql.schema.GraphQLFieldDefinition fieldDef;
     private final DataFetchingEnvironment environment;
 
-    public FieldParameters(ExecutionContext executionContext, GraphQLFieldDefinition fieldDef, DataFetchingEnvironment environment) {
+    public InstrumentationFieldParameters(ExecutionContext executionContext, GraphQLFieldDefinition fieldDef, DataFetchingEnvironment environment) {
         this.executionContext = executionContext;
         this.fieldDef = fieldDef;
         this.environment = environment;

--- a/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationValidationParameters.java
+++ b/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationValidationParameters.java
@@ -8,10 +8,10 @@ import java.util.Map;
 /**
  * Parameters sent to {@link Instrumentation} methods
  */
-public class ValidationParameters extends ExecutionParameters {
+public class InstrumentationValidationParameters extends InstrumentationExecutionParameters {
     private final Document document;
 
-    public ValidationParameters(String query, String operation, Object context, Map<String, Object> arguments, Document document) {
+    public InstrumentationValidationParameters(String query, String operation, Object context, Map<String, Object> arguments, Document document) {
         super(query, operation, context, arguments);
         this.document = document;
     }

--- a/src/main/java/graphql/schema/DataFetchingEnvironment.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironment.java
@@ -13,9 +13,15 @@ import java.util.Map;
  */
 @PublicApi
 public interface DataFetchingEnvironment {
+
     /**
+     * This is the value of the current object to be queried.
+     * Or to put it differently: it is the value of the parent field.
+     * <p>
+     * For the root query, it is equal to {{@link DataFetchingEnvironment#getRoot}
+     *
      * @param <T> you decide what type it is
-     * @return the current object being queried
+     * @return can be null for the root query, otherwise it is never null
      */
     <T> T getSource();
 
@@ -42,14 +48,22 @@ public interface DataFetchingEnvironment {
     <T> T getArgument(String name);
 
     /**
-     * Returns a context argument that is set up when the {@link graphql.GraphQL#execute(String, Object)} method
-     * is invoked
+     * Returns a context argument that is set up when the {@link graphql.GraphQL#execute} method
+     * is invoked.
+     * <p>
+     * This is a info object which is provided to all DataFetcher, but never used by graphql-java itself.
      *
      * @param <T> you decide what type it is
-     * @return a context object
+     * @return can be null
      */
     <T> T getContext();
 
+    /**
+     * This is the source object for the root query.
+     *
+     * @param <T>
+     * @return can be null
+     */
     <T> T getRoot();
 
     /**

--- a/src/main/java/graphql/schema/DataFetchingEnvironment.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironment.java
@@ -15,7 +15,6 @@ import java.util.Map;
 public interface DataFetchingEnvironment {
     /**
      * @param <T> you decide what type it is
-     *
      * @return the current object being queried
      */
     <T> T getSource();
@@ -29,7 +28,6 @@ public interface DataFetchingEnvironment {
      * Returns true of the named argument is present
      *
      * @param name the name of the argument
-     *
      * @return true of the named argument is present
      */
     boolean containsArgument(String name);
@@ -39,7 +37,6 @@ public interface DataFetchingEnvironment {
      *
      * @param name the name of the argument
      * @param <T>  you decide what type it is
-     *
      * @return the named argument or null if its not [present
      */
     <T> T getArgument(String name);
@@ -49,10 +46,11 @@ public interface DataFetchingEnvironment {
      * is invoked
      *
      * @param <T> you decide what type it is
-     *
      * @return a context object
      */
     <T> T getContext();
+
+    <T> T getRoot();
 
     /**
      * @return the list of fields currently in query context

--- a/src/main/java/graphql/schema/DataFetchingEnvironment.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironment.java
@@ -61,7 +61,7 @@ public interface DataFetchingEnvironment {
     /**
      * This is the source object for the root query.
      *
-     * @param <T>
+     * @param <T>  you decide what type it is
      * @return can be null
      */
     <T> T getRoot();

--- a/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
@@ -13,6 +13,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
     private final Object source;
     private final Map<String, Object> arguments;
     private final Object context;
+    private final Object root;
     private final List<Field> fields;
     private final GraphQLOutputType fieldType;
     private final GraphQLType parentType;
@@ -21,10 +22,11 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
     private final ExecutionId executionId;
     private final DataFetchingFieldSelectionSet selectionSet;
 
-    public DataFetchingEnvironmentImpl(Object source, Map<String, Object> arguments, Object context, List<Field> fields, GraphQLOutputType fieldType, GraphQLType parentType, GraphQLSchema graphQLSchema, Map<String, FragmentDefinition> fragmentsByName, ExecutionId executionId, DataFetchingFieldSelectionSet selectionSet) {
+    public DataFetchingEnvironmentImpl(Object source, Map<String, Object> arguments, Object context, Object root, List<Field> fields, GraphQLOutputType fieldType, GraphQLType parentType, GraphQLSchema graphQLSchema, Map<String, FragmentDefinition> fragmentsByName, ExecutionId executionId, DataFetchingFieldSelectionSet selectionSet) {
         this.source = source;
         this.arguments = arguments;
         this.context = context;
+        this.root = root;
         this.fields = fields;
         this.fieldType = fieldType;
         this.parentType = parentType;
@@ -57,6 +59,11 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
     @Override
     public <T> T getContext() {
         return (T) context;
+    }
+
+    @Override
+    public <T> T getRoot() {
+        return (T) root;
     }
 
     @Override

--- a/src/test/groovy/graphql/DataFetcherTest.groovy
+++ b/src/test/groovy/graphql/DataFetcherTest.groovy
@@ -59,6 +59,7 @@ class DataFetcherTest extends Specification {
                 dataHolder,
                 Collections.emptyMap(),
                 null,
+                null,
                 Collections.emptyList(),
                 type,
                 null,

--- a/src/test/groovy/graphql/execution/ExecutionIdTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionIdTest.groovy
@@ -11,7 +11,7 @@ class ExecutionIdTest extends Specification {
         ExecutionId executionId = null
 
         @Override
-        ExecutionResult execute(ExecutionContext executionContext, ExecutionParameters parameters) {
+        ExecutionResult execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
             executionId = executionContext.executionId
             return super.execute(executionContext, parameters)
         }

--- a/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
@@ -9,7 +9,7 @@ import graphql.schema.GraphQLList
 import graphql.schema.GraphQLScalarType
 import spock.lang.Specification
 
-import static graphql.execution.ExecutionParameters.newParameters
+import static ExecutionStrategyParameters.newParameters
 import static graphql.schema.GraphQLNonNull.nonNull
 
 @SuppressWarnings("GroovyPointlessBoolean")
@@ -21,14 +21,14 @@ class ExecutionStrategyTest extends Specification {
         executionStrategy = new ExecutionStrategy() {
 
             @Override
-            ExecutionResult execute(ExecutionContext executionContext, ExecutionParameters parameters) {
+            ExecutionResult execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
                 return null
             }
         }
     }
 
     def buildContext() {
-        new ExecutionContext(null, null, null, executionStrategy, executionStrategy, executionStrategy, null, null, null, null)
+        new ExecutionContext(null, null, null, executionStrategy, executionStrategy, executionStrategy, null, null, null, null, null)
     }
 
 

--- a/src/test/groovy/graphql/execution/ExecutionTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionTest.groovy
@@ -30,7 +30,7 @@ class ExecutionTest extends Specification {
         def document = parser.parseDocument(query)
 
         when:
-        execution.execute(ExecutionId.generate(), MutationSchema.schema, null, document, null, null)
+        execution.execute(ExecutionId.generate(), MutationSchema.schema, null, null, document, null, null)
 
         then:
         1 * queryStrategy.execute(*_)
@@ -50,7 +50,7 @@ class ExecutionTest extends Specification {
         def document = parser.parseDocument(query)
 
         when:
-        execution.execute(ExecutionId.generate(), MutationSchema.schema, null, document, null, null)
+        execution.execute(ExecutionId.generate(), MutationSchema.schema, null, null, document, null, null)
 
         then:
         0 * queryStrategy.execute(*_)
@@ -70,7 +70,7 @@ class ExecutionTest extends Specification {
         def document = parser.parseDocument(query)
 
         when:
-        execution.execute(ExecutionId.generate(), MutationSchema.schema, null, document, null, null)
+        execution.execute(ExecutionId.generate(), MutationSchema.schema, null, null, document, null, null)
 
         then:
         0 * queryStrategy.execute(*_)

--- a/src/test/groovy/graphql/execution/NonNullableFieldValidatorTest.groovy
+++ b/src/test/groovy/graphql/execution/NonNullableFieldValidatorTest.groovy
@@ -7,7 +7,7 @@ import static graphql.schema.GraphQLNonNull.nonNull
 
 class NonNullableFieldValidatorTest extends Specification {
 
-    ExecutionContext context = new ExecutionContext(null, null, null, null, null, null, null, null, null, null)
+    ExecutionContext context = Mock(ExecutionContext)
 
     def "non nullable field throws exception"() {
         TypeInfo typeInfo = TypeInfo.newTypeInfo().type(nonNull(GraphQLString)).build()

--- a/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
@@ -105,17 +105,17 @@ class InstrumentationTest extends Specification {
             }
 
             @Override
-            InstrumentationContext<ExecutionResult> beginDataFetch(DataFetchParameters parameters) {
+            InstrumentationContext<ExecutionResult> beginDataFetch(InstrumentationDataFetchParameters parameters) {
                 return new Timer("data-fetch", executionList)
             }
 
             @Override
-            InstrumentationContext<ExecutionResult> beginField(FieldParameters parameters) {
+            InstrumentationContext<ExecutionResult> beginField(InstrumentationFieldParameters parameters) {
                 return new Timer("field-$parameters.field.name", executionList)
             }
 
             @Override
-            InstrumentationContext<Object> beginFieldFetch(FieldFetchParameters parameters) {
+            InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters) {
                 return new Timer("fetch-$parameters.field.name", executionList)
             }
         }

--- a/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
@@ -90,17 +90,17 @@ class InstrumentationTest extends Specification {
             def executionList = []
 
             @Override
-            InstrumentationContext<ExecutionResult> beginExecution(ExecutionParameters parameters) {
+            InstrumentationContext<ExecutionResult> beginExecution(InstrumentationExecutionParameters parameters) {
                 new Timer("execution", executionList)
             }
 
             @Override
-            InstrumentationContext<Document> beginParse(ExecutionParameters parameters) {
+            InstrumentationContext<Document> beginParse(InstrumentationExecutionParameters parameters) {
                 return new Timer("parse", executionList)
             }
 
             @Override
-            InstrumentationContext<List<ValidationError>> beginValidation(ValidationParameters parameters) {
+            InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters) {
                 return new Timer("validation", executionList)
             }
 

--- a/src/test/groovy/graphql/relay/SimpleListConnectionTest.groovy
+++ b/src/test/groovy/graphql/relay/SimpleListConnectionTest.groovy
@@ -1,6 +1,5 @@
 package graphql.relay
 
-import graphql.schema.DataFetchingEnvironment
 import graphql.schema.DataFetchingEnvironmentImpl
 import spock.lang.Specification
 
@@ -11,7 +10,7 @@ class SimpleListConnectionTest extends Specification {
         given:
         def testList = ["a", "b"]
         def listConnection = new SimpleListConnection(testList)
-        def env = new DataFetchingEnvironmentImpl(null, ["after": createCursor(3)], null, null, null, null, null, null, null, null);
+        def env = new DataFetchingEnvironmentImpl(null, ["after": createCursor(3)], null, null, null, null, null, null, null, null, null);
 
         when:
         Object item = listConnection.get(env);

--- a/src/test/groovy/graphql/schema/PropertyDataFetcherTest.groovy
+++ b/src/test/groovy/graphql/schema/PropertyDataFetcherTest.groovy
@@ -15,6 +15,7 @@ class PropertyDataFetcherTest extends Specification {
                 null,
                 null,
                 null,
+                null,
                 Collections.emptyMap(),
                 null,
                 null


### PR DESCRIPTION
This adds a explicit `root` object, which is used as the `source` object
for the root query instead of `context`.

Adds also a new `ExecutionInput` to be used as Input for `GraphQL.execute`.

Important: Old `GraphQL.execute` calls are unchanged: `root` is set to `context`
in order to not break it!

other breaking changes (just renaming) made along the way to make the overall
naming better and to avoid confusion with the new `ExecutionInput`:

- `instrumentation.ExecutionParameters` is renamed to `InstrumentationExecutionParameters`
- `instrumentation.ValidationParameters` is renamed to `InstrumentationValidationParameters`
- `ExecutionParameters` is renamed to ExecutionStrategyParameters

- `DataFetchParameters` is renamed to `InstrumentationDataFetchParameters`
- `FieldFetchParameters` is renamed to `InstrumentationFieldFetchParameters`
- `FieldParameters` is renamed to `InstrumentationFieldParameters`