### PR TITLE
SchemaPrinter: print implemented interfaces for types

### DIFF
--- a/src/main/java/graphql/schema/idl/SchemaPrinter.java
+++ b/src/main/java/graphql/schema/idl/SchemaPrinter.java
@@ -27,6 +27,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Stack;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static graphql.schema.visibility.DefaultGraphqlFieldVisibility.DEFAULT_FIELD_VISIBILITY;
@@ -214,7 +215,13 @@ public class SchemaPrinter {
                 return;
             }
             printComments(out, type, "");
-            out.format("type %s {\n", type.getName());
+            if (type.getInterfaces().isEmpty()) {
+                out.format("type %s {\n", type.getName());
+            } else
+                out.format("type %s implements %s {\n",
+                    type.getName(),
+                    type.getInterfaces().stream().map(GraphQLType::getName).collect(Collectors.joining(", ")));
+
             visibility.getFieldDefinitions(type).forEach(fd -> {
                 printComments(out, fd, "  ");
                 out.format("  %s%s: %s\n",

--- a/src/test/groovy/graphql/schema/visibility/GraphqlFieldVisibilityTest.groovy
+++ b/src/test/groovy/graphql/schema/visibility/GraphqlFieldVisibilityTest.groovy
@@ -133,7 +133,7 @@ interface Character {
 }
 
 #A mechanical creature in the Star Wars universe.
-type Droid {
+type Droid implements Character {
   #The id of the droid.
   id: String!
   #The name of the droid.
@@ -147,7 +147,7 @@ type Droid {
 }
 
 #A humanoid creature in the Star Wars universe.
-type Human {
+type Human implements Character {
   #The id of the human.
   id: String!
   #The name of the human.
@@ -212,7 +212,7 @@ interface Character {
 }
 
 #A mechanical creature in the Star Wars universe.
-type Droid {
+type Droid implements Character {
   #The name of the droid.
   name: String
   #The friends of the droid, or an empty list if they have none.
@@ -224,7 +224,7 @@ type Droid {
 }
 
 #A humanoid creature in the Star Wars universe.
-type Human {
+type Human implements Character {
   #The id of the human.
   id: String!
   #The name of the human.


### PR DESCRIPTION
I discovered this as a limitation of the graphql-java SchemaPrinter that is preventing us from using it as part of our Relay Modern development workflow 

Based on: https://github.com/graphql/graphql-js/blob/ff4338daadb7f86e0d0700faff086dd46cbfb7b2/src/utilities/schemaPrinter.js#L160-L168

