### PR TITLE
Preparsed document provider/cache to avoid costly parse and validation

### DIFF
--- a/docs/execution.rst
+++ b/docs/execution.rst
@@ -158,9 +158,9 @@ Please note that this does not cache the result of the query, only the parsed ``
             .preparsedDocumentProvider(cache::get) (2)
             .build();
 
+
 1. Create an instance of preferred cache instance, here is `Caffeine <https://github.com/ben-manes/caffeine>`_  used as it is a high quality caching solution. The cache instance should be thread safe and shared.
-2. The ``PreparsedDocumentProvider`` is a functional interface with only a get method and we can therefore pass a method reference that matches the signature
-into the builder.
+2. The ``PreparsedDocumentProvider`` is a functional interface with only a get method and we can therefore pass a method reference that matches the signature into the builder.
 
 
 In order to achieve high cache hit ration it is recommended that field arguments are passed in as variables instead of directly in the query.

--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -300,27 +300,29 @@ public class GraphQL {
     }
 
     private ExecutionResult parseValidateAndExecute(ExecutionInput executionInput) {
-        PreparsedDocumentEntry preparsedDoc = preparsedDocumentProvider.get(executionInput.getQuery(), query -> {
-            ParseResult parseResult = parse(executionInput);
-            if (parseResult.isFailure()) {
-                return new PreparsedDocumentEntry(toInvalidSyntaxError(parseResult.getException()));
-            } else {
-                final Document document = parseResult.getDocument();
-
-                final List<ValidationError> errors = validate(executionInput, document);
-                if (!errors.isEmpty()) {
-                    return new PreparsedDocumentEntry(errors);
-                }
-
-                return  new PreparsedDocumentEntry(document);
-            }
-        });
+        PreparsedDocumentEntry preparsedDoc = preparsedDocumentProvider.get(executionInput.getQuery(), query -> parseAndValidate(executionInput));
 
         if (preparsedDoc.hasErrors()) {
             return new ExecutionResultImpl(preparsedDoc.getErrors());
         }
 
         return execute(executionInput, preparsedDoc.getDocument());
+    }
+
+    private PreparsedDocumentEntry parseAndValidate(ExecutionInput executionInput) {
+        ParseResult parseResult = parse(executionInput);
+        if (parseResult.isFailure()) {
+            return new PreparsedDocumentEntry(toInvalidSyntaxError(parseResult.getException()));
+        } else {
+            final Document document = parseResult.getDocument();
+
+            final List<ValidationError> errors = validate(executionInput, document);
+            if (!errors.isEmpty()) {
+                return new PreparsedDocumentEntry(errors);
+            }
+
+            return new PreparsedDocumentEntry(document);
+        }
     }
 
     private ParseResult parse(ExecutionInput executionInput) {

--- a/src/main/java/graphql/execution/ExecutionContextBuilder.java
+++ b/src/main/java/graphql/execution/ExecutionContextBuilder.java
@@ -130,7 +130,7 @@ public class ExecutionContextBuilder {
                 fragmentsByName,
                 operation,
                 variableValues,
-                root,
-                context);
+                context,
+                root);
     }
 }

--- a/src/main/java/graphql/execution/preparsed/NoOpPreparsedDocumentProvider.java
+++ b/src/main/java/graphql/execution/preparsed/NoOpPreparsedDocumentProvider.java
@@ -1,0 +1,16 @@
+package graphql.execution.preparsed;
+
+
+public class NoOpPreparsedDocumentProvider implements PreparsedDocumentProvider {
+    public static final NoOpPreparsedDocumentProvider INSTANCE = new NoOpPreparsedDocumentProvider();
+
+    @Override
+    public PreparsedDocumentEntry get(String query) {
+        return null;
+    }
+
+    @Override
+    public void put(String query, PreparsedDocumentEntry entry) {
+
+    }
+}

--- a/src/main/java/graphql/execution/preparsed/NoOpPreparsedDocumentProvider.java
+++ b/src/main/java/graphql/execution/preparsed/NoOpPreparsedDocumentProvider.java
@@ -1,16 +1,13 @@
 package graphql.execution.preparsed;
 
 
+import java.util.function.Function;
+
 public class NoOpPreparsedDocumentProvider implements PreparsedDocumentProvider {
     public static final NoOpPreparsedDocumentProvider INSTANCE = new NoOpPreparsedDocumentProvider();
 
     @Override
-    public PreparsedDocumentEntry get(String query) {
-        return null;
-    }
-
-    @Override
-    public void put(String query, PreparsedDocumentEntry entry) {
-
+    public PreparsedDocumentEntry get(String query, Function<String, PreparsedDocumentEntry> compute) {
+        return compute.apply(query);
     }
 }

--- a/src/main/java/graphql/execution/preparsed/PreparsedDocumentEntry.java
+++ b/src/main/java/graphql/execution/preparsed/PreparsedDocumentEntry.java
@@ -5,25 +5,30 @@ import graphql.language.Document;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * An instance of a preparsed doucument entry represents the result of a query parse and validation, like
  * an either implementation it contains either the correct result in th document property or the errors.
  */
 public class PreparsedDocumentEntry {
-    private Document document;
-    private List<? extends GraphQLError> errors;
+    private final Document document;
+    private final List<? extends GraphQLError> errors;
 
     public PreparsedDocumentEntry(Document document) {
+        Objects.requireNonNull(document);
         this.document = document;
+        this.errors = null;
     }
 
     public PreparsedDocumentEntry(List<? extends GraphQLError> errors) {
+        Objects.requireNonNull(errors);
+        this.document = null;
         this.errors = errors;
     }
 
     public PreparsedDocumentEntry(GraphQLError error) {
-        this.errors = Collections.singletonList(error);
+        this(Collections.singletonList(Objects.requireNonNull(error)));
     }
 
     public Document getDocument() {
@@ -33,8 +38,7 @@ public class PreparsedDocumentEntry {
     public List<? extends GraphQLError> getErrors() {
         return errors;
     }
-
-
+    
     public boolean hasErrors() {
         return errors != null && !errors.isEmpty();
     }

--- a/src/main/java/graphql/execution/preparsed/PreparsedDocumentEntry.java
+++ b/src/main/java/graphql/execution/preparsed/PreparsedDocumentEntry.java
@@ -1,0 +1,41 @@
+package graphql.execution.preparsed;
+
+import graphql.GraphQLError;
+import graphql.language.Document;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * An instance of a preparsed doucument entry represents the result of a query parse and validation, like
+ * an either implementation it contains either the correct result in th document property or the errors.
+ */
+public class PreparsedDocumentEntry {
+    private Document document;
+    private List<? extends GraphQLError> errors;
+
+    public PreparsedDocumentEntry(Document document) {
+        this.document = document;
+    }
+
+    public PreparsedDocumentEntry(List<? extends GraphQLError> errors) {
+        this.errors = errors;
+    }
+
+    public PreparsedDocumentEntry(GraphQLError error) {
+        this.errors = Collections.singletonList(error);
+    }
+
+    public Document getDocument() {
+        return document;
+    }
+
+    public List<? extends GraphQLError> getErrors() {
+        return errors;
+    }
+
+
+    public boolean hasErrors() {
+        return errors != null && !errors.isEmpty();
+    }
+}

--- a/src/main/java/graphql/execution/preparsed/PreparsedDocumentProvider.java
+++ b/src/main/java/graphql/execution/preparsed/PreparsedDocumentProvider.java
@@ -1,0 +1,25 @@
+package graphql.execution.preparsed;
+
+
+/**
+ * Interface that allows clients to hook in Document caching and/or whitelisting of queries
+ */
+public interface PreparsedDocumentProvider {
+    /**
+     * Get existing instance of a preparsed query
+     *
+     * @param query The graphql query
+     * @return Null of missing or an instance of {@link PreparsedDocumentEntry}
+     */
+    PreparsedDocumentEntry get(String query);
+
+    /**
+     * Put the parse and validate result into the provider
+     *
+     * @param query The graphql query
+     * @param entry The result of parse and validation of the query
+     */
+    void put(String query, PreparsedDocumentEntry entry);
+}
+
+

--- a/src/main/java/graphql/execution/preparsed/PreparsedDocumentProvider.java
+++ b/src/main/java/graphql/execution/preparsed/PreparsedDocumentProvider.java
@@ -1,9 +1,12 @@
 package graphql.execution.preparsed;
 
 
+import java.util.function.Function;
+
 /**
  * Interface that allows clients to hook in Document caching and/or whitelisting of queries
  */
+@FunctionalInterface
 public interface PreparsedDocumentProvider {
     /**
      * Get existing instance of a preparsed query
@@ -11,15 +14,7 @@ public interface PreparsedDocumentProvider {
      * @param query The graphql query
      * @return Null of missing or an instance of {@link PreparsedDocumentEntry}
      */
-    PreparsedDocumentEntry get(String query);
-
-    /**
-     * Put the parse and validate result into the provider
-     *
-     * @param query The graphql query
-     * @param entry The result of parse and validation of the query
-     */
-    void put(String query, PreparsedDocumentEntry entry);
+    PreparsedDocumentEntry get(String query, Function<String, PreparsedDocumentEntry> compute);
 }
 
 

--- a/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
@@ -1,44 +1,12 @@
 package graphql.execution.instrumentation
 
-import graphql.ExecutionResult
 import graphql.GraphQL
 import graphql.StarWarsSchema
 import graphql.execution.SimpleExecutionStrategy
-import graphql.execution.instrumentation.parameters.*
-import graphql.language.Document
-import graphql.validation.ValidationError
 import spock.lang.Specification
 
 class InstrumentationTest extends Specification {
 
-    class Timer<T> implements InstrumentationContext<T> {
-        def op
-        def start = System.currentTimeMillis()
-        def executionList = []
-
-        Timer(op, executionList) {
-            this.op = op
-            this.executionList = executionList
-            executionList << "start:$op"
-            println("Started $op...")
-        }
-
-        def end() {
-            this.executionList << "end:$op"
-            def ms = System.currentTimeMillis() - start
-            println("\tEnded $op in ${ms}ms")
-        }
-
-        @Override
-        void onEnd(T result) {
-            end()
-        }
-
-        @Override
-        void onEnd(Exception e) {
-            end()
-        }
-    }
 
 
     def 'Instrumentation of simple serial execution'() {
@@ -85,40 +53,7 @@ class InstrumentationTest extends Specification {
 
         when:
 
-        def instrumentation = new Instrumentation() {
-
-            def executionList = []
-
-            @Override
-            InstrumentationContext<ExecutionResult> beginExecution(InstrumentationExecutionParameters parameters) {
-                new Timer("execution", executionList)
-            }
-
-            @Override
-            InstrumentationContext<Document> beginParse(InstrumentationExecutionParameters parameters) {
-                return new Timer("parse", executionList)
-            }
-
-            @Override
-            InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters) {
-                return new Timer("validation", executionList)
-            }
-
-            @Override
-            InstrumentationContext<ExecutionResult> beginDataFetch(InstrumentationDataFetchParameters parameters) {
-                return new Timer("data-fetch", executionList)
-            }
-
-            @Override
-            InstrumentationContext<ExecutionResult> beginField(InstrumentationFieldParameters parameters) {
-                return new Timer("field-$parameters.field.name", executionList)
-            }
-
-            @Override
-            InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters) {
-                return new Timer("fetch-$parameters.field.name", executionList)
-            }
-        }
+        def instrumentation = new TestingInstrumentation()
 
         def strategy = new SimpleExecutionStrategy()
         def graphQL = GraphQL

--- a/src/test/groovy/graphql/execution/instrumentation/TestingInstrumentContext.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/TestingInstrumentContext.groovy
@@ -1,0 +1,31 @@
+package graphql.execution.instrumentation
+
+class TestingInstrumentContext<T> implements InstrumentationContext<T> {
+    def op
+    def start = System.currentTimeMillis()
+    def executionList = []
+
+    TestingInstrumentContext(op, executionList) {
+        this.op = op
+        this.executionList = executionList
+        executionList << "start:$op"
+        println("Started $op...")
+    }
+
+    def end() {
+        this.executionList << "end:$op"
+        def ms = System.currentTimeMillis() - start
+        println("\tEnded $op in ${ms}ms")
+    }
+
+    @Override
+    void onEnd(T result) {
+        end()
+    }
+
+    @Override
+    void onEnd(Exception e) {
+        end()
+    }
+}
+

--- a/src/test/groovy/graphql/execution/instrumentation/TestingInstrumentation.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/TestingInstrumentation.groovy
@@ -1,0 +1,42 @@
+package graphql.execution.instrumentation
+
+import graphql.ExecutionResult
+import graphql.execution.instrumentation.parameters.*
+import graphql.language.Document
+import graphql.validation.ValidationError
+
+class TestingInstrumentation implements Instrumentation {
+
+    def executionList = []
+
+    @Override
+    InstrumentationContext<ExecutionResult> beginExecution(InstrumentationExecutionParameters parameters) {
+        new TestingInstrumentContext("execution", executionList)
+    }
+
+    @Override
+    InstrumentationContext<Document> beginParse(InstrumentationExecutionParameters parameters) {
+        return new TestingInstrumentContext("parse", executionList)
+    }
+
+    @Override
+    InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters) {
+        return new TestingInstrumentContext("validation", executionList)
+    }
+
+    @Override
+    InstrumentationContext<ExecutionResult> beginDataFetch(InstrumentationDataFetchParameters parameters) {
+        return new TestingInstrumentContext("data-fetch", executionList)
+    }
+
+    @Override
+    InstrumentationContext<ExecutionResult> beginField(InstrumentationFieldParameters parameters) {
+        return new TestingInstrumentContext("field-$parameters.field.name", executionList)
+    }
+
+    @Override
+    InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters) {
+        return new TestingInstrumentContext("fetch-$parameters.field.name", executionList)
+    }
+}
+

--- a/src/test/groovy/graphql/execution/preparsed/NoOpPreparsedDocumentProviderTest.groovy
+++ b/src/test/groovy/graphql/execution/preparsed/NoOpPreparsedDocumentProviderTest.groovy
@@ -1,0 +1,20 @@
+package graphql.execution.preparsed
+
+import graphql.language.Document
+import spock.lang.Specification
+
+
+class NoOpPreparsedDocumentProviderTest extends Specification {
+    def "NoOp always returns result of compute function"() {
+        given:
+        def provider = NoOpPreparsedDocumentProvider.INSTANCE
+        def documentEntry = new PreparsedDocumentEntry(new Document())
+
+        when:
+        def actual = provider.get("{}", { return documentEntry})
+
+        then:
+        actual == documentEntry
+
+    }
+}

--- a/src/test/groovy/graphql/execution/preparsed/PreparsedDocumentEntryTest.groovy
+++ b/src/test/groovy/graphql/execution/preparsed/PreparsedDocumentEntryTest.groovy
@@ -1,0 +1,62 @@
+package graphql.execution.preparsed
+
+import graphql.GraphQLError
+import graphql.InvalidSyntaxError
+import graphql.language.Document
+import graphql.language.SourceLocation
+import graphql.validation.ValidationError
+import graphql.validation.ValidationErrorType
+import spock.lang.Specification
+
+class PreparsedDocumentEntryTest extends Specification {
+    def "Ensure a non-null document returns"() {
+        given:
+        def document = new Document()
+
+        when:
+        def docEntry = new PreparsedDocumentEntry(document)
+
+        then:
+        docEntry.document == document
+        docEntry.errors == null
+    }
+
+    def "Ensure a null document throws NPE"() {
+        when:
+        new PreparsedDocumentEntry((Document) null)
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    def "Ensure a non-null errors returns"() {
+        given:
+        def errors = [new InvalidSyntaxError(new SourceLocation(0, 0)),
+                      new ValidationError(ValidationErrorType.InvalidSyntax)]
+
+        when:
+        def docEntry = new PreparsedDocumentEntry(errors)
+
+        then:
+        docEntry.document == null
+        docEntry.errors == errors
+    }
+
+    def "Ensure a null errors throws NPE"() {
+        when:
+        new PreparsedDocumentEntry((List<GraphQLError>) null)
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    def "Ensure a null error throws NPE"() {
+        when:
+        new PreparsedDocumentEntry((GraphQLError) null)
+
+        then:
+        thrown(NullPointerException)
+    }
+
+
+}

--- a/src/test/groovy/graphql/execution/preparsed/PreparsedDocumentProviderTest.groovy
+++ b/src/test/groovy/graphql/execution/preparsed/PreparsedDocumentProviderTest.groovy
@@ -8,7 +8,7 @@ import graphql.execution.SimpleExecutionStrategy
 import graphql.execution.instrumentation.TestingInstrumentation
 import spock.lang.Specification
 
-class PreparsedTest extends Specification {
+class PreparsedDocumentProviderTest extends Specification {
 
     def 'Preparse of simple serial execution'() {
         given:
@@ -21,10 +21,6 @@ class PreparsedTest extends Specification {
         }
         """
 
-        //
-        // for testing purposes we must use SimpleExecutionStrategy under the covers to get such
-        // serial behaviour.  The Instrumentation of a parallel strategy would be much different
-        // and certainly harder to test
         def expected = [
                 "start:execution",
 

--- a/src/test/groovy/graphql/execution/preparsed/PreparsedTest.groovy
+++ b/src/test/groovy/graphql/execution/preparsed/PreparsedTest.groovy
@@ -1,6 +1,7 @@
 package graphql.execution.preparsed
 
 import graphql.ErrorType
+import graphql.ExecutionInput
 import graphql.GraphQL
 import graphql.StarWarsSchema
 import graphql.execution.SimpleExecutionStrategy
@@ -84,14 +85,14 @@ class PreparsedTest extends Specification {
                 .instrumentation(instrumentation)
                 .preparsedDocumentProvider(preparsedCache)
                 .build()
-                .execute(query).data
+                .execute(ExecutionInput.newExecutionInput().query(query).build()).data
 
         def data2 = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema)
                 .queryExecutionStrategy(strategy)
                 .instrumentation(instrumentationPreparsed)
                 .preparsedDocumentProvider(preparsedCache)
                 .build()
-                .execute(query).data
+                .execute(ExecutionInput.newExecutionInput().query(query).build()).data
 
 
         then:
@@ -119,12 +120,12 @@ class PreparsedTest extends Specification {
         def result1 = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema)
                 .preparsedDocumentProvider(preparsedCache)
                 .build()
-                .execute(query)
+                .execute(ExecutionInput.newExecutionInput().query(query).build())
 
         def result2 = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema)
                 .preparsedDocumentProvider(preparsedCache)
                 .build()
-                .execute(query)
+                .execute(ExecutionInput.newExecutionInput().query(query).build())
 
         then: "Both the first and the second result should give the same validation error"
         result1.errors.size() == 1

--- a/src/test/groovy/graphql/execution/preparsed/TestingPreparsedDocumentProvider.groovy
+++ b/src/test/groovy/graphql/execution/preparsed/TestingPreparsedDocumentProvider.groovy
@@ -1,0 +1,15 @@
+package graphql.execution.preparsed
+
+
+class TestingPreparsedDocumentProvider implements PreparsedDocumentProvider{
+    private Map<String, PreparsedDocumentEntry> cache = new HashMap<>()
+    @Override
+    PreparsedDocumentEntry get(String query) {
+        return cache.get(query)
+    }
+
+    @Override
+    void put(String query, PreparsedDocumentEntry entry) {
+        cache.put(query, entry)
+    }
+}

--- a/src/test/groovy/graphql/execution/preparsed/TestingPreparsedDocumentProvider.groovy
+++ b/src/test/groovy/graphql/execution/preparsed/TestingPreparsedDocumentProvider.groovy
@@ -1,15 +1,14 @@
 package graphql.execution.preparsed
 
+import java.util.function.Function
 
-class TestingPreparsedDocumentProvider implements PreparsedDocumentProvider{
+
+class TestingPreparsedDocumentProvider implements PreparsedDocumentProvider {
     private Map<String, PreparsedDocumentEntry> cache = new HashMap<>()
-    @Override
-    PreparsedDocumentEntry get(String query) {
-        return cache.get(query)
-    }
 
     @Override
-    void put(String query, PreparsedDocumentEntry entry) {
-        cache.put(query, entry)
+    PreparsedDocumentEntry get(String query, Function<String, PreparsedDocumentEntry> compute) {
+        return cache.computeIfAbsent(query, compute)
     }
+
 }


### PR DESCRIPTION
Query parsing and validation can be costly in terms of execution performance, this PR introduces a preparsed provider/cache that allows implementations to hook in a cache to avoid re- parse and validation.

Another possible use case could be white listing queries.

One showstopper for this might be that it requires the Document tree to be thread safe, and from what I can see it is not modified after its been created.