### PR TITLE
An easy way to work with context objects and such

### DIFF
--- a/src/main/java/graphql/context/EasyObj.java
+++ b/src/main/java/graphql/context/EasyObj.java
@@ -1,0 +1,101 @@
+package graphql.context;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * You can put any object into the graphql context but often its a map of named things and with
+ * Java your are going to have boiler plate cast these lookups a lot.
+ *
+ * <pre>
+ * {@code
+ *
+ *      Map<String,Object> ctx = dataFetchingEnvironment.getContext()
+ *      UserManager userManager = (UserManager) ctx.get("UserManager");
+ * }
+ * </pre>
+ *
+ * This container object allows you to cheat by auto casting values for you at the expense of strict type safety.  Its
+ * a great compromise between type safety and having to write map like boiler plate.
+ *
+ * <pre>
+ * {@code
+ *
+ *      EasyObj ctx = dataFetchingEnvironment.getContext()
+ *      UserManager userManager = ctx.get("UserManager");
+ * }
+ * </pre>
+ *
+ * You can make it a one liner like this
+ *
+ * <pre>
+ * {@code
+ *
+ *      Foo foo = dataFetchingEnvironment.<EasyObj>getContext().get("Foo");
+ * }
+ * </pre>
+ *
+ * Be careful with this class.  Its most useful in and around DataFetchers with their opaque access to Java typing and with
+ * JSON map responses.  Don't go crazy with it otherwise its all fun and games until some one looses an eye.
+ */
+public class EasyObj {
+    private final Map<Object, Object> map;
+
+    private EasyObj(Map<Object, Object> map) {
+        this.map = Collections.unmodifiableMap(map);
+    }
+
+    /**
+     * Returns the value held under the key
+     *
+     * @param key the key to look up
+     * @param <T> the type to cast the value to
+     *
+     * @return a value or null
+     */
+    public <T> T get(Object key) {
+        //noinspection unchecked
+        return (T) map.get(key);
+    }
+
+    /**
+     * @return a builder of EasyObj objects
+     */
+    public static Builder newObject() {
+        return new Builder();
+    }
+
+    /**
+     * Again this helps create an easy object if you KNOW you have a Map
+     * but you don't want to litter your code with boilerplate casts
+     *
+     * @param mapThing an object that is a Map
+     *
+     * @return a new EasyObj object
+     *
+     * @throws java.lang.ClassCastException if its not a Map
+     */
+    public static EasyObj newObject(Object mapThing) {
+        //noinspection unchecked
+        return new Builder().putAll((Map<Object, Object>) mapThing).build();
+    }
+
+    public static class Builder {
+        private final Map<Object, Object> map = new HashMap<>();
+
+        public Builder put(Object key, Object value) {
+            map.put(key, value);
+            return this;
+        }
+
+        public Builder putAll(Map<Object, Object> map) {
+            this.map.putAll(map);
+            return this;
+        }
+
+        public EasyObj build() {
+            return new EasyObj(map);
+        }
+    }
+}

--- a/src/test/groovy/graphql/context/EasyObjTest.groovy
+++ b/src/test/groovy/graphql/context/EasyObjTest.groovy
@@ -1,0 +1,32 @@
+package graphql.context
+
+import spock.lang.Specification
+
+class EasyObjTest extends Specification {
+
+    def "basic creation"() {
+        when:
+        def ctx = EasyObj.newObject()
+                .put("string", "String")
+                .put("int", 1)
+                .putAll([
+                "float": 10f,
+                "true" : true
+        ])
+                .build()
+
+        then:
+        ctx.get("string") == "String"
+        ctx.get("int") == 1
+        ctx.get("float") == 10f
+        ctx.get("true") == true
+        ctx.get("null") == null
+
+        when:
+        def directCtx = EasyObj.newObject(["a": "A", "b": "B"])
+
+        then:
+        directCtx.get("a") == "A"
+        directCtx.get("b") == "B"
+    }
+}


### PR DESCRIPTION
I have been writing a few apps lately and dealing with the context / source objects and JSON response objects is a PITA.

I am forever casting everything anyway so I thought - why not formalize it

    EasyObj ctx = dataFetchingEnvironment.getContext()
    UserManager userManager = ctx.get("UserManager");

I know this sets of most decent Java programmers spidey senses but the opaque nature of the objects that DataFetchers are given and what they give back make this useful I think.