### PR TITLE
Utilise BeanUtils and follow Java Bean conventions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ jar {
 dependencies {
     compile 'org.antlr:antlr4-runtime:4.5.1'
     compile 'org.slf4j:slf4j-api:1.7.22'
+    compile group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.3'
     antlr "org.antlr:antlr4:4.5.1"
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'

--- a/src/main/java/graphql/schema/PropertyDataFetcher.java
+++ b/src/main/java/graphql/schema/PropertyDataFetcher.java
@@ -1,13 +1,9 @@
 package graphql.schema;
 
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-import java.util.Map;
+import org.apache.commons.beanutils.PropertyUtils;
 
-import static graphql.Scalars.GraphQLBoolean;
+import java.lang.reflect.InvocationTargetException;
 
 public class PropertyDataFetcher<T> implements DataFetcher<T> {
 
@@ -22,77 +18,13 @@ public class PropertyDataFetcher<T> implements DataFetcher<T> {
     public T get(DataFetchingEnvironment environment) {
         Object source = environment.getSource();
         if (source == null) return null;
-        if (source instanceof Map) {
-            return (T) ((Map<?, ?>) source).get(propertyName);
-        }
-        return (T) getPropertyViaGetter(source, environment.getFieldType());
-    }
-
-    /**
-     * Invoking public methods on package-protected classes via reflection
-     * causes exceptions. This method searches a class's hierarchy for
-     * public visibility parent classes with the desired getter. This
-     * particular case is required to support AutoValue style data classes,
-     * which have abstract public interfaces implemented by package-protected
-     * (generated) subclasses.
-     */
-    private Method findAccessibleMethod(Class root, String methodName) throws NoSuchMethodException {
-        Class cur = root;
-        while(cur != null) {
-            if(Modifier.isPublic(cur.getModifiers())){
-                Method m = cur.getMethod(methodName);
-                if (Modifier.isPublic(m.getModifiers())) {
-                    return m;
-                }
-            }
-            cur = cur.getSuperclass();
-        }
-        return root.getMethod(methodName);
-    }
-
-    private Object getPropertyViaGetter(Object object, GraphQLOutputType outputType) {
         try {
-            if (isBooleanProperty(outputType)) {
-                try {
-                    return getPropertyViaGetterUsingPrefix(object, "is");
-                } catch (NoSuchMethodException e) {
-                    return getPropertyViaGetterUsingPrefix(object, "get");
-                }
-            } else {
-                return getPropertyViaGetterUsingPrefix(object, "get");
-            }
-        } catch (NoSuchMethodException e1) {
-            return getPropertyViaFieldAccess(object);
-        }
-    }
-
-    private Object getPropertyViaGetterUsingPrefix(Object object, String prefix) throws NoSuchMethodException {
-        String getterName = prefix + propertyName.substring(0, 1).toUpperCase() + propertyName.substring(1);
-        try {
-            Method method = findAccessibleMethod(object.getClass(), getterName);
-            return method.invoke(object);
-
+            return (T) PropertyUtils.getProperty(source, propertyName);
+        } catch (NoSuchMethodException e) {
+            return null;
         } catch (IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeException(e);
         }
     }
 
-    private boolean isBooleanProperty(GraphQLOutputType outputType) {
-        if (outputType == GraphQLBoolean) return true;
-        if (outputType instanceof GraphQLNonNull) {
-            return ((GraphQLNonNull) outputType).getWrappedType() == GraphQLBoolean;
-        }
-        return false;
-    }
-
-    private Object getPropertyViaFieldAccess(Object object) {
-        try {
-            Field field = object.getClass().getField(propertyName);
-            return field.get(object);
-        } catch (NoSuchFieldException e) {
-            return null;
-        } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
-    }
 }

--- a/src/test/groovy/graphql/DataFetcherTest.groovy
+++ b/src/test/groovy/graphql/DataFetcherTest.groovy
@@ -46,16 +46,35 @@ class DataFetcherTest extends Specification {
 
     DataHolder dataHolder
 
+    Map<String, Integer> mapHolder
+
     def setup() {
         dataHolder = new DataHolder()
         dataHolder.publicField = "publicValue"
         dataHolder.setProperty("propertyValue")
         dataHolder.setBooleanField(true)
         dataHolder.setBooleanFieldWithGet(false)
+
+        mapHolder = [
+                test: 5
+        ]
     }
 
     def env(GraphQLOutputType type) {
-        newDataFetchingEnvironment().source(dataHolder).fieldType(type).build()
+        env(type, dataHolder)
+    }
+
+    def env(GraphQLOutputType type, Object source) {
+        newDataFetchingEnvironment().source(source).fieldType(type).build()
+    }
+
+    def "get map value by key"() {
+        given:
+        def environment = env(GraphQLString, mapHolder)
+        when:
+        def result = new PropertyDataFetcher("test").get(environment)
+        then:
+        result == 5
     }
 
     def "get field value"() {

--- a/src/test/groovy/graphql/DataFetcherTest.groovy
+++ b/src/test/groovy/graphql/DataFetcherTest.groovy
@@ -16,7 +16,7 @@ class DataFetcherTest extends Specification {
 
         private String privateField
         public String publicField
-        private Boolean booleanField
+        private boolean booleanField
         private Boolean booleanFieldWithGet
 
         String getProperty() {
@@ -27,7 +27,7 @@ class DataFetcherTest extends Specification {
             privateField = value
         }
 
-        Boolean isBooleanField() {
+        boolean isBooleanField() {
             return booleanField
         }
 
@@ -98,7 +98,7 @@ class DataFetcherTest extends Specification {
         given:
         def environment = env(GraphQLString)
         when:
-        def result = new PropertyDataFetcher("publicField").get(environment)
+        def result = new FieldDataFetcher("publicField").get(environment)
         then:
         result == "publicValue"
     }


### PR DESCRIPTION
I am not sure whether these changes are preferable to you all, but I thought I'd put it out there anyway.

While testing, I found out that the de facto convention is to only use `isXXX` getters for primitive `boolean` values, and not for `Boolean` objects. This PR alters the test bean, its test and swaps the custom `PropertyDataFetcher` with an implementation that uses the widely adopted [Commons BeanUtils](http://commons.apache.org/proper/commons-beanutils/). Added benefit could be the reflection caching from BeanUtils even though a true performance benefit could not be measured for the current test suite.