### PR TITLE
Add data loader dispatcher instrumentation copied from Braid

### DIFF
--- a/src/main/java/graphql/execution/instrumentation/dataloader/BraidDataLoaderDispatcherInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/BraidDataLoaderDispatcherInstrumentation.java
@@ -16,10 +16,9 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import static graphql.execution.instrumentation.SimpleInstrumentationContext.whenDispatched;
+import static graphql.util.FpKit.concat;
 import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.CompletableFuture.completedFuture;
 
 public final class BraidDataLoaderDispatcherInstrumentation extends SimpleInstrumentation {
     private static final Logger log = LoggerFactory.getLogger(BraidDataLoaderDispatcherInstrumentation.class);
@@ -37,76 +36,57 @@ public final class BraidDataLoaderDispatcherInstrumentation extends SimpleInstru
 
     private void dispatch() {
         log.debug("Dispatching all data loaders ({})", dataLoaderRegistry.getKeys());
-        final DispatchedBatchLoaders allDispatched = dataLoaderRegistry.getKeys().stream()
+        final CombinedDataLoaderDispatchCalls allDispatched = dataLoaderRegistry.getKeys().stream()
                 .map(key -> dispatchBatchLoader(dataLoaderRegistry, key))
-                .reduce(new DispatchedBatchLoaders(), DispatchedBatchLoaders::add, DispatchedBatchLoaders::combine);
+                .reduce(new CombinedDataLoaderDispatchCalls(), CombinedDataLoaderDispatchCalls::add, CombinedDataLoaderDispatchCalls::combine);
 
         if (allDispatched.depth > 0) {
             allDispatched.whenComplete(this::dispatch);
         }
     }
 
-    private DispatchedBatchLoader dispatchBatchLoader(DataLoaderRegistry dataLoaderRegistry, String key) {
+    private DataLoaderDispatchCall dispatchBatchLoader(DataLoaderRegistry dataLoaderRegistry, String key) {
         final DataLoader<Object, DataFetcherResult> dataLoader = dataLoaderRegistry.getDataLoader(key);
-        final int dispatchDepth = dataLoader.dispatchDepth();
-
-        return new DispatchedBatchLoader<>(key,
-                dispatchDepth,
-                dispatchDepth > 0 ? dataLoader.dispatch() : completedFuture(emptyList()));
+        return new DataLoaderDispatchCall<>(dataLoader.dispatchDepth(), dataLoader.dispatch());
     }
 
-    private static class DispatchedBatchLoader<V> {
-        private final String key;
+    private static class DataLoaderDispatchCall<V> {
         private final int depth;
         private final CompletableFuture<List<V>> futures;
 
-        private DispatchedBatchLoader(String key, int depth, CompletableFuture<List<V>> futures) {
-            this.key = key;
+        private DataLoaderDispatchCall(int depth, CompletableFuture<List<V>> futures) {
             this.depth = depth;
             this.futures = futures;
         }
     }
 
-    private static class DispatchedBatchLoaders {
+    private static class CombinedDataLoaderDispatchCalls {
         private final int depth;
         private final List<CompletableFuture<List<?>>> futures;
 
-        private DispatchedBatchLoaders() {
-            this(0);
+        private CombinedDataLoaderDispatchCalls() {
+            this(0, emptyList());
         }
 
-        private DispatchedBatchLoaders(int depth) {
-            this.depth = depth;
-            this.futures = new ArrayList<>();
-        }
-
-        private DispatchedBatchLoaders(int depth, List<CompletableFuture<List<?>>> futures) {
+        private CombinedDataLoaderDispatchCalls(int depth, List<CompletableFuture<List<?>>> futures) {
             this.depth = depth;
             this.futures = new ArrayList<>(futures);
         }
 
-        private DispatchedBatchLoaders add(DispatchedBatchLoader dbl) {
-            return new DispatchedBatchLoaders(this.depth + dbl.depth, concat(this.futures, dbl.futures));
+        @SuppressWarnings("unchecked")
+        private CombinedDataLoaderDispatchCalls add(DataLoaderDispatchCall ddc) {
+            return new CombinedDataLoaderDispatchCalls(this.depth + ddc.depth, concat(this.futures, ddc.futures));
         }
 
-        private static DispatchedBatchLoaders combine(DispatchedBatchLoaders ds1, DispatchedBatchLoaders ds2) {
-            return new DispatchedBatchLoaders(ds1.depth + ds2.depth, concat(ds1.futures, ds2.futures));
+        private static CombinedDataLoaderDispatchCalls combine(CombinedDataLoaderDispatchCalls cdldc1,
+                                                               CombinedDataLoaderDispatchCalls cdldc2) {
+            return new CombinedDataLoaderDispatchCalls(
+                    cdldc1.depth + cdldc2.depth,
+                    concat(cdldc1.futures, cdldc2.futures));
         }
 
         void whenComplete(Runnable run) {
             CompletableFutureKit.allOf(futures).whenComplete((__, ___) -> run.run());
         }
     }
-
-    static <T> List<T> concat(List<T> l, T t) {
-        return concat(l, singletonList(t));
-    }
-
-    static <T> List<T> concat(List<T> l1, List<T> l2) {
-        ArrayList<T> l = new ArrayList<>(l1);
-        l.addAll(l2);
-        l.trimToSize();
-        return l;
-    }
-
 }

--- a/src/main/java/graphql/execution/instrumentation/dataloader/BraidDataLoaderDispatcherInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/BraidDataLoaderDispatcherInstrumentation.java
@@ -1,0 +1,112 @@
+package graphql.execution.instrumentation.dataloader;
+
+import graphql.ExecutionResult;
+import graphql.execution.DataFetcherResult;
+import graphql.execution.instrumentation.InstrumentationContext;
+import graphql.execution.instrumentation.SimpleInstrumentation;
+import graphql.execution.instrumentation.parameters.InstrumentationExecuteOperationParameters;
+import org.dataloader.DataLoader;
+import org.dataloader.DataLoaderRegistry;
+import org.dataloader.impl.CompletableFutureKit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static graphql.execution.instrumentation.SimpleInstrumentationContext.whenDispatched;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+public final class BraidDataLoaderDispatcherInstrumentation extends SimpleInstrumentation {
+    private static final Logger log = LoggerFactory.getLogger(BraidDataLoaderDispatcherInstrumentation.class);
+
+    private final DataLoaderRegistry dataLoaderRegistry;
+
+    public BraidDataLoaderDispatcherInstrumentation(DataLoaderRegistry dataLoaderRegistry) {
+        this.dataLoaderRegistry = requireNonNull(dataLoaderRegistry);
+    }
+
+    @Override
+    public InstrumentationContext<ExecutionResult> beginExecuteOperation(InstrumentationExecuteOperationParameters parameters) {
+        return whenDispatched(__ -> dispatch());
+    }
+
+    private void dispatch() {
+        log.debug("Dispatching all data loaders ({})", dataLoaderRegistry.getKeys());
+        final DispatchedBatchLoaders allDispatched = dataLoaderRegistry.getKeys().stream()
+                .map(key -> dispatchBatchLoader(dataLoaderRegistry, key))
+                .reduce(new DispatchedBatchLoaders(), DispatchedBatchLoaders::add, DispatchedBatchLoaders::combine);
+
+        if (allDispatched.depth > 0) {
+            allDispatched.whenComplete(this::dispatch);
+        }
+    }
+
+    private DispatchedBatchLoader dispatchBatchLoader(DataLoaderRegistry dataLoaderRegistry, String key) {
+        final DataLoader<Object, DataFetcherResult> dataLoader = dataLoaderRegistry.getDataLoader(key);
+        final int dispatchDepth = dataLoader.dispatchDepth();
+
+        return new DispatchedBatchLoader<>(key,
+                dispatchDepth,
+                dispatchDepth > 0 ? dataLoader.dispatch() : completedFuture(emptyList()));
+    }
+
+    private static class DispatchedBatchLoader<V> {
+        private final String key;
+        private final int depth;
+        private final CompletableFuture<List<V>> futures;
+
+        private DispatchedBatchLoader(String key, int depth, CompletableFuture<List<V>> futures) {
+            this.key = key;
+            this.depth = depth;
+            this.futures = futures;
+        }
+    }
+
+    private static class DispatchedBatchLoaders {
+        private final int depth;
+        private final List<CompletableFuture<List<?>>> futures;
+
+        private DispatchedBatchLoaders() {
+            this(0);
+        }
+
+        private DispatchedBatchLoaders(int depth) {
+            this.depth = depth;
+            this.futures = new ArrayList<>();
+        }
+
+        private DispatchedBatchLoaders(int depth, List<CompletableFuture<List<?>>> futures) {
+            this.depth = depth;
+            this.futures = new ArrayList<>(futures);
+        }
+
+        private DispatchedBatchLoaders add(DispatchedBatchLoader dbl) {
+            return new DispatchedBatchLoaders(this.depth + dbl.depth, concat(this.futures, dbl.futures));
+        }
+
+        private static DispatchedBatchLoaders combine(DispatchedBatchLoaders ds1, DispatchedBatchLoaders ds2) {
+            return new DispatchedBatchLoaders(ds1.depth + ds2.depth, concat(ds1.futures, ds2.futures));
+        }
+
+        void whenComplete(Runnable run) {
+            CompletableFutureKit.allOf(futures).whenComplete((__, ___) -> run.run());
+        }
+    }
+
+    static <T> List<T> concat(List<T> l, T t) {
+        return concat(l, singletonList(t));
+    }
+
+    static <T> List<T> concat(List<T> l1, List<T> l2) {
+        ArrayList<T> l = new ArrayList<>(l1);
+        l.addAll(l2);
+        l.trimToSize();
+        return l;
+    }
+
+}

--- a/src/main/java/graphql/util/FpKit.java
+++ b/src/main/java/graphql/util/FpKit.java
@@ -14,6 +14,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static java.util.Collections.singletonList;
 import static java.util.function.Function.identity;
 
 @Internal
@@ -38,9 +39,7 @@ public class FpKit {
      * it alone if it is already is one.  Useful when you want to get the size of something
      *
      * @param iterableResult the result object
-     *
      * @return an Iterable from that object
-     *
      * @throws java.lang.ClassCastException if its not an Iterable
      */
     @SuppressWarnings("unchecked")
@@ -61,5 +60,32 @@ public class FpKit {
             list.add(iterator.next());
         }
         return list;
+    }
+
+    /**
+     * Concatenates (appends) a single elements to an existing list
+     *
+     * @param l the list onto which to append the element
+     * @param t the element to append
+     * @param <T> the type of elements of the list
+     * @return a <strong>new</strong> list componsed of the first list elements and the new element
+     */
+    public static <T> List<T> concat(List<T> l, T t) {
+        return concat(l, singletonList(t));
+    }
+
+    /**
+     * Concatenates two lists into one
+     *
+     * @param l1 the first list to concatenate
+     * @param l2 the second list to concatenate
+     * @param <T> the type of element of the lists
+     * @return a <strong>new</strong> list composed of the two concatenated lists elements
+     */
+    public static <T> List<T> concat(List<T> l1, List<T> l2) {
+        ArrayList<T> l = new ArrayList<>(l1);
+        l.addAll(l2);
+        l.trimToSize();
+        return l;
     }
 }

--- a/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderPerformanceTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderPerformanceTest.groovy
@@ -151,7 +151,7 @@ class DataLoaderPerformanceTest extends Specification {
         DataLoaderRegistry dataLoaderRegistry = new DataLoaderRegistry()
         dataLoaderRegistry.register("departments", BatchCompareDataFetchers.departmentsForShopDataLoader)
         dataLoaderRegistry.register("products", BatchCompareDataFetchers.productsForDepartmentDataLoader)
-        def instrumentation = new DataLoaderDispatcherInstrumentation(dataLoaderRegistry)
+        def instrumentation = new BraidDataLoaderDispatcherInstrumentation(dataLoaderRegistry)
         GraphQL graphQL = GraphQL
                 .newGraphQL(schema)
                 .instrumentation(instrumentation)
@@ -175,7 +175,7 @@ class DataLoaderPerformanceTest extends Specification {
         DataLoaderRegistry dataLoaderRegistry = new DataLoaderRegistry()
         dataLoaderRegistry.register("departments", BatchCompareDataFetchers.departmentsForShopDataLoader)
         dataLoaderRegistry.register("products", BatchCompareDataFetchers.productsForDepartmentDataLoader)
-        def instrumentation = new DataLoaderDispatcherInstrumentation(dataLoaderRegistry)
+        def instrumentation = new BraidDataLoaderDispatcherInstrumentation(dataLoaderRegistry)
         GraphQL graphQL = GraphQL
                 .newGraphQL(schema)
                 .instrumentation(instrumentation)


### PR DESCRIPTION
This demonstrate how the _recursive_ dispatch strategy could be used to improve performance of dataloading. 

@bbakerman @andimarek I've already pinged you on the _braid_ PR. Let me know what you think about this strategy. 

As I mentioned it has some implications about the context in which the dataloader is used, i.e. one instance per request, or being able to _contextualize_ the dataloading to recurse only for a given context. I'm happy to work more on this to make it work in a more generic way. Let's discuss.

