### PR TITLE
Adding the ability to deeply instrument data fetchers

### DIFF
--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -47,7 +47,7 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 
 /**
  * An execution strategy is give a list of fields from the graphql query to execute and find values for using a recursive strategy.
- * 
+ *
  * <pre>
  *     query {
  *          friends {
@@ -237,6 +237,7 @@ public abstract class ExecutionStrategy {
         Object fetchedValue = null;
         try {
             DataFetcher dataFetcher = fieldDef.getDataFetcher();
+            dataFetcher = instrumentation.instrumentDataFetcher(dataFetcher);
             fetchedValue = dataFetcher.get(environment);
 
             fetchCtx.onEnd(fetchedValue);

--- a/src/main/java/graphql/execution/instrumentation/Instrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/Instrumentation.java
@@ -79,4 +79,18 @@ public interface Instrumentation {
      * @return a non null {@link InstrumentationContext} object that will be called back when the step ends
      */
     InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters);
+
+    /**
+     * This is called to instrument a {@link DataFetcher} just before it is used to fetch a field, allowing you
+     * to adjust what information is passed back or record information about specific data fetches.  Note
+     * the same data fetcher instance maybe presented to you many times and that data fetcher
+     * implementations widely vary.
+     *
+     * @param dataFetcher the data fetcher about to be used
+     *
+     * @return a non null instrumented data fetcher, the default is to return to the same object
+     */
+    default DataFetcher<?> instrumentDataFetcher(DataFetcher<?> dataFetcher) {
+        return dataFetcher;
+    }
 }

--- a/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
@@ -3,6 +3,8 @@ package graphql.execution.instrumentation
 import graphql.GraphQL
 import graphql.StarWarsSchema
 import graphql.execution.SimpleExecutionStrategy
+import graphql.schema.PropertyDataFetcher
+import graphql.schema.StaticDataFetcher
 import spock.lang.Specification
 
 class InstrumentationTest extends Specification {
@@ -67,6 +69,14 @@ class InstrumentationTest extends Specification {
         then:
 
         instrumentation.executionList == expected
+
+        instrumentation.dfClasses.size() == 2
+        instrumentation.dfClasses[0] == StaticDataFetcher.class
+        instrumentation.dfClasses[1] == PropertyDataFetcher.class
+
+        instrumentation.dfInvocations.size() == 2
+        instrumentation.dfInvocations[0].getFieldDefinition().name == 'hero'
+        instrumentation.dfInvocations[1].getFieldDefinition().name == 'id'
     }
 
 }


### PR DESCRIPTION
Adding the ability to deeply instrument data fetchers, allowing them to be wrapped

I see this as allowing an AOP way of instrumenting the system of ANY schema.

Not all data fetchers (for example PropertyFetchers etc..) are wired in by the caller and hence
this allows interception of the data fetcher to be used at execution time