### PR TITLE
Handle the case correctly when both @include and @skip exist

### DIFF
--- a/src/main/java/graphql/execution/ConditionalNodes.java
+++ b/src/main/java/graphql/execution/ConditionalNodes.java
@@ -12,28 +12,16 @@ import static graphql.language.NodeUtil.directivesByName;
 
 public class ConditionalNodes {
 
-    final ValuesResolver valuesResolver;
+    private final ValuesResolver valuesResolver;
 
     public ConditionalNodes() {
         valuesResolver = new ValuesResolver();
     }
 
     public boolean shouldInclude(Map<String, Object> variables, List<Directive> directives) {
-
-        Directive skipDirective = getDirectiveByName(directives, SkipDirective.getName());
-        if (skipDirective != null) {
-            Map<String, Object> argumentValues = valuesResolver.getArgumentValues(SkipDirective.getArguments(), skipDirective.getArguments(), variables);
-            return !(Boolean) argumentValues.get("if");
-        }
-
-
-        Directive includeDirective = getDirectiveByName(directives, IncludeDirective.getName());
-        if (includeDirective != null) {
-            Map<String, Object> argumentValues = valuesResolver.getArgumentValues(IncludeDirective.getArguments(), includeDirective.getArguments(), variables);
-            return (Boolean) argumentValues.get("if");
-        }
-
-        return true;
+        boolean skip = getDirectiveResult(variables, directives, SkipDirective.getName(), false);
+        boolean include = getDirectiveResult(variables, directives, IncludeDirective.getName(), true);
+        return !skip && include;
     }
 
     private Directive getDirectiveByName(List<Directive> directives, String name) {
@@ -41,6 +29,16 @@ public class ConditionalNodes {
             return null;
         }
         return directivesByName(directives).get(name);
+    }
+
+    private boolean getDirectiveResult(Map<String, Object> variables, List<Directive> directives, String directiveName, boolean defaultValue) {
+        Directive directive = getDirectiveByName(directives, directiveName);
+        if (directive != null) {
+            Map<String, Object> argumentValues = valuesResolver.getArgumentValues(SkipDirective.getArguments(), directive.getArguments(), variables);
+            return (Boolean) argumentValues.get("if");
+        }
+
+        return defaultValue;
     }
 
 }

--- a/src/test/groovy/graphql/SkipAndInclude.groovy
+++ b/src/test/groovy/graphql/SkipAndInclude.groovy
@@ -1,0 +1,38 @@
+package graphql
+
+import spock.lang.Specification
+
+class SkipAndInclude extends Specification {
+
+    def "@skip and @include"() {
+        when:
+        def schema = TestUtil.schema("""
+            type Query {
+                field: Int
+            }
+        """)
+
+        def graphQL = GraphQL.newGraphQL(schema).build()
+
+        def executionInput = ExecutionInput.newExecutionInput()
+                .query('''
+                    query QueryWithSkipAndInclude($skip: Boolean!, $include: Boolean!) {
+                        field @skip(if: $skip) @include(if: $include)
+                    }   
+                    ''')
+                .variables([skip: skip, include: include])
+                .build()
+
+        def executionResult = graphQL.execute(executionInput)
+
+        then:
+        ((Map) executionResult.data).containsKey("field") == quaried
+
+        where:
+        skip    | include | quaried
+        true    | true    | false
+        true    | false   | false
+        false   | true    | true
+        false   | false   | false
+    }
+}


### PR DESCRIPTION
Correct the behavior based on the spec: http://facebook.github.io/graphql/October2016/#sec--include

>  In the case that both the @skip and  @include directives are provided in on the same the field or fragment, it must be queried only if the  @skip condition is false and the @include condition is true. 