### PR TITLE
Fix BatchedExectionStrategy - IndexOutOfBoundException @ line 349

### DIFF
--- a/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
+++ b/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
@@ -328,7 +328,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
         try {
             values = (List<Object>) getDataFetcher(fieldDef).get(environment);
         } catch (Exception e) {
-            values = new ArrayList<>(nodeData.size());
+            values = Collections.nCopies(nodeData.size(), null);
             log.warn("Exception while fetching data", e);
 
             DataFetcherExceptionHandlerParameters handlerParameters = DataFetcherExceptionHandlerParameters.newExceptionParameters()

--- a/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
+++ b/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
@@ -332,7 +332,6 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
             }
         } catch (Exception e) {
             values = Collections.nCopies(nodeData.size(), null);
-            log.warn("Exception while fetching data", e);
 
             DataFetcherExceptionHandlerParameters handlerParameters = DataFetcherExceptionHandlerParameters.newExceptionParameters()
                     .executionContext(executionContext)
@@ -343,7 +342,6 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
                     .path(parameters.path())
                     .exception(e)
                     .build();
-
             dataFetcherExceptionHandler.accept(handlerParameters);
         }
 

--- a/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
+++ b/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
@@ -327,6 +327,9 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
         List<Object> values;
         try {
             values = (List<Object>) getDataFetcher(fieldDef).get(environment);
+            if (values == null || values.size() != nodeData.size()) {
+                throw new DataFetchingException("BatchedDataFetcher provided invalid number of result values. Affected fields are set to null.");
+            }
         } catch (Exception e) {
             values = Collections.nCopies(nodeData.size(), null);
             log.warn("Exception while fetching data", e);

--- a/src/main/java/graphql/execution/batched/DataFetchingException.java
+++ b/src/main/java/graphql/execution/batched/DataFetchingException.java
@@ -1,0 +1,26 @@
+package graphql.execution.batched;
+
+import graphql.GraphQLException;
+
+
+
+/**
+ * Thrown when an exception occurred while trying to fetch data from a GraphQL field.
+ */
+public class DataFetchingException extends GraphQLException {
+    public DataFetchingException() {
+        super();
+    }
+
+    public DataFetchingException(String message) {
+        super(message);
+    }
+
+    public DataFetchingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public DataFetchingException(Throwable cause) {
+        super(cause);
+    }
+}


### PR DESCRIPTION
new ArrayList<>(nodeData.size()); does not init a list of that size, just prepares space for it. Thus a IndexOutOfBound is thrown @ line 349.

Also right now, when an invalid number of values is provided back the whole query is aborted without a meaningful message. Instead, provide a meaningful message and just return null for affected fields, thus going in line with the behavior of unbatched fields.