### PR TITLE
Move boolean inversion to correct place

### DIFF
--- a/src/main/java/graphql/validation/rules/KnownDirectives.java
+++ b/src/main/java/graphql/validation/rules/KnownDirectives.java
@@ -45,7 +45,7 @@ public class KnownDirectives extends AbstractRule {
         } else if (ancestor instanceof FragmentDefinition) {
             return !(directive.validLocations().contains(DirectiveLocation.FRAGMENT_DEFINITION) || directive.isOnFragment());
         } else if (ancestor instanceof InlineFragment) {
-            return (!directive.validLocations().contains(DirectiveLocation.INLINE_FRAGMENT) || directive.isOnFragment());
+            return !(directive.validLocations().contains(DirectiveLocation.INLINE_FRAGMENT) || directive.isOnFragment());
         }
         return true;
     }

--- a/src/test/groovy/graphql/validation/SpecValidation562Test.groovy
+++ b/src/test/groovy/graphql/validation/SpecValidation562Test.groovy
@@ -10,7 +10,7 @@ import spock.lang.Specification
  * validation examples used in the spec in given section
  * http://facebook.github.io/graphql/#sec-Validation
  * @author dwinsor
- *        
+ *
  */
 class SpecValidation562Test extends SpecValidationBase {
 
@@ -33,7 +33,7 @@ fragment interfaceFieldSelection on Pet {
         validationErrors.size() == 1
         validationErrors.get(0).getValidationErrorType() == ValidationErrorType.MisplacedDirective
     }
-    
+
     def 'Directives Are In Valid Locations -- Skip frag def'() {
         def query = """
 query {
@@ -52,5 +52,23 @@ fragment interfaceFieldSelection on Pet @skip(if: false) {
         !validationErrors.empty
         validationErrors.size() == 1
         validationErrors.get(0).getValidationErrorType() == ValidationErrorType.MisplacedDirective
+    }
+
+    def 'Directives Are In Valid Locations -- Skip inline frag def'() {
+        def query = """
+query {
+  dog {
+    ...on Pet @skip(if: false) {
+        name
+    }
+  }
+}
+"""
+        when:
+        def validationErrors = validate(query)
+
+        then:
+        validationErrors.empty
+        validationErrors.size() == 0
     }
 }


### PR DESCRIPTION
While looking around the code for hasInvalidLocation, I noticed that the inversion appeared to be incorrect inside of the InlineFragment use case - I believe it should be on the outside of the parentheses like the other cases, not inside on the .validLocations() check)