### PR TITLE
Set javadoc encoding to utf8 to build on windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,10 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
     from javadoc.destinationDir
 }
 
+javadoc {
+    options.encoding = 'UTF-8'
+}
+
 artifacts {
     archives sourcesJar
     archives javadocJar


### PR DESCRIPTION
Sorry for the back to back quick PRs 😄

Some of the Javadocs contain UTF8 characters and by default, on windows, it assumes Windows 1252 encoding, which fails. The fix is to explicitly call for the javadocs encoded as UTF8