### PR TITLE
Platform agnostic field selection separator

### DIFF
--- a/src/main/java/graphql/schema/DataFetchingFieldSelectionSetImpl.java
+++ b/src/main/java/graphql/schema/DataFetchingFieldSelectionSetImpl.java
@@ -129,7 +129,7 @@ public class DataFetchingFieldSelectionSetImpl implements DataFetchingFieldSelec
         }
     }
 
-    private final static String SEP = FileSystems.getDefault().getSeparator();
+    private final static String SEP = "/";
 
 
     private void traverseFields(List<Field> fieldList, GraphQLFieldsContainer parentFieldType, String fieldPrefix) {


### PR DESCRIPTION
I don't think it's a good idea to have the DataFetchingFieldSelectionSetImpl to list field names separated by a platform specific separator (considering these aren't files we're dealing with).

This fixes the build on windows machines (see test "field selection can be captured via data environment").

This is backwards incompatible change but IMO relatively minor and what looks like an oversight. If not, let me know the reasoning and feel free to close.