### PR TITLE
Pass parentType to DataFetcher-related methods in WiringFactory

### DIFF
--- a/src/main/java/graphql/schema/idl/CombinedWiringFactory.java
+++ b/src/main/java/graphql/schema/idl/CombinedWiringFactory.java
@@ -2,6 +2,7 @@ package graphql.schema.idl;
 
 import graphql.language.FieldDefinition;
 import graphql.language.InterfaceTypeDefinition;
+import graphql.language.TypeDefinition;
 import graphql.language.UnionTypeDefinition;
 import graphql.schema.DataFetcher;
 import graphql.schema.TypeResolver;
@@ -64,9 +65,9 @@ public class CombinedWiringFactory implements WiringFactory {
     }
 
     @Override
-    public boolean providesDataFetcher(TypeDefinitionRegistry registry, FieldDefinition definition) {
+    public boolean providesDataFetcher(TypeDefinitionRegistry registry, TypeDefinition parentType, FieldDefinition definition) {
         for (WiringFactory factory : factories) {
-            if (factory.providesDataFetcher(registry, definition)) {
+            if (factory.providesDataFetcher(registry, parentType, definition)) {
                 return true;
             }
         }
@@ -74,10 +75,10 @@ public class CombinedWiringFactory implements WiringFactory {
     }
 
     @Override
-    public DataFetcher getDataFetcher(TypeDefinitionRegistry registry, FieldDefinition definition) {
+    public DataFetcher getDataFetcher(TypeDefinitionRegistry registry, TypeDefinition parentType, FieldDefinition definition) {
         for (WiringFactory factory : factories) {
-            if (factory.providesDataFetcher(registry, definition)) {
-                return factory.getDataFetcher(registry, definition);
+            if (factory.providesDataFetcher(registry, parentType, definition)) {
+                return factory.getDataFetcher(registry, parentType, definition);
             }
         }
         return null;

--- a/src/main/java/graphql/schema/idl/CombinedWiringFactory.java
+++ b/src/main/java/graphql/schema/idl/CombinedWiringFactory.java
@@ -1,8 +1,6 @@
 package graphql.schema.idl;
 
-import graphql.language.FieldDefinition;
 import graphql.language.InterfaceTypeDefinition;
-import graphql.language.TypeDefinition;
 import graphql.language.UnionTypeDefinition;
 import graphql.schema.DataFetcher;
 import graphql.schema.TypeResolver;
@@ -65,9 +63,9 @@ public class CombinedWiringFactory implements WiringFactory {
     }
 
     @Override
-    public boolean providesDataFetcher(TypeDefinitionRegistry registry, TypeDefinition parentType, FieldDefinition definition) {
+    public boolean providesDataFetcher(WiringContext context) {
         for (WiringFactory factory : factories) {
-            if (factory.providesDataFetcher(registry, parentType, definition)) {
+            if (factory.providesDataFetcher(context)) {
                 return true;
             }
         }
@@ -75,10 +73,10 @@ public class CombinedWiringFactory implements WiringFactory {
     }
 
     @Override
-    public DataFetcher getDataFetcher(TypeDefinitionRegistry registry, TypeDefinition parentType, FieldDefinition definition) {
+    public DataFetcher getDataFetcher(WiringContext context) {
         for (WiringFactory factory : factories) {
-            if (factory.providesDataFetcher(registry, parentType, definition)) {
-                return factory.getDataFetcher(registry, parentType, definition);
+            if (factory.providesDataFetcher(context)) {
+                return factory.getDataFetcher(context);
             }
         }
         return null;

--- a/src/main/java/graphql/schema/idl/NoopWiringFactory.java
+++ b/src/main/java/graphql/schema/idl/NoopWiringFactory.java
@@ -1,9 +1,7 @@
 package graphql.schema.idl;
 
-import graphql.language.FieldDefinition;
 import graphql.language.InterfaceTypeDefinition;
 import graphql.language.UnionTypeDefinition;
-import graphql.schema.DataFetcher;
 import graphql.schema.TypeResolver;
 
 import static graphql.Assert.assertNeverCalled;
@@ -27,15 +25,5 @@ public class NoopWiringFactory implements WiringFactory {
     @Override
     public TypeResolver getTypeResolver(TypeDefinitionRegistry registry, UnionTypeDefinition unionType) {
         return assertNeverCalled();
-    }
-
-    @Override
-    public boolean providesDataFetcher(TypeDefinitionRegistry registry, FieldDefinition definition) {
-        return false;
-    }
-
-    @Override
-    public DataFetcher getDataFetcher(TypeDefinitionRegistry registry, FieldDefinition definition) {
-        return null;
     }
 }

--- a/src/main/java/graphql/schema/idl/SchemaGenerator.java
+++ b/src/main/java/graphql/schema/idl/SchemaGenerator.java
@@ -464,8 +464,8 @@ public class SchemaGenerator {
         WiringFactory wiringFactory = wiring.getWiringFactory();
 
         DataFetcher dataFetcher;
-        if (wiringFactory.providesDataFetcher(typeRegistry, fieldDef)) {
-            dataFetcher = wiringFactory.getDataFetcher(typeRegistry, fieldDef);
+        if (wiringFactory.providesDataFetcher(typeRegistry, parentType, fieldDef)) {
+            dataFetcher = wiringFactory.getDataFetcher(typeRegistry, parentType, fieldDef);
             assertNotNull(dataFetcher, "The WiringFactory indicated it provides a data fetcher but then returned null");
         } else {
             dataFetcher = wiring.getDataFetcherForType(parentType.getName()).get(fieldName);

--- a/src/main/java/graphql/schema/idl/SchemaGenerator.java
+++ b/src/main/java/graphql/schema/idl/SchemaGenerator.java
@@ -463,9 +463,11 @@ public class SchemaGenerator {
         RuntimeWiring wiring = buildCtx.getWiring();
         WiringFactory wiringFactory = wiring.getWiringFactory();
 
+        WiringContext wiringContext = new WiringContext(typeRegistry, parentType, fieldDef);
+
         DataFetcher dataFetcher;
-        if (wiringFactory.providesDataFetcher(typeRegistry, parentType, fieldDef)) {
-            dataFetcher = wiringFactory.getDataFetcher(typeRegistry, parentType, fieldDef);
+        if (wiringFactory.providesDataFetcher(wiringContext)) {
+            dataFetcher = wiringFactory.getDataFetcher(wiringContext);
             assertNotNull(dataFetcher, "The WiringFactory indicated it provides a data fetcher but then returned null");
         } else {
             dataFetcher = wiring.getDataFetcherForType(parentType.getName()).get(fieldName);

--- a/src/main/java/graphql/schema/idl/WiringContext.java
+++ b/src/main/java/graphql/schema/idl/WiringContext.java
@@ -1,0 +1,29 @@
+package graphql.schema.idl;
+
+import graphql.language.FieldDefinition;
+import graphql.language.TypeDefinition;
+
+public class WiringContext {
+
+    private final TypeDefinitionRegistry registry;
+    private final TypeDefinition parentType;
+    private final FieldDefinition definition;
+
+    public WiringContext(TypeDefinitionRegistry registry, TypeDefinition parentType, FieldDefinition definition) {
+        this.registry = registry;
+        this.parentType = parentType;
+        this.definition = definition;
+    }
+
+    public TypeDefinitionRegistry getRegistry() {
+        return registry;
+    }
+
+    public TypeDefinition getParentType() {
+        return parentType;
+    }
+
+    public FieldDefinition getDefinition() {
+        return definition;
+    }
+}

--- a/src/main/java/graphql/schema/idl/WiringFactory.java
+++ b/src/main/java/graphql/schema/idl/WiringFactory.java
@@ -2,6 +2,7 @@ package graphql.schema.idl;
 
 import graphql.language.FieldDefinition;
 import graphql.language.InterfaceTypeDefinition;
+import graphql.language.TypeDefinition;
 import graphql.language.UnionTypeDefinition;
 import graphql.schema.DataFetcher;
 import graphql.schema.TypeResolver;
@@ -53,10 +54,38 @@ public interface WiringFactory {
      * This is called to ask if this factory can provide a data fetcher for the definition
      *
      * @param registry   the registry of all types
+     * @param parentType the type of the parent
      * @param definition the field definition in play
      * @return true if the factory can give out a date fetcher
      */
-    boolean providesDataFetcher(TypeDefinitionRegistry registry, FieldDefinition definition);
+    default boolean providesDataFetcher(TypeDefinitionRegistry registry, TypeDefinition parentType, FieldDefinition definition) {
+        return providesDataFetcher(registry, definition);
+    }
+
+    /**
+     * This is called to ask if this factory can provide a data fetcher for the definition
+     *
+     * @param registry   the registry of all types
+     * @param definition the field definition in play
+     * @return true if the factory can give out a date fetcher
+     * @deprecated use overloaded version with parentType
+     */
+    @Deprecated
+    default boolean providesDataFetcher(TypeDefinitionRegistry registry, FieldDefinition definition) {
+        return false;
+    }
+
+    /**
+     * Returns a {@link DataFetcher} given the type definition
+     *
+     * @param registry   the registry of all types
+     * @param parentType the type of the parent
+     * @param definition the definition to be resolved
+     * @return a {@link DataFetcher}
+     */
+    default DataFetcher getDataFetcher(TypeDefinitionRegistry registry, TypeDefinition parentType, FieldDefinition definition) {
+        return getDataFetcher(registry, definition);
+    }
 
     /**
      * Returns a {@link DataFetcher} given the type definition
@@ -64,7 +93,11 @@ public interface WiringFactory {
      * @param registry   the registry of all types
      * @param definition the definition to be resolved
      * @return a {@link DataFetcher}
+     * @deprecated use overloaded version with parentType
      */
-    DataFetcher getDataFetcher(TypeDefinitionRegistry registry, FieldDefinition definition);
+    @Deprecated
+    default DataFetcher getDataFetcher(TypeDefinitionRegistry registry, FieldDefinition definition) {
+        return null;
+    }
 
 }

--- a/src/main/java/graphql/schema/idl/WiringFactory.java
+++ b/src/main/java/graphql/schema/idl/WiringFactory.java
@@ -1,8 +1,7 @@
 package graphql.schema.idl;
 
-import graphql.language.FieldDefinition;
+import graphql.Assert;
 import graphql.language.InterfaceTypeDefinition;
-import graphql.language.TypeDefinition;
 import graphql.language.UnionTypeDefinition;
 import graphql.schema.DataFetcher;
 import graphql.schema.TypeResolver;
@@ -53,51 +52,21 @@ public interface WiringFactory {
     /**
      * This is called to ask if this factory can provide a data fetcher for the definition
      *
-     * @param registry   the registry of all types
-     * @param parentType the type of the parent
-     * @param definition the field definition in play
-     * @return true if the factory can give out a date fetcher
+     * @param context the context where wiring is happening
+     * @return true if the factory can give out a data fetcher
      */
-    default boolean providesDataFetcher(TypeDefinitionRegistry registry, TypeDefinition parentType, FieldDefinition definition) {
-        return providesDataFetcher(registry, definition);
-    }
-
-    /**
-     * This is called to ask if this factory can provide a data fetcher for the definition
-     *
-     * @param registry   the registry of all types
-     * @param definition the field definition in play
-     * @return true if the factory can give out a date fetcher
-     * @deprecated use overloaded version with parentType
-     */
-    @Deprecated
-    default boolean providesDataFetcher(TypeDefinitionRegistry registry, FieldDefinition definition) {
+    default boolean providesDataFetcher(WiringContext context) {
         return false;
     }
 
     /**
      * Returns a {@link DataFetcher} given the type definition
      *
-     * @param registry   the registry of all types
-     * @param parentType the type of the parent
-     * @param definition the definition to be resolved
+     * @param context the context where wiring is happening
      * @return a {@link DataFetcher}
      */
-    default DataFetcher getDataFetcher(TypeDefinitionRegistry registry, TypeDefinition parentType, FieldDefinition definition) {
-        return getDataFetcher(registry, definition);
-    }
-
-    /**
-     * Returns a {@link DataFetcher} given the type definition
-     *
-     * @param registry   the registry of all types
-     * @param definition the definition to be resolved
-     * @return a {@link DataFetcher}
-     * @deprecated use overloaded version with parentType
-     */
-    @Deprecated
-    default DataFetcher getDataFetcher(TypeDefinitionRegistry registry, FieldDefinition definition) {
-        return null;
+    default DataFetcher getDataFetcher(WiringContext context) {
+        return Assert.assertNeverCalled();
     }
 
 }

--- a/src/test/groovy/graphql/TestUtil.groovy
+++ b/src/test/groovy/graphql/TestUtil.groovy
@@ -16,6 +16,7 @@ import graphql.schema.idl.SchemaGenerator
 import graphql.schema.idl.SchemaParser
 import graphql.schema.idl.TypeDefinitionRegistry
 import graphql.schema.idl.TypeRuntimeWiring
+import graphql.schema.idl.WiringContext
 import graphql.schema.idl.WiringFactory
 import graphql.schema.idl.errors.SchemaProblem
 
@@ -98,13 +99,13 @@ class TestUtil {
         }
 
         @Override
-        boolean providesDataFetcher(TypeDefinitionRegistry registry, FieldDefinition definition) {
+        boolean providesDataFetcher(WiringContext context) {
             return true
         }
 
         @Override
-        DataFetcher getDataFetcher(TypeDefinitionRegistry registry, FieldDefinition definition) {
-            return new PropertyDataFetcher(definition.getName())
+        DataFetcher getDataFetcher(WiringContext context) {
+            return new PropertyDataFetcher(context.definition.getName())
         }
     }
 

--- a/src/test/groovy/graphql/schema/idl/SchemaTypeCheckerTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaTypeCheckerTest.groovy
@@ -2,7 +2,6 @@ package graphql.schema.idl
 
 import graphql.GraphQLError
 import graphql.TypeResolutionEnvironment
-import graphql.language.FieldDefinition
 import graphql.language.InterfaceTypeDefinition
 import graphql.language.UnionTypeDefinition
 import graphql.schema.DataFetcher
@@ -52,12 +51,12 @@ class SchemaTypeCheckerTest extends Specification {
         }
 
         @Override
-        boolean providesDataFetcher(TypeDefinitionRegistry registry, FieldDefinition definition) {
+        boolean providesDataFetcher(WiringContext context) {
             false
         }
 
         @Override
-        DataFetcher getDataFetcher(TypeDefinitionRegistry registry, FieldDefinition definition) {
+        DataFetcher getDataFetcher(WiringContext context) {
             throw new UnsupportedOperationException("Not implemented")
         }
     }

--- a/src/test/groovy/graphql/schema/idl/WiringFactoryTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/WiringFactoryTest.groovy
@@ -1,7 +1,6 @@
 package graphql.schema.idl
 
 import graphql.TypeResolutionEnvironment
-import graphql.language.FieldDefinition
 import graphql.language.InterfaceTypeDefinition
 import graphql.language.UnionTypeDefinition
 import graphql.schema.*
@@ -63,12 +62,12 @@ class WiringFactoryTest extends Specification {
         }
 
         @Override
-        boolean providesDataFetcher(TypeDefinitionRegistry registry, FieldDefinition definition) {
-            return name == definition.getName()
+        boolean providesDataFetcher(WiringContext context) {
+            return name == context.definition.getName()
         }
 
         @Override
-        DataFetcher getDataFetcher(TypeDefinitionRegistry registry, FieldDefinition definition) {
+        DataFetcher getDataFetcher(WiringContext context) {
             return new NamedDataFetcher(name)
         }
     }

--- a/src/test/groovy/readme/ReadmeExamples.java
+++ b/src/test/groovy/readme/ReadmeExamples.java
@@ -27,11 +27,7 @@ import graphql.schema.GraphQLTypeReference;
 import graphql.schema.GraphQLUnionType;
 import graphql.schema.StaticDataFetcher;
 import graphql.schema.TypeResolver;
-import graphql.schema.idl.RuntimeWiring;
-import graphql.schema.idl.SchemaGenerator;
-import graphql.schema.idl.SchemaParser;
-import graphql.schema.idl.TypeDefinitionRegistry;
-import graphql.schema.idl.WiringFactory;
+import graphql.schema.idl.*;
 
 import java.io.File;
 import java.util.HashMap;
@@ -390,14 +386,14 @@ public class ReadmeExamples {
             }
 
             @Override
-            public boolean providesDataFetcher(TypeDefinitionRegistry registry, FieldDefinition definition) {
-                return getDirective(definition,"dataFetcher") != null;
+            public boolean providesDataFetcher(WiringContext context) {
+                return getDirective(context.getDefinition(), "dataFetcher") != null;
             }
 
             @Override
-            public DataFetcher getDataFetcher(TypeDefinitionRegistry registry, FieldDefinition definition) {
-                Directive directive = getDirective(definition, "dataFetcher");
-                return createDataFetcher(definition,directive);
+            public DataFetcher getDataFetcher(WiringContext context) {
+                Directive directive = getDirective(context.getDefinition(), "dataFetcher");
+                return createDataFetcher(context.getDefinition(), directive);
             }
         };
         return RuntimeWiring.newRuntimeWiring()


### PR DESCRIPTION
This is a breaking change, but since the API wasn't officially public this should be fine. 

I *did not* implement a builder for WiringContext because it's not an object others will create. We might add a builder in the future.