### PR TITLE
Fix validation of non-null Interface member

### DIFF
--- a/src/main/java/graphql/schema/validation/ObjectsImplementInterfaces.java
+++ b/src/main/java/graphql/schema/validation/ObjectsImplementInterfaces.java
@@ -131,8 +131,14 @@ public class ObjectsImplementInterfaces implements SchemaValidationRule {
             GraphQLOutputType wrappedObjectType = (GraphQLOutputType) ((GraphQLList) objectType).getWrappedType();
             return isCompatible(wrappedConstraintType, wrappedObjectType);
         } else if (objectType instanceof GraphQLNonNull) {
-            GraphQLOutputType wrappedObjectType = (GraphQLOutputType) ((GraphQLNonNull) objectType).getWrappedType();
-            return isCompatible(constraintType, wrappedObjectType);
+            GraphQLOutputType nullableConstraint;
+            if (constraintType instanceof GraphQLNonNull) {
+                nullableConstraint = (GraphQLOutputType) ((GraphQLNonNull) constraintType).getWrappedType();
+            } else {
+                nullableConstraint = constraintType;
+            }
+            GraphQLOutputType nullableObjectType = (GraphQLOutputType) ((GraphQLNonNull) objectType).getWrappedType();
+            return isCompatible(nullableConstraint, nullableObjectType);
         } else {
             return false;
         }

--- a/src/test/groovy/graphql/schema/validation/ObjectsImplementInterfacesTest.groovy
+++ b/src/test/groovy/graphql/schema/validation/ObjectsImplementInterfacesTest.groovy
@@ -283,4 +283,40 @@ class ObjectsImplementInterfacesTest extends Specification {
         !badErrorCollector.getErrors().isEmpty()
     }
 
+
+    def "field is a non null object"() {
+        given:
+        GraphQLInterfaceType memberInterface = newInterface()
+                .name("TestMemberInterface")
+                .field(newFieldDefinition().name("field").type(GraphQLString).build())
+                .typeResolver({})
+                .build()
+
+        GraphQLObjectType memberInterfaceImpl = newObject()
+                .name("TestMemberInterfaceImpl")
+                .field(newFieldDefinition().name("field").type(GraphQLString).build())
+                .withInterface(memberInterface)
+                .build()
+
+        GraphQLInterfaceType testInterface = newInterface()
+                .name("TestInterface")
+                .field(newFieldDefinition().name("field").type(new GraphQLNonNull(memberInterface)).build())
+                .typeResolver({})
+                .build()
+
+        GraphQLObjectType testInterfaceImpl = newObject()
+                .name("TestInterfaceImpl")
+                .field(newFieldDefinition().name("field").type(new GraphQLNonNull(memberInterfaceImpl)).build())
+                .withInterface(testInterface)
+                .build()
+        
+        SchemaValidationErrorCollector goodErrorCollector = new SchemaValidationErrorCollector()
+
+        when:
+        new ObjectsImplementInterfaces().check(testInterfaceImpl, goodErrorCollector)
+
+        then:
+        goodErrorCollector.getErrors().isEmpty()
+    }
+
 }


### PR DESCRIPTION
If an interface has a member which is a non-null interface, an implementation of that interface with a concrete implementation of that interface fails.

I.E.

```GraphQL
interface TestMemberInterface {
  field: String
 }

type TestMemberInterfaceImpl implements TestMemberInterface {
  field: String
 }

interface TestInterface {
  field: TestMemberInterface!
}

type TestInterfaceImpl implements TestInterface {
  field: TestMemberInterfaceImpl!
}
```

Will fail to validate with error
```
object type 'TestInterfaceImpl' does not implement interface 'TestInterface' because field 'field' is defined as 'TestMemberInterfaceImpl!' type and not as 'TestMemberInterface!' type
```