### PR TITLE
Support for serialization of other optional types

### DIFF
--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -37,6 +37,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.stream.IntStream;
@@ -558,11 +561,33 @@ public abstract class ExecutionStrategy {
         if (result instanceof Optional) {
             Optional optional = (Optional) result;
             if (optional.isPresent()) {
-                result = optional.get();
+                return optional.get();
             } else {
-                result = null;
+                return null;
+            }
+        } else if (result instanceof OptionalInt) {
+            OptionalInt optional = (OptionalInt)result;
+            if (optional.isPresent()) {
+                return optional.getAsInt();
+            } else {
+                return null;
+            }
+        } else if (result instanceof OptionalDouble) {
+            OptionalDouble optional = (OptionalDouble)result;
+            if (optional.isPresent()) {
+                return optional.getAsDouble();
+            } else {
+                return null;
+            }
+        } else if (result instanceof OptionalLong) {
+            OptionalLong optional = (OptionalLong)result;
+            if (optional.isPresent()) {
+                return optional.getAsLong();
+            } else {
+                return null;
             }
         }
+
         return result;
     }
 

--- a/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
@@ -178,6 +178,147 @@ class ExecutionStrategyTest extends Specification {
         thrown(NonNullableFieldWasNullException)
     }
 
+    def "completes value for java.util.OptionalInt"() {
+        given:
+        ExecutionContext executionContext = buildContext()
+        def fieldType = GraphQLString
+        def fldDef = newFieldDefinition().name("test").type(fieldType).build()
+        def typeInfo = ExecutionTypeInfo.newTypeInfo().type(fieldType).fieldDefinition(fldDef).build()
+        NonNullableFieldValidator nullableFieldValidator = new NonNullableFieldValidator(executionContext, typeInfo)
+        def parameters = newParameters()
+                .typeInfo(typeInfo)
+                .nonNullFieldValidator(nullableFieldValidator)
+                .source(result)
+                .fields(["fld": []])
+                .build()
+
+        when:
+        def executionResult = executionStrategy.completeValue(executionContext, parameters).join()
+
+        then:
+        executionResult.data == expected
+
+        where:
+        result                    || expected
+        OptionalInt.of(10)      || "10"
+        OptionalInt.empty() || null
+    }
+
+    def "completes value for an empty java.util.OptionalInt that triggers non null exception"() {
+        given:
+        ExecutionContext executionContext = buildContext()
+        def fieldType = nonNull(GraphQLString)
+        def fldDef = newFieldDefinition().name("test").type(fieldType).build()
+        def typeInfo = ExecutionTypeInfo.newTypeInfo().type(fieldType).fieldDefinition(fldDef).build()
+        NonNullableFieldValidator nullableFieldValidator = new NonNullableFieldValidator(executionContext, typeInfo)
+        def parameters = newParameters()
+                .typeInfo(typeInfo)
+                .nonNullFieldValidator(nullableFieldValidator)
+                .source(OptionalInt.empty())
+                .fields(["fld": []])
+                .build()
+
+        when:
+        executionStrategy.completeValue(executionContext, parameters).join()
+
+        then:
+        thrown(NonNullableFieldWasNullException)
+    }
+
+    def "completes value for java.util.OptionalDouble"() {
+        given:
+        ExecutionContext executionContext = buildContext()
+        def fieldType = GraphQLString
+        def fldDef = newFieldDefinition().name("test").type(fieldType).build()
+        def typeInfo = ExecutionTypeInfo.newTypeInfo().type(fieldType).fieldDefinition(fldDef).build()
+        NonNullableFieldValidator nullableFieldValidator = new NonNullableFieldValidator(executionContext, typeInfo)
+        def parameters = newParameters()
+                .typeInfo(typeInfo)
+                .nonNullFieldValidator(nullableFieldValidator)
+                .source(result)
+                .fields(["fld": []])
+                .build()
+
+        when:
+        def executionResult = executionStrategy.completeValue(executionContext, parameters).join()
+
+        then:
+        executionResult.data == expected
+
+        where:
+        result                    || expected
+        OptionalDouble.of(10)      || "10.0"
+        OptionalDouble.empty() || null
+    }
+
+    def "completes value for an empty java.util.OptionalDouble that triggers non null exception"() {
+        given:
+        ExecutionContext executionContext = buildContext()
+        def fieldType = nonNull(GraphQLString)
+        def fldDef = newFieldDefinition().name("test").type(fieldType).build()
+        def typeInfo = ExecutionTypeInfo.newTypeInfo().type(fieldType).fieldDefinition(fldDef).build()
+        NonNullableFieldValidator nullableFieldValidator = new NonNullableFieldValidator(executionContext, typeInfo)
+        def parameters = newParameters()
+                .typeInfo(typeInfo)
+                .nonNullFieldValidator(nullableFieldValidator)
+                .source(OptionalDouble.empty())
+                .fields(["fld": []])
+                .build()
+
+        when:
+        executionStrategy.completeValue(executionContext, parameters).join()
+
+        then:
+        thrown(NonNullableFieldWasNullException)
+    }
+
+    def "completes value for java.util.OptionalLong"() {
+        given:
+        ExecutionContext executionContext = buildContext()
+        def fieldType = GraphQLString
+        def fldDef = newFieldDefinition().name("test").type(fieldType).build()
+        def typeInfo = ExecutionTypeInfo.newTypeInfo().type(fieldType).fieldDefinition(fldDef).build()
+        NonNullableFieldValidator nullableFieldValidator = new NonNullableFieldValidator(executionContext, typeInfo)
+        def parameters = newParameters()
+                .typeInfo(typeInfo)
+                .nonNullFieldValidator(nullableFieldValidator)
+                .source(result)
+                .fields(["fld": []])
+                .build()
+
+        when:
+        def executionResult = executionStrategy.completeValue(executionContext, parameters).join()
+
+        then:
+        executionResult.data == expected
+
+        where:
+        result                    || expected
+        OptionalLong.of(10)      || "10"
+        OptionalLong.empty() || null
+    }
+
+    def "completes value for an empty java.util.OptionalLong that triggers non null exception"() {
+        given:
+        ExecutionContext executionContext = buildContext()
+        def fieldType = nonNull(GraphQLString)
+        def fldDef = newFieldDefinition().name("test").type(fieldType).build()
+        def typeInfo = ExecutionTypeInfo.newTypeInfo().type(fieldType).fieldDefinition(fldDef).build()
+        NonNullableFieldValidator nullableFieldValidator = new NonNullableFieldValidator(executionContext, typeInfo)
+        def parameters = newParameters()
+                .typeInfo(typeInfo)
+                .nonNullFieldValidator(nullableFieldValidator)
+                .source(OptionalLong.empty())
+                .fields(["fld": []])
+                .build()
+
+        when:
+        executionStrategy.completeValue(executionContext, parameters).join()
+
+        then:
+        thrown(NonNullableFieldWasNullException)
+    }
+
     def "completes value for an array"() {
         given:
         ExecutionContext executionContext = buildContext()


### PR DESCRIPTION
Adds support for serializing values of:

- java.util.OptionalDouble
- java.util.OptionalInt
- java.util.OptionalLong

These types were originally created for performance reasons, but should be
included here for readability and convenience for graphql users.

Closes #899