### PR TITLE
Tests for Known directives validation rule

### DIFF
--- a/src/main/java/graphql/validation/rules/KnownDirectives.java
+++ b/src/main/java/graphql/validation/rules/KnownDirectives.java
@@ -1,28 +1,16 @@
 package graphql.validation.rules;
 
 
-import graphql.GraphQLException;
 import graphql.introspection.Introspection.DirectiveLocation;
-import static graphql.introspection.Introspection.DirectiveLocation.FIELD;
-import static graphql.introspection.Introspection.DirectiveLocation.FRAGMENT_SPREAD;
-import static graphql.introspection.Introspection.DirectiveLocation.FRAGMENT_DEFINITION;
-import static graphql.introspection.Introspection.DirectiveLocation.INLINE_FRAGMENT;
-import static graphql.introspection.Introspection.DirectiveLocation.QUERY;
-import static graphql.introspection.Introspection.DirectiveLocation.MUTATION;
 import graphql.language.Directive;
 import graphql.language.Field;
 import graphql.language.FragmentDefinition;
 import graphql.language.FragmentSpread;
 import graphql.language.InlineFragment;
 import graphql.language.Node;
-import graphql.language.NodeVisitorStub;
 import graphql.language.OperationDefinition;
 import graphql.language.OperationDefinition.Operation;
 import graphql.schema.GraphQLDirective;
-import graphql.util.SimpleTraverserContext;
-import graphql.util.TraversalControl;
-import static graphql.util.TraversalControl.QUIT;
-import graphql.util.TraverserContext;
 import graphql.validation.AbstractRule;
 import graphql.validation.ValidationContext;
 import graphql.validation.ValidationErrorCollector;
@@ -53,101 +41,22 @@ public class KnownDirectives extends AbstractRule {
         }
     }
 
+    @SuppressWarnings("deprecation") // the suppression stands because its deprecated but still in graphql spec
     private boolean hasInvalidLocation(GraphQLDirective directive, Node ancestor) {
-        Context context = new Context(ancestor,directive);
-        ancestor.accept(context,LOCATION_VISITOR);
-        return context.isValid();
-    }
-
-    private final static LocationVisitor LOCATION_VISITOR = new LocationVisitor();
-
-    private class Context extends SimpleTraverserContext<Node> {
-        final GraphQLDirective directive;
-
-        Context(Node node, GraphQLDirective directive) {
-            super(node);
-            this.directive = directive;
+        if (ancestor instanceof OperationDefinition) {
+            Operation operation = ((OperationDefinition) ancestor).getOperation();
+            return Operation.QUERY.equals(operation) ?
+                    !(directive.validLocations().contains(DirectiveLocation.QUERY) || directive.isOnOperation()) :
+                    !(directive.validLocations().contains(DirectiveLocation.MUTATION) || directive.isOnOperation());
+        } else if (ancestor instanceof Field) {
+            return !(directive.validLocations().contains(DirectiveLocation.FIELD) || directive.isOnField());
+        } else if (ancestor instanceof FragmentSpread) {
+            return !(directive.validLocations().contains(DirectiveLocation.FRAGMENT_SPREAD) || directive.isOnFragment());
+        } else if (ancestor instanceof FragmentDefinition) {
+            return !(directive.validLocations().contains(DirectiveLocation.FRAGMENT_DEFINITION) || directive.isOnFragment());
+        } else if (ancestor instanceof InlineFragment) {
+            return !(directive.validLocations().contains(DirectiveLocation.INLINE_FRAGMENT) || directive.isOnFragment());
         }
-
-        @Override
-        public Object getInitialData() {
-            return directive;
-        }
-
-        Boolean isValid() {
-            return (Boolean)getResult();
-        }
-    }
-
-    private static class LocationVisitor extends NodeVisitorStub {
-        @Override
-        public TraversalControl visitField(Field node, TraverserContext<Node> context) {
-            return setAndQuit(context, FIELD);
-        }
-
-        @Override
-        public TraversalControl visitFragmentSpread(FragmentSpread node, TraverserContext<Node> context) {
-            return setAndQuit(context, FRAGMENT_SPREAD);
-        }
-
-        @Override
-        public TraversalControl visitFragmentDefinition(FragmentDefinition node, TraverserContext<Node> context) {
-            return setAndQuit(context, FRAGMENT_DEFINITION);
-        }
-
-        @Override
-        public TraversalControl visitInlineFragment(InlineFragment node, TraverserContext<Node> context) {
-            return setAndQuit(context, INLINE_FRAGMENT);
-        }
-
-        @Override
-        public TraversalControl visitOperationDefinition(OperationDefinition node, TraverserContext<Node> context) {
-            return setAndQuit(context, Operation.QUERY.equals(node.getOperation()) ? QUERY : MUTATION);
-        }
-
-        @Override
-        protected TraversalControl visitNode(Node node, TraverserContext<Node> context) {
-            context.setResult(true);
-            return QUIT;
-        }
-
-        private boolean has(GraphQLDirective directive, DirectiveLocation thing) {
-            return directive.validLocations().contains(thing);
-        }
-
-        private TraversalControl setAndQuit(TraverserContext<Node> context, DirectiveLocation location) {
-            context.setResult(isInvalidLocation(context,location));
-            return QUIT;
-        }
-
-        private GraphQLDirective getDirective(TraverserContext<Node> context) {
-            return (GraphQLDirective)context.getInitialData();
-        }
-
-        @SuppressWarnings("deprecation") // the suppression stands because its deprecated but still in graphql spec
-        private boolean legacyIsOnDirective(DirectiveLocation location, GraphQLDirective directive) {
-            switch (location) {
-                case FIELD:
-                    return directive.isOnField();
-
-                case FRAGMENT_SPREAD:
-                case FRAGMENT_DEFINITION:
-                case INLINE_FRAGMENT:
-                    return directive.isOnFragment();
-
-                case QUERY:
-                case MUTATION:
-                    return directive.isOnOperation();
-
-                default:
-                    throw new GraphQLException("Legacy behaviour did not expect location " + location.toString());
-            }
-        }
-
-        private boolean isInvalidLocation(TraverserContext<Node> context, DirectiveLocation location) {
-            GraphQLDirective directive = getDirective(context);
-            return !(has(directive,location) || legacyIsOnDirective(location, directive));
-
-        }
+        return true;
     }
 }

--- a/src/test/groovy/graphql/validation/rules/KnownDirectivesTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/KnownDirectivesTest.groovy
@@ -62,5 +62,177 @@ class KnownDirectivesTest extends Specification {
 
     }
 
+    def "correct placed directive on mutation"() {
+        given:
+        def query = """
+          mutation Foo  {
+                name @include(if: true)
+              }
+        """
+
+        Document document = new Parser().parseDocument(query)
+        LanguageTraversal languageTraversal = new LanguageTraversal()
+
+        when:
+        languageTraversal.traverse(document, new RulesVisitor(validationContext, [knownDirectives]))
+
+        then:
+        errorCollector.errors.isEmpty()
+
+    }
+
+
+    def "misplaced directive on mutation"() {
+        given:
+        def query = """
+          mutation Foo @include(if: true) {
+                name
+              }
+        """
+
+        Document document = new Parser().parseDocument(query)
+        LanguageTraversal languageTraversal = new LanguageTraversal()
+
+        when:
+        languageTraversal.traverse(document, new RulesVisitor(validationContext, [knownDirectives]))
+
+        then:
+        errorCollector.containsValidationError(ValidationErrorType.MisplacedDirective)
+
+    }
+
+
+
+    def "bogus directive"() {
+        given:
+        def query = """
+          query Foo @helloWorld {
+                name
+              }
+        """
+
+        Document document = new Parser().parseDocument(query)
+        LanguageTraversal languageTraversal = new LanguageTraversal()
+
+        when:
+        languageTraversal.traverse(document, new RulesVisitor(validationContext, [knownDirectives]))
+
+        then:
+        errorCollector.containsValidationError(ValidationErrorType.UnknownDirective)
+
+    }
+
+
+    def "misplaced directive on fragment definition"() {
+        given:
+        def query = """
+          fragment getName on Foo @include(if: true) {
+            name  
+          }
+          query Foo {
+                ...getName
+              }
+        """
+
+        Document document = new Parser().parseDocument(query)
+        LanguageTraversal languageTraversal = new LanguageTraversal()
+
+        when:
+        languageTraversal.traverse(document, new RulesVisitor(validationContext, [knownDirectives]))
+
+        then:
+        errorCollector.containsValidationError(ValidationErrorType.MisplacedDirective)
+
+    }
+
+
+    def "directive on external fragment spread"() {
+        given:
+        def query = """
+          fragment getName on Foo {
+             ... @include(if: true) {
+                    name
+             }
+          }
+          query Foo {
+                ...getName
+              }
+        """
+
+        Document document = new Parser().parseDocument(query)
+        LanguageTraversal languageTraversal = new LanguageTraversal()
+
+        when:
+        languageTraversal.traverse(document, new RulesVisitor(validationContext, [knownDirectives]))
+
+        then:
+        errorCollector.errors.isEmpty()
+
+    }
+
+    def "directive on inline fragment spread"() {
+        given:
+        def query = """
+          query Foo {
+                 ... @include(if: true) {
+                    name
+                  }
+              }
+        """
+
+        Document document = new Parser().parseDocument(query)
+        LanguageTraversal languageTraversal = new LanguageTraversal()
+
+        when:
+        languageTraversal.traverse(document, new RulesVisitor(validationContext, [knownDirectives]))
+
+        then:
+        errorCollector.errors.isEmpty()
+
+    }
+
+    def "directive on inline fragment spread and type"() {
+        given:
+        def query = """
+          query Foo {
+                 ... on Foo @include(if: true) {
+                    name
+                  }
+              }
+        """
+
+        Document document = new Parser().parseDocument(query)
+        LanguageTraversal languageTraversal = new LanguageTraversal()
+
+        when:
+        languageTraversal.traverse(document, new RulesVisitor(validationContext, [knownDirectives]))
+
+        then:
+        errorCollector.errors.isEmpty()
+
+    }
+
+    def "directive on fragment spread"() {
+        given:
+        def query = """
+          fragment getName on Foo {
+            name
+          }
+          query Foo {
+                ...getName @include(if: true)
+              }
+        """
+
+        Document document = new Parser().parseDocument(query)
+        LanguageTraversal languageTraversal = new LanguageTraversal()
+
+        when:
+        languageTraversal.traverse(document, new RulesVisitor(validationContext, [knownDirectives]))
+
+        then:
+        errorCollector.errors.isEmpty()
+
+    }
+
 
 }


### PR DESCRIPTION
* Known directives validator start using node visitor, which allows to verify type at compile time
* more tests 
* legacy directive mapping `directive.isOnXXXX()` is moved to a single method

PS
Intent behind this PR is to try out new node/graph traversal :)