### PR TITLE
support async execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 classes
 _site
 generated-src/
+out

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ dependencies {
     testCompile 'com.google.code.gson:gson:2.8.0'
     testCompile 'org.eclipse.jetty:jetty-server:9.4.5.v20170502'
     testCompile 'org.slf4j:slf4j-simple:1.7.22'
+    testCompile 'org.awaitility:awaitility-groovy:3.0.0'
+
 }
 
 compileJava.source file("build/generated-src"), sourceSets.main.java

--- a/src/main/java/graphql/ExecutionResultImpl.java
+++ b/src/main/java/graphql/ExecutionResultImpl.java
@@ -10,8 +10,8 @@ import java.util.Map;
 @Internal
 public class ExecutionResultImpl implements ExecutionResult {
 
-    private final List<GraphQLError> errors;
     private final Object data;
+    private final List<GraphQLError> errors;
     private final transient boolean dataPresent;
     private final transient Map<Object, Object> extensions;
 
@@ -73,5 +73,15 @@ public class ExecutionResultImpl implements ExecutionResult {
             result.put("extensions", extensions);
         }
         return result;
+    }
+
+    @Override
+    public String toString() {
+        return "ExecutionResultImpl{" +
+                "data=" + data +
+                ", errors=" + errors +
+                ", dataPresent=" + dataPresent +
+                ", extensions=" + extensions +
+                '}';
     }
 }

--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -1,10 +1,11 @@
 package graphql;
 
+import graphql.execution.AsyncExecutionStrategy;
+import graphql.execution.AsyncSerialExecutionStrategy;
 import graphql.execution.Execution;
 import graphql.execution.ExecutionId;
 import graphql.execution.ExecutionIdProvider;
 import graphql.execution.ExecutionStrategy;
-import graphql.execution.SimpleExecutionStrategy;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.InstrumentationState;
@@ -106,9 +107,9 @@ public class GraphQL {
 
     private GraphQL(GraphQLSchema graphQLSchema, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy, ExecutionStrategy subscriptionStrategy, ExecutionIdProvider idProvider, Instrumentation instrumentation, PreparsedDocumentProvider preparsedDocumentProvider) {
         this.graphQLSchema = assertNotNull(graphQLSchema, "queryStrategy must be non null");
-        this.queryStrategy = queryStrategy != null ? queryStrategy : new SimpleExecutionStrategy();
-        this.mutationStrategy = mutationStrategy != null ? mutationStrategy : new SimpleExecutionStrategy();
-        this.subscriptionStrategy = subscriptionStrategy != null ? subscriptionStrategy : new SimpleExecutionStrategy();
+        this.queryStrategy = queryStrategy != null ? queryStrategy : new AsyncExecutionStrategy();
+        this.mutationStrategy = mutationStrategy != null ? mutationStrategy : new AsyncSerialExecutionStrategy();
+        this.subscriptionStrategy = subscriptionStrategy != null ? subscriptionStrategy : new AsyncExecutionStrategy();
         this.idProvider = assertNotNull(idProvider, "idProvider must be non null");
         this.instrumentation = instrumentation;
         this.preparsedDocumentProvider = assertNotNull(preparsedDocumentProvider, "preparsedDocumentProvider must be non null");
@@ -129,9 +130,9 @@ public class GraphQL {
     @PublicApi
     public static class Builder {
         private GraphQLSchema graphQLSchema;
-        private ExecutionStrategy queryExecutionStrategy = new SimpleExecutionStrategy();
-        private ExecutionStrategy mutationExecutionStrategy = new SimpleExecutionStrategy();
-        private ExecutionStrategy subscriptionExecutionStrategy = new SimpleExecutionStrategy();
+        private ExecutionStrategy queryExecutionStrategy = new AsyncExecutionStrategy();
+        private ExecutionStrategy mutationExecutionStrategy = new AsyncSerialExecutionStrategy();
+        private ExecutionStrategy subscriptionExecutionStrategy = new AsyncExecutionStrategy();
         private ExecutionIdProvider idProvider = DEFAULT_EXECUTION_ID_PROVIDER;
         private Instrumentation instrumentation = NoOpInstrumentation.INSTANCE;
         private PreparsedDocumentProvider preparsedDocumentProvider = NoOpPreparsedDocumentProvider.INSTANCE;

--- a/src/main/java/graphql/execution/AbstractAsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AbstractAsyncExecutionStrategy.java
@@ -1,0 +1,48 @@
+package graphql.execution;
+
+import graphql.ExecutionResult;
+import graphql.ExecutionResultImpl;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+
+public abstract class AbstractAsyncExecutionStrategy extends ExecutionStrategy {
+
+    public AbstractAsyncExecutionStrategy() {
+    }
+
+    public AbstractAsyncExecutionStrategy(DataFetcherExceptionHandler dataFetcherExceptionHandler) {
+        super(dataFetcherExceptionHandler);
+    }
+
+    protected void handleException(ExecutionContext executionContext, CompletableFuture<ExecutionResult> result, Throwable e) {
+        if (e instanceof CompletionException && e.getCause() instanceof NonNullableFieldWasNullException) {
+            assertNonNullFieldPrecondition((NonNullableFieldWasNullException) e.getCause(), result);
+            if (!result.isDone()) {
+                result.complete(new ExecutionResultImpl(null, executionContext.getErrors()));
+            }
+        } else {
+            result.completeExceptionally(e);
+        }
+    }
+
+    protected void completeCompletableFuture(ExecutionContext executionContext, List<String> fieldNames, List<CompletableFuture<ExecutionResult>> futures, CompletableFuture<ExecutionResult> result) {
+        Map<String, Object> resolvedValuesByField = new LinkedHashMap<>();
+        int ix = 0;
+        for (CompletableFuture<ExecutionResult> future : futures) {
+
+            if (future.isCompletedExceptionally()) {
+                future.whenComplete((Null, e) -> handleException(executionContext, result, e));
+                return;
+            }
+            String fieldName = fieldNames.get(ix++);
+            ExecutionResult resolvedResult = future.join();
+            resolvedValuesByField.put(fieldName, resolvedResult.getData());
+        }
+        result.complete(new ExecutionResultImpl(resolvedValuesByField, executionContext.getErrors()));
+    }
+}

--- a/src/main/java/graphql/execution/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncExecutionStrategy.java
@@ -1,0 +1,92 @@
+package graphql.execution;
+
+import graphql.ExecutionResult;
+import graphql.ExecutionResultImpl;
+import graphql.language.Field;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.function.BiConsumer;
+
+/**
+ * The standard graphql execution strategy that runs fields asynchronously
+ */
+public class AsyncExecutionStrategy extends ExecutionStrategy {
+
+    /**
+     * The standard graphql execution strategy that runs fields asynchronously
+     */
+    public AsyncExecutionStrategy() {
+        super(new SimpleDataFetcherExceptionHandler());
+    }
+
+    /**
+     * Creates a execution strategy that uses the provided exception handler
+     *
+     * @param exceptionHandler the exception handler to use
+     */
+    public AsyncExecutionStrategy(DataFetcherExceptionHandler exceptionHandler) {
+        super(exceptionHandler);
+    }
+
+    @Override
+    public CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) throws NonNullableFieldWasNullException {
+
+        Map<String, List<Field>> fields = parameters.fields();
+        List<String> fieldNames = new ArrayList<>(fields.keySet());
+        List<CompletableFuture<ExecutionResult>> futures = new ArrayList<>();
+        for (String fieldName : fieldNames) {
+            List<Field> currentField = fields.get(fieldName);
+
+            ExecutionPath fieldPath = parameters.path().segment(fieldName);
+            ExecutionStrategyParameters newParameters = parameters
+                    .transform(builder -> builder.field(currentField).path(fieldPath));
+
+            CompletableFuture<ExecutionResult> future = resolveField(executionContext, newParameters);
+            futures.add(future);
+        }
+
+        CompletableFuture<ExecutionResult> result = new CompletableFuture<>();
+        CompletableFuture
+                .allOf(futures.toArray(new CompletableFuture[futures.size()]))
+                .whenComplete(futuresCompleted(executionContext, fieldNames, futures, result));
+
+        return result;
+    }
+
+    private BiConsumer<Void, Throwable> futuresCompleted(ExecutionContext executionContext,
+                                                         List<String> fieldNames,
+                                                         List<CompletableFuture<ExecutionResult>> futures,
+                                                         CompletableFuture<ExecutionResult> result) {
+        return (notUsed1, notUsed2) -> {
+            Map<String, Object> resolvedValuesByField = new LinkedHashMap<>();
+            int ix = 0;
+            for (CompletableFuture<ExecutionResult> future : futures) {
+
+                if (future.isCompletedExceptionally()) {
+                    future.whenComplete((Null, e) -> handleException(executionContext, result, e));
+                    return;
+                }
+                String fieldName = fieldNames.get(ix++);
+                ExecutionResult resolvedResult = future.join();
+                resolvedValuesByField.put(fieldName, resolvedResult.getData());
+            }
+            result.complete(new ExecutionResultImpl(resolvedValuesByField, executionContext.getErrors()));
+        };
+    }
+
+    private void handleException(ExecutionContext executionContext, CompletableFuture<ExecutionResult> result, Throwable e) {
+        if (e instanceof CompletionException && e.getCause() instanceof NonNullableFieldWasNullException) {
+            assertNonNullFieldPrecondition((NonNullableFieldWasNullException) e.getCause(), result);
+            if (!result.isDone()) {
+                result.complete(new ExecutionResultImpl(null, executionContext.getErrors()));
+            }
+        } else {
+            result.completeExceptionally(e);
+        }
+    }
+}

--- a/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
@@ -1,0 +1,87 @@
+package graphql.execution;
+
+import graphql.ExecutionResult;
+import graphql.ExecutionResultImpl;
+import graphql.language.Field;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+public class AsyncSerialExecutionStrategy extends ExecutionStrategy {
+
+    public AsyncSerialExecutionStrategy() {
+        super(new SimpleDataFetcherExceptionHandler());
+    }
+
+    public AsyncSerialExecutionStrategy(DataFetcherExceptionHandler exceptionHandler) {
+        super(exceptionHandler);
+    }
+
+    @Override
+    public CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) throws NonNullableFieldWasNullException {
+
+        CompletableFuture<ExecutionResult> result = new CompletableFuture<>();
+        resolveNthField(executionContext, parameters, 0, new ArrayList<>(), result);
+
+        return result;
+    }
+
+    private void resolveNthField(ExecutionContext executionContext,
+                                 ExecutionStrategyParameters parameters,
+                                 int index,
+                                 List<CompletableFuture<ExecutionResult>> allFutures,
+                                 CompletableFuture<ExecutionResult> overallResult) {
+        Map<String, List<Field>> fields = parameters.fields();
+        List<String> fieldNames = new ArrayList<>(fields.keySet());
+        String fieldName = fieldNames.get(index);
+
+        List<Field> currentField = fields.get(fieldName);
+        ExecutionPath fieldPath = parameters.path().segment(fieldName);
+        ExecutionStrategyParameters newParameters = parameters
+                .transform(builder -> builder.field(currentField).path(fieldPath));
+        CompletableFuture<ExecutionResult> future = resolveField(executionContext, newParameters);
+        future.whenComplete((notUsed1, notUsed2) -> {
+            allFutures.add(future);
+            if (index + 1 == fields.size()) {
+                futuresCompleted(executionContext, fieldNames, allFutures, overallResult);
+            } else {
+                resolveNthField(executionContext, parameters, index + 1, allFutures, overallResult);
+            }
+        });
+    }
+
+    private void futuresCompleted(ExecutionContext executionContext,
+                                  List<String> fieldNames,
+                                  List<CompletableFuture<ExecutionResult>> futures,
+                                  CompletableFuture<ExecutionResult> result) {
+        Map<String, Object> resolvedValuesByField = new LinkedHashMap<>();
+        int ix = 0;
+        for (CompletableFuture<ExecutionResult> future : futures) {
+
+            if (future.isCompletedExceptionally()) {
+                future.whenComplete((Null, e) -> handleException(executionContext, result, e));
+                return;
+            }
+            String fieldName = fieldNames.get(ix++);
+            ExecutionResult resolvedResult = future.join();
+            resolvedValuesByField.put(fieldName, resolvedResult.getData());
+        }
+        result.complete(new ExecutionResultImpl(resolvedValuesByField, executionContext.getErrors()));
+    }
+
+    private void handleException(ExecutionContext executionContext, CompletableFuture<ExecutionResult> result, Throwable e) {
+        if (e instanceof CompletionException && e.getCause() instanceof NonNullableFieldWasNullException) {
+            assertNonNullFieldPrecondition((NonNullableFieldWasNullException) e.getCause(), result);
+            if (!result.isDone()) {
+                result.complete(new ExecutionResultImpl(null, executionContext.getErrors()));
+            }
+        } else {
+            result.completeExceptionally(e);
+        }
+    }
+
+}

--- a/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
@@ -1,17 +1,18 @@
 package graphql.execution;
 
 import graphql.ExecutionResult;
-import graphql.ExecutionResultImpl;
 import graphql.language.Field;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 
-public class AsyncSerialExecutionStrategy extends ExecutionStrategy {
+/**
+ * Async non-blocking execution, but serial: only one field at the the time will be resolved.
+ * See {@link AsyncExecutionStrategy} for a non serial (parallel) execution of every field.
+ */
+public class AsyncSerialExecutionStrategy extends AbstractAsyncExecutionStrategy {
 
     public AsyncSerialExecutionStrategy() {
         super(new SimpleDataFetcherExceptionHandler());
@@ -47,41 +48,12 @@ public class AsyncSerialExecutionStrategy extends ExecutionStrategy {
         future.whenComplete((notUsed1, notUsed2) -> {
             allFutures.add(future);
             if (index + 1 == fields.size()) {
-                futuresCompleted(executionContext, fieldNames, allFutures, overallResult);
+                completeCompletableFuture(executionContext, fieldNames, allFutures, overallResult);
             } else {
                 resolveNthField(executionContext, parameters, index + 1, allFutures, overallResult);
             }
         });
     }
 
-    private void futuresCompleted(ExecutionContext executionContext,
-                                  List<String> fieldNames,
-                                  List<CompletableFuture<ExecutionResult>> futures,
-                                  CompletableFuture<ExecutionResult> result) {
-        Map<String, Object> resolvedValuesByField = new LinkedHashMap<>();
-        int ix = 0;
-        for (CompletableFuture<ExecutionResult> future : futures) {
-
-            if (future.isCompletedExceptionally()) {
-                future.whenComplete((Null, e) -> handleException(executionContext, result, e));
-                return;
-            }
-            String fieldName = fieldNames.get(ix++);
-            ExecutionResult resolvedResult = future.join();
-            resolvedValuesByField.put(fieldName, resolvedResult.getData());
-        }
-        result.complete(new ExecutionResultImpl(resolvedValuesByField, executionContext.getErrors()));
-    }
-
-    private void handleException(ExecutionContext executionContext, CompletableFuture<ExecutionResult> result, Throwable e) {
-        if (e instanceof CompletionException && e.getCause() instanceof NonNullableFieldWasNullException) {
-            assertNonNullFieldPrecondition((NonNullableFieldWasNullException) e.getCause(), result);
-            if (!result.isDone()) {
-                result.complete(new ExecutionResultImpl(null, executionContext.getErrors()));
-            }
-        } else {
-            result.completeExceptionally(e);
-        }
-    }
 
 }

--- a/src/main/java/graphql/execution/DataFetcherExceptionHandlerParameters.java
+++ b/src/main/java/graphql/execution/DataFetcherExceptionHandlerParameters.java
@@ -17,9 +17,9 @@ public class DataFetcherExceptionHandlerParameters {
     private final GraphQLFieldDefinition fieldDefinition;
     private final Map<String, Object> argumentValues;
     private final ExecutionPath path;
-    private final Exception exception;
+    private final Throwable exception;
 
-    public DataFetcherExceptionHandlerParameters(ExecutionContext executionContext, DataFetchingEnvironment dataFetchingEnvironment, Field field, GraphQLFieldDefinition fieldDefinition, Map<String, Object> argumentValues, ExecutionPath path, Exception exception) {
+    public DataFetcherExceptionHandlerParameters(ExecutionContext executionContext, DataFetchingEnvironment dataFetchingEnvironment, Field field, GraphQLFieldDefinition fieldDefinition, Map<String, Object> argumentValues, ExecutionPath path, Throwable exception) {
         this.executionContext = executionContext;
         this.dataFetchingEnvironment = dataFetchingEnvironment;
         this.field = field;
@@ -57,7 +57,7 @@ public class DataFetcherExceptionHandlerParameters {
         return path;
     }
 
-    public Exception getException() {
+    public Throwable getException() {
         return exception;
     }
 
@@ -68,7 +68,7 @@ public class DataFetcherExceptionHandlerParameters {
         GraphQLFieldDefinition fieldDefinition;
         Map<String, Object> argumentValues;
         ExecutionPath path;
-        Exception exception;
+        Throwable exception;
 
         private Builder() {
         }
@@ -103,7 +103,7 @@ public class DataFetcherExceptionHandlerParameters {
             return this;
         }
 
-        public Builder exception(Exception exception) {
+        public Builder exception(Throwable exception) {
             this.exception = exception;
             return this;
         }

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -40,7 +40,7 @@ public class Execution {
 
     public Execution(ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy, ExecutionStrategy subscriptionStrategy, Instrumentation instrumentation) {
         this.queryStrategy = queryStrategy != null ? queryStrategy : new AsyncExecutionStrategy();
-        this.mutationStrategy = mutationStrategy != null ? mutationStrategy : new AsyncExecutionStrategy();
+        this.mutationStrategy = mutationStrategy != null ? mutationStrategy : new AsyncSerialExecutionStrategy();
         this.subscriptionStrategy = subscriptionStrategy != null ? subscriptionStrategy : new AsyncExecutionStrategy();
         this.instrumentation = instrumentation;
     }

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -39,9 +39,9 @@ public class Execution {
     private final Instrumentation instrumentation;
 
     public Execution(ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy, ExecutionStrategy subscriptionStrategy, Instrumentation instrumentation) {
-        this.queryStrategy = queryStrategy != null ? queryStrategy : new SimpleExecutionStrategy();
-        this.mutationStrategy = mutationStrategy != null ? mutationStrategy : new SimpleExecutionStrategy();
-        this.subscriptionStrategy = subscriptionStrategy != null ? subscriptionStrategy : new SimpleExecutionStrategy();
+        this.queryStrategy = queryStrategy != null ? queryStrategy : new AsyncExecutionStrategy();
+        this.mutationStrategy = mutationStrategy != null ? mutationStrategy : new AsyncExecutionStrategy();
+        this.subscriptionStrategy = subscriptionStrategy != null ? subscriptionStrategy : new AsyncExecutionStrategy();
         this.instrumentation = instrumentation;
     }
 

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -130,9 +130,7 @@ public abstract class ExecutionStrategy {
      *
      * @param executionContext contains the top level execution parameters
      * @param parameters       contains the parameters holding the fields to be executed and source object
-     *
      * @return an {@link ExecutionResult}
-     *
      * @throws NonNullableFieldWasNullException if a non null field resolves to a null value
      */
     public abstract CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) throws NonNullableFieldWasNullException;
@@ -148,9 +146,7 @@ public abstract class ExecutionStrategy {
      *
      * @param executionContext contains the top level execution parameters
      * @param parameters       contains the parameters holding the fields to be executed and source object
-     *
      * @return an {@link ExecutionResult}
-     *
      * @throws NonNullableFieldWasNullException if a non null field resolves to a null value
      */
     protected CompletableFuture<ExecutionResult> resolveField(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
@@ -161,12 +157,11 @@ public abstract class ExecutionStrategy {
                 new InstrumentationFieldParameters(executionContext, fieldDef, fieldTypeInfo(parameters, fieldDef))
         );
 
-        Object fetchedValue = fetchField(executionContext, parameters);
-
-        CompletableFuture<ExecutionResult> result = completeField(executionContext, parameters, fetchedValue);
+        CompletableFuture<ExecutionResult> result = fetchField(executionContext, parameters)
+                .thenCompose((fetchedValue) ->
+                        completeField(executionContext, parameters, fetchedValue));
 
         result.thenAccept(fieldCtx::onEnd);
-
         return result;
     }
 
@@ -179,12 +174,10 @@ public abstract class ExecutionStrategy {
      *
      * @param executionContext contains the top level execution parameters
      * @param parameters       contains the parameters holding the fields to be executed and source object
-     *
      * @return a fetched object
-     *
      * @throws NonNullableFieldWasNullException if a non null field resolves to a null value
      */
-    protected Object fetchField(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
+    protected CompletableFuture<Object> fetchField(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
         Field field = parameters.field().get(0);
         GraphQLObjectType parentType = parameters.typeInfo().castType(GraphQLObjectType.class);
         GraphQLFieldDefinition fieldDef = getFieldDef(executionContext.getGraphQLSchema(), parentType, field);
@@ -210,29 +203,52 @@ public abstract class ExecutionStrategy {
 
         InstrumentationFieldFetchParameters instrumentationFieldFetchParams = new InstrumentationFieldFetchParameters(executionContext, fieldDef, environment);
         InstrumentationContext<Object> fetchCtx = instrumentation.beginFieldFetch(instrumentationFieldFetchParams);
-        Object fetchedValue = null;
+        CompletableFuture<?> fetchedValue;
+        DataFetcher dataFetcher = fieldDef.getDataFetcher();
+        dataFetcher = instrumentation.instrumentDataFetcher(dataFetcher, instrumentationFieldFetchParams);
         try {
-            DataFetcher dataFetcher = fieldDef.getDataFetcher();
-            dataFetcher = instrumentation.instrumentDataFetcher(dataFetcher, instrumentationFieldFetchParams);
-            fetchedValue = dataFetcher.get(environment);
-
-            fetchCtx.onEnd(fetchedValue);
+            Object fetchedValueRaw = dataFetcher.get(environment);
+            if (fetchedValueRaw instanceof CompletableFuture) {
+                fetchedValue = (CompletableFuture<?>) fetchedValueRaw;
+            } else {
+                fetchedValue = CompletableFuture.completedFuture(fetchedValueRaw);
+            }
         } catch (Exception e) {
-            fetchCtx.onEnd(e);
-
-            DataFetcherExceptionHandlerParameters handlerParameters = DataFetcherExceptionHandlerParameters.newExceptionParameters()
-                    .executionContext(executionContext)
-                    .dataFetchingEnvironment(environment)
-                    .argumentValues(argumentValues)
-                    .field(field)
-                    .fieldDefinition(fieldDef)
-                    .path(parameters.path())
-                    .exception(e)
-                    .build();
-
-            dataFetcherExceptionHandler.accept(handlerParameters);
+            fetchedValue = new CompletableFuture<>();
+            fetchedValue.completeExceptionally(e);
         }
-        return fetchedValue;
+        fetchedValue.thenAccept(fetchCtx::onEnd);
+        return fetchedValue.handle((result, exception) -> {
+            if (exception != null) {
+                handleFetchingException(executionContext, parameters, field, fieldDef, argumentValues, environment, fetchCtx, exception);
+                return null;
+            } else {
+                return result;
+            }
+        });
+    }
+
+    private void handleFetchingException(ExecutionContext executionContext,
+                                         ExecutionStrategyParameters parameters,
+                                         Field field,
+                                         GraphQLFieldDefinition fieldDef,
+                                         Map<String, Object> argumentValues,
+                                         DataFetchingEnvironment environment,
+                                         InstrumentationContext<Object> fetchCtx,
+                                         Throwable e) {
+        fetchCtx.onEnd(e);
+
+        DataFetcherExceptionHandlerParameters handlerParameters = DataFetcherExceptionHandlerParameters.newExceptionParameters()
+                .executionContext(executionContext)
+                .dataFetchingEnvironment(environment)
+                .argumentValues(argumentValues)
+                .field(field)
+                .fieldDefinition(fieldDef)
+                .path(parameters.path())
+                .exception(e)
+                .build();
+
+        dataFetcherExceptionHandler.accept(handlerParameters);
     }
 
     /**
@@ -247,9 +263,7 @@ public abstract class ExecutionStrategy {
      * @param executionContext contains the top level execution parameters
      * @param parameters       contains the parameters holding the fields to be executed and source object
      * @param fetchedValue     the fetched raw value
-     *
      * @return an {@link ExecutionResult}
-     *
      * @throws NonNullableFieldWasNullException if a non null field resolves to a null value
      */
     protected CompletableFuture<ExecutionResult> completeField(ExecutionContext executionContext, ExecutionStrategyParameters parameters, Object fetchedValue) {
@@ -288,9 +302,7 @@ public abstract class ExecutionStrategy {
      *
      * @param executionContext contains the top level execution parameters
      * @param parameters       contains the parameters holding the fields to be executed and source object
-     *
      * @return an {@link ExecutionResult}
-     *
      * @throws NonNullableFieldWasNullException if a non null field resolves to a null value
      */
     protected CompletableFuture<ExecutionResult> completeValue(ExecutionContext executionContext, ExecutionStrategyParameters parameters) throws NonNullableFieldWasNullException {
@@ -299,7 +311,7 @@ public abstract class ExecutionStrategy {
         GraphQLType fieldType = typeInfo.getType();
 
         if (result == null) {
-            return completedFuture(parameters.nonNullFieldValidator().validate(parameters.path(), null));
+            return completedFuture(new ExecutionResultImpl(parameters.nonNullFieldValidator().validate(parameters.path(), null), null));
         } else if (fieldType instanceof GraphQLList) {
             return completeValueForList(executionContext, parameters, toIterable(result));
         } else if (fieldType instanceof GraphQLScalarType) {
@@ -370,7 +382,6 @@ public abstract class ExecutionStrategy {
      * Called to resolve a {@link GraphQLInterfaceType} into a specific {@link GraphQLObjectType} so the object can be executed in terms of that type
      *
      * @param params the params needed for type resolution
-     *
      * @return a {@link GraphQLObjectType}
      */
     protected GraphQLObjectType resolveTypeForInterface(TypeResolutionParameters params) {
@@ -386,7 +397,6 @@ public abstract class ExecutionStrategy {
      * Called to resolve a {@link GraphQLUnionType} into a specific {@link GraphQLObjectType} so the object can be executed in terms of that type
      *
      * @param params the params needed for type resolution
-     *
      * @return a {@link GraphQLObjectType}
      */
     protected GraphQLObjectType resolveTypeForUnion(TypeResolutionParameters params) {
@@ -405,7 +415,6 @@ public abstract class ExecutionStrategy {
      * @param parameters       contains the parameters holding the fields to be executed and source object
      * @param enumType         the type of the enum
      * @param result           the result to be coerced
-     *
      * @return an {@link ExecutionResult}
      */
     protected CompletableFuture<ExecutionResult> completeValueForEnum(ExecutionContext executionContext, ExecutionStrategyParameters parameters, GraphQLEnumType enumType, Object result) {
@@ -427,7 +436,6 @@ public abstract class ExecutionStrategy {
      * @param parameters       contains the parameters holding the fields to be executed and source object
      * @param scalarType       the type of the scalar
      * @param result           the result to be coerced
-     *
      * @return an {@link ExecutionResult}
      */
     protected CompletableFuture<ExecutionResult> completeValueForScalar(ExecutionContext executionContext, ExecutionStrategyParameters parameters, GraphQLScalarType scalarType, Object result) {
@@ -461,7 +469,6 @@ public abstract class ExecutionStrategy {
      * @param executionContext contains the top level execution parameters
      * @param parameters       contains the parameters holding the fields to be executed and source object
      * @param iterableValues   the values to complete
-     *
      * @return an {@link ExecutionResult}
      */
     protected CompletableFuture<ExecutionResult> completeValueForList(ExecutionContext executionContext, ExecutionStrategyParameters parameters, Iterable<Object> iterableValues) {
@@ -498,7 +505,6 @@ public abstract class ExecutionStrategy {
      * @param executionContext contains the top level execution parameters
      * @param parameters       contains the parameters holding the fields to be executed and source object
      * @param field            the field to find the definition of
-     *
      * @return a {@link GraphQLFieldDefinition}
      */
     protected GraphQLFieldDefinition getFieldDef(ExecutionContext executionContext, ExecutionStrategyParameters parameters, Field field) {
@@ -512,7 +518,6 @@ public abstract class ExecutionStrategy {
      * @param schema     the schema in play
      * @param parentType the parent type of the field
      * @param field      the field to find the definition of
-     *
      * @return a {@link GraphQLFieldDefinition}
      */
     protected GraphQLFieldDefinition getFieldDef(GraphQLSchema schema, GraphQLObjectType parentType, Field field) {
@@ -546,7 +551,6 @@ public abstract class ExecutionStrategy {
      *
      * @param e this indicates that a null value was returned for a non null field, which needs to cause the parent field
      *          to become null OR continue on as an exception
-     *
      * @throws NonNullableFieldWasNullException if a non null field resolves to a null value
      */
     protected void assertNonNullFieldPrecondition(NonNullableFieldWasNullException e) throws NonNullableFieldWasNullException {
@@ -556,14 +560,19 @@ public abstract class ExecutionStrategy {
         }
     }
 
+    protected void assertNonNullFieldPrecondition(NonNullableFieldWasNullException e, CompletableFuture<?> completableFuture) throws NonNullableFieldWasNullException {
+        ExecutionTypeInfo typeInfo = e.getTypeInfo();
+        if (typeInfo.hasParentType() && typeInfo.getParentTypeInfo().isNonNullType()) {
+            completableFuture.completeExceptionally(new NonNullableFieldWasNullException(e));
+        }
+    }
+
     /**
      * This will join all of the promises of a result as one and return a execution result that
      * is a list of all the promised values
      *
      * @param completableFutures the list of futures to wait for to complete
-     *
      * @return a new execution result of all the values in the promises
-     *
      * @throws CompletionException if anything bad happens while waiting
      */
     protected ExecutionResult joinAllOf(List<CompletableFuture<ExecutionResult>> completableFutures) throws CompletionException {
@@ -575,7 +584,7 @@ public abstract class ExecutionStrategy {
         List<Object> completedResults = new ArrayList<>();
         completableFutures.forEach(future -> {
             ExecutionResult completedValue = future.getNow(null);
-            completedResults.add(completedValue != null ? completedValue.getData() : null);
+            completedResults.add(completedValue.getData());
         });
         return new ExecutionResultImpl(completedResults, null);
     }
@@ -586,7 +595,6 @@ public abstract class ExecutionStrategy {
      *
      * @param parameters      contains the parameters holding the fields to be executed and source object
      * @param fieldDefinition the field definition to build type info for
-     *
      * @return a new type info
      */
     protected ExecutionTypeInfo fieldTypeInfo(ExecutionStrategyParameters parameters, GraphQLFieldDefinition fieldDefinition) {

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
 
 import static graphql.execution.ExecutionTypeInfo.newTypeInfo;
 import static graphql.execution.FieldCollectorParameters.newParameters;
@@ -208,8 +209,8 @@ public abstract class ExecutionStrategy {
         dataFetcher = instrumentation.instrumentDataFetcher(dataFetcher, instrumentationFieldFetchParams);
         try {
             Object fetchedValueRaw = dataFetcher.get(environment);
-            if (fetchedValueRaw instanceof CompletableFuture) {
-                fetchedValue = (CompletableFuture<?>) fetchedValueRaw;
+            if (fetchedValueRaw instanceof CompletionStage) {
+                fetchedValue = ((CompletionStage) fetchedValueRaw).toCompletableFuture();
             } else {
                 fetchedValue = CompletableFuture.completedFuture(fetchedValueRaw);
             }

--- a/src/main/java/graphql/execution/ExecutorServiceExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutorServiceExecutionStrategy.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -47,10 +48,10 @@ public class ExecutorServiceExecutionStrategy extends ExecutionStrategy {
     @Override
     public CompletableFuture<ExecutionResult> execute(final ExecutionContext executionContext, final ExecutionStrategyParameters parameters) {
         if (executorService == null)
-            return new SimpleExecutionStrategy().execute(executionContext, parameters);
+            return new AsyncExecutionStrategy().execute(executionContext, parameters);
 
         Map<String, List<Field>> fields = parameters.fields();
-        Map<String, Future<ExecutionResult>> futures = new LinkedHashMap<>();
+        Map<String, Future<CompletableFuture<ExecutionResult>>> futures = new LinkedHashMap<>();
         for (String fieldName : fields.keySet()) {
             final List<Field> currentField = fields.get(fieldName);
 
@@ -58,7 +59,7 @@ public class ExecutorServiceExecutionStrategy extends ExecutionStrategy {
             ExecutionStrategyParameters newParameters = parameters
                     .transform(builder -> builder.field(currentField).path(fieldPath));
 
-            Callable<ExecutionResult> resolveField = () -> resolveField(executionContext, newParameters).join();
+            Callable<CompletableFuture<ExecutionResult>> resolveField = () -> resolveField(executionContext, newParameters);
             futures.put(fieldName, executorService.submit(resolveField));
         }
         try {
@@ -66,8 +67,8 @@ public class ExecutorServiceExecutionStrategy extends ExecutionStrategy {
             for (String fieldName : futures.keySet()) {
                 ExecutionResult executionResult;
                 try {
-                    executionResult = futures.get(fieldName).get();
-                } catch (ExecutionException e) {
+                    executionResult = futures.get(fieldName).get().join();
+                } catch (CompletionException e) {
                     if (e.getCause() instanceof NonNullableFieldWasNullException) {
                         assertNonNullFieldPrecondition((NonNullableFieldWasNullException) e.getCause());
                         results = null;

--- a/src/main/java/graphql/execution/SimpleDataFetcherExceptionHandler.java
+++ b/src/main/java/graphql/execution/SimpleDataFetcherExceptionHandler.java
@@ -1,7 +1,6 @@
 package graphql.execution;
 
 import graphql.ExceptionWhileDataFetching;
-import graphql.language.Field;
 import graphql.language.SourceLocation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,7 +14,7 @@ public class SimpleDataFetcherExceptionHandler implements DataFetcherExceptionHa
 
     @Override
     public void accept(DataFetcherExceptionHandlerParameters handlerParameters) {
-        Exception exception = handlerParameters.getException();
+        Throwable exception = handlerParameters.getException();
         SourceLocation sourceLocation = handlerParameters.getField().getSourceLocation();
         ExecutionPath path = handlerParameters.getPath();
 

--- a/src/main/java/graphql/execution/preparsed/PreparsedDocumentEntry.java
+++ b/src/main/java/graphql/execution/preparsed/PreparsedDocumentEntry.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * An instance of a preparsed doucument entry represents the result of a query parse and validation, like
+ * An instance of a preparsed document entry represents the result of a query parse and validation, like
  * an either implementation it contains either the correct result in th document property or the errors.
  */
 public class PreparsedDocumentEntry {

--- a/src/test/groovy/graphql/NonNullHandlingTest.groovy
+++ b/src/test/groovy/graphql/NonNullHandlingTest.groovy
@@ -1,10 +1,11 @@
 package graphql
 
+import graphql.execution.AsyncExecutionStrategy
 import graphql.execution.ExecutorServiceExecutionStrategy
-import graphql.execution.SimpleExecutionStrategy
 import graphql.schema.GraphQLOutputType
 import graphql.schema.GraphQLSchema
 import spock.lang.Specification
+import spock.lang.Unroll
 
 import static graphql.Scalars.GraphQLString
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
@@ -33,7 +34,8 @@ class NonNullHandlingTest extends Specification {
         ExecutionInput.newExecutionInput().query(query).build()
     }
 
-    def "#268 - null child field values are allowed in nullable parent type"() {
+    @Unroll
+    def "#268 - null child field values are allowed in nullable parent type (strategy: #strategyName)"() {
 
         // see https://github.com/graphql-java/graphql-java/issues/268
 
@@ -83,10 +85,11 @@ class NonNullHandlingTest extends Specification {
 
         strategyName | executionStrategy
         'executor'   | new ExecutorServiceExecutionStrategy(commonPool())
-        'simple'     | new SimpleExecutionStrategy()
+        'simple'     | new AsyncExecutionStrategy()
     }
 
-    def "#268 - null child field values are NOT allowed in non nullable parent types"() {
+    @Unroll
+    def "#268 - null child field values are NOT allowed in non nullable parent types (strategy: #strategyName)"() {
 
         // see https://github.com/graphql-java/graphql-java/issues/268
 
@@ -137,10 +140,11 @@ class NonNullHandlingTest extends Specification {
 
         strategyName | executionStrategy
         'executor'   | new ExecutorServiceExecutionStrategy(commonPool())
-        'simple'     | new SimpleExecutionStrategy()
+        'simple'     | new AsyncExecutionStrategy()
     }
 
-    def "#581 - null child field values are allowed in nullable grand parent type"() {
+    @Unroll
+    def "#581 - null child field values are allowed in nullable grand parent type (strategy: #strategyName)"() {
 
         given:
 
@@ -200,11 +204,12 @@ class NonNullHandlingTest extends Specification {
 
         strategyName | executionStrategy
         'executor'   | new ExecutorServiceExecutionStrategy(commonPool())
-        'simple'     | new SimpleExecutionStrategy()
+        'simple'     | new AsyncExecutionStrategy()
 
     }
 
-    def "#581 - null child field values are NOT allowed in non nullable grand parent types"() {
+    @Unroll
+    def "#581 - null child field values are NOT allowed in non nullable grand parent types (strategy: #strategyName)"() {
 
         given:
 
@@ -264,7 +269,7 @@ class NonNullHandlingTest extends Specification {
 
         strategyName | executionStrategy
         'executor'   | new ExecutorServiceExecutionStrategy(commonPool())
-        'simple'     | new SimpleExecutionStrategy()
+        'simple'     | new AsyncExecutionStrategy()
 
     }
 

--- a/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy
@@ -1,0 +1,213 @@
+package graphql.execution
+
+import graphql.ErrorType
+import graphql.execution.instrumentation.NoOpInstrumentation
+import graphql.language.Field
+import graphql.parser.Parser
+import graphql.schema.DataFetcher
+import graphql.schema.GraphQLFieldDefinition
+import graphql.schema.GraphQLSchema
+import spock.lang.Specification
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.locks.ReentrantLock
+
+import static graphql.Scalars.GraphQLString
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
+import static graphql.schema.GraphQLObjectType.newObject
+import static graphql.schema.GraphQLSchema.newSchema
+
+class AsyncExecutionStrategyTest extends Specification {
+
+    GraphQLSchema schema(DataFetcher dataFetcher1, DataFetcher dataFetcher2) {
+        GraphQLFieldDefinition.Builder fieldDefinition = newFieldDefinition()
+                .name("hello")
+                .type(GraphQLString)
+                .dataFetcher(dataFetcher1)
+        GraphQLFieldDefinition.Builder fieldDefinition2 = newFieldDefinition()
+                .name("hello2")
+                .type(GraphQLString)
+                .dataFetcher(dataFetcher2)
+
+        GraphQLSchema schema = newSchema().query(
+                newObject()
+                        .name("RootQueryType")
+                        .field(fieldDefinition)
+                        .field(fieldDefinition2)
+                        .build()
+        ).build()
+        schema
+    }
+
+
+    def "execution is serial if the dataFetchers are blocking"() {
+        given:
+        def lock = new ReentrantLock()
+        def counter = new AtomicInteger()
+        GraphQLSchema schema = schema(
+                { env ->
+                    assert lock.tryLock()
+                    Thread.sleep(100)
+                    def result = "world" + (counter.incrementAndGet())
+                    lock.unlock()
+                    result
+                },
+                { env ->
+                    assert lock.tryLock()
+                    def result = "world" + (counter.incrementAndGet())
+                    lock.unlock()
+                    result
+                }
+        )
+        String query = "{hello, hello2}"
+        def document = new Parser().parseDocument(query)
+
+        def typeInfo = ExecutionTypeInfo.newTypeInfo()
+                .type(schema.getQueryType())
+                .build()
+
+        ExecutionContext executionContext = new ExecutionContextBuilder()
+                .graphQLSchema(schema)
+                .executionId(ExecutionId.generate())
+                .document(document)
+                .valuesResolver(new ValuesResolver())
+                .instrumentation(NoOpInstrumentation.INSTANCE)
+                .build()
+        ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
+                .newParameters()
+                .typeInfo(typeInfo)
+                .fields(['hello': [new Field('hello')], 'hello2': [new Field('hello2')]])
+                .build()
+
+        AsyncExecutionStrategy asyncExecutionStrategy = new AsyncExecutionStrategy()
+        when:
+        def result = asyncExecutionStrategy.execute(executionContext, executionStrategyParameters)
+
+
+        then:
+        result.isDone()
+        result.get().data == ['hello': 'world1', 'hello2': 'world2']
+
+    }
+
+    def "execution with already completed futures"() {
+        given:
+
+        GraphQLSchema schema = schema(
+                { env -> CompletableFuture.completedFuture("world") },
+                { env -> CompletableFuture.completedFuture("world2") }
+        )
+        String query = "{hello, hello2}"
+        def document = new Parser().parseDocument(query)
+
+        def typeInfo = ExecutionTypeInfo.newTypeInfo()
+                .type(schema.getQueryType())
+                .build()
+
+        ExecutionContext executionContext = new ExecutionContextBuilder()
+                .graphQLSchema(schema)
+                .executionId(ExecutionId.generate())
+                .document(document)
+                .valuesResolver(new ValuesResolver())
+                .instrumentation(NoOpInstrumentation.INSTANCE)
+                .build()
+        ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
+                .newParameters()
+                .typeInfo(typeInfo)
+                .fields(['hello': [new Field('hello')], 'hello2': [new Field('hello2')]])
+                .build()
+
+        AsyncExecutionStrategy asyncExecutionStrategy = new AsyncExecutionStrategy()
+        when:
+        def result = asyncExecutionStrategy.execute(executionContext, executionStrategyParameters)
+
+
+        then:
+        result.isDone()
+        result.get().data == ['hello': 'world', 'hello2': 'world2']
+    }
+
+    def "async execution"() {
+        GraphQLSchema schema = schema(
+                { env -> CompletableFuture.completedFuture("world") },
+                { env ->
+                    CompletableFuture.supplyAsync({ ->
+                        Thread.sleep(100)
+                        "world2"
+                    })
+                }
+        )
+        String query = "{hello, hello2}"
+        def document = new Parser().parseDocument(query)
+
+        def typeInfo = ExecutionTypeInfo.newTypeInfo()
+                .type(schema.getQueryType())
+                .build()
+
+        ExecutionContext executionContext = new ExecutionContextBuilder()
+                .graphQLSchema(schema)
+                .executionId(ExecutionId.generate())
+                .document(document)
+                .valuesResolver(new ValuesResolver())
+                .instrumentation(NoOpInstrumentation.INSTANCE)
+                .build()
+        ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
+                .newParameters()
+                .typeInfo(typeInfo)
+                .fields(['hello': [new Field('hello')], 'hello2': [new Field('hello2')]])
+                .build()
+
+        AsyncExecutionStrategy asyncExecutionStrategy = new AsyncExecutionStrategy()
+        when:
+        def result = asyncExecutionStrategy.execute(executionContext, executionStrategyParameters)
+
+
+        then:
+        !result.isDone()
+        Thread.sleep(200)
+        result.isDone()
+        result.get().data == ['hello': 'world', 'hello2': 'world2']
+
+    }
+
+    def "exception while fetching data"() {
+        GraphQLSchema schema = schema(
+                { env -> CompletableFuture.completedFuture("world") },
+                { env ->
+                    throw new NullPointerException()
+                }
+        )
+        String query = "{hello, hello2}"
+        def document = new Parser().parseDocument(query)
+
+        def typeInfo = ExecutionTypeInfo.newTypeInfo()
+                .type(schema.getQueryType())
+                .build()
+
+        ExecutionContext executionContext = new ExecutionContextBuilder()
+                .graphQLSchema(schema)
+                .executionId(ExecutionId.generate())
+                .document(document)
+                .valuesResolver(new ValuesResolver())
+                .instrumentation(NoOpInstrumentation.INSTANCE)
+                .build()
+        ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
+                .newParameters()
+                .typeInfo(typeInfo)
+                .fields(['hello': [new Field('hello')], 'hello2': [new Field('hello2')]])
+                .build()
+
+        AsyncExecutionStrategy asyncExecutionStrategy = new AsyncExecutionStrategy()
+        when:
+        def result = asyncExecutionStrategy.execute(executionContext, executionStrategyParameters)
+
+
+        then:
+        result.isDone()
+        result.get().data == ['hello': 'world', 'hello2': null]
+        result.get().getErrors().size() == 1
+        result.get().getErrors().get(0).errorType == ErrorType.DataFetchingException
+
+    }
+}

--- a/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy
@@ -17,6 +17,7 @@ import static graphql.Scalars.GraphQLString
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
 import static graphql.schema.GraphQLObjectType.newObject
 import static graphql.schema.GraphQLSchema.newSchema
+import static org.awaitility.Awaitility.await
 
 class AsyncExecutionStrategyTest extends Specification {
 
@@ -165,8 +166,7 @@ class AsyncExecutionStrategyTest extends Specification {
 
         then:
         !result.isDone()
-        Thread.sleep(200)
-        result.isDone()
+        await().until({ result.isDone() })
         result.get().data == ['hello': 'world', 'hello2': 'world2']
 
     }

--- a/src/test/groovy/graphql/execution/AsyncSerialExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/AsyncSerialExecutionStrategyTest.groovy
@@ -1,0 +1,172 @@
+package graphql.execution
+
+import graphql.execution.instrumentation.NoOpInstrumentation
+import graphql.language.Field
+import graphql.parser.Parser
+import graphql.schema.DataFetcher
+import graphql.schema.GraphQLFieldDefinition
+import graphql.schema.GraphQLSchema
+import spock.lang.Specification
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.locks.ReentrantLock
+
+import static graphql.Scalars.GraphQLString
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
+import static graphql.schema.GraphQLObjectType.newObject
+import static graphql.schema.GraphQLSchema.newSchema
+
+class AsyncSerialExecutionStrategyTest extends Specification {
+    GraphQLSchema schema(DataFetcher dataFetcher1, DataFetcher dataFetcher2, DataFetcher dataFetcher3) {
+        GraphQLFieldDefinition.Builder fieldDefinition = newFieldDefinition()
+                .name("hello")
+                .type(GraphQLString)
+                .dataFetcher(dataFetcher1)
+        GraphQLFieldDefinition.Builder fieldDefinition2 = newFieldDefinition()
+                .name("hello2")
+                .type(GraphQLString)
+                .dataFetcher(dataFetcher2)
+        GraphQLFieldDefinition.Builder fieldDefinition3 = newFieldDefinition()
+                .name("hello3")
+                .type(GraphQLString)
+                .dataFetcher(dataFetcher3)
+
+        GraphQLSchema schema = newSchema().query(
+                newObject()
+                        .name("RootQueryType")
+                        .field(fieldDefinition)
+                        .field(fieldDefinition2)
+                        .field(fieldDefinition3)
+                        .build()
+        ).build()
+        schema
+    }
+
+
+    def "serial execution"() {
+        given:
+        def atomicInteger = new AtomicInteger()
+        def reentrantLock = new ReentrantLock()
+        GraphQLSchema schema = schema(
+                { env ->
+                    assert reentrantLock.tryLock()
+                    def result = CompletableFuture.completedFuture("world" + (atomicInteger.incrementAndGet()))
+                    reentrantLock.unlock()
+                    result
+                },
+                { env ->
+                    assert reentrantLock.tryLock()
+                    def result = CompletableFuture.completedFuture("world" + (atomicInteger.incrementAndGet()))
+                    reentrantLock.unlock()
+                    result
+                },
+                { env ->
+                    assert reentrantLock.tryLock()
+                    def result = CompletableFuture.completedFuture("world" + (atomicInteger.incrementAndGet()))
+                    reentrantLock.unlock()
+                    result
+                }
+        )
+        String query = "{hello, hello2, hello3}"
+        def document = new Parser().parseDocument(query)
+
+        def typeInfo = ExecutionTypeInfo.newTypeInfo()
+                .type(schema.getQueryType())
+                .build()
+
+        ExecutionContext executionContext = new ExecutionContextBuilder()
+                .graphQLSchema(schema)
+                .executionId(ExecutionId.generate())
+                .document(document)
+                .valuesResolver(new ValuesResolver())
+                .instrumentation(NoOpInstrumentation.INSTANCE)
+                .build()
+        ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
+                .newParameters()
+                .typeInfo(typeInfo)
+                .fields(['hello': [new Field('hello')], 'hello2': [new Field('hello2')], 'hello3': [new Field('hello3')]])
+                .build()
+
+        AsyncSerialExecutionStrategy strategy = new AsyncSerialExecutionStrategy()
+        when:
+        def result = strategy.execute(executionContext, executionStrategyParameters)
+
+
+        then:
+        result.isDone()
+        result.get().data == ['hello': 'world1', 'hello2': 'world2', 'hello3': 'world3']
+    }
+
+    def "async serial execution test"() {
+        given:
+        def df1 = Mock(DataFetcher)
+        def cf1 = new CompletableFuture()
+
+        def df2 = Mock(DataFetcher)
+        def cf2 = new CompletableFuture()
+
+        def df3 = Mock(DataFetcher)
+        def cf3 = new CompletableFuture()
+
+        GraphQLSchema schema = schema(df1, df2, df3)
+        String query = "{hello, hello2, hello3}"
+        def document = new Parser().parseDocument(query)
+
+        def typeInfo = ExecutionTypeInfo.newTypeInfo()
+                .type(schema.getQueryType())
+                .build()
+
+        ExecutionContext executionContext = new ExecutionContextBuilder()
+                .graphQLSchema(schema)
+                .executionId(ExecutionId.generate())
+                .document(document)
+                .valuesResolver(new ValuesResolver())
+                .instrumentation(NoOpInstrumentation.INSTANCE)
+                .build()
+        ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
+                .newParameters()
+                .typeInfo(typeInfo)
+                .fields(['hello': [new Field('hello')], 'hello2': [new Field('hello2')], 'hello3': [new Field('hello3')]])
+                .build()
+
+        AsyncSerialExecutionStrategy strategy = new AsyncSerialExecutionStrategy()
+        when:
+        def result = strategy.execute(executionContext, executionStrategyParameters)
+
+
+        then:
+        !result.isDone()
+        1 * df1.get(_) >> cf1
+        0 * df2.get(_) >> cf2
+        0 * df3.get(_) >> cf3
+
+        when:
+        cf1.complete("world1")
+
+        then:
+        !result.isDone()
+        0 * df1.get(_) >> cf1
+        1 * df2.get(_) >> cf2
+        0 * df3.get(_) >> cf3
+
+        when:
+        cf2.complete("world2")
+
+        then:
+        !result.isDone()
+        0 * df1.get(_) >> cf1
+        0 * df2.get(_) >> cf2
+        1 * df3.get(_) >> cf3
+
+        when:
+        cf3.complete("world3")
+
+        then:
+        0 * df1.get(_) >> cf1
+        0 * df2.get(_) >> cf2
+        0 * df3.get(_) >> cf3
+        result.isDone()
+        result.get().data == ['hello': 'world1', 'hello2': 'world2', 'hello3': 'world3']
+    }
+}

--- a/src/test/groovy/graphql/execution/BreadthFirstExecutionTestStrategy.java
+++ b/src/test/groovy/graphql/execution/BreadthFirstExecutionTestStrategy.java
@@ -60,7 +60,7 @@ public class BreadthFirstExecutionTestStrategy extends ExecutionStrategy {
         ExecutionStrategyParameters newParameters = parameters
                 .transform(builder -> builder.field(currentField).path(fieldPath));
 
-        return fetchField(executionContext, newParameters);
+        return fetchField(executionContext, newParameters).join();
     }
 
     private void completeValue(ExecutionContext executionContext, Map<String, Object> results, String fieldName, Object fetchedValue, ExecutionStrategyParameters newParameters) {

--- a/src/test/groovy/graphql/execution/BreadthFirstTestStrategy.java
+++ b/src/test/groovy/graphql/execution/BreadthFirstTestStrategy.java
@@ -10,25 +10,19 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ForkJoinPool;
 import java.util.stream.Collectors;
 
-import static java.util.concurrent.CompletableFuture.supplyAsync;
-
 /**
- * To prove we can write other execution strategies this one does a breath first asynch approach
- * running all fields asynch first, waiting for the results
+ * To prove we can write other execution strategies this one does a breadth first async approach
+ * running all fields async first, waiting for the results
  */
 @SuppressWarnings("Duplicates")
 @Internal
-public class AsyncFetchThenCompleteExecutionTestStrategy extends ExecutionStrategy {
+public class BreadthFirstTestStrategy extends ExecutionStrategy {
 
-    private final ExecutorService executor;
 
-    public AsyncFetchThenCompleteExecutionTestStrategy() {
+    public BreadthFirstTestStrategy() {
         super(new SimpleDataFetcherExceptionHandler());
-        this.executor = ForkJoinPool.commonPool();
     }
 
     @Override
@@ -46,10 +40,9 @@ public class AsyncFetchThenCompleteExecutionTestStrategy extends ExecutionStrate
 
         // first fetch every value
         for (String fieldName : fields.keySet()) {
-            ExecutionStrategyParameters newParameters = newParameters(parameters, fields,fieldName);
+            ExecutionStrategyParameters newParameters = newParameters(parameters, fields, fieldName);
 
-            CompletableFuture<Object> fetchFuture = supplyAsync(() ->
-                    fetchField(executionContext, newParameters), executor);
+            CompletableFuture<Object> fetchFuture = fetchField(executionContext, newParameters);
             fetchFutures.put(fieldName, fetchFuture);
         }
 

--- a/src/test/groovy/graphql/execution/ExecutionIdTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionIdTest.groovy
@@ -9,7 +9,7 @@ import java.util.concurrent.CompletableFuture
 
 class ExecutionIdTest extends Specification {
 
-    class CaptureIdStrategy extends SimpleExecutionStrategy {
+    class CaptureIdStrategy extends AsyncExecutionStrategy {
         ExecutionId executionId = null
 
         @Override

--- a/src/test/groovy/graphql/execution/ExecutionStrategyEquivalenceTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategyEquivalenceTest.groovy
@@ -4,6 +4,7 @@ import graphql.ExecutionInput
 import graphql.GraphQL
 import graphql.StarWarsSchema
 import spock.lang.Specification
+import spock.lang.Unroll
 
 import java.util.concurrent.ForkJoinPool
 
@@ -109,7 +110,8 @@ class ExecutionStrategyEquivalenceTest extends Specification {
     }
 
 
-    def "execution strategy equivalence"() {
+    @Unroll
+    def "execution strategy equivalence (strategy: #strategyType)"() {
 
         expect:
 
@@ -130,11 +132,12 @@ class ExecutionStrategyEquivalenceTest extends Specification {
 
         where:
 
-        strategyType      | strategyUnderTest                                 | expectedQueriesAndResults
-        "simple"          | new SimpleExecutionStrategy()                     | standardQueriesAndResults()
-        "breadthFirst"    | new BreadthFirstExecutionTestStrategy()           | standardQueriesAndResults()
-        "executorService" | executorServiceStrategy()                         | standardQueriesAndResults()
-        "asyncFetch"      | new AsyncFetchThenCompleteExecutionTestStrategy() | standardQueriesAndResults()
+        strategyType      | strategyUnderTest                       | expectedQueriesAndResults
+        "async"           | new AsyncExecutionStrategy()            | standardQueriesAndResults()
+        "asyncSerial"     | new AsyncSerialExecutionStrategy()      | standardQueriesAndResults()
+        "breadthFirst"    | new BreadthFirstExecutionTestStrategy() | standardQueriesAndResults()
+        "executorService" | executorServiceStrategy()               | standardQueriesAndResults()
+        "breadthFirst"    | new BreadthFirstTestStrategy()          | standardQueriesAndResults()
 
     }
 

--- a/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
@@ -1,5 +1,6 @@
 package graphql.execution
 
+import graphql.Assert
 import graphql.ExceptionWhileDataFetching
 import graphql.ExecutionResult
 import graphql.Scalars
@@ -9,6 +10,7 @@ import graphql.language.Argument
 import graphql.language.Field
 import graphql.language.SourceLocation
 import graphql.language.StringValue
+import graphql.parser.Parser
 import graphql.schema.Coercing
 import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironment
@@ -41,7 +43,7 @@ class ExecutionStrategyTest extends Specification {
 
             @Override
             CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
-                return null
+                return Assert.assertShouldNeverHappen("should not be called")
             }
         }
     }
@@ -50,6 +52,47 @@ class ExecutionStrategyTest extends Specification {
         ExecutionId executionId = ExecutionId.from("executionId123")
         def variables = [arg1: "value1"]
         new ExecutionContext(NoOpInstrumentation.INSTANCE, executionId, schema, null, executionStrategy, executionStrategy, executionStrategy, null, null, variables, "context", "root")
+    }
+
+    def "complete values always calls query strategy to execute more"() {
+        given:
+        def dataFetcher = Mock(DataFetcher)
+        def fieldDefinition = newFieldDefinition()
+                .name("someField")
+                .type(GraphQLString)
+                .dataFetcher(dataFetcher)
+                .build()
+        def objectType = newObject()
+                .name("Test")
+                .field(fieldDefinition)
+                .build()
+
+        GraphQLSchema schema = GraphQLSchema.newSchema().query(objectType).build()
+        def builder = new ExecutionContextBuilder()
+        builder.queryStrategy(Mock(ExecutionStrategy))
+        builder.mutationStrategy(Mock(ExecutionStrategy))
+        builder.subscriptionStrategy(Mock(ExecutionStrategy))
+        builder.graphQLSchema(schema)
+        builder.document(new Parser().parseDocument("{someField}"))
+        builder.executionId(ExecutionId.generate())
+        builder.valuesResolver(new ValuesResolver());
+
+        def executionContext = builder.build()
+        def result = new Object()
+        def parameters = newParameters()
+                .typeInfo(ExecutionTypeInfo.newTypeInfo().type(objectType))
+                .source(result)
+                .fields(["fld": [new Field()]])
+                .field([new Field()])
+                .build()
+
+        when:
+        executionStrategy.completeValue(executionContext, parameters)
+
+        then:
+        1 * executionContext.queryStrategy.execute(_, _)
+        0 * executionContext.mutationStrategy.execute(_, _)
+        0 * executionContext.subscriptionStrategy.execute(_, _)
     }
 
 
@@ -281,8 +324,6 @@ class ExecutionStrategyTest extends Specification {
                 .build()
         [executionContext, fieldDefinition, expectedPath, parameters, field, sourceLocation]
     }
-
-
 
 
     def "test that the new data fetcher error handler interface is called"() {

--- a/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
@@ -294,7 +294,7 @@ class ExecutionStrategyTest extends Specification {
 
 
         boolean handlerCalled = false
-        ExecutionStrategy overridingStrategy = new SimpleExecutionStrategy(new SimpleDataFetcherExceptionHandler() {
+        ExecutionStrategy overridingStrategy = new AsyncExecutionStrategy(new SimpleDataFetcherExceptionHandler() {
             @Override
             void accept(DataFetcherExceptionHandlerParameters handlerParameters) {
                 handlerCalled = true

--- a/src/test/groovy/graphql/execution/SerialExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/SerialExecutionStrategyTest.groovy
@@ -1,0 +1,101 @@
+package graphql.execution
+
+import graphql.execution.instrumentation.NoOpInstrumentation
+import graphql.language.Field
+import graphql.parser.Parser
+import graphql.schema.DataFetcher
+import graphql.schema.GraphQLFieldDefinition
+import graphql.schema.GraphQLSchema
+import spock.lang.Specification
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.locks.ReentrantLock
+
+import static graphql.Scalars.GraphQLString
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
+import static graphql.schema.GraphQLObjectType.newObject
+import static graphql.schema.GraphQLSchema.newSchema
+
+class SerialExecutionStrategyTest extends Specification {
+
+    GraphQLSchema schema(DataFetcher dataFetcher1, DataFetcher dataFetcher2, DataFetcher dataFetcher3) {
+        GraphQLFieldDefinition.Builder fieldDefinition = newFieldDefinition()
+                .name("hello")
+                .type(GraphQLString)
+                .dataFetcher(dataFetcher1)
+        GraphQLFieldDefinition.Builder fieldDefinition2 = newFieldDefinition()
+                .name("hello2")
+                .type(GraphQLString)
+                .dataFetcher(dataFetcher2)
+        GraphQLFieldDefinition.Builder fieldDefinition3 = newFieldDefinition()
+                .name("hello3")
+                .type(GraphQLString)
+                .dataFetcher(dataFetcher3)
+
+        GraphQLSchema schema = newSchema().query(
+                newObject()
+                        .name("RootQueryType")
+                        .field(fieldDefinition)
+                        .field(fieldDefinition2)
+                        .field(fieldDefinition3)
+                        .build()
+        ).build()
+        schema
+    }
+
+
+    def "serial execution"() {
+        given:
+        def atomicInteger = new AtomicInteger()
+        def reentrantLock = new ReentrantLock()
+        GraphQLSchema schema = schema(
+                { env ->
+                    assert reentrantLock.tryLock()
+                    def result = CompletableFuture.completedFuture("world" + (atomicInteger.incrementAndGet()))
+                    reentrantLock.unlock()
+                    result
+                },
+                { env ->
+                    assert reentrantLock.tryLock()
+                    def result = CompletableFuture.completedFuture("world" + (atomicInteger.incrementAndGet()))
+                    reentrantLock.unlock()
+                    result
+                },
+                { env ->
+                    assert reentrantLock.tryLock()
+                    def result = CompletableFuture.completedFuture("world" + (atomicInteger.incrementAndGet()))
+                    reentrantLock.unlock()
+                    result
+                }
+        )
+        String query = "{hello, hello2, hello3}"
+        def document = new Parser().parseDocument(query)
+
+        def typeInfo = ExecutionTypeInfo.newTypeInfo()
+                .type(schema.getQueryType())
+                .build()
+
+        ExecutionContext executionContext = new ExecutionContextBuilder()
+                .graphQLSchema(schema)
+                .executionId(ExecutionId.generate())
+                .document(document)
+                .valuesResolver(new ValuesResolver())
+                .instrumentation(NoOpInstrumentation.INSTANCE)
+                .build()
+        ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
+                .newParameters()
+                .typeInfo(typeInfo)
+                .fields(['hello': [new Field('hello')], 'hello2': [new Field('hello2')], 'hello3': [new Field('hello3')]])
+                .build()
+
+        SerialExecutionStrategy strategy = new SerialExecutionStrategy()
+        when:
+        def result = strategy.execute(executionContext, executionStrategyParameters)
+
+
+        then:
+        result.isDone()
+        result.get().data == ['hello': 'world1', 'hello2': 'world2', 'hello3': 'world3']
+    }
+}

--- a/src/test/groovy/graphql/execution/batched/GraphqlExecutionTest.groovy
+++ b/src/test/groovy/graphql/execution/batched/GraphqlExecutionTest.groovy
@@ -7,7 +7,7 @@ package graphql.execution.batched
 import graphql.ExceptionWhileDataFetching
 import graphql.ExecutionResult
 import graphql.GraphQL
-import graphql.execution.SimpleExecutionStrategy
+import graphql.execution.AsyncExecutionStrategy
 import graphql.schema.GraphQLSchema
 import spock.lang.Specification
 
@@ -18,7 +18,7 @@ class GraphqlExecutionTest extends Specification {
     private GraphQLSchema schema = new FunWithStringsSchemaFactory().createSchema();
 
     private GraphQL graphQLSimple = GraphQL.newGraphQL(schema)
-            .queryExecutionStrategy(new SimpleExecutionStrategy())
+            .queryExecutionStrategy(new AsyncExecutionStrategy())
             .build()
 
     private GraphQL graphQLBatchedButUnbatched = GraphQL.newGraphQL(this.schema)

--- a/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
@@ -2,7 +2,7 @@ package graphql.execution.instrumentation
 
 import graphql.GraphQL
 import graphql.StarWarsSchema
-import graphql.execution.SimpleExecutionStrategy
+import graphql.execution.AsyncExecutionStrategy
 import graphql.schema.PropertyDataFetcher
 import graphql.schema.StaticDataFetcher
 import spock.lang.Specification
@@ -22,7 +22,7 @@ class InstrumentationTest extends Specification {
         """
 
         //
-        // for testing purposes we must use SimpleExecutionStrategy under the covers to get such
+        // for testing purposes we must use AsyncExecutionStrategy under the covers to get such
         // serial behaviour.  The Instrumentation of a parallel strategy would be much different
         // and certainly harder to test
         def expected = [
@@ -56,7 +56,7 @@ class InstrumentationTest extends Specification {
 
         def instrumentation = new TestingInstrumentation()
 
-        def strategy = new SimpleExecutionStrategy()
+        def strategy = new AsyncExecutionStrategy()
         def graphQL = GraphQL
                 .newGraphQL(StarWarsSchema.starWarsSchema)
                 .queryExecutionStrategy(strategy)

--- a/src/test/groovy/graphql/execution/instrumentation/TracingInstrumentationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/TracingInstrumentationTest.groovy
@@ -2,7 +2,7 @@ package graphql.execution.instrumentation
 
 import graphql.GraphQL
 import graphql.StarWarsSchema
-import graphql.execution.SimpleExecutionStrategy
+import graphql.execution.AsyncExecutionStrategy
 import graphql.execution.instrumentation.tracing.TracingInstrumentation
 import spock.lang.Specification
 
@@ -26,7 +26,7 @@ class TracingInstrumentationTest extends Specification {
 
         def instrumentation = new TracingInstrumentation();
 
-        def strategy = new SimpleExecutionStrategy()
+        def strategy = new AsyncExecutionStrategy()
         def graphQL = GraphQL
                 .newGraphQL(StarWarsSchema.starWarsSchema)
                 .queryExecutionStrategy(strategy)

--- a/src/test/groovy/graphql/execution/preparsed/PreparsedDocumentProviderTest.groovy
+++ b/src/test/groovy/graphql/execution/preparsed/PreparsedDocumentProviderTest.groovy
@@ -4,7 +4,7 @@ import graphql.ErrorType
 import graphql.ExecutionInput
 import graphql.GraphQL
 import graphql.StarWarsSchema
-import graphql.execution.SimpleExecutionStrategy
+import graphql.execution.AsyncExecutionStrategy
 import graphql.execution.instrumentation.TestingInstrumentation
 import spock.lang.Specification
 
@@ -75,7 +75,7 @@ class PreparsedDocumentProviderTest extends Specification {
         def instrumentationPreparsed = new TestingInstrumentation()
         def preparsedCache = new TestingPreparsedDocumentProvider()
 
-        def strategy = new SimpleExecutionStrategy()
+        def strategy = new AsyncExecutionStrategy()
         def data1 = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema)
                 .queryExecutionStrategy(strategy)
                 .instrumentation(instrumentation)

--- a/src/test/groovy/readme/ReadmeExamples.java
+++ b/src/test/groovy/readme/ReadmeExamples.java
@@ -5,8 +5,8 @@ import graphql.Scalars;
 import graphql.StarWarsData;
 import graphql.StarWarsSchema;
 import graphql.TypeResolutionEnvironment;
+import graphql.execution.AsyncExecutionStrategy;
 import graphql.execution.ExecutorServiceExecutionStrategy;
-import graphql.execution.SimpleExecutionStrategy;
 import graphql.language.Directive;
 import graphql.language.FieldDefinition;
 import graphql.language.TypeDefinition;
@@ -184,8 +184,8 @@ public class ReadmeExamples {
 
         GraphQL graphQL = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema)
                 .queryExecutionStrategy(new ExecutorServiceExecutionStrategy(threadPoolExecutor))
-                .mutationExecutionStrategy(new SimpleExecutionStrategy())
-                .subscriptionExecutionStrategy(new SimpleExecutionStrategy())
+                .mutationExecutionStrategy(new AsyncExecutionStrategy())
+                .subscriptionExecutionStrategy(new AsyncExecutionStrategy())
                 .build();
 
     }


### PR DESCRIPTION
The main change is that `ExecutionStrategy.fetchField` returns now a `CompletableFuture` instead of `Object` and new `ExecutionStrategy`s.

`SimpleExecutionStrategy` is now `SerialExecutionStrategy` and is not used anymore by default, because it is blocking.

The new default strategy is `AsyncExecutionStrategy` for queries and `AsyncSerialExecutionStrategy` for mutations. Both are non blocking but are compatible to the old behaviour if `DataFetcher` are still blocking and not async.