### PR TITLE
fixed issue with graphql-java dependency

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -21,7 +21,7 @@ Dependency:
 .. code-block:: groovy
 
     dependencies {
-      compile 'com.graphql-java:graphql-java:5.0.0'
+      compile 'com.graphql-java:graphql-java:5.0'
     }
 
 


### PR DESCRIPTION
Gradle didn't seem to resolve 'com.graphql-java:graphql-java:5.0.0'. I changed it to 'com.graphql-java:graphql-java:5.0' and everything seems to work fine. I am not sure if you need to make the same changes to the Maven configuration just below my changes.