### PR TITLE
Refactoring to allow extension of Introspection datafetchers

### DIFF
--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -1,31 +1,12 @@
 package graphql.execution;
 
-import graphql.ExecutionResult;
-import graphql.ExecutionResultImpl;
-import graphql.GraphQLException;
-import graphql.PublicSpi;
-import graphql.SerializationError;
-import graphql.TypeResolutionEnvironment;
+import graphql.*;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldParameters;
 import graphql.language.Field;
-import graphql.schema.CoercingSerializeException;
-import graphql.schema.DataFetcher;
-import graphql.schema.DataFetchingEnvironment;
-import graphql.schema.DataFetchingFieldSelectionSet;
-import graphql.schema.DataFetchingFieldSelectionSetImpl;
-import graphql.schema.GraphQLEnumType;
-import graphql.schema.GraphQLFieldDefinition;
-import graphql.schema.GraphQLInterfaceType;
-import graphql.schema.GraphQLList;
-import graphql.schema.GraphQLObjectType;
-import graphql.schema.GraphQLOutputType;
-import graphql.schema.GraphQLScalarType;
-import graphql.schema.GraphQLSchema;
-import graphql.schema.GraphQLType;
-import graphql.schema.GraphQLUnionType;
+import graphql.schema.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,9 +19,6 @@ import java.util.concurrent.CompletionException;
 
 import static graphql.execution.FieldCollectorParameters.newParameters;
 import static graphql.execution.TypeInfo.newTypeInfo;
-import static graphql.introspection.Introspection.SchemaMetaFieldDef;
-import static graphql.introspection.Introspection.TypeMetaFieldDef;
-import static graphql.introspection.Introspection.TypeNameMetaFieldDef;
 import static graphql.schema.DataFetchingEnvironmentBuilder.newDataFetchingEnvironment;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
@@ -500,15 +478,15 @@ public abstract class ExecutionStrategy {
      */
     protected GraphQLFieldDefinition getFieldDef(GraphQLSchema schema, GraphQLObjectType parentType, Field field) {
         if (schema.getQueryType() == parentType) {
-            if (field.getName().equals(SchemaMetaFieldDef.getName())) {
-                return SchemaMetaFieldDef;
+            if (field.getName().equals(schema.getSchemaMetaFieldDef().getName())) {
+                return schema.getSchemaMetaFieldDef();
             }
-            if (field.getName().equals(TypeMetaFieldDef.getName())) {
-                return TypeMetaFieldDef;
+            if (field.getName().equals(schema.getTypeMetaFieldDef().getName())) {
+                return schema.getTypeMetaFieldDef();
             }
         }
-        if (field.getName().equals(TypeNameMetaFieldDef.getName())) {
-            return TypeNameMetaFieldDef;
+        if (field.getName().equals(schema.getTypeNameMetaFieldDef().getName())) {
+            return schema.getTypeNameMetaFieldDef();
         }
 
         GraphQLFieldDefinition fieldDefinition = parentType.getFieldDefinition(field.getName());

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -5,6 +5,7 @@ import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldParameters;
+import graphql.introspection.IntrospectionTypeProvider;
 import graphql.language.Field;
 import graphql.schema.*;
 import org.slf4j.Logger;
@@ -478,15 +479,16 @@ public abstract class ExecutionStrategy {
      */
     protected GraphQLFieldDefinition getFieldDef(GraphQLSchema schema, GraphQLObjectType parentType, Field field) {
         if (schema.getQueryType() == parentType) {
-            if (field.getName().equals(schema.getSchemaMetaFieldDef().getName())) {
-                return schema.getSchemaMetaFieldDef();
+            IntrospectionTypeProvider introspectionTypeProvider = schema.getIntrospectionTypeProvider();
+            if (field.getName().equals(introspectionTypeProvider.getSchemaMetaFieldDef().getName())) {
+                return introspectionTypeProvider.getSchemaMetaFieldDef();
             }
-            if (field.getName().equals(schema.getTypeMetaFieldDef().getName())) {
-                return schema.getTypeMetaFieldDef();
+            if (field.getName().equals(introspectionTypeProvider.getTypeMetaFieldDef().getName())) {
+                return introspectionTypeProvider.getTypeMetaFieldDef();
             }
         }
-        if (field.getName().equals(schema.getTypeNameMetaFieldDef().getName())) {
-            return schema.getTypeNameMetaFieldDef();
+        if (field.getName().equals(schema.getIntrospectionTypeProvider().getTypeNameMetaFieldDef().getName())) {
+            return schema.getIntrospectionTypeProvider().getTypeNameMetaFieldDef();
         }
 
         GraphQLFieldDefinition fieldDefinition = parentType.getFieldDefinition(field.getName());

--- a/src/main/java/graphql/introspection/IntrospectionTypeProvider.java
+++ b/src/main/java/graphql/introspection/IntrospectionTypeProvider.java
@@ -1,0 +1,38 @@
+package graphql.introspection;
+
+import graphql.PublicSpi;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLObjectType;
+
+@PublicSpi
+public interface IntrospectionTypeProvider {
+    GraphQLObjectType getIntrospectionSchema();
+
+    GraphQLFieldDefinition getSchemaMetaFieldDef();
+
+    GraphQLFieldDefinition getTypeMetaFieldDef();
+
+    GraphQLFieldDefinition getTypeNameMetaFieldDef();
+
+    IntrospectionTypeProvider DEFAULT = new IntrospectionTypeProvider() {
+        @Override
+        public GraphQLObjectType getIntrospectionSchema() {
+            return Introspection.__Schema;
+        }
+
+        @Override
+        public GraphQLFieldDefinition getSchemaMetaFieldDef() {
+            return Introspection.SchemaMetaFieldDef;
+        }
+
+        @Override
+        public GraphQLFieldDefinition getTypeMetaFieldDef() {
+            return Introspection.TypeMetaFieldDef;
+        }
+
+        @Override
+        public GraphQLFieldDefinition getTypeNameMetaFieldDef() {
+            return Introspection.TypeNameMetaFieldDef;
+        }
+    };
+}

--- a/src/main/java/graphql/schema/GraphQLSchema.java
+++ b/src/main/java/graphql/schema/GraphQLSchema.java
@@ -2,18 +2,12 @@ package graphql.schema;
 
 
 import graphql.Directives;
-import graphql.introspection.Introspection;
+import graphql.introspection.IntrospectionTypeProvider;
 import graphql.schema.validation.InvalidSchemaException;
 import graphql.schema.validation.SchemaValidationError;
 import graphql.schema.validation.SchemaValidator;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static graphql.Assert.assertNotNull;
 
@@ -23,6 +17,7 @@ public class GraphQLSchema {
     private final GraphQLObjectType mutationType;
     private final GraphQLObjectType subscriptionType;
     private final Map<String, GraphQLType> typeMap;
+    private final IntrospectionTypeProvider introspectionTypeProvider;
     private Set<GraphQLType> additionalTypes;
 
     public GraphQLSchema(GraphQLObjectType queryType) {
@@ -33,13 +28,16 @@ public class GraphQLSchema {
         this(queryType, mutationType, null, additionalTypes);
     }
 
-    public GraphQLSchema(GraphQLObjectType queryType, GraphQLObjectType mutationType, GraphQLObjectType subscriptionType, Set<GraphQLType> dictionary) {
+    public GraphQLSchema(GraphQLObjectType queryType, GraphQLObjectType mutationType, GraphQLObjectType subscriptionType, Set<GraphQLType> dictionary) {this(queryType, mutationType, subscriptionType, dictionary, IntrospectionTypeProvider.DEFAULT);}
+
+    public GraphQLSchema(GraphQLObjectType queryType, GraphQLObjectType mutationType, GraphQLObjectType subscriptionType, Set<GraphQLType> dictionary, IntrospectionTypeProvider introspectionTypeProvider) {
         assertNotNull(dictionary, "dictionary can't be null");
         assertNotNull(queryType, "queryType can't be null");
         this.queryType = queryType;
         this.mutationType = mutationType;
         this.subscriptionType = subscriptionType;
         this.additionalTypes = dictionary;
+        this.introspectionTypeProvider = introspectionTypeProvider;
         typeMap = new SchemaUtil().allTypes(this, dictionary);
     }
 
@@ -86,21 +84,7 @@ public class GraphQLSchema {
         return subscriptionType != null;
     }
 
-    public GraphQLObjectType getIntrospectionSchema() {
-        return Introspection.__Schema;
-    }
-
-    public GraphQLFieldDefinition getSchemaMetaFieldDef() {
-        return Introspection.SchemaMetaFieldDef;
-    }
-
-    public GraphQLFieldDefinition getTypeMetaFieldDef() {
-        return Introspection.TypeMetaFieldDef;
-    }
-
-    public GraphQLFieldDefinition getTypeNameMetaFieldDef() {
-        return Introspection.TypeNameMetaFieldDef;
-    }
+    public IntrospectionTypeProvider getIntrospectionTypeProvider() {return introspectionTypeProvider; }
 
     public static Builder newSchema() {
         return new Builder();
@@ -110,6 +94,7 @@ public class GraphQLSchema {
         protected GraphQLObjectType queryType;
         protected GraphQLObjectType mutationType;
         protected GraphQLObjectType subscriptionType;
+        protected IntrospectionTypeProvider introspectionTypeProvider = IntrospectionTypeProvider.DEFAULT;
 
         public Builder query(GraphQLObjectType.Builder builder) {
             return query(builder.build());
@@ -138,12 +123,17 @@ public class GraphQLSchema {
             return this;
         }
 
+        public Builder introspectionTypeProvider(IntrospectionTypeProvider introspectionTypeProvider) {
+            this.introspectionTypeProvider = introspectionTypeProvider;
+            return this;
+        }
+
         public GraphQLSchema build() {
             return build(Collections.emptySet());
         }
 
         protected GraphQLSchema instantiateType(Set<GraphQLType> additionalTypes) {
-            return new GraphQLSchema(queryType, mutationType, subscriptionType, additionalTypes);
+            return new GraphQLSchema(queryType, mutationType, subscriptionType, additionalTypes, introspectionTypeProvider);
         }
 
         public GraphQLSchema build(Set<GraphQLType> additionalTypes) {

--- a/src/main/java/graphql/schema/SchemaUtil.java
+++ b/src/main/java/graphql/schema/SchemaUtil.java
@@ -157,7 +157,7 @@ public class SchemaUtil {
                 collectTypes(type, typesByName);
             }
         }
-        collectTypes(schema.getIntrospectionSchema(), typesByName);
+        collectTypes(schema.getIntrospectionTypeProvider().getIntrospectionSchema(), typesByName);
         return typesByName;
     }
 

--- a/src/main/java/graphql/schema/SchemaUtil.java
+++ b/src/main/java/graphql/schema/SchemaUtil.java
@@ -4,13 +4,8 @@ package graphql.schema;
 import graphql.AssertException;
 import graphql.GraphQLException;
 import graphql.Internal;
-import graphql.introspection.Introspection;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static java.lang.String.format;
 
@@ -162,7 +157,7 @@ public class SchemaUtil {
                 collectTypes(type, typesByName);
             }
         }
-        collectTypes(Introspection.__Schema, typesByName);
+        collectTypes(schema.getIntrospectionSchema(), typesByName);
         return typesByName;
     }
 

--- a/src/main/java/graphql/validation/TraversalContext.java
+++ b/src/main/java/graphql/validation/TraversalContext.java
@@ -4,44 +4,11 @@ package graphql.validation;
 import graphql.Internal;
 import graphql.ShouldNotHappenException;
 import graphql.execution.TypeFromAST;
-import graphql.language.Argument;
-import graphql.language.ArrayValue;
-import graphql.language.Directive;
-import graphql.language.Field;
-import graphql.language.FragmentDefinition;
-import graphql.language.InlineFragment;
-import graphql.language.Node;
-import graphql.language.ObjectField;
-import graphql.language.OperationDefinition;
-import graphql.language.SelectionSet;
-import graphql.language.TypeName;
-import graphql.language.VariableDefinition;
-import graphql.schema.GraphQLArgument;
-import graphql.schema.GraphQLCompositeType;
-import graphql.schema.GraphQLDirective;
-import graphql.schema.GraphQLFieldDefinition;
-import graphql.schema.GraphQLFieldsContainer;
-import graphql.schema.GraphQLInputObjectField;
-import graphql.schema.GraphQLInputObjectType;
-import graphql.schema.GraphQLInputType;
-import graphql.schema.GraphQLInterfaceType;
-import graphql.schema.GraphQLList;
-import graphql.schema.GraphQLNonNull;
-import graphql.schema.GraphQLNullableType;
-import graphql.schema.GraphQLObjectType;
-import graphql.schema.GraphQLOutputType;
-import graphql.schema.GraphQLSchema;
-import graphql.schema.GraphQLType;
-import graphql.schema.GraphQLUnionType;
-import graphql.schema.GraphQLUnmodifiedType;
-import graphql.schema.SchemaUtil;
+import graphql.language.*;
+import graphql.schema.*;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static graphql.introspection.Introspection.SchemaMetaFieldDef;
-import static graphql.introspection.Introspection.TypeMetaFieldDef;
-import static graphql.introspection.Introspection.TypeNameMetaFieldDef;
 
 @Internal
 public class TraversalContext implements DocumentVisitor {
@@ -270,18 +237,18 @@ public class TraversalContext implements DocumentVisitor {
 
     private GraphQLFieldDefinition getFieldDef(GraphQLSchema schema, GraphQLType parentType, Field field) {
         if (schema.getQueryType().equals(parentType)) {
-            if (field.getName().equals(SchemaMetaFieldDef.getName())) {
-                return SchemaMetaFieldDef;
+            if (field.getName().equals(schema.getSchemaMetaFieldDef().getName())) {
+                return schema.getSchemaMetaFieldDef();
             }
-            if (field.getName().equals(TypeMetaFieldDef.getName())) {
-                return TypeMetaFieldDef;
+            if (field.getName().equals(schema.getTypeMetaFieldDef().getName())) {
+                return schema.getTypeMetaFieldDef();
             }
         }
-        if (field.getName().equals(TypeNameMetaFieldDef.getName())
+        if (field.getName().equals(schema.getTypeNameMetaFieldDef().getName())
                 && (parentType instanceof GraphQLObjectType ||
                 parentType instanceof GraphQLInterfaceType ||
                 parentType instanceof GraphQLUnionType)) {
-            return TypeNameMetaFieldDef;
+            return schema.getTypeNameMetaFieldDef();
         }
         if (parentType instanceof GraphQLFieldsContainer) {
             return ((GraphQLFieldsContainer) parentType).getFieldDefinition(field.getName());

--- a/src/main/java/graphql/validation/TraversalContext.java
+++ b/src/main/java/graphql/validation/TraversalContext.java
@@ -4,6 +4,7 @@ package graphql.validation;
 import graphql.Internal;
 import graphql.ShouldNotHappenException;
 import graphql.execution.TypeFromAST;
+import graphql.introspection.IntrospectionTypeProvider;
 import graphql.language.*;
 import graphql.schema.*;
 
@@ -237,18 +238,19 @@ public class TraversalContext implements DocumentVisitor {
 
     private GraphQLFieldDefinition getFieldDef(GraphQLSchema schema, GraphQLType parentType, Field field) {
         if (schema.getQueryType().equals(parentType)) {
-            if (field.getName().equals(schema.getSchemaMetaFieldDef().getName())) {
-                return schema.getSchemaMetaFieldDef();
+            IntrospectionTypeProvider introspectionTypeProvider = schema.getIntrospectionTypeProvider();
+            if (field.getName().equals(introspectionTypeProvider.getSchemaMetaFieldDef().getName())) {
+                return introspectionTypeProvider.getSchemaMetaFieldDef();
             }
-            if (field.getName().equals(schema.getTypeMetaFieldDef().getName())) {
-                return schema.getTypeMetaFieldDef();
+            if (field.getName().equals(introspectionTypeProvider.getTypeMetaFieldDef().getName())) {
+                return introspectionTypeProvider.getTypeMetaFieldDef();
             }
         }
-        if (field.getName().equals(schema.getTypeNameMetaFieldDef().getName())
+        if (field.getName().equals(schema.getIntrospectionTypeProvider().getTypeNameMetaFieldDef().getName())
                 && (parentType instanceof GraphQLObjectType ||
                 parentType instanceof GraphQLInterfaceType ||
                 parentType instanceof GraphQLUnionType)) {
-            return schema.getTypeNameMetaFieldDef();
+            return schema.getIntrospectionTypeProvider().getTypeNameMetaFieldDef();
         }
         if (parentType instanceof GraphQLFieldsContainer) {
             return ((GraphQLFieldsContainer) parentType).getFieldDefinition(field.getName());


### PR DESCRIPTION
See Issue #556 
Refactored static access to Introspection.SchemaMetaFieldDef, .TypeMe…taFieldDef and .TypeNameMetaFieldDef so that they are retrieved via the GraphQLSchema instance and can be overriden there.

Also, refactored the Builder in GraphQLSchema so that the actual class being instantiated can be overriden in a subclass (this was harder before because the build() method itself accesses SchemaUtil.replaceTypeReferences which is private.