### PR TITLE
703 make java dataloader a dep

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ jar {
 dependencies {
     compile 'org.antlr:antlr4-runtime:4.5.1'
     compile 'org.slf4j:slf4j-api:' + slf4jVersion
+    compile 'com.graphql-java:java-dataloader:2.0.0-alpha2'
     antlr "org.antlr:antlr4:4.5.1"
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'
@@ -42,7 +43,6 @@ dependencies {
     testCompile 'com.fasterxml.jackson.core:jackson-databind:2.8.8.1'
     testCompile 'org.slf4j:slf4j-simple:' + slf4jVersion
     testCompile 'org.awaitility:awaitility-groovy:3.0.0'
-    testCompile 'com.graphql-java:java-dataloader:1.0.1'
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ jar {
 dependencies {
     compile 'org.antlr:antlr4-runtime:4.5.1'
     compile 'org.slf4j:slf4j-api:' + slf4jVersion
-    compile 'com.graphql-java:java-dataloader:2.0.0-alpha2'
+    compile 'com.graphql-java:java-dataloader:2.0.0'
     antlr "org.antlr:antlr4:4.5.1"
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'

--- a/docs/batching.rst
+++ b/docs/batching.rst
@@ -1,0 +1,126 @@
+Using Dataloader
+================
+
+If you are using ``graphql``, you are likely to making queries on a graph of data (surprise surprise).  But its easy
+to implement inefficient code with naive loading of a graph of data.
+
+Using ``java-dataloader`` will help you to make this a more efficient process by both caching and batching requests for that graph of data items.  If ``dataloader``
+has previously see a data item before, it will cached the value and will return it without having to ask for it again.
+
+Imagine we have the StarWars query outlined below.  It asks us to find a hero and their friend's names and their friend's friend's
+names.  It is likely that many of these people will be friends in common.
+
+
+.. code-block:: graphql
+
+        {
+            hero {
+                name
+                friends {
+                    name
+                    friends {
+                       name
+                    }
+                }
+            }
+        }
+
+The result of this query is displayed below. You can see that Han, Leia, Luke and R2-D2 are tight knit bunch of friends and
+share many friends in common.
+
+.. code-block:: json
+
+        [hero: [name: 'R2-D2', friends: [
+                [name: 'Luke Skywalker', friends: [
+                        [name: 'Han Solo'], [name: 'Leia Organa'], [name: 'C-3PO'], [name: 'R2-D2']]],
+                [name: 'Han Solo', friends: [
+                        [name: 'Luke Skywalker'], [name: 'Leia Organa'], [name: 'R2-D2']]],
+                [name: 'Leia Organa', friends: [
+                        [name: 'Luke Skywalker'], [name: 'Han Solo'], [name: 'C-3PO'], [name: 'R2-D2']]]]]
+        ]
+
+A naive implementation would called a `DataFetcher` to retrieved a person object every time it was invoked.
+
+In this case it would be *15* calls over the network.  Even though the group of people have a lot of common friends.
+With `dataloader` you can make the `graphql` query much more efficient.
+
+As `graphql` descends each level of the query ( eg as it processes `hero` and then `friends` and then for each their `friends`),
+the data loader is called to "promise" to deliver a person object.  At each level `dataloader.dispatch()` will be
+called to fire off the batch requests for that part of the query. With caching turned on (the default) then
+any previously returned person will be returned as is for no cost.
+
+In the above example there are only *5* unique people mentioned but with caching and batching retrieval in place their will be only
+*3* calls to the batch loader function.  *3* calls over the network or to a database is much better than *15* calls you will agree.
+
+If you use capabilities like `java.util.concurrent.CompletableFuture.supplyAsync()` then you can make it even more efficient by making the
+the remote calls asynchronous to the rest of the query.  This will make it even more timely since multiple calls can happen at once
+if need be.
+
+Here is how you might put this in place:
+
+
+.. code-block:: java
+
+        // a batch loader function that will be called with N or more keys for batch loading
+        BatchLoader<String, Object> characterBatchLoader = new BatchLoader<String, Object>() {
+            @Override
+            public CompletionStage<List<Object>> load(List<String> keys) {
+                //
+                // we use supplyAsync() of values here for maximum parellisation
+                //
+                return CompletableFuture.supplyAsync(() -> getCharacterDataViaBatchHTTPApi(keys));
+            }
+        };
+
+        // a data loader for characters that points to the character batch loader
+        DataLoader<String, Object> characterDataLoader = new DataLoader<>(characterBatchLoader);
+
+        //
+        // use this data loader in the data fetchers associated with characters and put them into
+        // the graphql schema (not shown)
+        //
+        DataFetcher heroDataFetcher = new DataFetcher() {
+            @Override
+            public Object get(DataFetchingEnvironment environment) {
+                return characterDataLoader.load("2001"); // R2D2
+            }
+        };
+
+        DataFetcher friendsDataFetcher = new DataFetcher() {
+            @Override
+            public Object get(DataFetchingEnvironment environment) {
+                StarWarsCharacter starWarsCharacter = environment.getSource();
+                List<String> friendIds = starWarsCharacter.getFriendIds();
+                return characterDataLoader.loadMany(friendIds);
+            }
+        };
+
+        //
+        // DataLoaderRegistry is a place to register all data loaders in that needs to be dispatched together
+        // in this case there is 1 but you can have many
+        //
+        DataLoaderRegistry registry = new DataLoaderRegistry();
+        registry.register("character", characterDataLoader);
+
+        //
+        // this instrumentation implementation will dispatched all the dataloaders
+        // as each level fo the graphql query is executed and hence make batched objects
+        // available to the query and the associated DataFetchers
+        //
+        DataLoaderDispatcherInstrumentation dispatcherInstrumentation
+                = new DataLoaderDispatcherInstrumentation(registry);
+
+        //
+        // now build your graphql object and execute queries on it.
+        // the data loader will be invoked via the data fetchers on the
+        // schema fields
+        //
+        GraphQL graphQL = GraphQL.newGraphQL(buildSchema())
+                .instrumentation(dispatcherInstrumentation)
+                .build();
+```
+
+One thing to note is the above only works if you use `DataLoaderDispatcherInstrumentation` which makes sure `dataLoader.dispatch()`
+is called.  If this was not in place, then all the promises to data will never be dispatched ot the batch loader function
+and hence nothing would ever resolve.
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,6 +44,7 @@ graphql-java is licensed under the MIT License.
     getting_started
     schema
     execution
+    batching
     instrumentation
     relay
     logging

--- a/src/main/java/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentation.java
@@ -1,0 +1,45 @@
+package graphql.execution.instrumentation.dataloader;
+
+import graphql.ExecutionResult;
+import graphql.execution.instrumentation.InstrumentationContext;
+import graphql.execution.instrumentation.NoOpInstrumentation;
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionStrategyParameters;
+import org.dataloader.DataLoaderRegistry;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * This graphql {@link graphql.execution.instrumentation.Instrumentation} will dispatch
+ * all the contained {@link org.dataloader.DataLoader}s when each level of the graphql
+ * query is executed.
+ *
+ * This allows you to use {@link org.dataloader.DataLoader}s in your {@link graphql.schema.DataFetcher}s
+ * to optimal loading of data.
+ *
+ * @see org.dataloader.DataLoader
+ * @see org.dataloader.DataLoaderRegistry
+ */
+public class DataLoaderDispatcherInstrumentation extends NoOpInstrumentation {
+
+    private final DataLoaderRegistry dataLoaderRegistry;
+
+    /**
+     * You pass in a registry of N data loaders which will be {@link org.dataloader.DataLoader#dispatch() dispatched} as
+     * each level of the query executes.
+     *
+     * @param dataLoaderRegistry the regsitry of data loaders that will be dispatched
+     */
+    public DataLoaderDispatcherInstrumentation(DataLoaderRegistry dataLoaderRegistry) {
+        this.dataLoaderRegistry = dataLoaderRegistry;
+    }
+
+    @Override
+    public InstrumentationContext<CompletableFuture<ExecutionResult>> beginExecutionStrategy(InstrumentationExecutionStrategyParameters parameters) {
+        return (result, t) -> {
+            if (t == null) {
+                // only dispatch when there are no errors
+                dataLoaderRegistry.dispatchAll();
+            }
+        };
+    }
+}

--- a/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentationTest.groovy
@@ -1,0 +1,78 @@
+package graphql.execution.instrumentation.dataloader
+
+import graphql.ExecutionResult
+import graphql.execution.instrumentation.InstrumentationContext
+import org.dataloader.BatchLoader
+import org.dataloader.DataLoader
+import org.dataloader.DataLoaderRegistry
+import spock.lang.Specification
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+
+class DataLoaderDispatcherInstrumentationTest extends Specification {
+
+    class CountingLoader implements BatchLoader<Object, Object> {
+        int invocationCount = 0
+        List<Object> loadedKeys = new ArrayList<>()
+
+        @Override
+        CompletionStage<List<Object>> load(List<Object> keys) {
+            invocationCount++
+            loadedKeys.add(keys)
+            return CompletableFuture.completedFuture(keys)
+        }
+    }
+
+    def basic_invocation() {
+        given:
+
+        final CountingLoader batchLoader = new CountingLoader()
+
+        DataLoader<Object, Object> dlA = new DataLoader<>(batchLoader)
+        DataLoader<Object, Object> dlB = new DataLoader<>(batchLoader)
+        DataLoader<Object, Object> dlC = new DataLoader<>(batchLoader)
+        DataLoaderRegistry registry = new DataLoaderRegistry()
+                .register("a", dlA)
+                .register("b", dlB)
+                .register("c", dlC)
+
+        DataLoaderDispatcherInstrumentation dispatcher = new DataLoaderDispatcherInstrumentation(registry)
+        InstrumentationContext<CompletableFuture<ExecutionResult>> context = dispatcher.beginExecutionStrategy(null)
+
+        // cause some activity
+        dlA.load("A")
+        dlB.load("B")
+        dlC.load("C")
+
+        context.onEnd(null, null)
+
+
+
+        expect:
+        assert batchLoader.invocationCount == 3
+
+        // will be [[A],[B],[C]]
+        assert batchLoader.loadedKeys == [["A"], ["B"], ["C"]]
+    }
+
+    void exceptions_wont_cause_dispatches() throws Exception {
+        given:
+        final CountingLoader batchLoader = new CountingLoader()
+
+        DataLoader<Object, Object> dlA = new DataLoader<>(batchLoader)
+        DataLoaderRegistry registry = new DataLoaderRegistry()
+                .register("a", dlA)
+
+        DataLoaderDispatcherInstrumentation dispatcher = new DataLoaderDispatcherInstrumentation(registry)
+        InstrumentationContext<CompletableFuture<ExecutionResult>> context = dispatcher.beginExecutionStrategy(null)
+
+        // cause some activity
+        dlA.load("A")
+
+        context.onEnd(null, new RuntimeException("Should not run"))
+
+        expect:
+        assert batchLoader.invocationCount == 0
+    }
+}

--- a/src/test/groovy/readme/BatchingExamples.java
+++ b/src/test/groovy/readme/BatchingExamples.java
@@ -1,0 +1,97 @@
+package readme;
+
+import graphql.GraphQL;
+import graphql.execution.instrumentation.dataloader.DataLoaderDispatcherInstrumentation;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLSchema;
+import org.dataloader.BatchLoader;
+import org.dataloader.DataLoader;
+import org.dataloader.DataLoaderRegistry;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+@SuppressWarnings({"unused", "Convert2Lambda"})
+public class BatchingExamples {
+
+
+    class StarWarsCharacter {
+        List<String> getFriendIds() {
+            return null;
+        }
+    }
+
+    void starWarsExample() {
+
+        // a batch loader function that will be called with N or more keys for batch loading
+        BatchLoader<String, Object> characterBatchLoader = new BatchLoader<String, Object>() {
+            @Override
+            public CompletionStage<List<Object>> load(List<String> keys) {
+                //
+                // we use supplyAsync() of values here for maximum parellisation
+                //
+                return CompletableFuture.supplyAsync(() -> getCharacterDataViaBatchHTTPApi(keys));
+            }
+        };
+
+        // a data loader for characters that points to the character batch loader
+        DataLoader<String, Object> characterDataLoader = new DataLoader<>(characterBatchLoader);
+
+        //
+        // use this data loader in the data fetchers associated with characters and put them into
+        // the graphql schema (not shown)
+        //
+        DataFetcher heroDataFetcher = new DataFetcher() {
+            @Override
+            public Object get(DataFetchingEnvironment environment) {
+                return characterDataLoader.load("2001"); // R2D2
+            }
+        };
+
+        DataFetcher friendsDataFetcher = new DataFetcher() {
+            @Override
+            public Object get(DataFetchingEnvironment environment) {
+                StarWarsCharacter starWarsCharacter = environment.getSource();
+                List<String> friendIds = starWarsCharacter.getFriendIds();
+                return characterDataLoader.loadMany(friendIds);
+            }
+        };
+
+        //
+        // DataLoaderRegistry is a place to register all data loaders in that needs to be dispatched together
+        // in this case there is 1 but you can have many
+        //
+        DataLoaderRegistry registry = new DataLoaderRegistry();
+        registry.register("character", characterDataLoader);
+
+        //
+        // this instrumentation implementation will dispatched all the dataloaders
+        // as each level fo the graphql query is executed and hence make batched objects
+        // available to the query and the associated DataFetchers
+        //
+        DataLoaderDispatcherInstrumentation  dispatcherInstrumentation
+                = new DataLoaderDispatcherInstrumentation(registry);
+
+        //
+        // now build your graphql object and execute queries on it.
+        // the data loader will be invoked via the data fetchers on the
+        // schema fields
+        //
+        GraphQL graphQL = GraphQL.newGraphQL(buildSchema())
+                .instrumentation(dispatcherInstrumentation)
+                .build();
+
+    }
+
+    private GraphQLSchema buildSchema() {
+        return null;
+    }
+
+    private List<Object> getCharacterDataViaBatchHTTPApi(List<String> keys) {
+        return null;
+    }
+
+
+}


### PR DESCRIPTION
See #703 

The graphql code in java-dataloader has been removed and the dependency reversed.

This adds a new Instrumentation that causes dataloader dispatching and hence the AsyncExecutionSttrategy can be made even more efficient
