### PR TITLE
This is a refactor of the Instrumentation such that it now has 2 callbacks

### DIFF
--- a/docs/instrumentation.rst
+++ b/docs/instrumentation.rst
@@ -36,7 +36,7 @@ The following is a basic custom ``Instrumentation`` that measures overall execut
         }
     }
 
-    class CustomInstrumentation implements Instrumentation {
+    class CustomInstrumentation extends SimpleInstrumentation {
         @Override
         public InstrumentationState createState() {
             //
@@ -49,51 +49,19 @@ The following is a basic custom ``Instrumentation`` that measures overall execut
         @Override
         public InstrumentationContext<ExecutionResult> beginExecution(InstrumentationExecutionParameters parameters) {
             long startNanos = System.nanoTime();
-            return (result, throwable) -> {
-
-                CustomInstrumentationState state = parameters.getInstrumentationState();
-                state.recordTiming(parameters.getQuery(), System.nanoTime() - startNanos);
+            return new SimpleInstrumentationContext<ExecutionResult>() {
+                @Override
+                public void onCompleted(ExecutionResult result, Throwable t) {
+                    CustomInstrumentationState state = parameters.getInstrumentationState();
+                    state.recordTiming(parameters.getQuery(), System.nanoTime() - startNanos);
+                }
             };
-        }
-
-        @Override
-        public InstrumentationContext<Document> beginParse(InstrumentationExecutionParameters parameters) {
-            //
-            // You MUST return a non null object but it does not have to do anything and hence
-            // you use this class to return a no-op object
-            //
-            return new NoOpInstrumentation.NoOpInstrumentationContext<>();
-        }
-
-        @Override
-        public InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters) {
-            return new NoOpInstrumentation.NoOpInstrumentationContext<>();
-        }
-
-        @Override
-        public InstrumentationContext<ExecutionResult> beginDataFetch(InstrumentationDataFetchParameters parameters) {
-            return new NoOpInstrumentation.NoOpInstrumentationContext<>();
-        }
-
-        @Override
-        public InstrumentationContext<CompletableFuture<ExecutionResult>> beginExecutionStrategy(InstrumentationExecutionStrategyParameters parameters) {
-            return new NoOpInstrumentation.NoOpInstrumentationContext<>();
-        }
-
-        @Override
-        public InstrumentationContext<ExecutionResult> beginField(InstrumentationFieldParameters parameters) {
-            return new NoOpInstrumentation.NoOpInstrumentationContext<>();
-        }
-
-        @Override
-        public InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters) {
-            return new NoOpInstrumentation.NoOpInstrumentationContext<>();
         }
 
         @Override
         public DataFetcher<?> instrumentDataFetcher(DataFetcher<?> dataFetcher, InstrumentationFieldFetchParameters parameters) {
             //
-            // this allows you to intercept the data fetcher used ot fetch a field and provide another one, perhaps
+            // this allows you to intercept the data fetcher used to fetch a field and provide another one, perhaps
             // that enforces certain behaviours or has certain side effects on the data
             //
             return dataFetcher;

--- a/src/main/java/graphql/analysis/MaxQueryComplexityInstrumentation.java
+++ b/src/main/java/graphql/analysis/MaxQueryComplexityInstrumentation.java
@@ -3,7 +3,7 @@ package graphql.analysis;
 import graphql.PublicApi;
 import graphql.execution.AbortExecutionException;
 import graphql.execution.instrumentation.InstrumentationContext;
-import graphql.execution.instrumentation.NoOpInstrumentation;
+import graphql.execution.instrumentation.SimpleInstrumentation;
 import graphql.execution.instrumentation.parameters.InstrumentationValidationParameters;
 import graphql.validation.ValidationError;
 
@@ -13,12 +13,13 @@ import java.util.List;
 import java.util.Map;
 
 import static graphql.Assert.assertNotNull;
+import static graphql.execution.instrumentation.SimpleInstrumentationContext.whenCompleted;
 
 /**
  * Prevents execution if the query complexity is greater than the specified maxComplexity
  */
 @PublicApi
-public class MaxQueryComplexityInstrumentation extends NoOpInstrumentation {
+public class MaxQueryComplexityInstrumentation extends SimpleInstrumentation {
 
 
     private final int maxComplexity;
@@ -47,7 +48,7 @@ public class MaxQueryComplexityInstrumentation extends NoOpInstrumentation {
 
     @Override
     public InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters) {
-        return (errors, throwable) -> {
+        return whenCompleted((errors, throwable) -> {
             if ((errors != null && errors.size() > 0) || throwable != null) {
                 return;
             }
@@ -68,7 +69,7 @@ public class MaxQueryComplexityInstrumentation extends NoOpInstrumentation {
             if (totalComplexity > maxComplexity) {
                 throw mkAbortException(totalComplexity, maxComplexity);
             }
-        };
+        });
     }
 
     /**

--- a/src/main/java/graphql/analysis/MaxQueryDepthInstrumentation.java
+++ b/src/main/java/graphql/analysis/MaxQueryDepthInstrumentation.java
@@ -3,7 +3,8 @@ package graphql.analysis;
 import graphql.PublicApi;
 import graphql.execution.AbortExecutionException;
 import graphql.execution.instrumentation.InstrumentationContext;
-import graphql.execution.instrumentation.NoOpInstrumentation;
+import graphql.execution.instrumentation.SimpleInstrumentation;
+import graphql.execution.instrumentation.SimpleInstrumentationContext;
 import graphql.execution.instrumentation.parameters.InstrumentationValidationParameters;
 import graphql.validation.ValidationError;
 
@@ -13,7 +14,7 @@ import java.util.List;
  * Prevents execution if the query depth is greater than the specified maxDepth
  */
 @PublicApi
-public class MaxQueryDepthInstrumentation extends NoOpInstrumentation {
+public class MaxQueryDepthInstrumentation extends SimpleInstrumentation {
 
     private final int maxDepth;
 
@@ -23,7 +24,7 @@ public class MaxQueryDepthInstrumentation extends NoOpInstrumentation {
 
     @Override
     public InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters) {
-        return (errors, throwable) -> {
+        return SimpleInstrumentationContext.whenCompleted((errors, throwable) -> {
             if ((errors != null && errors.size() > 0) || throwable != null) {
                 return;
             }
@@ -32,7 +33,7 @@ public class MaxQueryDepthInstrumentation extends NoOpInstrumentation {
             if (depth > maxDepth) {
                 throw mkAbortException(depth, maxDepth);
             }
-        };
+        });
     }
 
     /**

--- a/src/main/java/graphql/analysis/MaxQueryDepthInstrumentation.java
+++ b/src/main/java/graphql/analysis/MaxQueryDepthInstrumentation.java
@@ -10,6 +10,8 @@ import graphql.validation.ValidationError;
 
 import java.util.List;
 
+import static graphql.execution.instrumentation.SimpleInstrumentationContext.*;
+
 /**
  * Prevents execution if the query depth is greater than the specified maxDepth
  */
@@ -24,7 +26,7 @@ public class MaxQueryDepthInstrumentation extends SimpleInstrumentation {
 
     @Override
     public InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters) {
-        return SimpleInstrumentationContext.whenCompleted((errors, throwable) -> {
+        return whenCompleted((errors, throwable) -> {
             if ((errors != null && errors.size() > 0) || throwable != null) {
                 return;
             }

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -168,7 +168,8 @@ public abstract class ExecutionStrategy {
                 .thenCompose((fetchedValue) ->
                         completeField(executionContext, parameters, fetchedValue));
 
-        result.whenComplete(fieldCtx::onEnd);
+        fieldCtx.onDispatched(result);
+        result.whenComplete(fieldCtx::onCompleted);
         return result;
     }
 
@@ -213,7 +214,8 @@ public abstract class ExecutionStrategy {
 
         InstrumentationFieldFetchParameters instrumentationFieldFetchParams = new InstrumentationFieldFetchParameters(executionContext, fieldDef, environment);
         InstrumentationContext<Object> fetchCtx = instrumentation.beginFieldFetch(instrumentationFieldFetchParams);
-        CompletableFuture<?> fetchedValue;
+
+        CompletableFuture<Object> fetchedValue;
         DataFetcher dataFetcher = fieldDef.getDataFetcher();
         dataFetcher = instrumentation.instrumentDataFetcher(dataFetcher, instrumentationFieldFetchParams);
         ExecutionId executionId = executionContext.getExecutionId();
@@ -229,9 +231,10 @@ public abstract class ExecutionStrategy {
             fetchedValue = new CompletableFuture<>();
             fetchedValue.completeExceptionally(e);
         }
+        fetchCtx.onDispatched(fetchedValue);
         return fetchedValue
                 .handle((result, exception) -> {
-                    fetchCtx.onEnd(result, exception);
+                    fetchCtx.onCompleted(result, exception);
                     if (exception != null) {
                         handleFetchingException(executionContext, parameters, field, fieldDef, argumentValues, environment, exception);
                         return null;
@@ -303,8 +306,10 @@ public abstract class ExecutionStrategy {
         GraphQLFieldDefinition fieldDef = getFieldDef(executionContext.getGraphQLSchema(), parentType, field);
         ExecutionTypeInfo fieldTypeInfo = fieldTypeInfo(parameters, fieldDef);
 
-        InstrumentationContext<CompletableFuture<ExecutionResult>> ctx = executionContext.getInstrumentation().beginCompleteField(
-                new InstrumentationFieldCompleteParameters(executionContext, parameters, fieldDef, fieldTypeInfo)
+        Instrumentation instrumentation = executionContext.getInstrumentation();
+        InstrumentationFieldCompleteParameters instrumentationParams = new InstrumentationFieldCompleteParameters(executionContext, parameters, fieldDef, fieldTypeInfo, fetchedValue);
+        InstrumentationContext<ExecutionResult> ctxCompleteField = instrumentation.beginFieldComplete(
+                instrumentationParams
         );
 
         GraphqlFieldVisibility fieldVisibility = executionContext.getGraphQLSchema().getFieldVisibility();
@@ -325,7 +330,9 @@ public abstract class ExecutionStrategy {
         log.debug("'{}' completing field '{}'...", executionContext.getExecutionId(), fieldTypeInfo.getPath());
 
         CompletableFuture<ExecutionResult> cf = completeValue(executionContext, newParameters);
-        ctx.onEnd(cf, null);
+
+        ctxCompleteField.onDispatched(cf);
+        cf.whenComplete(ctxCompleteField::onCompleted);
         return cf;
     }
 
@@ -408,8 +415,11 @@ public abstract class ExecutionStrategy {
         GraphQLList fieldType = typeInfo.castType(GraphQLList.class);
         GraphQLFieldDefinition fieldDef = parameters.typeInfo().getFieldDefinition();
 
-        InstrumentationContext<CompletableFuture<ExecutionResult>> ctx = executionContext.getInstrumentation().beginCompleteFieldList(
-                new InstrumentationFieldCompleteParameters(executionContext, parameters, fieldDef, fieldTypeInfo(parameters, fieldDef))
+        InstrumentationFieldCompleteParameters instrumentationParams = new InstrumentationFieldCompleteParameters(executionContext, parameters, fieldDef, fieldTypeInfo(parameters, fieldDef), iterableValues);
+        Instrumentation instrumentation = executionContext.getInstrumentation();
+
+        InstrumentationContext<ExecutionResult> completeListCtx = instrumentation.beginFieldListComplete(
+                instrumentationParams
         );
 
         CompletableFuture<List<ExecutionResult>> resultsFuture = Async.each(iterableValues, (item, index) -> {
@@ -436,19 +446,24 @@ public abstract class ExecutionStrategy {
 
             return completeValue(executionContext, newParameters);
         });
+
         CompletableFuture<ExecutionResult> overallResult = new CompletableFuture<>();
+        completeListCtx.onDispatched(overallResult);
+
         resultsFuture.whenComplete((results, exception) -> {
             if (exception != null) {
-                handleNonNullException(executionContext, overallResult, exception);
+                ExecutionResult executionResult = handleNonNullException(executionContext, overallResult, exception);
+                completeListCtx.onCompleted(executionResult, exception);
                 return;
             }
             List<Object> completedResults = new ArrayList<>();
             for (ExecutionResult completedValue : results) {
                 completedResults.add(completedValue.getData());
             }
-            overallResult.complete(new ExecutionResultImpl(completedResults, null));
+            ExecutionResultImpl executionResult = new ExecutionResultImpl(completedResults, null);
+            overallResult.complete(executionResult);
         });
-        ctx.onEnd(overallResult, null);
+        overallResult.whenComplete(completeListCtx::onCompleted);
         return overallResult;
     }
 
@@ -716,20 +731,24 @@ public abstract class ExecutionStrategy {
         }
     }
 
-    protected void handleNonNullException(ExecutionContext executionContext, CompletableFuture<ExecutionResult> result, Throwable e) {
+    protected ExecutionResult handleNonNullException(ExecutionContext executionContext, CompletableFuture<ExecutionResult> result, Throwable e) {
+        ExecutionResult executionResult = null;
         if (e instanceof NonNullableFieldWasNullException) {
             assertNonNullFieldPrecondition((NonNullableFieldWasNullException) e, result);
             if (!result.isDone()) {
-                result.complete(new ExecutionResultImpl(null, executionContext.getErrors()));
+                executionResult = new ExecutionResultImpl(null, executionContext.getErrors());
+                result.complete(executionResult);
             }
         } else if (e instanceof CompletionException && e.getCause() instanceof NonNullableFieldWasNullException) {
             assertNonNullFieldPrecondition((NonNullableFieldWasNullException) e.getCause(), result);
             if (!result.isDone()) {
-                result.complete(new ExecutionResultImpl(null, executionContext.getErrors()));
+                executionResult = new ExecutionResultImpl(null, executionContext.getErrors());
+                result.complete(executionResult);
             }
         } else {
             result.completeExceptionally(e);
         }
+        return executionResult;
     }
 
 

--- a/src/main/java/graphql/execution/ExecutorServiceExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutorServiceExecutionStrategy.java
@@ -55,10 +55,8 @@ public class ExecutorServiceExecutionStrategy extends ExecutionStrategy {
         }
 
         Instrumentation instrumentation = executionContext.getInstrumentation();
-        InstrumentationExecutionStrategyParameters instrumentationParameters = new InstrumentationExecutionStrategyParameters(executionContext);
-        InstrumentationContext<CompletableFuture<ExecutionResult>> executionStrategyCtx = instrumentation.beginExecutionStrategy(instrumentationParameters);
-
-        InstrumentationContext<Map<String, List<Field>>> beginFieldsCtx = instrumentation.beginFields(instrumentationParameters);
+        InstrumentationExecutionStrategyParameters instrumentationParameters = new InstrumentationExecutionStrategyParameters(executionContext, parameters);
+        InstrumentationContext<ExecutionResult> executionStrategyCtx = instrumentation.beginExecutionStrategy(instrumentationParameters);
 
         Map<String, List<Field>> fields = parameters.fields();
         Map<String, Future<CompletableFuture<ExecutionResult>>> futures = new LinkedHashMap<>();
@@ -72,7 +70,9 @@ public class ExecutorServiceExecutionStrategy extends ExecutionStrategy {
             Callable<CompletableFuture<ExecutionResult>> resolveField = () -> resolveField(executionContext, newParameters);
             futures.put(fieldName, executorService.submit(resolveField));
         }
-        beginFieldsCtx.onEnd(fields, null);
+
+        CompletableFuture<ExecutionResult> overallResult = new CompletableFuture<>();
+        executionStrategyCtx.onDispatched(overallResult);
 
         try {
             Map<String, Object> results = new LinkedHashMap<>();
@@ -92,11 +92,13 @@ public class ExecutorServiceExecutionStrategy extends ExecutionStrategy {
                 results.put(fieldName, executionResult != null ? executionResult.getData() : null);
             }
 
-            CompletableFuture<ExecutionResult> result = CompletableFuture.completedFuture(new ExecutionResultImpl(results, executionContext.getErrors()));
-            executionStrategyCtx.onEnd(result, null);
-            return result;
+            ExecutionResultImpl executionResult = new ExecutionResultImpl(results, executionContext.getErrors());
+            overallResult.complete(executionResult);
+
+            overallResult.whenComplete(executionStrategyCtx::onCompleted);
+            return overallResult;
         } catch (InterruptedException | ExecutionException e) {
-            executionStrategyCtx.onEnd(null, e);
+            executionStrategyCtx.onCompleted(null, e);
             throw new GraphQLException(e);
         }
     }

--- a/src/main/java/graphql/execution/instrumentation/Instrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/Instrumentation.java
@@ -3,7 +3,7 @@ package graphql.execution.instrumentation;
 import graphql.ExecutionInput;
 import graphql.ExecutionResult;
 import graphql.execution.ExecutionContext;
-import graphql.execution.instrumentation.parameters.InstrumentationDataFetchParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationExecuteOperationParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionStrategyParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldCompleteParameters;
@@ -11,13 +11,11 @@ import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchPar
 import graphql.execution.instrumentation.parameters.InstrumentationFieldParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationValidationParameters;
 import graphql.language.Document;
-import graphql.language.Field;
 import graphql.schema.DataFetcher;
 import graphql.schema.GraphQLSchema;
 import graphql.validation.ValidationError;
 
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -28,6 +26,10 @@ import java.util.concurrent.CompletableFuture;
  *
  * Remember that graphql calls can cross threads so make sure you think about the thread safety of any instrumentation
  * code when you are writing it.
+ *
+ * Each step gives back an {@link graphql.execution.instrumentation.InstrumentationContext} object.  This has two callbacks on it,
+ * one for the step is `dispatched` and one for when the step has `completed`.  This is done because many of the "steps" are asynchronous
+ * operations such as fetching data and resolving it into objects.
  */
 public interface Instrumentation {
 
@@ -42,8 +44,7 @@ public interface Instrumentation {
     }
 
     /**
-     * This is called just before a query is executed and when this step finishes the {@link InstrumentationContext#onEnd(Object, Throwable)}
-     * will be called indicating that the step has finished.
+     * This is called right at the start of query execution and its the first step in the instrumentation chain.
      *
      * @param parameters the parameters to this step
      *
@@ -52,8 +53,7 @@ public interface Instrumentation {
     InstrumentationContext<ExecutionResult> beginExecution(InstrumentationExecutionParameters parameters);
 
     /**
-     * This is called just before a query is parsed and when this step finishes the {@link InstrumentationContext#onEnd(Object, Throwable)}
-     * will be called indicating that the step has finished.
+     * This is called just before a query is parsed.
      *
      * @param parameters the parameters to this step
      *
@@ -62,8 +62,7 @@ public interface Instrumentation {
     InstrumentationContext<Document> beginParse(InstrumentationExecutionParameters parameters);
 
     /**
-     * This is called just before the parsed query Document is validated and when this step finishes the {@link InstrumentationContext#onEnd(Object, Throwable)}
-     * will be called indicating that the step has finished.
+     * This is called just before the parsed query document is validated.
      *
      * @param parameters the parameters to this step
      *
@@ -72,62 +71,26 @@ public interface Instrumentation {
     InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters);
 
     /**
-     * This is called just before the data fetching stage is started and finishes as soon as the query is dispatched ready for completion.  This
-     * is different to {@link #beginDataFetch(graphql.execution.instrumentation.parameters.InstrumentationDataFetchParameters)}
-     * in that this step does not wait for the values to be completed, only dispatched for completion.
+     * This is called just before the execution of the query operation is started.
      *
      * @param parameters the parameters to this step
      *
      * @return a non null {@link InstrumentationContext} object that will be called back when the step ends
      */
-    default InstrumentationContext<CompletableFuture<ExecutionResult>> beginDataFetchDispatch(InstrumentationDataFetchParameters parameters) {
-        return (result, t) -> {
-        };
-    }
+    InstrumentationContext<ExecutionResult> beginExecuteOperation(InstrumentationExecuteOperationParameters parameters);
 
     /**
-     * This is called just before the data fetching stage is started, waits for all data to be completed and when this step finishes the {@link InstrumentationContext#onEnd(Object, Throwable)}
-     * will be called indicating that the step has finished.
+     * This is called each time an {@link graphql.execution.ExecutionStrategy} is invoked, which may be multiple times
+     * per query as the engine recursively descends down over the query.
      *
      * @param parameters the parameters to this step
      *
      * @return a non null {@link InstrumentationContext} object that will be called back when the step ends
      */
-    InstrumentationContext<ExecutionResult> beginDataFetch(InstrumentationDataFetchParameters parameters);
+    InstrumentationContext<ExecutionResult> beginExecutionStrategy(InstrumentationExecutionStrategyParameters parameters);
 
     /**
-     * This is called each time the {@link graphql.execution.ExecutionStrategy} is invoked and when the
-     * {@link java.util.concurrent.CompletableFuture} has been dispatched for the query fields the
-     * {@link graphql.execution.instrumentation.InstrumentationContext#onEnd(Object, Throwable)}
-     * is called.
-     *
-     * Note because the execution strategy execution is asynchronous, the query data is not guaranteed to be
-     * completed when this step finishes.  It is however a chance to dispatch side effects that might cause
-     * asynchronous data fetching code to actually run or attach CompletableFuture handlers onto the result
-     * via Instrumentation.
-     *
-     * @param parameters the parameters to this step
-     *
-     * @return a non null {@link InstrumentationContext} object that will be called back when the step ends
-     */
-    InstrumentationContext<CompletableFuture<ExecutionResult>> beginExecutionStrategy(InstrumentationExecutionStrategyParameters parameters);
-
-    /**
-     * This is called just before a selection set of fields is resolved and when this step finishes the {@link InstrumentationContext#onEnd(Object, Throwable)}
-     * will be called indicating that the step has finished.
-     *
-     * @param parameters the parameters to this step
-     *
-     * @return a non null {@link InstrumentationContext} object that will be called back when the step ends
-     */
-    default InstrumentationContext<Map<String, List<Field>>> beginFields(InstrumentationExecutionStrategyParameters parameters) {
-        return (result, t) -> {
-        };
-    }
-
-    /**
-     * This is called just before a field is resolved and when this step finishes the {@link InstrumentationContext#onEnd(Object, Throwable)}
-     * will be called indicating that the step has finished.
+     * This is called just before a field is resolved into a value.
      *
      * @param parameters the parameters to this step
      *
@@ -136,8 +99,7 @@ public interface Instrumentation {
     InstrumentationContext<ExecutionResult> beginField(InstrumentationFieldParameters parameters);
 
     /**
-     * This is called just before a field {@link DataFetcher} is invoked and when this step finishes the {@link InstrumentationContext#onEnd(Object, Throwable)}
-     * will be called indicating that the step has finished.
+     * This is called just before a field {@link DataFetcher} is invoked.
      *
      * @param parameters the parameters to this step
      *
@@ -147,29 +109,25 @@ public interface Instrumentation {
 
 
     /**
-     * This is called just before the complete field is started and when this step finishes the {@link InstrumentationContext#onEnd(Object, Throwable)}
-     * will be called indicating that the step has finished.
+     * This is called just before the complete field is started.
      *
      * @param parameters the parameters to this step
      *
      * @return a non null {@link InstrumentationContext} object that will be called back when the step ends
      */
-    default InstrumentationContext<CompletableFuture<ExecutionResult>> beginCompleteField(InstrumentationFieldCompleteParameters parameters) {
-        return (result, t) -> {
-        };
+    default InstrumentationContext<ExecutionResult> beginFieldComplete(InstrumentationFieldCompleteParameters parameters) {
+        return new SimpleInstrumentationContext<>();
     }
 
     /**
-     * This is called just before the complete field list is started and when this step finishes the {@link InstrumentationContext#onEnd(Object, Throwable)}
-     * will be called indicating that the step has finished.
+     * This is called just before the complete field list is started.
      *
      * @param parameters the parameters to this step
      *
      * @return a non null {@link InstrumentationContext} object that will be called back when the step ends
      */
-    default InstrumentationContext<CompletableFuture<ExecutionResult>> beginCompleteFieldList(InstrumentationFieldCompleteParameters parameters) {
-        return (result, t) -> {
-        };
+    default InstrumentationContext<ExecutionResult> beginFieldListComplete(InstrumentationFieldCompleteParameters parameters) {
+        return new SimpleInstrumentationContext<>();
     }
 
     /**
@@ -238,4 +196,5 @@ public interface Instrumentation {
     default CompletableFuture<ExecutionResult> instrumentExecutionResult(ExecutionResult executionResult, InstrumentationExecutionParameters parameters) {
         return CompletableFuture.completedFuture(executionResult);
     }
+
 }

--- a/src/main/java/graphql/execution/instrumentation/InstrumentationContext.java
+++ b/src/main/java/graphql/execution/instrumentation/InstrumentationContext.java
@@ -1,8 +1,11 @@
 package graphql.execution.instrumentation;
 
+import java.util.concurrent.CompletableFuture;
+
 /**
- * When a {@link Instrumentation}.'beginXXX' method is called then it must return a non null InstrumentationContext
- * that will the be invoked as {@link #onEnd(Object, java.lang.Throwable)} when the step completes.
+ * When a {@link Instrumentation}.'beginXXX()' method is called then it must return a non null InstrumentationContext
+ * that will be invoked when the step is first dispatched and then when it completes.  Sometimes this is effectively the same time
+ * whereas at other times its when an asynchronous {@link java.util.concurrent.CompletableFuture} completes.
  *
  * This pattern of construction of an object then call back is intended to allow "timers" to be created that can instrument what has
  * just happened or "loggers" to be called to record what has happened.
@@ -10,11 +13,18 @@ package graphql.execution.instrumentation;
 public interface InstrumentationContext<T> {
 
     /**
-     * This is invoked when the execution step is completed
+     * This is invoked when the instrumentation step is initially dispatched
+     *
+     * @param result the result of the step as a completable future
+     */
+    void onDispatched(CompletableFuture<T> result);
+
+    /**
+     * This is invoked when the instrumentation step is fully completed
      *
      * @param result the result of the step (which may be null)
      * @param t      this exception will be non null if an exception was thrown during the step
      */
-    void onEnd(T result, Throwable t);
+    void onCompleted(T result, Throwable t);
 
 }

--- a/src/main/java/graphql/execution/instrumentation/SimpleInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/SimpleInstrumentation.java
@@ -3,7 +3,7 @@ package graphql.execution.instrumentation;
 import graphql.ExecutionResult;
 import graphql.PublicApi;
 import graphql.execution.ExecutionContext;
-import graphql.execution.instrumentation.parameters.InstrumentationDataFetchParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationExecuteOperationParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionStrategyParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldCompleteParameters;
@@ -11,13 +11,11 @@ import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchPar
 import graphql.execution.instrumentation.parameters.InstrumentationFieldParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationValidationParameters;
 import graphql.language.Document;
-import graphql.language.Field;
 import graphql.schema.DataFetcher;
 import graphql.schema.GraphQLSchema;
 import graphql.validation.ValidationError;
 
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -25,54 +23,14 @@ import java.util.concurrent.CompletableFuture;
  * as a base for derived classes where you only implement the methods you want to
  */
 @PublicApi
-public class NoOpInstrumentation implements Instrumentation {
+public class SimpleInstrumentation implements Instrumentation {
 
     /**
      * A singleton instance of a {@link graphql.execution.instrumentation.Instrumentation} that does nothing
      */
-    public static final NoOpInstrumentation INSTANCE = new NoOpInstrumentation();
+    public static final SimpleInstrumentation INSTANCE = new SimpleInstrumentation();
 
-    public NoOpInstrumentation() {
-    }
-
-    @Override
-    public InstrumentationContext<ExecutionResult> beginExecution(InstrumentationExecutionParameters parameters) {
-        return new NoOpInstrumentationContext<>();
-    }
-
-    @Override
-    public InstrumentationContext<Document> beginParse(InstrumentationExecutionParameters parameters) {
-        return new NoOpInstrumentationContext<>();
-    }
-
-    @Override
-    public InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters) {
-        return new NoOpInstrumentationContext<>();
-    }
-
-    @Override
-    public InstrumentationContext<CompletableFuture<ExecutionResult>> beginDataFetchDispatch(InstrumentationDataFetchParameters parameters) {
-        return new NoOpInstrumentationContext<>();
-    }
-
-    @Override
-    public InstrumentationContext<CompletableFuture<ExecutionResult>> beginExecutionStrategy(InstrumentationExecutionStrategyParameters parameters) {
-        return new NoOpInstrumentationContext<>();
-    }
-
-    @Override
-    public InstrumentationContext<ExecutionResult> beginDataFetch(InstrumentationDataFetchParameters parameters) {
-        return new NoOpInstrumentationContext<>();
-    }
-
-    @Override
-    public InstrumentationContext<ExecutionResult> beginField(InstrumentationFieldParameters parameters) {
-        return new NoOpInstrumentationContext<>();
-    }
-
-    @Override
-    public InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters) {
-        return new NoOpInstrumentationContext<>();
+    public SimpleInstrumentation() {
     }
 
     @Override
@@ -81,18 +39,49 @@ public class NoOpInstrumentation implements Instrumentation {
     }
 
     @Override
-    public InstrumentationContext<CompletableFuture<ExecutionResult>> beginCompleteField(InstrumentationFieldCompleteParameters parameters) {
-        return new NoOpInstrumentationContext<>();
+    public InstrumentationContext<ExecutionResult> beginExecution(InstrumentationExecutionParameters parameters) {
+        return new SimpleInstrumentationContext<>();
     }
 
     @Override
-    public InstrumentationContext<Map<String, List<Field>>> beginFields(InstrumentationExecutionStrategyParameters parameters) {
-        return new NoOpInstrumentationContext<>();
+    public InstrumentationContext<Document> beginParse(InstrumentationExecutionParameters parameters) {
+        return new SimpleInstrumentationContext<>();
     }
 
     @Override
-    public InstrumentationContext<CompletableFuture<ExecutionResult>> beginCompleteFieldList(InstrumentationFieldCompleteParameters parameters) {
-        return new NoOpInstrumentationContext<>();
+    public InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters) {
+        return new SimpleInstrumentationContext<>();
+    }
+
+    @Override
+    public InstrumentationContext<ExecutionResult> beginExecutionStrategy(InstrumentationExecutionStrategyParameters parameters) {
+        return new SimpleInstrumentationContext<>();
+    }
+
+    @Override
+    public InstrumentationContext<ExecutionResult> beginExecuteOperation(InstrumentationExecuteOperationParameters parameters) {
+        return new SimpleInstrumentationContext<>();
+    }
+
+    @Override
+    public InstrumentationContext<ExecutionResult> beginField(InstrumentationFieldParameters parameters) {
+        return new SimpleInstrumentationContext<>();
+    }
+
+    @Override
+    public InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters) {
+        return new SimpleInstrumentationContext<>();
+    }
+
+
+    @Override
+    public InstrumentationContext<ExecutionResult> beginFieldComplete(InstrumentationFieldCompleteParameters parameters) {
+        return new SimpleInstrumentationContext<>();
+    }
+
+    @Override
+    public InstrumentationContext<ExecutionResult> beginFieldListComplete(InstrumentationFieldCompleteParameters parameters) {
+        return new SimpleInstrumentationContext<>();
     }
 
     @Override
@@ -115,9 +104,4 @@ public class NoOpInstrumentation implements Instrumentation {
         return CompletableFuture.completedFuture(executionResult);
     }
 
-    public static class NoOpInstrumentationContext<T> implements InstrumentationContext<T> {
-        @Override
-        public void onEnd(T result, Throwable t) {
-        }
-    }
 }

--- a/src/main/java/graphql/execution/instrumentation/SimpleInstrumentationContext.java
+++ b/src/main/java/graphql/execution/instrumentation/SimpleInstrumentationContext.java
@@ -1,0 +1,66 @@
+package graphql.execution.instrumentation;
+
+import graphql.PublicApi;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+/**
+ * A simple implementation of {@link InstrumentationContext}
+ */
+@PublicApi
+public class SimpleInstrumentationContext<T> implements InstrumentationContext<T> {
+
+    private final BiConsumer<T, Throwable> codeToRunOnComplete;
+    private final Consumer<CompletableFuture<T>> codeToRunOnDispatch;
+
+    public SimpleInstrumentationContext() {
+        this(null, null);
+    }
+
+    private SimpleInstrumentationContext(Consumer<CompletableFuture<T>> codeToRunOnDispatch, BiConsumer<T, Throwable> codeToRunOnComplete) {
+        this.codeToRunOnComplete = codeToRunOnComplete;
+        this.codeToRunOnDispatch = codeToRunOnDispatch;
+    }
+
+    @Override
+    public void onDispatched(CompletableFuture<T> result) {
+        if (codeToRunOnDispatch != null) {
+            codeToRunOnDispatch.accept(result);
+        }
+    }
+
+    @Override
+    public void onCompleted(T result, Throwable t) {
+        if (codeToRunOnComplete != null) {
+            codeToRunOnComplete.accept(result, t);
+        }
+    }
+
+    /**
+     * Allows for the more fluent away to return an instrumentation context that runs the specified
+     * code on instrumentation step dispatch.
+     *
+     * @param codeToRun the code to run on dispatch
+     * @param <U>       the generic type
+     *
+     * @return an instrumentation context
+     */
+    public static <U> SimpleInstrumentationContext<U> whenDispatched(Consumer<CompletableFuture<U>> codeToRun) {
+        return new SimpleInstrumentationContext<>(codeToRun, null);
+    }
+
+    /**
+     * Allows for the more fluent away to return an instrumentation context that runs the specified
+     * code on instrumentation step completion.
+     *
+     * @param codeToRun the code to run on completion
+     * @param <U>       the generic type
+     *
+     * @return an instrumentation context
+     */
+    public static <U> SimpleInstrumentationContext<U> whenCompleted(BiConsumer<U, Throwable> codeToRun) {
+        return new SimpleInstrumentationContext<>(null, codeToRun);
+    }
+}

--- a/src/main/java/graphql/execution/instrumentation/fieldvalidation/FieldValidationInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/fieldvalidation/FieldValidationInstrumentation.java
@@ -5,8 +5,8 @@ import graphql.GraphQLError;
 import graphql.PublicApi;
 import graphql.execution.AbortExecutionException;
 import graphql.execution.instrumentation.InstrumentationContext;
-import graphql.execution.instrumentation.NoOpInstrumentation;
-import graphql.execution.instrumentation.parameters.InstrumentationDataFetchParameters;
+import graphql.execution.instrumentation.SimpleInstrumentation;
+import graphql.execution.instrumentation.parameters.InstrumentationExecuteOperationParameters;
 
 import java.util.List;
 
@@ -22,7 +22,7 @@ import static graphql.Assert.assertNotNull;
  * @see FieldValidation
  */
 @PublicApi
-public class FieldValidationInstrumentation extends NoOpInstrumentation {
+public class FieldValidationInstrumentation extends SimpleInstrumentation {
 
     private final FieldValidation fieldValidation;
 
@@ -36,12 +36,12 @@ public class FieldValidationInstrumentation extends NoOpInstrumentation {
     }
 
     @Override
-    public InstrumentationContext<ExecutionResult> beginDataFetch(InstrumentationDataFetchParameters parameters) {
+    public InstrumentationContext<ExecutionResult> beginExecuteOperation(InstrumentationExecuteOperationParameters parameters) {
 
         List<GraphQLError> errors = FieldValidationSupport.validateFieldsAndArguments(fieldValidation, parameters.getExecutionContext());
         if (errors != null && !errors.isEmpty()) {
             throw new AbortExecutionException(errors);
         }
-        return super.beginDataFetch(parameters);
+        return super.beginExecuteOperation(parameters);
     }
 }

--- a/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationExecuteOperationParameters.java
+++ b/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationExecuteOperationParameters.java
@@ -7,15 +7,15 @@ import graphql.execution.instrumentation.InstrumentationState;
 /**
  * Parameters sent to {@link Instrumentation} methods
  */
-public class InstrumentationDataFetchParameters {
+public class InstrumentationExecuteOperationParameters {
     private final ExecutionContext executionContext;
     private final InstrumentationState instrumentationState;
 
-    public InstrumentationDataFetchParameters(ExecutionContext executionContext) {
+    public InstrumentationExecuteOperationParameters(ExecutionContext executionContext) {
         this(executionContext, executionContext.getInstrumentationState());
     }
 
-    private InstrumentationDataFetchParameters(ExecutionContext executionContext, InstrumentationState instrumentationState) {
+    private InstrumentationExecuteOperationParameters(ExecutionContext executionContext, InstrumentationState instrumentationState) {
         this.executionContext = executionContext;
         this.instrumentationState = instrumentationState;
     }
@@ -27,8 +27,8 @@ public class InstrumentationDataFetchParameters {
      *
      * @return a new parameters object with the new state
      */
-    public InstrumentationDataFetchParameters withNewState(InstrumentationState instrumentationState) {
-        return new InstrumentationDataFetchParameters(executionContext, instrumentationState);
+    public InstrumentationExecuteOperationParameters withNewState(InstrumentationState instrumentationState) {
+        return new InstrumentationExecuteOperationParameters(executionContext, instrumentationState);
     }
 
     public ExecutionContext getExecutionContext() {

--- a/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationExecutionStrategyParameters.java
+++ b/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationExecutionStrategyParameters.java
@@ -1,6 +1,7 @@
 package graphql.execution.instrumentation.parameters;
 
 import graphql.execution.ExecutionContext;
+import graphql.execution.ExecutionStrategyParameters;
 import graphql.execution.instrumentation.InstrumentationState;
 
 /**
@@ -9,14 +10,16 @@ import graphql.execution.instrumentation.InstrumentationState;
 public class InstrumentationExecutionStrategyParameters {
 
     private final ExecutionContext executionContext;
+    private final ExecutionStrategyParameters executionStrategyParameters;
     private final InstrumentationState instrumentationState;
 
-    public InstrumentationExecutionStrategyParameters(ExecutionContext executionContext) {
-        this(executionContext, executionContext.getInstrumentationState());
+    public InstrumentationExecutionStrategyParameters(ExecutionContext executionContext, ExecutionStrategyParameters executionStrategyParameters) {
+        this(executionContext, executionStrategyParameters, executionContext.getInstrumentationState());
     }
 
-    private InstrumentationExecutionStrategyParameters(ExecutionContext executionContext, InstrumentationState instrumentationState) {
+    private InstrumentationExecutionStrategyParameters(ExecutionContext executionContext, ExecutionStrategyParameters executionStrategyParameters, InstrumentationState instrumentationState) {
         this.executionContext = executionContext;
+        this.executionStrategyParameters = executionStrategyParameters;
         this.instrumentationState = instrumentationState;
     }
 
@@ -28,11 +31,15 @@ public class InstrumentationExecutionStrategyParameters {
      * @return a new parameters object with the new state
      */
     public InstrumentationExecutionStrategyParameters withNewState(InstrumentationState instrumentationState) {
-        return new InstrumentationExecutionStrategyParameters(executionContext, instrumentationState);
+        return new InstrumentationExecutionStrategyParameters(executionContext, executionStrategyParameters, instrumentationState);
     }
 
     public ExecutionContext getExecutionContext() {
         return executionContext;
+    }
+
+    public ExecutionStrategyParameters getExecutionStrategyParameters() {
+        return executionStrategyParameters;
     }
 
     public <T extends InstrumentationState> T getInstrumentationState() {

--- a/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationFieldCompleteParameters.java
+++ b/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationFieldCompleteParameters.java
@@ -13,18 +13,20 @@ public class InstrumentationFieldCompleteParameters {
     private final ExecutionContext executionContext;
     private final GraphQLFieldDefinition fieldDef;
     private final ExecutionTypeInfo typeInfo;
+    private final Object fetchedValue;
     private final InstrumentationState instrumentationState;
     private final ExecutionStrategyParameters executionStrategyParameters;
 
-    public InstrumentationFieldCompleteParameters(ExecutionContext executionContext, ExecutionStrategyParameters executionStrategyParameters, GraphQLFieldDefinition fieldDef, ExecutionTypeInfo typeInfo) {
-        this(executionContext, executionStrategyParameters, fieldDef, typeInfo, executionContext.getInstrumentationState());
+    public InstrumentationFieldCompleteParameters(ExecutionContext executionContext, ExecutionStrategyParameters executionStrategyParameters, GraphQLFieldDefinition fieldDef, ExecutionTypeInfo typeInfo, Object fetchedValue) {
+        this(executionContext, executionStrategyParameters, fieldDef, typeInfo, fetchedValue, executionContext.getInstrumentationState());
     }
 
-    InstrumentationFieldCompleteParameters(ExecutionContext executionContext, ExecutionStrategyParameters executionStrategyParameters, GraphQLFieldDefinition fieldDef, ExecutionTypeInfo typeInfo, InstrumentationState instrumentationState) {
+    InstrumentationFieldCompleteParameters(ExecutionContext executionContext, ExecutionStrategyParameters executionStrategyParameters, GraphQLFieldDefinition fieldDef, ExecutionTypeInfo typeInfo, Object fetchedValue, InstrumentationState instrumentationState) {
         this.executionContext = executionContext;
         this.executionStrategyParameters = executionStrategyParameters;
         this.fieldDef = fieldDef;
         this.typeInfo = typeInfo;
+        this.fetchedValue = fetchedValue;
         this.instrumentationState = instrumentationState;
     }
 
@@ -37,7 +39,7 @@ public class InstrumentationFieldCompleteParameters {
      */
     public InstrumentationFieldCompleteParameters withNewState(InstrumentationState instrumentationState) {
         return new InstrumentationFieldCompleteParameters(
-                this.executionContext, executionStrategyParameters, this.fieldDef, this.typeInfo, instrumentationState);
+                this.executionContext, executionStrategyParameters, this.fieldDef, this.typeInfo, this.fetchedValue, instrumentationState);
     }
 
 
@@ -55,6 +57,10 @@ public class InstrumentationFieldCompleteParameters {
 
     public ExecutionTypeInfo getTypeInfo() {
         return typeInfo;
+    }
+
+    public Object getFetchedValue() {
+        return fetchedValue;
     }
 
     public <T extends InstrumentationState> T getInstrumentationState() {

--- a/src/main/java/graphql/execution/instrumentation/tracing/TracingInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/tracing/TracingInstrumentation.java
@@ -6,12 +6,9 @@ import graphql.PublicApi;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.InstrumentationState;
-import graphql.execution.instrumentation.NoOpInstrumentation.NoOpInstrumentationContext;
-import graphql.execution.instrumentation.parameters.InstrumentationDataFetchParameters;
+import graphql.execution.instrumentation.SimpleInstrumentation;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
-import graphql.execution.instrumentation.parameters.InstrumentationExecutionStrategyParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
-import graphql.execution.instrumentation.parameters.InstrumentationFieldParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationValidationParameters;
 import graphql.language.Document;
 import graphql.validation.ValidationError;
@@ -22,12 +19,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import static graphql.execution.instrumentation.SimpleInstrumentationContext.whenCompleted;
+
 /**
  * This {@link Instrumentation} implementation uses {@link TracingSupport} to
  * capture tracing information and puts it into the {@link ExecutionResult}
  */
 @PublicApi
-public class TracingInstrumentation implements Instrumentation {
+public class TracingInstrumentation extends SimpleInstrumentation {
 
     @Override
     public InstrumentationState createState() {
@@ -50,40 +49,20 @@ public class TracingInstrumentation implements Instrumentation {
     public InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters) {
         TracingSupport tracingSupport = parameters.getInstrumentationState();
         TracingSupport.TracingContext ctx = tracingSupport.beginField(parameters.getEnvironment());
-        return (result, t) -> ctx.onEnd();
-    }
-
-    @Override
-    public InstrumentationContext<ExecutionResult> beginExecution(InstrumentationExecutionParameters parameters) {
-        return new NoOpInstrumentationContext<>();
+        return whenCompleted((result, t) -> ctx.onEnd());
     }
 
     @Override
     public InstrumentationContext<Document> beginParse(InstrumentationExecutionParameters parameters) {
         TracingSupport tracingSupport = parameters.getInstrumentationState();
         TracingSupport.TracingContext ctx = tracingSupport.beginParse();
-        return (result, t) -> ctx.onEnd();
+        return whenCompleted((result, t) -> ctx.onEnd());
     }
 
     @Override
     public InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters) {
         TracingSupport tracingSupport = parameters.getInstrumentationState();
         TracingSupport.TracingContext ctx = tracingSupport.beginValidation();
-        return (result, t) -> ctx.onEnd();
-    }
-
-    @Override
-    public InstrumentationContext<CompletableFuture<ExecutionResult>> beginExecutionStrategy(InstrumentationExecutionStrategyParameters parameters) {
-        return new NoOpInstrumentationContext<>();
-    }
-
-    @Override
-    public InstrumentationContext<ExecutionResult> beginDataFetch(InstrumentationDataFetchParameters parameters) {
-        return new NoOpInstrumentationContext<>();
-    }
-
-    @Override
-    public InstrumentationContext<ExecutionResult> beginField(InstrumentationFieldParameters parameters) {
-        return new NoOpInstrumentationContext<>();
+        return whenCompleted((result, t) -> ctx.onEnd());
     }
 }

--- a/src/test/groovy/graphql/GraphQLTest.groovy
+++ b/src/test/groovy/graphql/GraphQLTest.groovy
@@ -10,7 +10,7 @@ import graphql.execution.ExecutionStrategyParameters
 import graphql.execution.MissingRootTypeException
 import graphql.execution.batched.BatchedExecutionStrategy
 import graphql.execution.instrumentation.Instrumentation
-import graphql.execution.instrumentation.NoOpInstrumentation
+import graphql.execution.instrumentation.SimpleInstrumentation
 import graphql.language.SourceLocation
 import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironment
@@ -844,7 +844,7 @@ class GraphQLTest extends Specification {
 
     def "graphql copying works as expected"() {
 
-        def instrumentation = new NoOpInstrumentation()
+        def instrumentation = new SimpleInstrumentation()
         def hello = ExecutionId.from("hello")
         def executionIdProvider = new ExecutionIdProvider() {
             @Override
@@ -873,7 +873,7 @@ class GraphQLTest extends Specification {
         when:
 
         // now make some changes
-        def newInstrumentation = new NoOpInstrumentation()
+        def newInstrumentation = new SimpleInstrumentation()
         def goodbye = ExecutionId.from("goodbye")
         def newExecutionIdProvider = new ExecutionIdProvider() {
             @Override

--- a/src/test/groovy/graphql/analysis/MaxQueryComplexityInstrumentationTest.groovy
+++ b/src/test/groovy/graphql/analysis/MaxQueryComplexityInstrumentationTest.groovy
@@ -40,7 +40,7 @@ class MaxQueryComplexityInstrumentationTest extends Specification {
         InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, null)
         InstrumentationContext instrumentationContext = maxQueryComplexityInstrumentation.beginValidation(validationParameters)
         when:
-        instrumentationContext.onEnd([new ValidationError(ValidationErrorType.SubSelectionNotAllowed)], null)
+        instrumentationContext.onCompleted([new ValidationError(ValidationErrorType.SubSelectionNotAllowed)], null)
         then:
         0 * queryTraversal._(_)
 
@@ -68,7 +68,7 @@ class MaxQueryComplexityInstrumentationTest extends Specification {
         InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, null)
         InstrumentationContext instrumentationContext = maxQueryComplexityInstrumentation.beginValidation(validationParameters)
         when:
-        instrumentationContext.onEnd(null, new RuntimeException())
+        instrumentationContext.onCompleted(null, new RuntimeException())
         then:
         0 * queryTraversal._(_)
 
@@ -94,7 +94,7 @@ class MaxQueryComplexityInstrumentationTest extends Specification {
         InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, null)
         InstrumentationContext instrumentationContext = queryComplexityInstrumentation.beginValidation(validationParameters)
         when:
-        instrumentationContext.onEnd(null, null)
+        instrumentationContext.onCompleted(null, null)
         then:
         def e = thrown(AbortExecutionException)
         e.message == "maximum query complexity exceeded 11 > 10"
@@ -122,7 +122,7 @@ class MaxQueryComplexityInstrumentationTest extends Specification {
         InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, null)
         InstrumentationContext instrumentationContext = queryComplexityInstrumentation.beginValidation(validationParameters)
         when:
-        instrumentationContext.onEnd(null, null)
+        instrumentationContext.onCompleted(null, null)
 
         then:
         1 * calculator.calculate({ FieldComplexityEnvironment env -> env.field.name == "scalar" }, 0) >> 10

--- a/src/test/groovy/graphql/analysis/MaxQueryDepthInstrumentationTest.groovy
+++ b/src/test/groovy/graphql/analysis/MaxQueryDepthInstrumentationTest.groovy
@@ -41,7 +41,7 @@ class MaxQueryDepthInstrumentationTest extends Specification {
         InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, null)
         InstrumentationContext instrumentationContext = maximumQueryDepthInstrumentation.beginValidation(validationParameters)
         when:
-        instrumentationContext.onEnd([new ValidationError(ValidationErrorType.SubSelectionNotAllowed)], null)
+        instrumentationContext.onCompleted([new ValidationError(ValidationErrorType.SubSelectionNotAllowed)], null)
         then:
         0 * queryTraversal._(_)
 
@@ -69,7 +69,7 @@ class MaxQueryDepthInstrumentationTest extends Specification {
         InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, null)
         InstrumentationContext instrumentationContext = maximumQueryDepthInstrumentation.beginValidation(validationParameters)
         when:
-        instrumentationContext.onEnd(null, new RuntimeException())
+        instrumentationContext.onCompleted(null, new RuntimeException())
         then:
         0 * queryTraversal._(_)
 
@@ -95,7 +95,7 @@ class MaxQueryDepthInstrumentationTest extends Specification {
         InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, null)
         InstrumentationContext instrumentationContext = maximumQueryDepthInstrumentation.beginValidation(validationParameters)
         when:
-        instrumentationContext.onEnd(null, null)
+        instrumentationContext.onCompleted(null, null)
         then:
         def e = thrown(AbortExecutionException)
         e.message.contains("maximum query depth exceeded 7 > 6")
@@ -121,7 +121,7 @@ class MaxQueryDepthInstrumentationTest extends Specification {
         InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, null)
         InstrumentationContext instrumentationContext = maximumQueryDepthInstrumentation.beginValidation(validationParameters)
         when:
-        instrumentationContext.onEnd(null, null)
+        instrumentationContext.onCompleted(null, null)
         then:
         notThrown(Exception)
     }

--- a/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy
@@ -1,7 +1,7 @@
 package graphql.execution
 
 import graphql.ErrorType
-import graphql.execution.instrumentation.NoOpInstrumentation
+import graphql.execution.instrumentation.SimpleInstrumentation
 import graphql.language.Field
 import graphql.language.OperationDefinition
 import graphql.parser.Parser
@@ -74,7 +74,7 @@ class AsyncExecutionStrategyTest extends Specification {
                 .graphQLSchema(schema)
                 .executionId(ExecutionId.generate())
                 .operationDefinition(operation)
-                .instrumentation(NoOpInstrumentation.INSTANCE)
+                .instrumentation(SimpleInstrumentation.INSTANCE)
                 .build()
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
@@ -112,7 +112,7 @@ class AsyncExecutionStrategyTest extends Specification {
                 .graphQLSchema(schema)
                 .executionId(ExecutionId.generate())
                 .operationDefinition(operation)
-                .instrumentation(NoOpInstrumentation.INSTANCE)
+                .instrumentation(SimpleInstrumentation.INSTANCE)
                 .build()
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
@@ -152,7 +152,7 @@ class AsyncExecutionStrategyTest extends Specification {
                 .graphQLSchema(schema)
                 .executionId(ExecutionId.generate())
                 .operationDefinition(operation)
-                .instrumentation(NoOpInstrumentation.INSTANCE)
+                .instrumentation(SimpleInstrumentation.INSTANCE)
                 .build()
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
@@ -191,7 +191,7 @@ class AsyncExecutionStrategyTest extends Specification {
                 .graphQLSchema(schema)
                 .executionId(ExecutionId.generate())
                 .operationDefinition(operation)
-                .instrumentation(NoOpInstrumentation.INSTANCE)
+                .instrumentation(SimpleInstrumentation.INSTANCE)
                 .build()
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()

--- a/src/test/groovy/graphql/execution/AsyncSerialExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/AsyncSerialExecutionStrategyTest.groovy
@@ -1,6 +1,6 @@
 package graphql.execution
 
-import graphql.execution.instrumentation.NoOpInstrumentation
+import graphql.execution.instrumentation.SimpleInstrumentation
 import graphql.language.Field
 import graphql.language.OperationDefinition
 import graphql.parser.Parser
@@ -81,7 +81,7 @@ class AsyncSerialExecutionStrategyTest extends Specification {
                 .graphQLSchema(schema)
                 .executionId(ExecutionId.generate())
                 .operationDefinition(operation)
-                .instrumentation(NoOpInstrumentation.INSTANCE)
+                .instrumentation(SimpleInstrumentation.INSTANCE)
                 .build()
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
@@ -124,7 +124,7 @@ class AsyncSerialExecutionStrategyTest extends Specification {
                 .graphQLSchema(schema)
                 .executionId(ExecutionId.generate())
                 .operationDefinition(operation)
-                .instrumentation(NoOpInstrumentation.INSTANCE)
+                .instrumentation(SimpleInstrumentation.INSTANCE)
                 .build()
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()

--- a/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
@@ -7,7 +7,7 @@ import graphql.ExecutionResult
 import graphql.Scalars
 import graphql.SerializationError
 import graphql.TypeMismatchError
-import graphql.execution.instrumentation.NoOpInstrumentation
+import graphql.execution.instrumentation.SimpleInstrumentation
 import graphql.language.Argument
 import graphql.language.Field
 import graphql.language.OperationDefinition
@@ -55,7 +55,7 @@ class ExecutionStrategyTest extends Specification {
     def buildContext(GraphQLSchema schema = null) {
         ExecutionId executionId = ExecutionId.from("executionId123")
         def variables = [arg1: "value1"]
-        new ExecutionContext(NoOpInstrumentation.INSTANCE, executionId, schema, null,
+        new ExecutionContext(SimpleInstrumentation.INSTANCE, executionId, schema, null,
                 executionStrategy, executionStrategy, executionStrategy,
                 null, null, null,
                 variables, "context", "root")

--- a/src/test/groovy/graphql/execution/ExecutionTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionTest.groovy
@@ -5,7 +5,7 @@ import graphql.ExecutionResult
 import graphql.ExecutionResultImpl
 import graphql.MutationSchema
 import graphql.execution.instrumentation.InstrumentationState
-import graphql.execution.instrumentation.NoOpInstrumentation
+import graphql.execution.instrumentation.SimpleInstrumentation
 import graphql.parser.Parser
 import spock.lang.Specification
 
@@ -34,7 +34,7 @@ class ExecutionTest extends Specification {
     def subscriptionStrategy = new CountingExecutionStrategy()
     def mutationStrategy = new CountingExecutionStrategy()
     def queryStrategy = new CountingExecutionStrategy()
-    def execution = new Execution(queryStrategy, mutationStrategy, subscriptionStrategy, NoOpInstrumentation.INSTANCE)
+    def execution = new Execution(queryStrategy, mutationStrategy, subscriptionStrategy, SimpleInstrumentation.INSTANCE)
     def emptyExecutionInput = ExecutionInput.newExecutionInput().build()
     def instrumentationState = new InstrumentationState() {}
 
@@ -43,7 +43,7 @@ class ExecutionTest extends Specification {
         def mutationStrategy = new CountingExecutionStrategy()
 
         def queryStrategy = new CountingExecutionStrategy()
-        def execution = new Execution(queryStrategy, mutationStrategy, subscriptionStrategy, NoOpInstrumentation.INSTANCE)
+        def execution = new Execution(queryStrategy, mutationStrategy, subscriptionStrategy, SimpleInstrumentation.INSTANCE)
 
         def query = '''
             query {

--- a/src/test/groovy/graphql/execution/instrumentation/ChainedInstrumentationStateTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/ChainedInstrumentationStateTest.groovy
@@ -4,7 +4,7 @@ import graphql.ExecutionResult
 import graphql.GraphQL
 import graphql.StarWarsSchema
 import graphql.execution.AsyncExecutionStrategy
-import graphql.execution.instrumentation.parameters.InstrumentationDataFetchParameters
+import graphql.execution.instrumentation.parameters.InstrumentationExecuteOperationParameters
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionStrategyParameters
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters
@@ -68,9 +68,9 @@ class ChainedInstrumentationStateTest extends Specification {
         }
 
         @Override
-        InstrumentationContext<ExecutionResult> beginDataFetch(InstrumentationDataFetchParameters parameters) {
+        InstrumentationContext<ExecutionResult> beginExecuteOperation(InstrumentationExecuteOperationParameters parameters) {
             assertState(parameters.getInstrumentationState())
-            return super.beginDataFetch(parameters)
+            return super.beginExecuteOperation(parameters)
         }
 
         @Override
@@ -126,13 +126,10 @@ class ChainedInstrumentationStateTest extends Specification {
                 "start:validation",
                 "end:validation",
 
-                "start:data-fetch-dispatch",
-
-                "start:data-fetch",
+                "start:execute-operation",
 
                 "start:execution-strategy",
 
-                "start:fields",
                 "start:field-hero",
                 "start:fetch-hero",
                 "end:fetch-hero",
@@ -140,25 +137,21 @@ class ChainedInstrumentationStateTest extends Specification {
 
                 "start:execution-strategy",
 
-                "start:fields",
                 "start:field-id",
                 "start:fetch-id",
                 "end:fetch-id",
                 "start:complete-id",
                 "end:complete-id",
                 "end:field-id",
-                "end:fields",
 
                 "end:execution-strategy",
 
                 "end:complete-hero",
                 "end:field-hero",
-                "end:fields",
 
                 "end:execution-strategy",
 
-                "end:data-fetch",
-                "end:data-fetch-dispatch",
+                "end:execute-operation",
 
                 "end:execution",
         ]

--- a/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
@@ -46,12 +46,10 @@ class InstrumentationTest extends Specification {
                 "start:validation",
                 "end:validation",
 
-                "start:data-fetch-dispatch",
-                "start:data-fetch",
+                "start:execute-operation",
 
                 "start:execution-strategy",
 
-                "start:fields",
                 "start:field-hero",
                 "start:fetch-hero",
                 "end:fetch-hero",
@@ -60,26 +58,21 @@ class InstrumentationTest extends Specification {
 
                 "start:execution-strategy",
 
-                "start:fields",
                 "start:field-id",
                 "start:fetch-id",
                 "end:fetch-id",
                 "start:complete-id",
                 "end:complete-id",
                 "end:field-id",
-                "end:fields",
 
                 "end:execution-strategy",
 
                 "end:complete-hero",
                 "end:field-hero",
-                "end:fields",
 
                 "end:execution-strategy",
 
-                "end:data-fetch",
-
-                "end:data-fetch-dispatch",
+                "end:execute-operation",
                 "end:execution",
         ]
         when:
@@ -132,8 +125,7 @@ class InstrumentationTest extends Specification {
                 "end:parse",
                 "start:validation",
                 "end:validation",
-                "start:data-fetch-dispatch",
-                "start:data-fetch",
+                "start:execute-operation",
                 "start:execution-strategy",
 
                 "start:field-hero",
@@ -147,8 +139,7 @@ class InstrumentationTest extends Specification {
                 "end:field-id",
 
                 "end:execution-strategy",
-                "end:data-fetch",
-                "end:data-fetch-dispatch",
+                "end:execute-operation",
                 "end:execution",
         ]
         when:
@@ -214,7 +205,7 @@ class InstrumentationTest extends Specification {
      * java-dataloader works.  That is calls inside DataFetchers are "batched"
      * until a "dispatch" signal is made.
      */
-    class WaitingInstrumentation extends NoOpInstrumentation {
+    class WaitingInstrumentation extends SimpleInstrumentation {
 
         final AtomicBoolean goSignal = new AtomicBoolean()
 
@@ -223,10 +214,15 @@ class InstrumentationTest extends Specification {
             System.out.println(String.format("t%s setting go signal off", Thread.currentThread().getId()))
             goSignal.set(false)
             return new InstrumentationContext<CompletableFuture<ExecutionResult>>() {
+
                 @Override
-                void onEnd(CompletableFuture<ExecutionResult> result, Throwable t) {
+                void onDispatched(CompletableFuture<CompletableFuture<ExecutionResult>> result) {
                     System.out.println(String.format("t%s setting go signal on", Thread.currentThread().getId()))
                     goSignal.set(true)
+                }
+
+                @Override
+                void onCompleted(CompletableFuture<ExecutionResult> result, Throwable t) {
                 }
             }
         }

--- a/src/test/groovy/graphql/execution/instrumentation/TestingInstrumentContext.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/TestingInstrumentContext.groovy
@@ -1,5 +1,7 @@
 package graphql.execution.instrumentation
 
+import java.util.concurrent.CompletableFuture
+
 class TestingInstrumentContext<T> implements InstrumentationContext<T> {
     def op
     def start = System.currentTimeMillis()
@@ -21,7 +23,11 @@ class TestingInstrumentContext<T> implements InstrumentationContext<T> {
     }
 
     @Override
-    void onEnd(T result, Throwable t) {
+    void onDispatched(CompletableFuture<T> result) {
+    }
+
+    @Override
+    void onCompleted(T result, Throwable t) {
         if (t) {
             throwableList.add(t)
         }

--- a/src/test/groovy/graphql/execution/instrumentation/TestingInstrumentation.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/TestingInstrumentation.groovy
@@ -3,7 +3,7 @@ package graphql.execution.instrumentation
 import graphql.ExecutionInput
 import graphql.ExecutionResult
 import graphql.execution.ExecutionContext
-import graphql.execution.instrumentation.parameters.InstrumentationDataFetchParameters
+import graphql.execution.instrumentation.parameters.InstrumentationExecuteOperationParameters
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionStrategyParameters
 import graphql.execution.instrumentation.parameters.InstrumentationFieldCompleteParameters
@@ -11,7 +11,6 @@ import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchPar
 import graphql.execution.instrumentation.parameters.InstrumentationFieldParameters
 import graphql.execution.instrumentation.parameters.InstrumentationValidationParameters
 import graphql.language.Document
-import graphql.language.Field
 import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironment
 import graphql.schema.GraphQLSchema
@@ -57,21 +56,9 @@ class TestingInstrumentation implements Instrumentation {
     }
 
     @Override
-    InstrumentationContext<CompletableFuture<ExecutionResult>> beginDataFetchDispatch(InstrumentationDataFetchParameters parameters) {
+    InstrumentationContext<ExecutionResult> beginExecuteOperation(InstrumentationExecuteOperationParameters parameters) {
         assert parameters.getInstrumentationState() == instrumentationState
-        return new TestingInstrumentContext("data-fetch-dispatch", executionList, throwableList)
-    }
-
-    @Override
-    InstrumentationContext<ExecutionResult> beginDataFetch(InstrumentationDataFetchParameters parameters) {
-        assert parameters.getInstrumentationState() == instrumentationState
-        return new TestingInstrumentContext("data-fetch", executionList, throwableList)
-    }
-
-    @Override
-    InstrumentationContext<Map<String, List<Field>>> beginFields(InstrumentationExecutionStrategyParameters parameters) {
-        assert parameters.getInstrumentationState() == instrumentationState
-        return new TestingInstrumentContext("fields", executionList, throwableList)
+        return new TestingInstrumentContext("execute-operation", executionList, throwableList)
     }
 
     @Override
@@ -87,13 +74,13 @@ class TestingInstrumentation implements Instrumentation {
     }
 
     @Override
-    InstrumentationContext<CompletableFuture<ExecutionResult>> beginCompleteField(InstrumentationFieldCompleteParameters parameters) {
+    InstrumentationContext<CompletableFuture<ExecutionResult>> beginFieldComplete(InstrumentationFieldCompleteParameters parameters) {
         assert parameters.getInstrumentationState() == instrumentationState
         return new TestingInstrumentContext("complete-$parameters.field.name", executionList, throwableList)
     }
 
     @Override
-    InstrumentationContext<CompletableFuture<ExecutionResult>> beginCompleteFieldList(InstrumentationFieldCompleteParameters parameters) {
+    InstrumentationContext<CompletableFuture<ExecutionResult>> beginFieldListComplete(InstrumentationFieldCompleteParameters parameters) {
         assert parameters.getInstrumentationState() == instrumentationState
         return new TestingInstrumentContext("complete-list-$parameters.field.name", executionList, throwableList)
     }

--- a/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentationTest.groovy
@@ -5,7 +5,7 @@ import graphql.execution.ExecutionContext
 import graphql.execution.ExecutionContextBuilder
 import graphql.execution.ExecutionId
 import graphql.execution.instrumentation.InstrumentationContext
-import graphql.execution.instrumentation.parameters.InstrumentationDataFetchParameters
+import graphql.execution.instrumentation.parameters.InstrumentationExecuteOperationParameters
 import org.dataloader.BatchLoader
 import org.dataloader.DataLoader
 import org.dataloader.DataLoaderRegistry
@@ -48,15 +48,15 @@ class DataLoaderDispatcherInstrumentationTest extends Specification {
                 .executionId(ExecutionId.generate())
                 .instrumentationState(instrumentationState)
                 .build()
-        def parameters = new InstrumentationDataFetchParameters(executionContext)
-        InstrumentationContext<CompletableFuture<ExecutionResult>> context = dispatcher.beginDataFetchDispatch(parameters)
+        def parameters = new InstrumentationExecuteOperationParameters(executionContext)
+        InstrumentationContext<CompletableFuture<ExecutionResult>> context = dispatcher.beginExecuteOperation(parameters)
 
         // cause some activity
         dlA.load("A")
         dlB.load("B")
         dlC.load("C")
 
-        context.onEnd(null, null)
+        context.onDispatched(null)
 
 
 

--- a/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderPerformanceTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderPerformanceTest.groovy
@@ -4,12 +4,11 @@ import graphql.ExecutionInput
 import graphql.ExecutionResult
 import graphql.GraphQL
 import graphql.execution.instrumentation.InstrumentationContext
+import graphql.execution.instrumentation.SimpleInstrumentationContext
 import graphql.execution.instrumentation.parameters.InstrumentationFieldCompleteParameters
 import graphql.schema.GraphQLSchema
 import org.dataloader.DataLoaderRegistry
 import spock.lang.Specification
-
-import java.util.concurrent.CompletableFuture
 
 class DataLoaderPerformanceTest extends Specification {
 
@@ -84,9 +83,9 @@ class DataLoaderPerformanceTest extends Specification {
         dataLoaderRegistry.register("products", BatchCompareDataFetchers.productsForDepartmentDataLoader)
         def instrumentation = new DataLoaderDispatcherInstrumentation(dataLoaderRegistry) {
             @Override
-            InstrumentationContext<CompletableFuture<ExecutionResult>> beginCompleteFieldList(InstrumentationFieldCompleteParameters parameters) {
+            InstrumentationContext<ExecutionResult> beginFieldListComplete(InstrumentationFieldCompleteParameters parameters) {
                 // if we never call super.xxx() then it wont record we are in a list and it wont be efficient
-                return { e, t -> }
+                return new SimpleInstrumentationContext<>()
             }
         }
         GraphQL graphQL = GraphQL

--- a/src/test/groovy/graphql/execution/instrumentation/fieldvalidation/FieldValidationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/fieldvalidation/FieldValidationTest.groovy
@@ -10,7 +10,7 @@ import graphql.execution.AsyncExecutionStrategy
 import graphql.execution.Execution
 import graphql.execution.ExecutionId
 import graphql.execution.ExecutionPath
-import graphql.execution.instrumentation.NoOpInstrumentation
+import graphql.execution.instrumentation.SimpleInstrumentation
 import spock.lang.Specification
 
 import java.util.concurrent.CompletableFuture
@@ -307,7 +307,7 @@ class FieldValidationTest extends Specification {
         def execution = new Execution(strategy, strategy, strategy, instrumentation)
 
         def executionInput = ExecutionInput.newExecutionInput().query(query).variables(variables).build()
-        execution.execute(document, schema, ExecutionId.generate(), executionInput, NoOpInstrumentation.INSTANCE.createState())
+        execution.execute(document, schema, ExecutionId.generate(), executionInput, SimpleInstrumentation.INSTANCE.createState())
     }
 
 }

--- a/src/test/groovy/graphql/execution/preparsed/PreparsedDocumentProviderTest.groovy
+++ b/src/test/groovy/graphql/execution/preparsed/PreparsedDocumentProviderTest.groovy
@@ -19,13 +19,10 @@ class PreparsedDocumentProviderTest extends Specification {
 
                 "start:validation",
                 "end:validation",
-                "start:data-fetch-dispatch",
-
-                "start:data-fetch",
+                "start:execute-operation",
 
                 "start:execution-strategy",
 
-                "start:fields",
                 "start:field-hero",
                 "start:fetch-hero",
                 "end:fetch-hero",
@@ -33,25 +30,21 @@ class PreparsedDocumentProviderTest extends Specification {
 
                 "start:execution-strategy",
 
-                "start:fields",
                 "start:field-id",
                 "start:fetch-id",
                 "end:fetch-id",
                 "start:complete-id",
                 "end:complete-id",
                 "end:field-id",
-                "end:fields",
 
                 "end:execution-strategy",
 
                 "end:complete-hero",
                 "end:field-hero",
-                "end:fields",
 
                 "end:execution-strategy",
 
-                "end:data-fetch",
-                "end:data-fetch-dispatch",
+                "end:execute-operation",
                 "end:execution",
         ]
         given:
@@ -68,11 +61,9 @@ class PreparsedDocumentProviderTest extends Specification {
         def expectedPreparsed = [
                 "start:execution",
 
-                "start:data-fetch-dispatch",
-                "start:data-fetch",
+                "start:execute-operation",
                 "start:execution-strategy",
 
-                "start:fields",
                 "start:field-hero",
                 "start:fetch-hero",
                 "end:fetch-hero",
@@ -80,24 +71,21 @@ class PreparsedDocumentProviderTest extends Specification {
 
                 "start:execution-strategy",
 
-                "start:fields",
                 "start:field-id",
                 "start:fetch-id",
                 "end:fetch-id",
                 "start:complete-id",
                 "end:complete-id",
                 "end:field-id",
-                "end:fields",
+
                 "end:execution-strategy",
 
                 "end:complete-hero",
                 "end:field-hero",
-                "end:fields",
+
                 "end:execution-strategy",
 
-                "end:data-fetch",
-
-                "end:data-fetch-dispatch",
+                "end:execute-operation",
                 "end:execution",
         ]
 

--- a/src/test/groovy/readme/InstrumentationExamples.java
+++ b/src/test/groovy/readme/InstrumentationExamples.java
@@ -8,23 +8,18 @@ import graphql.execution.instrumentation.ChainedInstrumentation;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.InstrumentationState;
-import graphql.execution.instrumentation.NoOpInstrumentation;
+import graphql.execution.instrumentation.SimpleInstrumentation;
+import graphql.execution.instrumentation.SimpleInstrumentationContext;
 import graphql.execution.instrumentation.fieldvalidation.FieldAndArguments;
 import graphql.execution.instrumentation.fieldvalidation.FieldValidation;
 import graphql.execution.instrumentation.fieldvalidation.FieldValidationEnvironment;
 import graphql.execution.instrumentation.fieldvalidation.FieldValidationInstrumentation;
 import graphql.execution.instrumentation.fieldvalidation.SimpleFieldValidation;
-import graphql.execution.instrumentation.parameters.InstrumentationDataFetchParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
-import graphql.execution.instrumentation.parameters.InstrumentationExecutionStrategyParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
-import graphql.execution.instrumentation.parameters.InstrumentationFieldParameters;
-import graphql.execution.instrumentation.parameters.InstrumentationValidationParameters;
 import graphql.execution.instrumentation.tracing.TracingInstrumentation;
-import graphql.language.Document;
 import graphql.schema.DataFetcher;
 import graphql.schema.GraphQLSchema;
-import graphql.validation.ValidationError;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -65,7 +60,7 @@ public class InstrumentationExamples {
         }
     }
 
-    class CustomInstrumentation implements Instrumentation {
+    class CustomInstrumentation extends SimpleInstrumentation {
         @Override
         public InstrumentationState createState() {
             //
@@ -78,51 +73,19 @@ public class InstrumentationExamples {
         @Override
         public InstrumentationContext<ExecutionResult> beginExecution(InstrumentationExecutionParameters parameters) {
             long startNanos = System.nanoTime();
-            return (result, throwable) -> {
-
-                CustomInstrumentationState state = parameters.getInstrumentationState();
-                state.recordTiming(parameters.getQuery(), System.nanoTime() - startNanos);
+            return new SimpleInstrumentationContext<ExecutionResult>() {
+                @Override
+                public void onCompleted(ExecutionResult result, Throwable t) {
+                    CustomInstrumentationState state = parameters.getInstrumentationState();
+                    state.recordTiming(parameters.getQuery(), System.nanoTime() - startNanos);
+                }
             };
-        }
-
-        @Override
-        public InstrumentationContext<Document> beginParse(InstrumentationExecutionParameters parameters) {
-            //
-            // You MUST return a non null object but it does not have to do anything and hence
-            // you use this class to return a no-op object
-            //
-            return new NoOpInstrumentation.NoOpInstrumentationContext<>();
-        }
-
-        @Override
-        public InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters) {
-            return new NoOpInstrumentation.NoOpInstrumentationContext<>();
-        }
-
-        @Override
-        public InstrumentationContext<ExecutionResult> beginDataFetch(InstrumentationDataFetchParameters parameters) {
-            return new NoOpInstrumentation.NoOpInstrumentationContext<>();
-        }
-
-        @Override
-        public InstrumentationContext<CompletableFuture<ExecutionResult>> beginExecutionStrategy(InstrumentationExecutionStrategyParameters parameters) {
-            return new NoOpInstrumentation.NoOpInstrumentationContext<>();
-        }
-
-        @Override
-        public InstrumentationContext<ExecutionResult> beginField(InstrumentationFieldParameters parameters) {
-            return new NoOpInstrumentation.NoOpInstrumentationContext<>();
-        }
-
-        @Override
-        public InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters) {
-            return new NoOpInstrumentation.NoOpInstrumentationContext<>();
         }
 
         @Override
         public DataFetcher<?> instrumentDataFetcher(DataFetcher<?> dataFetcher, InstrumentationFieldFetchParameters parameters) {
             //
-            // this allows you to intercept the data fetcher used ot fetch a field and provide another one, perhaps
+            // this allows you to intercept the data fetcher used to fetch a field and provide another one, perhaps
             // that enforces certain behaviours or has certain side effects on the data
             //
             return dataFetcher;


### PR DESCRIPTION
This is a refactor of the Instrumentation such that it now has 2 callbacks, one for on `dispatched` and one for on `complete`

This reduces the number of beginXX methods, keeping things simpler.

Examination of the code base revealed we ended up with beginXX and beginXXXDispatched methods. I found myself wanting to add more beingXXX methods to capture the dispatch and completion. This brings it back to one set of methods.

This is an API BREAKING change BTW.