### PR TITLE
Updates to Dataloader doc

### DIFF
--- a/docs/batching.rst
+++ b/docs/batching.rst
@@ -1,7 +1,7 @@
 Using Dataloader
 ================
 
-If you are using ``graphql``, you are likely to making queries on a graph of data (surprise surprise).  But its easy
+If you are using ``graphql``, you are likely to making queries on a graph of data (surprise surprise).  But it's easy
 to implement inefficient code with naive loading of a graph of data.
 
 Using ``java-dataloader`` will help you to make this a more efficient process by both caching and batching requests for that graph of data items.  If ``dataloader``
@@ -30,27 +30,52 @@ share many friends in common.
 
 .. code-block:: json
 
-        [hero: [name: 'R2-D2', friends: [
-                [name: 'Luke Skywalker', friends: [
-                        [name: 'Han Solo'], [name: 'Leia Organa'], [name: 'C-3PO'], [name: 'R2-D2']]],
-                [name: 'Han Solo', friends: [
-                        [name: 'Luke Skywalker'], [name: 'Leia Organa'], [name: 'R2-D2']]],
-                [name: 'Leia Organa', friends: [
-                        [name: 'Luke Skywalker'], [name: 'Han Solo'], [name: 'C-3PO'], [name: 'R2-D2']]]]]
+        [
+          hero: [
+            name: 'R2-D2',
+            friends: [
+              [
+                name: 'Luke Skywalker',
+                friends: [
+                  [name: 'Han Solo'],
+                  [name: 'Leia Organa'],
+                  [name: 'C-3PO'],
+                  [name: 'R2-D2']
+                ]
+              ],
+              [
+                name: 'Han Solo',
+                friends: [
+                  [name: 'Luke Skywalker'],
+                  [name: 'Leia Organa'],
+                  [name: 'R2-D2']
+                ]
+              ],
+              [
+                name: 'Leia Organa',
+                friends: [
+                  [name: 'Luke Skywalker'],
+                  [name: 'Han Solo'],
+                  [name: 'C-3PO'],
+                  [name: 'R2-D2']
+                ]
+              ]
+            ]
+          ]
         ]
 
-A naive implementation would called a `DataFetcher` to retrieved a person object every time it was invoked.
+A naive implementation would call a `DataFetcher` to retrieve a person object every time it was invoked.
 
 In this case it would be *15* calls over the network.  Even though the group of people have a lot of common friends.
 With `dataloader` you can make the `graphql` query much more efficient.
 
-As `graphql` descends each level of the query ( eg as it processes `hero` and then `friends` and then for each their `friends`),
+As `graphql` descends each level of the query (e.g. as it processes `hero` and then `friends` and then for each their `friends`),
 the data loader is called to "promise" to deliver a person object.  At each level `dataloader.dispatch()` will be
 called to fire off the batch requests for that part of the query. With caching turned on (the default) then
-any previously returned person will be returned as is for no cost.
+any previously returned person will be returned as-is for no cost.
 
-In the above example there are only *5* unique people mentioned but with caching and batching retrieval in place their will be only
-*3* calls to the batch loader function.  *3* calls over the network or to a database is much better than *15* calls you will agree.
+In the above example there are only *5* unique people mentioned but with caching and batching retrieval in place there will be only
+*3* calls to the batch loader function.  *3* calls over the network or to a database is much better than *15* calls, you will agree.
 
 If you use capabilities like `java.util.concurrent.CompletableFuture.supplyAsync()` then you can make it even more efficient by making the
 the remote calls asynchronous to the rest of the query.  This will make it even more timely since multiple calls can happen at once
@@ -118,7 +143,7 @@ Here is how you might put this in place:
         GraphQL graphQL = GraphQL.newGraphQL(buildSchema())
                 .instrumentation(dispatcherInstrumentation)
                 .build();
-```
+
 
 One thing to note is the above only works if you use `DataLoaderDispatcherInstrumentation` which makes sure `dataLoader.dispatch()`
 is called.  If this was not in place, then all the promises to data will never be dispatched ot the batch loader function
@@ -137,7 +162,7 @@ If your data can be shared across web requests then you might want to scope your
 longer than the web request say.
 
 But if you are doing per request data loaders then creating a new set of ``GraphQL`` and ``DataLoader`` objects per
-request is super cheap.  Its the ``GraphQLSchema`` creation that can be expensive, especially if you are using graphql SDL parsing.
+request is super cheap.  It's the ``GraphQLSchema`` creation that can be expensive, especially if you are using graphql SDL parsing.
 
 Structure your code so that the schema is statically held, perhaps in a static variable or in a singleton IoC component but
 build out a new ``GraphQL`` set of objects on each request.


### PR DESCRIPTION
The Dataloader doc at http://graphql-java.readthedocs.io/en/latest/batching.html has a few typos and the example is a little hard to read.

I've corrected the errors where I've spotted them and expanded the example a little to make the reoccurrence of common fields more obvious.