### PR TITLE
Modify docs for Modularising the Schema IDL by removing redundant word

### DIFF
--- a/docs/schema.rst
+++ b/docs/schema.rst
@@ -49,7 +49,7 @@ the property name of the source Object, no ``DataFetcher`` is needed.
 A ``TypeResolver`` helps ``graphql-java`` to decide which type a concrete value belongs to.
 This is needed for ``Interface`` and ``Union``.
 
-For example imagine you have a ``Interface``` called *MagicUserType* and it resolves back to a series of Java classes
+For example imagine you have a ``Interface`` called *MagicUserType* and it resolves back to a series of Java classes
 called perhaps *Wizard*, *Witch* and *Necromancer*.  The type resolver is responsible for examining a runtime object and deciding
 what ``GraphqlObjectType`` should be used to represent it and hence what data fetchers and fields will be invoked.
 

--- a/docs/schema.rst
+++ b/docs/schema.rst
@@ -445,7 +445,7 @@ When the schema is declared via IDL, no special handling of recursive types is n
 Modularising the Schema IDL
 ---------------------------
 
-Having one one large schema file is not always viable.  You can modularise you schema using two techniques.
+Having one large schema file is not always viable.  You can modularise you schema using two techniques.
 
 The first technique is to merge multiple Schema IDL files into one logic unit.  In the case below the schema has
 been split into multiple files and merged all together just before schema generation.


### PR DESCRIPTION
This pull request removes a redundant word which I noticed in the docs when reading about Modularising the schema file.