### PR TITLE
Add context to the TypeResolutionEnvironment

### DIFF
--- a/src/main/java/graphql/TypeResolutionEnvironment.java
+++ b/src/main/java/graphql/TypeResolutionEnvironment.java
@@ -18,13 +18,15 @@ public class TypeResolutionEnvironment {
     private final Field field;
     private final GraphQLType fieldType;
     private final GraphQLSchema schema;
+    private final Object context;
 
-    public TypeResolutionEnvironment(Object object, Map<String, Object> arguments, Field field, GraphQLType fieldType, GraphQLSchema schema) {
+    public TypeResolutionEnvironment(Object object, Map<String, Object> arguments, Field field, GraphQLType fieldType, GraphQLSchema schema, final Object context) {
         this.object = object;
         this.arguments = arguments;
         this.field = field;
         this.fieldType = fieldType;
         this.schema = schema;
+        this.context = context;
     }
 
     /**
@@ -66,5 +68,9 @@ public class TypeResolutionEnvironment {
      */
     public GraphQLSchema getSchema() {
         return schema;
+    }
+
+    public <T> T getContext() {
+        return (T) context;
     }
 }

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -349,6 +349,7 @@ public abstract class ExecutionStrategy {
                     .field(parameters.field().get(0))
                     .value(parameters.source())
                     .argumentValues(parameters.arguments())
+                    .context(executionContext.getContext())
                     .schema(executionContext.getGraphQLSchema()).build();
             resolvedType = resolveTypeForInterface(resolutionParams);
 
@@ -358,6 +359,7 @@ public abstract class ExecutionStrategy {
                     .field(parameters.field().get(0))
                     .value(parameters.source())
                     .argumentValues(parameters.arguments())
+                    .context(executionContext.getContext())
                     .schema(executionContext.getGraphQLSchema()).build();
             resolvedType = resolveTypeForUnion(resolutionParams);
         } else {
@@ -435,7 +437,7 @@ public abstract class ExecutionStrategy {
      * @return a {@link GraphQLObjectType}
      */
     protected GraphQLObjectType resolveTypeForInterface(TypeResolutionParameters params) {
-        TypeResolutionEnvironment env = new TypeResolutionEnvironment(params.getValue(), params.getArgumentValues(), params.getField(), params.getGraphQLInterfaceType(), params.getSchema());
+        TypeResolutionEnvironment env = new TypeResolutionEnvironment(params.getValue(), params.getArgumentValues(), params.getField(), params.getGraphQLInterfaceType(), params.getSchema(), params.getContext());
         GraphQLObjectType result = params.getGraphQLInterfaceType().getTypeResolver().getType(env);
         if (result == null) {
             throw new UnresolvedTypeException(params.getGraphQLInterfaceType());
@@ -451,7 +453,7 @@ public abstract class ExecutionStrategy {
      * @return a {@link GraphQLObjectType}
      */
     protected GraphQLObjectType resolveTypeForUnion(TypeResolutionParameters params) {
-        TypeResolutionEnvironment env = new TypeResolutionEnvironment(params.getValue(), params.getArgumentValues(), params.getField(), params.getGraphQLUnionType(), params.getSchema());
+        TypeResolutionEnvironment env = new TypeResolutionEnvironment(params.getValue(), params.getArgumentValues(), params.getField(), params.getGraphQLUnionType(), params.getSchema(), params.getContext());
         GraphQLObjectType result = params.getGraphQLUnionType().getTypeResolver().getType(env);
         if (result == null) {
             throw new UnresolvedTypeException(params.getGraphQLUnionType());

--- a/src/main/java/graphql/execution/TypeResolutionParameters.java
+++ b/src/main/java/graphql/execution/TypeResolutionParameters.java
@@ -15,15 +15,17 @@ public class TypeResolutionParameters {
     private final Object value;
     private final Map<String, Object> argumentValues;
     private final GraphQLSchema schema;
+    private final Object context;
 
     private TypeResolutionParameters(GraphQLInterfaceType graphQLInterfaceType, GraphQLUnionType graphQLUnionType,
-                                     Field field, Object value, Map<String, Object> argumentValues, GraphQLSchema schema) {
+                                     Field field, Object value, Map<String, Object> argumentValues, GraphQLSchema schema, final Object context) {
         this.graphQLInterfaceType = graphQLInterfaceType;
         this.graphQLUnionType = graphQLUnionType;
         this.field = field;
         this.value = value;
         this.argumentValues = argumentValues;
         this.schema = schema;
+        this.context = context;
     }
 
     public GraphQLInterfaceType getGraphQLInterfaceType() {
@@ -54,6 +56,10 @@ public class TypeResolutionParameters {
         return new Builder();
     }
 
+    public Object getContext() {
+        return context;
+    }
+
     public static class Builder {
 
         private Field field;
@@ -62,6 +68,7 @@ public class TypeResolutionParameters {
         private Object value;
         private Map<String, Object> argumentValues;
         private GraphQLSchema schema;
+        private Object context;
 
         public Builder field(Field field) {
             this.field = field;
@@ -93,8 +100,13 @@ public class TypeResolutionParameters {
             return this;
         }
 
+        public Builder context(Object context) {
+            this.context = context;
+            return this;
+        }
+
         public TypeResolutionParameters build() {
-            return new TypeResolutionParameters(graphQLInterfaceType, graphQLUnionType, field, value, argumentValues, schema);
+            return new TypeResolutionParameters(graphQLInterfaceType, graphQLUnionType, field, value, argumentValues, schema, context);
         }
     }
 }

--- a/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
+++ b/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
@@ -416,6 +416,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
                     .field(field)
                     .value(value)
                     .argumentValues(argumentValues)
+                    .context(executionContext.getContext())
                     .schema(executionContext.getGraphQLSchema())
                     .build());
         } else if (fieldType instanceof GraphQLUnionType) {
@@ -424,6 +425,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
                     .field(field)
                     .value(value)
                     .argumentValues(argumentValues)
+                    .context(executionContext.getContext())
                     .schema(executionContext.getGraphQLSchema())
                     .build());
         } else if (fieldType instanceof GraphQLObjectType) {


### PR DESCRIPTION
For a project we are working on it is useful to have the type resolvers have access to the context. As an example think of our data being a numerical ID that represents a person (interface type). That person can be an employee type or a customer type, and that needs to have access to the context to resolve which it is.