### PR TITLE
Use CallableWrappers to pass custom context to ExecutorService data fetching threads

### DIFF
--- a/src/main/java/graphql/execution/ExecutorServiceExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutorServiceExecutionStrategy.java
@@ -4,11 +4,13 @@ import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.GraphQLException;
 import graphql.PublicApi;
+import graphql.execution.support.CallableWrapper;
 import graphql.language.Field;
 
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -32,17 +34,29 @@ import java.util.concurrent.Future;
 @PublicApi
 public class ExecutorServiceExecutionStrategy extends ExecutionStrategy {
 
-    ExecutorService executorService;
+    private final ExecutorService executorService;
+    private final CallableWrapper callableWrapper;
 
+    /**
+     * Creates an {@link ExecutorServiceExecutionStrategy} with a {@link SimpleDataFetcherExceptionHandler} and
+     * a no-op {@link CallableWrapper}
+     */
     public ExecutorServiceExecutionStrategy(ExecutorService executorService) {
         this(executorService, new SimpleDataFetcherExceptionHandler());
     }
 
+    /**
+     * Creates an {@link ExecutorServiceExecutionStrategy} with a no-op {@link CallableWrapper}
+     */
     public ExecutorServiceExecutionStrategy(ExecutorService executorService, DataFetcherExceptionHandler dataFetcherExceptionHandler) {
-        super(dataFetcherExceptionHandler);
-        this.executorService = executorService;
+        this(executorService, dataFetcherExceptionHandler, new NoOpCallableWrapper());
     }
 
+    public ExecutorServiceExecutionStrategy(ExecutorService executorService, DataFetcherExceptionHandler dataFetcherExceptionHandler, CallableWrapper callableWrapper) {
+        super(dataFetcherExceptionHandler);
+        this.executorService = executorService;
+        this.callableWrapper = Objects.requireNonNull(callableWrapper);
+    }
 
     @Override
     public CompletableFuture<ExecutionResult> execute(final ExecutionContext executionContext, final ExecutionStrategyParameters parameters) {
@@ -58,8 +72,9 @@ public class ExecutorServiceExecutionStrategy extends ExecutionStrategy {
             ExecutionStrategyParameters newParameters = parameters
                     .transform(builder -> builder.field(currentField).path(fieldPath));
 
-            Callable<ExecutionResult> resolveField = () -> resolveField(executionContext, newParameters).join();
-            futures.put(fieldName, executorService.submit(resolveField));
+            Callable<ExecutionResult> fieldResolver = () -> resolveField(executionContext, newParameters).join();
+            Callable<ExecutionResult> wrappedFieldResolver = callableWrapper.wrapCallable(fieldResolver);
+            futures.put(fieldName, executorService.submit(wrappedFieldResolver));
         }
         try {
             Map<String, Object> results = new LinkedHashMap<>();
@@ -71,6 +86,13 @@ public class ExecutorServiceExecutionStrategy extends ExecutionStrategy {
             return CompletableFuture.completedFuture(new ExecutionResultImpl(results, executionContext.getErrors()));
         } catch (InterruptedException | ExecutionException e) {
             throw new GraphQLException(e);
+        }
+    }
+
+    private static class NoOpCallableWrapper implements CallableWrapper {
+        @Override
+        public <T> Callable<T> wrapCallable(Callable<T> callable) {
+            return callable;
         }
     }
 }

--- a/src/main/java/graphql/execution/support/CallableWrapper.java
+++ b/src/main/java/graphql/execution/support/CallableWrapper.java
@@ -1,0 +1,57 @@
+package graphql.execution.support;
+
+import java.util.concurrent.Callable;
+
+/**
+ * The entry point for defining implementation-specific logic for wrapping each {@link Callable} executed
+ * by the {@link graphql.execution.ExecutorServiceExecutionStrategy}.
+ * <p>
+ * This allows implementations to pass context (e.g. request attributes or logging MDC context) to child
+ * threads for data fetching.
+ * <pre>{@code
+ *  public class RequestAttributeAwareCallableWrapper implements CallableWrapper {
+ *
+ *      public <T> Callable<T> wrapCallable(Callable<T> callable) {
+ *          return new RequestAttributeAwareCallable<>(callable);
+ *      }
+ *  }
+ *
+ *  ...
+ *
+ *  public class RequestAttributeAwareCallable<T> implements Callable<T> {
+ *
+ *      private final Callable<T> callable;
+ *      private final RequestAttributes requestAttributes;
+ *
+ *      public RequestAttributeAwareCallable(Callable<T> callable) {
+ *          this(callable, RequestContextHolder.currentRequestAttributes());
+ *      }
+ *
+ *      private RequestAttributeAwareCallable(Callable<T> callable, RequestAttributes requestAttributes) {
+ *          this.callable = callable;
+ *          this.requestAttributes = requestAttributes;
+ *      }
+ *
+ *      public T call() throws Exception {
+ *          try {
+ *              RequestContextHolder.setRequestAttributes(requestAttributes, true);
+ *              return callable.call();
+ *          } finally {
+ *              RequestContextHolder.resetRequestAttributes();
+ *          }
+ *      }
+ *  }
+ *
+ * }</pre>
+ */
+public interface CallableWrapper {
+
+    /**
+     * Wraps a callable in order to pass context from the parent thread to Callable (child) thread.
+     *
+     * @param callable The callable to wrap
+     * @param <T>      The callable result type
+     * @return A wrapped callable
+     */
+    <T> Callable<T> wrapCallable(Callable<T> callable);
+}

--- a/src/main/java/graphql/execution/support/CallableWrapperChain.java
+++ b/src/main/java/graphql/execution/support/CallableWrapperChain.java
@@ -1,0 +1,25 @@
+package graphql.execution.support;
+
+import java.util.Iterator;
+import java.util.concurrent.Callable;
+
+/**
+ * A {@link CallableWrapper} that can be used to wrap a {@link Callable} in multiple wrappers.
+ */
+public class CallableWrapperChain implements CallableWrapper {
+
+    private final Iterator<CallableWrapper> wrappers;
+
+    public CallableWrapperChain(Iterator<CallableWrapper> wrappers) {
+        this.wrappers = wrappers;
+    }
+
+    @Override
+    public <T> Callable<T> wrapCallable(Callable<T> callable) {
+        Callable<T> result = callable;
+        while (wrappers.hasNext()) {
+            result = wrappers.next().wrapCallable(result);
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
We've run into a scenario where we need to pass Spring's `RequestAttributes` (a thread- or request-scoped singleton) from GraphQL `ExecutorServiceExecutionStrategy` threads to child threads executing DataFetchers.

`ExecutorServiceExecutionStrategy` provides no mechanism for this today. Previously we had implemented our own `ExecutionStrategy` which was essentially a copy-paste of `ExecutorServiceExecutionStrategy` with a `CallableWrapper` implementation. But of course in doing so we were not getting bugfixes and we introduced our own bugs :)

This PR will allow clients to provide `CallableWrappers` to `ExecutorServiceExecutionStrategy`. Multiple wrappers can be provided using a `CallableWrapperChain`.

This implementation is based on Netflix Hystrix's ConcurrencyStrategy callable wrapping and jmnarloch/hystrix-context-spring-boot-starter's `HystrixCallableWrapper`.
- Netflix [HystrixConcurrencyStrategy.java#L166-L181](https://github.com/Netflix/Hystrix/blob/master/hystrix-core/src/main/java/com/netflix/hystrix/strategy/concurrency/HystrixConcurrencyStrategy.java#L166-L181)
- hystrix-context-spring-boot-starter [HystrixContextAwareConcurrencyStrategy.java](https://github.com/jmnarloch/hystrix-context-spring-boot-starter/blob/master/src/main/java/io/jmnarloch/spring/boot/hystrix/support/HystrixContextAwareConcurrencyStrategy.java)
- hystrix-context-spring-boot-starter [HystrixCallableWrapper](https://github.com/jmnarloch/hystrix-context-spring-boot-starter/blob/master/src/main/java/io/jmnarloch/spring/boot/hystrix/context/HystrixCallableWrapper.java)