### PR TITLE
Allows matching from string input to enum putput

### DIFF
--- a/src/main/java/graphql/schema/GraphQLEnumType.java
+++ b/src/main/java/graphql/schema/GraphQLEnumType.java
@@ -96,6 +96,12 @@ public class GraphQLEnumType implements GraphQLType, GraphQLInputType, GraphQLOu
             if (value.equals(definitionValue)) {
                 return valueDefinition.getName();
             }
+            // we can treat enum backing values as strings in effect
+            if (definitionValue instanceof Enum  && value instanceof String) {
+                if (value.equals(definitionValue.toString())) {
+                    return valueDefinition.getName();
+                }
+            }
         }
         // ok we didn't match on pure object.equals().  Lets try the Java enum strategy
         if (value instanceof Enum) {

--- a/src/main/java/graphql/schema/GraphQLEnumType.java
+++ b/src/main/java/graphql/schema/GraphQLEnumType.java
@@ -98,7 +98,7 @@ public class GraphQLEnumType implements GraphQLType, GraphQLInputType, GraphQLOu
             }
             // we can treat enum backing values as strings in effect
             if (definitionValue instanceof Enum  && value instanceof String) {
-                if (value.equals(definitionValue.toString())) {
+                if (value.equals(((Enum) definitionValue).name())) {
                     return valueDefinition.getName();
                 }
             }

--- a/src/test/groovy/graphql/Issue921.groovy
+++ b/src/test/groovy/graphql/Issue921.groovy
@@ -1,0 +1,52 @@
+package graphql
+
+import groovy.json.JsonOutput
+import spock.lang.Specification
+
+class Issue921 extends Specification {
+
+    def "can run introspection on a default value enum schema"() {
+        def spec = '''
+            type Thread {
+                id: ID!
+                title: String!
+                content: String!
+            }
+
+            enum ThreadSort {
+                NEWEST_FIRST
+                OLDEST_FIRST
+                MOST_COMMENTS_FIRST
+            }
+            
+            type Query {
+                allThreads(sort: ThreadSort = NEWEST_FIRST) : [Thread!]!
+            }
+            '''
+
+        def qLSchema = TestUtil.schema(spec)
+        def graphql = GraphQL.newGraphQL(qLSchema).build()
+
+        when:
+        def result = graphql.execute('''
+                {
+                  __schema {
+                    queryType {
+                      fields {
+                        args {
+                          defaultValue
+                        }
+                      }
+                    }
+                  }
+                }   
+            ''')
+
+        then:
+        result.errors.isEmpty()
+
+        def json = JsonOutput.toJson(result.toSpecification())
+
+        json == '{"data":{"__schema":{"queryType":{"fields":[{"args":[{"defaultValue":"NEWEST_FIRST"}]}]}}}}'
+    }
+}

--- a/src/test/groovy/graphql/schema/GraphQLEnumTypeTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLEnumTypeTest.groovy
@@ -112,4 +112,21 @@ class GraphQLEnumTypeTest extends Specification {
         then:
         serialized == "NEWHOPE"
     }
+
+    def "serialize String objects with Java enum definition values"() {
+
+        given:
+        enumType = newEnum().name("Episode")
+                .value("NEWHOPE", Episode.NEWHOPE)
+                .value("EMPIRE", Episode.EMPIRE)
+                .build()
+
+        String stringInput = Episode.NEWHOPE.toString()
+
+        when:
+        def serialized = enumType.coercing.serialize(stringInput)
+
+        then:
+        serialized == "NEWHOPE"
+    }
 }


### PR DESCRIPTION
See #921 

Basically when the enum of backed by actual Java enums, but the input is a String, we can serialise now