### PR TITLE
This adds runtime directives to the graphql types.  

### DIFF
--- a/src/main/java/graphql/DirectivesUtil.java
+++ b/src/main/java/graphql/DirectivesUtil.java
@@ -1,0 +1,15 @@
+package graphql;
+
+import graphql.schema.GraphQLDirective;
+import graphql.util.FpKit;
+
+import java.util.List;
+import java.util.Map;
+
+@Internal
+public class DirectivesUtil {
+
+    public static Map<String, GraphQLDirective> directivesByName(List<GraphQLDirective> directiveList) {
+        return FpKit.getByName(directiveList, GraphQLDirective::getName, FpKit.mergeFirst());
+    }
+}

--- a/src/main/java/graphql/language/NodeUtil.java
+++ b/src/main/java/graphql/language/NodeUtil.java
@@ -2,15 +2,13 @@ package graphql.language;
 
 import graphql.GraphQLException;
 import graphql.Internal;
+import graphql.util.FpKit;
 
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.BinaryOperator;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
-import static java.util.function.Function.identity;
+import static graphql.util.FpKit.mergeFirst;
 
 /**
  * Helper class for working with {@link Node}s
@@ -31,23 +29,11 @@ public class NodeUtil {
 
 
     public static Map<String, Directive> directivesByName(List<Directive> directives) {
-        return getByName(directives, Directive::getName);
+        return FpKit.getByName(directives, Directive::getName, mergeFirst());
     }
 
     public static Map<String, Argument> argumentsByName(List<Argument> arguments) {
-        return getByName(arguments, Argument::getName);
-    }
-
-    private static <T> Map<String, T> getByName(List<T> namedObjects, Function<T, String> nameFn) {
-        return namedObjects.stream().collect(Collectors.toMap(
-                nameFn,
-                identity(),
-                mergeFirst())
-        );
-    }
-
-    private static <T> BinaryOperator<T> mergeFirst() {
-        return (o1, o2) -> o1;
+        return FpKit.getByName(arguments, Argument::getName, mergeFirst());
     }
 
 

--- a/src/main/java/graphql/schema/GraphQLDirective.java
+++ b/src/main/java/graphql/schema/GraphQLDirective.java
@@ -14,7 +14,7 @@ import static graphql.Assert.assertValidName;
 import static graphql.introspection.Introspection.DirectiveLocation;
 
 /**
- * A directive can be used to modify the behavior of a graphql field.
+ * A directive can be used to modify the behavior of a graphql field or type.
  *
  * See http://graphql.org/learn/queries/#directives for more details on the concept.
  */

--- a/src/main/java/graphql/schema/GraphQLDirectiveContainer.java
+++ b/src/main/java/graphql/schema/GraphQLDirectiveContainer.java
@@ -1,0 +1,33 @@
+package graphql.schema;
+
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents a type that can have {@link graphql.schema.GraphQLDirective}s
+ */
+public interface GraphQLDirectiveContainer extends GraphQLType {
+
+    /**
+     * @return a list of directives associated with the type
+     */
+    List<GraphQLDirective> getDirectives();
+
+    /**
+     * @return a a map of directives by directive name
+     */
+    Map<String, GraphQLDirective> getDirectivesByName();
+
+    /**
+     * Returns a named directive
+     *
+     * @param directiveName the name of the directive to retrive
+     *
+     * @return the directive or null if there is one one with that name
+     */
+    default GraphQLDirective getDirective(String directiveName) {
+        return getDirectivesByName().get(directiveName);
+    }
+
+}

--- a/src/main/java/graphql/schema/GraphQLDirectiveContainer.java
+++ b/src/main/java/graphql/schema/GraphQLDirectiveContainer.java
@@ -4,6 +4,8 @@ package graphql.schema;
 import java.util.List;
 import java.util.Map;
 
+import static graphql.DirectivesUtil.directivesByName;
+
 /**
  * Represents a type that can have {@link graphql.schema.GraphQLDirective}s
  */
@@ -17,7 +19,9 @@ public interface GraphQLDirectiveContainer extends GraphQLType {
     /**
      * @return a a map of directives by directive name
      */
-    Map<String, GraphQLDirective> getDirectivesByName();
+    default Map<String, GraphQLDirective> getDirectivesByName() {
+        return directivesByName(getDirectives());
+    }
 
     /**
      * Returns a named directive

--- a/src/main/java/graphql/schema/GraphQLFieldDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLFieldDefinition.java
@@ -1,6 +1,7 @@
 package graphql.schema;
 
 
+import graphql.DirectivesUtil;
 import graphql.Internal;
 import graphql.PublicApi;
 import graphql.language.FieldDefinition;
@@ -34,17 +35,19 @@ public class GraphQLFieldDefinition {
     private final DataFetcherFactory dataFetcherFactory;
     private final String deprecationReason;
     private final List<GraphQLArgument> arguments;
+    private final List<GraphQLDirective> directives;
     private final FieldDefinition definition;
 
 
     @Deprecated
     @Internal
     public GraphQLFieldDefinition(String name, String description, GraphQLOutputType type, DataFetcher<?> dataFetcher, List<GraphQLArgument> arguments, String deprecationReason) {
-        this(name, description, type, DataFetcherFactories.useDataFetcher(dataFetcher), arguments, deprecationReason, null);
+        this(name, description, type, DataFetcherFactories.useDataFetcher(dataFetcher), arguments, deprecationReason, Collections.emptyList(), null);
     }
 
     @Internal
-    public GraphQLFieldDefinition(String name, String description, GraphQLOutputType type, DataFetcherFactory dataFetcherFactory, List<GraphQLArgument> arguments, String deprecationReason, FieldDefinition definition) {
+    public GraphQLFieldDefinition(String name, String description, GraphQLOutputType type, DataFetcherFactory dataFetcherFactory, List<GraphQLArgument> arguments, String deprecationReason, List<GraphQLDirective> directives, FieldDefinition definition) {
+        this.directives = directives;
         assertValidName(name);
         assertNotNull(dataFetcherFactory, "you have to provide a DataFetcher (or DataFetcherFactory)");
         assertNotNull(type, "type can't be null");
@@ -83,6 +86,18 @@ public class GraphQLFieldDefinition {
             if (argument.getName().equals(name)) return argument;
         }
         return null;
+    }
+
+    public List<GraphQLDirective> getDirectives() {
+        return Collections.unmodifiableList(directives);
+    }
+
+    public Map<String, GraphQLDirective> getDirectivesByName() {
+        return DirectivesUtil.directivesByName(directives);
+    }
+
+    public GraphQLDirective getDirective(String directiveName) {
+        return getDirectivesByName().get(directiveName);
     }
 
     public List<GraphQLArgument> getArguments() {
@@ -130,6 +145,7 @@ public class GraphQLFieldDefinition {
         private GraphQLOutputType type;
         private DataFetcherFactory<?> dataFetcherFactory;
         private final List<GraphQLArgument> arguments = new ArrayList<>();
+        private final List<GraphQLDirective> directives = new ArrayList<>();
         private String deprecationReason;
         private boolean isField;
         private FieldDefinition definition;
@@ -262,6 +278,11 @@ public class GraphQLFieldDefinition {
             return this;
         }
 
+        public Builder withDirectives(GraphQLDirective... directives) {
+            Collections.addAll(this.directives, directives);
+            return this;
+        }
+
         public GraphQLFieldDefinition build() {
             if (dataFetcherFactory == null) {
                 if (isField) {
@@ -270,7 +291,7 @@ public class GraphQLFieldDefinition {
                     dataFetcherFactory = DataFetcherFactories.useDataFetcher(new PropertyDataFetcher<>(name));
                 }
             }
-            return new GraphQLFieldDefinition(name, description, type, dataFetcherFactory, arguments, deprecationReason, definition);
+            return new GraphQLFieldDefinition(name, description, type, dataFetcherFactory, arguments, deprecationReason, directives, definition);
         }
     }
 }

--- a/src/main/java/graphql/schema/GraphQLFieldDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLFieldDefinition.java
@@ -89,7 +89,7 @@ public class GraphQLFieldDefinition {
     }
 
     public List<GraphQLDirective> getDirectives() {
-        return Collections.unmodifiableList(directives);
+        return new ArrayList<>(directives);
     }
 
     public Map<String, GraphQLDirective> getDirectivesByName() {

--- a/src/main/java/graphql/schema/GraphQLObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLObjectType.java
@@ -1,11 +1,13 @@
 package graphql.schema;
 
 import graphql.AssertException;
+import graphql.DirectivesUtil;
 import graphql.Internal;
 import graphql.PublicApi;
 import graphql.language.ObjectTypeDefinition;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -15,6 +17,7 @@ import java.util.stream.Collectors;
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
 import static java.lang.String.format;
+import static java.util.Collections.emptyList;
 
 /**
  * This is the work horse type and represents an object with one or more field values that can be retrieved
@@ -26,24 +29,25 @@ import static java.lang.String.format;
  * See http://graphql.org/learn/schema/#object-types-and-fields for more details on the concept.
  */
 @PublicApi
-public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQLFieldsContainer, GraphQLCompositeType, GraphQLUnmodifiedType, GraphQLNullableType {
+public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQLFieldsContainer, GraphQLCompositeType, GraphQLUnmodifiedType, GraphQLNullableType, GraphQLDirectiveContainer {
 
 
     private final String name;
     private final String description;
     private final Map<String, GraphQLFieldDefinition> fieldDefinitionsByName = new LinkedHashMap<>();
     private List<GraphQLOutputType> interfaces = new ArrayList<>();
+    private final List<GraphQLDirective> directives;
     private final ObjectTypeDefinition definition;
 
     @Internal
     public GraphQLObjectType(String name, String description, List<GraphQLFieldDefinition> fieldDefinitions,
                              List<GraphQLOutputType> interfaces) {
-        this(name, description, fieldDefinitions, interfaces, null);
+        this(name, description, fieldDefinitions, interfaces, emptyList(), null);
     }
 
     @Internal
     public GraphQLObjectType(String name, String description, List<GraphQLFieldDefinition> fieldDefinitions,
-                             List<GraphQLOutputType> interfaces, ObjectTypeDefinition definition) {
+                             List<GraphQLOutputType> interfaces, List<GraphQLDirective> directives, ObjectTypeDefinition definition) {
         assertValidName(name);
         assertNotNull(fieldDefinitions, "fieldDefinitions can't be null");
         assertNotNull(interfaces, "interfaces can't be null");
@@ -51,6 +55,7 @@ public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQ
         this.description = description;
         this.interfaces = interfaces;
         this.definition = definition;
+        this.directives = assertNotNull(directives);
         buildDefinitionMap(fieldDefinitions);
     }
 
@@ -67,6 +72,16 @@ public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQ
                 throw new AssertException(format("Duplicated definition for field '%s' in type '%s'", name, this.name));
             fieldDefinitionsByName.put(name, fieldDefinition);
         }
+    }
+
+    @Override
+    public List<GraphQLDirective> getDirectives() {
+        return Collections.unmodifiableList(directives);
+    }
+
+    @Override
+    public Map<String, GraphQLDirective> getDirectivesByName() {
+        return DirectivesUtil.directivesByName(directives);
     }
 
     public GraphQLFieldDefinition getFieldDefinition(String name) {
@@ -121,6 +136,7 @@ public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQ
         private String description;
         private final List<GraphQLFieldDefinition> fieldDefinitions = new ArrayList<>();
         private final List<GraphQLOutputType> interfaces = new ArrayList<>();
+        private final List<GraphQLDirective> directives = new ArrayList<>();
         private ObjectTypeDefinition definition;
 
         public Builder name(String name) {
@@ -209,8 +225,13 @@ public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQ
             return this;
         }
 
+        public Builder withDirectives(GraphQLDirective... directives) {
+            Collections.addAll(this.directives, directives);
+            return this;
+        }
+
         public GraphQLObjectType build() {
-            return new GraphQLObjectType(name, description, fieldDefinitions, interfaces, definition);
+            return new GraphQLObjectType(name, description, fieldDefinitions, interfaces, directives, definition);
         }
 
     }

--- a/src/main/java/graphql/schema/GraphQLObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLObjectType.java
@@ -1,7 +1,6 @@
 package graphql.schema;
 
 import graphql.AssertException;
-import graphql.DirectivesUtil;
 import graphql.Internal;
 import graphql.PublicApi;
 import graphql.language.ObjectTypeDefinition;
@@ -76,18 +75,12 @@ public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQ
 
     @Override
     public List<GraphQLDirective> getDirectives() {
-        return Collections.unmodifiableList(directives);
-    }
-
-    @Override
-    public Map<String, GraphQLDirective> getDirectivesByName() {
-        return DirectivesUtil.directivesByName(directives);
+        return new ArrayList<>(directives);
     }
 
     public GraphQLFieldDefinition getFieldDefinition(String name) {
         return fieldDefinitionsByName.get(name);
     }
-
 
     public List<GraphQLFieldDefinition> getFieldDefinitions() {
         return new ArrayList<>(fieldDefinitionsByName.values());

--- a/src/main/java/graphql/schema/idl/SchemaGenerator.java
+++ b/src/main/java/graphql/schema/idl/SchemaGenerator.java
@@ -2,16 +2,21 @@ package graphql.schema.idl;
 
 import graphql.Assert;
 import graphql.GraphQLError;
+import graphql.Scalars;
+import graphql.introspection.Introspection;
 import graphql.language.Argument;
 import graphql.language.ArrayValue;
+import graphql.language.BooleanValue;
 import graphql.language.Comment;
 import graphql.language.Description;
 import graphql.language.Directive;
 import graphql.language.EnumTypeDefinition;
 import graphql.language.EnumValue;
 import graphql.language.FieldDefinition;
+import graphql.language.FloatValue;
 import graphql.language.InputObjectTypeDefinition;
 import graphql.language.InputValueDefinition;
+import graphql.language.IntValue;
 import graphql.language.InterfaceTypeDefinition;
 import graphql.language.Node;
 import graphql.language.NullValue;
@@ -31,6 +36,7 @@ import graphql.schema.DataFetcher;
 import graphql.schema.DataFetcherFactories;
 import graphql.schema.DataFetcherFactory;
 import graphql.schema.GraphQLArgument;
+import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLInputObjectField;
@@ -53,12 +59,14 @@ import graphql.schema.idl.errors.NotAnOutputTypeError;
 import graphql.schema.idl.errors.SchemaProblem;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.Stack;
@@ -344,6 +352,16 @@ public class SchemaGenerator {
 
         List<TypeExtensionDefinition> typeExtensions = getTypeExtensionsOf(typeDefinition, buildCtx);
 
+        List<Directive> extensionDirectives = typeExtensions.stream()
+                .map(ObjectTypeDefinition::getDirectives).filter(Objects::nonNull)
+                .flatMap(Collection::stream).collect(Collectors.toList());
+
+        // combine the type and its extension directives together as one
+        builder.withDirectives(
+                buildDirectives(buildCtx, typeDefinition.getDirectives(),
+                        extensionDirectives, Introspection.DirectiveLocation.OBJECT)
+        );
+
         buildObjectTypeFields(buildCtx, typeDefinition, builder, typeExtensions);
 
         buildObjectTypeInterfaces(buildCtx, typeDefinition, builder, typeExtensions);
@@ -466,6 +484,11 @@ public class SchemaGenerator {
 
         fieldDef.getInputValueDefinitions().forEach(inputValueDefinition ->
                 builder.argument(buildArgument(buildCtx, inputValueDefinition)));
+
+        builder.withDirectives(
+                buildDirectives(buildCtx, fieldDef.getDirectives(),
+                        Collections.emptyList(), Introspection.DirectiveLocation.FIELD)
+        );
 
         GraphQLOutputType outputType = buildOutputType(buildCtx, fieldDef.getType());
         builder.type(outputType);
@@ -661,4 +684,81 @@ public class SchemaGenerator {
         }
         return null;
     }
+
+    private GraphQLDirective[] buildDirectives(BuildContext buildCtx, List<Directive> directives, List<Directive> extensionDirectives, Introspection.DirectiveLocation directiveLocation) {
+        directives = directives == null ? Collections.emptyList() : directives;
+        extensionDirectives = extensionDirectives == null ? Collections.emptyList() : extensionDirectives;
+        Set<String> names = new HashSet<>();
+
+        List<GraphQLDirective> output = new ArrayList<>();
+        for (Directive directive : directives) {
+            if (!names.contains(directive.getName())) {
+                names.add(directive.getName());
+                output.add(buildDirective(buildCtx, directive, directiveLocation));
+            }
+        }
+        for (Directive directive : extensionDirectives) {
+            if (!names.contains(directive.getName())) {
+                names.add(directive.getName());
+                output.add(buildDirective(buildCtx, directive, directiveLocation));
+            }
+        }
+        return output.toArray(new GraphQLDirective[0]);
+    }
+
+    // builds directives from a type and its extensions
+    private GraphQLDirective buildDirective(BuildContext buildCtx, Directive directive, Introspection.DirectiveLocation directiveLocation) {
+        List<GraphQLArgument> arguments = directive.getArguments().stream()
+                .map(arg -> buildDirectiveArgument(buildCtx, arg))
+                .collect(Collectors.toList());
+
+        GraphQLDirective.Builder builder = GraphQLDirective.newDirective()
+                .name(directive.getName())
+                .description(buildDescription(directive, null))
+                .validLocations(directiveLocation);
+
+        for (GraphQLArgument argument : arguments) {
+            builder.argument(argument);
+        }
+        return builder.build();
+    }
+
+    private GraphQLArgument buildDirectiveArgument(BuildContext buildCtx, Argument arg) {
+        GraphQLArgument.Builder builder = GraphQLArgument.newArgument();
+        builder.name(arg.getName());
+        GraphQLInputType inputType = buildDirectiveInputType(buildCtx, arg.getValue());
+        builder.type(inputType);
+        builder.defaultValue(buildValue(arg.getValue(), inputType));
+        return builder.build();
+    }
+
+    /**
+     * We support the basic types as directive types
+     *
+     * @param buildCtx build ctx
+     * @param value    the value to use
+     *
+     * @return a graphql input type
+     */
+    private GraphQLInputType buildDirectiveInputType(BuildContext buildCtx, Value value) {
+        Object result = null;
+        if (value instanceof NullValue) {
+            return Scalars.GraphQLString;
+        }
+        if (value instanceof FloatValue) {
+            return Scalars.GraphQLFloat;
+        }
+        if (value instanceof StringValue) {
+            return Scalars.GraphQLString;
+        }
+        if (value instanceof IntValue) {
+            return Scalars.GraphQLInt;
+        }
+        if (value instanceof BooleanValue) {
+            return Scalars.GraphQLBoolean;
+        }
+        return Assert.assertShouldNeverHappen("Directive values of type '%s' are not supported yet", value.getClass().getName());
+    }
+
+
 }

--- a/src/main/java/graphql/util/FpKit.java
+++ b/src/main/java/graphql/util/FpKit.java
@@ -1,0 +1,31 @@
+package graphql.util;
+
+
+import graphql.Internal;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static java.util.function.Function.identity;
+
+@Internal
+public class FpKit {
+
+    //
+    // From a list of named things, get a map of them by name, merging them according to the merge function
+    public static <T> Map<String, T> getByName(List<T> namedObjects, Function<T, String> nameFn, BinaryOperator<T> mergeFunc) {
+        return namedObjects.stream().collect(Collectors.toMap(
+                nameFn,
+                identity(),
+                mergeFunc)
+        );
+    }
+
+    public static <T> BinaryOperator<T> mergeFirst() {
+        return (o1, o2) -> o1;
+    }
+
+}


### PR DESCRIPTION
We have started with ObjectType and FieldDefinition and will extend it to other types as we go

The DSL is now officially spec and hence we can start to add the new `extend XXX` type support and directives with that
