### PR TITLE
refactor schema classes

### DIFF
--- a/src/main/java/graphql/schema2/GraphQLArgument.java
+++ b/src/main/java/graphql/schema2/GraphQLArgument.java
@@ -1,0 +1,60 @@
+package graphql.schema2;
+
+
+import graphql.PublicApi;
+import graphql.language.InputValueDefinition;
+
+import static graphql.Assert.assertNotNull;
+import static graphql.Assert.assertValidName;
+
+/**
+ * This defines an argument that can be supplied to a graphql field (via {@link graphql.schema.GraphQLFieldDefinition}.
+ *
+ * Fields can be thought of as "functions" that take arguments and return a value.
+ *
+ * See http://graphql.org/learn/queries/#arguments for more details on the concept.
+ */
+@PublicApi
+public class GraphQLArgument {
+
+    private final String name;
+    private final String description;
+    private TypeReference type;
+    private final Object defaultValue;
+    private final InputValueDefinition definition;
+
+
+    public GraphQLArgument(String name, String description, TypeReference type, Object defaultValue, InputValueDefinition definition) {
+        assertValidName(name);
+        assertNotNull(type, "type can't be null");
+        this.name = name;
+        this.description = description;
+        this.type = type;
+        this.defaultValue = defaultValue;
+        this.definition = definition;
+    }
+
+
+    public String getName() {
+        return name;
+    }
+
+    public TypeReference getType() {
+        return type;
+    }
+
+    public Object getDefaultValue() {
+        return defaultValue;
+    }
+
+
+    public String getDescription() {
+        return description;
+    }
+
+    public InputValueDefinition getDefinition() {
+        return definition;
+    }
+
+
+}

--- a/src/main/java/graphql/schema2/GraphQLCompositeType.java
+++ b/src/main/java/graphql/schema2/GraphQLCompositeType.java
@@ -1,0 +1,7 @@
+package graphql.schema2;
+
+
+import graphql.schema.GraphQLType;
+
+public interface GraphQLCompositeType extends GraphQLType {
+}

--- a/src/main/java/graphql/schema2/GraphQLDirective.java
+++ b/src/main/java/graphql/schema2/GraphQLDirective.java
@@ -1,0 +1,211 @@
+package graphql.schema2;
+
+
+import graphql.PublicApi;
+import graphql.schema.GraphQLArgument;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.function.UnaryOperator;
+
+import static graphql.Assert.assertNotNull;
+import static graphql.Assert.assertValidName;
+import static graphql.introspection.Introspection.DirectiveLocation;
+
+/**
+ * A directive can be used to modify the behavior of a graphql field.
+ *
+ * See http://graphql.org/learn/queries/#directives for more details on the concept.
+ */
+@SuppressWarnings("DeprecatedIsStillUsed") // because the graphql spec still has some of these deprecated fields
+@PublicApi
+public class GraphQLDirective {
+
+    private final String name;
+    private final String description;
+    private final EnumSet<DirectiveLocation> locations;
+    private final List<GraphQLArgument> arguments = new ArrayList<>();
+    private final boolean onOperation;
+    private final boolean onFragment;
+    private final boolean onField;
+
+    public GraphQLDirective(String name, String description, EnumSet<DirectiveLocation> locations,
+                            List<GraphQLArgument> arguments, boolean onOperation, boolean onFragment, boolean onField) {
+        assertValidName(name);
+        assertNotNull(arguments, "arguments can't be null");
+        this.name = name;
+        this.description = description;
+        this.locations = locations;
+        this.arguments.addAll(arguments);
+        this.onOperation = onOperation;
+        this.onFragment = onFragment;
+        this.onField = onField;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<GraphQLArgument> getArguments() {
+        return new ArrayList<>(arguments);
+    }
+
+    public GraphQLArgument getArgument(String name) {
+        for (GraphQLArgument argument : arguments) {
+            if (argument.getName().equals(name)) return argument;
+        }
+        return null;
+    }
+
+    public EnumSet<DirectiveLocation> validLocations() {
+        return locations;
+    }
+
+    /**
+     * @return onOperation
+     *
+     * @deprecated Use {@link #validLocations()}
+     */
+    @Deprecated
+    public boolean isOnOperation() {
+        return onOperation;
+    }
+
+    /**
+     * @return onFragment
+     *
+     * @deprecated Use {@link #validLocations()}
+     */
+    @Deprecated
+    public boolean isOnFragment() {
+        return onFragment;
+    }
+
+    /**
+     * @return onField
+     *
+     * @deprecated Use {@link #validLocations()}
+     */
+    @Deprecated
+    public boolean isOnField() {
+        return onField;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public static Builder newDirective() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String name;
+        private final EnumSet<DirectiveLocation> locations = EnumSet.noneOf(DirectiveLocation.class);
+        private final List<GraphQLArgument> arguments = new ArrayList<>();
+        private String description;
+        private boolean onOperation;
+        private boolean onFragment;
+        private boolean onField;
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public Builder validLocations(DirectiveLocation... validLocations) {
+            Collections.addAll(locations, validLocations);
+            return this;
+        }
+
+        public Builder argument(GraphQLArgument fieldArgument) {
+            arguments.add(fieldArgument);
+            return this;
+        }
+
+        /**
+         * Take an argument builder in a function definition and apply. Can be used in a jdk8 lambda
+         * e.g.:
+         * <pre>
+         *     {@code
+         *      argument(a -> a.name("argumentName"))
+         *     }
+         * </pre>
+         *
+         * @param builderFunction a supplier for the builder impl
+         *
+         * @return this
+         */
+        public Builder argument(UnaryOperator<GraphQLArgument.Builder> builderFunction) {
+            GraphQLArgument.Builder builder = GraphQLArgument.newArgument();
+            builder = builderFunction.apply(builder);
+            return argument(builder);
+        }
+
+        /**
+         * Same effect as the argument(GraphQLArgument). Builder.build() is called
+         * from within
+         *
+         * @param builder an un-built/incomplete GraphQLArgument
+         *
+         * @return this
+         */
+        public Builder argument(GraphQLArgument.Builder builder) {
+            this.arguments.add(builder.build());
+            return this;
+        }
+
+        /**
+         * @param onOperation onOperation
+         *
+         * @return this builder
+         *
+         * @deprecated Use {@code graphql.schema.GraphQLDirective.Builder#validLocations(DirectiveLocation...)}
+         */
+        @Deprecated
+        public Builder onOperation(boolean onOperation) {
+            this.onOperation = onOperation;
+            return this;
+        }
+
+        /**
+         * @param onFragment onFragment
+         *
+         * @return this builder
+         *
+         * @deprecated Use {@code graphql.schema.GraphQLDirective.Builder#validLocations(DirectiveLocation...)}
+         */
+        @Deprecated
+        public Builder onFragment(boolean onFragment) {
+            this.onFragment = onFragment;
+            return this;
+        }
+
+        /**
+         * @param onField onField
+         *
+         * @return this builder
+         *
+         * @deprecated Use {@code graphql.schema.GraphQLDirective.Builder#validLocations(DirectiveLocation...)}
+         */
+        @Deprecated
+        public Builder onField(boolean onField) {
+            this.onField = onField;
+            return this;
+        }
+
+        public GraphQLDirective build() {
+            return new GraphQLDirective(name, description, locations, arguments, onOperation, onFragment, onField);
+        }
+
+
+    }
+}

--- a/src/main/java/graphql/schema2/GraphQLEnumType.java
+++ b/src/main/java/graphql/schema2/GraphQLEnumType.java
@@ -1,0 +1,136 @@
+package graphql.schema2;
+
+
+import graphql.AssertException;
+import graphql.Internal;
+import graphql.PublicApi;
+import graphql.language.EnumTypeDefinition;
+import graphql.language.EnumValue;
+import graphql.schema.Coercing;
+import graphql.schema.CoercingParseValueException;
+import graphql.schema.CoercingSerializeException;
+import graphql.schema.GraphQLInputType;
+import graphql.schema.GraphQLNullableType;
+import graphql.schema.GraphQLOutputType;
+import graphql.schema.GraphQLType;
+import graphql.schema.GraphQLUnmodifiedType;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static graphql.Assert.assertValidName;
+
+/**
+ * A graphql enumeration type has a limited set of values.
+ *
+ * This allows you to validate that any arguments of this type are one of the allowed values
+ * and communicate through the type system that a field will always be one of a finite set of values.
+ *
+ * See http://graphql.org/learn/schema/#enumeration-types for more details
+ */
+@PublicApi
+public class GraphQLEnumType implements GraphQLType, GraphQLInputType, GraphQLOutputType, GraphQLUnmodifiedType, GraphQLNullableType {
+
+    private final String name;
+    private final String description;
+    private final Map<String, GraphQLEnumValueDefinition> valueDefinitionMap = new LinkedHashMap<>();
+    private final EnumTypeDefinition definition;
+
+    private final Coercing coercing = new Coercing() {
+        @Override
+        public Object serialize(Object input) {
+            return getNameByValue(input);
+        }
+
+        @Override
+        public Object parseValue(Object input) {
+            return getValueByName(input);
+        }
+
+        @Override
+        public Object parseLiteral(Object input) {
+            if (!(input instanceof EnumValue)) return null;
+            EnumValue enumValue = (EnumValue) input;
+            GraphQLEnumValueDefinition enumValueDefinition = valueDefinitionMap.get(enumValue.getName());
+            if (enumValueDefinition == null) return null;
+            return enumValueDefinition.getValue();
+        }
+    };
+
+
+    @Internal
+    public GraphQLEnumType(String name, String description, List<GraphQLEnumValueDefinition> values) {
+        this(name, description, values, null);
+    }
+
+    @Internal
+    public GraphQLEnumType(String name, String description, List<GraphQLEnumValueDefinition> values, EnumTypeDefinition definition) {
+        assertValidName(name);
+        this.name = name;
+        this.description = description;
+        this.definition = definition;
+        buildMap(values);
+    }
+
+    public List<GraphQLEnumValueDefinition> getValues() {
+        return new ArrayList<>(valueDefinitionMap.values());
+    }
+
+    public GraphQLEnumValueDefinition getValue(String name) {
+        return valueDefinitionMap.get(name);
+    }
+
+    private void buildMap(List<GraphQLEnumValueDefinition> values) {
+        for (GraphQLEnumValueDefinition valueDefinition : values) {
+            String name = valueDefinition.getName();
+            if (valueDefinitionMap.containsKey(name))
+                throw new AssertException("value " + name + " redefined");
+            valueDefinitionMap.put(name, valueDefinition);
+        }
+    }
+
+    private Object getValueByName(Object value) {
+        GraphQLEnumValueDefinition enumValueDefinition = valueDefinitionMap.get(value.toString());
+        if (enumValueDefinition != null) return enumValueDefinition.getValue();
+        throw new CoercingParseValueException("Invalid input for Enum '" + name + "'. No value found for name '" + value.toString() + "'");
+    }
+
+    private Object getNameByValue(Object value) {
+        for (GraphQLEnumValueDefinition valueDefinition : valueDefinitionMap.values()) {
+            Object definitionValue = valueDefinition.getValue();
+            if (value.equals(definitionValue)) {
+                return valueDefinition.getName();
+            }
+        }
+        // ok we didn't match on pure object.equals().  Lets try the Java enum strategy
+        if (value instanceof Enum) {
+            String enumNameValue = ((Enum<?>) value).name();
+            for (GraphQLEnumValueDefinition valueDefinition : valueDefinitionMap.values()) {
+                Object definitionValue = String.valueOf(valueDefinition.getValue());
+                if (enumNameValue.equals(definitionValue)) {
+                    return valueDefinition.getName();
+                }
+            }
+        }
+        throw new CoercingSerializeException("Invalid input for Enum '" + name + "'. Unknown value '" + value + "'");
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Coercing getCoercing() {
+        return coercing;
+    }
+
+    public EnumTypeDefinition getDefinition() {
+        return definition;
+    }
+
+}

--- a/src/main/java/graphql/schema2/GraphQLEnumValueDefinition.java
+++ b/src/main/java/graphql/schema2/GraphQLEnumValueDefinition.java
@@ -1,0 +1,54 @@
+package graphql.schema2;
+
+
+import graphql.PublicApi;
+
+import static graphql.Assert.assertValidName;
+
+/**
+ * A graphql enumeration type has a limited set of values and this defines one of those unique values
+ *
+ * See http://graphql.org/learn/schema/#enumeration-types for more details
+ *
+ * @see GraphQLEnumType
+ */
+@PublicApi
+public class GraphQLEnumValueDefinition {
+
+    private final String name;
+    private final String description;
+    private final Object value;
+    private final String deprecationReason;
+
+    public GraphQLEnumValueDefinition(String name, String description, Object value, String deprecationReason) {
+        assertValidName(name);
+        this.name = name;
+        this.description = description;
+        this.value = value;
+        this.deprecationReason = deprecationReason;
+    }
+
+    public GraphQLEnumValueDefinition(String name, String description, Object value) {
+        this(name, description, value, null);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+
+    public boolean isDeprecated() {
+        return deprecationReason != null;
+    }
+
+    public String getDeprecationReason() {
+        return deprecationReason;
+    }
+}

--- a/src/main/java/graphql/schema2/GraphQLFieldDefinition.java
+++ b/src/main/java/graphql/schema2/GraphQLFieldDefinition.java
@@ -1,0 +1,90 @@
+package graphql.schema2;
+
+
+import graphql.PublicApi;
+import graphql.language.FieldDefinition;
+import graphql.schema.DataFetcher;
+import graphql.schema.GraphQLArgument;
+import graphql.schema.GraphQLOutputType;
+import graphql.schema.GraphQLTypeReference;
+
+import java.util.List;
+
+/**
+ * Fields are the ways you get data values in graphql and a field definition represents a field, its type, the arguments it takes
+ * and the {@link DataFetcher} used to get data values for that field.
+ *
+ * Fields can be thought of as functions in graphql, they have a name, take defined arguments and return a value.
+ *
+ * Fields can also be deprecated, which indicates the consumers that a field wont be supported in the future.
+ *
+ * See http://graphql.org/learn/queries/#fields for more details on the concept.
+ */
+@PublicApi
+public class GraphQLFieldDefinition {
+
+    private final String name;
+    private final String description;
+    private final GraphQLTypeReference type;
+    private final String deprecationReason;
+    private final List<GraphQLArgument> arguments;
+    private final FieldDefinition definition;
+
+    public GraphQLFieldDefinition(String name, String description, GraphQLTypeReference type, String deprecationReason, List<GraphQLArgument> arguments, FieldDefinition definition) {
+        this.name = name;
+        this.description = description;
+        this.type = type;
+        this.deprecationReason = deprecationReason;
+        this.arguments = arguments;
+        this.definition = definition;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+
+    public GraphQLOutputType getType() {
+        return type;
+    }
+
+    public GraphQLArgument getArgument(String name) {
+        for (GraphQLArgument argument : arguments) {
+            if (argument.getName().equals(name)) return argument;
+        }
+        return null;
+    }
+
+    public List<GraphQLArgument> getArguments() {
+        return arguments;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public FieldDefinition getDefinition() {
+        return definition;
+    }
+
+    public String getDeprecationReason() {
+        return deprecationReason;
+    }
+
+    public boolean isDeprecated() {
+        return deprecationReason != null;
+    }
+
+    @Override
+    public String toString() {
+        return "GraphQLFieldDefinition{" +
+                "name='" + name + '\'' +
+                ", type=" + type +
+                ", arguments=" + arguments +
+                ", description='" + description + '\'' +
+                ", deprecationReason='" + deprecationReason + '\'' +
+                ", definition=" + definition +
+                '}';
+    }
+
+}

--- a/src/main/java/graphql/schema2/GraphQLFieldsContainer.java
+++ b/src/main/java/graphql/schema2/GraphQLFieldsContainer.java
@@ -1,0 +1,19 @@
+package graphql.schema2;
+
+import graphql.schema.GraphQLType;
+
+import java.util.List;
+
+
+/**
+ * Types that can contain output fields are marked with this interface
+ *
+ * @see graphql.schema.GraphQLObjectType
+ * @see graphql.schema.GraphQLInterfaceType
+ */
+public interface GraphQLFieldsContainer extends GraphQLType {
+
+    graphql.schema2.GraphQLFieldDefinition getFieldDefinition(String name);
+
+    List<graphql.schema2.GraphQLFieldDefinition> getFieldDefinitions();
+}

--- a/src/main/java/graphql/schema2/GraphQLInputFieldsContainer.java
+++ b/src/main/java/graphql/schema2/GraphQLInputFieldsContainer.java
@@ -1,0 +1,19 @@
+package graphql.schema2;
+
+import graphql.PublicApi;
+import graphql.schema.GraphQLType;
+
+import java.util.List;
+
+/**
+ * Types that can contain input fields are marked with this interface
+ *
+ * @see graphql.schema.GraphQLInputType
+ */
+@PublicApi
+public interface GraphQLInputFieldsContainer extends GraphQLType {
+
+    graphql.schema2.GraphQLInputObjectField getFieldDefinition(String name);
+
+    List<graphql.schema2.GraphQLInputObjectField> getFieldDefinitions();
+}

--- a/src/main/java/graphql/schema2/GraphQLInputObjectField.java
+++ b/src/main/java/graphql/schema2/GraphQLInputObjectField.java
@@ -1,0 +1,70 @@
+package graphql.schema2;
+
+
+import graphql.Internal;
+import graphql.PublicApi;
+import graphql.language.InputValueDefinition;
+import graphql.schema.GraphQLInputType;
+
+import static graphql.Assert.assertNotNull;
+import static graphql.Assert.assertValidName;
+
+/**
+ * Input objects defined via {@link GraphQLInputObjectType} contains these input fields.
+ *
+ * There are similar to {@link graphql.schema.GraphQLFieldDefinition} however they can ONLY be used on input objects, that
+ * is to describe values that are fed into a graphql mutation.
+ *
+ * See http://graphql.org/learn/schema/#input-types for more details on the concept.
+ */
+@PublicApi
+public class GraphQLInputObjectField {
+
+    private final String name;
+    private final String description;
+    private GraphQLInputType type;
+    private final Object defaultValue;
+    private final InputValueDefinition definition;
+
+    @Internal
+    public GraphQLInputObjectField(String name, GraphQLInputType type) {
+        this(name, null, type, null, null);
+    }
+
+    @Internal
+    public GraphQLInputObjectField(String name, String description, GraphQLInputType type, Object defaultValue) {
+        this(name, description, type, defaultValue, null);
+    }
+
+    @Internal
+    public GraphQLInputObjectField(String name, String description, GraphQLInputType type, Object defaultValue, InputValueDefinition definition) {
+        assertValidName(name);
+        assertNotNull(type, "type can't be null");
+        this.name = name;
+        this.type = type;
+        this.defaultValue = defaultValue;
+        this.description = description;
+        this.definition = definition;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public GraphQLInputType getType() {
+        return type;
+    }
+
+    public Object getDefaultValue() {
+        return defaultValue;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public InputValueDefinition getDefinition() {
+        return definition;
+    }
+
+}

--- a/src/main/java/graphql/schema2/GraphQLInputObjectType.java
+++ b/src/main/java/graphql/schema2/GraphQLInputObjectType.java
@@ -1,0 +1,85 @@
+package graphql.schema2;
+
+import graphql.AssertException;
+import graphql.Internal;
+import graphql.PublicApi;
+import graphql.language.InputObjectTypeDefinition;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static graphql.Assert.assertNotNull;
+import static graphql.Assert.assertValidName;
+
+/**
+ * graphql clearly delineates between the types of objects that represent the output of a query and input objects that
+ * can be fed into a graphql mutation.  You can define objects as input to graphql via this class
+ *
+ * See http://graphql.org/learn/schema/#input-types for more details on the concept
+ */
+@PublicApi
+public class GraphQLInputObjectType implements GraphQLType, GraphQLInputType, GraphQLUnmodifiedType, GraphQLNullableType, GraphQLInputFieldsContainer {
+
+    private final String name;
+    private final String description;
+    private final Map<String, GraphQLInputObjectField> fieldMap = new LinkedHashMap<>();
+    private final InputObjectTypeDefinition definition;
+
+    @Internal
+    public GraphQLInputObjectType(String name, String description, List<GraphQLInputObjectField> fields) {
+        this(name, description, fields, null);
+    }
+
+    @Internal
+    public GraphQLInputObjectType(String name, String description, List<GraphQLInputObjectField> fields, InputObjectTypeDefinition definition) {
+        assertValidName(name);
+        assertNotNull(fields, "fields can't be null");
+        this.name = name;
+        this.description = description;
+        this.definition = definition;
+        buildMap(fields);
+    }
+
+    private void buildMap(List<GraphQLInputObjectField> fields) {
+        for (GraphQLInputObjectField field : fields) {
+            String name = field.getName();
+            if (fieldMap.containsKey(name))
+                throw new AssertException("field " + name + " redefined");
+            fieldMap.put(name, field);
+        }
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public List<GraphQLInputObjectField> getFields() {
+        return new ArrayList<>(fieldMap.values());
+    }
+
+    public GraphQLInputObjectField getField(String name) {
+        return fieldMap.get(name);
+    }
+
+
+    @Override
+    public GraphQLInputObjectField getFieldDefinition(String name) {
+        return fieldMap.get(name);
+    }
+
+    @Override
+    public List<GraphQLInputObjectField> getFieldDefinitions() {
+        return new ArrayList<>(fieldMap.values());
+    }
+
+    public InputObjectTypeDefinition getDefinition() {
+        return definition;
+    }
+
+}

--- a/src/main/java/graphql/schema2/GraphQLInputType.java
+++ b/src/main/java/graphql/schema2/GraphQLInputType.java
@@ -1,0 +1,13 @@
+package graphql.schema2;
+
+
+import graphql.PublicApi;
+import graphql.schema.GraphQLType;
+
+/**
+ * Input types represent those set of types that are allowed to be accepted as graphql mutation input, as opposed
+ * to {@link graphql.schema.GraphQLOutputType}s which can only be used as graphql response output.
+ */
+@PublicApi
+public interface GraphQLInputType extends GraphQLType {
+}

--- a/src/main/java/graphql/schema2/GraphQLNonNull.java
+++ b/src/main/java/graphql/schema2/GraphQLNonNull.java
@@ -1,0 +1,59 @@
+package graphql.schema2;
+
+
+import graphql.PublicApi;
+import graphql.schema.GraphQLInputType;
+import graphql.schema.GraphQLModifiedType;
+import graphql.schema.GraphQLOutputType;
+import graphql.schema.GraphQLType;
+
+import static graphql.Assert.assertNotNull;
+
+/**
+ * A modified type that indicates there the underlying wrapped type will not be null.
+ *
+ * See http://graphql.org/learn/schema/#lists-and-non-null for more details on the concept
+ */
+@PublicApi
+public class GraphQLNonNull implements GraphQLType, GraphQLInputType, GraphQLOutputType, GraphQLModifiedType {
+
+    private final TypeReference wrappedType;
+
+    public GraphQLNonNull(TypeReference wrappedType) {
+        assertNotNull(wrappedType, "wrappedType can't be null");
+        this.wrappedType = wrappedType;
+    }
+
+    @Override
+    public TypeReference getWrappedType() {
+        return wrappedType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        GraphQLNonNull that = (GraphQLNonNull) o;
+
+        return !(wrappedType != null ? !wrappedType.equals(that.wrappedType) : that.wrappedType != null);
+
+    }
+
+    @Override
+    public int hashCode() {
+        return wrappedType != null ? wrappedType.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return "GraphQLNonNull{" +
+                "wrappedType=" + wrappedType +
+                '}';
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+}

--- a/src/main/java/graphql/schema2/GraphQLNullableType.java
+++ b/src/main/java/graphql/schema2/GraphQLNullableType.java
@@ -1,0 +1,7 @@
+package graphql.schema2;
+
+
+import graphql.schema.GraphQLType;
+
+public interface GraphQLNullableType extends GraphQLType {
+}

--- a/src/main/java/graphql/schema2/GraphQLObjectType.java
+++ b/src/main/java/graphql/schema2/GraphQLObjectType.java
@@ -1,0 +1,101 @@
+package graphql.schema2;
+
+import graphql.AssertException;
+import graphql.Internal;
+import graphql.PublicApi;
+import graphql.language.ObjectTypeDefinition;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static graphql.Assert.assertNotNull;
+import static graphql.Assert.assertValidName;
+import static java.lang.String.format;
+
+/**
+ * This is the work horse type and represents an object with one or more field values that can be retrieved
+ * by the graphql system.
+ *
+ * Those fields can themselves by object types and so on until you reach the leaf nodes of the type tree represented
+ * by {@link graphql.schema.GraphQLScalarType}s.
+ *
+ * See http://graphql.org/learn/schema/#object-types-and-fields for more details on the concept.
+ */
+@PublicApi
+public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQLFieldsContainer, GraphQLCompositeType, GraphQLUnmodifiedType, GraphQLNullableType {
+
+
+    private final String name;
+    private final String description;
+    private final Map<String, GraphQLFieldDefinition> fieldDefinitionsByName = new LinkedHashMap<>();
+    private List<TypeReference> interfaces = new ArrayList<>();
+    private final ObjectTypeDefinition definition;
+
+
+    @Internal
+    public GraphQLObjectType(String name, String description, List<GraphQLFieldDefinition> fieldDefinitions,
+                             List<TypeReference> interfaces, ObjectTypeDefinition definition) {
+        assertValidName(name);
+        assertNotNull(fieldDefinitions, "fieldDefinitions can't be null");
+        assertNotNull(interfaces, "interfaces can't be null");
+        this.name = name;
+        this.description = description;
+        this.interfaces = interfaces;
+        this.definition = definition;
+        buildDefinitionMap(fieldDefinitions);
+    }
+
+    private void buildDefinitionMap(List<GraphQLFieldDefinition> fieldDefinitions) {
+        for (GraphQLFieldDefinition fieldDefinition : fieldDefinitions) {
+            String name = fieldDefinition.getName();
+            if (fieldDefinitionsByName.containsKey(name))
+                throw new AssertException(format("Duplicated definition for field '%s' in type '%s'", name, this.name));
+            fieldDefinitionsByName.put(name, fieldDefinition);
+        }
+    }
+
+    public GraphQLFieldDefinition getFieldDefinition(String name) {
+        return fieldDefinitionsByName.get(name);
+    }
+
+
+    public List<GraphQLFieldDefinition> getFieldDefinitions() {
+        return new ArrayList<>(fieldDefinitionsByName.values());
+    }
+
+
+    /**
+     * @return This returns GraphQLInterface or GraphQLTypeReference instances, if the type
+     * references are not resolved yet. After they are resolved it contains only GraphQLInterface.
+     * Reference resolving happens when a full schema is built.
+     */
+    public List<TypeReference> getInterfaces() {
+        return new ArrayList<>(interfaces);
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+
+    public String getName() {
+        return name;
+    }
+
+    public ObjectTypeDefinition getDefinition() {
+        return definition;
+    }
+
+    @Override
+    public String toString() {
+        return "GraphQLObjectType{" +
+                "name='" + name + '\'' +
+                ", description='" + description + '\'' +
+                ", fieldDefinitionsByName=" + fieldDefinitionsByName.keySet() +
+                ", interfaces=" + interfaces +
+                '}';
+    }
+
+}

--- a/src/main/java/graphql/schema2/GraphQLOutputType.java
+++ b/src/main/java/graphql/schema2/GraphQLOutputType.java
@@ -1,0 +1,13 @@
+package graphql.schema2;
+
+
+import graphql.PublicApi;
+import graphql.schema.GraphQLType;
+
+/**
+ * Output types represent those set of types that are allowed to be sent back as a graphql response, as opposed
+ * to {@link graphql.schema.GraphQLInputType}s which can only be used as graphql mutation input.
+ */
+@PublicApi
+public interface GraphQLOutputType extends GraphQLType {
+}

--- a/src/main/java/graphql/schema2/GraphQLSchema.java
+++ b/src/main/java/graphql/schema2/GraphQLSchema.java
@@ -1,0 +1,31 @@
+package graphql.schema2;
+
+import graphql.schema.visibility.GraphqlFieldVisibility;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class GraphQLSchema {
+
+    private final GraphQLObjectType queryType;
+    private final GraphQLObjectType mutationType;
+    private final GraphQLObjectType subscriptionType;
+    private final Map<String, GraphQLType> types = new LinkedHashMap<>();
+    private final Set<GraphQLType> additionalTypes;
+    private final Set<GraphQLDirective> directives;
+    private final GraphqlFieldVisibility fieldVisibility;
+
+    public GraphQLSchema(GraphQLObjectType queryType, GraphQLObjectType mutationType, GraphQLObjectType subscriptionType, Set<GraphQLType> additionalTypes, Set<GraphQLDirective> directives, GraphqlFieldVisibility fieldVisibility) {
+        this.queryType = queryType;
+        this.mutationType = mutationType;
+        this.subscriptionType = subscriptionType;
+        this.additionalTypes = additionalTypes;
+        this.directives = directives;
+        this.fieldVisibility = fieldVisibility;
+    }
+
+    public GraphQLType resolveTypeReference(TypeReference typeReference) {
+        return types.get(typeReference.getName());
+    }
+}

--- a/src/main/java/graphql/schema2/GraphQLSchemaLogic.java
+++ b/src/main/java/graphql/schema2/GraphQLSchemaLogic.java
@@ -1,0 +1,14 @@
+package graphql.schema2;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.TypeResolver;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class GraphQLSchemaLogic {
+
+    private final Map<String, DataFetcher> dataFetcherMap = new LinkedHashMap<>();
+    private final Map<String, TypeResolver> typeResolverMap = new LinkedHashMap<>();
+    private final Map<String, Object> metadata = new LinkedHashMap<>();
+}

--- a/src/main/java/graphql/schema2/GraphQLType.java
+++ b/src/main/java/graphql/schema2/GraphQLType.java
@@ -1,0 +1,15 @@
+package graphql.schema2;
+
+
+import graphql.PublicApi;
+
+/**
+ * All types in graphql have a name
+ */
+@PublicApi
+public interface GraphQLType {
+    /**
+     * @return the name of the type which MUST fit within the regular expression {@code [_A-Za-z][_0-9A-Za-z]*}
+     */
+    String getName();
+}

--- a/src/main/java/graphql/schema2/GraphQLUnionType.java
+++ b/src/main/java/graphql/schema2/GraphQLUnionType.java
@@ -1,0 +1,146 @@
+package graphql.schema2;
+
+
+import graphql.Internal;
+import graphql.PublicApi;
+import graphql.language.UnionTypeDefinition;
+import graphql.schema.GraphQLCompositeType;
+import graphql.schema.GraphQLNullableType;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLOutputType;
+import graphql.schema.GraphQLType;
+import graphql.schema.GraphQLTypeReference;
+import graphql.schema.GraphQLUnmodifiedType;
+import graphql.schema.TypeResolver;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static graphql.Assert.assertNotEmpty;
+import static graphql.Assert.assertNotNull;
+import static graphql.Assert.assertValidName;
+
+/**
+ * A union type is a polymorphic type that dynamically represents one of more concrete object types.
+ *
+ * At runtime a {@link TypeResolver} is used to take an union object value and decide what {@link GraphQLObjectType}
+ * represents this union of types.
+ *
+ * Note that members of a union type need to be concrete object types; you can't create a union type out of interfaces or other unions.
+ *
+ * See http://graphql.org/learn/schema/#union-types for more details on the concept.
+ */
+@PublicApi
+public class GraphQLUnionType implements GraphQLType, GraphQLOutputType, GraphQLCompositeType, GraphQLUnmodifiedType, GraphQLNullableType {
+
+    private final String name;
+    private final String description;
+    private List<TypeReference> types = new ArrayList<>();
+    private final UnionTypeDefinition definition;
+
+
+    @Internal
+    public GraphQLUnionType(String name, String description, List<GraphQLOutputType> types, TypeResolver typeResolver) {
+        this(name, description, types, typeResolver, null);
+    }
+
+    @Internal
+    public GraphQLUnionType(String name, String description, List<TypeReference> types, TypeResolver typeResolver, UnionTypeDefinition definition) {
+        assertValidName(name);
+        assertNotNull(types, "types can't be null");
+        assertNotEmpty(types, "A Union type must define one or more member types.");
+        assertNotNull(typeResolver, "typeResolver can't be null");
+        this.name = name;
+        this.description = description;
+        this.types = types;
+        this.definition = definition;
+    }
+
+    /**
+     * @return This returns GraphQLObjectType or GraphQLTypeReference instances, if the type
+     * references are not resolved yet. After they are resolved it contains only GraphQLObjectType.
+     * Reference resolving happens when a full schema is built.
+     */
+    public List<TypeReference> getTypes() {
+        return new ArrayList<>(types);
+    }
+
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public UnionTypeDefinition getDefinition() {
+        return definition;
+    }
+
+    public static Builder newUnionType() {
+        return new Builder();
+    }
+
+    @PublicApi
+    public static class Builder {
+        private String name;
+        private String description;
+        private final List<GraphQLOutputType> types = new ArrayList<>();
+        private TypeResolver typeResolver;
+        private UnionTypeDefinition definition;
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public Builder definition(UnionTypeDefinition definition) {
+            this.definition = definition;
+            return this;
+        }
+
+
+        public Builder typeResolver(TypeResolver typeResolver) {
+            this.typeResolver = typeResolver;
+            return this;
+        }
+
+
+        public Builder possibleType(GraphQLObjectType type) {
+            assertNotNull(type, "possible type can't be null");
+            types.add(type);
+            return this;
+        }
+
+        public Builder possibleType(GraphQLTypeReference reference) {
+            assertNotNull(reference, "reference can't be null");
+            types.add(reference);
+            return this;
+        }
+
+        public Builder possibleTypes(GraphQLObjectType... type) {
+            for (GraphQLObjectType graphQLType : type) {
+                possibleType(graphQLType);
+            }
+            return this;
+        }
+
+        public Builder possibleTypes(GraphQLTypeReference... references) {
+            for (GraphQLTypeReference reference : references) {
+                possibleType(reference);
+            }
+            return this;
+        }
+
+        public GraphQLUnionType build() {
+            return new GraphQLUnionType(name, description, types, typeResolver, definition);
+        }
+    }
+}

--- a/src/main/java/graphql/schema2/GraphQLUnmodifiedType.java
+++ b/src/main/java/graphql/schema2/GraphQLUnmodifiedType.java
@@ -1,0 +1,7 @@
+package graphql.schema2;
+
+
+import graphql.schema.GraphQLType;
+
+public interface GraphQLUnmodifiedType extends GraphQLType {
+}

--- a/src/main/java/graphql/schema2/TypeReference.java
+++ b/src/main/java/graphql/schema2/TypeReference.java
@@ -1,0 +1,14 @@
+package graphql.schema2;
+
+public class TypeReference {
+
+    private final String name;
+
+    public TypeReference(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/graphql/schema2/builder/GraphQLObjectTypeBuilder.java
+++ b/src/main/java/graphql/schema2/builder/GraphQLObjectTypeBuilder.java
@@ -1,0 +1,109 @@
+package graphql.schema2.builder;
+
+import graphql.language.ObjectTypeDefinition;
+import graphql.schema2.GraphQLFieldDefinition;
+import graphql.schema2.GraphQLOutputType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class GraphQLObjectTypeBuilder {
+
+    private String name;
+    private String description;
+    private final List<GraphQLFieldDefinition> fieldDefinitions = new ArrayList<>();
+    private final List<GraphQLOutputType> interfaces = new ArrayList<>();
+    private ObjectTypeDefinition definition;
+
+    public GraphQLObjectTypeBuilder name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public GraphQLObjectTypeBuilder description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public GraphQLObjectTypeBuilder definition(ObjectTypeDefinition definition) {
+        this.definition = definition;
+        return this;
+    }
+
+    public GraphQLObjectTypeBuilder field(GraphQLFieldDefinition fieldDefinition) {
+        assertNotNull(fieldDefinition, "fieldDefinition can't be null");
+        this.fieldDefinitions.add(fieldDefinition);
+        return this;
+    }
+
+    /**
+     * Take a field builder in a function definition and apply. Can be used in a jdk8 lambda
+     * e.g.:
+     * <pre>
+     *     {@code
+     *      field(f -> f.name("fieldName"))
+     *     }
+     * </pre>
+     *
+     * @param builderFunction a supplier for the builder impl
+     *
+     * @return this
+     */
+    public GraphQLObjectTypeBuilder field(UnaryOperator<GraphQLFieldDefinition.Builder> builderFunction) {
+        assertNotNull(builderFunction, "builderFunction can't be null");
+        GraphQLFieldDefinition.Builder builder = GraphQLFieldDefinition.newFieldDefinition();
+        builder = builderFunction.apply(builder);
+        return field(builder.build());
+    }
+
+    /**
+     * Same effect as the field(GraphQLFieldDefinition). Builder.build() is called
+     * from within
+     *
+     * @param builder an un-built/incomplete GraphQLFieldDefinition
+     *
+     * @return this
+     */
+    public GraphQLObjectTypeBuilder field(GraphQLFieldDefinition.Builder builder) {
+        this.fieldDefinitions.add(builder.build());
+        return this;
+    }
+
+    public Builder fields(List<GraphQLFieldDefinition> fieldDefinitions) {
+        assertNotNull(fieldDefinitions, "fieldDefinitions can't be null");
+        this.fieldDefinitions.addAll(fieldDefinitions);
+        return this;
+    }
+
+    public Builder withInterface(GraphQLInterfaceType interfaceType) {
+        assertNotNull(interfaceType, "interfaceType can't be null");
+        this.interfaces.add(interfaceType);
+        return this;
+    }
+
+    public Builder withInterface(GraphQLTypeReference reference) {
+        assertNotNull(reference, "reference can't be null");
+        this.interfaces.add(reference);
+        return this;
+    }
+
+    public Builder withInterfaces(GraphQLInterfaceType... interfaceType) {
+        for (GraphQLInterfaceType type : interfaceType) {
+            withInterface(type);
+        }
+        return this;
+    }
+
+    public Builder withInterfaces(GraphQLTypeReference... references) {
+        for (GraphQLTypeReference reference : references) {
+            withInterface(reference);
+        }
+        return this;
+    }
+
+    public GraphQLObjectType build() {
+        return new GraphQLObjectType(name, description, fieldDefinitions, interfaces, definition);
+    }
+
+}
+}


### PR DESCRIPTION
This is a very rough spike (won't even compile) about refactoring the core schema classes of graphql-java.

There are a few things that got mixed up and are too tightly coupled over the years, this spike is an attempt to correct that:

- The Builder of the schema objects are directly embedded into the schema classes itself. It should be separated to allow maybe other kinds of builders in the futures. They are also not so important anymore as they where: when this project was started the Builders were they only way to create schemas. We recommend now to uses SDL based approaches.

- TypeReferences should be just names: I underestimated the problem of recursive type references at the beginning. The result is an awkward attempt to make it immutable when the schema is created. Now type references are just names and you have to manually resolve it against a schema. This simplifies the overall handling and makes it more clear.

- Logic should be separated from Data: DataFetcher and other "logic" should not be living in the same class as the data which describes the schema. By separating it (see GraphQLSchemaLogic) we can finally implement equals/hashcode for the schema classes. This will also allow us the attach more flexible metadata in the same way while preserving the schema data itself (which we can easily copy/modify because it is very lightweight even for very large schemas.)


@bbakerman thoughts?

P.S.: The migration path is not completely clear for now. I would like to get some feedback first.
