### PR TITLE
Change operationName condition (2)

### DIFF
--- a/src/main/java/graphql/language/NodeUtil.java
+++ b/src/main/java/graphql/language/NodeUtil.java
@@ -77,7 +77,7 @@ public class NodeUtil {
         }
         OperationDefinition operation;
 
-        if (operationName == null || "".equals(operationName)) {
+        if (operationName == null || operationName.isEmpty()) {
             operation = operationsByName.values().iterator().next();
         } else {
             operation = operationsByName.get(operationName);


### PR DESCRIPTION
#845  

I was heard advice that str.isEmpty() is better then "".equals(). 

So, I modify the code  ! 

etc  

I am considering Whether or not Optional Type  is available. 

```
     //  A
     final Optional<String> optional = Optional.of(operationName);
     Predicate<String> emptyCheck = String::isEmpty;
     if(optional.filter(emptyCheck.negate()).isPresent()){
            //
     }

    // B

     if (operationName == null || operationName.isEmpty()) {
           //
    }

```   

But I think that A is not clean...

So, I used the code you gave me !   

Thank you for teaching me 👍 
