### PR TITLE
Minor performance improvements

### DIFF
--- a/src/main/java/graphql/execution/Async.java
+++ b/src/main/java/graphql/execution/Async.java
@@ -1,8 +1,5 @@
 package graphql.execution;
 
-import graphql.Assert;
-import graphql.Internal;
-
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -10,6 +7,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
+
+import graphql.Assert;
+import graphql.Internal;
 
 @Internal
 public class Async {
@@ -23,7 +23,7 @@ public class Async {
         CompletableFuture<List<U>> overallResult = new CompletableFuture<>();
 
         CompletableFuture
-                .allOf(futures.toArray(new CompletableFuture[futures.size()]))
+                .allOf(futures.toArray(new CompletableFuture[0]))
                 .whenComplete((noUsed, exception) -> {
                     if (exception != null) {
                         overallResult.completeExceptionally(exception);

--- a/src/main/java/graphql/execution/NonNullableValueCoercedAsNullException.java
+++ b/src/main/java/graphql/execution/NonNullableValueCoercedAsNullException.java
@@ -1,5 +1,10 @@
 package graphql.execution;
 
+import static java.lang.String.format;
+
+import java.util.Collections;
+import java.util.List;
+
 import graphql.ErrorType;
 import graphql.GraphQLError;
 import graphql.GraphQLException;
@@ -9,11 +14,6 @@ import graphql.language.VariableDefinition;
 import graphql.schema.GraphQLInputObjectField;
 import graphql.schema.GraphQLType;
 import graphql.schema.GraphQLTypeUtil;
-
-import java.util.Arrays;
-import java.util.List;
-
-import static java.lang.String.format;
 
 /**
  * This is thrown if a non nullable value is coerced to a null value
@@ -25,7 +25,7 @@ public class NonNullableValueCoercedAsNullException extends GraphQLException imp
     public NonNullableValueCoercedAsNullException(VariableDefinition variableDefinition, GraphQLType graphQLType) {
         super(format("Variable '%s' has coerced Null value for NonNull type '%s'",
                 variableDefinition.getName(), GraphQLTypeUtil.getUnwrappedTypeName(graphQLType)));
-        this.sourceLocations = Arrays.asList(variableDefinition.getSourceLocation());
+        this.sourceLocations = Collections.singletonList(variableDefinition.getSourceLocation());
     }
 
     public NonNullableValueCoercedAsNullException(GraphQLInputObjectField inputTypeField) {

--- a/src/main/java/graphql/language/AstPrinter.java
+++ b/src/main/java/graphql/language/AstPrinter.java
@@ -1,6 +1,8 @@
 package graphql.language;
 
-import graphql.AssertException;
+import static graphql.Assert.assertTrue;
+import static java.lang.String.valueOf;
+import static java.util.stream.Collectors.joining;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -11,9 +13,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import static graphql.Assert.assertTrue;
-import static java.lang.String.valueOf;
-import static java.util.stream.Collectors.joining;
+import graphql.AssertException;
 
 /**
  * This can take graphql language AST and print it out as a string
@@ -169,7 +169,7 @@ public class AstPrinter {
     }
 
     private static boolean hasComments(List<? extends Node> nodes) {
-        return nodes.stream().filter(it -> it.getComments().size() > 0).count() > 0;
+        return nodes.stream().anyMatch(it -> it.getComments().size() > 0);
     }
 
     private static NodePrinter<FragmentDefinition> fragmentDefinition() {

--- a/src/main/java/graphql/schema/CoercingParseLiteralException.java
+++ b/src/main/java/graphql/schema/CoercingParseLiteralException.java
@@ -1,13 +1,13 @@
 package graphql.schema;
 
+import java.util.Collections;
+import java.util.List;
+
 import graphql.ErrorType;
 import graphql.GraphQLError;
 import graphql.GraphQLException;
 import graphql.PublicApi;
 import graphql.language.SourceLocation;
-
-import java.util.Arrays;
-import java.util.List;
 
 @PublicApi
 public class CoercingParseLiteralException extends GraphQLException implements GraphQLError {
@@ -26,7 +26,7 @@ public class CoercingParseLiteralException extends GraphQLException implements G
 
     public CoercingParseLiteralException(String message, Throwable cause, SourceLocation sourceLocation) {
         super(message, cause);
-        this.sourceLocations = Arrays.asList(sourceLocation);
+        this.sourceLocations = Collections.singletonList(sourceLocation);
     }
 
     public CoercingParseLiteralException(Throwable cause) {

--- a/src/main/java/graphql/schema/CoercingParseValueException.java
+++ b/src/main/java/graphql/schema/CoercingParseValueException.java
@@ -1,13 +1,13 @@
 package graphql.schema;
 
+import java.util.Collections;
+import java.util.List;
+
 import graphql.ErrorType;
 import graphql.GraphQLError;
 import graphql.GraphQLException;
 import graphql.PublicApi;
 import graphql.language.SourceLocation;
-
-import java.util.Arrays;
-import java.util.List;
 
 @PublicApi
 public class CoercingParseValueException extends GraphQLException implements GraphQLError {
@@ -26,7 +26,7 @@ public class CoercingParseValueException extends GraphQLException implements Gra
 
     public CoercingParseValueException(String message, Throwable cause, SourceLocation sourceLocation) {
         super(message, cause);
-        this.sourceLocations = Arrays.asList(sourceLocation);
+        this.sourceLocations = Collections.singletonList(sourceLocation);
     }
 
     public CoercingParseValueException(Throwable cause) {

--- a/src/main/java/graphql/schema/idl/SchemaPrinter.java
+++ b/src/main/java/graphql/schema/idl/SchemaPrinter.java
@@ -1,5 +1,20 @@
 package graphql.schema.idl;
 
+import static graphql.schema.visibility.DefaultGraphqlFieldVisibility.DEFAULT_FIELD_VISIBILITY;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
 import graphql.Assert;
 import graphql.PublicApi;
 import graphql.language.AstPrinter;
@@ -26,21 +41,6 @@ import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
 import graphql.schema.GraphQLUnionType;
 import graphql.schema.visibility.GraphqlFieldVisibility;
-
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Stack;
-import java.util.function.Supplier;
-import java.util.stream.Stream;
-
-import static graphql.schema.visibility.DefaultGraphqlFieldVisibility.DEFAULT_FIELD_VISIBILITY;
-import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toList;
 
 
 /**
@@ -400,7 +400,7 @@ public class SchemaPrinter {
     }
 
     String argsString(List<GraphQLArgument> arguments) {
-        boolean hasDescriptions = arguments.stream().filter(arg -> !isNullOrEmpty(arg.getDescription())).count() > 0;
+        boolean hasDescriptions = arguments.stream().anyMatch(arg -> !isNullOrEmpty(arg.getDescription()));
         String prefix = hasDescriptions ? "  " : "";
         int count = 0;
         StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
* Replaced `count() > 0` with `anyMatch`
* Replaced `Arrays.asList(<single_element>)` to `Collections.singletonList()`
* Replaced `Collections.toArray(T[<size>])` to `Collections.toArray(T[0])`. This is the best performing and contractually cleaner way as [explained ](https://shipilev.net/blog/2016/arrays-wisdom-ancients/)by Aleksey Shipilev