### PR TITLE
fix(AstPrinter): fix missing strings and misformat in the AstPrinter

### DIFF
--- a/src/main/java/graphql/language/AstPrinter.java
+++ b/src/main/java/graphql/language/AstPrinter.java
@@ -207,6 +207,7 @@ public class AstPrinter {
         return (out, node) -> {
             out.printf("%s", comments(node));
             out.printf("%s", spaced(
+                    "input",
                     node.getName(),
                     directives(node.getDirectives()),
                     block(node.getInputValueDefinitions())
@@ -291,7 +292,10 @@ public class AstPrinter {
     private static NodePrinter<ScalarTypeDefinition> scalarTypeDefinition() {
         return (out, node) -> {
             out.printf("%s", comments(node));
-            out.printf("%s", spaced(node.getName(), directives(node.getDirectives())));
+            out.printf("%s", spaced(
+                    "scalar",
+                    node.getName(),
+                    directives(node.getDirectives())));
         };
     }
 
@@ -461,6 +465,9 @@ public class AstPrinter {
 
     static String wrap(String start, String maybeString, String end) {
         if (isEmpty(maybeString)) {
+            if (start.equals("\"") && end.equals("\"")) {
+                return "\"\"";
+            }
             return "";
         }
         return start + maybeString + (!isEmpty(end) ? end : "");

--- a/src/test/groovy/graphql/introspection/IntrospectionResultToSchemaTest.groovy
+++ b/src/test/groovy/graphql/introspection/IntrospectionResultToSchemaTest.groovy
@@ -346,7 +346,7 @@ union Everything = Character | Episode"""
 
         then:
         result == """#input for characters
-CharacterInput {
+input CharacterInput {
   #first name
   firstName: String
   lastName: String
@@ -533,7 +533,7 @@ type MutationResult {
   success: Boolean
 }
 
-CharacterInput {
+input CharacterInput {
   firstName: String
   lastName: String
   family: Boolean

--- a/src/test/groovy/graphql/language/AstPrinterTest.groovy
+++ b/src/test/groovy/graphql/language/AstPrinterTest.groovy
@@ -24,6 +24,7 @@ class AstPrinterTest extends Specification {
 # over a number of lines
 schema {
     query: QueryType
+    mutation: Mutation
 }
 
 type QueryType {
@@ -31,6 +32,10 @@ type QueryType {
     hero(episode: Episode): Character
     human(id : String) : Human
     droid(id: ID!): Droid
+}
+
+type Mutation {
+    createReview(episode: Episode, review: ReviewInput): Review
 }
 
 enum Episode {
@@ -64,6 +69,18 @@ type Droid implements Character {
 
 union SearchResult = Human | Droid | Starship
 
+type Review {
+  id: ID!
+  stars: Int!
+  commentary: String
+}
+
+input ReviewInput {
+  stars: Int!
+  commentary: String
+}
+
+scalar DateTime
 """
 
     //-------------------------------------------------
@@ -78,6 +95,7 @@ union SearchResult = Human | Droid | Starship
 # over a number of lines
 schema {
   query: QueryType
+  mutation: Mutation
 }
 
 type QueryType {
@@ -85,6 +103,10 @@ type QueryType {
   hero(episode: Episode): Character
   human(id: String): Human
   droid(id: ID!): Droid
+}
+
+type Mutation {
+  createReview(episode: Episode, review: ReviewInput): Review
 }
 
 enum Episode {
@@ -117,6 +139,19 @@ type Droid implements Character {
 }
 
 union SearchResult = Human | Droid | Starship
+
+type Review {
+  id: ID!
+  stars: Int!
+  commentary: String
+}
+
+input ReviewInput {
+  stars: Int!
+  commentary: String
+}
+
+scalar DateTime
 """
     }
 
@@ -130,6 +165,7 @@ union SearchResult = Human | Droid | Starship
 # over a number of lines
 schema {
   query: QueryType
+  mutation: Mutation
 }"""
     }
 
@@ -343,6 +379,26 @@ query NullEpisodeQuery {
 }
 '''
     }
+//-------------------------------------------------
+    def "ast printing of empty string"() {
+        def query = '''
+query NullEpisodeQuery {
+  human(id: "") {
+    name
+  }
+}
+'''
+        def document = parse(query)
+        String output = printAst(document)
+
+        expect:
+        output == '''query NullEpisodeQuery {
+  human(id: "") {
+    name
+  }
+}
+'''
+    }
 
     //-------------------------------------------------
     def "ast printing of default variables with null"() {
@@ -399,6 +455,5 @@ type Query {
 '''
 
     }
-
 
 }


### PR DESCRIPTION
fix missing "scalar" and "input" type key word for the corresponding node; add double-quotes for
empty string value

#787 