### PR TITLE
Coercing exception handling

### DIFF
--- a/src/main/java/graphql/Scalars.java
+++ b/src/main/java/graphql/Scalars.java
@@ -6,10 +6,14 @@ import graphql.language.FloatValue;
 import graphql.language.IntValue;
 import graphql.language.StringValue;
 import graphql.schema.Coercing;
+import graphql.schema.CoercingParseValueException;
+import graphql.schema.CoercingSerializeException;
 import graphql.schema.GraphQLScalarType;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+
+import static graphql.Assert.assertShouldNeverHappen;
 
 public class Scalars {
 
@@ -35,8 +39,8 @@ public class Scalars {
 
     public static GraphQLScalarType GraphQLInt = new GraphQLScalarType("Int", "Built-in Int", new Coercing<Integer, Integer>() {
 
-        @Override
-        public Integer serialize(Object input) {
+
+        private Integer convertImpl(Object input) {
             if (input instanceof Integer) {
                 return (Integer) input;
             } else if (isNumberIsh(input)) {
@@ -44,21 +48,34 @@ public class Scalars {
                 try {
                     value = new BigDecimal(input.toString());
                 } catch (NumberFormatException e) {
-                    throw new GraphQLException("Invalid input " + input + " for Int");
+                    return null;
                 }
                 try {
                     return value.intValueExact();
                 } catch (ArithmeticException e) {
-                    throw new GraphQLException("Invalid input " + input + " for Int");
+                    return null;
                 }
             } else {
-                throw new GraphQLException("Invalid input " + input + " for Int");
+                return null;
             }
         }
 
         @Override
+        public Integer serialize(Object input) {
+            Integer result = convertImpl(input);
+            if (result == null) {
+                throw new CoercingSerializeException("Invalid value " + input + " for Int");
+            }
+            return result;
+        }
+
+        @Override
         public Integer parseValue(Object input) {
-            return serialize(input);
+            Integer result = convertImpl(input);
+            if (result == null) {
+                throw new CoercingParseValueException("Invalid value " + input + " for Int");
+            }
+            return result;
         }
 
         @Override
@@ -73,8 +90,7 @@ public class Scalars {
     });
 
     public static GraphQLScalarType GraphQLLong = new GraphQLScalarType("Long", "Long type", new Coercing<Long, Long>() {
-        @Override
-        public Long serialize(Object input) {
+        private Long convertImpl(Object input) {
             if (input instanceof Long) {
                 return (Long) input;
             } else if (isNumberIsh(input)) {
@@ -82,21 +98,35 @@ public class Scalars {
                 try {
                     value = new BigDecimal(input.toString());
                 } catch (NumberFormatException e) {
-                    throw new GraphQLException("Invalid input " + input + " for Long");
+                    return null;
                 }
                 try {
                     return value.longValueExact();
                 } catch (ArithmeticException e) {
-                    throw new GraphQLException("Invalid input " + input + " for Long");
+                    return null;
                 }
             } else {
-                throw new GraphQLException("Invalid input " + input + " for Int");
+                return null;
             }
+
+        }
+
+        @Override
+        public Long serialize(Object input) {
+            Long result = convertImpl(input);
+            if (result == null) {
+                throw new CoercingSerializeException("Invalid input " + input + " for Long");
+            }
+            return result;
         }
 
         @Override
         public Long parseValue(Object input) {
-            return serialize(input);
+            Long result = convertImpl(input);
+            if (result == null) {
+                throw new CoercingParseValueException("Invalid input " + input + " for Long");
+            }
+            return result;
         }
 
         @Override
@@ -119,8 +149,8 @@ public class Scalars {
     });
 
     public static GraphQLScalarType GraphQLShort = new GraphQLScalarType("Short", "Built-in Short as Int", new Coercing<Short, Short>() {
-        @Override
-        public Short serialize(Object input) {
+
+        private Short convertImpl(Object input) {
             if (input instanceof Short) {
                 return (Short) input;
             } else if (isNumberIsh(input)) {
@@ -128,21 +158,35 @@ public class Scalars {
                 try {
                     value = new BigDecimal(input.toString());
                 } catch (NumberFormatException e) {
-                    throw new GraphQLException("Invalid input " + input + " for Short");
+                    return null;
                 }
                 try {
                     return value.shortValueExact();
                 } catch (ArithmeticException e) {
-                    throw new GraphQLException("Invalid input " + input + " for Short");
+                    return null;
                 }
             } else {
-                throw new GraphQLException("Invalid input " + input + " for Short");
+                return null;
             }
+
+        }
+
+        @Override
+        public Short serialize(Object input) {
+            Short result = convertImpl(input);
+            if (result == null) {
+                throw new CoercingSerializeException("Invalid input " + input + " for Short");
+            }
+            return result;
         }
 
         @Override
         public Short parseValue(Object input) {
-            return serialize(input);
+            Short result = convertImpl(input);
+            if (result == null) {
+                throw new CoercingParseValueException("Invalid input " + input + " for Short");
+            }
+            return result;
         }
 
         @Override
@@ -157,8 +201,7 @@ public class Scalars {
     });
 
     public static GraphQLScalarType GraphQLByte = new GraphQLScalarType("Byte", "Built-in Byte as Int", new Coercing<Byte, Byte>() {
-        @Override
-        public Byte serialize(Object input) {
+        private Byte convertImpl(Object input) {
             if (input instanceof Byte) {
                 return (Byte) input;
             } else if (isNumberIsh(input)) {
@@ -166,21 +209,35 @@ public class Scalars {
                 try {
                     value = new BigDecimal(input.toString());
                 } catch (NumberFormatException e) {
-                    throw new GraphQLException("Invalid input " + input + " for Byte");
+                    return null;
                 }
                 try {
                     return value.byteValueExact();
                 } catch (ArithmeticException e) {
-                    throw new GraphQLException("Invalid input " + input + " for Byte");
+                    return null;
                 }
             } else {
-                throw new GraphQLException("Invalid input " + input + " for Byte");
+                return null;
             }
+
+        }
+
+        @Override
+        public Byte serialize(Object input) {
+            Byte result = convertImpl(input);
+            if (result == null) {
+                throw new CoercingSerializeException("Invalid input " + input + " for Byte");
+            }
+            return result;
         }
 
         @Override
         public Byte parseValue(Object input) {
-            return serialize(input);
+            Byte result = convertImpl(input);
+            if (result == null) {
+                throw new CoercingParseValueException("Invalid input " + input + " for Byte");
+            }
+            return result;
         }
 
         @Override
@@ -199,24 +256,39 @@ public class Scalars {
      * Note: The Float type in GraphQL is equivalent to Double in Java. (double precision IEEE 754)
      */
     public static GraphQLScalarType GraphQLFloat = new GraphQLScalarType("Float", "Built-in Float", new Coercing<Double, Double>() {
-        @Override
-        public Double serialize(Object input) {
+
+        private Double convertImpl(Object input) {
             if (isNumberIsh(input)) {
                 BigDecimal value;
                 try {
                     value = new BigDecimal(input.toString());
                 } catch (NumberFormatException e) {
-                    throw new GraphQLException("Invalid input " + input + " for Byte");
+                    return null;
                 }
                 return value.doubleValue();
             } else {
-                throw new GraphQLException("Invalid input " + input + " for Byte");
+                return null;
             }
+
+        }
+
+        @Override
+        public Double serialize(Object input) {
+            Double result = convertImpl(input);
+            if (result == null) {
+                throw new CoercingSerializeException("Invalid input " + input + " for Byte");
+            }
+            return result;
+
         }
 
         @Override
         public Double parseValue(Object input) {
-            return serialize(input);
+            Double result = convertImpl(input);
+            if (result == null) {
+                throw new CoercingParseValueException("Invalid input " + input + " for Byte");
+            }
+            return result;
         }
 
         @Override
@@ -232,27 +304,41 @@ public class Scalars {
     });
 
     public static GraphQLScalarType GraphQLBigInteger = new GraphQLScalarType("BigInteger", "Built-in java.math.BigInteger", new Coercing<BigInteger, BigInteger>() {
-        @Override
-        public BigInteger serialize(Object input) {
+
+        private BigInteger convertImpl(Object input) {
             if (isNumberIsh(input)) {
                 BigDecimal value;
                 try {
                     value = new BigDecimal(input.toString());
                 } catch (NumberFormatException e) {
-                    throw new GraphQLException("Invalid input " + input + " for BigDecimal");
+                    return null;
                 }
                 try {
                     return value.toBigIntegerExact();
                 } catch (ArithmeticException e) {
-                    throw new GraphQLException("Invalid input " + input + " for BigDecimal");
+                    return null;
                 }
             }
-            throw new GraphQLException("Invalid input " + input + " for BigDecimal");
+            return null;
+
+        }
+
+        @Override
+        public BigInteger serialize(Object input) {
+            BigInteger result = convertImpl(input);
+            if (result == null) {
+                throw new CoercingSerializeException("Invalid input " + input + " for BigDecimal");
+            }
+            return result;
         }
 
         @Override
         public BigInteger parseValue(Object input) {
-            return serialize(input);
+            BigInteger result = convertImpl(input);
+            if (result == null) {
+                throw new CoercingParseValueException("Invalid input " + input + " for BigDecimal");
+            }
+            return result;
         }
 
         @Override
@@ -277,21 +363,35 @@ public class Scalars {
     });
 
     public static GraphQLScalarType GraphQLBigDecimal = new GraphQLScalarType("BigDecimal", "Built-in java.math.BigDecimal", new Coercing<BigDecimal, BigDecimal>() {
-        @Override
-        public BigDecimal serialize(Object input) {
+
+        private BigDecimal convertImpl(Object input) {
             if (isNumberIsh(input)) {
                 try {
                     return new BigDecimal(input.toString());
                 } catch (NumberFormatException e) {
-                    throw new GraphQLException("Invalid input " + input + " for BigDecimal");
+                    return null;
                 }
             }
-            throw new GraphQLException("Invalid input " + input + " for BigDecimal");
+            return null;
+
+        }
+
+        @Override
+        public BigDecimal serialize(Object input) {
+            BigDecimal result = convertImpl(input);
+            if (result == null) {
+                throw new CoercingSerializeException("Invalid input " + input + " for BigDecimal");
+            }
+            return result;
         }
 
         @Override
         public BigDecimal parseValue(Object input) {
-            return serialize(input);
+            BigDecimal result = convertImpl(input);
+            if (result == null) {
+                throw new CoercingParseValueException("Invalid input " + input + " for BigDecimal");
+            }
+            return result;
         }
 
         @Override
@@ -332,8 +432,8 @@ public class Scalars {
 
 
     public static GraphQLScalarType GraphQLBoolean = new GraphQLScalarType("Boolean", "Built-in Boolean", new Coercing<Boolean, Boolean>() {
-        @Override
-        public Boolean serialize(Object input) {
+
+        private Boolean convertImpl(Object input) {
             if (input instanceof Boolean) {
                 return (Boolean) input;
             } else if (input instanceof String) {
@@ -344,17 +444,31 @@ public class Scalars {
                     value = new BigDecimal(input.toString());
                 } catch (NumberFormatException e) {
                     // this should never happen because String is handled above
-                    throw new GraphQLException("Invalid input " + input + " for Boolean");
+                    return assertShouldNeverHappen();
                 }
                 return value.compareTo(BigDecimal.ZERO) != 0;
             } else {
-                throw new GraphQLException("Invalid input " + input + " for Boolean");
+                return null;
             }
+
+        }
+
+        @Override
+        public Boolean serialize(Object input) {
+            Boolean result = convertImpl(input);
+            if (result == null) {
+                throw new CoercingSerializeException("Invalid input " + input + " for Boolean");
+            }
+            return result;
         }
 
         @Override
         public Boolean parseValue(Object input) {
-            return serialize(input);
+            Boolean result = convertImpl(input);
+            if (result == null) {
+                throw new CoercingParseValueException("Invalid input " + input + " for Boolean");
+            }
+            return result;
         }
 
         @Override
@@ -366,20 +480,33 @@ public class Scalars {
 
 
     public static GraphQLScalarType GraphQLID = new GraphQLScalarType("ID", "Built-in ID", new Coercing<Object, Object>() {
-        @Override
-        public String serialize(Object input) {
+        private String convertImpl(Object input) {
             if (input instanceof String) {
                 return (String) input;
             }
             if (input instanceof Integer) {
                 return String.valueOf(input);
             }
-            throw new GraphQLException("Invalid input " + input + " for ID");
+            return null;
+
+        }
+
+        @Override
+        public String serialize(Object input) {
+            String result = convertImpl(input);
+            if (result == null) {
+                throw new CoercingSerializeException("Invalid input " + input + " for ID");
+            }
+            return result;
         }
 
         @Override
         public String parseValue(Object input) {
-            return serialize(input);
+            String result = convertImpl(input);
+            if (result == null) {
+                throw new CoercingParseValueException("Invalid input " + input + " for ID");
+            }
+            return result;
         }
 
         @Override
@@ -396,20 +523,34 @@ public class Scalars {
 
 
     public static GraphQLScalarType GraphQLChar = new GraphQLScalarType("Char", "Built-in Char as Character", new Coercing<Character, Character>() {
-        @Override
-        public Character serialize(Object input) {
+
+        private Character convertImpl(Object input) {
             if (input instanceof String && ((String) input).length() == 1) {
                 return ((String) input).charAt(0);
             } else if (input instanceof Character) {
                 return (Character) input;
             } else {
-                throw new GraphQLException("Invalid input " + input + " for Char");
+                return null;
             }
+
+        }
+
+        @Override
+        public Character serialize(Object input) {
+            Character result = convertImpl(input);
+            if (result == null) {
+                throw new CoercingSerializeException("Invalid input " + input + " for Char");
+            }
+            return result;
         }
 
         @Override
         public Character parseValue(Object input) {
-            return serialize(input);
+            Character result = convertImpl(input);
+            if (result == null) {
+                throw new CoercingParseValueException("Invalid input " + input + " for Char");
+            }
+            return result;
         }
 
         @Override

--- a/src/main/java/graphql/SerializationError.java
+++ b/src/main/java/graphql/SerializationError.java
@@ -1,0 +1,54 @@
+package graphql;
+
+
+import graphql.language.SourceLocation;
+import graphql.schema.CoercingSerializeException;
+
+import java.util.List;
+
+@PublicApi
+public class SerializationError implements GraphQLError {
+
+    private final CoercingSerializeException exception;
+
+    public SerializationError(CoercingSerializeException exception) {
+        this.exception = exception;
+    }
+
+    public CoercingSerializeException getException() {
+        return exception;
+    }
+
+
+    @Override
+    public String getMessage() {
+        return "Can't serialize value: " + exception.getMessage();
+    }
+
+    @Override
+    public List<SourceLocation> getLocations() {
+        return null;
+    }
+
+    @Override
+    public ErrorType getErrorType() {
+        return ErrorType.DataFetchingException;
+    }
+
+    @Override
+    public String toString() {
+        return "ExceptionWhileDataFetching{" +
+                "exception=" + exception +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return Helper.equals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return Helper.hashCode(this);
+    }
+}

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -145,7 +145,7 @@ public abstract class ExecutionStrategy {
         } else if (fieldType instanceof GraphQLScalarType) {
             return completeValueForScalar((GraphQLScalarType) fieldType, parameters, result, executionContext);
         } else if (fieldType instanceof GraphQLEnumType) {
-            return completeValueForEnum((GraphQLEnumType) fieldType, parameters, result);
+            return completeValueForEnum((GraphQLEnumType) fieldType, parameters, result, executionContext);
         }
 
 
@@ -221,8 +221,14 @@ public abstract class ExecutionStrategy {
         return result;
     }
 
-    protected ExecutionResult completeValueForEnum(GraphQLEnumType enumType, ExecutionStrategyParameters parameters, Object result) {
-        Object serialized = enumType.getCoercing().serialize(result);
+    protected ExecutionResult completeValueForEnum(GraphQLEnumType enumType, ExecutionStrategyParameters parameters, Object result, ExecutionContext context) {
+        Object serialized;
+        try {
+            serialized = enumType.getCoercing().serialize(result);
+        } catch (CoercingSerializeException e) {
+            context.addError(new SerializationError(e));
+            serialized = null;
+        }
         serialized = parameters.nonNullFieldValidator().validate(serialized);
         return new ExecutionResultImpl(serialized, null);
     }

--- a/src/main/java/graphql/schema/Coercing.java
+++ b/src/main/java/graphql/schema/Coercing.java
@@ -10,24 +10,23 @@ public interface Coercing<I, O> {
     /**
      * Called to convert a result of a DataFetcher to a valid runtime value.
      *
-     * @param input is never null
+     * @param dataFetcherResult is never null
      * @return never null
-     * @throws graphql.GraphQLException if value input can't be serialized
+     * @throws graphql.schema.CoercingSerializeException if value input can't be serialized
      */
-    O serialize(Object input);
+    O serialize(Object dataFetcherResult);
 
     /**
      * Called to resolve a input from a variable.
-     * Null if not possible.
      *
      * @param input is never null
      * @return never null
-     * @throws graphql.GraphQLException if value input can't be serialized
+     * @throws graphql.schema.CoercingParseValueException if value input can't be parsed
      */
     I parseValue(Object input);
 
     /**
-     * Called to convert a AST node
+     * Called to convert an input AST node
      *
      * @param input is never null
      * @return A null value indicates that the literal is not valid. See {@link graphql.validation.ValidationUtil#isValidLiteralValue}

--- a/src/main/java/graphql/schema/CoercingParseValueException.java
+++ b/src/main/java/graphql/schema/CoercingParseValueException.java
@@ -1,0 +1,21 @@
+package graphql.schema;
+
+import graphql.GraphQLException;
+
+public class CoercingParseValueException extends GraphQLException {
+
+    public CoercingParseValueException() {
+    }
+
+    public CoercingParseValueException(String message) {
+        super(message);
+    }
+
+    public CoercingParseValueException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public CoercingParseValueException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/graphql/schema/CoercingSerializeException.java
+++ b/src/main/java/graphql/schema/CoercingSerializeException.java
@@ -1,0 +1,21 @@
+package graphql.schema;
+
+import graphql.GraphQLException;
+
+public class CoercingSerializeException extends GraphQLException {
+
+    public CoercingSerializeException() {
+    }
+
+    public CoercingSerializeException(String message) {
+        super(message);
+    }
+
+    public CoercingSerializeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public CoercingSerializeException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/graphql/schema/GraphQLEnumType.java
+++ b/src/main/java/graphql/schema/GraphQLEnumType.java
@@ -2,7 +2,6 @@ package graphql.schema;
 
 
 import graphql.AssertException;
-import graphql.GraphQLException;
 import graphql.Internal;
 import graphql.PublicApi;
 import graphql.language.EnumTypeDefinition;
@@ -80,14 +79,14 @@ public class GraphQLEnumType implements GraphQLType, GraphQLInputType, GraphQLOu
     private Object getValueByName(Object value) {
         GraphQLEnumValueDefinition enumValueDefinition = valueDefinitionMap.get(value.toString());
         if (enumValueDefinition != null) return enumValueDefinition.getValue();
-        throw new GraphQLException("Invalid input for Enum '" + name + "'. No value found for name " + value.toString());
+        throw new CoercingParseValueException("Invalid input for Enum '" + name + "'. No value found for name '" + value.toString() + "'");
     }
 
     private Object getNameByValue(Object value) {
         for (GraphQLEnumValueDefinition valueDefinition : valueDefinitionMap.values()) {
             if (value.equals(valueDefinition.getValue())) return valueDefinition.getName();
         }
-        throw new GraphQLException("Invalid input for Enum '" + name + "'. Unknown value " + value);
+        throw new CoercingSerializeException("Invalid input for Enum '" + name + "'. Unknown value '" + value + "'");
     }
 
 

--- a/src/test/groovy/graphql/ScalarsBigDecimalTest.groovy
+++ b/src/test/groovy/graphql/ScalarsBigDecimalTest.groovy
@@ -4,6 +4,8 @@ import graphql.language.BooleanValue
 import graphql.language.FloatValue
 import graphql.language.IntValue
 import graphql.language.StringValue
+import graphql.schema.CoercingParseValueException
+import graphql.schema.CoercingSerializeException
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -59,20 +61,11 @@ class ScalarsBigDecimalTest extends Specification {
     }
 
     @Unroll
-    def "serialize/parseValue throws exception for invalid input #value"() {
-        expect:
-        try {
-            Scalars.GraphQLBigDecimal.getCoercing().serialize(value)
-            assert false: "no exception thrown"
-        } catch (GraphQLException e) {
-            // expected
-        }
-        try {
-            Scalars.GraphQLBigDecimal.getCoercing().parseValue(value)
-            assert false: "no exception thrown"
-        } catch (GraphQLException e) {
-            // expected
-        }
+    def "serialize throws exception for invalid input #value"() {
+        when:
+        Scalars.GraphQLBigDecimal.getCoercing().serialize(value)
+        then:
+        thrown(CoercingSerializeException)
 
         where:
         value           | _
@@ -81,5 +74,18 @@ class ScalarsBigDecimalTest extends Specification {
         new Object()    | _
     }
 
+    @Unroll
+    def "parseValue throws exception for invalid input #value"() {
+        when:
+        Scalars.GraphQLBigDecimal.getCoercing().parseValue(value)
+        then:
+        thrown(CoercingParseValueException)
+
+        where:
+        value           | _
+        ""              | _
+        "not a number " | _
+        new Object()    | _
+    }
 
 }

--- a/src/test/groovy/graphql/ScalarsBigIntegerTest.groovy
+++ b/src/test/groovy/graphql/ScalarsBigIntegerTest.groovy
@@ -4,6 +4,8 @@ import graphql.language.BooleanValue
 import graphql.language.FloatValue
 import graphql.language.IntValue
 import graphql.language.StringValue
+import graphql.schema.CoercingParseValueException
+import graphql.schema.CoercingSerializeException
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -56,20 +58,11 @@ class ScalarsBigIntegerTest extends Specification {
     }
 
     @Unroll
-    def "serialize/parseValue throws exception for invalid input #value"() {
-        expect:
-        try {
-            Scalars.GraphQLBigInteger.getCoercing().serialize(value)
-            assert false: "no exception thrown"
-        } catch (GraphQLException e) {
-            // expected
-        }
-        try {
-            Scalars.GraphQLBigInteger.getCoercing().parseValue(value)
-            assert false: "no exception thrown"
-        } catch (GraphQLException e) {
-            // expected
-        }
+    def "serialize throws exception for invalid input #value"() {
+        when:
+        Scalars.GraphQLBigInteger.getCoercing().serialize(value)
+        then:
+        thrown(CoercingSerializeException)
 
         where:
         value                   | _
@@ -80,5 +73,20 @@ class ScalarsBigIntegerTest extends Specification {
         new Object()            | _
     }
 
+    @Unroll
+    def "parseValue throws exception for invalid input #value"() {
+        when:
+        Scalars.GraphQLBigInteger.getCoercing().parseValue(value)
+        then:
+        thrown(CoercingParseValueException)
+
+        where:
+        value                   | _
+        ""                      | _
+        "not a number "         | _
+        new BigDecimal("12.12") | _
+        "12.12"                 | _
+        new Object()            | _
+    }
 
 }

--- a/src/test/groovy/graphql/ScalarsBooleanTest.groovy
+++ b/src/test/groovy/graphql/ScalarsBooleanTest.groovy
@@ -4,6 +4,8 @@ import graphql.language.BooleanValue
 import graphql.language.FloatValue
 import graphql.language.IntValue
 import graphql.language.StringValue
+import graphql.schema.CoercingParseValueException
+import graphql.schema.CoercingSerializeException
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -58,25 +60,27 @@ class ScalarsBooleanTest extends Specification {
     }
 
     @Unroll
-    def "serialize/parseValue throws exception for invalid input #value"() {
-        expect:
-        try {
-            Scalars.GraphQLBoolean.getCoercing().serialize(value)
-            assert false: "no exception thrown"
-        } catch (GraphQLException e) {
-            // expected
-        }
-        try {
-            Scalars.GraphQLBoolean.getCoercing().parseValue(value)
-            assert false: "no exception thrown"
-        } catch (GraphQLException e) {
-            // expected
-        }
+    def "serialize throws exception for invalid input #value"() {
+        when:
+        Scalars.GraphQLBoolean.getCoercing().serialize(value)
+        then:
+        thrown(CoercingSerializeException)
 
         where:
         value        | _
         new Object() | _
     }
 
+    @Unroll
+    def "parseValue throws exception for invalid input #value"() {
+        when:
+        Scalars.GraphQLBoolean.getCoercing().parseValue(value)
+        then:
+        thrown(CoercingParseValueException)
+
+        where:
+        value        | _
+        new Object() | _
+    }
 
 }

--- a/src/test/groovy/graphql/ScalarsByteTest.groovy
+++ b/src/test/groovy/graphql/ScalarsByteTest.groovy
@@ -3,6 +3,8 @@ package graphql
 import graphql.language.FloatValue
 import graphql.language.IntValue
 import graphql.language.StringValue
+import graphql.schema.CoercingParseValueException
+import graphql.schema.CoercingSerializeException
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -66,20 +68,11 @@ class ScalarsByteTest extends Specification {
     }
 
     @Unroll
-    def "serialize/parseValue throws exception for invalid input #value"() {
-        expect:
-        try {
-            Scalars.GraphQLByte.getCoercing().serialize(value)
-            assert false: "no exception thrown"
-        } catch (GraphQLException e) {
-            // expected
-        }
-        try {
-            Scalars.GraphQLByte.getCoercing().parseValue(value)
-            assert false: "no exception thrown"
-        } catch (GraphQLException e) {
-            // expected
-        }
+    def "serialize throws exception for invalid input #value"() {
+        when:
+        Scalars.GraphQLByte.getCoercing().serialize(value)
+        then:
+        thrown(CoercingSerializeException)
 
         where:
         value                        | _
@@ -95,5 +88,25 @@ class ScalarsByteTest extends Specification {
 
     }
 
+    @Unroll
+    def "parseValue throws exception for invalid input #value"() {
+        when:
+        Scalars.GraphQLByte.getCoercing().parseValue(value)
+        then:
+        thrown(CoercingParseValueException)
+
+        where:
+        value                        | _
+        ""                           | _
+        "not a number "              | _
+        "42.3"                       | _
+        new Long(42345784398534785l) | _
+        new Double(42.3)             | _
+        new Float(42.3)              | _
+        Byte.MAX_VALUE + 1l          | _
+        Byte.MIN_VALUE - 1l          | _
+        new Object()                 | _
+
+    }
 
 }

--- a/src/test/groovy/graphql/ScalarsCharTest.groovy
+++ b/src/test/groovy/graphql/ScalarsCharTest.groovy
@@ -2,6 +2,8 @@ package graphql
 
 import graphql.language.IntValue
 import graphql.language.StringValue
+import graphql.schema.CoercingParseValueException
+import graphql.schema.CoercingSerializeException
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -43,20 +45,11 @@ class ScalarsCharTest extends Specification {
     }
 
     @Unroll
-    def "serialize/parseValue throws exception for invalid input #value"() {
-        expect:
-        try {
-            Scalars.GraphQLChar.getCoercing().serialize(value)
-            assert false: "no exception thrown"
-        } catch (GraphQLException e) {
-            // expected
-        }
-        try {
-            Scalars.GraphQLChar.getCoercing().parseValue(value)
-            assert false: "no exception thrown"
-        } catch (GraphQLException e) {
-            // expected
-        }
+    def "serialize throws exception for invalid input #value"() {
+        when:
+        Scalars.GraphQLChar.getCoercing().serialize(value)
+        then:
+        thrown(CoercingSerializeException)
 
         where:
         value        | _
@@ -66,5 +59,19 @@ class ScalarsCharTest extends Specification {
 
     }
 
+    @Unroll
+    def "parseValue throws exception for invalid input #value"() {
+        when:
+        Scalars.GraphQLChar.getCoercing().parseValue(value)
+        then:
+        thrown(CoercingParseValueException)
+
+        where:
+        value        | _
+        ""           | _
+        "aa"         | _
+        new Object() | _
+
+    }
 
 }

--- a/src/test/groovy/graphql/ScalarsFloatTest.groovy
+++ b/src/test/groovy/graphql/ScalarsFloatTest.groovy
@@ -4,6 +4,8 @@ import graphql.language.BooleanValue
 import graphql.language.FloatValue
 import graphql.language.IntValue
 import graphql.language.StringValue
+import graphql.schema.CoercingParseValueException
+import graphql.schema.CoercingSerializeException
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -62,20 +64,11 @@ class ScalarsFloatTest extends Specification {
     }
 
     @Unroll
-    def "serialize/parseValue throws exception for invalid input #value"() {
-        expect:
-        try {
-            Scalars.GraphQLFloat.getCoercing().serialize(value)
-            assert false: "no exception thrown"
-        } catch (GraphQLException e) {
-            // expected
-        }
-        try {
-            Scalars.GraphQLFloat.getCoercing().parseValue(value)
-            assert false: "no exception thrown"
-        } catch (GraphQLException e) {
-            // expected
-        }
+    def "serialize throws exception for invalid input #value"() {
+        when:
+        Scalars.GraphQLFloat.getCoercing().serialize(value)
+        then:
+        thrown(CoercingSerializeException)
 
         where:
         value           | _
@@ -84,5 +77,18 @@ class ScalarsFloatTest extends Specification {
         Double.NaN      | _
     }
 
+    @Unroll
+    def "serialize/parseValue throws exception for invalid input #value"() {
+        when:
+        Scalars.GraphQLFloat.getCoercing().parseValue(value)
+        then:
+        thrown(CoercingParseValueException)
+
+        where:
+        value           | _
+        ""              | _
+        "not a number " | _
+        Double.NaN      | _
+    }
 
 }

--- a/src/test/groovy/graphql/ScalarsIDTest.groovy
+++ b/src/test/groovy/graphql/ScalarsIDTest.groovy
@@ -3,6 +3,8 @@ package graphql
 import graphql.language.BooleanValue
 import graphql.language.IntValue
 import graphql.language.StringValue
+import graphql.schema.CoercingParseValueException
+import graphql.schema.CoercingSerializeException
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -43,20 +45,24 @@ class ScalarsIDTest extends Specification {
     }
 
     @Unroll
-    def "serialize/parseValue throws exception for invalid input #value"() {
-        expect:
-        try {
-            Scalars.GraphQLID.getCoercing().serialize(value)
-            assert false: "no exception thrown"
-        } catch (GraphQLException e) {
-            // expected
-        }
-        try {
-            Scalars.GraphQLID.getCoercing().parseValue(value)
-            assert false: "no exception thrown"
-        } catch (GraphQLException e) {
-            // expected
-        }
+    def "serialize throws exception for invalid input #value"() {
+        when:
+        Scalars.GraphQLID.getCoercing().serialize(value)
+        then:
+        thrown(CoercingSerializeException)
+
+        where:
+        value        | _
+        new Object() | _
+
+    }
+
+    @Unroll
+    def "parseValue throws exception for invalid input #value"() {
+        when:
+        Scalars.GraphQLID.getCoercing().parseValue(value)
+        then:
+        thrown(CoercingParseValueException)
 
         where:
         value        | _

--- a/src/test/groovy/graphql/ScalarsIntTest.groovy
+++ b/src/test/groovy/graphql/ScalarsIntTest.groovy
@@ -3,6 +3,8 @@ package graphql
 import graphql.language.FloatValue
 import graphql.language.IntValue
 import graphql.language.StringValue
+import graphql.schema.CoercingParseValueException
+import graphql.schema.CoercingSerializeException
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -66,20 +68,11 @@ class ScalarsIntTest extends Specification {
     }
 
     @Unroll
-    def "serialize/parseValue throws exception for invalid input #value"() {
-        expect:
-        try {
-            Scalars.GraphQLInt.getCoercing().serialize(value)
-            assert false: "no exception thrown"
-        } catch (GraphQLException e) {
-            // expected
-        }
-        try {
-            Scalars.GraphQLInt.getCoercing().parseValue(value)
-            assert false: "no exception thrown"
-        } catch (GraphQLException e) {
-            // expected
-        }
+    def "serialize throws exception for invalid input #value"() {
+        when:
+        Scalars.GraphQLInt.getCoercing().serialize(value)
+        then:
+        thrown(CoercingSerializeException)
 
         where:
         value                        | _
@@ -95,5 +88,26 @@ class ScalarsIntTest extends Specification {
 
     }
 
+    @Unroll
+    def "parsValue throws exception for invalid input #value"() {
+        when:
+        Scalars.GraphQLInt.getCoercing().parseValue(value)
+        then:
+        thrown(CoercingParseValueException)
+
+
+        where:
+        value                        | _
+        ""                           | _
+        "not a number "              | _
+        "42.3"                       | _
+        new Long(42345784398534785l) | _
+        new Double(42.3)             | _
+        new Float(42.3)              | _
+        Integer.MAX_VALUE + 1l       | _
+        Integer.MIN_VALUE - 1l       | _
+        new Object()                 | _
+
+    }
 
 }

--- a/src/test/groovy/graphql/ScalarsLongTest.groovy
+++ b/src/test/groovy/graphql/ScalarsLongTest.groovy
@@ -3,6 +3,8 @@ package graphql
 import graphql.language.FloatValue
 import graphql.language.IntValue
 import graphql.language.StringValue
+import graphql.schema.CoercingParseValueException
+import graphql.schema.CoercingSerializeException
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -72,20 +74,11 @@ class ScalarsLongTest extends Specification {
     }
 
     @Unroll
-    def "serialize/parseValue throws exception for invalid input #value"() {
-        expect:
-        try {
-            Scalars.GraphQLLong.getCoercing().serialize(value)
-            assert false: "no exception thrown"
-        } catch (GraphQLException e) {
-            // expected
-        }
-        try {
-            Scalars.GraphQLLong.getCoercing().parseValue(value)
-            assert false: "no exception thrown"
-        } catch (GraphQLException e) {
-            // expected
-        }
+    def "serialize throws exception for invalid input #value"() {
+        when:
+        Scalars.GraphQLLong.getCoercing().serialize(value)
+        then:
+        thrown(CoercingSerializeException)
 
         where:
         value            | _
@@ -99,5 +92,23 @@ class ScalarsLongTest extends Specification {
         new Object()     | _
     }
 
+    @Unroll
+    def "parseValue throws exception for invalid input #value"() {
+        when:
+        Scalars.GraphQLLong.getCoercing().parseValue(value)
+        then:
+        thrown(CoercingParseValueException)
+
+        where:
+        value            | _
+        ""               | _
+        "not a number "  | _
+        "42.3"           | _
+        new Double(42.3) | _
+        new Float(42.3)  | _
+        tooBig           | _
+        tooSmall         | _
+        new Object()     | _
+    }
 
 }

--- a/src/test/groovy/graphql/ScalarsQueryTest.groovy
+++ b/src/test/groovy/graphql/ScalarsQueryTest.groovy
@@ -106,7 +106,7 @@ class ScalarsQueryTest extends Specification {
         def result = GraphQL.newGraphQL(ScalarsQuerySchema.scalarsQuerySchema).build().execute(query)
         
         then:
-        thrown(GraphQLException)
+        result.errors[0] instanceof SerializationError
 
         where:
         number       | _

--- a/src/test/groovy/graphql/ScalarsShortTest.groovy
+++ b/src/test/groovy/graphql/ScalarsShortTest.groovy
@@ -3,6 +3,8 @@ package graphql
 import graphql.language.FloatValue
 import graphql.language.IntValue
 import graphql.language.StringValue
+import graphql.schema.CoercingParseValueException
+import graphql.schema.CoercingSerializeException
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -65,20 +67,11 @@ class ScalarsShortTest extends Specification {
     }
 
     @Unroll
-    def "serialize/parseValue throws exception for invalid input #value"() {
-        expect:
-        try {
-            Scalars.GraphQLShort.getCoercing().serialize(value)
-            assert false: "no exception thrown"
-        } catch (GraphQLException e) {
-            // expected
-        }
-        try {
-            Scalars.GraphQLShort.getCoercing().parseValue(value)
-            assert false: "no exception thrown"
-        } catch (GraphQLException e) {
-            // expected
-        }
+    def "serialize throws exception for invalid input #value"() {
+        when:
+        Scalars.GraphQLShort.getCoercing().serialize(value)
+        then:
+        thrown(CoercingSerializeException)
 
         where:
         value                        | _
@@ -94,5 +87,25 @@ class ScalarsShortTest extends Specification {
 
     }
 
+    @Unroll
+    def "parseValue throws exception for invalid input #value"() {
+        when:
+        Scalars.GraphQLShort.getCoercing().parseValue(value)
+        then:
+        thrown(CoercingParseValueException)
+
+        where:
+        value                        | _
+        ""                           | _
+        "not a number "              | _
+        "42.3"                       | _
+        new Long(42345784398534785l) | _
+        new Double(42.3)             | _
+        new Float(42.3)              | _
+        Short.MAX_VALUE + 1l         | _
+        Short.MIN_VALUE - 1l         | _
+        new Object()                 | _
+
+    }
 
 }

--- a/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
@@ -5,11 +5,13 @@ import graphql.Scalars
 import graphql.SerializationError
 import graphql.language.Field
 import graphql.schema.Coercing
+import graphql.schema.GraphQLEnumType
 import graphql.schema.GraphQLList
 import graphql.schema.GraphQLScalarType
 import spock.lang.Specification
 
 import static ExecutionStrategyParameters.newParameters
+import static graphql.schema.GraphQLEnumType.newEnum
 import static graphql.schema.GraphQLNonNull.nonNull
 
 @SuppressWarnings("GroovyPointlessBoolean")
@@ -70,7 +72,6 @@ class ExecutionStrategyTest extends Specification {
         executionResult.data == ["test"]
     }
 
-    // this is wrong: we should return null with an error
     def "completing value with serializing throwing exception"() {
         given:
         ExecutionContext executionContext = buildContext()
@@ -78,6 +79,31 @@ class ExecutionStrategyTest extends Specification {
         def typeInfo = TypeInfo.newTypeInfo().type(fieldType).build()
         NonNullableFieldValidator nullableFieldValidator = new NonNullableFieldValidator(executionContext, typeInfo)
         String result = "not a number"
+
+        def parameters = newParameters()
+                .typeInfo(typeInfo)
+                .source(result)
+                .nonNullFieldValidator(nullableFieldValidator)
+                .fields(["dummy": []])
+                .build()
+
+        when:
+        def executionResult = executionStrategy.completeValue(executionContext, parameters, [new Field()])
+
+        then:
+        executionResult.data == null
+        executionContext.errors.size() == 1
+        executionContext.errors[0] instanceof SerializationError
+
+    }
+
+    def "completing enum with serializing throwing exception"() {
+        given:
+        ExecutionContext executionContext = buildContext()
+        GraphQLEnumType enumType = newEnum().name("Enum").value("value").build()
+        def typeInfo = TypeInfo.newTypeInfo().type(enumType).build()
+        NonNullableFieldValidator nullableFieldValidator = new NonNullableFieldValidator(executionContext, typeInfo)
+        String result = "not a enum number"
 
         def parameters = newParameters()
                 .typeInfo(typeInfo)

--- a/src/test/groovy/graphql/schema/GraphQLEnumTypeTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLEnumTypeTest.groovy
@@ -1,7 +1,6 @@
 package graphql.schema
 
 import graphql.AssertException
-import graphql.GraphQLException
 import graphql.language.EnumValue
 import graphql.language.StringValue
 import spock.lang.Specification
@@ -23,7 +22,7 @@ class GraphQLEnumTypeTest extends Specification {
         enumType.getCoercing().parseValue("UNKNOWN")
 
         then:
-        thrown(GraphQLException)
+        thrown(CoercingParseValueException)
     }
 
 
@@ -41,7 +40,7 @@ class GraphQLEnumTypeTest extends Specification {
         when:
         enumType.getCoercing().serialize(12)
         then:
-        thrown(GraphQLException)
+        thrown(CoercingSerializeException)
     }
 
 


### PR DESCRIPTION
This PR introduces two different GraphQLException for Coercing serialize/parseValue.

It handles enum values serialization and scalars serialization correctly by catching the exception, adding an Error and setting the value to null.

It is a breaking change, because some protected methods ins `ExecutionStrategy` are changed including the logic (not sure if the logic changes classifie as bug fix or not)

