### PR TITLE
Added builders to each of the graphql runtime objects

### DIFF
--- a/src/main/java/graphql/schema/GraphQLArgument.java
+++ b/src/main/java/graphql/schema/GraphQLArgument.java
@@ -5,6 +5,7 @@ import graphql.PublicApi;
 import graphql.language.InputValueDefinition;
 
 import java.util.Map;
+import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
@@ -69,8 +70,26 @@ public class GraphQLArgument {
         return definition;
     }
 
+    /**
+     * This helps you transform the current GraphQLArgument into another one by starting a builder with all
+     * the current values and allows you to transform it how you want.
+     *
+     * @param builderConsumer the consumer code that will be given a builder to transform
+     *
+     * @return a new field based on calling build on that builder
+     */
+    public GraphQLArgument transform(Consumer<Builder> builderConsumer) {
+        Builder builder = newArgument(this);
+        builderConsumer.accept(builder);
+        return builder.build();
+    }
+
     public static Builder newArgument() {
         return new Builder();
+    }
+
+    public static Builder newArgument(GraphQLArgument existing) {
+        return new Builder(existing);
     }
 
     public static class Builder {
@@ -80,6 +99,17 @@ public class GraphQLArgument {
         private Object defaultValue;
         private String description;
         private InputValueDefinition definition;
+
+        public Builder() {
+        }
+
+        public Builder(GraphQLArgument existing) {
+            this.name = existing.getName();
+            this.type = existing.getType();
+            this.defaultValue = existing.getDefaultValue();
+            this.description = existing.getDescription();
+            this.definition = existing.getDefinition();
+        }
 
         public Builder name(String name) {
             this.name = name;

--- a/src/main/java/graphql/schema/GraphQLDirective.java
+++ b/src/main/java/graphql/schema/GraphQLDirective.java
@@ -1,17 +1,23 @@
 package graphql.schema;
 
 
+import graphql.Assert;
 import graphql.PublicApi;
+import graphql.util.FpKit;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
 import static graphql.introspection.Introspection.DirectiveLocation;
+import static graphql.util.FpKit.getByName;
 
 /**
  * A directive can be used to modify the behavior of a graphql field or type.
@@ -105,19 +111,52 @@ public class GraphQLDirective {
                 '}';
     }
 
+    /**
+     * This helps you transform the current GraphQLDirective into another one by starting a builder with all
+     * the current values and allows you to transform it how you want.
+     *
+     * @param builderConsumer the consumer code that will be given a builder to transform
+     *
+     * @return a new field based on calling build on that builder
+     */
+    public GraphQLDirective transform(Consumer<Builder> builderConsumer) {
+        Builder builder = newDirective(this);
+        builderConsumer.accept(builder);
+        return builder.build();
+    }
+
+
     public static Builder newDirective() {
         return new Builder();
+    }
+
+    public static Builder newDirective(GraphQLDirective existing) {
+        return new Builder(existing);
     }
 
     public static class Builder {
 
         private String name;
-        private final EnumSet<DirectiveLocation> locations = EnumSet.noneOf(DirectiveLocation.class);
-        private final List<GraphQLArgument> arguments = new ArrayList<>();
         private String description;
         private boolean onOperation;
         private boolean onFragment;
         private boolean onField;
+        private EnumSet<DirectiveLocation> locations = EnumSet.noneOf(DirectiveLocation.class);
+        private final Map<String, GraphQLArgument> arguments = new LinkedHashMap<>();
+
+        public Builder() {
+        }
+
+        @SuppressWarnings("deprecation")
+        public Builder(GraphQLDirective existing) {
+            this.name = existing.getName();
+            this.description = existing.getDescription();
+            this.onOperation = existing.isOnOperation();
+            this.onFragment = existing.isOnFragment();
+            this.onField = existing.isOnField();
+            this.locations = existing.validLocations();
+            this.arguments.putAll(getByName(existing.getArguments(), GraphQLArgument::getName));
+        }
 
         public Builder name(String name) {
             this.name = name;
@@ -134,8 +173,19 @@ public class GraphQLDirective {
             return this;
         }
 
-        public Builder argument(GraphQLArgument fieldArgument) {
-            arguments.add(fieldArgument);
+        public Builder validLocation(DirectiveLocation validLocation) {
+            locations.add(validLocation);
+            return this;
+        }
+
+        public Builder clearValidLocations() {
+            locations = EnumSet.noneOf(DirectiveLocation.class);
+            return this;
+        }
+
+        public Builder argument(GraphQLArgument argument) {
+            Assert.assertNotNull(argument, "argument must not be null");
+            arguments.put(argument.getName(), argument);
             return this;
         }
 
@@ -167,9 +217,19 @@ public class GraphQLDirective {
          * @return this
          */
         public Builder argument(GraphQLArgument.Builder builder) {
-            this.arguments.add(builder.build());
+            return argument(builder.build());
+        }
+
+        /**
+         * This is used to clear all the arguments in the builder so far.
+         *
+         * @return the builder
+         */
+        public Builder clearArguments() {
+            arguments.clear();
             return this;
         }
+
 
         /**
          * @param onOperation onOperation
@@ -211,7 +271,7 @@ public class GraphQLDirective {
         }
 
         public GraphQLDirective build() {
-            return new GraphQLDirective(name, description, locations, arguments, onOperation, onFragment, onField);
+            return new GraphQLDirective(name, description, locations, FpKit.valuesToList(arguments), onOperation, onFragment, onField);
         }
 
 

--- a/src/main/java/graphql/schema/GraphQLDirective.java
+++ b/src/main/java/graphql/schema/GraphQLDirective.java
@@ -3,7 +3,6 @@ package graphql.schema;
 
 import graphql.Assert;
 import graphql.PublicApi;
-import graphql.util.FpKit;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -18,6 +17,7 @@ import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
 import static graphql.introspection.Introspection.DirectiveLocation;
 import static graphql.util.FpKit.getByName;
+import static graphql.util.FpKit.valuesToList;
 
 /**
  * A directive can be used to modify the behavior of a graphql field or type.
@@ -271,7 +271,7 @@ public class GraphQLDirective {
         }
 
         public GraphQLDirective build() {
-            return new GraphQLDirective(name, description, locations, FpKit.valuesToList(arguments), onOperation, onFragment, onField);
+            return new GraphQLDirective(name, description, locations, valuesToList(arguments), onOperation, onFragment, onField);
         }
 
 

--- a/src/main/java/graphql/schema/GraphQLEnumValueDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLEnumValueDefinition.java
@@ -4,7 +4,6 @@ package graphql.schema;
 import graphql.DirectivesUtil;
 import graphql.Internal;
 import graphql.PublicApi;
-import graphql.util.FpKit;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -14,7 +13,8 @@ import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
-import static graphql.util.FpKit.*;
+import static graphql.util.FpKit.getByName;
+import static graphql.util.FpKit.valuesToList;
 import static java.util.Collections.emptyList;
 
 /**

--- a/src/main/java/graphql/schema/GraphQLEnumValueDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLEnumValueDefinition.java
@@ -4,14 +4,17 @@ package graphql.schema;
 import graphql.DirectivesUtil;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.util.FpKit;
 
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
+import static graphql.util.FpKit.*;
 import static java.util.Collections.emptyList;
 
 /**
@@ -84,8 +87,26 @@ public class GraphQLEnumValueDefinition {
         return getDirectivesByName().get(directiveName);
     }
 
+    /**
+     * This helps you transform the current GraphQLEnumValueDefinition into another one by starting a builder with all
+     * the current values and allows you to transform it how you want.
+     *
+     * @param builderConsumer the consumer code that will be given a builder to transform
+     *
+     * @return a new field based on calling build on that builder
+     */
+    public GraphQLEnumValueDefinition transform(Consumer<Builder> builderConsumer) {
+        Builder builder = newEnumValueDefinition(this);
+        builderConsumer.accept(builder);
+        return builder.build();
+    }
+
     public static Builder newEnumValueDefinition() {
         return new Builder();
+    }
+
+    public static Builder newEnumValueDefinition(GraphQLEnumValueDefinition existing) {
+        return new Builder(existing);
     }
 
     @PublicApi
@@ -94,7 +115,18 @@ public class GraphQLEnumValueDefinition {
         private String description;
         private Object value;
         private String deprecationReason;
-        private List<GraphQLDirective> directives = new ArrayList<>();
+        private final Map<String, GraphQLDirective> directives = new LinkedHashMap<>();
+
+        public Builder() {
+        }
+
+        public Builder(GraphQLEnumValueDefinition existing) {
+            this.name = existing.getName();
+            this.description = existing.getDescription();
+            this.value = existing.getValue();
+            this.deprecationReason = existing.getDeprecationReason();
+            this.directives.putAll(getByName(existing.getDirectives(), GraphQLDirective::getName));
+        }
 
         public Builder name(String name) {
             this.name = name;
@@ -117,12 +149,35 @@ public class GraphQLEnumValueDefinition {
         }
 
         public Builder withDirectives(GraphQLDirective... directives) {
-            Collections.addAll(this.directives, directives);
+            assertNotNull(directives, "directives can't be null");
+            for (GraphQLDirective directive : directives) {
+                withDirective(directive);
+            }
+            return this;
+        }
+
+        public Builder withDirective(GraphQLDirective directive) {
+            assertNotNull(directive, "directive can't be null");
+            directives.put(directive.getName(), directive);
+            return this;
+        }
+
+        public Builder withDirective(GraphQLDirective.Builder builder) {
+            return withDirective(builder.build());
+        }
+
+        /**
+         * This is used to clear all the directives in the builder so far.
+         *
+         * @return the builder
+         */
+        public Builder clearDirectives() {
+            directives.clear();
             return this;
         }
 
         public GraphQLEnumValueDefinition build() {
-            return new GraphQLEnumValueDefinition(name, description, value, deprecationReason, directives);
+            return new GraphQLEnumValueDefinition(name, description, value, deprecationReason, valuesToList(directives));
         }
     }
 }

--- a/src/main/java/graphql/schema/GraphQLInputObjectField.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectField.java
@@ -6,12 +6,15 @@ import graphql.PublicApi;
 import graphql.language.InputValueDefinition;
 
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
+import static graphql.util.FpKit.getByName;
+import static graphql.util.FpKit.valuesToList;
 import static java.util.Collections.emptyList;
 
 /**
@@ -85,6 +88,25 @@ public class GraphQLInputObjectField implements GraphQLDirectiveContainer {
         return new ArrayList<>(directives);
     }
 
+    /**
+     * This helps you transform the current GraphQLInputObjectField into another one by starting a builder with all
+     * the current values and allows you to transform it how you want.
+     *
+     * @param builderConsumer the consumer code that will be given a builder to transform
+     *
+     * @return a new object based on calling build on that builder
+     */
+    public GraphQLInputObjectField transform(Consumer<Builder> builderConsumer) {
+        Builder builder = newInputObjectField(this);
+        builderConsumer.accept(builder);
+        return builder.build();
+    }
+
+    public static Builder newInputObjectField(GraphQLInputObjectField existing) {
+        return new Builder(existing);
+    }
+
+
     public static Builder newInputObjectField() {
         return new Builder();
     }
@@ -96,7 +118,19 @@ public class GraphQLInputObjectField implements GraphQLDirectiveContainer {
         private Object defaultValue;
         private GraphQLInputType type;
         private InputValueDefinition definition;
-        private final List<GraphQLDirective> directives = new ArrayList<>();
+        private final Map<String, GraphQLDirective> directives = new LinkedHashMap<>();
+
+        public Builder() {
+        }
+
+        public Builder(GraphQLInputObjectField existing) {
+            this.name = existing.getName();
+            this.description = existing.getDescription();
+            this.defaultValue = existing.getDefaultValue();
+            this.type = existing.getType();
+            this.definition = existing.getDefinition();
+            this.directives.putAll(getByName(existing.getDirectives(), GraphQLDirective::getName));
+        }
 
         public Builder name(String name) {
             this.name = name;
@@ -128,12 +162,35 @@ public class GraphQLInputObjectField implements GraphQLDirectiveContainer {
         }
 
         public Builder withDirectives(GraphQLDirective... directives) {
-            Collections.addAll(this.directives, directives);
+            assertNotNull(directives, "directives can't be null");
+            for (GraphQLDirective directive : directives) {
+                withDirective(directive);
+            }
+            return this;
+        }
+
+        public Builder withDirective(GraphQLDirective directive) {
+            assertNotNull(directive, "directive can't be null");
+            directives.put(directive.getName(), directive);
+            return this;
+        }
+
+        public Builder withDirective(GraphQLDirective.Builder builder) {
+            return withDirective(builder.build());
+        }
+
+        /**
+         * This is used to clear all the directives in the builder so far.
+         *
+         * @return the builder
+         */
+        public Builder clearDirectives() {
+            directives.clear();
             return this;
         }
 
         public GraphQLInputObjectField build() {
-            return new GraphQLInputObjectField(name, description, type, defaultValue, directives, definition);
+            return new GraphQLInputObjectField(name, description, type, defaultValue, valuesToList(directives), definition);
         }
     }
 }

--- a/src/main/java/graphql/schema/GraphQLObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLObjectType.java
@@ -1,21 +1,22 @@
 package graphql.schema;
 
 import graphql.AssertException;
-import graphql.DirectivesUtil;
 import graphql.Internal;
 import graphql.PublicApi;
 import graphql.language.ObjectTypeDefinition;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
+import static graphql.util.FpKit.getByName;
+import static graphql.util.FpKit.valuesToList;
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 
@@ -120,18 +121,48 @@ public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQ
                 '}';
     }
 
+    /**
+     * This helps you transform the current GraphQLObjectType into another one by starting a builder with all
+     * the current values and allows you to transform it how you want.
+     *
+     * @param builderConsumer the consumer code that will be given a builder to transform
+     *
+     * @return a new object based on calling build on that builder
+     */
+    public GraphQLObjectType transform(Consumer<Builder> builderConsumer) {
+        Builder builder = newObject(this);
+        builderConsumer.accept(builder);
+        return builder.build();
+    }
+
     public static Builder newObject() {
         return new Builder();
+    }
+
+    public static Builder newObject(GraphQLObjectType existing) {
+        return new Builder(existing);
     }
 
     @PublicApi
     public static class Builder {
         private String name;
         private String description;
-        private final List<GraphQLFieldDefinition> fieldDefinitions = new ArrayList<>();
-        private final List<GraphQLOutputType> interfaces = new ArrayList<>();
-        private final List<GraphQLDirective> directives = new ArrayList<>();
         private ObjectTypeDefinition definition;
+        private final Map<String, GraphQLFieldDefinition> fieldDefinitions = new LinkedHashMap<>();
+        private final Map<String, GraphQLOutputType> interfaces = new LinkedHashMap<>();
+        private final Map<String, GraphQLDirective> directives = new LinkedHashMap<>();
+
+        public Builder() {
+        }
+
+        public Builder(GraphQLObjectType existing) {
+            name = existing.getName();
+            description = existing.getDescription();
+            definition = existing.getDefinition();
+            fieldDefinitions.putAll(getByName(existing.getFieldDefinitions(), GraphQLFieldDefinition::getName));
+            interfaces.putAll(getByName(existing.getInterfaces(), GraphQLType::getName));
+            directives.putAll(getByName(existing.getDirectives(), GraphQLDirective::getName));
+        }
 
         public Builder name(String name) {
             this.name = name;
@@ -150,7 +181,7 @@ public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQ
 
         public Builder field(GraphQLFieldDefinition fieldDefinition) {
             assertNotNull(fieldDefinition, "fieldDefinition can't be null");
-            this.fieldDefinitions.add(fieldDefinition);
+            this.fieldDefinitions.put(fieldDefinition.getName(), fieldDefinition);
             return this;
         }
 
@@ -183,30 +214,39 @@ public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQ
          * @return this
          */
         public Builder field(GraphQLFieldDefinition.Builder builder) {
-            this.fieldDefinitions.add(builder.build());
-            return this;
+            return field(builder.build());
         }
 
         public Builder fields(List<GraphQLFieldDefinition> fieldDefinitions) {
             assertNotNull(fieldDefinitions, "fieldDefinitions can't be null");
-            this.fieldDefinitions.addAll(fieldDefinitions);
+            fieldDefinitions.forEach(this::field);
+            return this;
+        }
+
+        /**
+         * This is used to clear all the fields in the builder so far.
+         *
+         * @return the builder
+         */
+        public Builder clearFields() {
+            fieldDefinitions.clear();
             return this;
         }
 
         public boolean hasField(String fieldName) {
-            return fieldDefinitions.stream().anyMatch(f -> f.getName().equals(fieldName));
+            return fieldDefinitions.containsKey(fieldName);
         }
 
 
         public Builder withInterface(GraphQLInterfaceType interfaceType) {
             assertNotNull(interfaceType, "interfaceType can't be null");
-            this.interfaces.add(interfaceType);
+            this.interfaces.put(interfaceType.getName(), interfaceType);
             return this;
         }
 
         public Builder withInterface(GraphQLTypeReference reference) {
             assertNotNull(reference, "reference can't be null");
-            this.interfaces.add(reference);
+            this.interfaces.put(reference.getName(), reference);
             return this;
         }
 
@@ -224,13 +264,48 @@ public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQ
             return this;
         }
 
+        /**
+         * This is used to clear all the interfaces in the builder so far.
+         *
+         * @return the builder
+         */
+        public Builder clearInterfaces() {
+            interfaces.clear();
+            return this;
+        }
+
+
         public Builder withDirectives(GraphQLDirective... directives) {
-            Collections.addAll(this.directives, directives);
+            for (GraphQLDirective directive : directives) {
+                withDirective(directive);
+            }
+            return this;
+        }
+
+        public Builder withDirective(GraphQLDirective directive) {
+            assertNotNull(directive, "directive can't be null");
+            directives.put(directive.getName(), directive);
+            return this;
+        }
+
+        public Builder withDirective(GraphQLDirective.Builder builder) {
+            return withDirective(builder.build());
+        }
+
+        /**
+         * This is used to clear all the directives in the builder so far.
+         *
+         * @return the builder
+         */
+        public Builder clearDirectives() {
+            directives.clear();
             return this;
         }
 
         public GraphQLObjectType build() {
-            return new GraphQLObjectType(name, description, fieldDefinitions, interfaces, directives, definition);
+            return new GraphQLObjectType(name, description,
+                    valuesToList(fieldDefinitions), valuesToList(interfaces), valuesToList(directives),
+                    definition);
         }
 
     }

--- a/src/main/java/graphql/schema/GraphQLObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLObjectType.java
@@ -148,7 +148,7 @@ public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQ
         private String name;
         private String description;
         private ObjectTypeDefinition definition;
-        private final Map<String, GraphQLFieldDefinition> fieldDefinitions = new LinkedHashMap<>();
+        private final Map<String, GraphQLFieldDefinition> fields = new LinkedHashMap<>();
         private final Map<String, GraphQLOutputType> interfaces = new LinkedHashMap<>();
         private final Map<String, GraphQLDirective> directives = new LinkedHashMap<>();
 
@@ -159,7 +159,7 @@ public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQ
             name = existing.getName();
             description = existing.getDescription();
             definition = existing.getDefinition();
-            fieldDefinitions.putAll(getByName(existing.getFieldDefinitions(), GraphQLFieldDefinition::getName));
+            fields.putAll(getByName(existing.getFieldDefinitions(), GraphQLFieldDefinition::getName));
             interfaces.putAll(getByName(existing.getInterfaces(), GraphQLType::getName));
             directives.putAll(getByName(existing.getDirectives(), GraphQLDirective::getName));
         }
@@ -181,7 +181,7 @@ public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQ
 
         public Builder field(GraphQLFieldDefinition fieldDefinition) {
             assertNotNull(fieldDefinition, "fieldDefinition can't be null");
-            this.fieldDefinitions.put(fieldDefinition.getName(), fieldDefinition);
+            this.fields.put(fieldDefinition.getName(), fieldDefinition);
             return this;
         }
 
@@ -229,12 +229,12 @@ public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQ
          * @return the builder
          */
         public Builder clearFields() {
-            fieldDefinitions.clear();
+            fields.clear();
             return this;
         }
 
         public boolean hasField(String fieldName) {
-            return fieldDefinitions.containsKey(fieldName);
+            return fields.containsKey(fieldName);
         }
 
 
@@ -304,7 +304,7 @@ public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQ
 
         public GraphQLObjectType build() {
             return new GraphQLObjectType(name, description,
-                    valuesToList(fieldDefinitions), valuesToList(interfaces), valuesToList(directives),
+                    valuesToList(fields), valuesToList(interfaces), valuesToList(directives),
                     definition);
         }
 

--- a/src/main/java/graphql/schema/idl/SchemaGenerator.java
+++ b/src/main/java/graphql/schema/idl/SchemaGenerator.java
@@ -67,6 +67,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static graphql.Assert.assertNotNull;
+import static graphql.introspection.Introspection.DirectiveLocation.ARGUMENT_DEFINITION;
 import static graphql.introspection.Introspection.DirectiveLocation.ENUM;
 import static graphql.introspection.Introspection.DirectiveLocation.ENUM_VALUE;
 import static graphql.introspection.Introspection.DirectiveLocation.INPUT_FIELD_DEFINITION;
@@ -647,6 +648,10 @@ public class SchemaGenerator {
             builder.defaultValue(schemaGeneratorHelper.buildValue(defaultValue, inputType));
         }
 
+        builder.withDirectives(
+                buildDirectives(valueDefinition.getDirectives(),
+                        Collections.emptyList(), ARGUMENT_DEFINITION)
+        );
         return builder.build();
     }
 

--- a/src/main/java/graphql/util/FpKit.java
+++ b/src/main/java/graphql/util/FpKit.java
@@ -3,6 +3,7 @@ package graphql.util;
 
 import graphql.Internal;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BinaryOperator;
@@ -24,8 +25,20 @@ public class FpKit {
         );
     }
 
+    //
+    // From a list of named things, get a map of them by name, merging them first one added
+    public static <T> Map<String, T> getByName(List<T> namedObjects, Function<T, String> nameFn) {
+        return getByName(namedObjects, nameFn, mergeFirst());
+    }
+
     public static <T> BinaryOperator<T> mergeFirst() {
         return (o1, o2) -> o1;
+    }
+
+    //
+    // quickly turn a map of values into its list equivalent
+    public static <T> List<T> valuesToList(Map<?, T> map) {
+        return new ArrayList<>(map.values());
     }
 
 }

--- a/src/test/groovy/graphql/schema/GraphQLArgumentTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLArgumentTest.groovy
@@ -1,0 +1,37 @@
+package graphql.schema
+
+import spock.lang.Specification
+
+import static graphql.Scalars.GraphQLInt
+import static graphql.Scalars.GraphQLString
+
+class GraphQLArgumentTest extends Specification {
+
+    def "object can be transformed"() {
+        given:
+        def startingArgument = GraphQLArgument.newArgument().name("A1")
+                .description("A1_description")
+                .type(GraphQLInt)
+                .build()
+        when:
+        def transformedArgument = startingArgument.transform({
+            it
+                    .name("A2")
+                    .description("A2_description")
+                    .type(GraphQLString)
+                    .defaultValue("DEFAULT")
+        })
+
+        then:
+        startingArgument.name == "A1"
+        startingArgument.description == "A1_description"
+        startingArgument.type == GraphQLInt
+        startingArgument.defaultValue == null
+
+        transformedArgument.name == "A2"
+        transformedArgument.description == "A2_description"
+        transformedArgument.type == GraphQLString
+        transformedArgument.defaultValue == "DEFAULT"
+
+    }
+}

--- a/src/test/groovy/graphql/schema/GraphQLArgumentTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLArgumentTest.groovy
@@ -4,6 +4,7 @@ import spock.lang.Specification
 
 import static graphql.Scalars.GraphQLInt
 import static graphql.Scalars.GraphQLString
+import static graphql.schema.GraphQLDirective.newDirective
 
 class GraphQLArgumentTest extends Specification {
 
@@ -12,6 +13,7 @@ class GraphQLArgumentTest extends Specification {
         def startingArgument = GraphQLArgument.newArgument().name("A1")
                 .description("A1_description")
                 .type(GraphQLInt)
+                .withDirective(newDirective().name("directive1"))
                 .build()
         when:
         def transformedArgument = startingArgument.transform({
@@ -19,6 +21,8 @@ class GraphQLArgumentTest extends Specification {
                     .name("A2")
                     .description("A2_description")
                     .type(GraphQLString)
+                    .withDirective(newDirective().name("directive1"))
+                    .withDirective(newDirective().name("directive3"))
                     .defaultValue("DEFAULT")
         })
 
@@ -27,11 +31,61 @@ class GraphQLArgumentTest extends Specification {
         startingArgument.description == "A1_description"
         startingArgument.type == GraphQLInt
         startingArgument.defaultValue == null
+        startingArgument.getDirectives().size() == 1
+        startingArgument.getDirective("directive1") != null
 
         transformedArgument.name == "A2"
         transformedArgument.description == "A2_description"
         transformedArgument.type == GraphQLString
         transformedArgument.defaultValue == "DEFAULT"
+        transformedArgument.getDirectives().size() == 2
+        transformedArgument.getDirective("directive1") != null
+        transformedArgument.getDirective("directive3") != null
+    }
 
+    def "directive support on arguments via builder"() {
+
+        def argument
+
+        given:
+        def builder = GraphQLArgument.newArgument().name("A1")
+                .type(GraphQLInt)
+                .withDirective(newDirective().name("directive1"))
+
+        when:
+        argument = builder.build()
+
+        then:
+        argument.getDirectives().size() == 1
+        argument.getDirective("directive1") != null
+        argument.getDirective("directive2") == null
+        argument.getDirective("directive3") == null
+
+
+        when:
+        argument = builder
+                .clearDirectives()
+                .withDirective(newDirective().name("directive2"))
+                .withDirective(newDirective().name("directive3"))
+                .build()
+
+        then:
+        argument.getDirectives().size() == 2
+        argument.getDirective("directive1") == null
+        argument.getDirective("directive2") != null
+        argument.getDirective("directive3") != null
+
+        when:
+        argument = builder
+                .withDirective(newDirective().name("directive1"))
+                .withDirective(newDirective().name("directive2")) // overwrite
+                .withDirective(newDirective().name("directive3")) // overwrite
+                .build()
+
+        then:
+        argument.getDirectives().size() == 3
+        argument.getDirective("directive1") != null
+        argument.getDirective("directive2") != null
+        argument.getDirective("directive3") != null
     }
 }

--- a/src/test/groovy/graphql/schema/GraphQLDirectiveTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLDirectiveTest.groovy
@@ -1,0 +1,51 @@
+package graphql.schema
+
+import spock.lang.Specification
+
+import static graphql.Scalars.GraphQLBoolean
+import static graphql.Scalars.GraphQLInt
+import static graphql.Scalars.GraphQLString
+import static graphql.introspection.Introspection.DirectiveLocation.ARGUMENT_DEFINITION
+import static graphql.introspection.Introspection.DirectiveLocation.FIELD_DEFINITION
+import static graphql.introspection.Introspection.DirectiveLocation.INTERFACE
+import static graphql.introspection.Introspection.DirectiveLocation.OBJECT
+import static graphql.introspection.Introspection.DirectiveLocation.UNION
+
+class GraphQLDirectiveTest extends Specification {
+
+    def "object can be transformed"() {
+        given:
+        def startingDirective = GraphQLDirective.newDirective()
+                .name("D1")
+                .description("D1_description")
+                .validLocation(ARGUMENT_DEFINITION)
+                .validLocations(FIELD_DEFINITION, OBJECT)
+                .argument(GraphQLArgument.newArgument().name("argStr").type(GraphQLString))
+                .argument(GraphQLArgument.newArgument().name("argInt").type(GraphQLInt))
+                .build()
+        when:
+        def transformedDirective = startingDirective.transform({ builder ->
+            builder.name("D2")
+                    .description("D2_description")
+                    .clearValidLocations()
+                    .validLocations(INTERFACE, UNION)
+                    .argument(GraphQLArgument.newArgument().name("argInt").type(GraphQLBoolean))
+                    .argument(GraphQLArgument.newArgument().name("argIntAdded").type(GraphQLInt))
+        })
+        then:
+        startingDirective.name == "D1"
+        startingDirective.description == "D1_description"
+        startingDirective.validLocations() == [ARGUMENT_DEFINITION, FIELD_DEFINITION, OBJECT].toSet()
+        startingDirective.arguments.size() == 2
+        startingDirective.getArgument("argStr").type == GraphQLString
+        startingDirective.getArgument("argInt").type == GraphQLInt
+
+        transformedDirective.name == "D2"
+        transformedDirective.description == "D2_description"
+        transformedDirective.validLocations() == [INTERFACE, UNION].toSet()
+        transformedDirective.arguments.size() == 3
+        transformedDirective.getArgument("argStr").type == GraphQLString
+        transformedDirective.getArgument("argInt").type == GraphQLBoolean // swapped
+        transformedDirective.getArgument("argIntAdded").type == GraphQLInt
+    }
+}

--- a/src/test/groovy/graphql/schema/GraphQLEnumTypeTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLEnumTypeTest.groovy
@@ -73,14 +73,14 @@ class GraphQLEnumTypeTest extends Specification {
     }
 
 
-    def "duplicate value definition fails"() {
+    def "duplicate value definition overwrites"() {
         when:
-        newEnum().name("AnotherTestEnum")
+        def enumType = newEnum().name("AnotherTestEnum")
                 .value("NAME", 42)
                 .value("NAME", 43)
                 .build()
         then:
-        thrown(AssertException)
+        enumType.getValue("NAME").getValue() == 43
     }
 
     enum Episode {
@@ -132,5 +132,43 @@ class GraphQLEnumTypeTest extends Specification {
 
         then:
         serialized == "NEWHOPE"
+    }
+
+    def "object can be transformed"() {
+        given:
+        def startEnum = newEnum().name("E1")
+                .description("E1_description")
+                .value("A")
+                .value("B")
+                .value("C")
+                .value("D")
+                .build()
+        when:
+        def transformedEnum = startEnum.transform({
+            it
+                    .name("E2")
+                    .clearValues()
+                    .value("X", 1)
+                    .value("Y", 2)
+                    .value("Z", 3)
+
+        })
+
+        then:
+        startEnum.name == "E1"
+        startEnum.description == "E1_description"
+        startEnum.getValues().size() == 4
+        startEnum.getValue("A").value == "A"
+        startEnum.getValue("B").value == "B"
+        startEnum.getValue("C").value == "C"
+        startEnum.getValue("D").value == "D"
+
+        transformedEnum.name == "E2"
+        transformedEnum.description == "E1_description" // left alone
+        transformedEnum.getValues().size() == 3
+        transformedEnum.getValue("X").value == 1
+        transformedEnum.getValue("Y").value == 2
+        transformedEnum.getValue("Z").value == 3
+
     }
 }

--- a/src/test/groovy/graphql/schema/GraphQLEnumValueDefinitionTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLEnumValueDefinitionTest.groovy
@@ -1,0 +1,41 @@
+package graphql.schema
+
+import spock.lang.Specification
+
+import static graphql.schema.GraphQLDirective.newDirective
+import static graphql.schema.GraphQLEnumValueDefinition.newEnumValueDefinition
+
+class GraphQLEnumValueDefinitionTest extends Specification {
+    def "object can be transformed"() {
+        given:
+        def startEnumValue = newEnumValueDefinition().name("EV1")
+                .description("EV1_description")
+                .value("A")
+                .withDirective(newDirective().name("directive1"))
+                .build()
+        when:
+        def transformedEnumValue = startEnumValue.transform({
+            it
+                    .name("EV2")
+                    .value("X")
+                    .withDirective(newDirective().name("directive2"))
+
+        })
+
+        then:
+        startEnumValue.name == "EV1"
+        startEnumValue.description == "EV1_description"
+        startEnumValue.value == "A"
+        startEnumValue.getDirectives().size() == 1
+        startEnumValue.getDirective("directive1") != null
+
+
+        transformedEnumValue.name == "EV2"
+        transformedEnumValue.description == "EV1_description" // left alone
+        transformedEnumValue.value == "X"
+        transformedEnumValue.getDirectives().size() == 2
+        transformedEnumValue.getDirective("directive1") != null
+        transformedEnumValue.getDirective("directive2") != null
+    }
+
+}

--- a/src/test/groovy/graphql/schema/GraphQLFieldDefinitionTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLFieldDefinitionTest.groovy
@@ -3,13 +3,79 @@ package graphql.schema
 import graphql.AssertException
 import spock.lang.Specification
 
+import static graphql.Scalars.GraphQLBoolean
+import static graphql.Scalars.GraphQLFloat
+import static graphql.Scalars.GraphQLInt
+import static graphql.Scalars.GraphQLString
+import static graphql.schema.GraphQLArgument.newArgument
+import static graphql.schema.GraphQLDirective.newDirective
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
+
 class GraphQLFieldDefinitionTest extends Specification {
 
     def "dataFetcher can't be null"() {
         when:
-        GraphQLFieldDefinition.newFieldDefinition().dataFetcher(null)
+        newFieldDefinition().dataFetcher(null)
         then:
         def exception = thrown(AssertException)
         exception.getMessage().contains("dataFetcher")
+    }
+
+    def "object can be transformed"() {
+        given:
+        def startingField = newFieldDefinition()
+                .name("F1")
+                .type(GraphQLFloat)
+                .description("F1_description")
+                .deprecate("F1_deprecated")
+                .argument(newArgument().name("argStr").type(GraphQLString))
+                .argument(newArgument().name("argInt").type(GraphQLInt))
+                .withDirective(newDirective().name("directive1"))
+                .withDirective(newDirective().name("directive2"))
+                .build()
+
+        when:
+        def transformedField = startingField.transform({ builder ->
+            builder.name("F2")
+                    .type(GraphQLInt)
+                    .deprecate(null)
+                    .argument(newArgument().name("argStr").type(GraphQLString))
+                    .argument(newArgument().name("argInt").type(GraphQLBoolean))
+                    .argument(newArgument().name("argIntAdded").type(GraphQLInt))
+                    .withDirective(newDirective().name("directive1"))
+                    .withDirective(newDirective().name("directive3"))
+
+        })
+
+
+        then:
+
+        startingField.name == "F1"
+        startingField.type == GraphQLFloat
+        startingField.description == "F1_description"
+        startingField.deprecated
+        startingField.deprecationReason == "F1_deprecated"
+        startingField.getArguments().size() == 2
+        startingField.getArgument("argStr").type == GraphQLString
+        startingField.getArgument("argInt").type == GraphQLInt
+
+        startingField.getDirectives().size() == 2
+        startingField.getDirective("directive1") != null
+        startingField.getDirective("directive2") != null
+
+        transformedField.name == "F2"
+        transformedField.type == GraphQLInt
+        transformedField.description == "F1_description" // left alone
+        !transformedField.deprecated
+        transformedField.deprecationReason == null
+        transformedField.getArguments().size() == 3
+        transformedField.getArgument("argStr").type == GraphQLString
+        transformedField.getArgument("argInt").type == GraphQLBoolean
+        transformedField.getArgument("argIntAdded").type == GraphQLInt
+
+        transformedField.getDirectives().size() == 3
+        transformedField.getDirective("directive1") != null
+        transformedField.getDirective("directive2") != null
+        transformedField.getDirective("directive3") != null
     }
 }

--- a/src/test/groovy/graphql/schema/GraphQLInputObjectFieldTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLInputObjectFieldTest.groovy
@@ -1,0 +1,51 @@
+package graphql.schema
+
+import spock.lang.Specification
+
+import static graphql.Scalars.GraphQLFloat
+import static graphql.Scalars.GraphQLInt
+import static graphql.schema.GraphQLDirective.newDirective
+import static graphql.schema.GraphQLInputObjectField.newInputObjectField
+
+class GraphQLInputObjectFieldTest extends Specification {
+
+    def "object can be transformed"() {
+        given:
+        def startingField = newInputObjectField()
+                .name("F1")
+                .type(GraphQLFloat)
+                .description("F1_description")
+                .withDirective(newDirective().name("directive1"))
+                .withDirective(newDirective().name("directive2"))
+                .build()
+
+        when:
+        def transformedField = startingField.transform({ builder ->
+            builder.name("F2")
+                    .type(GraphQLInt)
+                    .withDirective(newDirective().name("directive1"))
+                    .withDirective(newDirective().name("directive3"))
+
+        })
+
+
+        then:
+
+        startingField.name == "F1"
+        startingField.type == GraphQLFloat
+        startingField.description == "F1_description"
+
+        startingField.getDirectives().size() == 2
+        startingField.getDirective("directive1") != null
+        startingField.getDirective("directive2") != null
+
+        transformedField.name == "F2"
+        transformedField.type == GraphQLInt
+        transformedField.description == "F1_description" // left alone
+
+        transformedField.getDirectives().size() == 3
+        transformedField.getDirective("directive1") != null
+        transformedField.getDirective("directive2") != null
+        transformedField.getDirective("directive3") != null
+    }
+}

--- a/src/test/groovy/graphql/schema/GraphQLInputObjectTypeTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLInputObjectTypeTest.groovy
@@ -3,6 +3,8 @@ package graphql.schema
 import graphql.AssertException
 import spock.lang.Specification
 
+import static graphql.Scalars.GraphQLBoolean
+import static graphql.Scalars.GraphQLInt
 import static graphql.Scalars.GraphQLString
 import static graphql.schema.GraphQLInputObjectField.newInputObjectField
 import static graphql.schema.GraphQLInputObjectType.newInputObject
@@ -11,11 +13,59 @@ class GraphQLInputObjectTypeTest extends Specification {
 
     def "duplicate field definition fails"() {
         when:
-        newInputObject().name("TestInputObjectType")
-                .field(newInputObjectField().name("NAME").type(GraphQLString))
-                .field(newInputObjectField().name("NAME").type(GraphQLString))
-                .build()
+        // preserve old constructor behavior test
+        new GraphQLInputObjectType("TestInputObjectType", "description",
+                [
+                        newInputObjectField().name("NAME").type(GraphQLString).build(),
+                        newInputObjectField().name("NAME").type(GraphQLString).build()
+                ])
         then:
         thrown(AssertException)
     }
+
+
+    def "duplicate field definition overwrites"() {
+        when:
+        def inputObjectType = newInputObject().name("TestInputObjectType")
+                .field(newInputObjectField().name("NAME").type(GraphQLString))
+                .field(newInputObjectField().name("NAME").type(GraphQLInt))
+                .build()
+        then:
+        inputObjectType.getName() == "TestInputObjectType"
+        inputObjectType.getFieldDefinition("NAME").getType() == GraphQLInt
+    }
+
+    def "builder can change existing object into a new one"() {
+        given:
+        def inputObjectType = newInputObject().name("StartType")
+                .description("StartingDescription")
+                .field(newInputObjectField().name("Str").type(GraphQLString))
+                .field(newInputObjectField().name("Int").type(GraphQLInt))
+                .build()
+
+        when:
+        def transformedInputType = inputObjectType.transform({ builder ->
+            builder
+                    .name("NewObjectName")
+                    .description("NewDescription")
+                    .field(newInputObjectField().name("AddedInt").type(GraphQLInt)) // add more
+                    .field(newInputObjectField().name("Int").type(GraphQLInt)) // override and change
+                    .field(newInputObjectField().name("Str").type(GraphQLBoolean)) // override and change
+        })
+        then:
+
+        inputObjectType.getName() == "StartType"
+        inputObjectType.getDescription() == "StartingDescription"
+        inputObjectType.getFieldDefinitions().size() == 2
+        inputObjectType.getFieldDefinition("Int").getType() == GraphQLInt
+        inputObjectType.getFieldDefinition("Str").getType() == GraphQLString
+
+        transformedInputType.getName() == "NewObjectName"
+        transformedInputType.getDescription() == "NewDescription"
+        transformedInputType.getFieldDefinitions().size() == 3
+        transformedInputType.getFieldDefinition("AddedInt").getType() == GraphQLInt
+        transformedInputType.getFieldDefinition("Int").getType() == GraphQLInt
+        transformedInputType.getFieldDefinition("Str").getType() == GraphQLBoolean
+    }
+
 }

--- a/src/test/groovy/graphql/schema/GraphQLInterfaceTypeTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLInterfaceTypeTest.groovy
@@ -3,6 +3,8 @@ package graphql.schema
 import graphql.AssertException
 import spock.lang.Specification
 
+import static graphql.Scalars.GraphQLBoolean
+import static graphql.Scalars.GraphQLInt
 import static graphql.Scalars.GraphQLString
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
 import static graphql.schema.GraphQLInterfaceType.newInterface
@@ -11,12 +13,48 @@ class GraphQLInterfaceTypeTest extends Specification {
 
     def "duplicate field definition fails"() {
         when:
-        newInterface().name("TestInterfaceType")
-                .typeResolver(new TypeResolverProxy())
-                .field(newFieldDefinition().name("NAME").type(GraphQLString))
-                .field(newFieldDefinition().name("NAME").type(GraphQLString))
-                .build()
+        // preserve old constructor behavior test
+        new GraphQLInterfaceType("TestInputObjectType", "description",
+                [
+                        newFieldDefinition().name("NAME").type(GraphQLString).build(),
+                        newFieldDefinition().name("NAME").type(GraphQLString).build()
+                ], new TypeResolverProxy())
         then:
         thrown(AssertException)
     }
+
+    def "builder can change existing object into a new one"() {
+        given:
+        def startingInterface = newInterface().name("StartingType")
+                .description("StartingDescription")
+                .field(newFieldDefinition().name("Str").type(GraphQLString))
+                .field(newFieldDefinition().name("Int").type(GraphQLInt))
+                .typeResolver(new TypeResolverProxy())
+                .build()
+
+        when:
+        def objectType2 = startingInterface.transform({ builder ->
+            builder
+                    .name("NewName")
+                    .description("NewDescription")
+                    .field(newFieldDefinition().name("AddedInt").type(GraphQLInt)) // add more
+                    .field(newFieldDefinition().name("Int").type(GraphQLInt)) // override and change
+                    .field(newFieldDefinition().name("Str").type(GraphQLBoolean)) // override and change
+        })
+        then:
+
+        startingInterface.getName() == "StartingType"
+        startingInterface.getDescription() == "StartingDescription"
+        startingInterface.getFieldDefinitions().size() == 2
+        startingInterface.getFieldDefinition("Int").getType() == GraphQLInt
+        startingInterface.getFieldDefinition("Str").getType() == GraphQLString
+
+        objectType2.getName() == "NewName"
+        objectType2.getDescription() == "NewDescription"
+        objectType2.getFieldDefinitions().size() == 3
+        objectType2.getFieldDefinition("AddedInt").getType() == GraphQLInt
+        objectType2.getFieldDefinition("Int").getType() == GraphQLInt
+        objectType2.getFieldDefinition("Str").getType() == GraphQLBoolean
+    }
+
 }

--- a/src/test/groovy/graphql/schema/GraphQLObjectTypeTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLObjectTypeTest.groovy
@@ -3,6 +3,8 @@ package graphql.schema
 import graphql.AssertException
 import spock.lang.Specification
 
+import static graphql.Scalars.GraphQLBoolean
+import static graphql.Scalars.GraphQLInt
 import static graphql.Scalars.GraphQLString
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
 import static graphql.schema.GraphQLObjectType.newObject
@@ -11,11 +13,57 @@ class GraphQLObjectTypeTest extends Specification {
 
     def "duplicate field definition fails"() {
         when:
-        newObject().name("TestObjectType")
-                .field(newFieldDefinition().name("NAME").type(GraphQLString))
-                .field(newFieldDefinition().name("NAME").type(GraphQLString))
-                .build()
+        // preserve old constructor behavior test
+        new GraphQLObjectType("TestObjectType", "description",
+                [
+                        newFieldDefinition().name("NAME").type(GraphQLString).build(),
+                        newFieldDefinition().name("NAME").type(GraphQLString).build()
+                ], [])
         then:
         thrown(AssertException)
+    }
+
+    def "duplicate field definition overwrites existing value"() {
+        when:
+        def objectType = newObject().name("TestObjectType")
+                .field(newFieldDefinition().name("NAME").type(GraphQLString))
+                .field(newFieldDefinition().name("NAME").type(GraphQLInt))
+                .build()
+        then:
+        objectType.getName() == "TestObjectType"
+        objectType.getFieldDefinition("NAME").getType() == GraphQLInt
+    }
+
+    def "builder can change existing object into a new one"() {
+        given:
+        def objectType = newObject().name("StartObjectType")
+                .description("StartingDescription")
+                .field(newFieldDefinition().name("Str").type(GraphQLString))
+                .field(newFieldDefinition().name("Int").type(GraphQLInt))
+                .build()
+
+        when:
+        def objectType2 = objectType.transform({ builder ->
+            builder
+                    .name("NewObjectName")
+                    .description("NewDescription")
+                    .field(newFieldDefinition().name("AddedInt").type(GraphQLInt)) // add more
+                    .field(newFieldDefinition().name("Int").type(GraphQLInt)) // override and change
+                    .field(newFieldDefinition().name("Str").type(GraphQLBoolean)) // override and change
+        })
+        then:
+
+        objectType.getName() == "StartObjectType"
+        objectType.getDescription() == "StartingDescription"
+        objectType.getFieldDefinitions().size() == 2
+        objectType.getFieldDefinition("Int").getType() == GraphQLInt
+        objectType.getFieldDefinition("Str").getType() == GraphQLString
+
+        objectType2.getName() == "NewObjectName"
+        objectType2.getDescription() == "NewDescription"
+        objectType2.getFieldDefinitions().size() == 3
+        objectType2.getFieldDefinition("AddedInt").getType() == GraphQLInt
+        objectType2.getFieldDefinition("Int").getType() == GraphQLInt
+        objectType2.getFieldDefinition("Str").getType() == GraphQLBoolean
     }
 }

--- a/src/test/groovy/graphql/schema/GraphQLScalarTypeTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLScalarTypeTest.groovy
@@ -1,0 +1,61 @@
+package graphql.schema
+
+import spock.lang.Specification
+
+import static graphql.schema.GraphQLDirective.newDirective
+
+class GraphQLScalarTypeTest extends Specification {
+    Coercing<String, String> coercing = new Coercing<String, String>() {
+        @Override
+        String serialize(Object dataFetcherResult) throws CoercingSerializeException {
+            return null
+        }
+
+        @Override
+        String parseValue(Object input) throws CoercingParseValueException {
+            return null
+        }
+
+        @Override
+        String parseLiteral(Object input) throws CoercingParseLiteralException {
+            return null
+        }
+    }
+
+    def "builder works as expected"() {
+        given:
+        def startingScalar = GraphQLScalarType.newScalar()
+                .name("S1")
+                .description("S1_description")
+                .coercing(coercing)
+                .withDirective(newDirective().name("directive1"))
+                .withDirective(newDirective().name("directive2"))
+                .build()
+        when:
+        def transformedScalar = startingScalar.transform({ builder ->
+            builder.name("S2")
+                    .description("S2_description")
+                    .withDirective(newDirective().name("directive1"))
+                    .withDirective(newDirective().name("directive3"))
+        })
+
+        then:
+        startingScalar.getName() == "S1"
+        startingScalar.getDescription() == "S1_description"
+        startingScalar.getCoercing() == coercing
+
+        startingScalar.getDirectives().size() == 2
+        startingScalar.getDirective("directive1") != null
+        startingScalar.getDirective("directive2") != null
+
+        transformedScalar.name == "S2"
+        transformedScalar.description == "S2_description"
+        startingScalar.getCoercing() == coercing
+
+        transformedScalar.getDirectives().size() == 3
+        transformedScalar.getDirective("directive1") != null
+        transformedScalar.getDirective("directive2") != null
+        transformedScalar.getDirective("directive3") != null
+
+    }
+}

--- a/src/test/groovy/graphql/schema/GraphQLUnionTypeTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLUnionTypeTest.groovy
@@ -3,6 +3,9 @@ package graphql.schema
 import graphql.AssertException
 import spock.lang.Specification
 
+import static graphql.Scalars.GraphQLBoolean
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
+import static graphql.schema.GraphQLObjectType.newObject
 import static graphql.schema.GraphQLUnionType.newUnionType
 
 class GraphQLUnionTypeTest extends Specification {
@@ -16,4 +19,45 @@ class GraphQLUnionTypeTest extends Specification {
         then:
         thrown(AssertException)
     }
+
+    def objType1 = newObject().name("T1")
+            .field(newFieldDefinition().name("f1").type(GraphQLBoolean))
+            .build()
+    def objType2 = newObject().name("T2")
+            .field(newFieldDefinition().name("f1").type(GraphQLBoolean))
+            .build()
+
+    def objType3 = newObject().name("T3")
+            .field(newFieldDefinition().name("f2").type(GraphQLBoolean))
+            .build()
+
+    def "object transformation works as expected"() {
+
+        given:
+        def startingUnion = newUnionType().name("StartingType")
+                .description("StartingDescription")
+                .possibleType(objType1)
+                .possibleType(objType2)
+                .typeResolver(new TypeResolverProxy())
+                .build()
+
+        when:
+        def transformedUnion = startingUnion.transform({ builder ->
+            builder
+                    .name("NewName")
+                    .description("NewDescription")
+                    .clearPossibleTypes()
+                    .possibleType(objType3)
+        })
+        then:
+
+        startingUnion.getName() == "StartingType"
+        startingUnion.getDescription() == "StartingDescription"
+        startingUnion.getTypes().size() == 2
+
+        transformedUnion.getName() == "NewName"
+        transformedUnion.getDescription() == "NewDescription"
+        transformedUnion.getTypes().size() == 1
+    }
+
 }

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -1400,4 +1400,38 @@ class SchemaGeneratorTest extends Specification {
         inputObjectType.directivesByName.containsKey("directive")
     }
 
+    def "arguments can have directives (which themselves can have arguments)"() {
+        def spec = """
+            type Query {
+                obj : Object
+            }
+            
+            type Object {
+                field(argStr : String @strDirective @secondDirective, argInt : Int @intDirective(inception : true) @thirdDirective ) : String
+            }
+        """
+
+        def schema = schema(spec)
+        GraphQLObjectType type = schema.getType("Object") as GraphQLObjectType
+        def fieldDefinition = type.getFieldDefinition("field")
+        def argStr = fieldDefinition.getArgument("argStr")
+        def argInt = fieldDefinition.getArgument("argInt")
+
+        expect:
+        argStr.getDirectives().size() == 2
+        argStr.getDirective("strDirective") != null
+        argStr.getDirective("secondDirective") != null
+
+        argInt.getDirectives().size() == 2
+
+        argInt.getDirective("thirdDirective") != null
+
+        def intDirective = argInt.getDirective("intDirective")
+        intDirective.name == "intDirective"
+        intDirective.arguments.size() == 1
+        def directiveArg = intDirective.getArgument("inception")
+        directiveArg.name == "inception"
+        directiveArg.type == GraphQLBoolean
+        directiveArg.defaultValue == true
+    }
 }


### PR DESCRIPTION
This allows each runtime type to be transformed into new versions of themselves.

This is a staging change so later we can allow @directives that can enhance / change the SDL type model.