### PR TITLE
Improving exception for duplicated field definition

### DIFF
--- a/src/main/java/graphql/schema/GraphQLInterfaceType.java
+++ b/src/main/java/graphql/schema/GraphQLInterfaceType.java
@@ -13,6 +13,7 @@ import java.util.function.UnaryOperator;
 
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
+import static java.lang.String.format;
 
 @PublicApi
 public class GraphQLInterfaceType implements GraphQLType, GraphQLOutputType, GraphQLFieldsContainer, GraphQLCompositeType, GraphQLUnmodifiedType, GraphQLNullableType {
@@ -44,7 +45,7 @@ public class GraphQLInterfaceType implements GraphQLType, GraphQLOutputType, Gra
         for (GraphQLFieldDefinition fieldDefinition : fieldDefinitions) {
             String name = fieldDefinition.getName();
             if (fieldDefinitionsByName.containsKey(name))
-                throw new AssertException("field " + name + " redefined");
+                throw new AssertException(format("Duplicated definition for field '%s' in interface '%s'", name, this.name));
             fieldDefinitionsByName.put(name, fieldDefinition);
         }
     }

--- a/src/main/java/graphql/schema/GraphQLObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLObjectType.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
+import static java.lang.String.format;
 
 
 @PublicApi
@@ -55,7 +56,7 @@ public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQ
         for (GraphQLFieldDefinition fieldDefinition : fieldDefinitions) {
             String name = fieldDefinition.getName();
             if (fieldDefinitionsByName.containsKey(name))
-                throw new AssertException("field " + name + " redefined");
+                throw new AssertException(format("Duplicated definition for field '%s' in type '%s'", name, this.name));
             fieldDefinitionsByName.put(name, fieldDefinition);
         }
     }
@@ -145,7 +146,6 @@ public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQ
          * </pre>
          *
          * @param builderFunction a supplier for the builder impl
-         *
          * @return this
          */
         public Builder field(UnaryOperator<GraphQLFieldDefinition.Builder> builderFunction) {
@@ -160,7 +160,6 @@ public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQ
          * from within
          *
          * @param builder an un-built/incomplete GraphQLFieldDefinition
-         *
          * @return this
          */
         public Builder field(GraphQLFieldDefinition.Builder builder) {

--- a/src/main/java/graphql/schema/GraphQLObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLObjectType.java
@@ -146,6 +146,7 @@ public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQ
          * </pre>
          *
          * @param builderFunction a supplier for the builder impl
+         *
          * @return this
          */
         public Builder field(UnaryOperator<GraphQLFieldDefinition.Builder> builderFunction) {
@@ -160,6 +161,7 @@ public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQ
          * from within
          *
          * @param builder an un-built/incomplete GraphQLFieldDefinition
+         *
          * @return this
          */
         public Builder field(GraphQLFieldDefinition.Builder builder) {


### PR DESCRIPTION
At first, I found difficult to understand what the exception meant and where to find the problem to fix. So, I'm providing clearer description for that. Supposing the following schema:
```
type User {
  ...
  password: String
  password: String  // definition duplicated
}
```
We'll get the following exception:

Current:
`Exception in thread "main" graphql.AssertException: field password redefined`

Update:
`Exception in thread "main" graphql.AssertException: Duplicated definition for field 'password' in type 'User'`