### PR TITLE
Make a Relay mutation without a clientMutationId

### DIFF
--- a/src/main/java/graphql/relay/Relay.java
+++ b/src/main/java/graphql/relay/Relay.java
@@ -172,23 +172,39 @@ public class Relay {
                 .build();
     }
 
-
     public GraphQLFieldDefinition mutationWithClientMutationId(String name, String fieldName,
                                                                List<GraphQLInputObjectField> inputFields,
                                                                List<GraphQLFieldDefinition> outputFields,
                                                                DataFetcher dataFetcher) {
+        GraphQLInputObjectField clientMutationIdInputField = newInputObjectField()
+                .name("clientMutationId")
+                .type(GraphQLString)
+                .build();
+        GraphQLFieldDefinition clientMutationIdPayloadField = newFieldDefinition()
+                .name("clientMutationId")
+                .type(GraphQLString)
+                .build();
+
+        return mutation(name, fieldName, addElementToList(inputFields, clientMutationIdInputField), 
+                addElementToList(outputFields, clientMutationIdPayloadField), dataFetcher);
+    }
+    
+    private static <T> List<T> addElementToList(List<T> list, T element) {
+        ArrayList<T> result = new ArrayList<>(list);
+        result.add(element);
+        return result;
+    }
+
+    public GraphQLFieldDefinition mutation(String name, String fieldName,
+                                           List<GraphQLInputObjectField> inputFields,
+                                           List<GraphQLFieldDefinition> outputFields,
+                                           DataFetcher dataFetcher) {
         GraphQLInputObjectType inputObjectType = newInputObject()
                 .name(name + "Input")
-                .field(newInputObjectField()
-                        .name("clientMutationId")
-                        .type(GraphQLString))
                 .fields(inputFields)
                 .build();
         GraphQLObjectType outputType = newObject()
                 .name(name + "Payload")
-                .field(newFieldDefinition()
-                        .name("clientMutationId")
-                        .type(GraphQLString))
                 .fields(outputFields)
                 .build();
 


### PR DESCRIPTION
# Problem

A `clientMutationId` is no longer required for a Relay compliant mutation.

# Solution

Provide the method `graphql.relay.Relay#mutation` that creates a Relay compliant mutation without a `clientMutationId`.

---

### Extra Info

The need for the `clientMutationId` was removed form the [Relay Input Object Mutations Specification](https://facebook.github.io/relay/graphql/mutations.htm) with this commit facebook/relay@23a851cda10c112aa794b3480baeeb9381adf5c0. It now reads:

> All mutations **may** include in their input a `clientMutationId` string, which is then returned as part of the object returned by the mutation field.