### PR TITLE
Error if 'first' or 'last' is negative for a Relay connection argument

### DIFF
--- a/src/main/java/graphql/relay/InvalidPageSizeException.java
+++ b/src/main/java/graphql/relay/InvalidPageSizeException.java
@@ -1,0 +1,43 @@
+package graphql.relay;
+
+import graphql.ErrorType;
+import graphql.GraphQLError;
+import graphql.GraphqlErrorHelper;
+import graphql.language.SourceLocation;
+
+import java.util.List;
+
+import static graphql.ErrorType.DataFetchingException;
+
+public class InvalidPageSizeException extends RuntimeException implements GraphQLError {
+
+    InvalidPageSizeException(String message) {
+        this(message, null);
+    }
+
+    InvalidPageSizeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    @Override
+    public List<SourceLocation> getLocations() {
+        return null;
+    }
+
+    @Override
+    public ErrorType getErrorType() {
+        return DataFetchingException;
+    }
+
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
+    @Override
+    public boolean equals(Object o) {
+        return GraphqlErrorHelper.equals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return GraphqlErrorHelper.hashCode(this);
+    }
+
+}

--- a/src/main/java/graphql/relay/SimpleListConnection.java
+++ b/src/main/java/graphql/relay/SimpleListConnection.java
@@ -58,16 +58,22 @@ public class SimpleListConnection<T> implements DataFetcher<Connection<T>> {
             return emptyConnection();
         }
 
-        Integer first = environment.<Integer>getArgument("first");
-        Integer last = environment.<Integer>getArgument("last");
+        Integer first = environment.getArgument("first");
+        Integer last = environment.getArgument("last");
 
         ConnectionCursor firstPresliceCursor = edges.get(0).getCursor();
         ConnectionCursor lastPresliceCursor = edges.get(edges.size() - 1).getCursor();
 
         if (first != null) {
+            if (first < 0) {
+                throw new InvalidPageSizeException(format("The page size must not be negative: 'first'=%s", first));
+            }
             edges = edges.subList(0, first <= edges.size() ? first : edges.size());
         }
         if (last != null) {
+            if (last < 0) {
+                throw new InvalidPageSizeException(format("The page size must not be negative: 'last'=%s", last));
+            }
             edges = edges.subList(last > edges.size() ? 0 : edges.size() - last, edges.size());
         }
 


### PR DESCRIPTION
# Problem

`graphql.relay.SimpleListConnection` does not give an error if either the `first` or `last` argument is negative.

# Solution

Throw an exception if the value of either the `first` or `last` argument is negative.

---

### Extra Details

The [Relay Cursor Connections Specification](https://facebook.github.io/relay/graphql/connections.htm) section on the [Pagination Algorithm](https://facebook.github.io/relay/graphql/connections.htm#sec-Pagination-algorithm) says:

> If `first` is less than 0: Throw an error

and

> If `last` is less than 0: Throw an error