### PR TITLE
Use most specific possible field name in coercion errors

### DIFF
--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -67,31 +67,23 @@ public class ValuesResolver {
             String variableName = variableDefinition.getName();
             GraphQLType variableType = TypeFromAST.getTypeFromAST(schema, variableDefinition.getType());
 
-            try {
-                // 3.e
-                if (!variableValues.containsKey(variableName)) {
-                    Value defaultValue = variableDefinition.getDefaultValue();
-                    if (defaultValue != null) {
-                        // 3.e.i
-                        Object coercedValue = coerceValueAst(variableType, variableDefinition.getDefaultValue(), null);
-                        coercedValues.put(variableName, coercedValue);
-                    } else if (isNonNullType(variableType)) {
-                        // 3.e.ii
-                        throw new NonNullableValueCoercedAsNullException(variableDefinition, variableType);
-                    }
-                } else {
-                    Object value = variableValues.get(variableName);
-                    // 3.f
-                    Object coercedValue = getVariableValue(variableDefinition, variableType, value);
-                    // 3.g
+            // 3.e
+            if (!variableValues.containsKey(variableName)) {
+                Value defaultValue = variableDefinition.getDefaultValue();
+                if (defaultValue != null) {
+                    // 3.e.i
+                    Object coercedValue = coerceValueAst(variableType, variableDefinition.getDefaultValue(), null);
                     coercedValues.put(variableName, coercedValue);
+                } else if (isNonNullType(variableType)) {
+                    // 3.e.ii
+                    throw new NonNullableValueCoercedAsNullException(variableDefinition, variableType);
                 }
-            } catch (CoercingParseValueException e) {
-                throw new CoercingParseValueException(
-                        "Variable '" + variableName + "' has an invalid value. " + e.getMessage(),
-                        e.getCause(),
-                        variableDefinition.getSourceLocation()
-                );
+            } else {
+                Object value = variableValues.get(variableName);
+                // 3.f
+                Object coercedValue = getVariableValue(variableDefinition, variableType, value);
+                // 3.g
+                coercedValues.put(variableName, coercedValue);
             }
         }
 
@@ -104,7 +96,7 @@ public class ValuesResolver {
             return coerceValueAst(variableType, variableDefinition.getDefaultValue(), null);
         }
 
-        return coerceValue(variableDefinition, variableType, value);
+        return coerceValue(variableDefinition, variableDefinition.getName(), variableType, value);
     }
 
     private boolean isNonNullType(GraphQLType variableType) {
@@ -147,36 +139,49 @@ public class ValuesResolver {
 
 
     @SuppressWarnings("unchecked")
-    private Object coerceValue(VariableDefinition variableDefinition, GraphQLType graphQLType, Object value) {
-        if (graphQLType instanceof GraphQLNonNull) {
-            Object returnValue = coerceValue(variableDefinition, ((GraphQLNonNull) graphQLType).getWrappedType(), value);
-            if (returnValue == null) {
-                throw new NonNullableValueCoercedAsNullException(variableDefinition, graphQLType);
+    private Object coerceValue(VariableDefinition variableDefinition, String inputName, GraphQLType graphQLType, Object value) {
+        try {
+            if (graphQLType instanceof GraphQLNonNull) {
+                Object returnValue =
+                  coerceValue(variableDefinition, inputName, ((GraphQLNonNull) graphQLType).getWrappedType(), value);
+                if (returnValue == null) {
+                    throw new NonNullableValueCoercedAsNullException(variableDefinition, graphQLType);
+                }
+                return returnValue;
             }
-            return returnValue;
-        }
 
-        if (value == null) {
-            return null;
-        }
+            if (value == null) {
+                return null;
+            }
 
-        if (graphQLType instanceof GraphQLScalarType) {
-            return coerceValueForScalar((GraphQLScalarType) graphQLType, value);
-        } else if (graphQLType instanceof GraphQLEnumType) {
-            return coerceValueForEnum((GraphQLEnumType) graphQLType, value);
-        } else if (graphQLType instanceof GraphQLList) {
-            return coerceValueForList(variableDefinition, (GraphQLList) graphQLType, value);
-        } else if (graphQLType instanceof GraphQLInputObjectType) {
-            if (value instanceof Map) {
-                return coerceValueForInputObjectType(variableDefinition, (GraphQLInputObjectType) graphQLType, (Map<String, Object>) value);
+            if (graphQLType instanceof GraphQLScalarType) {
+                return coerceValueForScalar((GraphQLScalarType) graphQLType, value);
+            } else if (graphQLType instanceof GraphQLEnumType) {
+                return coerceValueForEnum((GraphQLEnumType) graphQLType, value);
+            } else if (graphQLType instanceof GraphQLList) {
+                return coerceValueForList(variableDefinition, inputName, (GraphQLList) graphQLType, value);
+            } else if (graphQLType instanceof GraphQLInputObjectType) {
+                if (value instanceof Map) {
+                    return coerceValueForInputObjectType(variableDefinition, (GraphQLInputObjectType) graphQLType, (Map<String, Object>) value);
+                } else {
+                    throw new CoercingParseValueException(
+                      "Expected type 'Map' but was '" + value.getClass().getSimpleName() +
+                      "'. Variables for input objects must be an instance of type 'Map'."
+                    );
+                }
             } else {
-                throw new CoercingParseValueException(
-                        "Expected type 'Map' but was '" + value.getClass().getSimpleName() +
-                                "'. Variables for input objects must be an instance of a 'Map'."
-                );
+                return assertShouldNeverHappen("unhandled type %s", graphQLType);
             }
-        } else {
-            return assertShouldNeverHappen("unhandled type %s", graphQLType);
+        } catch (CoercingParseValueException e) {
+            if (e.getLocations() != null) {
+              throw e;
+            }
+
+            throw new CoercingParseValueException(
+              "Variable '" + inputName + "' has an invalid value. " + e.getMessage(),
+              e.getCause(),
+              variableDefinition.getSourceLocation()
+            );
         }
     }
 
@@ -192,8 +197,11 @@ public class ValuesResolver {
 
         for (GraphQLInputObjectField inputField : fields) {
             if (input.containsKey(inputField.getName()) || alwaysHasValue(inputField)) {
-                Object value = coerceValue(variableDefinition, inputField.getType(), input.get(inputField.getName()));
-                result.put(inputField.getName(), value == null ? inputField.getDefaultValue() : value);
+                  Object value = coerceValue(variableDefinition,
+                                             inputField.getName(),
+                                             inputField.getType(),
+                                             input.get(inputField.getName()));
+                  result.put(inputField.getName(), value == null ? inputField.getDefaultValue() : value);
             }
         }
         return result;
@@ -212,15 +220,15 @@ public class ValuesResolver {
         return graphQLEnumType.getCoercing().parseValue(value);
     }
 
-    private List coerceValueForList(VariableDefinition variableDefinition, GraphQLList graphQLList, Object value) {
+    private List coerceValueForList(VariableDefinition variableDefinition, String inputName, GraphQLList graphQLList, Object value) {
         if (value instanceof Iterable) {
             List<Object> result = new ArrayList<>();
             for (Object val : (Iterable) value) {
-                result.add(coerceValue(variableDefinition, graphQLList.getWrappedType(), val));
+                result.add(coerceValue(variableDefinition, inputName, graphQLList.getWrappedType(), val));
             }
             return result;
         } else {
-            return Collections.singletonList(coerceValue(variableDefinition, graphQLList.getWrappedType(), value));
+            return Collections.singletonList(coerceValue(variableDefinition, inputName, graphQLList.getWrappedType(), value));
         }
     }
 
@@ -318,5 +326,4 @@ public class ValuesResolver {
         }
         return inputValueFieldsByName;
     }
-
 }


### PR DESCRIPTION
This PR improves the behavior of https://github.com/graphql-java/graphql-java/pull/818 by always including the most specific field name when throwing coercion errors.