### PR TITLE
Use chaining for all Builder parameters

### DIFF
--- a/src/main/java/graphql/execution/ExecutionContextBuilder.java
+++ b/src/main/java/graphql/execution/ExecutionContextBuilder.java
@@ -18,19 +18,77 @@ public class ExecutionContextBuilder {
     private ValuesResolver valuesResolver;
     private Instrumentation instrumentation;
     private ExecutionId executionId;
+    private GraphQLSchema graphQLSchema;
+    private ExecutionStrategy queryStrategy;
+    private ExecutionStrategy mutationStrategy;
+    private ExecutionStrategy subscriptionStrategy;
+    private Object context;
+    private Object root;
+    private Document document;
+    private String operationName;
+    private Map<String, Object> variables;
 
-    public ExecutionContextBuilder(ValuesResolver valuesResolver, Instrumentation instrumentation) {
+    public ExecutionContextBuilder valuesResolver(ValuesResolver valuesResolver) {
         this.valuesResolver = valuesResolver;
-        this.instrumentation = instrumentation;
+        return this;
     }
 
+    public ExecutionContextBuilder instrumentation(Instrumentation instrumentation) {
+        this.instrumentation = instrumentation;
+        return this;
+    }
 
     public ExecutionContextBuilder executionId(ExecutionId executionId) {
         this.executionId = executionId;
         return this;
     }
 
-    public ExecutionContext build(GraphQLSchema graphQLSchema, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy, ExecutionStrategy subscriptionStrategy, Object context, Object root, Document document, String operationName, Map<String, Object> variables) {
+    public ExecutionContextBuilder graphQLSchema(GraphQLSchema graphQLSchema) {
+        this.graphQLSchema = graphQLSchema;
+        return this;
+    }
+
+    public ExecutionContextBuilder queryStrategy(ExecutionStrategy queryStrategy) {
+        this.queryStrategy = queryStrategy;
+        return this;
+    }
+
+    public ExecutionContextBuilder mutationStrategy(ExecutionStrategy mutationStrategy) {
+        this.mutationStrategy = mutationStrategy;
+        return this;
+    }
+
+    public ExecutionContextBuilder subscriptionStrategy(ExecutionStrategy subscriptionStrategy) {
+        this.subscriptionStrategy = subscriptionStrategy;
+        return this;
+    }
+
+    public ExecutionContextBuilder context(Object context) {
+        this.context = context;
+        return this;
+    }
+
+    public ExecutionContextBuilder root(Object root) {
+        this.root = root;
+        return this;
+    }
+
+    public ExecutionContextBuilder document(Document document) {
+        this.document = document;
+        return this;
+    }
+
+    public ExecutionContextBuilder operationName(String operationName) {
+        this.operationName = operationName;
+        return this;
+    }
+
+    public ExecutionContextBuilder variables(Map<String, Object> variables) {
+        this.variables = variables;
+        return this;
+    }
+
+    public ExecutionContext build() {
         // preconditions
         assertNotNull(executionId, "You must provide a query identifier");
 

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -175,7 +175,9 @@ public abstract class ExecutionStrategy {
             resolvedType = (GraphQLObjectType) fieldType;
         }
 
-        FieldCollectorParameters collectorParameters = newParameters(executionContext.getGraphQLSchema(), resolvedType)
+        FieldCollectorParameters collectorParameters = newParameters()
+                .schema(executionContext.getGraphQLSchema())
+                .objectType(resolvedType)
                 .fragments(executionContext.getFragmentsByName())
                 .variables(executionContext.getVariables())
                 .build();

--- a/src/main/java/graphql/execution/ExecutionStrategyParameters.java
+++ b/src/main/java/graphql/execution/ExecutionStrategyParameters.java
@@ -61,6 +61,11 @@ public class ExecutionStrategyParameters {
         return builder.build();
     }
 
+    @Override
+    public String toString() {
+        return String.format("ExecutionStrategyParameters { path=%s, typeInfo=%s, source=%s, fields=%s }",
+                path, typeInfo, source, fields);
+    }
 
     public static Builder newParameters() {
         return new Builder();
@@ -68,12 +73,6 @@ public class ExecutionStrategyParameters {
 
     public static Builder newParameters(ExecutionStrategyParameters oldParameters) {
         return new Builder(oldParameters);
-    }
-
-    @Override
-    public String toString() {
-        return String.format("ExecutionStrategyParameters { path=%s, typeInfo=%s, source=%s, fields=%s }",
-                path, typeInfo, source, fields);
     }
 
     public static class Builder {
@@ -84,9 +83,15 @@ public class ExecutionStrategyParameters {
         NonNullableFieldValidator nonNullableFieldValidator;
         ExecutionPath path = ExecutionPath.rootPath();
 
+        /**
+         * @see ExecutionStrategyParameters#newParameters()
+         */
         private Builder() {
         }
 
+        /**
+         * @see ExecutionStrategyParameters#newParameters(ExecutionStrategyParameters)
+         */
         private Builder(ExecutionStrategyParameters oldParameters) {
             this.typeInfo = oldParameters.typeInfo;
             this.source = oldParameters.source;

--- a/src/main/java/graphql/execution/FieldCollectorParameters.java
+++ b/src/main/java/graphql/execution/FieldCollectorParameters.java
@@ -37,10 +37,8 @@ public class FieldCollectorParameters {
         this.objectType = objectType;
     }
 
-    public static Builder newParameters(GraphQLSchema graphQLSchema, GraphQLObjectType objectType) {
-        Assert.assertNotNull(graphQLSchema, "You must provide a schema");
-        Assert.assertNotNull(objectType, "You must provide an object type");
-        return new Builder().schema(graphQLSchema).objectType(objectType);
+    public static Builder newParameters() {
+        return new Builder();
     }
 
     public static class Builder {
@@ -48,6 +46,13 @@ public class FieldCollectorParameters {
         private Map<String, FragmentDefinition> fragmentsByName = new LinkedHashMap<>();
         private Map<String, Object> variables = new LinkedHashMap<>();
         private GraphQLObjectType objectType;
+
+        /**
+         * @see FieldCollectorParameters#newParameters()
+         */
+        private Builder() {
+
+        }
 
         public Builder schema(GraphQLSchema graphQLSchema) {
             this.graphQLSchema = graphQLSchema;
@@ -70,6 +75,8 @@ public class FieldCollectorParameters {
         }
 
         public FieldCollectorParameters build() {
+            Assert.assertNotNull(graphQLSchema, "You must provide a schema");
+            Assert.assertNotNull(objectType, "You must provide an object type");
             return new FieldCollectorParameters(graphQLSchema, variables, fragmentsByName, objectType);
         }
 

--- a/src/main/java/graphql/execution/TypeInfo.java
+++ b/src/main/java/graphql/execution/TypeInfo.java
@@ -55,10 +55,6 @@ public class TypeInfo {
         return new TypeInfo(unwrap(type), this.parentType, this.typeIsNonNull);
     }
 
-    public static Builder newTypeInfo() {
-        return new Builder();
-    }
-
     private static GraphQLType unwrap(GraphQLType type) {
         // its possible to have non nulls wrapping non nulls of things but it must end at some point
         while (type instanceof GraphQLNonNull) {
@@ -67,16 +63,25 @@ public class TypeInfo {
         return type;
     }
 
-
     @Override
     public String toString() {
         return String.format("TypeInfo { nonnull=%s, type=%s, parentType=%s }",
                 typeIsNonNull, type, parentType);
     }
 
+    public static TypeInfo.Builder newTypeInfo() {
+        return new Builder();
+    }
+
     public static class Builder {
         GraphQLType type;
         TypeInfo parentType;
+
+        /**
+         * @see TypeInfo#newTypeInfo()
+         */
+        private Builder() {
+        }
 
         public Builder type(GraphQLType type) {
             this.type = type;

--- a/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
+++ b/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
@@ -217,7 +217,9 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
     private Map<String, List<Field>> getChildFields(ExecutionContext executionContext, GraphQLObjectType resolvedType,
                                                     List<Field> fields) {
 
-        FieldCollectorParameters collectorParameters = newParameters(executionContext.getGraphQLSchema(), resolvedType)
+        FieldCollectorParameters collectorParameters = newParameters()
+                .schema(executionContext.getGraphQLSchema())
+                .objectType(resolvedType)
                 .fragments(executionContext.getFragmentsByName())
                 .variables(executionContext.getVariables())
                 .build();

--- a/src/main/java/graphql/schema/DataFetchingFieldSelectionSetImpl.java
+++ b/src/main/java/graphql/schema/DataFetchingFieldSelectionSetImpl.java
@@ -30,8 +30,9 @@ public class DataFetchingFieldSelectionSetImpl implements DataFetchingFieldSelec
     private DataFetchingFieldSelectionSetImpl(ExecutionContext executionContext, GraphQLObjectType fieldType, List<Field> fields) {
         this.fields = fields;
         this.fieldCollector = new FieldCollector();
-        this.parameters = FieldCollectorParameters.
-                newParameters(executionContext.getGraphQLSchema(), fieldType)
+        this.parameters = FieldCollectorParameters.newParameters()
+                .schema(executionContext.getGraphQLSchema())
+                .objectType(fieldType)
                 .fragments(executionContext.getFragmentsByName())
                 .variables(executionContext.getVariables())
                 .build();


### PR DESCRIPTION
Do you want this change? In summary, it maintains the `Foo.Builder newFoo()` pattern but moves any parameters passed to `newFoo` methods to chaining methods.