### PR TITLE
Added IntrospectionSupport to allow wiring of your own Introspection implementation

### DIFF
--- a/src/main/java/graphql/ExecutionResult.java
+++ b/src/main/java/graphql/ExecutionResult.java
@@ -27,7 +27,7 @@ public interface ExecutionResult {
      * should be present.  Certain JSON serializers may or may interpret {@link ExecutionResult} to spec, so this method
      * is provided to produce a map that strictly follows the specification.
      *
-     * See : <a href="http://facebook.github.io/graphql/#sec-Response-Format">http://facebook.github.io/graphql/#sec-Response-Format">http://facebook.github.io/graphql/#sec-Response-Format</a>
+     * See : <a href="http://facebook.github.io/graphql/#sec-Response-Format">http://facebook.github.io/graphql/#sec-Response-Format</a>
      *
      * @return a map of the result that strictly follows the spec
      */

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -9,6 +9,7 @@ import graphql.MutationNotSupportedError;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.parameters.InstrumentationDataFetchParameters;
+import graphql.introspection.IntrospectionSupport;
 import graphql.language.Document;
 import graphql.language.Field;
 import graphql.language.OperationDefinition;
@@ -36,12 +37,14 @@ public class Execution {
     private final ExecutionStrategy mutationStrategy;
     private final ExecutionStrategy subscriptionStrategy;
     private final Instrumentation instrumentation;
+    private final IntrospectionSupport introspectionSupport;
 
-    public Execution(ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy, ExecutionStrategy subscriptionStrategy, Instrumentation instrumentation) {
+    public Execution(ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy, ExecutionStrategy subscriptionStrategy, Instrumentation instrumentation, IntrospectionSupport introspectionSupport) {
         this.queryStrategy = queryStrategy != null ? queryStrategy : new SimpleExecutionStrategy();
         this.mutationStrategy = mutationStrategy != null ? mutationStrategy : new SimpleExecutionStrategy();
         this.subscriptionStrategy = subscriptionStrategy != null ? subscriptionStrategy : new SimpleExecutionStrategy();
         this.instrumentation = instrumentation;
+        this.introspectionSupport = introspectionSupport;
     }
 
     public CompletableFuture<ExecutionResult> execute(Document document, GraphQLSchema graphQLSchema, ExecutionId executionId, ExecutionInput executionInput) {
@@ -59,6 +62,7 @@ public class Execution {
                 .document(document)
                 .operationName(executionInput.getOperationName())
                 .variables(executionInput.getVariables())
+                .introspectionSupport(introspectionSupport)
                 .build();
         return executeOperation(executionContext, executionInput.getRoot(), executionContext.getOperationDefinition());
     }

--- a/src/main/java/graphql/execution/ExecutionContext.java
+++ b/src/main/java/graphql/execution/ExecutionContext.java
@@ -3,6 +3,7 @@ package graphql.execution;
 
 import graphql.GraphQLError;
 import graphql.execution.instrumentation.Instrumentation;
+import graphql.introspection.IntrospectionSupport;
 import graphql.language.FragmentDefinition;
 import graphql.language.OperationDefinition;
 import graphql.schema.GraphQLSchema;
@@ -25,8 +26,9 @@ public class ExecutionContext {
     private final Object context;
     private final List<GraphQLError> errors = new CopyOnWriteArrayList<>();
     private final Instrumentation instrumentation;
+    private final IntrospectionSupport introspectionSupport;
 
-    public ExecutionContext(Instrumentation instrumentation, ExecutionId executionId, GraphQLSchema graphQLSchema, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy, ExecutionStrategy subscriptionStrategy, Map<String, FragmentDefinition> fragmentsByName, OperationDefinition operationDefinition, Map<String, Object> variables, Object context, Object root) {
+    public ExecutionContext(Instrumentation instrumentation, ExecutionId executionId, GraphQLSchema graphQLSchema, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy, ExecutionStrategy subscriptionStrategy, Map<String, FragmentDefinition> fragmentsByName, OperationDefinition operationDefinition, Map<String, Object> variables, Object context, Object root, IntrospectionSupport introspectionSupport) {
         this.graphQLSchema = graphQLSchema;
         this.executionId = executionId;
         this.queryStrategy = queryStrategy;
@@ -38,6 +40,7 @@ public class ExecutionContext {
         this.context = context;
         this.root = root;
         this.instrumentation = instrumentation;
+        this.introspectionSupport = introspectionSupport;
     }
 
 
@@ -96,5 +99,9 @@ public class ExecutionContext {
 
     public ExecutionStrategy getSubscriptionStrategy() {
         return subscriptionStrategy;
+    }
+
+    public IntrospectionSupport getIntrospectionSupport() {
+        return introspectionSupport;
     }
 }

--- a/src/main/java/graphql/execution/ExecutionContextBuilder.java
+++ b/src/main/java/graphql/execution/ExecutionContextBuilder.java
@@ -2,6 +2,7 @@ package graphql.execution;
 
 import graphql.GraphQLException;
 import graphql.execution.instrumentation.Instrumentation;
+import graphql.introspection.IntrospectionSupport;
 import graphql.language.Definition;
 import graphql.language.Document;
 import graphql.language.FragmentDefinition;
@@ -27,6 +28,7 @@ public class ExecutionContextBuilder {
     private Document document;
     private String operationName;
     private Map<String, Object> variables;
+    private IntrospectionSupport introspectionSupport;
 
     public ExecutionContextBuilder valuesResolver(ValuesResolver valuesResolver) {
         this.valuesResolver = valuesResolver;
@@ -88,6 +90,11 @@ public class ExecutionContextBuilder {
         return this;
     }
 
+    public ExecutionContextBuilder introspectionSupport(IntrospectionSupport introspectionSupport) {
+        this.introspectionSupport = introspectionSupport;
+        return this;
+    }
+
     public ExecutionContext build() {
         // preconditions
         assertNotNull(executionId, "You must provide a query identifier");
@@ -131,6 +138,7 @@ public class ExecutionContextBuilder {
                 operation,
                 variableValues,
                 context,
-                root);
+                root,
+                introspectionSupport);
     }
 }

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -11,6 +11,8 @@ import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldParameters;
+import graphql.introspection.Introspection;
+import graphql.introspection.IntrospectionSupport;
 import graphql.language.Field;
 import graphql.schema.CoercingSerializeException;
 import graphql.schema.DataFetcher;
@@ -39,15 +41,12 @@ import java.util.concurrent.CompletionException;
 
 import static graphql.execution.FieldCollectorParameters.newParameters;
 import static graphql.execution.TypeInfo.newTypeInfo;
-import static graphql.introspection.Introspection.SchemaMetaFieldDef;
-import static graphql.introspection.Introspection.TypeMetaFieldDef;
-import static graphql.introspection.Introspection.TypeNameMetaFieldDef;
 import static graphql.schema.DataFetchingEnvironmentBuilder.newDataFetchingEnvironment;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
 /**
  * An execution strategy is give a list of fields from the graphql query to execute and find values for using a recursive strategy.
- * 
+ *
  * <pre>
  *     query {
  *          friends {
@@ -214,7 +213,7 @@ public abstract class ExecutionStrategy {
     protected Object fetchField(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
         Field field = parameters.field().get(0);
         GraphQLObjectType parentType = parameters.typeInfo().castType(GraphQLObjectType.class);
-        GraphQLFieldDefinition fieldDef = getFieldDef(executionContext.getGraphQLSchema(), parentType, field);
+        GraphQLFieldDefinition fieldDef = getFieldDef(executionContext, parentType, field);
 
         Map<String, Object> argumentValues = valuesResolver.getArgumentValues(fieldDef.getArguments(), field.getArguments(), executionContext.getVariables());
 
@@ -276,7 +275,7 @@ public abstract class ExecutionStrategy {
     protected CompletableFuture<ExecutionResult> completeField(ExecutionContext executionContext, ExecutionStrategyParameters parameters, Object fetchedValue) {
         Field field = parameters.field().get(0);
         GraphQLObjectType parentType = parameters.typeInfo().castType(GraphQLObjectType.class);
-        GraphQLFieldDefinition fieldDef = getFieldDef(executionContext.getGraphQLSchema(), parentType, field);
+        GraphQLFieldDefinition fieldDef = getFieldDef(executionContext, parentType, field);
 
         Map<String, Object> argumentValues = valuesResolver.getArgumentValues(fieldDef.getArguments(), field.getArguments(), executionContext.getVariables());
 
@@ -521,33 +520,37 @@ public abstract class ExecutionStrategy {
      */
     protected GraphQLFieldDefinition getFieldDef(ExecutionContext executionContext, ExecutionStrategyParameters parameters, Field field) {
         GraphQLObjectType parentType = parameters.typeInfo().castType(GraphQLObjectType.class);
-        return getFieldDef(executionContext.getGraphQLSchema(), parentType, field);
+        return getFieldDef(executionContext, parentType, field);
     }
 
     /**
      * Called to discover the field definition give the current parameters and the AST {@link Field}
      *
-     * @param schema     the schema in play
-     * @param parentType the parent type of the field
-     * @param field      the field to find the definition of
+     * @param executionContext the execution context in play
+     * @param parentType       the parent type of the field
+     * @param field            the field to find the definition of
+     *
      * @return a {@link GraphQLFieldDefinition}
      */
-    protected GraphQLFieldDefinition getFieldDef(GraphQLSchema schema, GraphQLObjectType parentType, Field field) {
-        if (schema.getQueryType() == parentType) {
-            if (field.getName().equals(SchemaMetaFieldDef.getName())) {
-                return SchemaMetaFieldDef;
+    protected GraphQLFieldDefinition getFieldDef(ExecutionContext executionContext, GraphQLObjectType parentType, Field field) {
+        IntrospectionSupport introspectionSupport = executionContext.getIntrospectionSupport();
+        GraphQLSchema graphQLSchema = executionContext.getGraphQLSchema();
+        String fieldName = field.getName();
+        if (graphQLSchema.getQueryType() == parentType) {
+            if (fieldName.equals(Introspection.__SCHEMA_FIELD)) {
+                return introspectionSupport.__Schema();
             }
-            if (field.getName().equals(TypeMetaFieldDef.getName())) {
-                return TypeMetaFieldDef;
+            if (fieldName.equals(Introspection.__TYPE_FIELD)) {
+                return introspectionSupport.__Type();
             }
         }
-        if (field.getName().equals(TypeNameMetaFieldDef.getName())) {
-            return TypeNameMetaFieldDef;
+        if (fieldName.equals(Introspection.__TYPENAME_FIELD)) {
+            return introspectionSupport.__TypeName();
         }
 
-        GraphQLFieldDefinition fieldDefinition = parentType.getFieldDefinition(field.getName());
+        GraphQLFieldDefinition fieldDefinition = parentType.getFieldDefinition(fieldName);
         if (fieldDefinition == null) {
-            throw new GraphQLException("Unknown field " + field.getName());
+            throw new GraphQLException("Unknown field " + fieldName);
         }
         return fieldDefinition;
     }

--- a/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
+++ b/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
@@ -112,7 +112,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
     private List<GraphQLExecutionNode> resolveField(ExecutionContext executionContext, ExecutionStrategyParameters parameters, GraphQLObjectType parentType,
                                                     List<GraphQLExecutionNodeDatum> nodeData, String fieldName, List<Field> fields) {
 
-        GraphQLFieldDefinition fieldDef = getFieldDef(executionContext.getGraphQLSchema(), parentType, fields.get(0));
+        GraphQLFieldDefinition fieldDef = getFieldDef(executionContext, parentType, fields.get(0));
         if (fieldDef == null) {
             return Collections.emptyList();
         }

--- a/src/main/java/graphql/introspection/Introspection.java
+++ b/src/main/java/graphql/introspection/Introspection.java
@@ -1,8 +1,8 @@
 package graphql.introspection;
 
 
-import graphql.language.AstValueHelper;
 import graphql.language.AstPrinter;
+import graphql.language.AstValueHelper;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.GraphQLArgument;
@@ -36,6 +36,19 @@ import static graphql.schema.GraphQLNonNull.nonNull;
 import static graphql.schema.GraphQLObjectType.newObject;
 
 public class Introspection {
+
+    /**
+     * A field called __schema in the top level query will return the introspection of the schema
+     */
+    public static final String __SCHEMA_FIELD = "__schema";
+    /**
+     * A field called __typename will return the type of the current object
+     */
+    public static final String __TYPENAME_FIELD = "__typename";
+    /**
+     * A field called __type can be used to get information on a named type
+     */
+    public static final String __TYPE_FIELD = "__type";
 
     public enum TypeKind {
         SCALAR,
@@ -399,13 +412,13 @@ public class Introspection {
 
 
     public static GraphQLFieldDefinition SchemaMetaFieldDef = newFieldDefinition()
-            .name("__schema")
+            .name(__SCHEMA_FIELD)
             .type(nonNull(__Schema))
             .description("Access the current type schema of this server.")
             .dataFetcher(DataFetchingEnvironment::getGraphQLSchema).build();
 
     public static GraphQLFieldDefinition TypeMetaFieldDef = newFieldDefinition()
-            .name("__type")
+            .name(__TYPE_FIELD)
             .type(__Type)
             .description("Request the type information of a single type.")
             .argument(newArgument()
@@ -417,7 +430,7 @@ public class Introspection {
             }).build();
 
     public static GraphQLFieldDefinition TypeNameMetaFieldDef = newFieldDefinition()
-            .name("__typename")
+            .name(__TYPENAME_FIELD)
             .type(nonNull(GraphQLString))
             .description("The name of the current Object type at runtime.")
             .dataFetcher(environment -> environment.getParentType().getName())

--- a/src/main/java/graphql/introspection/IntrospectionSupport.java
+++ b/src/main/java/graphql/introspection/IntrospectionSupport.java
@@ -1,0 +1,19 @@
+package graphql.introspection;
+
+import graphql.schema.GraphQLFieldDefinition;
+
+/**
+ * This interface allows a different implementation of Introspection
+ * to be used.  The graphql schema as defined by the specification
+ * is used by default.
+ *
+ * See <a href="http://facebook.github.io/graphql/#sec-Introspection">http://facebook.github.io/graphql/#sec-Introspection</a>
+ */
+public interface IntrospectionSupport {
+
+    GraphQLFieldDefinition __Schema();
+
+    GraphQLFieldDefinition __Type();
+
+    GraphQLFieldDefinition __TypeName();
+}

--- a/src/main/java/graphql/introspection/SpecificationIntrospectionSupport.java
+++ b/src/main/java/graphql/introspection/SpecificationIntrospectionSupport.java
@@ -1,0 +1,26 @@
+package graphql.introspection;
+
+import graphql.schema.GraphQLFieldDefinition;
+
+/**
+ * Defined in terms of http://facebook.github.io/graphql/#sec-Introspection
+ */
+public class SpecificationIntrospectionSupport implements IntrospectionSupport {
+
+    public static IntrospectionSupport INSTANCE = new SpecificationIntrospectionSupport();
+
+    @Override
+    public GraphQLFieldDefinition __Schema() {
+        return Introspection.SchemaMetaFieldDef;
+    }
+
+    @Override
+    public GraphQLFieldDefinition __Type() {
+        return Introspection.TypeMetaFieldDef;
+    }
+
+    @Override
+    public GraphQLFieldDefinition __TypeName() {
+        return Introspection.TypeNameMetaFieldDef;
+    }
+}

--- a/src/main/java/graphql/validation/ValidationContext.java
+++ b/src/main/java/graphql/validation/ValidationContext.java
@@ -2,6 +2,7 @@ package graphql.validation;
 
 
 import graphql.Internal;
+import graphql.introspection.IntrospectionSupport;
 import graphql.language.Definition;
 import graphql.language.Document;
 import graphql.language.FragmentDefinition;
@@ -26,10 +27,10 @@ public class ValidationContext {
     private final Map<String, FragmentDefinition> fragmentDefinitionMap = new LinkedHashMap<>();
 
 
-    public ValidationContext(GraphQLSchema schema, Document document) {
+    public ValidationContext(GraphQLSchema schema, IntrospectionSupport introspectionSupport, Document document) {
         this.schema = schema;
         this.document = document;
-        this.traversalContext = new TraversalContext(schema);
+        this.traversalContext = new TraversalContext(schema, introspectionSupport);
         buildFragmentMap();
     }
 

--- a/src/main/java/graphql/validation/Validator.java
+++ b/src/main/java/graphql/validation/Validator.java
@@ -2,6 +2,7 @@ package graphql.validation;
 
 
 import graphql.Internal;
+import graphql.introspection.IntrospectionSupport;
 import graphql.language.Document;
 import graphql.schema.GraphQLSchema;
 import graphql.validation.rules.ArgumentsOfCorrectType;
@@ -30,8 +31,8 @@ import java.util.List;
 @Internal
 public class Validator {
 
-    public List<ValidationError> validateDocument(GraphQLSchema schema, Document document) {
-        ValidationContext validationContext = new ValidationContext(schema, document);
+    public List<ValidationError> validateDocument(GraphQLSchema schema, IntrospectionSupport introspectionSupport, Document document) {
+        ValidationContext validationContext = new ValidationContext(schema, introspectionSupport, document);
 
 
         ValidationErrorCollector validationErrorCollector = new ValidationErrorCollector();

--- a/src/test/groovy/graphql/StarWarsValidationTest.groovy
+++ b/src/test/groovy/graphql/StarWarsValidationTest.groovy
@@ -1,5 +1,6 @@
 package graphql
 
+import graphql.introspection.SpecificationIntrospectionSupport
 import graphql.parser.Parser
 import graphql.validation.ValidationError
 import graphql.validation.Validator
@@ -10,7 +11,7 @@ class StarWarsValidationTest extends Specification {
 
     List<ValidationError> validate(String query) {
         def document = new Parser().parseDocument(query)
-        return new Validator().validateDocument(StarWarsSchema.starWarsSchema, document)
+        return new Validator().validateDocument(StarWarsSchema.starWarsSchema, SpecificationIntrospectionSupport.INSTANCE, document)
     }
 
     def 'Validates a complex but valid query'() {

--- a/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
@@ -5,6 +5,7 @@ import graphql.ExecutionResult
 import graphql.Scalars
 import graphql.SerializationError
 import graphql.execution.instrumentation.NoOpInstrumentation
+import graphql.introspection.SpecificationIntrospectionSupport
 import graphql.language.Field
 import graphql.language.SourceLocation
 import graphql.schema.Coercing
@@ -44,7 +45,7 @@ class ExecutionStrategyTest extends Specification {
     }
 
     def buildContext(GraphQLSchema schema = null) {
-        new ExecutionContext(NoOpInstrumentation.INSTANCE, null, schema, executionStrategy, executionStrategy, executionStrategy, null, null, null, "context", "root")
+        new ExecutionContext(NoOpInstrumentation.INSTANCE, null, schema, executionStrategy, executionStrategy, executionStrategy, null, null, null, "context", "root", SpecificationIntrospectionSupport.INSTANCE)
     }
 
 

--- a/src/test/groovy/graphql/execution/ExecutionTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionTest.groovy
@@ -5,6 +5,7 @@ import graphql.ExecutionResult
 import graphql.ExecutionResultImpl
 import graphql.MutationSchema
 import graphql.execution.instrumentation.NoOpInstrumentation
+import graphql.introspection.SpecificationIntrospectionSupport
 import graphql.parser.Parser
 import spock.lang.Specification
 
@@ -33,7 +34,7 @@ class ExecutionTest extends Specification {
     def subscriptionStrategy = new CountingExecutionStrategy()
     def mutationStrategy = new CountingExecutionStrategy()
     def queryStrategy = new CountingExecutionStrategy()
-    def execution = new Execution(queryStrategy, mutationStrategy, subscriptionStrategy, NoOpInstrumentation.INSTANCE)
+    def execution = new Execution(queryStrategy, mutationStrategy, subscriptionStrategy, NoOpInstrumentation.INSTANCE, SpecificationIntrospectionSupport.INSTANCE)
     def emptyExecutionInput = ExecutionInput.newExecutionInput().build()
 
     def "query strategy is used for query requests"() {
@@ -41,7 +42,7 @@ class ExecutionTest extends Specification {
         def mutationStrategy = new CountingExecutionStrategy()
 
         def queryStrategy = new CountingExecutionStrategy()
-        def execution = new Execution(queryStrategy, mutationStrategy, subscriptionStrategy, NoOpInstrumentation.INSTANCE)
+        def execution = new Execution(queryStrategy, mutationStrategy, subscriptionStrategy, NoOpInstrumentation.INSTANCE, SpecificationIntrospectionSupport.INSTANCE)
 
         def query = '''
             query {

--- a/src/test/groovy/graphql/validation/RulesVisitorTest.groovy
+++ b/src/test/groovy/graphql/validation/RulesVisitorTest.groovy
@@ -1,6 +1,7 @@
 package graphql.validation
 
 import graphql.TestUtil
+import graphql.introspection.SpecificationIntrospectionSupport
 import graphql.language.Document
 import graphql.parser.Parser
 import graphql.validation.rules.NoUnusedVariables
@@ -11,7 +12,7 @@ public class RulesVisitorTest extends Specification {
 
     def traverse(String query){
         Document document = new Parser().parseDocument(query)
-        ValidationContext validationContext = new ValidationContext(TestUtil.dummySchema, document)
+        ValidationContext validationContext = new ValidationContext(TestUtil.dummySchema, SpecificationIntrospectionSupport.INSTANCE, document)
         LanguageTraversal languageTraversal = new LanguageTraversal()
         // this is one of the rules which checks inside fragment spreads, so it's needed to test this
         NoUnusedVariables noUnusedVariables = new NoUnusedVariables(validationContext, errorCollector)

--- a/src/test/groovy/graphql/validation/SpecValidationBase.groovy
+++ b/src/test/groovy/graphql/validation/SpecValidationBase.groovy
@@ -1,16 +1,14 @@
 package graphql.validation
 
-import graphql.validation.SpecValidationSchema
+import graphql.introspection.SpecificationIntrospectionSupport
 import graphql.parser.Parser
-import graphql.validation.ValidationError
-import graphql.validation.Validator
 import spock.lang.Specification
 
 /**
  * validation examples used in the spec
  * http://facebook.github.io/graphql/#sec-Validation
  * @author dwinsor
- *        
+ *
  */
 class SpecValidationBase extends Specification {
 
@@ -18,6 +16,6 @@ class SpecValidationBase extends Specification {
 
     List<ValidationError> validate(String query) {
         def document = new Parser().parseDocument(query)
-        return new Validator().validateDocument(SpecValidationSchema.specValidationSchema, document)
+        return new Validator().validateDocument(SpecValidationSchema.specValidationSchema, SpecificationIntrospectionSupport.INSTANCE, document)
     }
 }

--- a/src/test/groovy/graphql/validation/TraversalContextTest.groovy
+++ b/src/test/groovy/graphql/validation/TraversalContextTest.groovy
@@ -1,6 +1,7 @@
 package graphql.validation
 
 import graphql.Directives
+import graphql.introspection.SpecificationIntrospectionSupport
 import graphql.language.Argument
 import graphql.language.ArrayValue
 import graphql.language.BooleanValue
@@ -30,7 +31,7 @@ import static graphql.language.OperationDefinition.Operation.QUERY
 
 class TraversalContextTest extends Specification {
 
-    TraversalContext traversalContext = new TraversalContext(starWarsSchema)
+    TraversalContext traversalContext = new TraversalContext(starWarsSchema, SpecificationIntrospectionSupport.INSTANCE)
 
     def "operation definition"() {
         given:
@@ -38,13 +39,13 @@ class TraversalContextTest extends Specification {
         OperationDefinition operationDefinition = new OperationDefinition(queryType.getName(), QUERY, selectionSet)
 
         when:
-        traversalContext.enter(operationDefinition,[])
+        traversalContext.enter(operationDefinition, [])
 
         then:
         traversalContext.getOutputType() == queryType
 
         when:
-        traversalContext.leave(operationDefinition,[])
+        traversalContext.leave(operationDefinition, [])
 
         then:
         traversalContext.getOutputType() == null
@@ -56,13 +57,13 @@ class TraversalContextTest extends Specification {
         traversalContext.outputTypeStack.add(new GraphQLNonNull(droidType))
 
         when:
-        traversalContext.enter(selectionSet,[])
+        traversalContext.enter(selectionSet, [])
 
         then:
         traversalContext.getParentType() == droidType
 
         when:
-        traversalContext.leave(selectionSet,[])
+        traversalContext.leave(selectionSet, [])
 
         then:
         traversalContext.getParentType() == null
@@ -75,14 +76,14 @@ class TraversalContextTest extends Specification {
         Field field = new Field("id")
 
         when:
-        traversalContext.enter(field,[])
+        traversalContext.enter(field, [])
 
         then:
         traversalContext.getOutputType() == droidType.getFieldDefinition("id").getType()
         traversalContext.getFieldDef() == droidType.getFieldDefinition("id")
 
         when:
-        traversalContext.leave(field,[])
+        traversalContext.leave(field, [])
 
         then:
         traversalContext.getOutputType() == null
@@ -95,13 +96,13 @@ class TraversalContextTest extends Specification {
         Directive directive = new Directive("skip")
 
         when:
-        traversalContext.enter(directive,[])
+        traversalContext.enter(directive, [])
 
         then:
         traversalContext.getDirective() == Directives.SkipDirective
 
         when:
-        traversalContext.leave(directive,[])
+        traversalContext.leave(directive, [])
 
         then:
         traversalContext.getDirective() == null
@@ -112,13 +113,13 @@ class TraversalContextTest extends Specification {
         InlineFragment inlineFragment = new InlineFragment(new TypeName(droidType.getName()))
 
         when:
-        traversalContext.enter(inlineFragment,[])
+        traversalContext.enter(inlineFragment, [])
 
         then:
         traversalContext.getOutputType() == droidType
 
         when:
-        traversalContext.leave(inlineFragment,[])
+        traversalContext.leave(inlineFragment, [])
 
         then:
         traversalContext.getOutputType() == null
@@ -129,13 +130,13 @@ class TraversalContextTest extends Specification {
         FragmentDefinition fragmentDefinition = new FragmentDefinition("fragment", new TypeName(droidType.getName()))
 
         when:
-        traversalContext.enter(fragmentDefinition,[])
+        traversalContext.enter(fragmentDefinition, [])
 
         then:
         traversalContext.getOutputType() == droidType
 
         when:
-        traversalContext.leave(fragmentDefinition,[])
+        traversalContext.leave(fragmentDefinition, [])
 
         then:
         traversalContext.getOutputType() == null
@@ -146,13 +147,13 @@ class TraversalContextTest extends Specification {
         VariableDefinition variableDefinition = new VariableDefinition("var", new TypeName("String"))
 
         when:
-        traversalContext.enter(variableDefinition,[])
+        traversalContext.enter(variableDefinition, [])
 
         then:
         traversalContext.getInputType() == GraphQLString
 
         when:
-        traversalContext.leave(variableDefinition,[])
+        traversalContext.leave(variableDefinition, [])
 
         then:
         traversalContext.getInputType() == null
@@ -164,14 +165,14 @@ class TraversalContextTest extends Specification {
         traversalContext.fieldDefStack.add(queryType.getFieldDefinition("droid"))
 
         when:
-        traversalContext.enter(argument,[])
+        traversalContext.enter(argument, [])
 
         then:
         traversalContext.getArgument() == queryType.getFieldDefinition("droid").getArgument("id")
         traversalContext.getInputType() == queryType.getFieldDefinition("droid").getArgument("id").getType()
 
         when:
-        traversalContext.leave(argument,[])
+        traversalContext.leave(argument, [])
 
         then:
         traversalContext.getArgument() == null
@@ -185,14 +186,14 @@ class TraversalContextTest extends Specification {
         traversalContext.directive = IncludeDirective
 
         when:
-        traversalContext.enter(argument,[])
+        traversalContext.enter(argument, [])
 
         then:
         traversalContext.getArgument() == IncludeDirective.getArgument("if")
         traversalContext.getInputType() == IncludeDirective.getArgument("if").getType()
 
         when:
-        traversalContext.leave(argument,[])
+        traversalContext.leave(argument, [])
 
         then:
         traversalContext.getArgument() == null
@@ -206,13 +207,13 @@ class TraversalContextTest extends Specification {
         ArrayValue arrayValue = new ArrayValue([new StringValue("string")])
 
         when:
-        traversalContext.enter(arrayValue,[])
+        traversalContext.enter(arrayValue, [])
 
         then:
         traversalContext.getInputType() == GraphQLString
 
         when:
-        traversalContext.leave(arrayValue,[])
+        traversalContext.leave(arrayValue, [])
 
         then:
         traversalContext.getInputType() == graphQLList
@@ -226,13 +227,13 @@ class TraversalContextTest extends Specification {
         ObjectField objectField = new ObjectField("field", new StringValue("value"))
 
         when:
-        traversalContext.enter(objectField,[])
+        traversalContext.enter(objectField, [])
 
         then:
         traversalContext.getInputType() == GraphQLString
 
         when:
-        traversalContext.leave(objectField,[])
+        traversalContext.leave(objectField, [])
 
         then:
         traversalContext.getInputType() == inputObjectType

--- a/src/test/groovy/graphql/validation/rules/NoFragmentCyclesTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/NoFragmentCyclesTest.groovy
@@ -1,6 +1,7 @@
 package graphql.validation.rules
 
 import graphql.TestUtil
+import graphql.introspection.SpecificationIntrospectionSupport
 import graphql.language.Document
 import graphql.parser.Parser
 import graphql.validation.*
@@ -12,7 +13,7 @@ class NoFragmentCyclesTest extends Specification {
 
     def traverse(String query) {
         Document document = new Parser().parseDocument(query)
-        ValidationContext validationContext = new ValidationContext(TestUtil.dummySchema, document)
+        ValidationContext validationContext = new ValidationContext(TestUtil.dummySchema, SpecificationIntrospectionSupport.INSTANCE, document)
         NoFragmentCycles noFragmentCycles = new NoFragmentCycles(validationContext, errorCollector)
         LanguageTraversal languageTraversal = new LanguageTraversal();
 

--- a/src/test/groovy/graphql/validation/rules/NoUndefinedVariablesTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/NoUndefinedVariablesTest.groovy
@@ -1,6 +1,7 @@
 package graphql.validation.rules
 
 import graphql.TestUtil
+import graphql.introspection.SpecificationIntrospectionSupport
 import graphql.language.Document
 import graphql.parser.Parser
 import graphql.validation.*
@@ -14,7 +15,7 @@ class NoUndefinedVariablesTest extends Specification {
 
     def traverse(String query){
         Document document = new Parser().parseDocument(query)
-        ValidationContext validationContext = new ValidationContext(TestUtil.dummySchema,document)
+        ValidationContext validationContext = new ValidationContext(TestUtil.dummySchema, SpecificationIntrospectionSupport.INSTANCE, document)
         NoUndefinedVariables noUndefinedVariables = new NoUndefinedVariables(validationContext, errorCollector)
         LanguageTraversal languageTraversal = new LanguageTraversal();
 

--- a/src/test/groovy/graphql/validation/rules/NoUnusedVariablesTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/NoUnusedVariablesTest.groovy
@@ -1,6 +1,7 @@
 package graphql.validation.rules
 
 import graphql.TestUtil
+import graphql.introspection.SpecificationIntrospectionSupport
 import graphql.language.Document
 import graphql.parser.Parser
 import graphql.validation.*
@@ -14,7 +15,7 @@ class NoUnusedVariablesTest extends Specification {
 
     def traverse(String query) {
         Document document = new Parser().parseDocument(query)
-        ValidationContext validationContext = new ValidationContext(TestUtil.dummySchema, document)
+        ValidationContext validationContext = new ValidationContext(TestUtil.dummySchema, SpecificationIntrospectionSupport.INSTANCE, document)
         NoUnusedVariables noUnusedVariables = new NoUnusedVariables(validationContext, errorCollector)
         LanguageTraversal languageTraversal = new LanguageTraversal();
 

--- a/src/test/groovy/graphql/validation/rules/OverlappingFieldsCanBeMergedTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/OverlappingFieldsCanBeMergedTest.groovy
@@ -1,6 +1,7 @@
 package graphql.validation.rules
 
 import graphql.TypeResolutionEnvironment
+import graphql.introspection.SpecificationIntrospectionSupport
 import graphql.language.Document
 import graphql.language.SourceLocation
 import graphql.parser.Parser
@@ -36,7 +37,7 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
         }
 
         Document document = new Parser().parseDocument(query)
-        ValidationContext validationContext = new ValidationContext(schema, document)
+        ValidationContext validationContext = new ValidationContext(schema, SpecificationIntrospectionSupport.INSTANCE, document)
         OverlappingFieldsCanBeMerged overlappingFieldsCanBeMerged = new OverlappingFieldsCanBeMerged(validationContext, errorCollector)
         LanguageTraversal languageTraversal = new LanguageTraversal()
 

--- a/src/test/groovy/graphql/validation/rules/PossibleFragmentSpreadsTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/PossibleFragmentSpreadsTest.groovy
@@ -1,5 +1,6 @@
 package graphql.validation.rules
 
+import graphql.introspection.SpecificationIntrospectionSupport
 import graphql.language.Document
 import graphql.parser.Parser
 import graphql.validation.LanguageTraversal
@@ -15,7 +16,7 @@ class PossibleFragmentSpreadsTest extends Specification {
 
     def traverse(String query) {
         Document document = new Parser().parseDocument(query)
-        ValidationContext validationContext = new ValidationContext(Harness.Schema, document)
+        ValidationContext validationContext = new ValidationContext(Harness.Schema, SpecificationIntrospectionSupport.INSTANCE, document)
         PossibleFragmentSpreads possibleFragmentSpreads = new PossibleFragmentSpreads(validationContext, errorCollector)
         LanguageTraversal languageTraversal = new LanguageTraversal();
 


### PR DESCRIPTION
Related to https://github.com/graphql-java/graphql-java/issues/556

This puts in a more structured way to replace the Introspection entry points `__schema` and so on
via an interface that can be wired in at the start of the `Graphql` object

