### PR TITLE
Coerce any type to id

### DIFF
--- a/src/main/java/graphql/Scalars.java
+++ b/src/main/java/graphql/Scalars.java
@@ -13,6 +13,7 @@ import graphql.schema.GraphQLScalarType;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.UUID;
 
 import static graphql.Assert.assertShouldNeverHappen;
 
@@ -265,17 +266,7 @@ public class Scalars {
     public static final GraphQLScalarType GraphQLID = new GraphQLScalarType("ID", "Built-in ID", new Coercing<Object, Object>() {
 
         private String convertImpl(Object input) {
-            if (input instanceof String) {
-                return (String) input;
-            }
-            if (input instanceof Integer) {
-                return String.valueOf(input);
-            }
-            if (input instanceof Long) {
-                return String.valueOf(input);
-            }
-            return null;
-
+            return String.valueOf(input);
         }
 
         @Override

--- a/src/test/groovy/graphql/ScalarsIDTest.groovy
+++ b/src/test/groovy/graphql/ScalarsIDTest.groovy
@@ -46,33 +46,8 @@ class ScalarsIDTest extends Specification {
         "123ab"             | "123ab"
         123                 | "123"
         123123123123123123L | "123123123123123123"
+        new URL("http://example.com")  | "http://example.com"
+        UUID.fromString("037ebc7a-f9b8-4d76-89f6-31b34a40e10b") | "037ebc7a-f9b8-4d76-89f6-31b34a40e10b"
     }
-
-    @Unroll
-    def "serialize throws exception for invalid input #value"() {
-        when:
-        Scalars.GraphQLID.getCoercing().serialize(value)
-        then:
-        thrown(CoercingSerializeException)
-
-        where:
-        value        | _
-        new Object() | _
-
-    }
-
-    @Unroll
-    def "parseValue throws exception for invalid input #value"() {
-        when:
-        Scalars.GraphQLID.getCoercing().parseValue(value)
-        then:
-        thrown(CoercingParseValueException)
-
-        where:
-        value        | _
-        new Object() | _
-
-    }
-
 
 }


### PR DESCRIPTION
Since GraphQL doesn't care about the format of ID types, is there any reason to restrict it to these?