### PR TITLE
Make propertyName protected instead of private to allow extend-ability

### DIFF
--- a/src/main/java/graphql/schema/PropertyDataFetcher.java
+++ b/src/main/java/graphql/schema/PropertyDataFetcher.java
@@ -42,8 +42,8 @@ import static graphql.Scalars.GraphQLBoolean;
 @PublicApi
 public class PropertyDataFetcher<T> implements DataFetcher<T> {
 
-    private final String propertyName;
-    private final Function<Object, Object> function;
+    protected final String propertyName;
+    protected final Function<Object, Object> function;
 
     /**
      * This constructor will use the property name and examine the {@link DataFetchingEnvironment#getSource()}


### PR DESCRIPTION
Currently PropertyDataFetcher is not extendable since propertyName field is private. we have cases we'd like to extend it in order to use different getter algorithm on some fields but not all (e.g. one field is a jsonObject which we get values from).
Today we need to wrap the PropertyDataFetcher with our impelentation of DataFetcher and call PropertyDataFetcher in case source is not instance of JsonObject (similar to what you do with maps). making propertyName protected will make it cleaner - extend the class and call super.get()