### PR TITLE
Cached DataFetcherFactory and getSchema for DFFEnvironment

### DIFF
--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -219,7 +219,7 @@ public abstract class ExecutionStrategy {
         InstrumentationContext<Object> fetchCtx = instrumentation.beginFieldFetch(instrumentationFieldFetchParams);
 
         CompletableFuture<Object> fetchedValue;
-        DataFetcher dataFetcher = fieldDef.getDataFetcher();
+        DataFetcher dataFetcher = fieldDef.getDataFetcher(executionContext.getGraphQLSchema());
         dataFetcher = instrumentation.instrumentDataFetcher(dataFetcher, instrumentationFieldFetchParams);
         ExecutionId executionId = executionContext.getExecutionId();
         try {

--- a/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
+++ b/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
@@ -33,6 +33,7 @@ import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLOutputType;
 import graphql.schema.GraphQLScalarType;
+import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
 import graphql.schema.GraphQLUnionType;
 import graphql.schema.visibility.GraphqlFieldVisibility;
@@ -243,7 +244,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
         CompletableFuture<Object> fetchedValue;
         try {
             DataFetcher<?> dataFetcher = instrumentation.instrumentDataFetcher(
-                    getDataFetcher(fieldDef), instrumentationFieldFetchParameters);
+                    getDataFetcher(fieldDef, executionContext.getGraphQLSchema()), instrumentationFieldFetchParameters);
             Object fetchedValueRaw = dataFetcher.get(environment);
             fetchedValue = Async.toCompletableFuture(fetchedValueRaw);
         } catch (Exception e) {
@@ -486,8 +487,8 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
         return result;
     }
 
-    private BatchedDataFetcher getDataFetcher(GraphQLFieldDefinition fieldDef) {
-        DataFetcher supplied = fieldDef.getDataFetcher();
+    private BatchedDataFetcher getDataFetcher(GraphQLFieldDefinition fieldDef, GraphQLSchema graphQLSchema) {
+        DataFetcher supplied = fieldDef.getDataFetcher(graphQLSchema);
         return batchingFactory.create(supplied);
     }
 }

--- a/src/main/java/graphql/schema/CachedDataFetcherFactory.java
+++ b/src/main/java/graphql/schema/CachedDataFetcherFactory.java
@@ -1,0 +1,32 @@
+package graphql.schema;
+
+import static graphql.Assert.assertNotNull;
+
+/**
+ * Threadsafe Implementation of a cached DataFetcherFactory:
+ * The DataFetcherFactory will only be called once!
+ * It is a double checked locking implementation: https://en.wikipedia.org/wiki/Double-checked_locking#Usage_in_Java
+ */
+public class CachedDataFetcherFactory implements DataFetcherFactory {
+
+    private final DataFetcherFactory delegate;
+    private volatile DataFetcher dataFetcher;
+
+    public CachedDataFetcherFactory(DataFetcherFactory delegate) {
+        this.delegate = assertNotNull(delegate, "delegate DataFetcherFactory can't be null");
+    }
+
+    @Override
+    public DataFetcher get(DataFetcherFactoryEnvironment environment) {
+        DataFetcher result = dataFetcher;
+        if (result == null) {
+            synchronized (this) {
+                result = dataFetcher;
+                if (result == null) {
+                    result = dataFetcher = this.delegate.get(environment);
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/graphql/schema/DataFetcherFactoryEnvironment.java
+++ b/src/main/java/graphql/schema/DataFetcherFactoryEnvironment.java
@@ -4,37 +4,20 @@ import graphql.PublicApi;
 
 /**
  * This is passed to a {@link graphql.schema.DataFetcherFactory} when it is invoked to
- * get a {@link graphql.schema.DataFetcher}
+ * get a {@link graphql.schema.DataFetcher}.
+ *
  */
 @PublicApi
-public class DataFetcherFactoryEnvironment {
-    private final GraphQLFieldDefinition fieldDefinition;
-
-    DataFetcherFactoryEnvironment(GraphQLFieldDefinition fieldDefinition) {
-        this.fieldDefinition = fieldDefinition;
-    }
+public interface DataFetcherFactoryEnvironment {
 
     /**
      * @return the field that needs a {@link graphql.schema.DataFetcher}
      */
-    public GraphQLFieldDefinition getFieldDefinition() {
-        return fieldDefinition;
-    }
+    GraphQLFieldDefinition getFieldDefinition();
 
-    public static Builder newDataFetchingFactoryEnvironment() {
-        return new Builder();
-    }
+    /**
+     * @return the overall schema
+     */
+    GraphQLSchema getSchema();
 
-    static class Builder {
-        GraphQLFieldDefinition fieldDefinition;
-
-        public Builder fieldDefinition(GraphQLFieldDefinition fieldDefinition) {
-            this.fieldDefinition = fieldDefinition;
-            return this;
-        }
-
-        public DataFetcherFactoryEnvironment build() {
-            return new DataFetcherFactoryEnvironment(fieldDefinition);
-        }
-    }
 }

--- a/src/main/java/graphql/schema/DataFetcherFactoryEnvironmentImpl.java
+++ b/src/main/java/graphql/schema/DataFetcherFactoryEnvironmentImpl.java
@@ -1,0 +1,46 @@
+package graphql.schema;
+
+import graphql.Internal;
+
+@Internal
+public class DataFetcherFactoryEnvironmentImpl implements DataFetcherFactoryEnvironment {
+    private final GraphQLFieldDefinition fieldDefinition;
+    private final GraphQLSchema graphQLSchema;
+
+    DataFetcherFactoryEnvironmentImpl(GraphQLFieldDefinition fieldDefinition, GraphQLSchema graphQLSchema) {
+        this.fieldDefinition = fieldDefinition;
+        this.graphQLSchema = graphQLSchema;
+    }
+
+    public GraphQLFieldDefinition getFieldDefinition() {
+        return fieldDefinition;
+    }
+
+    @Override
+    public GraphQLSchema getSchema() {
+        return this.graphQLSchema;
+    }
+
+    public static Builder newDataFetchingFactoryEnvironment() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private GraphQLFieldDefinition fieldDefinition;
+        private GraphQLSchema graphQLSchema;
+
+        public Builder fieldDefinition(GraphQLFieldDefinition fieldDefinition) {
+            this.fieldDefinition = fieldDefinition;
+            return this;
+        }
+
+        public Builder schema(GraphQLSchema graphQLSchema) {
+            this.graphQLSchema = graphQLSchema;
+            return this;
+        }
+
+        public DataFetcherFactoryEnvironmentImpl build() {
+            return new DataFetcherFactoryEnvironmentImpl(fieldDefinition, graphQLSchema);
+        }
+    }
+}

--- a/src/main/java/graphql/schema/GraphQLFieldDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLFieldDefinition.java
@@ -1,7 +1,6 @@
 package graphql.schema;
 
 
-import graphql.DirectivesUtil;
 import graphql.Internal;
 import graphql.PublicApi;
 import graphql.language.FieldDefinition;
@@ -14,7 +13,7 @@ import java.util.function.UnaryOperator;
 
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
-import static graphql.schema.DataFetcherFactoryEnvironment.newDataFetchingFactoryEnvironment;
+import static graphql.schema.DataFetcherFactoryEnvironmentImpl.newDataFetchingFactoryEnvironment;
 
 /**
  * Fields are the ways you get data values in graphql and a field definition represents a field, its type, the arguments it takes
@@ -75,9 +74,10 @@ public class GraphQLFieldDefinition implements GraphQLDirectiveContainer {
         return type;
     }
 
-    public DataFetcher getDataFetcher() {
+    public DataFetcher getDataFetcher(GraphQLSchema graphQLSchema) {
         return dataFetcherFactory.get(newDataFetchingFactoryEnvironment()
                 .fieldDefinition(this)
+                .schema(graphQLSchema)
                 .build());
     }
 

--- a/src/test/groovy/graphql/schema/CachedDataFetcherFactoryTest.groovy
+++ b/src/test/groovy/graphql/schema/CachedDataFetcherFactoryTest.groovy
@@ -1,0 +1,25 @@
+package graphql.schema
+
+import spock.lang.Specification
+
+class CachedDataFetcherFactoryTest extends Specification {
+
+    def "delegate is only called once"() {
+        given:
+        def delegate = Mock(DataFetcherFactory)
+        def cachedDFF = new CachedDataFetcherFactory(delegate)
+        def environment = Mock(DataFetcherFactoryEnvironment)
+        def result = Mock(DataFetcher)
+        when:
+        def returnedDF = cachedDFF.get(environment)
+        then:
+        returnedDF == result
+        1 * delegate.get(environment) >> result
+
+        when:
+        returnedDF = cachedDFF.get(environment)
+        then:
+        returnedDF == result
+        0 * delegate.get(environment)
+    }
+}

--- a/src/test/groovy/graphql/schema/idl/WiringFactoryTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/WiringFactoryTest.groovy
@@ -200,10 +200,10 @@ class WiringFactoryTest extends Specification {
 
         GraphQLObjectType humanType = schema.getType("Human") as GraphQLObjectType
 
-        def friendsDataFetcher = humanType.getFieldDefinition("friends").getDataFetcher() as NamedDataFetcher
+        def friendsDataFetcher = humanType.getFieldDefinition("friends").getDataFetcher(Mock(GraphQLSchema)) as NamedDataFetcher
         friendsDataFetcher.name == "friends"
 
-        def cyborgDataFetcher = humanType.getFieldDefinition("cyborg").getDataFetcher() as NamedDataFetcher
+        def cyborgDataFetcher = humanType.getFieldDefinition("cyborg").getDataFetcher(Mock(GraphQLSchema)) as NamedDataFetcher
         cyborgDataFetcher.name == "cyborg"
 
         GraphQLScalarType longScalar = schema.getType("Long") as GraphQLScalarType
@@ -319,7 +319,7 @@ class WiringFactoryTest extends Specification {
         GraphQLObjectType type = schema.getType("Query") as GraphQLObjectType
 
         expect:
-        def fetcher = type.getFieldDefinition("homePlanet").getDataFetcher()
+        def fetcher = type.getFieldDefinition("homePlanet").getDataFetcher(Mock(GraphQLSchema))
         fetcher instanceof PropertyDataFetcher
 
         PropertyDataFetcher propertyDataFetcher = fetcher
@@ -327,7 +327,7 @@ class WiringFactoryTest extends Specification {
         //
         // no directive - plain name
         //
-        def fetcher2 = type.getFieldDefinition("name").getDataFetcher()
+        def fetcher2 = type.getFieldDefinition("name").getDataFetcher(Mock(GraphQLSchema))
         fetcher2 instanceof PropertyDataFetcher
 
         PropertyDataFetcher propertyDataFetcher2 = fetcher2


### PR DESCRIPTION
This adds a `CachedDataFetcherFactory` which makes sure that a `DataFetcherFactory` is only called once.

Also: the DataFetcherFactoryEnvironment gets a new `getSchema` method. Because the `DataFetcher` is created lazily the whole Schema is available, which is a significant advantage to normal `DataFetcher`.

It is a breaking change because `getDataFetcher` in `GraphQLFieldDefinition` needs now a `GraphQLSchema` argument.


