### PR TITLE
SchemaPrinter improvements

### DIFF
--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -87,7 +87,7 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
  * <a href="http://facebook.github.io/graphql/#sec-Normal-and-Serial-Execution">http://facebook.github.io/graphql/#sec-Normal-and-Serial-Execution</a> says:
  * <blockquote>
  * Normally the executor can execute the entries in a grouped field set in whatever order it chooses (often in parallel). Because
- * the resolution of fields other than top‐level mutation fields must always be side effect‐free and idempotent, the
+ * the resolution of fields other than top-level mutation fields must always be side effect-free and idempotent, the
  * execution order must not affect the result, and hence the server has the freedom to execute the
  * field entries in whatever order it deems optimal.
  * </blockquote>


### PR DESCRIPTION
1.  Allow subclasses of the GraphQL schema types to be printed.
For example, graphql-spqr generates schema out of GraphQL types subclasses and changes in this commit allow to print such schema correctly.

2.  Replace '-' character in documentation with one from cp1252 code page.
Documentation build on windows failed as '-' character was not from cp1252 code page.

3.  Beautify printed output by ignoring empty descriptions.






