### PR TITLE
Partial result support

### DIFF
--- a/src/main/java/graphql/execution/AbortExecutionException.java
+++ b/src/main/java/graphql/execution/AbortExecutionException.java
@@ -15,6 +15,10 @@ import static java.util.Collections.emptyList;
 
 /**
  * This Exception indicates that the current execution should be aborted.
+ *
+ * If a {@link graphql.schema.DataFetcher} throws this exception then
+ * the execution of the query will be short circuited and any partial results
+ * up until that point will be returned.
  */
 @PublicApi
 public class AbortExecutionException extends GraphQLException implements GraphQLError {

--- a/src/main/java/graphql/execution/AbstractAsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AbstractAsyncExecutionStrategy.java
@@ -2,11 +2,14 @@ package graphql.execution;
 
 import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
+import graphql.GraphQLError;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.function.BiConsumer;
 
 
@@ -22,7 +25,12 @@ public abstract class AbstractAsyncExecutionStrategy extends ExecutionStrategy {
     protected BiConsumer<List<ExecutionResult>, Throwable> handleResults(ExecutionContext executionContext, List<String> fieldNames, CompletableFuture<ExecutionResult> overallResult) {
         return (List<ExecutionResult> results, Throwable exception) -> {
             if (exception != null) {
-                handleNonNullException(executionContext, overallResult, exception);
+                if (exception instanceof CompletionException && exception.getCause() instanceof PartialResultException) {
+                    PartialResultException partialResultException = (PartialResultException) exception.getCause();
+                    overallResult.complete(partialResultException.getPartialResult());
+                } else {
+                    handleNonNullException(executionContext, overallResult, exception);
+                }
                 return;
             }
             Map<String, Object> resolvedValuesByField = new LinkedHashMap<>();
@@ -35,4 +43,50 @@ public abstract class AbstractAsyncExecutionStrategy extends ExecutionStrategy {
             overallResult.complete(new ExecutionResultImpl(resolvedValuesByField, executionContext.getErrors()));
         };
     }
+
+    /**
+     * This will return a partial result if some part of the code threw an AbortExecutionException to stop
+     * the code processing
+     *
+     * @param executionContext the context in play
+     * @param abortException   the exception that called for a halt to execution
+     * @param fieldNames       the list of field names
+     * @param futures          the list of futures dispatched so far
+     *
+     * @return a partial result
+     */
+    protected CompletableFuture<ExecutionResult> partialResult(ExecutionContext executionContext, AbortExecutionException abortException, List<String> fieldNames, List<CompletableFuture<ExecutionResult>> futures) {
+        Map<String, Object> resolvedValuesByField = new LinkedHashMap<>();
+        int ix = 0;
+        for (CompletableFuture<ExecutionResult> future : futures) {
+            String fieldName = fieldNames.get(ix++);
+            if (future.isDone() && !future.isCompletedExceptionally()) {
+                ExecutionResult executionResult = future.join();
+                resolvedValuesByField.put(fieldName, executionResult.getData());
+            }
+        }
+        List<GraphQLError> errors = new ArrayList<>();
+        errors.addAll(executionContext.getErrors());
+        if (!abortException.getUnderlyingErrors().isEmpty()) {
+            errors.addAll(abortException.getUnderlyingErrors());
+        } else {
+            errors.add(abortException);
+        }
+        ExecutionResultImpl executionResult = new ExecutionResultImpl(resolvedValuesByField, errors);
+        return CompletableFuture.completedFuture(executionResult);
+    }
+
+    protected class PartialResultException extends RuntimeException {
+        private final CompletableFuture<ExecutionResult> partialResult;
+
+        public PartialResultException(CompletableFuture<ExecutionResult> partialResult) {
+            this.partialResult = partialResult;
+        }
+
+        public ExecutionResult getPartialResult() {
+            return partialResult.join();
+        }
+    }
+
+
 }

--- a/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
@@ -1,17 +1,16 @@
 package graphql.execution;
 
 import graphql.ExecutionResult;
-import graphql.ExecutionResultImpl;
 import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionStrategyParameters;
 import graphql.language.Field;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 
 /**
  * Async non-blocking execution, but serial: only one field at the the time will be resolved.
@@ -34,19 +33,27 @@ public class AsyncSerialExecutionStrategy extends AbstractAsyncExecutionStrategy
         Map<String, List<Field>> fields = parameters.fields();
         List<String> fieldNames = new ArrayList<>(fields.keySet());
 
-        CompletableFuture<List<ExecutionResult>> resultsFuture = Async.eachSequentially(fieldNames, (fieldName, index, prevResults) -> {
-            List<Field> currentField = fields.get(fieldName);
-            ExecutionPath fieldPath = parameters.path().segment(fieldName);
-            ExecutionStrategyParameters newParameters = parameters
-                    .transform(builder -> builder.field(currentField).path(fieldPath));
-            return resolveField(executionContext, newParameters);
+        CompletableFuture<List<ExecutionResult>> resultsFuture;
+        resultsFuture = Async.eachSequentially(fieldNames, (fieldName, index, prevResults) -> {
+            try {
+                List<Field> currentField = fields.get(fieldName);
+                ExecutionPath fieldPath = parameters.path().segment(fieldName);
+                ExecutionStrategyParameters newParameters = parameters
+                        .transform(builder -> builder.field(currentField).path(fieldPath));
+                return resolveField(executionContext, newParameters);
+            } catch (AbortExecutionException abortException) {
+                List<CompletableFuture<ExecutionResult>> futures = prevResults.stream()
+                        .map(CompletableFuture::completedFuture).collect(Collectors.toList());
+                CompletableFuture<ExecutionResult> partialResult = partialResult(executionContext, abortException, fieldNames, futures);
+                throw new PartialResultException(partialResult);
+            }
         });
 
         CompletableFuture<ExecutionResult> overallResult = new CompletableFuture<>();
         BiConsumer<List<ExecutionResult>, Throwable> listThrowableBiConsumer = handleResults(executionContext, fieldNames, overallResult);
         resultsFuture.whenComplete(listThrowableBiConsumer);
 
-        executionStrategyCtx.onEnd(overallResult,null);
+        executionStrategyCtx.onEnd(overallResult, null);
         return overallResult;
     }
 

--- a/src/test/groovy/graphql/execution/PartialResultTest.groovy
+++ b/src/test/groovy/graphql/execution/PartialResultTest.groovy
@@ -1,0 +1,80 @@
+package graphql.execution
+
+import graphql.ExecutionInput
+import graphql.ExecutionResult
+import graphql.GraphQL
+import graphql.TestUtil
+import graphql.execution.instrumentation.Instrumentation
+import graphql.execution.instrumentation.InstrumentationContext
+import graphql.execution.instrumentation.NoOpInstrumentation
+import graphql.execution.instrumentation.parameters.InstrumentationFieldParameters
+import graphql.schema.DataFetcher
+import graphql.schema.DataFetchingEnvironment
+import graphql.schema.idl.TypeRuntimeWiring
+import spock.lang.Specification
+
+import java.util.concurrent.CompletableFuture
+
+import static graphql.schema.idl.RuntimeWiring.newRuntimeWiring
+
+class PartialResultTest extends Specification {
+
+    def "#460 test partial result can be obtained"() {
+
+        def idl = '''
+            type Query {
+                field1 : String
+                field2 : String
+                slowField : String
+                bangField : String
+            }    
+        '''
+
+        DataFetcher slowAndAsyncDF = new DataFetcher() {
+            @Override
+            Object get(DataFetchingEnvironment environment) {
+                CompletableFuture.supplyAsync({
+                    Thread.sleep(60000)
+                    return "slow"
+                })
+            }
+        }
+
+        Instrumentation instrumentation = new NoOpInstrumentation() {
+            @Override
+            InstrumentationContext<ExecutionResult> beginField(InstrumentationFieldParameters parameters) {
+                if (parameters.field.name.contains("bang")) {
+                    throw new AbortExecutionException("Bang")
+                }
+                return super.beginField(parameters)
+            }
+        }
+
+
+        def schema = TestUtil.schema(idl, newRuntimeWiring().type(TypeRuntimeWiring.newTypeWiring("Query")
+                .dataFetcher("slowField", slowAndAsyncDF)))
+
+        def graphQL = GraphQL.newGraphQL(schema)
+                .instrumentation(instrumentation)
+                .queryExecutionStrategy(executionStrategy)
+                .build()
+
+        def rootObj = [field1: "hello", field2: "world"]
+        when:
+        def executionInput = ExecutionInput.newExecutionInput()
+                .query("{ field1, field2, bangField, slowField }")
+                .root(rootObj).build()
+        def result = graphQL.execute(executionInput)
+
+        then:
+        result.data == [field1: "hello", field2: "world"]
+        result.errors.size() == 1
+        result.errors[0].getMessage().contains("Bang")
+
+        where:
+        executionStrategy                  | _
+        new AsyncSerialExecutionStrategy() | _
+        new AsyncExecutionStrategy()       | _
+    }
+
+}

--- a/src/test/groovy/graphql/execution/PartialResultTest.groovy
+++ b/src/test/groovy/graphql/execution/PartialResultTest.groovy
@@ -19,7 +19,18 @@ import static graphql.schema.idl.RuntimeWiring.newRuntimeWiring
 
 class PartialResultTest extends Specification {
 
-    def "#460 test partial result can be obtained"() {
+    DataFetcher slowAndAsyncDF = new DataFetcher() {
+        @Override
+        Object get(DataFetchingEnvironment environment) {
+            CompletableFuture.supplyAsync({
+                Thread.sleep(60000)
+                return "slow"
+            })
+        }
+    }
+
+
+    def "#460 test partial result can be obtained from instrumentation"() {
 
         def idl = '''
             type Query {
@@ -29,16 +40,6 @@ class PartialResultTest extends Specification {
                 bangField : String
             }    
         '''
-
-        DataFetcher slowAndAsyncDF = new DataFetcher() {
-            @Override
-            Object get(DataFetchingEnvironment environment) {
-                CompletableFuture.supplyAsync({
-                    Thread.sleep(60000)
-                    return "slow"
-                })
-            }
-        }
 
         Instrumentation instrumentation = new NoOpInstrumentation() {
             @Override
@@ -56,6 +57,50 @@ class PartialResultTest extends Specification {
 
         def graphQL = GraphQL.newGraphQL(schema)
                 .instrumentation(instrumentation)
+                .queryExecutionStrategy(executionStrategy)
+                .build()
+
+        def rootObj = [field1: "hello", field2: "world"]
+        when:
+        def executionInput = ExecutionInput.newExecutionInput()
+                .query("{ field1, field2, bangField, slowField }")
+                .root(rootObj).build()
+        def result = graphQL.execute(executionInput)
+
+        then:
+        result.data == [field1: "hello", field2: "world"]
+        result.errors.size() == 1
+        result.errors[0].getMessage().contains("Bang")
+
+        where:
+        executionStrategy                  | _
+        new AsyncSerialExecutionStrategy() | _
+        new AsyncExecutionStrategy()       | _
+    }
+
+    def "#460 test partial result can be obtained from data fetcher"() {
+
+        def idl = '''
+            type Query {
+                field1 : String
+                field2 : String
+                slowField : String
+                bangField : String
+            }    
+        '''
+
+        DataFetcher bangDF = new DataFetcher() {
+            Object get(DataFetchingEnvironment environment) {
+                throw new AbortExecutionException("Bang!")
+            }
+        }
+
+        def schema = TestUtil.schema(idl, newRuntimeWiring().type(TypeRuntimeWiring.newTypeWiring("Query")
+                .dataFetcher("slowField", slowAndAsyncDF)
+                .dataFetcher("bangField", bangDF)
+        ))
+
+        def graphQL = GraphQL.newGraphQL(schema)
                 .queryExecutionStrategy(executionStrategy)
                 .build()
 


### PR DESCRIPTION
see #460 

If the Instrumentation code or Data Fetcher code throws an AbortExecutionException once exception processing is happening then it short circuit out of the processing

