### PR TITLE
Avoid defensive copy in GraphQLFieldDefinition::getArguments

### DIFF
--- a/src/main/java/graphql/schema/GraphQLFieldDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLFieldDefinition.java
@@ -6,6 +6,7 @@ import graphql.PublicApi;
 import graphql.language.FieldDefinition;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.UnaryOperator;
@@ -21,7 +22,7 @@ public class GraphQLFieldDefinition {
     private GraphQLOutputType type;
     private final DataFetcher dataFetcher;
     private final String deprecationReason;
-    private final List<GraphQLArgument> arguments = new ArrayList<>();
+    private final List<GraphQLArgument> arguments;
     private final FieldDefinition definition;
 
 
@@ -40,7 +41,7 @@ public class GraphQLFieldDefinition {
         this.description = description;
         this.type = type;
         this.dataFetcher = dataFetcher;
-        this.arguments.addAll(arguments);
+        this.arguments = Collections.unmodifiableList(new ArrayList<>(arguments));
         this.deprecationReason = deprecationReason;
         this.definition = definition;
     }
@@ -71,7 +72,7 @@ public class GraphQLFieldDefinition {
     }
 
     public List<GraphQLArgument> getArguments() {
-        return new ArrayList<>(arguments);
+        return arguments;
     }
 
     public String getDescription() {


### PR DESCRIPTION
By making arguments an unmodifiable list, we can avoid the need for a
defensive copy.