### PR TITLE
Schema printer comments

### DIFF
--- a/src/main/java/graphql/schema/idl/SchemaPrinter.java
+++ b/src/main/java/graphql/schema/idl/SchemaPrinter.java
@@ -148,8 +148,10 @@ public class SchemaPrinter {
             if (isIntrospectionType(type)) {
                 return;
             }
+            printComments(out, type, "");
             out.format("enum %s {\n", type.getName());
             for (GraphQLEnumValueDefinition enumValueDefinition : type.getValues()) {
+                printComments(out, enumValueDefinition, "   ");
                 out.format("   %s\n", enumValueDefinition.getName());
             }
             out.format("}\n\n");
@@ -193,7 +195,7 @@ public class SchemaPrinter {
             if (isIntrospectionType(type)) {
                 return;
             }
-            printComments(out, type);
+            printComments(out, type, "");
             out.format("type %s {\n", type.getName());
             type.getFieldDefinitions().forEach(fd -> {
                 printComments(out, fd, "   ");
@@ -335,8 +337,9 @@ public class SchemaPrinter {
         printer.print(out, type);
     }
 
-    void printComments(PrintWriter out, GraphQLFieldDefinition fieldDefinition, String prefix) {
-        String description = fieldDefinition.getDescription();
+
+    private void printComments(PrintWriter out, Object graphQLType, String prefix) {
+        String description = getDescription(graphQLType);
         if (description == null) {
             return;
         }
@@ -344,18 +347,15 @@ public class SchemaPrinter {
         stream.map(s -> prefix + "#" + s + "\n").forEach(out::write);
     }
 
-    void printComments(PrintWriter out, GraphQLType graphQLType) {
-        String description = getDescription(graphQLType);
-        if (description == null) {
-            return;
-        }
-        Stream<String> stream = Arrays.stream(description.split("\n"));
-        stream.map(s -> "#" + s + "\n").forEach(out::write);
-    }
-
-    String getDescription(GraphQLType graphQLType) {
-        if (graphQLType instanceof GraphQLObjectType) {
-            return ((GraphQLObjectType) graphQLType).getDescription();
+    private String getDescription(Object descriptionHolder) {
+        if (descriptionHolder instanceof GraphQLObjectType) {
+            return ((GraphQLObjectType) descriptionHolder).getDescription();
+        } else if (descriptionHolder instanceof GraphQLEnumType) {
+            return ((GraphQLEnumType) descriptionHolder).getDescription();
+        } else if (descriptionHolder instanceof GraphQLFieldDefinition) {
+            return ((GraphQLFieldDefinition) descriptionHolder).getDescription();
+        } else if (descriptionHolder instanceof GraphQLEnumValueDefinition) {
+            return ((GraphQLEnumValueDefinition) descriptionHolder).getDescription();
         } else {
             return Assert.assertShouldNeverHappen();
         }

--- a/src/main/java/graphql/schema/idl/SchemaPrinter.java
+++ b/src/main/java/graphql/schema/idl/SchemaPrinter.java
@@ -140,6 +140,7 @@ public class SchemaPrinter {
                 return;
             }
             if (!ScalarInfo.isStandardScalar(type)) {
+                printComments(out, type, "");
                 out.format("scalar %s\n\n", type.getName());
             }
         };
@@ -373,6 +374,8 @@ public class SchemaPrinter {
             return ((GraphQLInputObjectField) descriptionHolder).getDescription();
         } else if (descriptionHolder instanceof GraphQLInterfaceType) {
             return ((GraphQLInterfaceType) descriptionHolder).getDescription();
+        } else if (descriptionHolder instanceof GraphQLScalarType) {
+            return ((GraphQLScalarType) descriptionHolder).getDescription();
         } else {
             return Assert.assertShouldNeverHappen();
         }

--- a/src/main/java/graphql/schema/idl/SchemaPrinter.java
+++ b/src/main/java/graphql/schema/idl/SchemaPrinter.java
@@ -18,11 +18,13 @@ import graphql.schema.GraphQLUnionType;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Stack;
+import java.util.stream.Stream;
 
 /**
  * This can print an in memory GraphQL schema back to a logical schema definition
@@ -58,7 +60,6 @@ public class SchemaPrinter {
          * This will allow you to include introspection types that are contained in a schema
          *
          * @param flag whether to include them
-         *
          * @return options
          */
         public Options includeIntrospectionTypes(boolean flag) {
@@ -69,7 +70,6 @@ public class SchemaPrinter {
          * This will allow you to include scalar types that are contained in a schema
          *
          * @param flag whether to include them
-         *
          * @return options
          */
         public Options includeScalarTypes(boolean flag) {
@@ -99,7 +99,6 @@ public class SchemaPrinter {
      * This can print an in memory GraphQL schema back to a logical schema definition
      *
      * @param schema the schema in play
-     *
      * @return the logical schema definition
      */
     public String print(GraphQLSchema schema) {
@@ -192,6 +191,7 @@ public class SchemaPrinter {
             if (isIntrospectionType(type)) {
                 return;
             }
+            printComments(out, type);
             out.format("type %s {\n", type.getName());
             type.getFieldDefinitions().forEach(fd ->
                     out.format("   %s%s : %s\n",
@@ -329,5 +329,13 @@ public class SchemaPrinter {
     private void printType(PrintWriter out, GraphQLType type) {
         TypePrinter<Object> printer = printer(type.getClass());
         printer.print(out, type);
+    }
+
+    void printComments(PrintWriter out, GraphQLObjectType graphQLType) {
+        if (graphQLType.getDescription() == null) {
+            return;
+        }
+        Stream<String> stream = Arrays.stream(graphQLType.getDescription().split("\n"));
+        stream.map(s -> "#" + s + "\n").forEach(out::write);
     }
 }

--- a/src/main/java/graphql/schema/idl/SchemaPrinter.java
+++ b/src/main/java/graphql/schema/idl/SchemaPrinter.java
@@ -165,10 +165,13 @@ public class SchemaPrinter {
             if (isIntrospectionType(type)) {
                 return;
             }
+            printComments(out, type, "");
             out.format("interface %s {\n", type.getName());
-            type.getFieldDefinitions().forEach(fd ->
-                    out.format("   %s%s : %s\n",
-                            fd.getName(), argsString(fd.getArguments()), typeString(fd.getType())));
+            type.getFieldDefinitions().forEach(fd -> {
+                printComments(out, fd, "   ");
+                out.format("   %s%s : %s\n",
+                        fd.getName(), argsString(fd.getArguments()), typeString(fd.getType()));
+            });
             out.format("}\n\n");
         };
     }
@@ -368,6 +371,8 @@ public class SchemaPrinter {
             return ((GraphQLInputObjectType) descriptionHolder).getDescription();
         } else if (descriptionHolder instanceof GraphQLInputObjectField) {
             return ((GraphQLInputObjectField) descriptionHolder).getDescription();
+        } else if (descriptionHolder instanceof GraphQLInterfaceType) {
+            return ((GraphQLInterfaceType) descriptionHolder).getDescription();
         } else {
             return Assert.assertShouldNeverHappen();
         }

--- a/src/main/java/graphql/schema/idl/SchemaPrinter.java
+++ b/src/main/java/graphql/schema/idl/SchemaPrinter.java
@@ -5,6 +5,7 @@ import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLEnumValueDefinition;
 import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLInputObjectField;
 import graphql.schema.GraphQLInputObjectType;
 import graphql.schema.GraphQLInputType;
 import graphql.schema.GraphQLInterfaceType;
@@ -118,6 +119,7 @@ public class SchemaPrinter {
         printType(out, typesAsList, GraphQLObjectType.class);
         printType(out, typesAsList, GraphQLEnumType.class);
         printType(out, typesAsList, GraphQLScalarType.class);
+        printType(out, typesAsList, GraphQLInputObjectType.class);
 
         return sw.toString();
     }
@@ -213,10 +215,13 @@ public class SchemaPrinter {
             if (isIntrospectionType(type)) {
                 return;
             }
+            printComments(out, type, "");
             out.format("input %s {\n", type.getName());
-            type.getFieldDefinitions().forEach(fd ->
-                    out.format("   %s : %s\n",
-                            fd.getName(), typeString(fd.getType())));
+            type.getFieldDefinitions().forEach(fd -> {
+                printComments(out, fd, "   ");
+                out.format("   %s : %s\n",
+                        fd.getName(), typeString(fd.getType()));
+            });
             out.format("}\n\n");
         };
     }
@@ -359,6 +364,10 @@ public class SchemaPrinter {
             return ((GraphQLEnumValueDefinition) descriptionHolder).getDescription();
         } else if (descriptionHolder instanceof GraphQLUnionType) {
             return ((GraphQLUnionType) descriptionHolder).getDescription();
+        } else if (descriptionHolder instanceof GraphQLInputObjectType) {
+            return ((GraphQLInputObjectType) descriptionHolder).getDescription();
+        } else if (descriptionHolder instanceof GraphQLInputObjectField) {
+            return ((GraphQLInputObjectField) descriptionHolder).getDescription();
         } else {
             return Assert.assertShouldNeverHappen();
         }

--- a/src/main/java/graphql/schema/idl/SchemaPrinter.java
+++ b/src/main/java/graphql/schema/idl/SchemaPrinter.java
@@ -176,6 +176,7 @@ public class SchemaPrinter {
             if (isIntrospectionType(type)) {
                 return;
             }
+            printComments(out, type, "");
             out.format("union %s = ", type.getName());
             List<GraphQLOutputType> types = type.getTypes();
             for (int i = 0; i < types.size(); i++) {
@@ -185,7 +186,7 @@ public class SchemaPrinter {
                 }
                 out.format("%s", objectType.getName());
             }
-            out.format("}\n\n");
+            out.format("\n\n");
         };
     }
 
@@ -356,6 +357,8 @@ public class SchemaPrinter {
             return ((GraphQLFieldDefinition) descriptionHolder).getDescription();
         } else if (descriptionHolder instanceof GraphQLEnumValueDefinition) {
             return ((GraphQLEnumValueDefinition) descriptionHolder).getDescription();
+        } else if (descriptionHolder instanceof GraphQLUnionType) {
+            return ((GraphQLUnionType) descriptionHolder).getDescription();
         } else {
             return Assert.assertShouldNeverHappen();
         }

--- a/src/test/groovy/graphql/language/AstPrinterTest.groovy
+++ b/src/test/groovy/graphql/language/AstPrinterTest.groovy
@@ -371,5 +371,34 @@ query NullVariableDefaultValueQuery($episode: Episode = null) {
 '''
     }
 
+    def "print arguments descriptions"() {
+        def query = '''
+type Query {
+    field(
+    #description1
+    arg1: String,
+    arg2: String,
+    #description3
+    arg3: String
+    ): String
+}
+'''
+        def document = parse(query)
+        String output = printAst(document)
+
+        expect:
+        output == '''type Query {
+  field(
+  #description1
+  arg1: String
+  arg2: String
+  #description3
+  arg3: String
+  ): String
+}
+'''
+
+    }
+
 
 }

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -2,7 +2,16 @@ package graphql.schema.idl
 
 import graphql.Scalars
 import graphql.TypeResolutionEnvironment
-import graphql.schema.*
+import graphql.schema.Coercing
+import graphql.schema.GraphQLArgument
+import graphql.schema.GraphQLFieldDefinition
+import graphql.schema.GraphQLList
+import graphql.schema.GraphQLNonNull
+import graphql.schema.GraphQLObjectType
+import graphql.schema.GraphQLScalarType
+import graphql.schema.GraphQLSchema
+import graphql.schema.GraphQLType
+import graphql.schema.TypeResolver
 import spock.lang.Specification
 
 import java.util.function.UnaryOperator
@@ -210,6 +219,24 @@ type Query {
 }
 
 type Subscription {
+   field : String
+}
+
+"""
+    }
+
+    def "prints object description as comment"() {
+        given:
+        GraphQLFieldDefinition fieldDefinition = GraphQLFieldDefinition.newFieldDefinition()
+                .name("field").description("About field").type(Scalars.GraphQLString).build()
+        def queryType = GraphQLObjectType.newObject().name("Query").description("About Query").field(fieldDefinition).build()
+        def schema = GraphQLSchema.newSchema().query(queryType).build()
+        when:
+        def result = new SchemaPrinter().print(schema)
+
+        then:
+        result == """#About Query
+type Query {
    field : String
 }
 

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -437,5 +437,41 @@ type Query {
 """
     }
 
+    def "prints scalar description as comment"() {
+        given:
+        GraphQLScalarType myScalar = new GraphQLScalarType("Scalar", "about scalar", new Coercing() {
+            @Override
+            Object serialize(Object input) {
+                return null
+            }
+
+            @Override
+            Object parseValue(Object input) {
+                return null
+            }
+
+            @Override
+            Object parseLiteral(Object input) {
+                return null
+            }
+        });
+        GraphQLFieldDefinition fieldDefinition = newFieldDefinition()
+                .name("field").type(myScalar).build()
+        def queryType = GraphQLObjectType.newObject().name("Query").field(fieldDefinition).build()
+        def schema = GraphQLSchema.newSchema().query(queryType).build()
+        when:
+        def result = new SchemaPrinter(SchemaPrinter.Options.defaultOptions().includeScalarTypes(true)).print(schema)
+
+        then:
+        result == """type Query {
+   field : Scalar
+}
+
+#about scalar
+scalar Scalar
+
+"""
+    }
+
 
 }

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -8,6 +8,7 @@ import graphql.schema.GraphQLEnumType
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLInputObjectType
 import graphql.schema.GraphQLInputType
+import graphql.schema.GraphQLInterfaceType
 import graphql.schema.GraphQLList
 import graphql.schema.GraphQLNonNull
 import graphql.schema.GraphQLObjectType
@@ -24,6 +25,7 @@ import static graphql.Scalars.GraphQLString
 import static graphql.schema.GraphQLArgument.newArgument
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
 import static graphql.schema.GraphQLInputObjectField.newInputObjectField
+import static graphql.schema.GraphQLInterfaceType.newInterface
 
 class SchemaPrinterTest extends Specification {
 
@@ -404,6 +406,35 @@ input Input {
 
 """
 
+    }
+
+    def "prints interface description as comment"() {
+        given:
+        GraphQLInterfaceType graphQLInterfaceType = newInterface()
+                .name("Interface")
+                .description("about interface")
+                .field(newFieldDefinition().name("field").description("about field").type(GraphQLString).build())
+                .typeResolver({ it -> null })
+                .build()
+        GraphQLFieldDefinition fieldDefinition = newFieldDefinition()
+                .name("field").type(graphQLInterfaceType).build()
+        def queryType = GraphQLObjectType.newObject().name("Query").field(fieldDefinition).build()
+        def schema = GraphQLSchema.newSchema().query(queryType).build()
+        when:
+        def result = new SchemaPrinter().print(schema)
+
+        then:
+        result == """#about interface
+interface Interface {
+   #about field
+   field : String
+}
+
+type Query {
+   field : Interface
+}
+
+"""
     }
 
 

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -228,19 +228,40 @@ type Subscription {
     def "prints object description as comment"() {
         given:
         GraphQLFieldDefinition fieldDefinition = GraphQLFieldDefinition.newFieldDefinition()
-                .name("field").description("About field").type(Scalars.GraphQLString).build()
-        def queryType = GraphQLObjectType.newObject().name("Query").description("About Query").field(fieldDefinition).build()
+                .name("field").type(Scalars.GraphQLString).build()
+        def queryType = GraphQLObjectType.newObject().name("Query").description("About Query\nSecond Line").field(fieldDefinition).build()
         def schema = GraphQLSchema.newSchema().query(queryType).build()
         when:
         def result = new SchemaPrinter().print(schema)
 
         then:
         result == """#About Query
+#Second Line
 type Query {
    field : String
 }
 
 """
+    }
+
+    def "prints field description as comment"() {
+        given:
+        GraphQLFieldDefinition fieldDefinition = GraphQLFieldDefinition.newFieldDefinition()
+                .name("field").description("About field\nsecond").type(Scalars.GraphQLString).build()
+        def queryType = GraphQLObjectType.newObject().name("Query").field(fieldDefinition).build()
+        def schema = GraphQLSchema.newSchema().query(queryType).build()
+        when:
+        def result = new SchemaPrinter().print(schema)
+
+        then:
+        result == """type Query {
+   #About field
+   #second
+   field : String
+}
+
+"""
+
     }
 
 }

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -4,6 +4,7 @@ import graphql.Scalars
 import graphql.TypeResolutionEnvironment
 import graphql.schema.Coercing
 import graphql.schema.GraphQLArgument
+import graphql.schema.GraphQLEnumType
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLList
 import graphql.schema.GraphQLNonNull
@@ -258,6 +259,35 @@ type Query {
    #About field
    #second
    field : String
+}
+
+"""
+
+    }
+
+    def "prints enum description as comment"() {
+        given:
+        GraphQLEnumType graphQLEnumType = GraphQLEnumType.newEnum()
+                .name("Enum")
+                .description("About enum")
+                .value("value", "value", "value desc")
+                .build()
+        GraphQLFieldDefinition fieldDefinition = GraphQLFieldDefinition.newFieldDefinition()
+                .name("field").type(graphQLEnumType).build()
+        def queryType = GraphQLObjectType.newObject().name("Query").field(fieldDefinition).build()
+        def schema = GraphQLSchema.newSchema().query(queryType).build()
+        when:
+        def result = new SchemaPrinter().print(schema)
+
+        then:
+        result == """type Query {
+   field : Enum
+}
+
+#About enum
+enum Enum {
+   #value desc
+   value
 }
 
 """


### PR DESCRIPTION
This addresses #462.

It adds several tests regarding comments as description.

It fixes a bug that input objects were not printed at all.

And it changes the format to not have a space before a colon.


