### PR TITLE
Optimize the case when there are no directives

### DIFF
--- a/src/main/java/graphql/execution/ConditionalNodes.java
+++ b/src/main/java/graphql/execution/ConditionalNodes.java
@@ -1,7 +1,6 @@
 package graphql.execution;
 
 import graphql.language.Directive;
-import graphql.language.NodeUtil;
 
 import java.util.List;
 import java.util.Map;
@@ -38,6 +37,9 @@ public class ConditionalNodes {
     }
 
     private Directive getDirectiveByName(List<Directive> directives, String name) {
+        if (directives.isEmpty()) {
+            return null;
+        }
         return directivesByName(directives).get(name);
     }
 


### PR DESCRIPTION
directivesByName is relatively expensive - it builds a Map of all
directives and then fetches the directive by name.  In the common case
when there are no directives at all, we can immediately return null.