### PR TITLE
Allow GraphQLError to be extended with custom data

### DIFF
--- a/src/main/java/graphql/CustomGraphQLError.java
+++ b/src/main/java/graphql/CustomGraphQLError.java
@@ -1,0 +1,8 @@
+package graphql;
+
+import java.util.Map;
+
+@PublicApi
+public interface CustomGraphQLError extends GraphQLError{
+    Map<String,?> getCustomData(); 
+}

--- a/src/main/java/graphql/CustomGraphQLErrorSupport.java
+++ b/src/main/java/graphql/CustomGraphQLErrorSupport.java
@@ -1,0 +1,7 @@
+package graphql;
+
+import java.util.Map;
+
+public interface CustomGraphQLErrorSupport {
+    Map<String,?> getErrors();
+}

--- a/src/main/java/graphql/ExceptionWhileDataFetching.java
+++ b/src/main/java/graphql/ExceptionWhileDataFetching.java
@@ -5,13 +5,15 @@ import graphql.execution.ExecutionPath;
 import graphql.language.SourceLocation;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static graphql.Assert.assertNotNull;
 import static java.lang.String.format;
 
 @PublicApi
-public class ExceptionWhileDataFetching implements GraphQLError {
+public class ExceptionWhileDataFetching implements CustomGraphQLError {
 
     private final ExecutionPath path;
     private final Throwable exception;
@@ -46,6 +48,18 @@ public class ExceptionWhileDataFetching implements GraphQLError {
      */
     public List<Object> getPath() {
         return path.toList();
+    }
+
+
+    @Override
+    public Map<String, ?> getCustomData() {
+        Map<String,Object> customData = new HashMap<>();
+        
+        if( exception instanceof CustomGraphQLErrorSupport ){
+            customData.putAll(((CustomGraphQLErrorSupport)exception).getErrors());
+        }        
+        customData.put("path",getPath());
+        return customData;
     }
 
     @Override


### PR DESCRIPTION
According to the GraphQL spec the error response is allowed to be customized: 
```
GraphQL servers may provide additional entries to error as they choose to produce more helpful or 
machine‐readable errors, however future versions of the spec may describe additional entries to errors.
```

This proposal is to extend the default GraphQLError with a CustomGraphQLError which can be checked for additional error messages. 
A CustomGraphQLErrorSupport interface is added which can be implemented by exceptions to append to the getCustomData. CustomGraphQLError is added to ExceptionWhileDataFetching so it can return the path. 