### PR TITLE
Optimization: Avoid allocation in ExecutionResultImpl

### DIFF
--- a/src/main/java/graphql/ExecutionResultImpl.java
+++ b/src/main/java/graphql/ExecutionResultImpl.java
@@ -10,7 +10,7 @@ import java.util.Map;
 @Internal
 public class ExecutionResultImpl implements ExecutionResult {
 
-    private final List<GraphQLError> errors = new ArrayList<>();
+    private final List<GraphQLError> errors;
     private final Object data;
     private final transient boolean dataPresent;
 
@@ -31,7 +31,9 @@ public class ExecutionResultImpl implements ExecutionResult {
         this.data = data;
 
         if (errors != null && !errors.isEmpty()) {
-            this.errors.addAll(errors);
+            this.errors = Collections.unmodifiableList(new ArrayList<>(errors));
+        } else {
+            this.errors = Collections.emptyList();
         }
     }
 
@@ -43,7 +45,7 @@ public class ExecutionResultImpl implements ExecutionResult {
 
     @Override
     public List<GraphQLError> getErrors() {
-        return new ArrayList<>(errors);
+        return errors;
     }
 
     @Override


### PR DESCRIPTION
We avoid allocating an ArrayList when there are no errors (the common
case).

By making the errors List unmodifiable, we can also avoid the need for a
defensive copy in the getter.