### PR TITLE
fix and test ExecutionContextBuilder: root and context was mixed up

### DIFF
--- a/src/main/java/graphql/execution/ExecutionContextBuilder.java
+++ b/src/main/java/graphql/execution/ExecutionContextBuilder.java
@@ -116,7 +116,7 @@ public class ExecutionContextBuilder {
             operation = operationsByName.get(operationName);
         }
         if (operation == null) {
-            throw new GraphQLException();
+            throw new GraphQLException("no operation found");
         }
         Map<String, Object> variableValues = valuesResolver.getVariableValues(graphQLSchema, operation.getVariableDefinitions(), variables);
 
@@ -130,7 +130,7 @@ public class ExecutionContextBuilder {
                 fragmentsByName,
                 operation,
                 variableValues,
-                root,
-                context);
+                context,
+                root);
     }
 }

--- a/src/test/groovy/graphql/execution/ExecutionContextBuilderTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionContextBuilderTest.groovy
@@ -1,0 +1,74 @@
+package graphql.execution
+
+import graphql.execution.instrumentation.Instrumentation
+import graphql.language.Document
+import graphql.language.FragmentDefinition
+import graphql.language.OperationDefinition
+import graphql.parser.Parser
+import graphql.schema.GraphQLSchema
+import spock.lang.Specification
+
+class ExecutionContextBuilderTest extends Specification {
+
+
+    def "builds the correct ExecutionContext"() {
+        given:
+        ExecutionContextBuilder executionContextBuilder = new ExecutionContextBuilder()
+
+        ValuesResolver valuesResolver = Mock(ValuesResolver)
+        executionContextBuilder.valuesResolver(valuesResolver)
+
+        Instrumentation instrumentation = Mock(Instrumentation)
+        executionContextBuilder.instrumentation(instrumentation)
+
+        ExecutionStrategy queryStrategy = Mock(ExecutionStrategy)
+        executionContextBuilder.queryStrategy(queryStrategy)
+
+        ExecutionStrategy mutationStrategy = Mock(ExecutionStrategy)
+        executionContextBuilder.mutationStrategy(mutationStrategy)
+
+        ExecutionStrategy subscriptionStrategy = Mock(ExecutionStrategy)
+        executionContextBuilder.subscriptionStrategy(subscriptionStrategy)
+
+        GraphQLSchema schema = Mock(GraphQLSchema)
+        executionContextBuilder.graphQLSchema(schema)
+
+        def executionId = ExecutionId.generate()
+        executionContextBuilder.executionId(executionId)
+
+        def context = "context"
+        executionContextBuilder.context(context)
+
+        def root = "root"
+        executionContextBuilder.root(root)
+
+        Document document = new Parser().parseDocument("query myQuery(\$var: String){...MyFragment} fragment MyFragment on Query{foo}")
+        def operation = document.definitions[0] as OperationDefinition
+        def fragment = document.definitions[1] as FragmentDefinition
+        executionContextBuilder.document(document)
+
+        String operationName = "myQuery"
+        executionContextBuilder.operationName(operationName)
+
+        def variables = Collections.emptyMap()
+        executionContextBuilder.variables(variables)
+
+
+        valuesResolver.getVariableValues(schema, operation.getVariableDefinitions(), variables) >> [var: 'value']
+        when:
+        def executionContext = executionContextBuilder.build()
+
+        then:
+        executionContext.executionId == executionId
+        executionContext.instrumentation == instrumentation
+        executionContext.graphQLSchema == schema
+        executionContext.queryStrategy == queryStrategy
+        executionContext.mutationStrategy == mutationStrategy
+        executionContext.subscriptionStrategy == subscriptionStrategy
+        executionContext.root == root
+        executionContext.context == context
+        executionContext.variables == [var: 'value']
+        executionContext.getFragmentsByName() == [MyFragment: fragment]
+        executionContext.operationDefinition == operation
+    }
+}


### PR DESCRIPTION
This fixes an ExecutionContextBuilder bug where root and context was mixed up. (Thanks @LarsKrogJensen for spotting it)

It also adds a unit test for the builder, which was completely missing.