### PR TITLE
#438 now with double checks in null values that might come out of coercion

### DIFF
--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -56,7 +56,7 @@ public class Execution {
         } else if (operation == QUERY) {
             return graphQLSchema.getQueryType();
 
-        }  else if (operation == SUBSCRIPTION) {
+        } else if (operation == SUBSCRIPTION) {
             return graphQLSchema.getSubscriptionType();
 
         } else {
@@ -90,10 +90,14 @@ public class Execution {
 
         Map<String, List<Field>> fields = fieldCollector.collectFields(collectorParameters, operationDefinition.getSelectionSet());
 
+        TypeInfo typeInfo = newTypeInfo().type(operationRootType).build();
+        NonNullableFieldValidator nonNullableFieldValidator = new NonNullableFieldValidator(executionContext, typeInfo);
+
         ExecutionParameters parameters = newParameters()
-                .typeInfo(newTypeInfo().type(operationRootType))
+                .typeInfo(typeInfo)
                 .source(root)
                 .fields(fields)
+                .nonNullFieldValidator(nonNullableFieldValidator)
                 .build();
 
         ExecutionResult result;

--- a/src/main/java/graphql/execution/ExecutionParameters.java
+++ b/src/main/java/graphql/execution/ExecutionParameters.java
@@ -1,5 +1,6 @@
 package graphql.execution;
 
+import graphql.Assert;
 import graphql.language.Field;
 
 import java.util.List;
@@ -15,12 +16,14 @@ public class ExecutionParameters {
     private final Object source;
     private final Map<String, Object> arguments;
     private final Map<String, List<Field>> fields;
+    private final NonNullableFieldValidator nonNullableFieldValidator;
 
-    private ExecutionParameters(TypeInfo typeInfo, Object source, Map<String, List<Field>> fields, Map<String, Object> arguments) {
+    private ExecutionParameters(TypeInfo typeInfo, Object source, Map<String, List<Field>> fields, Map<String, Object> arguments, NonNullableFieldValidator nonNullableFieldValidator) {
         this.typeInfo = assertNotNull(typeInfo, "typeInfo is null");
         this.fields = assertNotNull(fields, "fields is null");
         this.source = source;
         this.arguments = arguments;
+        this.nonNullableFieldValidator = nonNullableFieldValidator;
     }
 
     public TypeInfo typeInfo() {
@@ -39,6 +42,10 @@ public class ExecutionParameters {
         return arguments;
     }
 
+    public NonNullableFieldValidator nonNullFieldValidator() {
+        return nonNullableFieldValidator;
+    }
+
     public static Builder newParameters() {
         return new Builder();
     }
@@ -54,6 +61,7 @@ public class ExecutionParameters {
         Object source;
         Map<String, List<Field>> fields;
         Map<String, Object> arguments;
+        NonNullableFieldValidator nonNullableFieldValidator;
 
         public Builder typeInfo(TypeInfo type) {
             this.typeInfo = type;
@@ -79,9 +87,14 @@ public class ExecutionParameters {
             this.arguments = arguments;
             return this;
         }
+        
+        public Builder nonNullFieldValidator(NonNullableFieldValidator nonNullableFieldValidator) {
+            this.nonNullableFieldValidator = Assert.assertNotNull(nonNullableFieldValidator,"requires a NonNullValidator");
+            return this;
+        }
 
         public ExecutionParameters build() {
-            return new ExecutionParameters(typeInfo, source, fields, arguments);
+            return new ExecutionParameters(typeInfo, source, fields, arguments, nonNullableFieldValidator);
         }
     }
 }

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -59,6 +59,7 @@ public abstract class ExecutionStrategy {
      * @param argumentValues   the map of arguments
      * @param e                the exception that occurred
      */
+    @SuppressWarnings("unused")
     protected void handleDataFetchingException(
             ExecutionContext executionContext,
             GraphQLFieldDefinition fieldDef,
@@ -111,11 +112,15 @@ public abstract class ExecutionStrategy {
                 .build();
 
 
+        NonNullableFieldValidator nonNullableFieldValidator = new NonNullableFieldValidator(executionContext, fieldTypeInfo);
+
         ExecutionParameters newParameters = ExecutionParameters.newParameters()
                 .typeInfo(fieldTypeInfo)
                 .fields(parameters.fields())
                 .arguments(argumentValues)
-                .source(resolvedValue).build();
+                .source(resolvedValue)
+                .nonNullFieldValidator(nonNullableFieldValidator)
+                .build();
 
         ExecutionResult result = completeValue(executionContext, newParameters, fields);
 
@@ -129,19 +134,13 @@ public abstract class ExecutionStrategy {
         GraphQLType fieldType = parameters.typeInfo().type();
 
         if (result == null) {
-            if (typeInfo.typeIsNonNull()) {
-                // see http://facebook.github.io/graphql/#sec-Errors-and-Non-Nullability
-                NonNullableFieldWasNullException nonNullException = new NonNullableFieldWasNullException(typeInfo);
-                executionContext.addError(nonNullException);
-                throw nonNullException;
-            }
-            return null;
+            return parameters.nonNullFieldValidator().validate(null);
         } else if (fieldType instanceof GraphQLList) {
             return completeValueForList(executionContext, parameters, fields, toIterable(result));
         } else if (fieldType instanceof GraphQLScalarType) {
-            return completeValueForScalar((GraphQLScalarType) fieldType, result);
+            return completeValueForScalar((GraphQLScalarType) fieldType, parameters, result);
         } else if (fieldType instanceof GraphQLEnumType) {
-            return completeValueForEnum((GraphQLEnumType) fieldType, result);
+            return completeValueForEnum((GraphQLEnumType) fieldType, parameters, result);
         }
 
 
@@ -177,9 +176,13 @@ public abstract class ExecutionStrategy {
 
         Map<String, List<Field>> subFields = fieldCollector.collectFields(collectorParameters, fields);
 
+        TypeInfo newTypeInfo = typeInfo.asType(resolvedType);
+        NonNullableFieldValidator nonNullableFieldValidator = new NonNullableFieldValidator(executionContext, newTypeInfo);
+
         ExecutionParameters newParameters = ExecutionParameters.newParameters()
-                .typeInfo(typeInfo.asType(resolvedType))
+                .typeInfo(newTypeInfo)
                 .fields(subFields)
+                .nonNullFieldValidator(nonNullableFieldValidator)
                 .source(result).build();
 
         // Calling this from the executionContext to ensure we shift back from mutation strategy to the query strategy.
@@ -213,16 +216,19 @@ public abstract class ExecutionStrategy {
         return result;
     }
 
-    protected ExecutionResult completeValueForEnum(GraphQLEnumType enumType, Object result) {
-        return new ExecutionResultImpl(enumType.getCoercing().serialize(result), null);
+    protected ExecutionResult completeValueForEnum(GraphQLEnumType enumType, ExecutionParameters parameters, Object result) {
+        Object serialized = enumType.getCoercing().serialize(result);
+        serialized = parameters.nonNullFieldValidator().validate(serialized);
+        return new ExecutionResultImpl(serialized, null);
     }
 
-    protected ExecutionResult completeValueForScalar(GraphQLScalarType scalarType, Object result) {
+    protected ExecutionResult completeValueForScalar(GraphQLScalarType scalarType, ExecutionParameters parameters, Object result) {
         Object serialized = scalarType.getCoercing().serialize(result);
         //6.6.1 http://facebook.github.io/graphql/#sec-Field-entries
         if (serialized instanceof Double && ((Double) serialized).isNaN()) {
             serialized = null;
         }
+        serialized = parameters.nonNullFieldValidator().validate(serialized);
         return new ExecutionResultImpl(serialized, null);
     }
 
@@ -232,9 +238,13 @@ public abstract class ExecutionStrategy {
         GraphQLList fieldType = typeInfo.castType(GraphQLList.class);
         for (Object item : result) {
 
+            TypeInfo wrappedTypeInfo = typeInfo.asType(fieldType.getWrappedType());
+            NonNullableFieldValidator nonNullableFieldValidator = new NonNullableFieldValidator(executionContext, wrappedTypeInfo);
+
             ExecutionParameters newParameters = ExecutionParameters.newParameters()
-                    .typeInfo(typeInfo.asType(fieldType.getWrappedType()))
+                    .typeInfo(wrappedTypeInfo)
                     .fields(parameters.fields())
+                    .nonNullFieldValidator(nonNullableFieldValidator)
                     .source(item).build();
 
             ExecutionResult completedValue = completeValue(executionContext, newParameters, fields);

--- a/src/main/java/graphql/execution/NonNullableFieldValidator.java
+++ b/src/main/java/graphql/execution/NonNullableFieldValidator.java
@@ -1,0 +1,40 @@
+package graphql.execution;
+
+
+/**
+ * This will check that a value is non null when the type definition says it must be and it will throw {@link NonNullableFieldWasNullException}
+ * if this is not the case.
+ *
+ * See: http://facebook.github.io/graphql/#sec-Errors-and-Non-Nullability
+ */
+public class NonNullableFieldValidator {
+    private final ExecutionContext executionContext;
+    private final TypeInfo typeInfo;
+
+    public NonNullableFieldValidator(ExecutionContext executionContext, TypeInfo typeInfo) {
+        this.executionContext = executionContext;
+        this.typeInfo = typeInfo;
+    }
+
+    /**
+     * Called to check that a value is non null if the type requires it to be non null
+     *
+     * @param result the result to check
+     *
+     * @return the result back
+     *
+     * @throws NonNullableFieldWasNullException if the value is null but the type requires it to be non null
+     */
+    <T> T validate(T result) throws NonNullableFieldWasNullException {
+        if (result == null) {
+            if (typeInfo.typeIsNonNull()) {
+                // see http://facebook.github.io/graphql/#sec-Errors-and-Non-Nullability
+                NonNullableFieldWasNullException nonNullException = new NonNullableFieldWasNullException(typeInfo);
+                executionContext.addError(nonNullException);
+                throw nonNullException;
+            }
+        }
+        return result;
+    }
+
+}

--- a/src/test/groovy/graphql/execution/NonNullableFieldValidatorTest.groovy
+++ b/src/test/groovy/graphql/execution/NonNullableFieldValidatorTest.groovy
@@ -1,0 +1,36 @@
+package graphql.execution
+
+import spock.lang.Specification
+
+import static graphql.Scalars.GraphQLString
+import static graphql.schema.GraphQLNonNull.nonNull
+
+class NonNullableFieldValidatorTest extends Specification {
+
+    ExecutionContext context = new ExecutionContext(null, null, null, null, null, null, null, null, null, null)
+
+    def "non nullable field throws exception"() {
+        TypeInfo typeInfo = TypeInfo.newTypeInfo().type(nonNull(GraphQLString)).build()
+
+        NonNullableFieldValidator validator = new NonNullableFieldValidator(context, typeInfo)
+
+        when:
+        validator.validate(null)
+
+        then:
+        thrown(NonNullableFieldWasNullException)
+
+    }
+
+    def "nullable field does not throw exception"() {
+        TypeInfo typeInfo = TypeInfo.newTypeInfo().type(GraphQLString).build()
+
+        NonNullableFieldValidator validator = new NonNullableFieldValidator(context, typeInfo)
+
+        when:
+        def result = validator.validate(null)
+
+        then:
+        result == null
+    }
+}


### PR DESCRIPTION
A custom scalar could return null and we can now enforce that it matches a non null graphql type