### PR TITLE
enum values provider

### DIFF
--- a/src/main/java/graphql/schema/idl/EnumValuesProvider.java
+++ b/src/main/java/graphql/schema/idl/EnumValuesProvider.java
@@ -1,0 +1,19 @@
+package graphql.schema.idl;
+
+import graphql.PublicSpi;
+
+/**
+ * Provides the Java runtime value for each graphql Enum value. Used for IDL driven schema creation.
+ * <p>
+ * Enum values are considered static: This is called when a schema is created. It is not used when a query is executed.
+ */
+@PublicSpi
+public interface EnumValuesProvider {
+
+    /**
+     * @param name
+     * @return not null
+     */
+    Object getValue(String name);
+
+}

--- a/src/main/java/graphql/schema/idl/RuntimeWiring.java
+++ b/src/main/java/graphql/schema/idl/RuntimeWiring.java
@@ -21,13 +21,15 @@ public class RuntimeWiring {
     private final Map<String, Map<String, DataFetcher>> dataFetchers;
     private final Map<String, GraphQLScalarType> scalars;
     private final Map<String, TypeResolver> typeResolvers;
+    private Map<String, EnumValuesProvider> enumValuesProviders;
     private final WiringFactory wiringFactory;
 
-    private RuntimeWiring(Map<String, Map<String, DataFetcher>> dataFetchers, Map<String, GraphQLScalarType> scalars, Map<String, TypeResolver> typeResolvers, WiringFactory wiringFactory) {
+    private RuntimeWiring(Map<String, Map<String, DataFetcher>> dataFetchers, Map<String, GraphQLScalarType> scalars, Map<String, TypeResolver> typeResolvers, Map<String, EnumValuesProvider> enumValuesProviders, WiringFactory wiringFactory) {
         this.dataFetchers = dataFetchers;
         this.scalars = scalars;
         this.typeResolvers = typeResolvers;
         this.wiringFactory = wiringFactory;
+        this.enumValuesProviders = enumValuesProviders;
     }
 
     public Map<String, GraphQLScalarType> getScalars() {
@@ -46,6 +48,10 @@ public class RuntimeWiring {
         return typeResolvers;
     }
 
+    public Map<String, EnumValuesProvider> getEnumValuesProviders() {
+        return this.enumValuesProviders;
+    }
+
     public WiringFactory getWiringFactory() {
         return wiringFactory;
     }
@@ -62,6 +68,7 @@ public class RuntimeWiring {
         private final Map<String, Map<String, DataFetcher>> dataFetchers = new LinkedHashMap<>();
         private final Map<String, GraphQLScalarType> scalars = new LinkedHashMap<>();
         private final Map<String, TypeResolver> typeResolvers = new LinkedHashMap<>();
+        private final Map<String, EnumValuesProvider> enumValuesProviders = new LinkedHashMap<>();
         private WiringFactory wiringFactory = new NoopWiringFactory();
 
         private Builder() {
@@ -72,7 +79,6 @@ public class RuntimeWiring {
          * Adds a wiring factory into the runtime wiring
          *
          * @param wiringFactory the wiring factory to add
-         *
          * @return this outer builder
          */
         public Builder wiringFactory(WiringFactory wiringFactory) {
@@ -85,7 +91,6 @@ public class RuntimeWiring {
          * This allows you to add in new custom Scalar implementations beyond the standard set.
          *
          * @param scalarType the new scalar implementation
-         *
          * @return the runtime wiring builder
          */
         public Builder scalar(GraphQLScalarType scalarType) {
@@ -97,7 +102,6 @@ public class RuntimeWiring {
          * This allows you to add a new type wiring via a builder
          *
          * @param builder the type wiring builder to use
-         *
          * @return this outer builder
          */
         public Builder type(TypeRuntimeWiring.Builder builder) {
@@ -109,7 +113,6 @@ public class RuntimeWiring {
          *
          * @param typeName        the name of the type to wire
          * @param builderFunction a function that will be given the builder to use
-         *
          * @return the runtime wiring builder
          */
         public Builder type(String typeName, UnaryOperator<TypeRuntimeWiring.Builder> builderFunction) {
@@ -121,7 +124,6 @@ public class RuntimeWiring {
          * This adds a type wiring
          *
          * @param typeRuntimeWiring the new type wiring
-         *
          * @return the runtime wiring builder
          */
         public Builder type(TypeRuntimeWiring typeRuntimeWiring) {
@@ -133,6 +135,11 @@ public class RuntimeWiring {
             if (typeResolver != null) {
                 this.typeResolvers.put(typeName, typeResolver);
             }
+
+            EnumValuesProvider enumValuesProvider = typeRuntimeWiring.getEnumValuesProvider();
+            if (enumValuesProvider != null) {
+                this.enumValuesProviders.put(typeName, enumValuesProvider);
+            }
             return this;
         }
 
@@ -140,7 +147,7 @@ public class RuntimeWiring {
          * @return the built runtime wiring
          */
         public RuntimeWiring build() {
-            return new RuntimeWiring(dataFetchers, scalars, typeResolvers, wiringFactory);
+            return new RuntimeWiring(dataFetchers, scalars, typeResolvers, enumValuesProviders, wiringFactory);
         }
 
     }

--- a/src/main/java/graphql/schema/idl/StaticEnumValuesProvider.java
+++ b/src/main/java/graphql/schema/idl/StaticEnumValuesProvider.java
@@ -1,0 +1,26 @@
+package graphql.schema.idl;
+
+import graphql.Assert;
+import graphql.PublicApi;
+
+/**
+ * Simple EnumValuesProvided which maps the GraphQL Enum name to the Java Enum instance.
+ *
+ * @param <T>
+ */
+@PublicApi
+public class StaticEnumValuesProvider<T extends Enum<T>> implements EnumValuesProvider {
+
+
+    private final Class<T> enumType;
+
+    public StaticEnumValuesProvider(Class<T> enumType) {
+        Assert.assertNotNull(enumType, "enumType can't be null");
+        this.enumType = enumType;
+    }
+
+    @Override
+    public T getValue(String name) {
+        return Enum.valueOf(enumType, name);
+    }
+}

--- a/src/main/java/graphql/schema/idl/TypeRuntimeWiring.java
+++ b/src/main/java/graphql/schema/idl/TypeRuntimeWiring.java
@@ -19,11 +19,13 @@ public class TypeRuntimeWiring {
     private final String typeName;
     private final Map<String, DataFetcher> fieldDataFetchers;
     private final TypeResolver typeResolver;
+    private final EnumValuesProvider enumValuesProvider;
 
-    private TypeRuntimeWiring(String typeName, Map<String, DataFetcher> fieldDataFetchers, TypeResolver typeResolver) {
+    private TypeRuntimeWiring(String typeName, Map<String, DataFetcher> fieldDataFetchers, TypeResolver typeResolver, EnumValuesProvider enumValuesProvider) {
         this.typeName = typeName;
         this.fieldDataFetchers = fieldDataFetchers;
         this.typeResolver = typeResolver;
+        this.enumValuesProvider = enumValuesProvider;
     }
 
     public String getTypeName() {
@@ -36,6 +38,10 @@ public class TypeRuntimeWiring {
 
     public TypeResolver getTypeResolver() {
         return typeResolver;
+    }
+
+    public EnumValuesProvider getEnumValuesProvider() {
+        return enumValuesProvider;
     }
 
     /**
@@ -66,6 +72,7 @@ public class TypeRuntimeWiring {
         private String typeName;
         private final Map<String, DataFetcher> fieldDataFetchers = new LinkedHashMap<>();
         private TypeResolver typeResolver;
+        private EnumValuesProvider enumValuesProvider;
 
         /**
          * Sets the type name for this type wiring.  You MUST set this.
@@ -121,12 +128,18 @@ public class TypeRuntimeWiring {
             return this;
         }
 
+        public Builder enumValues(EnumValuesProvider enumValuesProvider) {
+            assertNotNull(enumValuesProvider, "you must provide a type resolver");
+            this.enumValuesProvider = enumValuesProvider;
+            return this;
+        }
+
         /**
          * @return the built type wiring
          */
         public TypeRuntimeWiring build() {
             assertNotNull(typeName, "you must provide a type name");
-            return new TypeRuntimeWiring(typeName, fieldDataFetchers, typeResolver);
+            return new TypeRuntimeWiring(typeName, fieldDataFetchers, typeResolver, enumValuesProvider);
         }
     }
 


### PR DESCRIPTION
Introducing the possibility to define a Java value for each graphql enum value,
when defining a schema via IDL.

Default Implementation for using a Java Enum is `StaticEnumValuesProvider`: 

Example usage:

**Java Enum:**

```java
enum Color {
  Blue, 
  Red
}
```

**GraphQL Schema Definition:**

```graphql
enum Color {
  Blue
  Red
}
```

**Creating the Schema:**

```java
StaticEnumValuesProvider colorValues = new StaticEnumValuesProvider(Color.class);
RuntimeWiring.newRuntimeWiring()
            .type("Color", typeWiring -> typeWiring.enumValues(colorValues))
....

```


