### PR TITLE
863 introspection results default values

### DIFF
--- a/src/main/antlr/Graphql.g4
+++ b/src/main/antlr/Graphql.g4
@@ -199,7 +199,7 @@ NAME: [_A-Za-z][_0-9A-Za-z]*;
 
 IntValue : Sign? IntegerPart;
 
-FloatValue : Sign? IntegerPart ('.' Digit*)? ExponentPart?;
+FloatValue : Sign? IntegerPart ('.' Digit+)? ExponentPart?;
 
 Sign : '-';
 

--- a/src/main/java/graphql/introspection/IntrospectionResultToSchema.java
+++ b/src/main/java/graphql/introspection/IntrospectionResultToSchema.java
@@ -3,6 +3,7 @@ package graphql.introspection;
 import graphql.ExecutionResult;
 import graphql.PublicApi;
 import graphql.language.Argument;
+import graphql.language.AstValueHelper;
 import graphql.language.Comment;
 import graphql.language.Directive;
 import graphql.language.Document;
@@ -24,6 +25,7 @@ import graphql.language.Type;
 import graphql.language.TypeDefinition;
 import graphql.language.TypeName;
 import graphql.language.UnionTypeDefinition;
+import graphql.language.Value;
 import graphql.schema.idl.ScalarInfo;
 
 import java.util.ArrayList;
@@ -250,8 +252,9 @@ public class IntrospectionResultToSchema {
             InputValueDefinition inputValueDefinition = new InputValueDefinition((String) arg.get("name"), argType);
             inputValueDefinition.setComments(toComment((String) arg.get("description")));
 
-            if (arg.get("defaultValue") != null) {
-                StringValue defaultValue = new StringValue((String) arg.get("defaultValue"));
+            String valueLiteral = (String) arg.get("defaultValue");
+            if (valueLiteral != null) {
+                Value defaultValue = AstValueHelper.valueFromAst(valueLiteral);
                 inputValueDefinition.setDefaultValue(defaultValue);
             }
             result.add(inputValueDefinition);

--- a/src/main/java/graphql/language/AstValueHelper.java
+++ b/src/main/java/graphql/language/AstValueHelper.java
@@ -1,8 +1,10 @@
 package graphql.language;
 
+import graphql.Assert;
 import graphql.AssertException;
 import graphql.GraphQLException;
 import graphql.Scalars;
+import graphql.parser.Parser;
 import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLInputObjectField;
 import graphql.schema.GraphQLInputObjectType;
@@ -197,5 +199,29 @@ public class AstValueHelper {
             throw new GraphQLException(e);
         }
         return result;
+    }
+
+    /**
+     * Parses an AST value literal into the correct {@link graphql.language.Value} which
+     * MUST be of the correct shape eg '"string"' or 'true' or '1' or '{ "object", "form" }'
+     * or '[ "array", "form" ]' otherwise an exception is thrown
+     *
+     * @param astLiteral the string to parse an AST literal
+     *
+     * @return a valid Value
+     *
+     * @throws graphql.AssertException if the input can be parsed
+     */
+    public static Value valueFromAst(String astLiteral) {
+        // we use the parser to give us the AST elements as if we defined an inputType
+        String toParse = "input X { x : String = " + astLiteral + "}";
+        try {
+            Document doc = new Parser().parseDocument(toParse);
+            InputObjectTypeDefinition inputType = (InputObjectTypeDefinition) doc.getDefinitions().get(0);
+            InputValueDefinition inputValueDefinition = inputType.getInputValueDefinitions().get(0);
+            return inputValueDefinition.getDefaultValue();
+        } catch (Exception e) {
+            return Assert.assertShouldNeverHappen("valueFromAst of '%s' failed because of '%s'", astLiteral, e.getMessage());
+        }
     }
 }

--- a/src/test/groovy/graphql/language/AstValueHelperTest.groovy
+++ b/src/test/groovy/graphql/language/AstValueHelperTest.groovy
@@ -160,4 +160,17 @@ class AstValueHelperTest extends Specification {
         )
     }
 
+    def 'parse ast literals'() {
+        expect:
+        AstValueHelper.valueFromAst(valueLiteral) in expectedValue
+
+        where:
+        valueLiteral                                  | expectedValue
+        '"s"'                                         | StringValue.class
+        'true'                                        | BooleanValue.class
+        '666'                                         | IntValue.class
+        '666.6'                                       | FloatValue.class
+        '["A", "B", "C"]'                             | ArrayValue.class
+        '{string : "s", integer : 1, boolean : true}' | ObjectValue.class
+    }
 }

--- a/src/test/groovy/graphql/parser/ParserTest.groovy
+++ b/src/test/groovy/graphql/parser/ParserTest.groovy
@@ -313,14 +313,14 @@ class ParserTest extends Specification {
         given:
         def input = """
             query myQuery {
-              hello(arg: {intKey:1, floatKey: 4., stringKey: \"world\", subObject: {subKey:true} } ) }
+              hello(arg: {intKey:1, floatKey: 4.1, stringKey: \"world\", subObject: {subKey:true} } ) }
             """
 
         and: "expected query"
 
         def objectValue = new ObjectValue()
         objectValue.getObjectFields().add(new ObjectField("intKey", new IntValue(1)))
-        objectValue.getObjectFields().add(new ObjectField("floatKey", new FloatValue(4)))
+        objectValue.getObjectFields().add(new ObjectField("floatKey", new FloatValue(4.1)))
         objectValue.getObjectFields().add(new ObjectField("stringKey", new StringValue("world")))
         def subObject = new ObjectValue()
         subObject.getObjectFields().add(new ObjectField("subKey", new BooleanValue(true)))
@@ -377,6 +377,18 @@ class ParserTest extends Specification {
         '3e4'       | 3e4
         '123e-4'    | 123e-4
 
+    }
+
+    def "#848 floats must have digits"() {
+        given:
+        def input = """
+            { hello(arg: 4.) }
+            """
+        when:
+        def document = new Parser().parseDocument(input)
+
+        then:
+        thrown(ParseCancellationException)
     }
 
     def "extraneous input is an exception"() {


### PR DESCRIPTION
It now uses proper AST values so that strings are '"string"' and ints are '123' and objects can be '{"object", "form"} and arrays are '[ "array", "form" ]

This was causing the double encoding (not the JSON encoding) but that we treated everything as strings incorrectly

see #863 

