### PR TITLE
Removed List<Field> from execution strategy signature

### DIFF
--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -47,7 +47,7 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 
 /**
  * An execution strategy is give a list of fields from the graphql query to execute and find values for using a recursive strategy.
- * <p>
+ * 
  * <pre>
  *     query {
  *          friends {

--- a/src/main/java/graphql/execution/ExecutionStrategyParameters.java
+++ b/src/main/java/graphql/execution/ExecutionStrategyParameters.java
@@ -21,14 +21,16 @@ public class ExecutionStrategyParameters {
     private final Map<String, List<Field>> fields;
     private final NonNullableFieldValidator nonNullableFieldValidator;
     private final ExecutionPath path;
+    private final List<Field> currentField;
 
-    private ExecutionStrategyParameters(TypeInfo typeInfo, Object source, Map<String, List<Field>> fields, Map<String, Object> arguments, NonNullableFieldValidator nonNullableFieldValidator, ExecutionPath path) {
+    private ExecutionStrategyParameters(TypeInfo typeInfo, Object source, Map<String, List<Field>> fields, Map<String, Object> arguments, NonNullableFieldValidator nonNullableFieldValidator, ExecutionPath path, List<Field> currentField) {
         this.typeInfo = assertNotNull(typeInfo, "typeInfo is null");
         this.fields = assertNotNull(fields, "fields is null");
         this.source = source;
         this.arguments = arguments;
         this.nonNullableFieldValidator = nonNullableFieldValidator;
         this.path = path;
+        this.currentField = currentField;
     }
 
     public TypeInfo typeInfo() {
@@ -53,6 +55,17 @@ public class ExecutionStrategyParameters {
 
     public ExecutionPath path() {
         return path;
+    }
+
+    /**
+     * This returns the current field in its query representations.  Global fragments mean that
+     * a single named field can have multiple representations and different field subselections
+     * hence the use of a list of Field
+     *
+     * @return the current field in list form  or null if this has not be computed yet
+     */
+    public List<Field> field() {
+        return currentField;
     }
 
     public ExecutionStrategyParameters transform(Consumer<Builder> builderConsumer) {
@@ -82,6 +95,7 @@ public class ExecutionStrategyParameters {
         Map<String, Object> arguments;
         NonNullableFieldValidator nonNullableFieldValidator;
         ExecutionPath path = ExecutionPath.rootPath();
+        List<Field> currentField;
 
         /**
          * @see ExecutionStrategyParameters#newParameters()
@@ -115,6 +129,11 @@ public class ExecutionStrategyParameters {
             return this;
         }
 
+        public Builder field(List<Field> currentField) {
+            this.currentField = currentField;
+            return this;
+        }
+
         public Builder source(Object source) {
             this.source = source;
             return this;
@@ -136,7 +155,7 @@ public class ExecutionStrategyParameters {
         }
 
         public ExecutionStrategyParameters build() {
-            return new ExecutionStrategyParameters(typeInfo, source, fields, arguments, nonNullableFieldValidator, path);
+            return new ExecutionStrategyParameters(typeInfo, source, fields, arguments, nonNullableFieldValidator, path, currentField);
         }
     }
 }

--- a/src/main/java/graphql/execution/ExecutorServiceExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutorServiceExecutionStrategy.java
@@ -51,12 +51,13 @@ public class ExecutorServiceExecutionStrategy extends ExecutionStrategy {
         Map<String, List<Field>> fields = parameters.fields();
         Map<String, Future<ExecutionResult>> futures = new LinkedHashMap<>();
         for (String fieldName : fields.keySet()) {
-            final List<Field> fieldList = fields.get(fieldName);
+            final List<Field> currentField = fields.get(fieldName);
 
             ExecutionPath fieldPath = parameters.path().segment(fieldName);
-            ExecutionStrategyParameters newParameters = parameters.transform(bldr -> bldr.path(fieldPath));
+            ExecutionStrategyParameters newParameters = parameters
+                    .transform(builder -> builder.field(currentField).path(fieldPath));
 
-            Callable<ExecutionResult> resolveField = () -> resolveField(executionContext, newParameters, fieldList);
+            Callable<ExecutionResult> resolveField = () -> resolveField(executionContext, newParameters);
             futures.put(fieldName, executorService.submit(resolveField));
         }
         try {

--- a/src/main/java/graphql/execution/SimpleExecutionStrategy.java
+++ b/src/main/java/graphql/execution/SimpleExecutionStrategy.java
@@ -34,13 +34,14 @@ public class SimpleExecutionStrategy extends ExecutionStrategy {
         Map<String, List<Field>> fields = parameters.fields();
         Map<String, Object> results = new LinkedHashMap<>();
         for (String fieldName : fields.keySet()) {
-            List<Field> fieldList = fields.get(fieldName);
+            List<Field> currentField = fields.get(fieldName);
 
             ExecutionPath fieldPath = parameters.path().segment(fieldName);
-            ExecutionStrategyParameters newParameters = parameters.transform(builder -> builder.path(fieldPath));
+            ExecutionStrategyParameters newParameters = parameters
+                    .transform(builder -> builder.field(currentField).path(fieldPath));
 
             try {
-                ExecutionResult resolvedResult = resolveField(executionContext, newParameters, fieldList);
+                ExecutionResult resolvedResult = resolveField(executionContext, newParameters);
 
                 results.put(fieldName, resolvedResult != null ? resolvedResult.getData() : null);
             } catch (NonNullableFieldWasNullException e) {

--- a/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
+++ b/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
@@ -86,11 +86,12 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
             for (String fieldName : node.getFields().keySet()) {
 
                 ExecutionPath fieldPath = parameters.path().segment(fieldName);
-                ExecutionStrategyParameters newParameters = parameters.transform(bldr -> bldr.path(fieldPath));
+                List<Field> currentField = node.getFields().get(fieldName);
+                ExecutionStrategyParameters newParameters = parameters
+                        .transform(builder -> builder.path(fieldPath).field(currentField));
 
-                List<Field> fieldList = node.getFields().get(fieldName);
                 List<GraphQLExecutionNode> childNodes = resolveField(executionContext, newParameters, node.getParentType(),
-                        node.getData(), fieldName, fieldList);
+                        node.getData(), fieldName, currentField);
                 nodes.addAll(childNodes);
             }
         }

--- a/src/test/groovy/graphql/execution/AsyncFetchThenCompleteExecutionTestStrategy.java
+++ b/src/test/groovy/graphql/execution/AsyncFetchThenCompleteExecutionTestStrategy.java
@@ -46,12 +46,10 @@ public class AsyncFetchThenCompleteExecutionTestStrategy extends ExecutionStrate
 
         // first fetch every value
         for (String fieldName : fields.keySet()) {
-            List<Field> fieldList = fields.get(fieldName);
-
-            ExecutionStrategyParameters newParameters = newParameters(parameters, fieldName);
+            ExecutionStrategyParameters newParameters = newParameters(parameters, fields,fieldName);
 
             CompletableFuture<Object> fetchFuture = supplyAsync(() ->
-                    fetchField(executionContext, newParameters, fieldList), executor);
+                    fetchField(executionContext, newParameters), executor);
             fetchFutures.put(fieldName, fetchFuture);
         }
 
@@ -71,11 +69,11 @@ public class AsyncFetchThenCompleteExecutionTestStrategy extends ExecutionStrate
         for (String fieldName : fetchedValues.keySet()) {
             List<Field> fieldList = fields.get(fieldName);
 
-            ExecutionStrategyParameters newParameters = newParameters(parameters, fieldName);
+            ExecutionStrategyParameters newParameters = newParameters(parameters, fields, fieldName);
 
             Object fetchedValue = fetchedValues.get(fieldName);
             try {
-                ExecutionResult resolvedResult = completeField(executionContext, newParameters, fieldList, fetchedValue);
+                ExecutionResult resolvedResult = completeField(executionContext, newParameters, fetchedValue);
                 results.put(fieldName, resolvedResult != null ? resolvedResult.getData() : null);
             } catch (NonNullableFieldWasNullException e) {
                 assertNonNullFieldPrecondition(e);
@@ -86,9 +84,11 @@ public class AsyncFetchThenCompleteExecutionTestStrategy extends ExecutionStrate
         return new ExecutionResultImpl(results, executionContext.getErrors());
     }
 
-    private ExecutionStrategyParameters newParameters(ExecutionStrategyParameters parameters, String fieldName) {
+    private ExecutionStrategyParameters newParameters(ExecutionStrategyParameters parameters, Map<String, List<Field>> fields, String fieldName) {
+        List<Field> currentField = fields.get(fieldName);
         ExecutionPath fieldPath = parameters.path().segment(fieldName);
-        return parameters.transform(builder -> builder.path(fieldPath));
+        return parameters
+                .transform(builder -> builder.field(currentField).path(fieldPath));
     }
 
 

--- a/src/test/groovy/graphql/execution/BreadthFirstExecutionTestStrategy.java
+++ b/src/test/groovy/graphql/execution/BreadthFirstExecutionTestStrategy.java
@@ -34,14 +34,15 @@ public class BreadthFirstExecutionTestStrategy extends ExecutionStrategy {
         // then for every fetched value, complete it
         Map<String, Object> results = new LinkedHashMap<>();
         for (String fieldName : fetchedValues.keySet()) {
-            List<Field> fieldList = fields.get(fieldName);
+            List<Field> currentField = fields.get(fieldName);
             Object fetchedValue = fetchedValues.get(fieldName);
 
             ExecutionPath fieldPath = parameters.path().segment(fieldName);
-            ExecutionStrategyParameters newParameters = parameters.transform(bldr -> bldr.path(fieldPath));
+            ExecutionStrategyParameters newParameters = parameters
+                    .transform(builder -> builder.field(currentField).path(fieldPath));
 
             try {
-                completeValue(executionContext, results, fieldName, fieldList, fetchedValue, newParameters);
+                completeValue(executionContext, results, fieldName, fetchedValue, newParameters);
             } catch (NonNullableFieldWasNullException e) {
                 assertNonNullFieldPrecondition(e);
                 results = null;
@@ -52,16 +53,17 @@ public class BreadthFirstExecutionTestStrategy extends ExecutionStrategy {
     }
 
     private Object fetchField(ExecutionContext executionContext, ExecutionStrategyParameters parameters, Map<String, List<Field>> fields, String fieldName) {
-        List<Field> fieldList = fields.get(fieldName);
+        List<Field> currentField = fields.get(fieldName);
 
         ExecutionPath fieldPath = parameters.path().segment(fieldName);
-        ExecutionStrategyParameters newParameters = parameters.transform(bldr -> bldr.path(fieldPath));
+        ExecutionStrategyParameters newParameters = parameters
+                .transform(builder -> builder.field(currentField).path(fieldPath));
 
-        return fetchField(executionContext, newParameters, fieldList);
+        return fetchField(executionContext, newParameters);
     }
 
-    private void completeValue(ExecutionContext executionContext, Map<String, Object> results, String fieldName, List<Field> fieldList, Object fetchedValue, ExecutionStrategyParameters newParameters) {
-        ExecutionResult resolvedResult = completeField(executionContext, newParameters, fieldList, fetchedValue);
+    private void completeValue(ExecutionContext executionContext, Map<String, Object> results, String fieldName, Object fetchedValue, ExecutionStrategyParameters newParameters) {
+        ExecutionResult resolvedResult = completeField(executionContext, newParameters, fetchedValue);
         results.put(fieldName, resolvedResult != null ? resolvedResult.getData() : null);
     }
 

--- a/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
@@ -49,7 +49,6 @@ class ExecutionStrategyTest extends Specification {
     def "completes value for a java.util.List"() {
         given:
         ExecutionContext executionContext = buildContext()
-        Field field = new Field()
         def fieldType = new GraphQLList(GraphQLString)
         def result = Arrays.asList("test")
         def parameters = newParameters()
@@ -59,7 +58,7 @@ class ExecutionStrategyTest extends Specification {
                 .build()
 
         when:
-        def executionResult = executionStrategy.completeValue(executionContext, parameters, [field])
+        def executionResult = executionStrategy.completeValue(executionContext, parameters)
 
         then:
         executionResult.data == ["test"]
@@ -68,7 +67,6 @@ class ExecutionStrategyTest extends Specification {
     def "completes value for an array"() {
         given:
         ExecutionContext executionContext = buildContext()
-        Field field = new Field()
         def fieldType = new GraphQLList(GraphQLString)
         String[] result = ["test"]
         def parameters = newParameters()
@@ -78,7 +76,7 @@ class ExecutionStrategyTest extends Specification {
                 .build()
 
         when:
-        def executionResult = executionStrategy.completeValue(executionContext, parameters, [field])
+        def executionResult = executionStrategy.completeValue(executionContext, parameters)
 
         then:
         executionResult.data == ["test"]
@@ -100,7 +98,7 @@ class ExecutionStrategyTest extends Specification {
                 .build()
 
         when:
-        def executionResult = executionStrategy.completeValue(executionContext, parameters, [new Field()])
+        def executionResult = executionStrategy.completeValue(executionContext, parameters)
 
         then:
         executionResult.data == null
@@ -125,7 +123,7 @@ class ExecutionStrategyTest extends Specification {
                 .build()
 
         when:
-        def executionResult = executionStrategy.completeValue(executionContext, parameters, [new Field()])
+        def executionResult = executionStrategy.completeValue(executionContext, parameters)
 
         then:
         executionResult.data == null
@@ -172,7 +170,7 @@ class ExecutionStrategyTest extends Specification {
 
         Exception actualException = null
         try {
-            executionStrategy.completeValue(executionContext, parameters, [new Field()])
+            executionStrategy.completeValue(executionContext, parameters)
         } catch (Exception e) {
             actualException = e
         }
@@ -211,12 +209,13 @@ class ExecutionStrategyTest extends Specification {
                 .typeInfo(typeInfo)
                 .source("source")
                 .fields(["someField": [field]])
+                .field([field])
                 .nonNullFieldValidator(nullableFieldValidator)
                 .build()
         DataFetchingEnvironment environment
 
         when:
-        executionStrategy.resolveField(executionContext, parameters, [field])
+        executionStrategy.resolveField(executionContext, parameters)
 
         then:
         1 * dataFetcher.get({ it -> environment = it } as DataFetchingEnvironment)
@@ -255,6 +254,7 @@ class ExecutionStrategyTest extends Specification {
                 .typeInfo(typeInfo)
                 .source("source")
                 .fields(["someField": [field]])
+                .field([field])
                 .path(expectedPath)
                 .nonNullFieldValidator(nullableFieldValidator)
                 .build()
@@ -267,7 +267,7 @@ class ExecutionStrategyTest extends Specification {
         def expectedException = new UnsupportedOperationException("This is the exception you are looking for")
 
         //noinspection GroovyAssignabilityCheck
-        def (ExecutionContext executionContext, GraphQLFieldDefinition fieldDefinition, ExecutionPath expectedPath, ExecutionStrategyParameters parameters, Field field) = exceptionSetupFixture(expectedException)
+        def (ExecutionContext executionContext, GraphQLFieldDefinition fieldDefinition, ExecutionPath expectedPath, ExecutionStrategyParameters parameters) = exceptionSetupFixture(expectedException)
 
 
         boolean handleDataFetchingExceptionCalled = false
@@ -288,7 +288,7 @@ class ExecutionStrategyTest extends Specification {
         }
 
         when:
-        overridingStrategy.resolveField(executionContext, parameters, [field])
+        overridingStrategy.resolveField(executionContext, parameters)
 
         then:
         handleDataFetchingExceptionCalled == true
@@ -299,7 +299,7 @@ class ExecutionStrategyTest extends Specification {
 
         def expectedException = new UnsupportedOperationException("This is the exception you are looking for")
 
-        //noinspection GroovyAssignabilityCheck
+        //noinspection GroovyAssignabilityCheck,GroovyUnusedAssignment
         def (ExecutionContext executionContext, GraphQLFieldDefinition fieldDefinition, ExecutionPath expectedPath, ExecutionStrategyParameters parameters, Field field, SourceLocation sourceLocation) = exceptionSetupFixture(expectedException)
 
 
@@ -330,7 +330,7 @@ class ExecutionStrategyTest extends Specification {
         }
 
         when:
-        overridingStrategy.resolveField(executionContext, parameters, [field])
+        overridingStrategy.resolveField(executionContext, parameters)
 
         then:
         handlerCalled == true
@@ -344,7 +344,7 @@ class ExecutionStrategyTest extends Specification {
 
         def expectedException = new UnsupportedOperationException("This is the exception you are looking for")
 
-        //noinspection GroovyAssignabilityCheck
+        //noinspection GroovyAssignabilityCheck,GroovyUnusedAssignment
         def (ExecutionContext executionContext, GraphQLFieldDefinition fieldDefinition, ExecutionPath expectedPath, ExecutionStrategyParameters parameters, Field field, SourceLocation sourceLocation) = exceptionSetupFixture(expectedException)
 
 
@@ -356,7 +356,7 @@ class ExecutionStrategyTest extends Specification {
         }
 
         when:
-        overridingStrategy.resolveField(executionContext, parameters, [field])
+        overridingStrategy.resolveField(executionContext, parameters)
 
         then:
         executionContext.errors.size() == 1


### PR DESCRIPTION
While this is a breaking change, its more inline with all the other method parameters
on execution strategy . ie use the "parameters pattern"

In terms of breaking change, since we are going to break the API for async support, we should take the opportunity to clean it up now.