### PR TITLE
Add operationName condition

### DIFF
--- a/src/main/java/graphql/language/NodeUtil.java
+++ b/src/main/java/graphql/language/NodeUtil.java
@@ -77,7 +77,7 @@ public class NodeUtil {
         }
         OperationDefinition operation;
 
-        if (operationName == null) {
+        if (operationName == null || operationName == "") {
             operation = operationsByName.values().iterator().next();
         } else {
             operation = operationsByName.get(operationName);


### PR DESCRIPTION
When I use operationName in blank, this code generate an exception.      

```
 ExecutionInput.newExecutionInput()
                .query(query.get("query").toString())
                .variables((Map) query.get("variables"))
                .operationName(query.getOrDefault("operationName", "").toString())
                .build();
```  

`query`is HashMap.   when map has not operationName key, It is return blank.

if operationName is blank,  previous code generate an exception.
So, add the code to check the blank.

sorry .. I am not good at English. :( 