### PR TITLE
Use correct preslice cursors in SimpleListConnection

### DIFF
--- a/src/main/java/graphql/relay/SimpleListConnection.java
+++ b/src/main/java/graphql/relay/SimpleListConnection.java
@@ -46,6 +46,9 @@ public class SimpleListConnection<T> implements DataFetcher<Connection<T>> {
 
         List<Edge<T>> edges = buildEdges();
 
+        ConnectionCursor firstPresliceCursor = edges.get(0).getCursor();
+        ConnectionCursor lastPresliceCursor = edges.get(edges.size() - 1).getCursor();
+
         int afterOffset = getOffsetFromCursor(environment.getArgument("after"), -1);
         int begin = Math.max(afterOffset, -1) + 1;
         int beforeOffset = getOffsetFromCursor(environment.getArgument("before"), edges.size());
@@ -60,9 +63,6 @@ public class SimpleListConnection<T> implements DataFetcher<Connection<T>> {
 
         Integer first = environment.<Integer>getArgument("first");
         Integer last = environment.<Integer>getArgument("last");
-
-        ConnectionCursor firstPresliceCursor = edges.get(0).getCursor();
-        ConnectionCursor lastPresliceCursor = edges.get(edges.size() - 1).getCursor();
 
         if (first != null) {
             edges = edges.subList(0, first <= edges.size() ? first : edges.size());


### PR DESCRIPTION
# Problem

When using `graphql.relay.SimpleListConnection`: `PageInfo/hasPerviousPage` is always `false` when using the `after` argument and `PageInfo/hasNextPage` is always `false` when using the `before` argument.

This is because the `firstPresliceCursor` and `lastPresliceCursor` are being taken **AFTER** the original `edges` have been sliced based on the `before` and `after` cursor arguments.

# Solution

Take the `firstPresliceCursor` and `lastPresliceCursor` as soon the original `edges` list is computed.

--- 

### More Detail

The current time that the `firstPresliceCursor` and `lastPresliceCursor` are taken (after taking a sublist based on the cursors):

https://github.com/graphql-java/graphql-java/blob/2fc5fdacf3bf58967cdf515a1f379803e492cf18/src/main/java/graphql/relay/SimpleListConnection.java#L47-L65

