### PR TITLE
Refactor GraphQL#execute implementation

### DIFF
--- a/src/main/java/graphql/ExecutionResultImpl.java
+++ b/src/main/java/graphql/ExecutionResultImpl.java
@@ -2,6 +2,7 @@ package graphql;
 
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @Internal
@@ -9,6 +10,10 @@ public class ExecutionResultImpl implements ExecutionResult {
 
     private final List<GraphQLError> errors = new ArrayList<>();
     private Object data;
+
+    public ExecutionResultImpl(GraphQLError error) {
+        this(Collections.singletonList(error));
+    }
 
     public ExecutionResultImpl(List<? extends GraphQLError> errors) {
         this(null, errors);
@@ -22,8 +27,6 @@ public class ExecutionResultImpl implements ExecutionResult {
         }
 
     }
-
-
 
     @Override
     public <T> T getData() {

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -1,6 +1,7 @@
 package graphql.execution;
 
 
+import graphql.ExecutionInput;
 import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.GraphQLException;
@@ -41,7 +42,12 @@ public class Execution {
         this.instrumentation = instrumentation;
     }
 
-    public ExecutionResult execute(ExecutionId executionId, GraphQLSchema graphQLSchema, Object context, Object root, Document document, String operationName, Map<String, Object> variables) {
+    public ExecutionResult execute(Document document, GraphQLSchema graphQLSchema, ExecutionId executionId, ExecutionInput executionInput) {
+        final Object context = executionInput.getContext();
+        final Object root = executionInput.getRoot();
+        final String operationName = executionInput.getOperationName();
+        final Map<String, Object> variables = executionInput.getVariables();
+
         ExecutionContextBuilder executionContextBuilder = new ExecutionContextBuilder(new ValuesResolver(), instrumentation);
         ExecutionContext executionContext = executionContextBuilder
                 .executionId(executionId)

--- a/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationExecutionParameters.java
+++ b/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationExecutionParameters.java
@@ -1,8 +1,10 @@
 package graphql.execution.instrumentation.parameters;
 
+import graphql.ExecutionInput;
 import graphql.PublicApi;
 import graphql.execution.instrumentation.Instrumentation;
 
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -14,6 +16,15 @@ public class InstrumentationExecutionParameters {
     private final String operation;
     private final Object context;
     private final Map<String, Object> variables;
+
+    public InstrumentationExecutionParameters(ExecutionInput executionInput) {
+        this(
+                executionInput.getQuery(),
+                executionInput.getOperationName(),
+                executionInput.getContext(),
+                executionInput.getVariables() != null ? executionInput.getVariables() : Collections.emptyMap()
+        );
+    }
 
     public InstrumentationExecutionParameters(String query, String operation, Object context, Map<String, Object> variables) {
         this.query = query;

--- a/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationValidationParameters.java
+++ b/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationValidationParameters.java
@@ -1,9 +1,8 @@
 package graphql.execution.instrumentation.parameters;
 
+import graphql.ExecutionInput;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.language.Document;
-
-import java.util.Map;
 
 /**
  * Parameters sent to {@link Instrumentation} methods
@@ -11,8 +10,8 @@ import java.util.Map;
 public class InstrumentationValidationParameters extends InstrumentationExecutionParameters {
     private final Document document;
 
-    public InstrumentationValidationParameters(String query, String operation, Object context, Map<String, Object> arguments, Document document) {
-        super(query, operation, context, arguments);
+    public InstrumentationValidationParameters(ExecutionInput executionInput, Document document) {
+        super(executionInput);
         this.document = document;
     }
 

--- a/src/test/groovy/graphql/execution/ExecutionTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionTest.groovy
@@ -1,5 +1,6 @@
 package graphql.execution
 
+import graphql.ExecutionInput
 import graphql.MutationSchema
 import graphql.execution.instrumentation.NoOpInstrumentation
 import graphql.parser.Parser
@@ -12,6 +13,7 @@ class ExecutionTest extends Specification {
     def mutationStrategy = Mock(ExecutionStrategy)
     def queryStrategy = Mock(ExecutionStrategy)
     def execution = new Execution(queryStrategy, mutationStrategy, subscriptionStrategy, NoOpInstrumentation.INSTANCE)
+    def emptyExecutionInput = ExecutionInput.newExecutionInput().build()
 
     def "query strategy is used for query requests"() {
         given:
@@ -30,7 +32,7 @@ class ExecutionTest extends Specification {
         def document = parser.parseDocument(query)
 
         when:
-        execution.execute(ExecutionId.generate(), MutationSchema.schema, null, null, document, null, null)
+        execution.execute(document, MutationSchema.schema, ExecutionId.generate(), emptyExecutionInput)
 
         then:
         1 * queryStrategy.execute(*_)
@@ -50,7 +52,7 @@ class ExecutionTest extends Specification {
         def document = parser.parseDocument(query)
 
         when:
-        execution.execute(ExecutionId.generate(), MutationSchema.schema, null, null, document, null, null)
+        execution.execute(document, MutationSchema.schema, ExecutionId.generate(), emptyExecutionInput)
 
         then:
         0 * queryStrategy.execute(*_)
@@ -70,7 +72,7 @@ class ExecutionTest extends Specification {
         def document = parser.parseDocument(query)
 
         when:
-        execution.execute(ExecutionId.generate(), MutationSchema.schema, null, null, document, null, null)
+        execution.execute(document, MutationSchema.schema, ExecutionId.generate(), emptyExecutionInput)
 
         then:
         0 * queryStrategy.execute(*_)


### PR DESCRIPTION
The goal here was to 
- Hide implementation details in sub-methods, which should
- Make it easier to understand what is happening from a quick read, and
- Make the lifecycle of the instrumentation instances easy to see and validate

I believe that I have not significantly changed when or under what conditions the `onEnd` instrumentation methods are called. Its worth noting that the `onEnd` methods are not guaranteed to be called in all possible error scenarios.