### PR TITLE
Ability to use Method references in PropertyDataFetchers

### DIFF
--- a/src/main/java/graphql/schema/PropertyDataFetcher.java
+++ b/src/main/java/graphql/schema/PropertyDataFetcher.java
@@ -1,6 +1,7 @@
 package graphql.schema;
 
 
+import graphql.Assert;
 import graphql.GraphQLException;
 import graphql.PublicApi;
 
@@ -9,12 +10,14 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Map;
+import java.util.function.Function;
 
 import static graphql.Scalars.GraphQLBoolean;
 
 /**
  * This is the default data fetcher used in graphql-java.  It will examine
- * maps and POJO java beans for values that match the desired name, typically the field name.
+ * maps and POJO java beans for values that match the desired name, typically the field name
+ * or it will use a provided function to obtain values.
  *
  * You can write your own data fetchers to get data from some other backing system
  *
@@ -24,16 +27,54 @@ import static graphql.Scalars.GraphQLBoolean;
 public class PropertyDataFetcher<T> implements DataFetcher<T> {
 
     private final String propertyName;
+    private final Function<Object, Object> function;
 
+    /**
+     * This constructor will use the property name and examine the {@link DataFetchingEnvironment#getSource()}
+     * object for a getter method or field with that name.
+     *
+     * @param propertyName the name of the property to retrieve
+     */
     public PropertyDataFetcher(String propertyName) {
         this.propertyName = propertyName;
+        this.function = null;
+    }
+
+    /**
+     * This constructor will present the {@link DataFetchingEnvironment#getSource()} object to the supplied
+     * function to obtain a value, which allows you to use Java 8 method references say obtain values in a
+     * more type safe way.
+     *
+     * For example :
+     * <pre>
+     * {@code
+     *
+     *      DataFetcher functionDataFetcher = new PropertyDataFetcher(Thing::getId);
+     *
+     * }
+     * </pre>
+     *
+     * @param function the function to use to obtain a value from the source object
+     * @param <O>      the type of the source object
+     */
+    @SuppressWarnings("unchecked")
+    public <O> PropertyDataFetcher(Function<O, T> function) {
+        this.propertyName = null;
+        this.function = (Function<Object, Object>) Assert.assertNotNull(function);
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public T get(DataFetchingEnvironment environment) {
         Object source = environment.getSource();
-        if (source == null) return null;
+        if (source == null) {
+            return null;
+        }
+
+        if (function != null) {
+            return (T) function.apply(source);
+        }
+
         if (source instanceof Map) {
             return (T) ((Map<?, ?>) source).get(propertyName);
         }

--- a/src/test/groovy/graphql/schema/PropertyDataFetcherTest.groovy
+++ b/src/test/groovy/graphql/schema/PropertyDataFetcherTest.groovy
@@ -28,7 +28,7 @@ class PropertyDataFetcherTest extends Specification {
     def "function based fetcher works with non null source"() {
         def environment = env(new SomeObject(value: "aValue"))
         Function<Object, String> f = { obj -> obj['value'] }
-        def fetcher = new PropertyDataFetcher(f)
+        def fetcher = PropertyDataFetcher.fetching(f)
         expect:
         fetcher.get(environment) == "aValue"
     }
@@ -36,14 +36,14 @@ class PropertyDataFetcherTest extends Specification {
     def "function based fetcher works with null source"() {
         def environment = env(null)
         Function<Object, String> f = { obj -> obj['value'] }
-        def fetcher = new PropertyDataFetcher(f)
+        def fetcher = PropertyDataFetcher.fetching(f)
         expect:
         fetcher.get(environment) == null
     }
 
     def "fetch via map lookup"() {
         def environment = env(["mapProperty": "aValue"])
-        def fetcher = new PropertyDataFetcher("mapProperty")
+        def fetcher = PropertyDataFetcher.fetching("mapProperty")
         expect:
         fetcher.get(environment) == "aValue"
     }

--- a/src/test/groovy/graphql/schema/PropertyDataFetcherTest.groovy
+++ b/src/test/groovy/graphql/schema/PropertyDataFetcherTest.groovy
@@ -4,12 +4,48 @@ import graphql.schema.somepackage.TestClass
 import graphql.schema.somepackage.TwoClassesDown
 import spock.lang.Specification
 
+import java.util.function.Function
+
 import static graphql.schema.DataFetchingEnvironmentBuilder.newDataFetchingEnvironment
 
 class PropertyDataFetcherTest extends Specification {
 
     def env(obj) {
         newDataFetchingEnvironment().source(obj).build()
+    }
+
+    class SomeObject {
+        String value
+    }
+
+    def "null source is always null"() {
+        def environment = env(null)
+        def fetcher = new PropertyDataFetcher("someProperty")
+        expect:
+        fetcher.get(environment) == null
+    }
+
+    def "function based fetcher works with non null source"() {
+        def environment = env(new SomeObject(value: "aValue"))
+        Function<Object, String> f = { obj -> obj['value'] }
+        def fetcher = new PropertyDataFetcher(f)
+        expect:
+        fetcher.get(environment) == "aValue"
+    }
+
+    def "function based fetcher works with null source"() {
+        def environment = env(null)
+        Function<Object, String> f = { obj -> obj['value'] }
+        def fetcher = new PropertyDataFetcher(f)
+        expect:
+        fetcher.get(environment) == null
+    }
+
+    def "fetch via map lookup"() {
+        def environment = env(["mapProperty": "aValue"])
+        def fetcher = new PropertyDataFetcher("mapProperty")
+        expect:
+        fetcher.get(environment) == "aValue"
     }
 
     def "fetch via public getter with private subclass"() {


### PR DESCRIPTION
This allows for a simple and natural type safe way to get Java POJO properties

     DataFetcher df = new PropertyDataFetcher(Thing::getId); // ok
     DataFetcher<Long> df2 = new PropertyDataFetcher(Thing::getId); // ok
     DataFetcher<String> df3 = new PropertyDataFetcher(Thing::getId); // wont compile


I originally added a new type of data fetcher (eg FunctionDataFetcher) but then I realised its too fine grained.  This adds just enough behavior so that you mostly only need to think about property data fetches and this is getting properties (via method references)