### PR TITLE
Assert performance improvement

### DIFF
--- a/src/main/java/graphql/Assert.java
+++ b/src/main/java/graphql/Assert.java
@@ -2,12 +2,14 @@ package graphql;
 
 import java.util.Collection;
 
+import static java.lang.String.format;
+
 @Internal
 public class Assert {
 
-    public static <T> T assertNotNull(T object, String errorMessage) {
+    public static <T> T assertNotNull(T object, String format, Object... args) {
         if (object != null) return object;
-        throw new AssertException(errorMessage);
+        throw new AssertException(format(format, args));
     }
 
     public static <T> T assertNotNull(T object) {
@@ -19,22 +21,23 @@ public class Assert {
         throw new AssertException("Should never been called");
     }
 
-    public static <T> T assertShouldNeverHappen(String errorMessage) {
-        throw new AssertException("Internal error: should never happen: " + errorMessage);
+    public static <T> T assertShouldNeverHappen(String format, Object... args) {
+        throw new AssertException("Internal error: should never happen: " + format(format, args));
     }
 
     public static <T> T assertShouldNeverHappen() {
         throw new AssertException("Internal error: should never happen");
     }
 
-    public static <T> Collection<T> assertNotEmpty(Collection<T> c, String errorMessage) {
-        if (c == null || c.isEmpty()) throw new AssertException(errorMessage);
+    public static <T> Collection<T> assertNotEmpty(Collection<T> c, String format, Object... args) {
+        if (c == null || c.isEmpty())
+            throw new AssertException(format(format, args));
         return c;
     }
 
-    public static void assertTrue(boolean condition, String errorMessage) {
+    public static void assertTrue(boolean condition, String format, Object... args) {
         if (condition) return;
-        throw new AssertException(errorMessage);
+        throw new AssertException(format(format, args));
     }
 
     private static final String invalidNameErrorMessage = "Name must be non-null, non-empty and match [_A-Za-z][_0-9A-Za-z]*";

--- a/src/main/java/graphql/execution/ExecutionPath.java
+++ b/src/main/java/graphql/execution/ExecutionPath.java
@@ -10,6 +10,7 @@ import java.util.StringTokenizer;
 
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertTrue;
+import static java.lang.String.format;
 
 
 /**
@@ -60,15 +61,15 @@ public class ExecutionPath {
         while (st.hasMoreTokens()) {
             String token = st.nextToken();
             if ("/".equals(token)) {
-                assertTrue(st.hasMoreTokens(), mkErrMsg(pathString));
+                assertTrue(st.hasMoreTokens(), mkErrMsg(), pathString);
                 path = path.segment(st.nextToken());
             } else if ("[".equals(token)) {
-                assertTrue(st.countTokens() >= 2, mkErrMsg(pathString));
+                assertTrue(st.countTokens() >= 2, mkErrMsg(), pathString);
                 path = path.segment(Integer.parseInt(st.nextToken()));
                 String closingBrace = st.nextToken();
-                assertTrue(closingBrace.equals("]"), mkErrMsg(pathString));
+                assertTrue(closingBrace.equals("]"), mkErrMsg(), pathString);
             } else {
-                throw new AssertException(mkErrMsg(pathString));
+                throw new AssertException(format(mkErrMsg(), pathString));
             }
         }
         return path;
@@ -94,8 +95,8 @@ public class ExecutionPath {
         return path;
     }
 
-    private static String mkErrMsg(String pathString) {
-        return "Invalid path string : '" + pathString + "'";
+    private static String mkErrMsg() {
+        return "Invalid path string : '%s'";
     }
 
     /**

--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -176,7 +176,7 @@ public class ValuesResolver {
                 );
             }
         } else {
-            return assertShouldNeverHappen("unhandled type " + graphQLType);
+            return assertShouldNeverHappen("unhandled type %s", graphQLType);
         }
     }
 

--- a/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
+++ b/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
@@ -313,7 +313,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
         } else if (isList(unwrappedFieldType)) {
             return handleList(executionContext, argumentValues, fetchedValues, fieldName, fields, typeInfo);
         } else {
-            return Assert.assertShouldNeverHappen("can't handle type: " + unwrappedFieldType);
+            return Assert.assertShouldNeverHappen("can't handle type: %s", unwrappedFieldType);
         }
     }
 

--- a/src/main/java/graphql/introspection/Introspection.java
+++ b/src/main/java/graphql/introspection/Introspection.java
@@ -83,7 +83,7 @@ public class Introspection {
         } else if (type instanceof GraphQLNonNull) {
             return TypeKind.NON_NULL;
         } else {
-            return Assert.assertShouldNeverHappen("Unknown kind of type: " + type);
+            return Assert.assertShouldNeverHappen("Unknown kind of type: %s", type);
         }
     };
 
@@ -496,10 +496,10 @@ public class Introspection {
             return TypeNameMetaFieldDef;
         }
 
-        assertTrue(parentType instanceof GraphQLFieldsContainer, "should not happen : parent type must be an object or interface : " + parentType);
+        assertTrue(parentType instanceof GraphQLFieldsContainer, "should not happen : parent type must be an object or interface %s", parentType);
         GraphQLFieldsContainer fieldsContainer = (GraphQLFieldsContainer) parentType;
         GraphQLFieldDefinition fieldDefinition = schema.getFieldVisibility().getFieldDefinition(fieldsContainer, fieldName);
-        Assert.assertTrue(fieldDefinition != null, "Unknown field " + fieldName);
+        Assert.assertTrue(fieldDefinition != null, "Unknown field '%s'", fieldName);
         return fieldDefinition;
     }
 }

--- a/src/main/java/graphql/introspection/IntrospectionResultToSchema.java
+++ b/src/main/java/graphql/introspection/IntrospectionResultToSchema.java
@@ -122,7 +122,7 @@ public class IntrospectionResultToSchema {
             case "SCALAR":
                 return createScalar(type);
             default:
-                return assertShouldNeverHappen("unexpected kind " + kind);
+                return assertShouldNeverHappen("unexpected kind %s", kind);
         }
     }
 
@@ -275,7 +275,7 @@ public class IntrospectionResultToSchema {
             case "LIST":
                 return new ListType(createTypeIndirection((Map<String, Object>) type.get("ofType")));
             default:
-                return assertShouldNeverHappen("Unknown kind " + kind);
+                return assertShouldNeverHappen("Unknown kind %s", kind);
         }
     }
 

--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -138,7 +138,7 @@ public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
             }
         }
         if (required) {
-            Assert.assertShouldNeverHappen("not found" + contextProperty);
+            Assert.assertShouldNeverHappen("not found %s", contextProperty);
         }
         return null;
     }
@@ -202,7 +202,7 @@ public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
         } else if (operationTypeContext.getText().equals("subscription")) {
             return OperationDefinition.Operation.SUBSCRIPTION;
         } else {
-            return Assert.assertShouldNeverHappen("InternalError: unknown operationTypeContext=" + operationTypeContext.getText());
+            return Assert.assertShouldNeverHappen("InternalError: unknown operationTypeContext=%s", operationTypeContext.getText());
         }
     }
 

--- a/src/main/java/graphql/schema/SchemaUtil.java
+++ b/src/main/java/graphql/schema/SchemaUtil.java
@@ -63,7 +63,7 @@ public class SchemaUtil {
         } else if (root instanceof GraphQLTypeReference) {
             // nothing to do
         } else {
-            Assert.assertShouldNeverHappen("Unknown type " + root);
+            Assert.assertShouldNeverHappen("Unknown type %s", root);
         }
     }
 
@@ -218,7 +218,7 @@ public class SchemaUtil {
     GraphQLType resolveTypeReference(GraphQLType type, Map<String, GraphQLType> typeMap) {
         if (type instanceof GraphQLTypeReference || typeMap.containsKey(type.getName())) {
             GraphQLType resolvedType = typeMap.get(type.getName());
-            Assert.assertTrue(resolvedType != null, "type " + type.getName() + " not found in schema");
+            Assert.assertTrue(resolvedType != null, "type %s not found in schema", type.getName());
             return resolvedType;
         }
         if (type instanceof GraphQLList) {

--- a/src/main/java/graphql/schema/idl/SchemaGenerator.java
+++ b/src/main/java/graphql/schema/idl/SchemaGenerator.java
@@ -440,7 +440,7 @@ public class SchemaGenerator {
             Object value;
             if (enumValuesProvider != null) {
                 value = enumValuesProvider.getValue(evd.getName());
-                assertNotNull(value, String.format("EnumValuesProvider for %s returned null for %s", typeDefinition.getName(), evd.getName()));
+                assertNotNull(value, "EnumValuesProvider for %s returned null for %s", typeDefinition.getName(), evd.getName());
             } else {
                 value = evd.getName();
             }
@@ -564,7 +564,7 @@ public class SchemaGenerator {
             result = buildObjectValue((ObjectValue) value, (GraphQLInputObjectType) requiredType);
         } else if (value != null && !(value instanceof NullValue)) {
             Assert.assertShouldNeverHappen(
-                    "cannot build value of " + requiredType.getName() + " from " + String.valueOf(value));
+                    "cannot build value of %s from %s", requiredType.getName(), String.valueOf(value));
         }
         return result;
     }

--- a/src/test/groovy/graphql/AssertTest.groovy
+++ b/src/test/groovy/graphql/AssertTest.groovy
@@ -1,0 +1,153 @@
+package graphql
+
+import spock.lang.Specification
+
+class AssertTest extends Specification {
+    def "assertNull should not throw on none null value"() {
+        when:
+        Assert.assertNotNull("some object")
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "assertNull should throw on null value"() {
+        when:
+        Assert.assertNotNull(null)
+
+        then:
+        thrown(AssertException)
+    }
+
+    def "assertNull with error message should not throw on none null value"() {
+        when:
+        Assert.assertNotNull("some object", "error message")
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "assertNull with error message should throw on null value with formatted message"() {
+        when:
+        Assert.assertNotNull(value, format, arg)
+
+        then:
+        def error = thrown(AssertException)
+        error.message == expectedMessage
+
+        where:
+        value | format     | arg   || expectedMessage
+        null  | "error %s" | "msg" || "error msg"
+        null  | "code %d"  | 1     || "code 1"
+        null  | "code"     | null  || "code"
+    }
+
+    def "assertNeverCalled should always throw"() {
+        when:
+        Assert.assertNeverCalled()
+
+        then:
+        def e = thrown(AssertException)
+        e.message == "Should never been called"
+    }
+
+    def "assertShouldNeverHappen should always throw"() {
+        when:
+        Assert.assertShouldNeverHappen()
+
+        then:
+        def e = thrown(AssertException)
+        e.message == "Internal error: should never happen"
+    }
+
+    def "assertShouldNeverHappen should always throw with formatted message"() {
+        when:
+        Assert.assertShouldNeverHappen(format, arg)
+
+        then:
+        def error = thrown(AssertException)
+        error.message == "Internal error: should never happen: " + expectedMessage
+
+        where:
+        format     | arg   || expectedMessage
+        "error %s" | "msg" || "error msg"
+        "code %d"  | 1     || "code 1"
+        "code"     | null  || "code"
+    }
+
+    def "assertNotEmpty collection should throw on null or empty"() {
+        when:
+        Assert.assertNotEmpty(value, format, arg)
+
+        then:
+        def error = thrown(AssertException)
+        error.message == expectedMessage
+
+        where:
+        value | format     | arg   || expectedMessage
+        null  | "error %s" | "msg" || "error msg"
+        []    | "code %d"  | 1     || "code 1"
+    }
+
+    def "assertNotEmpty should not throw on none empty collection"() {
+        when:
+        Assert.assertNotEmpty(["some object"], "error message")
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "assertTrue should not throw on true value"() {
+        when:
+        Assert.assertTrue(true, "error message")
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "assertTrue with error message should throw on false value with formatted message"() {
+        when:
+        Assert.assertTrue(false, format, arg)
+
+        then:
+        def error = thrown(AssertException)
+        error.message == expectedMessage
+
+        where:
+        format     | arg   || expectedMessage
+        "error %s" | "msg" || "error msg"
+        "code %d"  | 1     || "code 1"
+        "code"     | null  || "code"
+    }
+
+    def "assertValidName should not throw on valid names"() {
+        when:
+        Assert.assertValidName(name)
+
+        then:
+        noExceptionThrown()
+
+        where:
+        name     | _
+        "msg"    | _
+        "__"     | _
+        "_01"    | _
+        "_a01b1" | _
+
+    }
+
+    def "assertValidName should throw on invalid names"() {
+        when:
+        Assert.assertValidName(name)
+
+        then:
+        def error = thrown(AssertException)
+        error.message == "Name must be non-null, non-empty and match [_A-Za-z][_0-9A-Za-z]*"
+
+        where:
+        name   | _
+        "0abc" | _
+        "едц"  | _
+        "_()"  | _
+    }
+}


### PR DESCRIPTION
## Background
During stress testing of an app using graphql-java we encountered a hot spot that was unexpected.

Introspection.getFieldDef is invoked very frequently and the hot spot originated in this line:

`assertTrue(parentType instanceof GraphQLFieldsContainer, "should not happen : parent type must be an object or interface : " + parentType);`

The string concatenation of the error message is rarely thrown, to make things worse the 'parentType' it self was building new messages in recursively.

## Proposed solution
The Assert.assertTrue is modified to accept a format message and a varargs arguments array. The error message is only built if needed.

This is basically the same solutions logging frameworks has faced back in the days, and solve similar.

The Assert class lacked tests so these are added.
Usage of the Assert methods is also updated.



