### PR TITLE
162 pluggable variable validation

### DIFF
--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -15,6 +15,7 @@ import graphql.language.Field;
 import graphql.language.FragmentDefinition;
 import graphql.language.NodeUtil;
 import graphql.language.OperationDefinition;
+import graphql.language.VariableDefinition;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
 
@@ -55,7 +56,9 @@ public class Execution {
 
         ValuesResolver valuesResolver = new ValuesResolver();
         Map<String, Object> inputVariables = executionInput.getVariables();
-        Map<String, Object> variableValues = valuesResolver.getVariableValues(graphQLSchema, operationDefinition.getVariableDefinitions(), inputVariables);
+        List<VariableDefinition> variableDefinitions = operationDefinition.getVariableDefinitions();
+
+        Map<String, Object> variableValues = valuesResolver.coerceArgumentValues(graphQLSchema, variableDefinitions, inputVariables);
 
         ExecutionContext executionContext = new ExecutionContextBuilder()
                 .instrumentation(instrumentation)

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -12,6 +12,8 @@ import graphql.execution.instrumentation.InstrumentationState;
 import graphql.execution.instrumentation.parameters.InstrumentationDataFetchParameters;
 import graphql.language.Document;
 import graphql.language.Field;
+import graphql.language.FragmentDefinition;
+import graphql.language.NodeUtil;
 import graphql.language.OperationDefinition;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
@@ -47,8 +49,15 @@ public class Execution {
 
     public CompletableFuture<ExecutionResult> execute(Document document, GraphQLSchema graphQLSchema, ExecutionId executionId, ExecutionInput executionInput, InstrumentationState instrumentationState) {
 
+        NodeUtil.GetOperationResult getOperationResult = NodeUtil.getOperation(document, executionInput.getOperationName());
+        Map<String, FragmentDefinition> fragmentsByName = getOperationResult.fragmentsByName;
+        OperationDefinition operationDefinition = getOperationResult.operationDefinition;
+
+        ValuesResolver valuesResolver = new ValuesResolver();
+        Map<String, Object> inputVariables = executionInput.getVariables();
+        Map<String, Object> variableValues = valuesResolver.getVariableValues(graphQLSchema, operationDefinition.getVariableDefinitions(), inputVariables);
+
         ExecutionContext executionContext = new ExecutionContextBuilder()
-                .valuesResolver(new ValuesResolver())
                 .instrumentation(instrumentation)
                 .instrumentationState(instrumentationState)
                 .executionId(executionId)
@@ -58,9 +67,9 @@ public class Execution {
                 .subscriptionStrategy(subscriptionStrategy)
                 .context(executionInput.getContext())
                 .root(executionInput.getRoot())
-                .document(document)
-                .operationName(executionInput.getOperationName())
-                .variables(executionInput.getVariables())
+                .fragmentsByName(fragmentsByName)
+                .variables(variableValues)
+                .operationDefinition(operationDefinition)
                 .build();
         return executeOperation(executionContext, executionInput.getRoot(), executionContext.getOperationDefinition());
     }

--- a/src/main/java/graphql/execution/ExecutionContextBuilder.java
+++ b/src/main/java/graphql/execution/ExecutionContextBuilder.java
@@ -2,19 +2,17 @@ package graphql.execution;
 
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationState;
-import graphql.language.Document;
 import graphql.language.FragmentDefinition;
-import graphql.language.NodeUtil;
 import graphql.language.OperationDefinition;
 import graphql.schema.GraphQLSchema;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static graphql.Assert.assertNotNull;
 
 public class ExecutionContextBuilder {
 
-    private ValuesResolver valuesResolver;
     private Instrumentation instrumentation;
     private ExecutionId executionId;
     private InstrumentationState instrumentationState;
@@ -24,14 +22,9 @@ public class ExecutionContextBuilder {
     private ExecutionStrategy subscriptionStrategy;
     private Object context;
     private Object root;
-    private Document document;
-    private String operationName;
-    private Map<String, Object> variables;
-
-    public ExecutionContextBuilder valuesResolver(ValuesResolver valuesResolver) {
-        this.valuesResolver = valuesResolver;
-        return this;
-    }
+    private OperationDefinition operationDefinition;
+    private Map<String, Object> variables = new HashMap<>();
+    private Map<String, FragmentDefinition> fragmentsByName = new HashMap<>();
 
     public ExecutionContextBuilder instrumentation(Instrumentation instrumentation) {
         this.instrumentation = instrumentation;
@@ -78,18 +71,18 @@ public class ExecutionContextBuilder {
         return this;
     }
 
-    public ExecutionContextBuilder document(Document document) {
-        this.document = document;
-        return this;
-    }
-
-    public ExecutionContextBuilder operationName(String operationName) {
-        this.operationName = operationName;
-        return this;
-    }
-
     public ExecutionContextBuilder variables(Map<String, Object> variables) {
         this.variables = variables;
+        return this;
+    }
+
+    public ExecutionContextBuilder fragmentsByName(Map<String, FragmentDefinition> fragmentsByName) {
+        this.fragmentsByName = fragmentsByName;
+        return this;
+    }
+
+    public ExecutionContextBuilder operationDefinition(OperationDefinition operationDefinition) {
+        this.operationDefinition = operationDefinition;
         return this;
     }
 
@@ -97,11 +90,6 @@ public class ExecutionContextBuilder {
         // preconditions
         assertNotNull(executionId, "You must provide a query identifier");
 
-        NodeUtil.GetOperationResult getOperationResult = NodeUtil.getOperation(document, operationName);
-        Map<String, FragmentDefinition> fragmentsByName = getOperationResult.fragmentsByName;
-        OperationDefinition operationDefinition = getOperationResult.operationDefinition;
-
-        Map<String, Object> variableValues = valuesResolver.getVariableValues(graphQLSchema, operationDefinition.getVariableDefinitions(), variables);
 
         return new ExecutionContext(
                 instrumentation,
@@ -113,7 +101,7 @@ public class ExecutionContextBuilder {
                 subscriptionStrategy,
                 fragmentsByName,
                 operationDefinition,
-                variableValues,
+                variables,
                 context,
                 root);
     }

--- a/src/main/java/graphql/execution/fieldvalidation/FieldAndArguments.java
+++ b/src/main/java/graphql/execution/fieldvalidation/FieldAndArguments.java
@@ -1,0 +1,49 @@
+package graphql.execution.fieldvalidation;
+
+import graphql.PublicApi;
+import graphql.execution.ExecutionPath;
+import graphql.language.Field;
+import graphql.schema.GraphQLCompositeType;
+import graphql.schema.GraphQLFieldDefinition;
+
+import java.util.Map;
+
+/**
+ * This represents a field and its arguments that may be validated.
+ */
+@PublicApi
+public interface FieldAndArguments {
+
+    /**
+     * @return the field in play
+     */
+    Field getField();
+
+    /**
+     * @return the runtime type definition of the field
+     */
+    GraphQLFieldDefinition getFieldDefinition();
+
+    /**
+     * @return the containing type of the field
+     */
+    GraphQLCompositeType getParentType();
+
+    /**
+     * @return the parent arguments or null if there is no parent
+     */
+    FieldAndArguments getParentFieldAndArguments();
+
+    /**
+     * @return the path to this field
+     */
+    ExecutionPath getPath();
+
+    /**
+     * This will be a map of argument names to argument values.  This will contain any variables transferred
+     * along with any default values ready for execution.  This is what you use to do most of your validation against
+     *
+     * @return a map of argument names to values
+     */
+    Map<String, Object> getFieldArgumentValues();
+}

--- a/src/main/java/graphql/execution/fieldvalidation/FieldAndArgumentsValidationEnvironment.java
+++ b/src/main/java/graphql/execution/fieldvalidation/FieldAndArgumentsValidationEnvironment.java
@@ -1,0 +1,47 @@
+package graphql.execution.fieldvalidation;
+
+import graphql.GraphQLError;
+import graphql.PublicApi;
+import graphql.execution.ExecutionPath;
+import graphql.language.Field;
+import graphql.language.OperationDefinition;
+import graphql.schema.GraphQLSchema;
+
+import java.util.Map;
+
+/**
+ * This contains all of the field and their arguments for a given query.  The method
+ * {@link #getFieldArguments()} will be where most of the useful validation information is
+ * contained.  It also gives you a helper to make validation error messages.
+ *
+ * @see FieldAndArguments
+ */
+@PublicApi
+public interface FieldAndArgumentsValidationEnvironment {
+
+    /**
+     * @return the schema in play
+     */
+    GraphQLSchema getSchema();
+
+    /**
+     * @return the operation being executed
+     */
+    OperationDefinition getOperation();
+
+    /**
+     * @return a map of field paths to {@link FieldAndArguments}
+     */
+    Map<ExecutionPath, FieldAndArguments> getFieldArguments();
+
+    /**
+     * This helper method allows you to make error messages to be passed back out in case of validation failure
+     *
+     * @param msg   the error message
+     * @param field the (optional) field in error
+     * @param path  the (optional) path to the field
+     *
+     * @return a graphql error
+     */
+    GraphQLError mkError(String msg, Field field, ExecutionPath path);
+}

--- a/src/main/java/graphql/execution/fieldvalidation/FieldAndArgumentsValidator.java
+++ b/src/main/java/graphql/execution/fieldvalidation/FieldAndArgumentsValidator.java
@@ -1,0 +1,31 @@
+package graphql.execution.fieldvalidation;
+
+import graphql.GraphQLError;
+import graphql.PublicSpi;
+
+import java.util.List;
+
+/**
+ * This pluggable interface allows you to validate the fields and their argument inputs before query execution.
+ *
+ * You will be called with fields and their arguments expanded out ready for execution and you can check business logic
+ * concerns like the lengths of input objects (eg an input string cant be longer than say 255 chars) or that the
+ * input objects have a certain shape that required for this query.
+ *
+ * You are only called once with all the field information expanded out for you.  This allows you to set up cross field business rules,
+ * for example if field argument X has a value then field Y argument must also have a value say.
+ *
+ * @see FieldAndArgumentsValidationEnvironment
+ */
+@PublicSpi
+public interface FieldAndArgumentsValidator {
+
+    /**
+     * This is called to validate the fields and their arguments
+     *
+     * @param validationEnvironment the validation environment
+     *
+     * @return a list of errors.  If this is non empty then the query will not execute
+     */
+    List<GraphQLError> validateFieldArguments(FieldAndArgumentsValidationEnvironment validationEnvironment);
+}

--- a/src/main/java/graphql/execution/fieldvalidation/FieldArgumentValidationSupport.java
+++ b/src/main/java/graphql/execution/fieldvalidation/FieldArgumentValidationSupport.java
@@ -1,0 +1,177 @@
+package graphql.execution.fieldvalidation;
+
+import graphql.ErrorType;
+import graphql.GraphQLError;
+import graphql.Internal;
+import graphql.analysis.QueryTraversal;
+import graphql.analysis.QueryVisitorEnvironment;
+import graphql.execution.ExecutionPath;
+import graphql.language.Document;
+import graphql.language.Field;
+import graphql.language.OperationDefinition;
+import graphql.language.SourceLocation;
+import graphql.schema.GraphQLCompositeType;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLSchema;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+
+@Internal
+public class FieldArgumentValidationSupport {
+
+    public static List<GraphQLError> validateFieldsAndArguments(FieldAndArgumentsValidator fieldAndArgumentsValidator, GraphQLSchema schema, Document document, OperationDefinition operationDefinition, Map<String, Object> coercedVariables) {
+
+        Map<ExecutionPath, FieldAndArguments> fieldArgumentsMap = new HashMap<>();
+
+        QueryTraversal queryTraversal = new QueryTraversal(schema, document, operationDefinition.getName(), coercedVariables);
+        queryTraversal.visitPreOrder(traversalEnv -> {
+            Field field = traversalEnv.getField();
+            if (field.getArguments() != null && !field.getArguments().isEmpty()) {
+                //
+                // only fields that have arguments make any sense to placed in play
+                // since only they have variable input
+                FieldAndArguments fieldArguments = new FieldAndArgumentsImpl(traversalEnv);
+                fieldArgumentsMap.put(fieldArguments.getPath(), fieldArguments);
+            }
+        });
+
+        FieldAndArgumentsValidationEnvironment environment = new FieldAndArgumentsValidationEnvironmentImpl(schema, operationDefinition, fieldArgumentsMap);
+        //
+        // this will allow a consumer to plugin their own validation of fields and arguments
+        return fieldAndArgumentsValidator.validateFieldArguments(environment);
+    }
+
+    private static class FieldAndArgumentsImpl implements FieldAndArguments {
+        private final QueryVisitorEnvironment traversalEnv;
+        private final FieldAndArguments parentArgs;
+        private final ExecutionPath path;
+
+        FieldAndArgumentsImpl(QueryVisitorEnvironment traversalEnv) {
+            this.traversalEnv = traversalEnv;
+            this.parentArgs = mkParentArgs(traversalEnv);
+            this.path = mkPath(traversalEnv);
+        }
+
+        private FieldAndArguments mkParentArgs(QueryVisitorEnvironment traversalEnv) {
+            return traversalEnv.getParentEnvironment() != null ? new FieldAndArgumentsImpl(traversalEnv.getParentEnvironment()) : null;
+        }
+
+        private ExecutionPath mkPath(QueryVisitorEnvironment traversalEnv) {
+            QueryVisitorEnvironment parentEnvironment = traversalEnv.getParentEnvironment();
+            if (parentEnvironment == null) {
+                return ExecutionPath.rootPath().segment(traversalEnv.getField().getName());
+            } else {
+                Stack<QueryVisitorEnvironment> stack = new Stack<>();
+                stack.push(traversalEnv);
+                while (parentEnvironment != null) {
+                    stack.push(parentEnvironment);
+                    parentEnvironment = parentEnvironment.getParentEnvironment();
+                }
+                ExecutionPath path = ExecutionPath.rootPath();
+                while (!stack.isEmpty()) {
+                    QueryVisitorEnvironment environment = stack.pop();
+                    path = path.segment(environment.getField().getName());
+                }
+                return path;
+            }
+        }
+
+        @Override
+        public Field getField() {
+            return traversalEnv.getField();
+        }
+
+        @Override
+        public GraphQLFieldDefinition getFieldDefinition() {
+            return traversalEnv.getFieldDefinition();
+        }
+
+        @Override
+        public GraphQLCompositeType getParentType() {
+            return traversalEnv.getParentType();
+        }
+
+        @Override
+        public ExecutionPath getPath() {
+            return path;
+        }
+
+        @Override
+        public Map<String, Object> getFieldArgumentValues() {
+            return traversalEnv.getArguments();
+        }
+
+        @Override
+        public FieldAndArguments getParentFieldAndArguments() {
+            return parentArgs;
+        }
+    }
+
+    private static class FieldAndArgumentsValidationEnvironmentImpl implements FieldAndArgumentsValidationEnvironment {
+        private final GraphQLSchema schema;
+        private final OperationDefinition operationDefinition;
+        private final Map<ExecutionPath, FieldAndArguments> fieldArgumentsMap;
+
+        FieldAndArgumentsValidationEnvironmentImpl(GraphQLSchema schema, OperationDefinition operationDefinition, Map<ExecutionPath, FieldAndArguments> fieldArgumentsMap) {
+            this.schema = schema;
+            this.operationDefinition = operationDefinition;
+            this.fieldArgumentsMap = fieldArgumentsMap;
+        }
+
+        @Override
+        public GraphQLSchema getSchema() {
+            return schema;
+        }
+
+        @Override
+        public OperationDefinition getOperation() {
+            return operationDefinition;
+        }
+
+        @Override
+        public Map<ExecutionPath, FieldAndArguments> getFieldArguments() {
+            return fieldArgumentsMap;
+        }
+
+        @Override
+        public GraphQLError mkError(String msg, Field field, ExecutionPath path) {
+            return new FieldAndArgError(msg, field, path);
+        }
+
+        private static class FieldAndArgError implements GraphQLError {
+            private final String message;
+            private final List<SourceLocation> locations;
+            private final List<Object> path;
+
+            public FieldAndArgError(String message, Field field, ExecutionPath path) {
+                this.message = message;
+                this.locations = field == null ? null : Collections.singletonList(field.getSourceLocation());
+                this.path = path == null ? null : path.toList();
+            }
+
+            @Override
+            public String getMessage() {
+                return message;
+            }
+
+            @Override
+            public ErrorType getErrorType() {
+                return ErrorType.ValidationError;
+            }
+
+            @Override
+            public List<SourceLocation> getLocations() {
+                return locations;
+            }
+
+            @Override
+            public List<Object> getPath() {
+                return path;
+            }
+        }
+    }
+}

--- a/src/main/java/graphql/execution/fieldvalidation/SimpleFieldAndArgumentsValidator.java
+++ b/src/main/java/graphql/execution/fieldvalidation/SimpleFieldAndArgumentsValidator.java
@@ -1,0 +1,50 @@
+package graphql.execution.fieldvalidation;
+
+import graphql.GraphQLError;
+import graphql.PublicApi;
+import graphql.execution.ExecutionPath;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+/**
+ * This very simple field validator will run the supplied function for a given field path and if it returns an error
+ * it will be added to the list of problems
+ */
+@PublicApi
+public class SimpleFieldAndArgumentsValidator implements FieldAndArgumentsValidator {
+
+    private Map<ExecutionPath, BiFunction<FieldAndArguments, FieldAndArgumentsValidationEnvironment, GraphQLError>> rules = new LinkedHashMap<>();
+
+    /**
+     * Adds the rule against the field address path.  If the rule returns a non null error, it will be added to to the list of errors
+     *
+     * @param fieldPath the path to the field
+     * @param rule      the rule function
+     *
+     * @return this validator
+     */
+    public SimpleFieldAndArgumentsValidator addRule(ExecutionPath fieldPath, BiFunction<FieldAndArguments, FieldAndArgumentsValidationEnvironment, GraphQLError> rule) {
+        rules.put(fieldPath, rule);
+        return this;
+    }
+
+    @Override
+    public List<GraphQLError> validateFieldArguments(FieldAndArgumentsValidationEnvironment validationEnvironment) {
+        List<GraphQLError> errors = new ArrayList<>();
+        for (ExecutionPath fieldPath : rules.keySet()) {
+            FieldAndArguments fieldAndArguments = validationEnvironment.getFieldArguments().get(fieldPath);
+            if (fieldAndArguments != null) {
+                BiFunction<FieldAndArguments, FieldAndArgumentsValidationEnvironment, GraphQLError> ruleFunction = rules.get(fieldPath);
+                GraphQLError graphQLError = ruleFunction.apply(fieldAndArguments, validationEnvironment);
+                if (graphQLError != null) {
+                    errors.add(graphQLError);
+                }
+            }
+        }
+        return errors;
+    }
+}

--- a/src/test/groovy/graphql/TestUtil.groovy
+++ b/src/test/groovy/graphql/TestUtil.groovy
@@ -1,5 +1,7 @@
 package graphql
 
+import graphql.language.Document
+import graphql.parser.Parser
 import graphql.schema.DataFetcher
 import graphql.schema.GraphQLArgument
 import graphql.schema.GraphQLFieldDefinition
@@ -116,4 +118,9 @@ class TestUtil {
             return new PropertyDataFetcher(environment.getFieldDefinition().getName())
         }
     }
+
+    static Document parseQuery(String query) {
+        new Parser().parseDocument(query)
+    }
+
 }

--- a/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy
@@ -3,6 +3,7 @@ package graphql.execution
 import graphql.ErrorType
 import graphql.execution.instrumentation.NoOpInstrumentation
 import graphql.language.Field
+import graphql.language.OperationDefinition
 import graphql.parser.Parser
 import graphql.schema.DataFetcher
 import graphql.schema.GraphQLFieldDefinition
@@ -63,6 +64,7 @@ class AsyncExecutionStrategyTest extends Specification {
         )
         String query = "{hello, hello2}"
         def document = new Parser().parseDocument(query)
+        def operation = document.definitions[0] as OperationDefinition
 
         def typeInfo = ExecutionTypeInfo.newTypeInfo()
                 .type(schema.getQueryType())
@@ -71,8 +73,7 @@ class AsyncExecutionStrategyTest extends Specification {
         ExecutionContext executionContext = new ExecutionContextBuilder()
                 .graphQLSchema(schema)
                 .executionId(ExecutionId.generate())
-                .document(document)
-                .valuesResolver(new ValuesResolver())
+                .operationDefinition(operation)
                 .instrumentation(NoOpInstrumentation.INSTANCE)
                 .build()
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
@@ -101,6 +102,7 @@ class AsyncExecutionStrategyTest extends Specification {
         )
         String query = "{hello, hello2}"
         def document = new Parser().parseDocument(query)
+        def operation = document.definitions[0] as OperationDefinition
 
         def typeInfo = ExecutionTypeInfo.newTypeInfo()
                 .type(schema.getQueryType())
@@ -109,8 +111,7 @@ class AsyncExecutionStrategyTest extends Specification {
         ExecutionContext executionContext = new ExecutionContextBuilder()
                 .graphQLSchema(schema)
                 .executionId(ExecutionId.generate())
-                .document(document)
-                .valuesResolver(new ValuesResolver())
+                .operationDefinition(operation)
                 .instrumentation(NoOpInstrumentation.INSTANCE)
                 .build()
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
@@ -141,6 +142,7 @@ class AsyncExecutionStrategyTest extends Specification {
         )
         String query = "{hello, hello2}"
         def document = new Parser().parseDocument(query)
+        def operation = document.definitions[0] as OperationDefinition
 
         def typeInfo = ExecutionTypeInfo.newTypeInfo()
                 .type(schema.getQueryType())
@@ -149,8 +151,7 @@ class AsyncExecutionStrategyTest extends Specification {
         ExecutionContext executionContext = new ExecutionContextBuilder()
                 .graphQLSchema(schema)
                 .executionId(ExecutionId.generate())
-                .document(document)
-                .valuesResolver(new ValuesResolver())
+                .operationDefinition(operation)
                 .instrumentation(NoOpInstrumentation.INSTANCE)
                 .build()
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
@@ -180,6 +181,7 @@ class AsyncExecutionStrategyTest extends Specification {
         )
         String query = "{hello, hello2}"
         def document = new Parser().parseDocument(query)
+        def operation = document.definitions[0] as OperationDefinition
 
         def typeInfo = ExecutionTypeInfo.newTypeInfo()
                 .type(schema.getQueryType())
@@ -188,8 +190,7 @@ class AsyncExecutionStrategyTest extends Specification {
         ExecutionContext executionContext = new ExecutionContextBuilder()
                 .graphQLSchema(schema)
                 .executionId(ExecutionId.generate())
-                .document(document)
-                .valuesResolver(new ValuesResolver())
+                .operationDefinition(operation)
                 .instrumentation(NoOpInstrumentation.INSTANCE)
                 .build()
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters

--- a/src/test/groovy/graphql/execution/AsyncSerialExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/AsyncSerialExecutionStrategyTest.groovy
@@ -2,6 +2,7 @@ package graphql.execution
 
 import graphql.execution.instrumentation.NoOpInstrumentation
 import graphql.language.Field
+import graphql.language.OperationDefinition
 import graphql.parser.Parser
 import graphql.schema.DataFetcher
 import graphql.schema.GraphQLFieldDefinition
@@ -70,6 +71,7 @@ class AsyncSerialExecutionStrategyTest extends Specification {
         )
         String query = "{hello, hello2, hello3}"
         def document = new Parser().parseDocument(query)
+        def operation = document.definitions[0] as OperationDefinition
 
         def typeInfo = ExecutionTypeInfo.newTypeInfo()
                 .type(schema.getQueryType())
@@ -78,8 +80,7 @@ class AsyncSerialExecutionStrategyTest extends Specification {
         ExecutionContext executionContext = new ExecutionContextBuilder()
                 .graphQLSchema(schema)
                 .executionId(ExecutionId.generate())
-                .document(document)
-                .valuesResolver(new ValuesResolver())
+                .operationDefinition(operation)
                 .instrumentation(NoOpInstrumentation.INSTANCE)
                 .build()
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
@@ -98,6 +99,7 @@ class AsyncSerialExecutionStrategyTest extends Specification {
         result.get().data == ['hello': 'world1', 'hello2': 'world2', 'hello3': 'world3']
     }
 
+    @SuppressWarnings("GroovyAssignabilityCheck")
     def "async serial execution test"() {
         given:
         def df1 = Mock(DataFetcher)
@@ -112,6 +114,7 @@ class AsyncSerialExecutionStrategyTest extends Specification {
         GraphQLSchema schema = schema(df1, df2, df3)
         String query = "{hello, hello2, hello3}"
         def document = new Parser().parseDocument(query)
+        def operation = document.definitions[0] as OperationDefinition
 
         def typeInfo = ExecutionTypeInfo.newTypeInfo()
                 .type(schema.getQueryType())
@@ -120,8 +123,7 @@ class AsyncSerialExecutionStrategyTest extends Specification {
         ExecutionContext executionContext = new ExecutionContextBuilder()
                 .graphQLSchema(schema)
                 .executionId(ExecutionId.generate())
-                .document(document)
-                .valuesResolver(new ValuesResolver())
+                .operationDefinition(operation)
                 .instrumentation(NoOpInstrumentation.INSTANCE)
                 .build()
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters

--- a/src/test/groovy/graphql/execution/ExecutionContextBuilderTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionContextBuilderTest.groovy
@@ -15,9 +15,6 @@ class ExecutionContextBuilderTest extends Specification {
         given:
         ExecutionContextBuilder executionContextBuilder = new ExecutionContextBuilder()
 
-        ValuesResolver valuesResolver = Mock(ValuesResolver)
-        executionContextBuilder.valuesResolver(valuesResolver)
-
         Instrumentation instrumentation = Mock(Instrumentation)
         executionContextBuilder.instrumentation(instrumentation)
 
@@ -45,16 +42,15 @@ class ExecutionContextBuilderTest extends Specification {
         Document document = new Parser().parseDocument("query myQuery(\$var: String){...MyFragment} fragment MyFragment on Query{foo}")
         def operation = document.definitions[0] as OperationDefinition
         def fragment = document.definitions[1] as FragmentDefinition
-        executionContextBuilder.document(document)
+        executionContextBuilder.operationDefinition(operation)
 
-        String operationName = "myQuery"
-        executionContextBuilder.operationName(operationName)
+        executionContextBuilder.fragmentsByName([MyFragment:fragment])
 
         def variables = Collections.emptyMap()
         executionContextBuilder.variables(variables)
 
+        executionContextBuilder.variables([var: 'value'])
 
-        valuesResolver.getVariableValues(schema, operation.getVariableDefinitions(), variables) >> [var: 'value']
         when:
         def executionContext = executionContextBuilder.build()
 

--- a/src/test/groovy/graphql/execution/ExecutionPathTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionPathTest.groovy
@@ -1,5 +1,6 @@
 package graphql.execution
 
+import graphql.AssertException
 import graphql.ExceptionWhileDataFetching
 import graphql.ExecutionInput
 import graphql.GraphQL
@@ -134,4 +135,57 @@ class ExecutionPathTest extends Specification {
         def error4 = errors.get(3) as NonNullableFieldWasNullError
         ["f4", "nonNullField"] == error4.getPath()
     }
+
+    def "test best case parsing"() {
+
+
+        expect:
+        ExecutionPath.fromString(pathString).toList() == expectedList
+
+        where:
+
+        pathString     | expectedList
+        ""             | []
+        null           | []
+        "/a"           | ["a"]
+        "/a/b"         | ["a", "b"]
+        " /a/b "       | ["a", "b"]
+        "/a/b[0]/c[1]" | ["a", "b", 0, "c", 1]
+    }
+
+    def "test worst case parsing"() {
+
+        when:
+        ExecutionPath.fromString(badPathString)
+
+        then:
+        thrown(AssertException)
+
+        where:
+
+        badPathString | _
+        "a"           | _
+        "a/b"         | _
+        "a/b[x]"      | _
+        "a/b[0"       | _
+        "a/b[0/c[1]"  | _
+        "a/b[0]c[1/"  | _
+        "/"           | _
+    }
+
+    def "test from test fromList"() {
+
+
+        expect:
+        ExecutionPath.fromList(inputList).toString() == expectedString
+
+        where:
+
+        expectedString | inputList
+        ""             | []
+        "/a"           | ["a"]
+        "/a/b"         | ["a", "b"]
+        "/a/b[0]/c[1]" | ["a", "b", 0, "c", 1]
+    }
+
 }

--- a/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
@@ -8,6 +8,7 @@ import graphql.SerializationError
 import graphql.execution.instrumentation.NoOpInstrumentation
 import graphql.language.Argument
 import graphql.language.Field
+import graphql.language.OperationDefinition
 import graphql.language.SourceLocation
 import graphql.language.StringValue
 import graphql.parser.Parser
@@ -55,6 +56,7 @@ class ExecutionStrategyTest extends Specification {
         new ExecutionContext(NoOpInstrumentation.INSTANCE, executionId, schema, null, executionStrategy, executionStrategy, executionStrategy, null, null, variables, "context", "root")
     }
 
+    @SuppressWarnings("GroovyAssignabilityCheck")
     def "complete values always calls query strategy to execute more"() {
         given:
         def dataFetcher = Mock(DataFetcher)
@@ -68,15 +70,18 @@ class ExecutionStrategyTest extends Specification {
                 .field(fieldDefinition)
                 .build()
 
+        def document = new Parser().parseDocument("{someField}")
+        def operation = document.definitions[0] as OperationDefinition
+
         GraphQLSchema schema = GraphQLSchema.newSchema().query(objectType).build()
         def builder = new ExecutionContextBuilder()
         builder.queryStrategy(Mock(ExecutionStrategy))
         builder.mutationStrategy(Mock(ExecutionStrategy))
         builder.subscriptionStrategy(Mock(ExecutionStrategy))
         builder.graphQLSchema(schema)
-        builder.document(new Parser().parseDocument("{someField}"))
+
+        builder.operationDefinition(operation)
         builder.executionId(ExecutionId.generate())
-        builder.valuesResolver(new ValuesResolver())
 
         def executionContext = builder.build()
         def result = new Object()

--- a/src/test/groovy/graphql/execution/ExecutionTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionTest.groovy
@@ -34,7 +34,7 @@ class ExecutionTest extends Specification {
     def subscriptionStrategy = new CountingExecutionStrategy()
     def mutationStrategy = new CountingExecutionStrategy()
     def queryStrategy = new CountingExecutionStrategy()
-    def execution = new Execution(queryStrategy, mutationStrategy, subscriptionStrategy, NoOpInstrumentation.INSTANCE)
+    def execution = new Execution(queryStrategy, mutationStrategy, subscriptionStrategy, NoOpInstrumentation.INSTANCE, variableValidator)
     def emptyExecutionInput = ExecutionInput.newExecutionInput().build()
     def instrumentationState = new InstrumentationState() {}
 
@@ -43,7 +43,7 @@ class ExecutionTest extends Specification {
         def mutationStrategy = new CountingExecutionStrategy()
 
         def queryStrategy = new CountingExecutionStrategy()
-        def execution = new Execution(queryStrategy, mutationStrategy, subscriptionStrategy, NoOpInstrumentation.INSTANCE)
+        def execution = new Execution(queryStrategy, mutationStrategy, subscriptionStrategy, NoOpInstrumentation.INSTANCE, variableValidator)
 
         def query = '''
             query {

--- a/src/test/groovy/graphql/execution/fieldvalidation/FieldAndArgumentsValidatorTest.groovy
+++ b/src/test/groovy/graphql/execution/fieldvalidation/FieldAndArgumentsValidatorTest.groovy
@@ -1,0 +1,191 @@
+package graphql.execution.fieldvalidation
+
+import graphql.ExecutionInput
+import graphql.ExecutionResult
+import graphql.GraphQL
+import graphql.GraphQLError
+import graphql.TestUtil
+import graphql.execution.AsyncExecutionStrategy
+import graphql.execution.Execution
+import graphql.execution.ExecutionId
+import graphql.execution.ExecutionPath
+import graphql.execution.instrumentation.NoOpInstrumentation
+import spock.lang.Specification
+
+import java.util.concurrent.CompletableFuture
+
+class FieldAndArgumentsValidatorTest extends Specification {
+    def idl = """
+            type Information {
+                informationString(fmt1 : String = "defaultFmt1", fmt2 : String = "defaultFmt2" ) : String
+                informationInt : Int
+                informationLink : Information
+            }
+            
+            input InputData {
+                string: String
+                int: Int
+            }
+            
+            type Query {
+                field1(inputData : InputData, id : ID) : Information
+                field2(stringArg : String) : String
+                field3(intArg : Int) : Int
+                noArgField : Int
+            }
+        """
+
+    def schema = TestUtil.schema(idl)
+
+    def query = '''
+        query VarTest($stringVar : String, $intVar : Int, $inputDataVar : InputData, $idVar : ID, $fmt1Var : String) {
+            field1(inputData : $inputDataVar, id : $idVar) {
+                informationString 
+                informationLink {
+                    informationString(fmt1 : "inlineFmt1")
+                        informationLink {
+                        informationString(fmt1 : $fmt1Var)
+                    }
+                }
+            }
+            field2(stringArg : $stringVar)
+            field3(intArg : $intVar)
+        }
+        '''
+
+
+    def "test_field_args_can_be_validated"() {
+        given:
+
+        def variables = [
+                stringVar   : "stringValue",
+                intVar      : 666,
+                inputDataVar: [string: "string", int: 0],
+                idVar       : "ID12345",
+                fmt1Var     : "fmt1Value"
+        ]
+
+        def validator = new FieldAndArgumentsValidator() {
+            @Override
+            List<GraphQLError> validateFieldArguments(FieldAndArgumentsValidationEnvironment validationEnvironment) {
+                Map<String, Object> values
+
+                def fieldArguments = validationEnvironment.getFieldArguments()
+
+                FieldAndArguments field1Args = fieldArguments.get(ExecutionPath.fromString("/field1"))
+
+                values = field1Args.getFieldArgumentValues()
+
+                assert values['inputData'] == [string: "string", int: 0]
+                assert values['id'] == "ID12345"
+                assert !values.containsKey('stringArg')
+                assert !values.containsKey('intArg')
+
+
+                values = fieldArguments.get(ExecutionPath.fromString("/field2"))
+                        .getFieldArgumentValues()
+
+                assert values['stringArg'] == "stringValue"
+
+                values = fieldArguments.get(ExecutionPath.fromString("/field3"))
+                        .getFieldArgumentValues()
+
+                assert values['intArg'] == 666
+
+                assert !fieldArguments.containsKey(ExecutionPath.fromString("/noArgField"))
+
+                values = fieldArguments.get(ExecutionPath.fromString("/field1/informationLink/informationString"))
+                        .getFieldArgumentValues()
+
+                assert values['fmt1'] == "inlineFmt1" // inlined from query
+                assert values['fmt2'] == "defaultFmt2" // defaulted from schema
+
+                values = fieldArguments.get(ExecutionPath.fromString("/field1/informationLink/informationLink/informationString"))
+                        .getFieldArgumentValues()
+
+
+                assert values['fmt1'] == "fmt1Value" // from variables
+                assert values['fmt2'] == "defaultFmt2" // defaulted from schema
+
+
+                return [
+                        validationEnvironment.mkError("Made up some error here", field1Args.getField(), field1Args.getPath())
+                ]
+            }
+        }
+
+        when:
+
+        def result = setupExecution(validator, query, variables)
+
+        then:
+        result.get().getErrors().size() == 1
+        result.get().getErrors()[0].getMessage() == "Made up some error here"
+        result.get().getErrors()[0].getLocations().size() == 1
+        result.get().getErrors()[0].getPath() == ["field1"]
+    }
+
+    def "test graphql from end to end"() {
+
+        GraphQL graphql = GraphQL.newGraphQL(schema).fieldArgumentValidator(new FieldAndArgumentsValidator() {
+            @Override
+            List<GraphQLError> validateFieldArguments(FieldAndArgumentsValidationEnvironment validationEnvironment) {
+                return [validationEnvironment.mkError("I was called", null, null)]
+            }
+        }).build()
+
+        when:
+        def result = graphql.execute("{ field2 }")
+
+        then:
+        result.getErrors()[0].getMessage() == "I was called"
+    }
+
+    def "test SimpleFieldAndArgumentsValidator"() {
+        given:
+
+        def variables = [
+                stringVar   : "stringValue",
+                intVar      : 666,
+                inputDataVar: [string: "string", int: 0],
+                idVar       : "ID12345",
+                fmt1Var     : "fmt1Value"
+        ]
+
+        SimpleFieldAndArgumentsValidator validator = new SimpleFieldAndArgumentsValidator()
+                .addRule(ExecutionPath.fromString("/field1"),
+                { fieldAndArguments, env -> err("Not happy Jan!", env, fieldAndArguments) })
+                .addRule(ExecutionPath.fromString("/field1/informationLink/informationLink/informationString"),
+                { fieldAndArguments, env -> err("Also not happy Jan!", env, fieldAndArguments) })
+                .addRule(ExecutionPath.fromString("/does/not/exist"),
+                { fieldAndArguments, env -> err("Wont happen", env, fieldAndArguments) })
+
+
+        when:
+        def result = setupExecution(validator, query, variables)
+
+        then:
+        result.get().getErrors().size() == 2
+        result.get().getErrors()[0].getMessage() == "Not happy Jan!"
+        result.get().getErrors()[0].getLocations().size() == 1
+        result.get().getErrors()[0].getPath() == ["field1"]
+
+        result.get().getErrors()[1].getMessage() == "Also not happy Jan!"
+
+    }
+
+    static GraphQLError err(String msg, FieldAndArgumentsValidationEnvironment env, FieldAndArguments fieldAndArguments) {
+        env.mkError(msg, fieldAndArguments.getField(), fieldAndArguments.getPath())
+    }
+
+
+    private CompletableFuture<ExecutionResult> setupExecution(FieldAndArgumentsValidator variableValidator, String query, Map<String, Object> variables) {
+        def document = TestUtil.parseQuery(query)
+        def strategy = new AsyncExecutionStrategy()
+        def execution = new Execution(strategy, strategy, strategy, NoOpInstrumentation.INSTANCE, Optional.of(variableValidator))
+
+        def executionInput = ExecutionInput.newExecutionInput().query(query).variables(variables).build()
+        execution.execute(document, schema, ExecutionId.generate(), executionInput, NoOpInstrumentation.INSTANCE.createState())
+    }
+
+}


### PR DESCRIPTION
see #162 

This adds the ability to have a pluggable validation mechanism before execution occurs but AFTER query validation has occurred.

The query will be valid and the variables transferred against each field and then this allows you to put more business logic in place before you start executing the query against data fetchers.

I put in a simple validator but in reality I am sure people will create more complex ones

