### PR TITLE
printer improvments

### DIFF
--- a/src/main/java/graphql/introspection/IntrospectionResultToSchema.java
+++ b/src/main/java/graphql/introspection/IntrospectionResultToSchema.java
@@ -40,27 +40,35 @@ public class IntrospectionResultToSchema {
         assertTrue(introspectionResult.get("__schema") != null, "__schema expected");
         Map<String, Object> schema = (Map<String, Object>) introspectionResult.get("__schema");
 
-        SchemaDefinition schemaDefinition = new SchemaDefinition();
 
         Map<String, Object> queryType = (Map<String, Object>) schema.get("queryType");
         assertNotNull(queryType, "queryType expected");
         TypeName query = new TypeName((String) queryType.get("name"));
+        boolean nonDefaultQueryName = !"Query".equals(query.getName());
+
+        SchemaDefinition schemaDefinition = new SchemaDefinition();
         schemaDefinition.getOperationTypeDefinitions().add(new OperationTypeDefinition("query", query));
 
         Map<String, Object> mutationType = (Map<String, Object>) schema.get("mutationType");
+        boolean nonDefaultMutationName = false;
         if (mutationType != null) {
             TypeName mutation = new TypeName((String) mutationType.get("name"));
+            nonDefaultMutationName = !"Mutation".equals(mutation.getName());
             schemaDefinition.getOperationTypeDefinitions().add(new OperationTypeDefinition("mutation", mutation));
         }
 
         Map<String, Object> subscriptionType = (Map<String, Object>) schema.get("subscriptionType");
+        boolean nonDefaultSubscriptionName = false;
         if (subscriptionType != null) {
             TypeName subscription = new TypeName((String) subscriptionType.get("name"));
+            nonDefaultSubscriptionName = !"Subscription".equals(subscription.getName());
             schemaDefinition.getOperationTypeDefinitions().add(new OperationTypeDefinition("subscription", subscription));
         }
 
         Document document = new Document();
-        document.getDefinitions().add(schemaDefinition);
+        if (nonDefaultQueryName || nonDefaultMutationName || nonDefaultSubscriptionName) {
+            document.getDefinitions().add(schemaDefinition);
+        }
 
         List<Map<String, Object>> types = (List<Map<String, Object>>) schema.get("types");
         for (Map<String, Object> type : types) {

--- a/src/main/java/graphql/schema/idl/SchemaPrinter.java
+++ b/src/main/java/graphql/schema/idl/SchemaPrinter.java
@@ -121,7 +121,11 @@ public class SchemaPrinter {
         printType(out, typesAsList, GraphQLScalarType.class);
         printType(out, typesAsList, GraphQLInputObjectType.class);
 
-        return sw.toString();
+        String result = sw.toString();
+        if (result.endsWith("\n\n")) {
+            result = result.substring(0, result.length() - 1);
+        }
+        return result;
     }
 
     private interface TypePrinter<T> {
@@ -154,8 +158,8 @@ public class SchemaPrinter {
             printComments(out, type, "");
             out.format("enum %s {\n", type.getName());
             for (GraphQLEnumValueDefinition enumValueDefinition : type.getValues()) {
-                printComments(out, enumValueDefinition, "   ");
-                out.format("   %s\n", enumValueDefinition.getName());
+                printComments(out, enumValueDefinition, "  ");
+                out.format("  %s\n", enumValueDefinition.getName());
             }
             out.format("}\n\n");
         };
@@ -169,8 +173,8 @@ public class SchemaPrinter {
             printComments(out, type, "");
             out.format("interface %s {\n", type.getName());
             type.getFieldDefinitions().forEach(fd -> {
-                printComments(out, fd, "   ");
-                out.format("   %s%s: %s\n",
+                printComments(out, fd, "  ");
+                out.format("  %s%s: %s\n",
                         fd.getName(), argsString(fd.getArguments()), typeString(fd.getType()));
             });
             out.format("}\n\n");
@@ -205,8 +209,8 @@ public class SchemaPrinter {
             printComments(out, type, "");
             out.format("type %s {\n", type.getName());
             type.getFieldDefinitions().forEach(fd -> {
-                printComments(out, fd, "   ");
-                out.format("   %s%s: %s\n",
+                printComments(out, fd, "  ");
+                out.format("  %s%s: %s\n",
                         fd.getName(), argsString(fd.getArguments()), typeString(fd.getType()));
             });
             out.format("}\n\n");
@@ -222,8 +226,8 @@ public class SchemaPrinter {
             printComments(out, type, "");
             out.format("input %s {\n", type.getName());
             type.getFieldDefinitions().forEach(fd -> {
-                printComments(out, fd, "   ");
-                out.format("   %s: %s\n",
+                printComments(out, fd, "  ");
+                out.format("  %s: %s\n",
                         fd.getName(), typeString(fd.getType()));
             });
             out.format("}\n\n");
@@ -254,13 +258,13 @@ public class SchemaPrinter {
             if (needsSchemaPrinted) {
                 out.format("schema {\n");
                 if (queryType != null) {
-                    out.format("   query: %s\n", queryType.getName());
+                    out.format("  query: %s\n", queryType.getName());
                 }
                 if (mutationType != null) {
-                    out.format("   mutation: %s\n", mutationType.getName());
+                    out.format("  mutation: %s\n", mutationType.getName());
                 }
                 if (subscriptionType != null) {
-                    out.format("   subscription: %s\n", subscriptionType.getName());
+                    out.format("  subscription: %s\n", subscriptionType.getName());
                 }
                 out.format("}\n\n");
             }
@@ -294,7 +298,7 @@ public class SchemaPrinter {
 
     String argsString(List<GraphQLArgument> arguments) {
         boolean hasDescriptions = arguments.stream().filter(arg -> arg.getDescription() != null).count() > 0;
-        String prefix = hasDescriptions ? "   " : "";
+        String prefix = hasDescriptions ? "  " : "";
         int count = 0;
         StringBuilder sb = new StringBuilder();
         for (GraphQLArgument argument : arguments) {
@@ -309,7 +313,7 @@ public class SchemaPrinter {
             String description = argument.getDescription();
             if (description != null) {
                 Stream<String> stream = Arrays.stream(description.split("\n"));
-                stream.map(s -> "   #" + s + "\n").forEach(sb::append);
+                stream.map(s -> "  #" + s + "\n").forEach(sb::append);
             }
             sb.append(prefix + argument.getName()).append(": ").append(typeString(argument.getType()));
             Object defaultValue = argument.getDefaultValue();

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -119,10 +119,10 @@ class SchemaPrinterTest extends Specification {
         expect:
         result ==
                 """interface Character {
-   id: ID!
-   name: String!
-   friends: [Character]
-   appearsIn: [Episode]!
+  id: ID!
+  name: String!
+  friends: [Character]
+  appearsIn: [Episode]!
 }
 
 """
@@ -167,7 +167,6 @@ class SchemaPrinterTest extends Specification {
             type Subscription {
                 field: String
             }
-            
         """)
 
 
@@ -175,17 +174,16 @@ class SchemaPrinterTest extends Specification {
 
         expect:
         result == """type Mutation {
-   field: String
+  field: String
 }
 
 type Query {
-   field: String
+  field: String
 }
 
 type Subscription {
-   field: String
+  field: String
 }
-
 """
     }
 
@@ -216,23 +214,22 @@ type Subscription {
 
         expect:
         result == """schema {
-   query: Query
-   mutation: MutationX
-   subscription: Subscription
+  query: Query
+  mutation: MutationX
+  subscription: Subscription
 }
 
 type MutationX {
-   field: String
+  field: String
 }
 
 type Query {
-   field: String
+  field: String
 }
 
 type Subscription {
-   field: String
+  field: String
 }
-
 """
     }
 
@@ -249,9 +246,8 @@ type Subscription {
         result == """#About Query
 #Second Line
 type Query {
-   field: String
+  field: String
 }
-
 """
     }
 
@@ -266,11 +262,10 @@ type Query {
 
         then:
         result == """type Query {
-   #About field
-   #second
-   field: String
+  #About field
+  #second
+  field: String
 }
-
 """
 
     }
@@ -291,15 +286,14 @@ type Query {
 
         then:
         result == """type Query {
-   field: Enum
+  field: Enum
 }
 
 #About enum
 enum Enum {
-   #value desc
-   value
+  #value desc
+  value
 }
-
 """
 
     }
@@ -327,13 +321,12 @@ enum Enum {
 union Union = PossibleType
 
 type PossibleType {
-   field: String
+  field: String
 }
 
 type Query {
-   field: Union
+  field: Union
 }
-
 """
 
     }
@@ -362,17 +355,16 @@ type Query {
         result == """union Union = PossibleType1 | PossibleType2
 
 type PossibleType1 {
-   field: String
+  field: String
 }
 
 type PossibleType2 {
-   field: String
+  field: String
 }
 
 type Query {
-   field: Union
+  field: Union
 }
-
 """
 
     }
@@ -395,15 +387,14 @@ type Query {
 
         then:
         result == """type Query {
-   field(arg: Input): String
+  field(arg: Input): String
 }
 
 #About input
 input Input {
-   #about field
-   field: String
+  #about field
+  field: String
 }
-
 """
 
     }
@@ -426,14 +417,13 @@ input Input {
         then:
         result == """#about interface
 interface Interface {
-   #about field
-   field: String
+  #about field
+  field: String
 }
 
 type Query {
-   field: Interface
+  field: Interface
 }
-
 """
     }
 
@@ -464,12 +454,11 @@ type Query {
 
         then:
         result == """type Query {
-   field: Scalar
+  field: Scalar
 }
 
 #about scalar
 scalar Scalar
-
 """
     }
 
@@ -487,16 +476,15 @@ scalar Scalar
 
         then:
         result == """type Query {
-   field(
-   #about arg1
-   arg1: String, 
-   arg2: String, 
-   #about 3
-   #second line
-   arg3: String
-   ): String
+  field(
+  #about arg1
+  arg1: String, 
+  arg2: String, 
+  #about 3
+  #second line
+  arg3: String
+  ): String
 }
-
 """
 
     }


### PR DESCRIPTION
aligns schema printer and AstPrinter regarding indention and new lines

adds test which completes a full round trip with SchemaPrinter,
Introspection and AstPrinter

changes IntrospectionResultToSchema to only create a SchemaDefinition
if needed because non default names are used