### PR TITLE
Fixed stack overflow on toString()

### DIFF
--- a/src/main/java/graphql/schema/GraphQLInterfaceType.java
+++ b/src/main/java/graphql/schema/GraphQLInterfaceType.java
@@ -90,7 +90,7 @@ public class GraphQLInterfaceType implements GraphQLType, GraphQLOutputType, Gra
         return "GraphQLInterfaceType{" +
                 "name='" + name + '\'' +
                 ", description='" + description + '\'' +
-                ", fieldDefinitionsByName=" + fieldDefinitionsByName +
+                ", fieldDefinitionsByName=" + fieldDefinitionsByName.keySet() +
                 ", typeResolver=" + typeResolver +
                 '}';
     }


### PR DESCRIPTION
Hi,
The toString() of GraphQLInterfaceType goes into StackOverflow with this example :
```
        GraphQLObjectType objectType = newObject()
                .name("root")
                .field(newFieldDefinition()
                        .name("test")
                        .type(GraphQLInterfaceType.newInterface()
                                .name("test")
                                .typeResolver(new TypeResolver() {
                                    @Override
                                    public GraphQLObjectType getType(TypeResolutionEnvironment env) {
                                        return null;
                                    }
                                })
                                .field(newFieldDefinition()
                                        .name("test")
                                        .type(new GraphQLTypeReference("test"))))).build();
        GraphQLSchema graphQLSchema = newSchema().query(objectType).build();
        graphQLSchema.getType("test").toString();
```
It should use `fieldDefinitionsByName.keySet()` instead of `fieldDefinitionsByName`, as in GraphQLObjectType 