### PR TITLE
Fix some bugs in idl

### DIFF
--- a/src/main/java/graphql/schema/idl/SchemaPrinter.java
+++ b/src/main/java/graphql/schema/idl/SchemaPrinter.java
@@ -1,6 +1,16 @@
 package graphql.schema.idl;
 
 import graphql.Assert;
+import graphql.language.Argument;
+import graphql.language.ArrayValue;
+import graphql.language.BooleanValue;
+import graphql.language.Directive;
+import graphql.language.EnumValue;
+import graphql.language.FloatValue;
+import graphql.language.IntValue;
+import graphql.language.NullValue;
+import graphql.language.StringValue;
+import graphql.language.Value;
 import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLEnumValueDefinition;
@@ -22,11 +32,14 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Stack;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -210,8 +223,9 @@ public class SchemaPrinter {
             out.format("type %s {\n", type.getName());
             type.getFieldDefinitions().forEach(fd -> {
                 printComments(out, fd, "  ");
-                out.format("  %s%s: %s\n",
-                        fd.getName(), argsString(fd.getArguments()), typeString(fd.getType()));
+                out.format("  %s%s: %s%s\n",
+                        fd.getName(), argsString(fd.getArguments()),
+                        typeString(fd.getType()), directivesString(getDirectives(fd)));
             });
             out.format("}\n\n");
         };
@@ -336,6 +350,55 @@ public class SchemaPrinter {
         return sb.toString();
     }
 
+    String directivesString(List<Directive> directives) {
+        if (directives.isEmpty()) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder(" ");
+        boolean firstDirective = true;
+        for (Directive directive : directives) {
+            if (!firstDirective) {
+                sb.append(' ');
+            } else {
+                firstDirective = false;
+            }
+            sb.append('@').append(directive.getName()).append('(');
+            boolean firstArgument = true;
+            for (Argument argument : directive.getArguments()) {
+                if (!firstArgument) {
+                    sb.append(", ");
+                } else {
+                    firstArgument = false;
+                }
+                sb.append(argument.getName()).append(": ")
+                    .append(valueString(argument.getValue()));
+            }
+            sb.append(')');
+        }
+        return sb.toString();
+    }
+
+    String valueString(Value value) {
+        if (value instanceof IntValue) {
+            return ((IntValue) value).getValue().toString();
+        } else if (value instanceof ArrayValue) {
+            return ((ArrayValue) value).getValues().stream().map(this::valueString)
+                .collect(Collectors.joining(", "));
+        } else if (value instanceof BooleanValue) {
+            return ((BooleanValue) value).isValue() ? "true": "false";
+        } else if(value instanceof EnumValue) {
+            return ((EnumValue) value).getName();
+        } else if (value instanceof FloatValue) {
+            return ((FloatValue) value).getValue().toString();
+        } else if (value instanceof NullValue) {
+            return "null";
+        } else if (value instanceof StringValue) {
+            return "\"" + ((StringValue) value).getValue() + "\"";
+        } else {
+            return Assert.assertShouldNeverHappen();
+        }
+    }
+
     @SuppressWarnings("unchecked")
     private <T> TypePrinter<T> printer(Class<?> clazz) {
         TypePrinter typePrinter = printers.computeIfAbsent(clazz,
@@ -398,5 +461,57 @@ public class SchemaPrinter {
         } else {
             return Assert.assertShouldNeverHappen();
         }
+    }
+
+    private List<Directive> getDirectives(Object directiveHolder) {
+        if (directiveHolder instanceof GraphQLObjectType) {
+            return ((GraphQLObjectType) directiveHolder).getDefinition().getDirectives();
+        } else if (directiveHolder instanceof GraphQLEnumType) {
+            return ((GraphQLEnumType) directiveHolder).getDefinition().getDirectives();
+        } else if (directiveHolder instanceof GraphQLFieldDefinition) {
+          return buildFullDirectives(
+              (GraphQLFieldDefinition)directiveHolder,
+              t -> null,
+              GraphQLFieldDefinition::isDeprecated, GraphQLFieldDefinition::getDeprecationReason);
+        } else if (directiveHolder instanceof GraphQLEnumValueDefinition) {
+          return buildFullDirectives((GraphQLEnumValueDefinition)directiveHolder,
+              t-> null,
+              GraphQLEnumValueDefinition::isDeprecated,
+              GraphQLEnumValueDefinition::getDeprecationReason);
+        } else if (directiveHolder instanceof GraphQLUnionType) {
+            return ((GraphQLUnionType) directiveHolder).getDefinition().getDirectives();
+        } else if (directiveHolder instanceof GraphQLInputObjectType) {
+            return ((GraphQLInputObjectType) directiveHolder).getDefinition().getDirectives();
+        } else if (directiveHolder instanceof GraphQLInputObjectField) {
+            return ((GraphQLInputObjectField) directiveHolder).getDefinition().getDirectives();
+        } else if (directiveHolder instanceof GraphQLInterfaceType) {
+            return ((GraphQLInterfaceType) directiveHolder).getDefinition().getDirectives();
+        } else if (directiveHolder instanceof GraphQLScalarType) {
+            return ((GraphQLScalarType) directiveHolder).getDefinition().getDirectives();
+        } else if (directiveHolder instanceof GraphQLArgument) {
+            return ((GraphQLArgument) directiveHolder).getDefinition().getDirectives();
+        } else {
+            return Assert.assertShouldNeverHappen();
+        }
+    }
+
+    private <T> List<Directive> buildFullDirectives(T target,
+        Function<T, List<Directive>> directiveResolver,
+        Function<T, Boolean> isDeprecatedResolver,
+        Function<T, String> deprecateReasonResolver) {
+        List<Directive> allDirectives = new ArrayList<>();
+        if (directiveResolver != null) {
+            List<Directive> definedDirectives = directiveResolver.apply(target);
+            if (definedDirectives != null) {
+                allDirectives.addAll(definedDirectives);
+            }
+        }
+        if (isDeprecatedResolver != null && isDeprecatedResolver.apply(target)) {
+            String deprecateReason = deprecateReasonResolver == null
+                ? null : deprecateReasonResolver.apply(target);
+          allDirectives.add(new Directive("deprecate", Collections.singletonList(
+                new Argument("reason", new StringValue(deprecateReason)))));
+        }
+        return allDirectives;
     }
 }

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -951,7 +951,7 @@ class SchemaGeneratorTest extends Specification {
     def "scalar default value is parsed"() {
         def spec = """
             type Query {
-              field(arg1 : Int! = 10, arg2 : [Int!] = [20]) : String
+              field(arg1 : Int! = 10, arg2 : [Int!]! = [20]) : String
             }
         """
 

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -947,4 +947,44 @@ class SchemaGeneratorTest extends Specification {
         schema.getType("UnReferencedC") instanceof GraphQLInterfaceType
         schema.getType("UnReferencedD") instanceof GraphQLUnionType
     }
+
+    def "scalar default value is parsed"() {
+        def spec = """
+            type Query {
+              field(arg1 : Int! = 10, arg2 : [Int!] = [20]) : String
+            }
+        """
+
+        def schema = schema(spec)
+        schema.getType("Query") instanceof GraphQLObjectType
+        GraphQLObjectType query = schema.getType("Query") as GraphQLObjectType
+        Object arg1 = query.getFieldDefinition("field").getArgument("arg1").defaultValue
+        Object arg2 = query.getFieldDefinition("field").getArgument("arg2").defaultValue
+
+        expect:
+        arg1 instanceof Integer
+        arg2 instanceof List
+        (arg2 as List).get(0) instanceof Integer
+    }
+
+    def "input object default value is parsed"() {
+        def spec = """
+            input InputObject {
+                str : String
+                num : Int
+            }
+            type Query {
+              field(arg : InputObject = {str : "string", num : 100}) : String
+            }
+        """
+
+        def schema = schema(spec)
+        schema.getType("Query") instanceof GraphQLObjectType
+        GraphQLObjectType query = schema.getType("Query") as GraphQLObjectType
+        Object arg = query.getFieldDefinition("field").getArgument("arg").defaultValue as Map
+
+        expect:
+        arg["str"] instanceof String
+        arg["num"] instanceof Integer
+    }
 }

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -2,21 +2,7 @@ package graphql.schema.idl
 
 import graphql.Scalars
 import graphql.TypeResolutionEnvironment
-import graphql.schema.Coercing
-import graphql.schema.GraphQLArgument
-import graphql.schema.GraphQLEnumType
-import graphql.schema.GraphQLFieldDefinition
-import graphql.schema.GraphQLInputObjectType
-import graphql.schema.GraphQLInputType
-import graphql.schema.GraphQLInterfaceType
-import graphql.schema.GraphQLList
-import graphql.schema.GraphQLNonNull
-import graphql.schema.GraphQLObjectType
-import graphql.schema.GraphQLScalarType
-import graphql.schema.GraphQLSchema
-import graphql.schema.GraphQLType
-import graphql.schema.GraphQLUnionType
-import graphql.schema.TypeResolver
+import graphql.schema.*
 import spock.lang.Specification
 
 import java.util.function.UnaryOperator
@@ -329,6 +315,24 @@ type Query {
 }
 """
 
+    }
+
+    def "prints directives"() {
+        given:
+        GraphQLFieldDefinition fieldDefinition = newFieldDefinition()
+                .name("field")
+                .deprecate("reason")
+                .type(GraphQLString).build()
+        def queryType = GraphQLObjectType.newObject().name("Query").field(fieldDefinition).build()
+        def schema = GraphQLSchema.newSchema().query(queryType).build()
+        when:
+        def result = new SchemaPrinter().print(schema)
+
+        then:
+        result == """type Query {
+  field: String @deprecate(reason: "reason")
+}
+"""
     }
 
     def "prints union"() {

--- a/src/test/resources/starWarsSchemaExtended.graphqls
+++ b/src/test/resources/starWarsSchemaExtended.graphqls
@@ -7,7 +7,6 @@ type Query {
     droid(id: ID!): Droid
 }
 
-
 enum Episode {
     NEWHOPE
     EMPIRE


### PR DESCRIPTION
Default values of scalar type were not parsed. For example:
```
query(arg : Int = 100) : String
```
default value of arg should be Integer but BigInteger is got.

Directives are not printed in SchemaPrinter currently.