### PR TITLE
AbsoluteGraphQLError returns null sourceLocation when relativeError sourceLocation is empty.

### DIFF
--- a/src/main/java/graphql/execution/AbsoluteGraphQLError.java
+++ b/src/main/java/graphql/execution/AbsoluteGraphQLError.java
@@ -2,7 +2,9 @@ package graphql.execution;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -11,8 +13,6 @@ import graphql.GraphQLError;
 import graphql.language.Field;
 import graphql.language.SourceLocation;
 import graphql.schema.DataFetcher;
-import java.util.HashMap;
-import java.util.Map;
 
 import static graphql.Assert.assertNotNull;
 
@@ -25,7 +25,7 @@ class AbsoluteGraphQLError implements GraphQLError {
     private final List<Object> absolutePath;
     private final String message;
     private final ErrorType errorType;
-    private final Map<String, Object> extentions;
+    private final Map<String, Object> extensions;
 
     AbsoluteGraphQLError(ExecutionStrategyParameters executionStrategyParameters, GraphQLError relativeError) {
         assertNotNull(executionStrategyParameters);
@@ -35,10 +35,10 @@ class AbsoluteGraphQLError implements GraphQLError {
         this.message = relativeError.getMessage();
         this.errorType = relativeError.getErrorType();
         if (relativeError.getExtensions() != null) {
-            this.extentions = new HashMap<>();
-            this.extentions.putAll(relativeError.getExtensions());
+            this.extensions = new HashMap<>();
+            this.extensions.putAll(relativeError.getExtensions());
         } else {
-            this.extentions = null;
+            this.extensions = null;
         }
     }
 
@@ -64,7 +64,7 @@ class AbsoluteGraphQLError implements GraphQLError {
 
     @Override
     public Map<String, Object> getExtensions() {
-        return extentions;
+        return extensions;
     }
 
     /**

--- a/src/test/groovy/graphql/execution/AbsoluteGraphQLErrorTest.groovy
+++ b/src/test/groovy/graphql/execution/AbsoluteGraphQLErrorTest.groovy
@@ -82,6 +82,32 @@ class AbsoluteGraphQLErrorTest extends Specification {
         error.getPath() == null
     }
 
+    def "when constructor receives empty path it should return the base field path"() {
+        given:
+
+        def field = new Field("test")
+        field.setSourceLocation(new SourceLocation(4, 5))
+
+        def parameters = newParameters()
+                .typeInfo(ExecutionTypeInfo.newTypeInfo().type(objectType))
+                .source(new Object())
+                .fields(["fld": [new Field()]])
+                .field([field])
+                .path(ExecutionPath.fromList(["foo", "bar"]))
+                .build()
+
+        def relativeError = new DataFetchingErrorGraphQLError("blah")
+        relativeError.path = []
+
+        when:
+
+        def error = new AbsoluteGraphQLError(parameters, relativeError)
+
+        then:
+
+        error.getPath() == ["foo", "bar"]
+    }
+
     def "constructor handles missing locations as null"() {
         given:
 
@@ -104,6 +130,32 @@ class AbsoluteGraphQLErrorTest extends Specification {
         then:
 
         error.getLocations() == null
+    }
+
+    def "when constructor receives empty locations it should return the base field locations"() {
+        given:
+
+        def field = new Field("test")
+        def expectedSourceLocation = new SourceLocation(1, 2)
+        field.setSourceLocation(expectedSourceLocation)
+
+        def parameters = newParameters()
+                .typeInfo(ExecutionTypeInfo.newTypeInfo().type(objectType))
+                .source(new Object())
+                .fields(["fld": [new Field()]])
+                .field([field])
+                .path(ExecutionPath.fromList(["foo", "bar"]))
+                .build()
+
+        def relativeError = new DataFetchingErrorGraphQLError("blah")
+        relativeError.locations = []
+
+        when:
+        def error = new AbsoluteGraphQLError(parameters, relativeError)
+
+        then:
+
+        error.getLocations() == [expectedSourceLocation]
     }
 
     def "constructor transforms multiple source locations"() {


### PR DESCRIPTION
Description
-----------
When returning a `DataFetcherResult`, the execution strategy constructs a `AbsoluteGraphQLError` that creates absolute path and source locations from the root of the GraphQL query.

When the relative error path or sourceLocation is null, it is expected that the absolute base path and source locations are null too.

When a relative error has an empty path, the expectation is for the `AbsoluteGraphQLError` to return a path up to the field that caused the error.

When a relative error has an empty source location, the same expectation should apply, that is for the `AbsoluteGraphQLError` to return the source location up to the field that caused the error. Instead `AbsoluteGraphQLError.createAbsoluteLocations` currently returns null. 

Steps to reproduce/Testing
---------------------------
I added a unit test that fails under the current implementation to showcase the error.

```groovy
def "when constructor receives empty locations it should return the base field locations"() {
        given:

        def field = new Field("test")
        def expectedSourceLocation = new SourceLocation(1, 2)
        field.setSourceLocation(expectedSourceLocation)

        def parameters = newParameters()
                .typeInfo(ExecutionTypeInfo.newTypeInfo().type(objectType))
                .source(new Object())
                .fields(["fld": [new Field()]])
                .field([field])
                .path(ExecutionPath.fromList(["foo", "bar"]))
                .build()

        def relativeError = new DataFetchingErrorGraphQLError("blah")
        relativeError.locations = []

        when:
        def error = new AbsoluteGraphQLError(parameters, relativeError)

        then:

        error.getLocations() == [expectedSourceLocation]
    }
```

Fix
----
Add a condition that checks for the relative error source Location to be empty, and use the baseLocation as the absolute location, instead of null.

