### PR TITLE
Correct execution example

### DIFF
--- a/docs/execution.rst
+++ b/docs/execution.rst
@@ -129,7 +129,7 @@ to use when mutating data.
             new LinkedBlockingQueue<Runnable>(),
             new ThreadPoolExecutor.CallerRunsPolicy());
 
-    GraphQL graphQL = GraphQL.newObject(StarWarsSchema.starWarsSchema)
+    GraphQL graphQL = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema)
             .queryExecutionStrategy(new ExecutorServiceExecutionStrategy(threadPoolExecutor))
             .mutationExecutionStrategy(new SimpleExecutionStrategy())
             .build();


### PR DESCRIPTION
There's a very small error in the execution example in the docs. I believe this corrects it.