### PR TITLE
Fixes the copying of schemas

### DIFF
--- a/src/main/java/graphql/schema/GraphQLSchema.java
+++ b/src/main/java/graphql/schema/GraphQLSchema.java
@@ -125,7 +125,9 @@ public class GraphQLSchema {
                 .query(existingSchema.getQueryType())
                 .mutation(existingSchema.getMutationType())
                 .subscription(existingSchema.getSubscriptionType())
-                .fieldVisibility(existingSchema.getFieldVisibility());
+                .fieldVisibility(existingSchema.getFieldVisibility())
+                .additionalDirectives(existingSchema.directives)
+                .additionalTypes(existingSchema.additionalTypes);
     }
 
     public static class Builder {
@@ -133,6 +135,8 @@ public class GraphQLSchema {
         private GraphQLObjectType mutationType;
         private GraphQLObjectType subscriptionType;
         private GraphqlFieldVisibility fieldVisibility = DEFAULT_FIELD_VISIBILITY;
+        private Set<GraphQLType> additionalTypes = Collections.emptySet();
+        private Set<GraphQLDirective> additionalDirectives = Collections.emptySet();
 
         public Builder query(GraphQLObjectType.Builder builder) {
             return query(builder.build());
@@ -166,8 +170,18 @@ public class GraphQLSchema {
             return this;
         }
 
+        public Builder additionalTypes(Set<GraphQLType> additionalTypes) {
+            this.additionalTypes = additionalTypes;
+            return this;
+        }
+
+        public Builder additionalDirectives(Set<GraphQLDirective> additionalDirectives) {
+            this.additionalDirectives = additionalDirectives;
+            return this;
+        }
+
         public GraphQLSchema build() {
-            return build(Collections.emptySet(), Collections.emptySet());
+            return build(additionalTypes, additionalDirectives);
         }
 
         public GraphQLSchema build(Set<GraphQLType> additionalTypes) {

--- a/src/main/java/graphql/schema/idl/SchemaGenerator.java
+++ b/src/main/java/graphql/schema/idl/SchemaGenerator.java
@@ -1,20 +1,16 @@
 package graphql.schema.idl;
 
 import graphql.Assert;
-import graphql.GraphQL;
 import graphql.GraphQLError;
 import graphql.language.Argument;
 import graphql.language.ArrayValue;
-import graphql.language.BooleanValue;
 import graphql.language.Comment;
 import graphql.language.Directive;
 import graphql.language.EnumTypeDefinition;
 import graphql.language.EnumValue;
 import graphql.language.FieldDefinition;
-import graphql.language.FloatValue;
 import graphql.language.InputObjectTypeDefinition;
 import graphql.language.InputValueDefinition;
-import graphql.language.IntValue;
 import graphql.language.InterfaceTypeDefinition;
 import graphql.language.Node;
 import graphql.language.NullValue;
@@ -219,6 +215,7 @@ public class SchemaGenerator {
 
         Set<GraphQLType> additionalTypes = buildAdditionalTypes(buildCtx);
 
+        schemaBuilder.fieldVisibility(buildCtx.getWiring().getFieldVisibility());
         return schemaBuilder.build(additionalTypes);
     }
 
@@ -540,22 +537,22 @@ public class SchemaGenerator {
     private Object buildValue(Value value, GraphQLType requiredType) {
         Object result = null;
         if (requiredType instanceof GraphQLNonNull) {
-            requiredType = ((GraphQLNonNull)requiredType).getWrappedType();
+            requiredType = ((GraphQLNonNull) requiredType).getWrappedType();
         }
         if (requiredType instanceof GraphQLScalarType) {
-            result = ((GraphQLScalarType)requiredType).getCoercing().parseLiteral(value);
+            result = ((GraphQLScalarType) requiredType).getCoercing().parseLiteral(value);
         } else if (value instanceof EnumValue && requiredType instanceof GraphQLEnumType) {
             result = ((EnumValue) value).getName();
         } else if (value instanceof ArrayValue && requiredType instanceof GraphQLList) {
             ArrayValue arrayValue = (ArrayValue) value;
             GraphQLType wrappedType = ((GraphQLList) requiredType).getWrappedType();
             result = arrayValue.getValues().stream()
-                .map(item -> this.buildValue(item, wrappedType)).collect(Collectors.toList());
+                    .map(item -> this.buildValue(item, wrappedType)).collect(Collectors.toList());
         } else if (value instanceof ObjectValue && requiredType instanceof GraphQLInputObjectType) {
             result = buildObjectValue((ObjectValue) value, (GraphQLInputObjectType) requiredType);
         } else if (value != null && !(value instanceof NullValue)) {
             Assert.assertShouldNeverHappen(
-                "cannot build value of " + requiredType.getName() + " from " + String.valueOf(value));
+                    "cannot build value of " + requiredType.getName() + " from " + String.valueOf(value));
         }
         return result;
     }
@@ -563,7 +560,7 @@ public class SchemaGenerator {
     private Object buildObjectValue(ObjectValue defaultValue, GraphQLInputObjectType objectType) {
         HashMap<String, Object> map = new LinkedHashMap<>();
         defaultValue.getObjectFields().forEach(of -> map.put(of.getName(),
-            buildValue(of.getValue(), objectType.getField(of.getName()).getType())));
+                buildValue(of.getValue(), objectType.getField(of.getName()).getType())));
         return map;
     }
 

--- a/src/test/groovy/graphql/schema/GraphQLSchemaTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLSchemaTest.groovy
@@ -1,0 +1,63 @@
+package graphql.schema
+
+import graphql.ExecutionInput
+import graphql.GraphQL
+import graphql.TestUtil
+import graphql.schema.idl.RuntimeWiring
+import spock.lang.Specification
+
+class GraphQLSchemaTest extends Specification {
+
+    def "#698 interfaces copied as expected"() {
+
+        def idl = """
+            type Query {
+              foo: Node
+            }
+            
+            interface Node {
+              id: String
+            }
+            
+            type Foo implements Node {
+              id: String
+            }
+        """
+
+        RuntimeWiring runtimeWiring = RuntimeWiring.newRuntimeWiring()
+                .type("Query", { wiring ->
+            wiring.dataFetcher("foo", { env ->
+                Map<String, Object> map = new HashMap<>()
+                map.put("id", "abc")
+                return map
+            })
+        })
+                .type("Node", { wiring ->
+            wiring.typeResolver({ env -> (GraphQLObjectType) env.getSchema().getType("Foo") })
+        })
+                .build()
+
+        def existingSchema = TestUtil.schema(idl, runtimeWiring)
+
+
+        GraphQLSchema schema = GraphQLSchema.newSchema(existingSchema).build()
+
+        expect:
+        assert 0 == runQuery(existingSchema).getErrors().size()
+        assert 0 == runQuery(schema).getErrors().size()
+    }
+
+
+    def runQuery(GraphQLSchema schema) {
+        GraphQL graphQL = GraphQL.newGraphQL(schema)
+                .build()
+
+        ExecutionInput executionInput = ExecutionInput.newExecutionInput()
+                .query("{foo {id}}")
+                .build()
+
+        return graphQL
+                .executeAsync(executionInput)
+                .join()
+    }
+}

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -1,6 +1,8 @@
 package graphql.schema.idl
 
 import graphql.schema.GraphQLEnumType
+import graphql.schema.GraphQLFieldDefinition
+import graphql.schema.GraphQLFieldsContainer
 import graphql.schema.GraphQLInputObjectType
 import graphql.schema.GraphQLInterfaceType
 import graphql.schema.GraphQLList
@@ -11,6 +13,7 @@ import graphql.schema.GraphQLType
 import graphql.schema.GraphQLUnionType
 import graphql.schema.idl.errors.NotAnInputTypeError
 import graphql.schema.idl.errors.NotAnOutputTypeError
+import graphql.schema.visibility.GraphqlFieldVisibility
 import spock.lang.Specification
 
 import java.util.function.UnaryOperator
@@ -1004,5 +1007,32 @@ class SchemaGeneratorTest extends Specification {
         expect:
         arg["str"] instanceof String
         arg["num"] instanceof Integer
+    }
+
+    def "field visibility is used"() {
+        def spec = """
+            type Query {
+              field : String
+            }
+        """
+
+        GraphqlFieldVisibility fieldVisibility = new GraphqlFieldVisibility() {
+            @Override
+            List<GraphQLFieldDefinition> getFieldDefinitions(GraphQLFieldsContainer fieldsContainer) {
+                return null
+            }
+
+            @Override
+            GraphQLFieldDefinition getFieldDefinition(GraphQLFieldsContainer fieldsContainer, String fieldName) {
+                return null
+            }
+        }
+
+        def schema = schema(spec, RuntimeWiring.newRuntimeWiring().fieldVisibility(fieldVisibility).build())
+
+        expect:
+
+        schema.getFieldVisibility() == fieldVisibility
+
     }
 }


### PR DESCRIPTION
Fixes the copying of schemas and also the fact you cant set field visibility on IDL schema creation runtime wiring

See #698 
