### PR TITLE
NOT TO MERGE: init all DFF at schema build once

### DIFF
--- a/src/main/java/graphql/schema/DataFetcherFactoryEnvironment.java
+++ b/src/main/java/graphql/schema/DataFetcherFactoryEnvironment.java
@@ -9,9 +9,11 @@ import graphql.PublicApi;
 @PublicApi
 public class DataFetcherFactoryEnvironment {
     private final GraphQLFieldDefinition fieldDefinition;
+    private final GraphQLSchema graphQLSchema;
 
-    DataFetcherFactoryEnvironment(GraphQLFieldDefinition fieldDefinition) {
+    DataFetcherFactoryEnvironment(GraphQLFieldDefinition fieldDefinition, GraphQLSchema graphQLSchema) {
         this.fieldDefinition = fieldDefinition;
+        this.graphQLSchema = graphQLSchema;
     }
 
     /**
@@ -21,20 +23,30 @@ public class DataFetcherFactoryEnvironment {
         return fieldDefinition;
     }
 
+    public GraphQLSchema getGraphQLSchema() {
+        return graphQLSchema;
+    }
+
     public static Builder newDataFetchingFactoryEnvironment() {
         return new Builder();
     }
 
     static class Builder {
         GraphQLFieldDefinition fieldDefinition;
+        GraphQLSchema schema;
 
         public Builder fieldDefinition(GraphQLFieldDefinition fieldDefinition) {
             this.fieldDefinition = fieldDefinition;
             return this;
         }
 
+        public Builder schema(GraphQLSchema schema) {
+            this.schema = schema;
+            return this;
+        }
+
         public DataFetcherFactoryEnvironment build() {
-            return new DataFetcherFactoryEnvironment(fieldDefinition);
+            return new DataFetcherFactoryEnvironment(fieldDefinition, schema);
         }
     }
 }

--- a/src/main/java/graphql/schema/GraphQLFieldDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLFieldDefinition.java
@@ -1,7 +1,6 @@
 package graphql.schema;
 
 
-import graphql.DirectivesUtil;
 import graphql.Internal;
 import graphql.PublicApi;
 import graphql.language.FieldDefinition;
@@ -37,6 +36,7 @@ public class GraphQLFieldDefinition implements GraphQLDirectiveContainer {
     private final List<GraphQLArgument> arguments;
     private final List<GraphQLDirective> directives;
     private final FieldDefinition definition;
+    private DataFetcher dataFetcher;
 
 
     @Deprecated
@@ -76,9 +76,15 @@ public class GraphQLFieldDefinition implements GraphQLDirectiveContainer {
     }
 
     public DataFetcher getDataFetcher() {
-        return dataFetcherFactory.get(newDataFetchingFactoryEnvironment()
+        assertNotNull(this.dataFetcher, "DataFetcher is not initialized");
+        return this.dataFetcher;
+    }
+
+    public void initDataFetcher(GraphQLSchema schema) {
+        this.dataFetcher = assertNotNull(dataFetcherFactory.get(newDataFetchingFactoryEnvironment()
                 .fieldDefinition(this)
-                .build());
+                .schema(schema)
+                .build()));
     }
 
     public GraphQLArgument getArgument(String name) {

--- a/src/main/java/graphql/schema/GraphQLSchema.java
+++ b/src/main/java/graphql/schema/GraphQLSchema.java
@@ -264,7 +264,16 @@ public class GraphQLSchema {
             if (errors.size() > 0) {
                 throw new InvalidSchemaException(errors);
             }
+            initDataFetchers(graphQLSchema);
             return graphQLSchema;
+        }
+
+        private void initDataFetchers(GraphQLSchema graphQLSchema) {
+            graphQLSchema.getAllTypesAsList().stream()
+                    .filter(GraphQLFieldsContainer.class::isInstance)
+                    .map(type -> (GraphQLFieldsContainer) type)
+                    .flatMap(graphQLFieldsContainer -> graphQLFieldsContainer.getFieldDefinitions().stream())
+                    .forEach(graphQLFieldDefinition -> graphQLFieldDefinition.initDataFetcher(graphQLSchema));
         }
     }
 }


### PR DESCRIPTION
@bbakerman This is basically the alternative to https://github.com/graphql-java/graphql-java/pull/946/ 

It would be a breaking change in that sense that a `DataFetcherFactory` is only called once, ever.

But it is hard for me think of a use case where you want to generate a new `DataFetcher` with every `getDataFetcher` call anyway. 

This is just a spike, it is not done and not mergeable, but I think I like this approach better than #946, because it simpler: There is a deterministic init call with when a schema created and we don't need to worry about thread safety.

What do u think?