### PR TITLE
Add source location for coercion errors

### DIFF
--- a/src/main/java/graphql/execution/NonNullableValueCoercedAsNullException.java
+++ b/src/main/java/graphql/execution/NonNullableValueCoercedAsNullException.java
@@ -10,6 +10,7 @@ import graphql.schema.GraphQLInputObjectField;
 import graphql.schema.GraphQLType;
 import graphql.schema.GraphQLTypeUtil;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static java.lang.String.format;
@@ -19,10 +20,12 @@ import static java.lang.String.format;
  */
 @PublicApi
 public class NonNullableValueCoercedAsNullException extends GraphQLException implements GraphQLError {
+    private List<SourceLocation> sourceLocations;
 
     public NonNullableValueCoercedAsNullException(VariableDefinition variableDefinition, GraphQLType graphQLType) {
         super(format("Variable '%s' has coerced Null value for NonNull type '%s'",
                 variableDefinition.getName(), GraphQLTypeUtil.getUnwrappedTypeName(graphQLType)));
+        this.sourceLocations = Arrays.asList(variableDefinition.getSourceLocation());
     }
 
     public NonNullableValueCoercedAsNullException(GraphQLInputObjectField inputTypeField) {

--- a/src/main/java/graphql/schema/CoercingParseValueException.java
+++ b/src/main/java/graphql/schema/CoercingParseValueException.java
@@ -5,9 +5,11 @@ import graphql.GraphQLError;
 import graphql.GraphQLException;
 import graphql.language.SourceLocation;
 
+import java.util.Arrays;
 import java.util.List;
 
 public class CoercingParseValueException extends GraphQLException implements GraphQLError {
+    private List<SourceLocation> sourceLocations;
 
     public CoercingParseValueException() {
     }
@@ -20,13 +22,18 @@ public class CoercingParseValueException extends GraphQLException implements Gra
         super(message, cause);
     }
 
+    public CoercingParseValueException(String message, Throwable cause, SourceLocation sourceLocation) {
+        super(message, cause);
+        this.sourceLocations = Arrays.asList(sourceLocation);
+    }
+
     public CoercingParseValueException(Throwable cause) {
         super(cause);
     }
 
     @Override
     public List<SourceLocation> getLocations() {
-        return null;
+        return sourceLocations;
     }
 
     @Override

--- a/src/test/groovy/graphql/Issue739.groovy
+++ b/src/test/groovy/graphql/Issue739.groovy
@@ -1,5 +1,6 @@
 package graphql
 
+import graphql.language.SourceLocation;
 import graphql.schema.CoercingParseValueException
 import graphql.schema.GraphQLObjectType
 import graphql.schema.idl.RuntimeWiring
@@ -90,5 +91,6 @@ class Issue739 extends Specification {
         varResult.errors.size() == 1
         varResult.errors[0].errorType == ErrorType.ValidationError
         varResult.errors[0].message == "Variables for GraphQLInputObjectType must be an instance of a Map according to the graphql specification.  The offending object was a java.lang.Integer"
+        varResult.errors[0].locations == [new SourceLocation(1, 11)]
     }
 }


### PR DESCRIPTION
This pull request adds `sourceLocations` for coercion errors.

I'm not sure if I've added this in the appropriate place, but it seemed the easier way to add this to all types of coercion errors without forcing each individual scalar to deal with handling the source location.