### PR TITLE
Improved object type validation with support for covariant types

### DIFF
--- a/src/main/java/graphql/schema/validation/ObjectsImplementInterfaces.java
+++ b/src/main/java/graphql/schema/validation/ObjectsImplementInterfaces.java
@@ -1,6 +1,14 @@
 package graphql.schema.validation;
 
-import graphql.schema.*;
+import graphql.schema.GraphQLArgument;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLInterfaceType;
+import graphql.schema.GraphQLList;
+import graphql.schema.GraphQLNonNull;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLOutputType;
+import graphql.schema.GraphQLType;
+import graphql.schema.GraphQLUnionType;
 
 import java.util.List;
 import java.util.Objects;

--- a/src/test/groovy/graphql/schema/validation/ObjectsImplementInterfacesTest.groovy
+++ b/src/test/groovy/graphql/schema/validation/ObjectsImplementInterfacesTest.groovy
@@ -9,13 +9,14 @@ import graphql.schema.TypeResolver
 import spock.lang.Specification
 
 import static SchemaValidationErrorType.ObjectDoesNotImplementItsInterfaces
-import static graphql.Scalars.*
+import static graphql.Scalars.GraphQLBoolean
+import static graphql.Scalars.GraphQLInt
+import static graphql.Scalars.GraphQLString
 import static graphql.schema.GraphQLArgument.newArgument
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
 import static graphql.schema.GraphQLInterfaceType.newInterface
 import static graphql.schema.GraphQLList.list
 import static graphql.schema.GraphQLNonNull.nonNull
-import static graphql.schema.GraphQLObjectType.newObject
 import static graphql.schema.GraphQLObjectType.newObject
 import static graphql.schema.GraphQLUnionType.newUnionType
 


### PR DESCRIPTION
The current implementation of ObjectsImplementInterfaces only allows objects with field types that exactly match the field types in the interface. This causes valid schemas to be rejected.

This pull request implements support for covariant types as specified in http://facebook.github.io/graphql/#sec-Object-type-validation
