### PR TITLE
 Add a helper class for making asynchronous data fetchers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ _site
 generated-src/
 out
 docs/_build/
+/bin/
+\.classpath
+\.project
+\.settings/

--- a/docs/execution.rst
+++ b/docs/execution.rst
@@ -323,24 +323,14 @@ threading strategy you use is up to your data fetcher code.
 The following code uses the standard Java ``java.util.concurrent.ForkJoinPool.commonPool()`` thread executor to supply values in another
 thread.
 
-.. code-block:: java
+You can use ``graphql.schema.AsynchronousDataFetcher.async(DataFetcher<T>)`` to wrap a ``DataFetcher`` so that it runs asynchronously.
 
-        DataFetcher userDataFetcher = new DataFetcher() {
-            @Override
-            public Object get(DataFetchingEnvironment environment) {
-                CompletableFuture<User> userPromise = CompletableFuture.supplyAsync(() -> {
-                    return fetchUserViaHttp(environment.getArgument("userId"));
-                });
-                return userPromise;
-            }
-        };
-
-The code above is written in long form.  With Java 8 lambdas it can be written more succinctly as follows
+This is designed to be used with static imports to produce more readable code.
 
 .. code-block:: java
 
-        DataFetcher userDataFetcher = environment -> CompletableFuture.supplyAsync(
-                () -> fetchUserViaHttp(environment.getArgument("userId")));
+        GraphQLFieldDefinition.newFieldDefinition()
+                .dataFetcher(async(fooDataFetcher))
 
 The graphql-java engine ensures that all the ``CompletableFuture`` objects are composed together to provide an execution result
 that follows the graphql specification.

--- a/src/main/java/graphql/schema/AsynchronousDataFetcher.java
+++ b/src/main/java/graphql/schema/AsynchronousDataFetcher.java
@@ -17,38 +17,48 @@ public class AsynchronousDataFetcher<T> implements DataFetcher<CompletableFuture
     /**
      * A factory method for creating asynchronous data fetchers so that when used with 
      * static imports allows more readable code such as:
+     * <p>
      * {@code .dataFetcher(async(fooDataFetcher))}
-     * <br><br>
+     * <p>
      * By default this will run in the {@link ForkJoinPool#commonPool()}. You can set 
-     * your own {@link Executor} with {@link #executeIn(Executor)}
+     * your own {@link Executor} with {@link #asyncWithExecutor(DataFetcher, Executor)}
      *
      * @param wrappedDataFetcher the data fetcher to run asynchronously
      *
-     * @return a DataFetcher that will run the wrappedDataFetcher asynchronously
+     * @return a {@link DataFetcher} that will run the wrappedDataFetcher asynchronously
      */
     public static <T> AsynchronousDataFetcher<T> async(DataFetcher<T> wrappedDataFetcher) {
         return new AsynchronousDataFetcher<>(wrappedDataFetcher);
     }
     
-    private final DataFetcher<T> wrappedDataFetcher;
-    private Executor executor = ForkJoinPool.commonPool();
-
-    public AsynchronousDataFetcher(DataFetcher<T> wrappedDataFetcher) {
-        assertNotNull(wrappedDataFetcher, "wrappedDataFetcher can't be null");
-        this.wrappedDataFetcher = wrappedDataFetcher;
+    /**
+     * A factory method for creating asynchronous data fetchers and setting the 
+     * {@link Executor} they run in so that when used with static imports allows 
+     * more readable code such as:
+     * <p>
+     * {@code .dataFetcher(asyncWithExecutor(fooDataFetcher, fooPool))}
+     *
+     * @param wrappedDataFetcher the data fetcher to run asynchronously
+     * @param executor to run the asynchronous data fetcher in
+     *
+     * @return a {@link DataFetcher} that will run the wrappedDataFetcher asynchronously in 
+     * the given {@link Executor}
+     */
+    public static <T> AsynchronousDataFetcher<T> asyncWithExecutor(DataFetcher<T> wrappedDataFetcher,
+            Executor executor) {
+        return new AsynchronousDataFetcher<>(wrappedDataFetcher, executor);
     }
     
-    /**
-     * This allows you to set the {@link Executor} that this {@link DataFetcher}
-     * will run in
-     * 
-     * @param executor the {@link Executor} to run the asynchronous data fetcher in
-     * 
-     * @return a reference to this object
-     */
-    public AsynchronousDataFetcher<T> executeIn(Executor executor) {
+    private final DataFetcher<T> wrappedDataFetcher;
+    private final Executor executor;
+
+    public AsynchronousDataFetcher(DataFetcher<T> wrappedDataFetcher) {
+        this(wrappedDataFetcher, ForkJoinPool.commonPool());
+    }
+
+    public AsynchronousDataFetcher(DataFetcher<T> wrappedDataFetcher, Executor executor) {
+        this.wrappedDataFetcher = assertNotNull(wrappedDataFetcher, "wrappedDataFetcher can't be null");
         this.executor = assertNotNull(executor, "executor can't be null");
-        return this;
     }
 
     @Override

--- a/src/main/java/graphql/schema/AsynchronousDataFetcher.java
+++ b/src/main/java/graphql/schema/AsynchronousDataFetcher.java
@@ -3,19 +3,24 @@ package graphql.schema;
 import static graphql.Assert.assertNotNull;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
 
 import graphql.PublicApi;
 
 /**
- * A modified type for that indicates the underlying data fetcher is run asynchronously.
+ * A modifier type that indicates the underlying data fetcher is run asynchronously
  */
 @PublicApi
 public class AsynchronousDataFetcher<T> implements DataFetcher<CompletableFuture<T>> {
     
     /**
      * A factory method for creating asynchronous data fetchers so that when used with 
-     * static imports allows more readable code such as
-     * {@code .dataFetcher(async(fooDataFetcher)) }
+     * static imports allows more readable code such as:
+     * {@code .dataFetcher(async(fooDataFetcher))}
+     * <br><br>
+     * By default this will run in the {@link ForkJoinPool#commonPool()}. You can set 
+     * your own {@link Executor} with {@link #executeIn(Executor)}
      *
      * @param wrappedDataFetcher the data fetcher to run asynchronously
      *
@@ -26,15 +31,29 @@ public class AsynchronousDataFetcher<T> implements DataFetcher<CompletableFuture
     }
     
     private final DataFetcher<T> wrappedDataFetcher;
+    private Executor executor = ForkJoinPool.commonPool();
 
     public AsynchronousDataFetcher(DataFetcher<T> wrappedDataFetcher) {
         assertNotNull(wrappedDataFetcher, "wrappedDataFetcher can't be null");
         this.wrappedDataFetcher = wrappedDataFetcher;
     }
+    
+    /**
+     * This allows you to set the {@link Executor} that this {@link DataFetcher}
+     * will run in
+     * 
+     * @param executor the {@link Executor} to run the asynchronous data fetcher in
+     * 
+     * @return a reference to this object
+     */
+    public AsynchronousDataFetcher<T> executeIn(Executor executor) {
+        this.executor = assertNotNull(executor, "executor can't be null");
+        return this;
+    }
 
     @Override
     public CompletableFuture<T> get(DataFetchingEnvironment environment) {
-        return CompletableFuture.supplyAsync(() -> wrappedDataFetcher.get(environment));
+        return CompletableFuture.supplyAsync(() -> wrappedDataFetcher.get(environment), executor);
     }
 
 }

--- a/src/main/java/graphql/schema/AsynchronousDataFetcher.java
+++ b/src/main/java/graphql/schema/AsynchronousDataFetcher.java
@@ -1,0 +1,40 @@
+package graphql.schema;
+
+import static graphql.Assert.assertNotNull;
+
+import java.util.concurrent.CompletableFuture;
+
+import graphql.PublicApi;
+
+/**
+ * A modified type for that indicates the underlying data fetcher is run asynchronously.
+ */
+@PublicApi
+public class AsynchronousDataFetcher<T> implements DataFetcher<CompletableFuture<T>> {
+    
+    /**
+     * A factory method for creating asynchronous data fetchers so that when used with 
+     * static imports allows more readable code such as
+     * {@code .dataFetcher(async(fooDataFetcher)) }
+     *
+     * @param wrappedDataFetcher the data fetcher to run asynchronously
+     *
+     * @return a DataFetcher that will run the wrappedDataFetcher asynchronously
+     */
+    public static <T> AsynchronousDataFetcher<T> async(DataFetcher<T> wrappedDataFetcher) {
+        return new AsynchronousDataFetcher<>(wrappedDataFetcher);
+    }
+    
+    private final DataFetcher<T> wrappedDataFetcher;
+
+    public AsynchronousDataFetcher(DataFetcher<T> wrappedDataFetcher) {
+        assertNotNull(wrappedDataFetcher, "wrappedDataFetcher can't be null");
+        this.wrappedDataFetcher = wrappedDataFetcher;
+    }
+
+    @Override
+    public CompletableFuture<T> get(DataFetchingEnvironment environment) {
+        return CompletableFuture.supplyAsync(() -> wrappedDataFetcher.get(environment));
+    }
+
+}

--- a/src/test/groovy/graphql/schema/AsynchronousDataFetcherTest.groovy
+++ b/src/test/groovy/graphql/schema/AsynchronousDataFetcherTest.groovy
@@ -1,0 +1,32 @@
+package graphql.schema
+
+import graphql.GraphQL
+import graphql.StarWarsData
+import graphql.TestUtil
+import graphql.execution.FieldCollector
+import graphql.language.AstPrinter
+import graphql.language.Field
+import graphql.schema.idl.MapEnumValuesProvider
+import graphql.schema.idl.RuntimeWiring
+import spock.lang.Specification
+
+import java.util.concurrent.CompletableFuture
+import java.util.stream.Collectors
+
+import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring
+
+
+class AsynchronousDataFetcherTest extends Specification {
+
+    def "A data fetcher can be made asynchronous with AsynchronousDataFetcher#async"() {
+        given:
+        DataFetchingEnvironment environment = Mock(DataFetchingEnvironment)
+
+        when:
+        DataFetcher asyncDataFetcher = AsynchronousDataFetcher.async({ env -> "value" })
+
+        then:
+        asyncDataFetcher.get(environment) instanceof CompletableFuture
+        asyncDataFetcher.get(environment).get() == "value"
+    }
+}


### PR DESCRIPTION
Adds the ability to make any `DataFetcher` appropriate for running asynchronously via a helper class `AsynchronousDataFetcher`.

This class has a static method `async(DataFetcher)` that wraps the given `Data Fetcher<T>` in a new `DataFetcher<CompletableFuture<T>>`. The `CompletableFuture` returned by the new `DataFetcher` runs the original `CompletableFuture` asynchronously.

Example use (with static imports to improve readability)
```java
GraphQLFieldDefinition.newFieldDefinition()
        .dataFetcher(async(fooDataFetcher))
        // ... rest of field definition
```

I have also added some stuff to the `.gitignore` for files generated by Eclipse.