### PR TITLE
Update coercion error messages

### DIFF
--- a/src/main/java/graphql/Scalars.java
+++ b/src/main/java/graphql/Scalars.java
@@ -38,6 +38,14 @@ public class Scalars {
         return input instanceof Number || input instanceof String;
     }
 
+    private static String typeName(Object input) {
+        if (input == null) {
+            return "null";
+        }
+
+        return input.getClass().getSimpleName();
+    }
+
     /**
      * This represents the "Int" type as defined in the graphql specification : http://facebook.github.io/graphql/#sec-Int
      *
@@ -70,7 +78,7 @@ public class Scalars {
             Integer result = convertImpl(input);
             if (result == null) {
                 throw new CoercingSerializeException(
-                  "Expected type 'Int' but was '" + input.getClass().getSimpleName() + "'."
+                  "Expected type 'Int' but was '" + typeName(input) + "'."
                 );
             }
             return result;
@@ -81,7 +89,7 @@ public class Scalars {
             Integer result = convertImpl(input);
             if (result == null) {
                 throw new CoercingParseValueException(
-                  "Expected type 'Int' but was '" + input.getClass().getSimpleName() + "'."
+                  "Expected type 'Int' but was '" + typeName(input) + "'."
                 );
             }
             return result;
@@ -125,7 +133,7 @@ public class Scalars {
             Double result = convertImpl(input);
             if (result == null) {
                 throw new CoercingSerializeException(
-                  "Expected type 'Float' but was '" + input.getClass().getSimpleName() + "'."
+                  "Expected type 'Float' but was '" + typeName(input) + "'."
                 );
             }
             return result;
@@ -137,7 +145,7 @@ public class Scalars {
             Double result = convertImpl(input);
             if (result == null) {
                 throw new CoercingParseValueException(
-                  "Expected type 'Float' but was '" + input.getClass().getSimpleName() + "'."
+                  "Expected type 'Float' but was '" + typeName(input) + "'."
                 );
             }
             return result;
@@ -206,7 +214,7 @@ public class Scalars {
             Boolean result = convertImpl(input);
             if (result == null) {
                 throw new CoercingSerializeException(
-                  "Expected type 'Boolean' but was '" + input.getClass().getSimpleName() + "'."
+                  "Expected type 'Boolean' but was '" + typeName(input) + "'."
                 );
             }
             return result;
@@ -217,7 +225,7 @@ public class Scalars {
             Boolean result = convertImpl(input);
             if (result == null) {
                 throw new CoercingParseValueException(
-                  "Expected type 'Boolean' but was '" + input.getClass().getSimpleName() + "'."
+                  "Expected type 'Boolean' but was '" + typeName(input) + "'."
                 );
             }
             return result;
@@ -258,7 +266,7 @@ public class Scalars {
             String result = convertImpl(input);
             if (result == null) {
                 throw new CoercingSerializeException(
-                  "Expected type 'ID' but was '" + input.getClass().getSimpleName() + "'."
+                  "Expected type 'ID' but was '" + typeName(input) + "'."
                 );
             }
             return result;
@@ -269,7 +277,7 @@ public class Scalars {
             String result = convertImpl(input);
             if (result == null) {
                 throw new CoercingParseValueException(
-                  "Expected type 'ID' but was '" + input.getClass().getSimpleName() + "'."
+                  "Expected type 'ID' but was '" + typeName(input) + "'."
                 );
             }
             return result;
@@ -318,7 +326,7 @@ public class Scalars {
             Long result = convertImpl(input);
             if (result == null) {
                 throw new CoercingSerializeException(
-                  "Expected type 'Long' but was '" + input.getClass().getSimpleName() + "'."
+                  "Expected type 'Long' but was '" + typeName(input) + "'."
                 );
             }
             return result;
@@ -329,7 +337,7 @@ public class Scalars {
             Long result = convertImpl(input);
             if (result == null) {
                 throw new CoercingParseValueException(
-                  "Expected type 'Long' but was '" + input.getClass().getSimpleName() + "'."
+                  "Expected type 'Long' but was '" + typeName(input) + "'."
                 );
             }
             return result;
@@ -385,7 +393,7 @@ public class Scalars {
             Short result = convertImpl(input);
             if (result == null) {
                 throw new CoercingSerializeException(
-                  "Expected type 'Short' but was '" + input.getClass().getSimpleName() + "'."
+                  "Expected type 'Short' but was '" + typeName(input) + "'."
                 );
             }
             return result;
@@ -396,7 +404,7 @@ public class Scalars {
             Short result = convertImpl(input);
             if (result == null) {
                 throw new CoercingParseValueException(
-                  "Expected type 'Short' but was '" + input.getClass().getSimpleName() + "'."
+                  "Expected type 'Short' but was '" + typeName(input) + "'."
                 );
             }
             return result;
@@ -444,7 +452,7 @@ public class Scalars {
             Byte result = convertImpl(input);
             if (result == null) {
                 throw new CoercingSerializeException(
-                  "Expected type 'Byte' but was '" + input.getClass().getSimpleName() + "'."
+                  "Expected type 'Byte' but was '" + typeName(input) + "'."
                 );
             }
             return result;
@@ -455,7 +463,7 @@ public class Scalars {
             Byte result = convertImpl(input);
             if (result == null) {
                 throw new CoercingParseValueException(
-                  "Expected type 'Byte' but was '" + input.getClass().getSimpleName() + "'."
+                  "Expected type 'Byte' but was '" + typeName(input) + "'."
                 );
             }
             return result;
@@ -501,7 +509,7 @@ public class Scalars {
             BigInteger result = convertImpl(input);
             if (result == null) {
                 throw new CoercingSerializeException(
-                  "Expected type 'BigInteger' but was '" + input.getClass().getSimpleName() + "'."
+                  "Expected type 'BigInteger' but was '" + typeName(input) + "'."
                 );
             }
             return result;
@@ -512,7 +520,7 @@ public class Scalars {
             BigInteger result = convertImpl(input);
             if (result == null) {
                 throw new CoercingParseValueException(
-                  "Expected type 'BigInteger' but was '" + input.getClass().getSimpleName() + "'."
+                  "Expected type 'BigInteger' but was '" + typeName(input) + "'."
                 );
             }
             return result;
@@ -561,7 +569,7 @@ public class Scalars {
             BigDecimal result = convertImpl(input);
             if (result == null) {
                 throw new CoercingSerializeException(
-                  "Expected type 'BigDecimal' but was '" + input.getClass().getSimpleName() + "'."
+                  "Expected type 'BigDecimal' but was '" + typeName(input) + "'."
                 );
             }
             return result;
@@ -572,7 +580,7 @@ public class Scalars {
             BigDecimal result = convertImpl(input);
             if (result == null) {
                 throw new CoercingParseValueException(
-                  "Expected type 'BigDecimal' but was '" + input.getClass().getSimpleName() + "'."
+                  "Expected type 'BigDecimal' but was '" + typeName(input) + "'."
                 );
             }
             return result;
@@ -617,7 +625,7 @@ public class Scalars {
             Character result = convertImpl(input);
             if (result == null) {
                 throw new CoercingSerializeException(
-                  "Expected type 'Char' but was '" + input.getClass().getSimpleName() + "'."
+                  "Expected type 'Char' but was '" + typeName(input) + "'."
                 );
             }
             return result;
@@ -628,7 +636,7 @@ public class Scalars {
             Character result = convertImpl(input);
             if (result == null) {
                 throw new CoercingParseValueException(
-                  "Expected type 'Char' but was '" + input.getClass().getSimpleName() + "'."
+                  "Expected type 'Char' but was '" + typeName(input) + "'."
                 );
             }
             return result;

--- a/src/main/java/graphql/Scalars.java
+++ b/src/main/java/graphql/Scalars.java
@@ -69,7 +69,7 @@ public class Scalars {
         public Integer serialize(Object input) {
             Integer result = convertImpl(input);
             if (result == null) {
-                throw new CoercingSerializeException("Invalid value '" + input + "' for Int");
+                throw new CoercingSerializeException("Expected type 'Int'.");
             }
             return result;
         }
@@ -78,7 +78,7 @@ public class Scalars {
         public Integer parseValue(Object input) {
             Integer result = convertImpl(input);
             if (result == null) {
-                throw new CoercingParseValueException("Invalid value '" + input + "' for Int");
+                throw new CoercingParseValueException("Expected type 'Int'.");
             }
             return result;
         }
@@ -120,7 +120,7 @@ public class Scalars {
         public Double serialize(Object input) {
             Double result = convertImpl(input);
             if (result == null) {
-                throw new CoercingSerializeException("Invalid input '" + input + "' for Float");
+                throw new CoercingSerializeException("Expected type 'Float'.");
             }
             return result;
 
@@ -130,7 +130,7 @@ public class Scalars {
         public Double parseValue(Object input) {
             Double result = convertImpl(input);
             if (result == null) {
-                throw new CoercingParseValueException("Invalid input '" + input + "' for Float");
+                throw new CoercingParseValueException("Expected type 'Float'.");
             }
             return result;
         }
@@ -197,7 +197,7 @@ public class Scalars {
         public Boolean serialize(Object input) {
             Boolean result = convertImpl(input);
             if (result == null) {
-                throw new CoercingSerializeException("Invalid input '" + input + "' for Boolean");
+                throw new CoercingSerializeException("Expected type 'Boolean'.");
             }
             return result;
         }
@@ -206,7 +206,7 @@ public class Scalars {
         public Boolean parseValue(Object input) {
             Boolean result = convertImpl(input);
             if (result == null) {
-                throw new CoercingParseValueException("Invalid input '" + input + "' for Boolean");
+                throw new CoercingParseValueException("Expected type 'Boolean'.");
             }
             return result;
         }
@@ -245,7 +245,7 @@ public class Scalars {
         public String serialize(Object input) {
             String result = convertImpl(input);
             if (result == null) {
-                throw new CoercingSerializeException("Invalid input '" + input + "' for ID");
+                throw new CoercingSerializeException("Expected type 'ID'.");
             }
             return result;
         }
@@ -254,7 +254,7 @@ public class Scalars {
         public String parseValue(Object input) {
             String result = convertImpl(input);
             if (result == null) {
-                throw new CoercingParseValueException("Invalid input '" + input + "' for ID");
+                throw new CoercingParseValueException("Expected type 'ID'.");
             }
             return result;
         }
@@ -301,7 +301,7 @@ public class Scalars {
         public Long serialize(Object input) {
             Long result = convertImpl(input);
             if (result == null) {
-                throw new CoercingSerializeException("Invalid input '" + input + "' for Long");
+                throw new CoercingSerializeException("Expected type 'Long'.");
             }
             return result;
         }
@@ -310,7 +310,7 @@ public class Scalars {
         public Long parseValue(Object input) {
             Long result = convertImpl(input);
             if (result == null) {
-                throw new CoercingParseValueException("Invalid input '" + input + "' for Long");
+                throw new CoercingParseValueException("Expected type 'Long'.");
             }
             return result;
         }
@@ -364,7 +364,7 @@ public class Scalars {
         public Short serialize(Object input) {
             Short result = convertImpl(input);
             if (result == null) {
-                throw new CoercingSerializeException("Invalid input '" + input + "' for Short");
+                throw new CoercingSerializeException("Expected type 'Short'.");
             }
             return result;
         }
@@ -373,7 +373,7 @@ public class Scalars {
         public Short parseValue(Object input) {
             Short result = convertImpl(input);
             if (result == null) {
-                throw new CoercingParseValueException("Invalid input '" + input + "' for Short");
+                throw new CoercingParseValueException("Expected type 'Short'.");
             }
             return result;
         }
@@ -419,7 +419,7 @@ public class Scalars {
         public Byte serialize(Object input) {
             Byte result = convertImpl(input);
             if (result == null) {
-                throw new CoercingSerializeException("Invalid input '" + input + "' for Byte");
+                throw new CoercingSerializeException("Expected type 'Byte'.");
             }
             return result;
         }
@@ -428,7 +428,7 @@ public class Scalars {
         public Byte parseValue(Object input) {
             Byte result = convertImpl(input);
             if (result == null) {
-                throw new CoercingParseValueException("Invalid input '" + input + "' for Byte");
+                throw new CoercingParseValueException("Expected type 'Byte'.");
             }
             return result;
         }
@@ -472,7 +472,7 @@ public class Scalars {
         public BigInteger serialize(Object input) {
             BigInteger result = convertImpl(input);
             if (result == null) {
-                throw new CoercingSerializeException("Invalid input '" + input + "' for BigInteger");
+                throw new CoercingSerializeException("Expected type 'BigInteger'.");
             }
             return result;
         }
@@ -481,7 +481,7 @@ public class Scalars {
         public BigInteger parseValue(Object input) {
             BigInteger result = convertImpl(input);
             if (result == null) {
-                throw new CoercingParseValueException("Invalid input '" + input + "' for BigInteger");
+                throw new CoercingParseValueException("Expected type 'BigInteger'.");
             }
             return result;
         }
@@ -528,7 +528,7 @@ public class Scalars {
         public BigDecimal serialize(Object input) {
             BigDecimal result = convertImpl(input);
             if (result == null) {
-                throw new CoercingSerializeException("Invalid input '" + input + "' for BigDecimal");
+                throw new CoercingSerializeException("Expected type 'BigDecimal'.");
             }
             return result;
         }
@@ -537,7 +537,7 @@ public class Scalars {
         public BigDecimal parseValue(Object input) {
             BigDecimal result = convertImpl(input);
             if (result == null) {
-                throw new CoercingParseValueException("Invalid input '" + input + "' for BigDecimal");
+                throw new CoercingParseValueException("Expected type 'BigDecimal'.");
             }
             return result;
         }
@@ -580,7 +580,7 @@ public class Scalars {
         public Character serialize(Object input) {
             Character result = convertImpl(input);
             if (result == null) {
-                throw new CoercingSerializeException("Invalid input '" + input + "' for Char");
+                throw new CoercingSerializeException("Expected type 'Char'.");
             }
             return result;
         }
@@ -589,7 +589,7 @@ public class Scalars {
         public Character parseValue(Object input) {
             Character result = convertImpl(input);
             if (result == null) {
-                throw new CoercingParseValueException("Invalid input '" + input + "' for Char");
+                throw new CoercingParseValueException("Expected type 'Char'.");
             }
             return result;
         }

--- a/src/main/java/graphql/Scalars.java
+++ b/src/main/java/graphql/Scalars.java
@@ -69,7 +69,9 @@ public class Scalars {
         public Integer serialize(Object input) {
             Integer result = convertImpl(input);
             if (result == null) {
-                throw new CoercingSerializeException("Expected type 'Int'.");
+                throw new CoercingSerializeException(
+                  "Expected type 'Int' but was '" + input.getClass().getSimpleName() + "'."
+                );
             }
             return result;
         }
@@ -78,7 +80,9 @@ public class Scalars {
         public Integer parseValue(Object input) {
             Integer result = convertImpl(input);
             if (result == null) {
-                throw new CoercingParseValueException("Expected type 'Int'.");
+                throw new CoercingParseValueException(
+                  "Expected type 'Int' but was '" + input.getClass().getSimpleName() + "'."
+                );
             }
             return result;
         }
@@ -120,7 +124,9 @@ public class Scalars {
         public Double serialize(Object input) {
             Double result = convertImpl(input);
             if (result == null) {
-                throw new CoercingSerializeException("Expected type 'Float'.");
+                throw new CoercingSerializeException(
+                  "Expected type 'Float' but was '" + input.getClass().getSimpleName() + "'."
+                );
             }
             return result;
 
@@ -130,7 +136,9 @@ public class Scalars {
         public Double parseValue(Object input) {
             Double result = convertImpl(input);
             if (result == null) {
-                throw new CoercingParseValueException("Expected type 'Float'.");
+                throw new CoercingParseValueException(
+                  "Expected type 'Float' but was '" + input.getClass().getSimpleName() + "'."
+                );
             }
             return result;
         }
@@ -197,7 +205,9 @@ public class Scalars {
         public Boolean serialize(Object input) {
             Boolean result = convertImpl(input);
             if (result == null) {
-                throw new CoercingSerializeException("Expected type 'Boolean'.");
+                throw new CoercingSerializeException(
+                  "Expected type 'Boolean' but was '" + input.getClass().getSimpleName() + "'."
+                );
             }
             return result;
         }
@@ -206,7 +216,9 @@ public class Scalars {
         public Boolean parseValue(Object input) {
             Boolean result = convertImpl(input);
             if (result == null) {
-                throw new CoercingParseValueException("Expected type 'Boolean'.");
+                throw new CoercingParseValueException(
+                  "Expected type 'Boolean' but was '" + input.getClass().getSimpleName() + "'."
+                );
             }
             return result;
         }
@@ -245,7 +257,9 @@ public class Scalars {
         public String serialize(Object input) {
             String result = convertImpl(input);
             if (result == null) {
-                throw new CoercingSerializeException("Expected type 'ID'.");
+                throw new CoercingSerializeException(
+                  "Expected type 'ID' but was '" + input.getClass().getSimpleName() + "'."
+                );
             }
             return result;
         }
@@ -254,7 +268,9 @@ public class Scalars {
         public String parseValue(Object input) {
             String result = convertImpl(input);
             if (result == null) {
-                throw new CoercingParseValueException("Expected type 'ID'.");
+                throw new CoercingParseValueException(
+                  "Expected type 'ID' but was '" + input.getClass().getSimpleName() + "'."
+                );
             }
             return result;
         }
@@ -301,7 +317,9 @@ public class Scalars {
         public Long serialize(Object input) {
             Long result = convertImpl(input);
             if (result == null) {
-                throw new CoercingSerializeException("Expected type 'Long'.");
+                throw new CoercingSerializeException(
+                  "Expected type 'Long' but was '" + input.getClass().getSimpleName() + "'."
+                );
             }
             return result;
         }
@@ -310,7 +328,9 @@ public class Scalars {
         public Long parseValue(Object input) {
             Long result = convertImpl(input);
             if (result == null) {
-                throw new CoercingParseValueException("Expected type 'Long'.");
+                throw new CoercingParseValueException(
+                  "Expected type 'Long' but was '" + input.getClass().getSimpleName() + "'."
+                );
             }
             return result;
         }
@@ -364,7 +384,9 @@ public class Scalars {
         public Short serialize(Object input) {
             Short result = convertImpl(input);
             if (result == null) {
-                throw new CoercingSerializeException("Expected type 'Short'.");
+                throw new CoercingSerializeException(
+                  "Expected type 'Short' but was '" + input.getClass().getSimpleName() + "'."
+                );
             }
             return result;
         }
@@ -373,7 +395,9 @@ public class Scalars {
         public Short parseValue(Object input) {
             Short result = convertImpl(input);
             if (result == null) {
-                throw new CoercingParseValueException("Expected type 'Short'.");
+                throw new CoercingParseValueException(
+                  "Expected type 'Short' but was '" + input.getClass().getSimpleName() + "'."
+                );
             }
             return result;
         }
@@ -419,7 +443,9 @@ public class Scalars {
         public Byte serialize(Object input) {
             Byte result = convertImpl(input);
             if (result == null) {
-                throw new CoercingSerializeException("Expected type 'Byte'.");
+                throw new CoercingSerializeException(
+                  "Expected type 'Byte' but was '" + input.getClass().getSimpleName() + "'."
+                );
             }
             return result;
         }
@@ -428,7 +454,9 @@ public class Scalars {
         public Byte parseValue(Object input) {
             Byte result = convertImpl(input);
             if (result == null) {
-                throw new CoercingParseValueException("Expected type 'Byte'.");
+                throw new CoercingParseValueException(
+                  "Expected type 'Byte' but was '" + input.getClass().getSimpleName() + "'."
+                );
             }
             return result;
         }
@@ -472,7 +500,9 @@ public class Scalars {
         public BigInteger serialize(Object input) {
             BigInteger result = convertImpl(input);
             if (result == null) {
-                throw new CoercingSerializeException("Expected type 'BigInteger'.");
+                throw new CoercingSerializeException(
+                  "Expected type 'BigInteger' but was '" + input.getClass().getSimpleName() + "'."
+                );
             }
             return result;
         }
@@ -481,7 +511,9 @@ public class Scalars {
         public BigInteger parseValue(Object input) {
             BigInteger result = convertImpl(input);
             if (result == null) {
-                throw new CoercingParseValueException("Expected type 'BigInteger'.");
+                throw new CoercingParseValueException(
+                  "Expected type 'BigInteger' but was '" + input.getClass().getSimpleName() + "'."
+                );
             }
             return result;
         }
@@ -528,7 +560,9 @@ public class Scalars {
         public BigDecimal serialize(Object input) {
             BigDecimal result = convertImpl(input);
             if (result == null) {
-                throw new CoercingSerializeException("Expected type 'BigDecimal'.");
+                throw new CoercingSerializeException(
+                  "Expected type 'BigDecimal' but was '" + input.getClass().getSimpleName() + "'."
+                );
             }
             return result;
         }
@@ -537,7 +571,9 @@ public class Scalars {
         public BigDecimal parseValue(Object input) {
             BigDecimal result = convertImpl(input);
             if (result == null) {
-                throw new CoercingParseValueException("Expected type 'BigDecimal'.");
+                throw new CoercingParseValueException(
+                  "Expected type 'BigDecimal' but was '" + input.getClass().getSimpleName() + "'."
+                );
             }
             return result;
         }
@@ -580,7 +616,9 @@ public class Scalars {
         public Character serialize(Object input) {
             Character result = convertImpl(input);
             if (result == null) {
-                throw new CoercingSerializeException("Expected type 'Char'.");
+                throw new CoercingSerializeException(
+                  "Expected type 'Char' but was '" + input.getClass().getSimpleName() + "'."
+                );
             }
             return result;
         }
@@ -589,7 +627,9 @@ public class Scalars {
         public Character parseValue(Object input) {
             Character result = convertImpl(input);
             if (result == null) {
-                throw new CoercingParseValueException("Expected type 'Char'.");
+                throw new CoercingParseValueException(
+                  "Expected type 'Char' but was '" + input.getClass().getSimpleName() + "'."
+                );
             }
             return result;
         }

--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -87,7 +87,11 @@ public class ValuesResolver {
                     coercedValues.put(variableName, coercedValue);
                 }
             } catch (CoercingParseValueException e) {
-                throw new CoercingParseValueException(e.getMessage(), e.getCause(), variableDefinition.getSourceLocation());
+                throw new CoercingParseValueException(
+                  "Variable '" + variableName + "' has an invalid value. " + e.getMessage(),
+                  e.getCause(),
+                  variableDefinition.getSourceLocation()
+                );
             }
         }
 
@@ -166,7 +170,7 @@ public class ValuesResolver {
             if (value instanceof Map) {
                 return coerceValueForInputObjectType(variableDefinition, (GraphQLInputObjectType) graphQLType, (Map<String, Object>) value);
             } else {
-                throw new CoercingParseValueException("Variables for GraphQLInputObjectType must be an instance of a Map according to the graphql specification.  The offending object was a " + value.getClass().getName());
+                throw new CoercingParseValueException("Expected type 'Map'.");
             }
         } else {
             return assertShouldNeverHappen("unhandled type " + graphQLType);

--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -170,7 +170,10 @@ public class ValuesResolver {
             if (value instanceof Map) {
                 return coerceValueForInputObjectType(variableDefinition, (GraphQLInputObjectType) graphQLType, (Map<String, Object>) value);
             } else {
-                throw new CoercingParseValueException("Expected type 'Map'.");
+                throw new CoercingParseValueException(
+                  "Expected type 'Map' but was '" + value.getClass().getSimpleName() +
+                  "'. Variables for input objects must be an instance of a 'Map'."
+                );
             }
         } else {
             return assertShouldNeverHappen("unhandled type " + graphQLType);

--- a/src/test/groovy/graphql/Issue739.groovy
+++ b/src/test/groovy/graphql/Issue739.groovy
@@ -1,7 +1,6 @@
 package graphql
 
-import graphql.language.SourceLocation;
-import graphql.schema.CoercingParseValueException
+import graphql.language.SourceLocation
 import graphql.schema.GraphQLObjectType
 import graphql.schema.idl.RuntimeWiring
 import spock.lang.Specification
@@ -90,7 +89,7 @@ class Issue739 extends Specification {
         varResult.data == null
         varResult.errors.size() == 1
         varResult.errors[0].errorType == ErrorType.ValidationError
-        varResult.errors[0].message == "Variables for GraphQLInputObjectType must be an instance of a Map according to the graphql specification.  The offending object was a java.lang.Integer"
+        varResult.errors[0].message == "Variable 'input' has an invalid value. Expected type 'Map'."
         varResult.errors[0].locations == [new SourceLocation(1, 11)]
     }
 }

--- a/src/test/groovy/graphql/Issue739.groovy
+++ b/src/test/groovy/graphql/Issue739.groovy
@@ -89,7 +89,8 @@ class Issue739 extends Specification {
         varResult.data == null
         varResult.errors.size() == 1
         varResult.errors[0].errorType == ErrorType.ValidationError
-        varResult.errors[0].message == "Variable 'input' has an invalid value. Expected type 'Map'."
+        varResult.errors[0].message == "Variable 'input' has an invalid value. Expected type 'Map' but was 'Integer'." +
+          " Variables for input objects must be an instance of a 'Map'.";
         varResult.errors[0].locations == [new SourceLocation(1, 11)]
     }
 }


### PR DESCRIPTION
Messages now include the name of the offending variable. They no longer
include the java-specific name of the offending type. This means we will
not leak language-specific idioms in error messages.