### PR TITLE
Fix #882, variable input type mismatch throws AssertException

### DIFF
--- a/src/main/java/graphql/execution/TypeFromAST.java
+++ b/src/main/java/graphql/execution/TypeFromAST.java
@@ -16,11 +16,15 @@ public class TypeFromAST {
 
 
     public static GraphQLType getTypeFromAST(GraphQLSchema schema, Type type) {
+        GraphQLType innerType;
         if (type instanceof ListType) {
-            return new GraphQLList(getTypeFromAST(schema, ((ListType) type).getType()));
+            innerType = getTypeFromAST(schema, ((ListType) type).getType());
+            return innerType != null ? new GraphQLList(innerType) : null;
         } else if (type instanceof NonNullType) {
-            return new GraphQLNonNull(getTypeFromAST(schema, ((NonNullType) type).getType()));
+            innerType = getTypeFromAST(schema, ((NonNullType) type).getType());
+            return innerType != null ? new GraphQLNonNull(innerType) : null;
         }
+
         return schema.getType(((TypeName) type).getName());
     }
 }

--- a/src/main/java/graphql/validation/TraversalContext.java
+++ b/src/main/java/graphql/validation/TraversalContext.java
@@ -1,6 +1,9 @@
 package graphql.validation;
 
 
+import java.util.ArrayList;
+import java.util.List;
+
 import graphql.Assert;
 import graphql.Internal;
 import graphql.execution.TypeFromAST;
@@ -35,9 +38,6 @@ import graphql.schema.GraphQLType;
 import graphql.schema.GraphQLUnionType;
 import graphql.schema.GraphQLUnmodifiedType;
 import graphql.schema.SchemaUtil;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import static graphql.introspection.Introspection.SchemaMetaFieldDef;
 import static graphql.introspection.Introspection.TypeMetaFieldDef;
@@ -139,7 +139,7 @@ public class TraversalContext implements DocumentVisitor {
 
     private void enterImpl(VariableDefinition variableDefinition) {
         GraphQLType type = TypeFromAST.getTypeFromAST(schema, variableDefinition.getType());
-        addInputType((GraphQLInputType) type);
+        addInputType(type != null ? (GraphQLInputType) type : null);
     }
 
     private void enterImpl(Argument argument) {

--- a/src/test/groovy/graphql/validation/SpecValidation573Test.groovy
+++ b/src/test/groovy/graphql/validation/SpecValidation573Test.groovy
@@ -1,0 +1,72 @@
+package graphql.validation
+/**
+ * validation examples used in the spec in given section
+ * http://facebook.github.io/graphql/#sec-Validation
+ *
+ */
+class SpecValidation573Test extends SpecValidationBase {
+
+    def '5.7.3 Variables Are Input Types - type mismatch (must be non-null)'() {
+        def query = """
+query madDog(\$dogCommand: DogCommand){
+    dog {
+        doesKnowCommand(dogCommand: \$dogCommand)
+    }
+}"""
+        when:
+        def validationErrors = validate(query)
+
+        then:
+        !validationErrors.empty
+        validationErrors.size() == 1
+        validationErrors.get(0).getValidationErrorType() == ValidationErrorType.VariableTypeMismatch
+    }
+
+    def '5.7.3 Variables Are Input Types - unknown type'() {
+        def query = """
+query madDog(\$dogCommand: UnknownType){
+    dog {
+        doesKnowCommand(dogCommand: \$dogCommand)
+    }
+}"""
+        when:
+        def validationErrors = validate(query)
+
+        then:
+        !validationErrors.empty
+        validationErrors.size() == 1
+        validationErrors.get(0).getValidationErrorType() == ValidationErrorType.UnknownType
+    }
+
+    def '5.7.3 Variables Are Input Types - non-null unknown type'() {
+        def query = """
+query madDog(\$dogCommand: UnknownType!){
+    dog {
+        doesKnowCommand(dogCommand: \$dogCommand)
+    }
+}"""
+        when:
+        def validationErrors = validate(query)
+
+        then:
+        !validationErrors.empty
+        validationErrors.size() == 1
+        validationErrors.get(0).getValidationErrorType() == ValidationErrorType.UnknownType
+    }
+
+    def '5.7.3 Variables Are Input Types - non-null list unknown type'() {
+        def query = """
+query madDog(\$dogCommand: [UnknownType]){
+    dog {
+        doesKnowCommand(dogCommand: \$dogCommand)
+    }
+}"""
+        when:
+        def validationErrors = validate(query)
+
+        then:
+        !validationErrors.empty
+        validationErrors.size() == 1
+        validationErrors.get(0).getValidationErrorType() == ValidationErrorType.UnknownType
+    }
+}


### PR DESCRIPTION
### Description

Added a null check in `getTypeFromAST`, similarly to what [graphql-js does](https://github.com/graphql/graphql-js/blob/7e147a8dd60496505cd5d491fb7126b2319095c9/src/utilities/typeFromAST.js#L49):
They return `void` (undefined in js) or the type itself.
```javascript
export function typeFromAST(schema, typeNode) {
  /* eslint-enable no-redeclare */
  let innerType;
  if (typeNode.kind === Kind.LIST_TYPE) {
    innerType = typeFromAST(schema, typeNode.type);
    return innerType && GraphQLList(innerType);
  }
  if (typeNode.kind === Kind.NON_NULL_TYPE) {
    innerType = typeFromAST(schema, typeNode.type);
    return innerType && GraphQLNonNull(innerType);
  }
  if (typeNode.kind === Kind.NAMED_TYPE) {
    return schema.getType(typeNode.name.value);
  }
  /* istanbul ignore next */
  throw new Error(`Unexpected type kind: ${(typeNode.kind: empty)}.`);
}
```

### Testing
Added unit tests to cover this issue + bonus spec cases we missed earlier.