### PR TITLE
Use unpadded url/filename-safe Base64 encoding for Relay global IDs.

### DIFF
--- a/src/main/java/graphql/relay/Relay.java
+++ b/src/main/java/graphql/relay/Relay.java
@@ -237,8 +237,8 @@ public class Relay {
         }
     }
 
-    private static final java.util.Base64.Encoder encoder = java.util.Base64.getEncoder();
-    private static final java.util.Base64.Decoder decoder = java.util.Base64.getDecoder();
+    private static final java.util.Base64.Encoder encoder = java.util.Base64.getUrlEncoder().withoutPadding();
+    private static final java.util.Base64.Decoder decoder = java.util.Base64.getUrlDecoder();
 
     public String toGlobalId(String type, String id) {
         return encoder.encodeToString((type + ":" + id).getBytes(StandardCharsets.UTF_8));

--- a/src/test/groovy/graphql/relay/RelayTest.groovy
+++ b/src/test/groovy/graphql/relay/RelayTest.groovy
@@ -1,0 +1,35 @@
+package graphql.relay
+
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
+
+class RelayTest extends Specification {
+
+    def urlSafe(String s) {
+        return s == URLEncoder.encode(s, StandardCharsets.UTF_8.name())
+    }
+
+    def "global id encoding is consistent and url-safe"() {
+        given:
+        def relay = new Relay()
+        def type = "Type"
+
+        expect:
+        def globalId = relay.toGlobalId(type, id)
+        def idResolved = relay.fromGlobalId(globalId)
+        type == idResolved.type && id == idResolved.id && urlSafe(globalId)
+
+        where:
+        id                 || base64UrlSafeReference
+        'null'             || 'VHlwZTpudWxs'
+        ''                 || 'VHlwZTo'
+        '1'                || 'VHlwZTox'
+        '99'               || 'VHlwZTo5OQ'
+        'abc'              || 'VHlwZTphYmM'
+        '.,-:;_=?()/&%$§!' || 'VHlwZTouLC06O189PygpLyYlJMKnIQ'
+        '~abc'             || 'VHlwZTp-YWJj'
+        '?_graphql'        || 'VHlwZTo_X2dyYXBocWw'
+    }
+
+}


### PR DESCRIPTION
In order to support using Relay global IDs from the GraphQL server in URLs or filesystem paths on the client, change to unpadded url/filename-safe Base64 encoding.