### PR TITLE
TracingSupport: no ! in parent type names

### DIFF
--- a/src/main/java/graphql/execution/instrumentation/tracing/TracingSupport.java
+++ b/src/main/java/graphql/execution/instrumentation/tracing/TracingSupport.java
@@ -66,7 +66,7 @@ public class TracingSupport implements InstrumentationState {
 
             Map<String, Object> fetchMap = new LinkedHashMap<>();
             fetchMap.put("path", typeInfo.getPath().toList());
-            fetchMap.put("parentType", typeInfo.getParentTypeInfo().toAst());
+            fetchMap.put("parentType", typeInfo.getParentTypeInfo().getType().getName());
             fetchMap.put("returnType", typeInfo.toAst());
             fetchMap.put("fieldName", typeInfo.getFieldDefinition().getName());
             fetchMap.put("startOffset", startOffset);


### PR DESCRIPTION
This breaks the Engine UI. Eg:

![image](https://user-images.githubusercontent.com/8641/32253660-7028ff84-be59-11e7-9067-2ee2192d595b.png)
