### PR TITLE
DO NOT MERGE  --  DRAFT implementation of @defer support

### DIFF
--- a/src/main/java/graphql/Directives.java
+++ b/src/main/java/graphql/Directives.java
@@ -37,6 +37,12 @@ public class Directives {
             .validLocations(FRAGMENT_SPREAD, INLINE_FRAGMENT, FIELD)
             .build();
 
+    public static final GraphQLDirective DeferDirective = GraphQLDirective.newDirective()
+            .name("defer")
+            .description("Directs the executor that it may skip this field or fragment in an initially returned result")
+            .validLocations(FRAGMENT_SPREAD, INLINE_FRAGMENT, FIELD)
+            .build();
+
     public static final GraphQLDirective FetchDirective = GraphQLDirective.newDirective()
             .name("fetch")
             .description("Directs the SDL type generation to create a data fetcher that uses this `from` argument as the property name")
@@ -46,6 +52,5 @@ public class Directives {
                     .description("The `name` used to fetch values from the underlying object"))
             .validLocations(FIELD_DEFINITION)
             .build();
-
 
 }

--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -1,8 +1,8 @@
 package graphql;
 
 import graphql.execution.AbortExecutionException;
-import graphql.execution.AsyncExecutionStrategy;
 import graphql.execution.AsyncSerialExecutionStrategy;
+import graphql.execution.DeferringAsyncExecutionStrategy;
 import graphql.execution.Execution;
 import graphql.execution.ExecutionId;
 import graphql.execution.ExecutionIdProvider;
@@ -148,7 +148,7 @@ public class GraphQL {
 
     private GraphQL(GraphQLSchema graphQLSchema, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy, ExecutionStrategy subscriptionStrategy, ExecutionIdProvider idProvider, Instrumentation instrumentation, PreparsedDocumentProvider preparsedDocumentProvider) {
         this.graphQLSchema = assertNotNull(graphQLSchema, "queryStrategy must be non null");
-        this.queryStrategy = queryStrategy != null ? queryStrategy : new AsyncExecutionStrategy();
+        this.queryStrategy = queryStrategy != null ? queryStrategy : new DeferringAsyncExecutionStrategy();
         this.mutationStrategy = mutationStrategy != null ? mutationStrategy : new AsyncSerialExecutionStrategy();
         this.subscriptionStrategy = subscriptionStrategy != null ? subscriptionStrategy : new SubscriptionExecutionStrategy();
         this.idProvider = assertNotNull(idProvider, "idProvider must be non null");
@@ -197,7 +197,7 @@ public class GraphQL {
     @PublicApi
     public static class Builder {
         private GraphQLSchema graphQLSchema;
-        private ExecutionStrategy queryExecutionStrategy = new AsyncExecutionStrategy();
+        private ExecutionStrategy queryExecutionStrategy = new DeferringAsyncExecutionStrategy();
         private ExecutionStrategy mutationExecutionStrategy = new AsyncSerialExecutionStrategy();
         private ExecutionStrategy subscriptionExecutionStrategy = new SubscriptionExecutionStrategy();
         private ExecutionIdProvider idProvider = DEFAULT_EXECUTION_ID_PROVIDER;

--- a/src/main/java/graphql/execution/ConditionalNodes.java
+++ b/src/main/java/graphql/execution/ConditionalNodes.java
@@ -24,7 +24,7 @@ public class ConditionalNodes {
         return !skip && include;
     }
 
-    private Directive getDirectiveByName(List<Directive> directives, String name) {
+    static Directive getDirectiveByName(List<Directive> directives, String name) {
         if (directives.isEmpty()) {
             return null;
         }

--- a/src/main/java/graphql/execution/DeferredFieldCollector.java
+++ b/src/main/java/graphql/execution/DeferredFieldCollector.java
@@ -1,0 +1,79 @@
+package graphql.execution;
+
+
+import graphql.Internal;
+import graphql.language.Field;
+import graphql.language.SelectionSet;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static graphql.execution.DeferredNodes.deferedNode;
+
+/**
+ * A field collector can iterate over field selection sets and build out the sub fields that have been selected,
+ * expanding named and inline fragments as it goes.s
+ *
+ * Fields with '@skip' and/or '@include' directive will be resolved to be included, or no.  If included, ONLY fields with the
+ * '@defer' directive will be collected.
+ */
+@Internal
+public class DeferredFieldCollector implements FieldCollector {
+
+    FieldCollector fieldCollector = new SimpleFieldCollector();
+
+    @Override
+    public Map<String, List<Field>> collectFields(FieldCollectorParameters parameters, List<Field> fields) {
+        Map<String, List<Field>> subFields = new LinkedHashMap<>();
+        List<String> visitedFragments = new ArrayList<>();
+
+        for (Field field : fields) {
+            if (field.getSelectionSet() == null) {
+                continue;
+            }
+            this.collectFields(parameters, field.getSelectionSet(), visitedFragments, subFields, true);
+        }
+        return subFields;
+    }
+
+    @Override
+    public Map<String, List<Field>> collectFields(FieldCollectorParameters parameters, SelectionSet selectionSet) {
+        Map<String, List<Field>> subFields = new LinkedHashMap<>();
+        List<String> visitedFragments = new ArrayList<>();
+
+        this.collectFields(parameters, selectionSet, visitedFragments, subFields, true);
+        return subFields;
+    }
+
+    @Override
+    public void collectFields(FieldCollectorParameters parameters, SelectionSet selectionSet, List<String> visitedFragments,
+                              Map<String, List<Field>> fields, boolean skipDeferred) {
+        // get set of all fields
+        fieldCollector.collectFields(parameters, selectionSet, visitedFragments, fields, false);
+
+        List<String> keysToRemove= new ArrayList<>();
+        for (String key : fields.keySet()) {
+            List<Field> fieldsToRemove = new ArrayList<>();
+            for (Field field : fields.get(key)) {
+                // trim fields that are not @defer
+                if (!deferedNode(field.getDirectives())) {
+                    fieldsToRemove.add(field);
+                }
+            }
+            if (fieldsToRemove.size() > 0) {
+                fields.get(key).removeAll(fieldsToRemove);
+            }
+
+            // delete entire map entry if now empty
+            if (fields.get(key).size() == 0) {
+                keysToRemove.add(key);
+            }
+        }
+        for (String key : keysToRemove) {
+            fields.remove(key);
+        }
+    }
+}
+

--- a/src/main/java/graphql/execution/DeferredFieldNodeFilter.java
+++ b/src/main/java/graphql/execution/DeferredFieldNodeFilter.java
@@ -1,0 +1,19 @@
+package graphql.execution;
+
+import graphql.language.Directive;
+
+import java.util.List;
+import java.util.Map;
+
+public class DeferredFieldNodeFilter implements FieldNodeFilter {
+    private final ConditionalNodes conditionalNodes;
+
+    public DeferredFieldNodeFilter() {
+        conditionalNodes = new ConditionalNodes();
+    }
+
+    public boolean includeNode(Map<String, Object> variables, List<Directive> directives) {
+        return conditionalNodes.shouldInclude(variables, directives) && DeferredNodes.deferedNode(directives);
+    }
+
+}

--- a/src/main/java/graphql/execution/DeferredNodes.java
+++ b/src/main/java/graphql/execution/DeferredNodes.java
@@ -1,0 +1,26 @@
+package graphql.execution;
+
+import graphql.language.Directive;
+
+import java.util.List;
+
+import static graphql.Directives.DeferDirective;
+import static graphql.execution.ConditionalNodes.getDirectiveByName;
+
+
+public class DeferredNodes {
+
+    public static boolean deferedNode(List<Directive> directives) {
+        return getDirectiveResult(directives, DeferDirective.getName(), false);
+    }
+
+    private static boolean getDirectiveResult(List<Directive> directives, String directiveName, boolean defaultValue) {
+        Directive directive = getDirectiveByName(directives, directiveName);
+        if (directive != null) {
+            return true;
+        }
+
+        return defaultValue;
+    }
+
+}

--- a/src/main/java/graphql/execution/DeferringAsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/DeferringAsyncExecutionStrategy.java
@@ -1,0 +1,161 @@
+package graphql.execution;
+
+import graphql.ExecutionResult;
+import graphql.ExecutionResultImpl;
+import graphql.GraphQLError;
+import graphql.execution.instrumentation.Instrumentation;
+import graphql.execution.instrumentation.InstrumentationContext;
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionStrategyParameters;
+import graphql.language.Field;
+import graphql.language.OperationDefinition;
+import graphql.schema.GraphQLObjectType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static graphql.execution.Execution.collectFields;
+import static graphql.execution.Execution.getExecutionStrategyParameters;
+import static graphql.execution.Execution.getOperationRootType;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+/**
+ * The standard graphql execution strategy that runs fields asynchronously non-blocking, honoring @defer directives.
+ *
+ * This implementation takes a simple-minded in that everything not marked with @defer will be processed in a first pass,
+ * and that result returned.  Then, in a second pass, everything marked with @defer will be processed, and returned.
+ * A more sophisticated, nuanced implementation could break that second payload up into multiple payloads.
+ *
+ * The implementation also leverage that of SubscriptionExecutionStrategy.
+ */
+public class DeferringAsyncExecutionStrategy extends AsyncExecutionStrategy {
+    private static final Logger log = LoggerFactory.getLogger(DeferringAsyncExecutionStrategy.class);
+
+    private final FieldCollector nonDeferredFieldCollector = NonDeferredFieldCollector.nonDeferredFieldCollector();
+    private final FieldCollector deferredFieldCollector = new DeferredFieldCollector();
+
+    /**
+     * The standard graphql execution strategy that runs fields asynchronously non-blocking, honoring @defer directives
+     */
+    public DeferringAsyncExecutionStrategy() {
+        super();
+    }
+
+    public DeferringAsyncExecutionStrategy(DataFetcherExceptionHandler dataFetcherExceptionHandler) {
+        super(dataFetcherExceptionHandler);
+    }
+
+    /*
+    private static String lastDeferredResults;
+
+    public static String getlastDeferredResults() {
+        return lastDeferredResults;
+    }
+    */
+
+    @Override
+    public CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) throws NonNullableFieldWasNullException {
+        return executeDeferringAsyncExecutionStrategy(executionContext, parameters);
+    }
+
+    private CompletableFuture<ExecutionResult> executeDeferringAsyncExecutionStrategy(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
+        Instrumentation instrumentation = executionContext.getInstrumentation();
+        InstrumentationExecutionStrategyParameters instrumentationParameters = new InstrumentationExecutionStrategyParameters(executionContext, parameters);
+
+        InstrumentationContext<ExecutionResult> executionStrategyCtx = instrumentation.beginExecutionStrategy(instrumentationParameters);
+
+        OperationDefinition operationDefinition = executionContext.getOperationDefinition();
+
+        GraphQLObjectType operationRootType;
+        try {
+            operationRootType = getOperationRootType(executionContext.getGraphQLSchema(), operationDefinition);
+        } catch (RuntimeException rte) {
+            if (rte instanceof GraphQLError) {
+                ExecutionResult executionResult = new ExecutionResultImpl(Collections.singletonList((GraphQLError) rte));
+                CompletableFuture<ExecutionResult> resultCompletableFuture = completedFuture(executionResult);
+
+                executionStrategyCtx.onDispatched(resultCompletableFuture);
+                executionStrategyCtx.onCompleted(executionResult, rte);
+                return resultCompletableFuture;
+            }
+            throw rte;
+        }
+
+        Map<String, List<Field>> deferredFields = collectDeferredFields(executionContext, operationRootType, operationDefinition);
+        if (deferredFields.isEmpty()) {
+            return super.execute(executionContext, parameters, true);
+        } else {
+            CompletableFuture<ExecutionResult> nonDeferredResult =
+                    executeNonDeferredFields(executionContext, operationRootType, operationDefinition);
+
+            ExecutionStrategyParameters deferredParameters = getExecutionStrategyParameters(executionContext,
+                    executionContext.getRoot(), operationRootType, deferredFields);
+            CompletableFuture<ExecutionResult> deferredResult = super.execute(executionContext, deferredParameters);
+            try {
+//                lastDeferredResults = deferredResult.get().toString();
+                log.debug("Deferred execution result: {}",  deferredResult.get().toString());
+            } catch (InterruptedException | ExecutionException e) { }
+
+            return nonDeferredResult;
+        }
+    }
+
+    private Map<String, List<Field>>  collectDeferredFields(ExecutionContext executionContext, GraphQLObjectType operationRootType, OperationDefinition operationDefinition) {
+        log.debug("Deferred collectFields:");
+        Map<String, List<Field>> deferredFields = collectFields(executionContext, operationRootType, operationDefinition,
+                deferredFieldCollector);
+        if (log.isDebugEnabled()) {
+            log.debug("deferred: {}", deferredFields.size());
+            for (String key : deferredFields.keySet()) log.debug(" {}", key);
+        }
+        return deferredFields;
+    }
+
+    private CompletableFuture<ExecutionResult> executeNonDeferredFields(ExecutionContext executionContext, GraphQLObjectType operationRootType, OperationDefinition operationDefinition) {
+        Map<String, List<Field>> nonDeferredFields = collectNonDeferredFields(executionContext, operationRootType, operationDefinition);
+        ExecutionStrategyParameters nonDeferredParameters = getExecutionStrategyParameters(executionContext,
+                executionContext.getRoot(), operationRootType, nonDeferredFields);
+
+        log.debug("Non-Deferred execution");
+        return super.execute(executionContext, nonDeferredParameters);
+    }
+
+    private Map<String, List<Field>> collectNonDeferredFields(ExecutionContext executionContext, GraphQLObjectType operationRootType, OperationDefinition operationDefinition) {
+        log.debug("Non-Deferred collectFields:");
+        Map<String, List<Field>> nonDeferredFields = collectFields(executionContext, operationRootType, operationDefinition,
+                nonDeferredFieldCollector);
+        if (log.isDebugEnabled()) {
+            log.debug("nondeferred: {}", nonDeferredFields.size());
+            for (String key : nonDeferredFields.keySet()) log.debug(" {}", key);
+        }
+        return nonDeferredFields;
+    }
+
+    /*
+        class ExecutionPublisher<T> implements Publisher<T> {
+            CompletableFuture<ExecutionResult> nonDeferredResult;
+            CompletableFuture<ExecutionResult> deferredResult;
+
+            public ExecutionPublisher(CompletableFuture<ExecutionResult> nonDeferredResult,
+                                      CompletableFuture<ExecutionResult> deferredResult) {
+                this.nonDeferredResult = nonDeferredResult;
+                this.deferredResult = deferredResult;
+           }
+
+            @Override
+            public void subscribe(Subscriber<? super T> subscriber) {
+                try {
+                    subscriber.onNext(nonDeferredResult);
+                    subscriber.onNext();
+                    subscriber.onComplete();
+                } catch (Throwable e) {
+                    subscriber.onError(e);
+                }
+            }
+        }
+        */
+}

--- a/src/main/java/graphql/execution/ExecutorServiceExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutorServiceExecutionStrategy.java
@@ -32,6 +32,8 @@ import java.util.concurrent.Future;
  * <p>Failure to follow 1. and 2. can result in a very large number of threads created or hanging. (deadlock)</p>
  *
  * See {@code graphql.execution.ExecutorServiceExecutionStrategyTest} for example usage.
+ *
+ * This does not yet support the @defer directive
  */
 @PublicApi
 public class ExecutorServiceExecutionStrategy extends ExecutionStrategy {
@@ -46,7 +48,6 @@ public class ExecutorServiceExecutionStrategy extends ExecutionStrategy {
         super(dataFetcherExceptionHandler);
         this.executorService = executorService;
     }
-
 
     @Override
     public CompletableFuture<ExecutionResult> execute(final ExecutionContext executionContext, final ExecutionStrategyParameters parameters) {
@@ -68,7 +69,7 @@ public class ExecutorServiceExecutionStrategy extends ExecutionStrategy {
                     .transform(builder -> builder.field(currentField).path(fieldPath));
 
             Callable<CompletableFuture<ExecutionResult>> resolveField = () -> resolveField(executionContext, newParameters);
-            futures.put(fieldName, executorService.submit(resolveField));
+            if (resolveField != null) { futures.put(fieldName, executorService.submit(resolveField)); }
         }
 
         CompletableFuture<ExecutionResult> overallResult = new CompletableFuture<>();

--- a/src/main/java/graphql/execution/FieldCollector.java
+++ b/src/main/java/graphql/execution/FieldCollector.java
@@ -1,162 +1,45 @@
 package graphql.execution;
 
-
 import graphql.Internal;
 import graphql.language.Field;
-import graphql.language.FragmentDefinition;
-import graphql.language.FragmentSpread;
-import graphql.language.InlineFragment;
-import graphql.language.Selection;
 import graphql.language.SelectionSet;
-import graphql.schema.GraphQLInterfaceType;
-import graphql.schema.GraphQLObjectType;
-import graphql.schema.GraphQLType;
-import graphql.schema.GraphQLUnionType;
-import graphql.schema.SchemaUtil;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-
-import static graphql.execution.TypeFromAST.getTypeFromAST;
 
 /**
  * A field collector can iterate over field selection sets and build out the sub fields that have been selected,
  * expanding named and inline fragments as it goes.s
  */
 @Internal
-public class FieldCollector {
-
-    private final ConditionalNodes conditionalNodes;
-
-    private final SchemaUtil schemaUtil = new SchemaUtil();
-
-    public FieldCollector() {
-        conditionalNodes = new ConditionalNodes();
-    }
-
-
+public interface FieldCollector {
     /**
      * Given a list of fields this will collect the sub-field selections and return it as a map
      *
      * @param parameters the parameters to this method
      * @param fields     the list of fields to collect for
-     *
      * @return a map of the sub field selections
      */
-    public Map<String, List<Field>> collectFields(FieldCollectorParameters parameters, List<Field> fields) {
-        Map<String, List<Field>> subFields = new LinkedHashMap<>();
-        List<String> visitedFragments = new ArrayList<>();
-        for (Field field : fields) {
-            if (field.getSelectionSet() == null) {
-                continue;
-            }
-            this.collectFields(parameters, field.getSelectionSet(), visitedFragments, subFields);
-        }
-        return subFields;
-    }
+    Map<String, List<Field>> collectFields(FieldCollectorParameters parameters, List<Field> fields);
 
     /**
      * Given a selection set this will collect the sub-field selections and return it as a map
      *
      * @param parameters   the parameters to this method
      * @param selectionSet the selection set to collect on
-     *
      * @return a map of the sub field selections
      */
-    public Map<String, List<Field>> collectFields(FieldCollectorParameters parameters, SelectionSet selectionSet) {
-        Map<String, List<Field>> subFields = new LinkedHashMap<>();
-        List<String> visitedFragments = new ArrayList<>();
-        this.collectFields(parameters, selectionSet, visitedFragments, subFields);
-        return subFields;
+    Map<String, List<Field>> collectFields(FieldCollectorParameters parameters, SelectionSet selectionSet);
+
+    /**
+     *
+     * @param parameters   the parameters to this method
+     * @param selectionSet the selection set to collect on
+     * @param visitedFragments list of fragments visited
+     * @param fields map of the sub fields selected
+     * @param skipDeferred if @defer fields should be skipped
+     */
+    public void collectFields(FieldCollectorParameters parameters, SelectionSet selectionSet, List<String> visitedFragments,
+                              Map<String, List<Field>> fields, boolean skipDeferred);
+
     }
-
-
-    private void collectFields(FieldCollectorParameters parameters, SelectionSet selectionSet, List<String> visitedFragments, Map<String, List<Field>> fields) {
-
-        for (Selection selection : selectionSet.getSelections()) {
-            if (selection instanceof Field) {
-                collectField(parameters, fields, (Field) selection);
-            } else if (selection instanceof InlineFragment) {
-                collectInlineFragment(parameters, visitedFragments, fields, (InlineFragment) selection);
-            } else if (selection instanceof FragmentSpread) {
-                collectFragmentSpread(parameters, visitedFragments, fields, (FragmentSpread) selection);
-            }
-        }
-    }
-
-    private void collectFragmentSpread(FieldCollectorParameters parameters, List<String> visitedFragments, Map<String, List<Field>> fields, FragmentSpread fragmentSpread) {
-        if (visitedFragments.contains(fragmentSpread.getName())) {
-            return;
-        }
-        if (!conditionalNodes.shouldInclude(parameters.getVariables(), fragmentSpread.getDirectives())) {
-            return;
-        }
-        visitedFragments.add(fragmentSpread.getName());
-        FragmentDefinition fragmentDefinition = parameters.getFragmentsByName().get(fragmentSpread.getName());
-
-        if (!conditionalNodes.shouldInclude(parameters.getVariables(), fragmentDefinition.getDirectives())) {
-            return;
-        }
-        if (!doesFragmentConditionMatch(parameters, fragmentDefinition)) {
-            return;
-        }
-        collectFields(parameters, fragmentDefinition.getSelectionSet(), visitedFragments, fields);
-    }
-
-    private void collectInlineFragment(FieldCollectorParameters parameters, List<String> visitedFragments, Map<String, List<Field>> fields, InlineFragment inlineFragment) {
-        if (!conditionalNodes.shouldInclude(parameters.getVariables(), inlineFragment.getDirectives()) ||
-                !doesFragmentConditionMatch(parameters, inlineFragment)) {
-            return;
-        }
-        collectFields(parameters, inlineFragment.getSelectionSet(), visitedFragments, fields);
-    }
-
-    private void collectField(FieldCollectorParameters parameters, Map<String, List<Field>> fields, Field field) {
-        if (!conditionalNodes.shouldInclude(parameters.getVariables(), field.getDirectives())) {
-            return;
-        }
-        String name = getFieldEntryKey(field);
-        fields.putIfAbsent(name, new ArrayList<>());
-        fields.get(name).add(field);
-    }
-
-    private String getFieldEntryKey(Field field) {
-        if (field.getAlias() != null) return field.getAlias();
-        else return field.getName();
-    }
-
-
-    private boolean doesFragmentConditionMatch(FieldCollectorParameters parameters, InlineFragment inlineFragment) {
-        if (inlineFragment.getTypeCondition() == null) {
-            return true;
-        }
-        GraphQLType conditionType;
-        conditionType = getTypeFromAST(parameters.getGraphQLSchema(), inlineFragment.getTypeCondition());
-        return checkTypeCondition(parameters, conditionType);
-    }
-
-    private boolean doesFragmentConditionMatch(FieldCollectorParameters parameters, FragmentDefinition fragmentDefinition) {
-        GraphQLType conditionType;
-        conditionType = getTypeFromAST(parameters.getGraphQLSchema(), fragmentDefinition.getTypeCondition());
-        return checkTypeCondition(parameters, conditionType);
-    }
-
-    private boolean checkTypeCondition(FieldCollectorParameters parameters, GraphQLType conditionType) {
-        GraphQLObjectType type = parameters.getObjectType();
-        if (conditionType.equals(type)) {
-            return true;
-        }
-
-        if (conditionType instanceof GraphQLInterfaceType) {
-            List<GraphQLObjectType> implementations = parameters.getGraphQLSchema().getImplementations((GraphQLInterfaceType)conditionType);
-            return implementations.contains(type);
-        } else if (conditionType instanceof GraphQLUnionType) {
-            return ((GraphQLUnionType) conditionType).getTypes().contains(type);
-        }
-        return false;
-    }
-
-
-}

--- a/src/main/java/graphql/execution/FieldNodeFilter.java
+++ b/src/main/java/graphql/execution/FieldNodeFilter.java
@@ -1,0 +1,20 @@
+package graphql.execution;
+
+import graphql.language.Directive;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A FieldNodeFilter determined whether to include a Field node of not, based on some set of criteria that involved
+ * field directives and, perhaps, variables.
+ */
+public interface FieldNodeFilter {
+    /**
+     * Used to determine whether to include a Field node.
+     * @param variables of a Field node
+     * @param directives of a Field node
+     * @return include Field node
+     */
+    boolean includeNode(Map<String, Object> variables, List<Directive> directives);
+}

--- a/src/main/java/graphql/execution/FieldNodeFilterImpl.java
+++ b/src/main/java/graphql/execution/FieldNodeFilterImpl.java
@@ -1,0 +1,20 @@
+package graphql.execution;
+
+import graphql.language.Directive;
+
+import java.util.List;
+import java.util.Map;
+
+public class FieldNodeFilterImpl implements FieldNodeFilter {
+    private final ConditionalNodes conditionalNodes;
+
+    public FieldNodeFilterImpl() {
+        conditionalNodes = new ConditionalNodes();
+    }
+
+    @Override
+    public boolean includeNode(Map<String, Object> variables, List<Directive> directives) {
+        return conditionalNodes.shouldInclude(variables, directives);
+    }
+
+}

--- a/src/main/java/graphql/execution/FieldSelectionCollector.java
+++ b/src/main/java/graphql/execution/FieldSelectionCollector.java
@@ -1,0 +1,27 @@
+package graphql.execution;
+
+import graphql.Internal;
+import graphql.language.Field;
+import graphql.language.FragmentSpread;
+import graphql.language.InlineFragment;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Internal because FieldCollector is internal.
+ * <p>
+ * Provides details of how Selections are handled; e.g., where filtering happens relative to recursion.
+ */
+@Internal
+public interface FieldSelectionCollector {
+
+    void collectField(FieldCollectorParameters parameters, Map<String, List<Field>> fields, Field field);
+
+    void collectFragmentSpread(FieldCollectorParameters parameters, List<String> visitedFragments,
+                               Map<String, List<Field>> fields, FragmentSpread fragmentSpread, FieldCollector fieldCollector);
+
+    void collectInlineFragment(FieldCollectorParameters parameters, List<String> visitedFragments, Map<String,
+            List<Field>> fields, InlineFragment inlineFragment, FieldCollector fieldCollector);
+
+}

--- a/src/main/java/graphql/execution/NonDeferredFieldCollector.java
+++ b/src/main/java/graphql/execution/NonDeferredFieldCollector.java
@@ -1,0 +1,23 @@
+package graphql.execution;
+
+
+import graphql.Internal;
+
+/**
+ * A field collector can iterate over field selection sets and build out the sub fields that have been selected,
+ * expanding named and inline fragments as it goes.s
+ *
+ * Fields with '@skip' and/or '@include' directive will be resolved to be included, or no.  If included, only fields WITHOUT the
+ * '@defer' directive will be collected.
+ */
+@Internal
+public class NonDeferredFieldCollector {
+
+    private static final FieldNodeFilter fieldNodeFilter = new NonDeferredFieldNodeFilter();
+    private static final FieldCollector fieldCollector = new SimpleFieldCollector(fieldNodeFilter);
+
+    public static FieldCollector nonDeferredFieldCollector() {
+        return fieldCollector;
+    }
+
+}

--- a/src/main/java/graphql/execution/NonDeferredFieldCollectorFactory.java
+++ b/src/main/java/graphql/execution/NonDeferredFieldCollectorFactory.java
@@ -1,0 +1,23 @@
+package graphql.execution;
+
+
+import graphql.Internal;
+
+/**
+ * A field collector can iterate over field selection sets and build out the sub fields that have been selected,
+ * expanding named and inline fragments as it goes.s
+ *
+ * Fields with '@skip' and/or '@include' directive will be resolved to be included, or no.  If included, only fields WITHOUT the
+ * '@defer' directive will be collected.
+ */
+@Internal
+public class NonDeferredFieldCollectorFactory {
+
+    private static final FieldNodeFilter fieldNodeFilter = new NonDeferredFieldNodeFilter();
+    private static final FieldCollector fieldCollector = new SimpleFieldCollector(fieldNodeFilter);
+
+    public static FieldCollector nonDeferredFieldCollector() {
+        return fieldCollector;
+    }
+
+}

--- a/src/main/java/graphql/execution/NonDeferredFieldNodeFilter.java
+++ b/src/main/java/graphql/execution/NonDeferredFieldNodeFilter.java
@@ -1,0 +1,19 @@
+package graphql.execution;
+
+import graphql.language.Directive;
+
+import java.util.List;
+import java.util.Map;
+
+public class NonDeferredFieldNodeFilter implements FieldNodeFilter {
+    private final ConditionalNodes conditionalNodes;
+
+    public NonDeferredFieldNodeFilter() {
+        conditionalNodes = new ConditionalNodes();
+    }
+
+    public boolean includeNode(Map<String, Object> variables, List<Directive> directives) {
+        return conditionalNodes.shouldInclude(variables, directives) && !DeferredNodes.deferedNode(directives);
+    }
+
+}

--- a/src/main/java/graphql/execution/SimnpleFieldNodeFilter.java
+++ b/src/main/java/graphql/execution/SimnpleFieldNodeFilter.java
@@ -1,0 +1,20 @@
+package graphql.execution;
+
+import graphql.language.Directive;
+
+import java.util.List;
+import java.util.Map;
+
+public class SimnpleFieldNodeFilter implements FieldNodeFilter {
+    private final ConditionalNodes conditionalNodes;
+
+    public SimnpleFieldNodeFilter() {
+        conditionalNodes = new ConditionalNodes();
+    }
+
+    @Override
+    public boolean includeNode(Map<String, Object> variables, List<Directive> directives) {
+        return conditionalNodes.shouldInclude(variables, directives);
+    }
+
+}

--- a/src/main/java/graphql/execution/SimpleFieldCollector.java
+++ b/src/main/java/graphql/execution/SimpleFieldCollector.java
@@ -1,0 +1,161 @@
+package graphql.execution;
+
+
+import graphql.language.Field;
+import graphql.language.FragmentDefinition;
+import graphql.language.FragmentSpread;
+import graphql.language.InlineFragment;
+import graphql.language.Selection;
+import graphql.language.SelectionSet;
+import graphql.schema.GraphQLInterfaceType;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLType;
+import graphql.schema.GraphQLUnionType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static graphql.execution.TypeFromAST.getTypeFromAST;
+
+public class SimpleFieldCollector implements FieldCollector {
+    private static final Logger log = LoggerFactory.getLogger(SimpleFieldCollector.class);
+
+    private final FieldNodeFilter fieldNodeFilter;
+
+    //
+    // private final SchemaUtil schemaUtil = new SchemaUtil();
+
+    /**
+     * Default constructor that uses {@link SimnpleFieldNodeFilter} as the Field node filter
+     */
+    public SimpleFieldCollector() {
+        fieldNodeFilter = new SimnpleFieldNodeFilter();
+    }
+
+    /**
+     * Constructor that uses a supplied fieldNodeFilter as the Field node filter
+     * @param fieldNodeFilter instance of {@link FieldNodeFilter}
+     */
+    public SimpleFieldCollector(FieldNodeFilter fieldNodeFilter) {
+        this.fieldNodeFilter = fieldNodeFilter;
+    }
+
+    @Override
+    public Map<String, List<Field>> collectFields(FieldCollectorParameters parameters, List<Field> fields) {
+        Map<String, List<Field>> subFields = new LinkedHashMap<>();
+        List<String> visitedFragments = new ArrayList<>();
+
+        for (Field field : fields) {
+            if (field.getSelectionSet() == null) {
+                continue;
+            }
+            this.collectFields(parameters, field.getSelectionSet(), visitedFragments, subFields, false);
+        }
+        return subFields;
+    }
+
+    @Override
+    public Map<String, List<Field>> collectFields(FieldCollectorParameters parameters, SelectionSet selectionSet) {
+        Map<String, List<Field>> subFields = new LinkedHashMap<>();
+        List<String> visitedFragments = new ArrayList<>();
+
+        this.collectFields(parameters, selectionSet, visitedFragments, subFields, false);
+        return subFields;
+    }
+
+    @Override
+    public void collectFields(FieldCollectorParameters parameters, SelectionSet selectionSet, List<String> visitedFragments, Map<String, List<Field>> fields,
+            // following arg not used, deliberately; this class is hard-wired to that arg. being false
+                              boolean skipDeferred) {
+        for (Selection selection : selectionSet.getSelections()) {
+            if (selection instanceof Field) {
+                collectField(parameters, fields, (Field) selection);
+            } else if (selection instanceof InlineFragment) {
+                collectInlineFragment(parameters, visitedFragments, fields, (InlineFragment) selection, this);
+            } else if (selection instanceof FragmentSpread) {
+                collectFragmentSpread(parameters, visitedFragments, fields, (FragmentSpread) selection, this);
+            }
+        }
+    }
+
+    private void collectField(FieldCollectorParameters parameters, Map<String, List<Field>> fields, Field field) {
+        if (!fieldNodeFilter.includeNode(parameters.getVariables(), field.getDirectives())) {
+            log.debug("{} skipping field: {}", fieldNodeFilter.getClass().getSimpleName(), getFieldEntryKey(field));
+            return;
+        }
+        String name = getFieldEntryKey(field);
+        log.debug("{} adding field: {} {}", fieldNodeFilter.getClass().getSimpleName(), name,
+                field.getDirectives());
+        fields.putIfAbsent(name, new ArrayList<>());
+        fields.get(name).add(field);
+    }
+
+    static String getFieldEntryKey(Field field) {
+        if (field.getAlias() != null) return field.getAlias();
+        else return field.getName();
+    }
+
+    private void collectFragmentSpread(FieldCollectorParameters parameters, List<String> visitedFragments, Map<String,
+            List<Field>> fields, FragmentSpread fragmentSpread, FieldCollector fieldCollector) {
+        if (visitedFragments.contains(fragmentSpread.getName())) {
+            return;
+        }
+        if (!fieldNodeFilter.includeNode(parameters.getVariables(), fragmentSpread.getDirectives())) {
+            return;
+        }
+        visitedFragments.add(fragmentSpread.getName());
+        FragmentDefinition fragmentDefinition = parameters.getFragmentsByName().get(fragmentSpread.getName());
+
+        if (!fieldNodeFilter.includeNode(parameters.getVariables(), fragmentSpread.getDirectives())) {
+            return;
+        }
+        if (!doesFragmentConditionMatch(parameters, fragmentDefinition)) {
+            return;
+        }
+        fieldCollector.collectFields(parameters, fragmentDefinition.getSelectionSet(), visitedFragments, fields, false);
+    }
+
+    private void collectInlineFragment(FieldCollectorParameters parameters, List<String> visitedFragments, Map<String,
+            List<Field>> fields, InlineFragment inlineFragment, FieldCollector fieldCollector) {
+        if (!fieldNodeFilter.includeNode(parameters.getVariables(), inlineFragment.getDirectives()) ||
+                !doesFragmentConditionMatch(parameters, inlineFragment)) {
+            return;
+        }
+        fieldCollector.collectFields(parameters, inlineFragment.getSelectionSet(), visitedFragments, fields, false);
+    }
+
+    static boolean doesFragmentConditionMatch(FieldCollectorParameters parameters, InlineFragment inlineFragment) {
+        if (inlineFragment.getTypeCondition() == null) {
+            return true;
+        }
+        GraphQLType conditionType;
+        conditionType = getTypeFromAST(parameters.getGraphQLSchema(), inlineFragment.getTypeCondition());
+        return checkTypeCondition(parameters, conditionType);
+    }
+
+    static boolean doesFragmentConditionMatch(FieldCollectorParameters parameters, FragmentDefinition fragmentDefinition) {
+        GraphQLType conditionType;
+        conditionType = getTypeFromAST(parameters.getGraphQLSchema(), fragmentDefinition.getTypeCondition());
+        return checkTypeCondition(parameters, conditionType);
+    }
+
+    static boolean checkTypeCondition(FieldCollectorParameters parameters, GraphQLType conditionType) {
+        GraphQLObjectType type = parameters.getObjectType();
+        if (conditionType.equals(type)) {
+            return true;
+        }
+
+        if (conditionType instanceof GraphQLInterfaceType) {
+            List<GraphQLObjectType> implementations = parameters.getGraphQLSchema().getImplementations((GraphQLInterfaceType)conditionType);
+            return implementations.contains(type);
+        } else if (conditionType instanceof GraphQLUnionType) {
+            return ((GraphQLUnionType) conditionType).getTypes().contains(type);
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/graphql/execution/SubscriptionExecutionStrategy.java
+++ b/src/main/java/graphql/execution/SubscriptionExecutionStrategy.java
@@ -67,7 +67,7 @@ public class SubscriptionExecutionStrategy extends ExecutionStrategy {
             Return {fieldStream}.
      */
 
-    private CompletableFuture<Publisher<Object>> createSourceEventStream(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
+     CompletableFuture<Publisher<Object>> createSourceEventStream(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
         ExecutionStrategyParameters newParameters = firstFieldOfSubscriptionSelection(parameters);
 
         CompletableFuture<Object> fieldFetched = fetchField(executionContext, newParameters);
@@ -102,7 +102,7 @@ public class SubscriptionExecutionStrategy extends ExecutionStrategy {
                 .thenApply(executionResult -> wrapWithRootFieldName(newParameters, executionResult));
     }
 
-    private ExecutionResult wrapWithRootFieldName(ExecutionStrategyParameters parameters, ExecutionResult executionResult) {
+    static ExecutionResult wrapWithRootFieldName(ExecutionStrategyParameters parameters, ExecutionResult executionResult) {
         String rootFieldName = getRootFieldName(parameters);
         return new ExecutionResultImpl(
                 singletonMap(rootFieldName, executionResult.getData()),
@@ -110,12 +110,12 @@ public class SubscriptionExecutionStrategy extends ExecutionStrategy {
         );
     }
 
-    private String getRootFieldName(ExecutionStrategyParameters parameters) {
+    static String getRootFieldName(ExecutionStrategyParameters parameters) {
         Field rootField = parameters.field().get(0);
         return rootField.getAlias() != null ? rootField.getAlias() : rootField.getName();
     }
 
-    private ExecutionStrategyParameters firstFieldOfSubscriptionSelection(ExecutionStrategyParameters parameters) {
+    static ExecutionStrategyParameters firstFieldOfSubscriptionSelection(ExecutionStrategyParameters parameters) {
         Map<String, List<Field>> fields = parameters.fields();
         List<String> fieldNames = new ArrayList<>(fields.keySet());
 

--- a/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
+++ b/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
@@ -430,7 +430,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
                 .variables(executionContext.getVariables())
                 .build();
 
-        return fieldCollector.collectFields(collectorParameters, fields);
+        return simpleFieldCollector.collectFields(collectorParameters, fields);
     }
 
     private GraphQLObjectType getGraphQLObjectType(ExecutionContext executionContext, Field field, GraphQLType fieldType, Object value, Map<String, Object> argumentValues) {

--- a/src/main/java/graphql/schema/DataFetchingFieldSelectionSetImpl.java
+++ b/src/main/java/graphql/schema/DataFetchingFieldSelectionSetImpl.java
@@ -5,6 +5,7 @@ import graphql.execution.ExecutionContext;
 import graphql.execution.ExecutionTypeInfo;
 import graphql.execution.FieldCollector;
 import graphql.execution.FieldCollectorParameters;
+import graphql.execution.SimpleFieldCollector;
 import graphql.execution.ValuesResolver;
 import graphql.introspection.Introspection;
 import graphql.language.Field;
@@ -133,7 +134,7 @@ public class DataFetchingFieldSelectionSetImpl implements DataFetchingFieldSelec
 
 
     private void traverseFields(List<Field> fieldList, GraphQLFieldsContainer parentFieldType, String fieldPrefix) {
-        FieldCollector fieldCollector = new FieldCollector();
+        FieldCollector fieldCollector = new SimpleFieldCollector();
         ValuesResolver valuesResolver = new ValuesResolver();
 
         FieldCollectorParameters parameters = FieldCollectorParameters.newParameters()

--- a/src/main/java/graphql/schema/GraphQLSchema.java
+++ b/src/main/java/graphql/schema/GraphQLSchema.java
@@ -69,7 +69,7 @@ public class GraphQLSchema {
         this.subscriptionType = subscriptionType;
         this.fieldVisibility = fieldVisibility;
         this.additionalTypes = additionalTypes;
-        this.directives = new LinkedHashSet<>(Arrays.asList(Directives.IncludeDirective, Directives.SkipDirective));
+        this.directives = new LinkedHashSet<>(Arrays.asList(Directives.IncludeDirective, Directives.SkipDirective, Directives.DeferDirective));
         this.directives.addAll(directives);
         this.typeMap = schemaUtil.allTypes(this, additionalTypes);
         this.byInterface = schemaUtil.groupImplementations(this);

--- a/src/main/java/graphql/util/TraverserVisitor.java
+++ b/src/main/java/graphql/util/TraverserVisitor.java
@@ -8,11 +8,13 @@ public interface TraverserVisitor<T> {
     TraversalControl enter(TraverserContext<T> context);
 
     /**
+     * @param context   {@link TraverserContext} for T
      * @return Only Continue or Quit allowed
      */
     TraversalControl leave(TraverserContext<T> context);
 
     /**
+     * @param context   {@link TraverserContext} for T
      * @return Only Continue or Quit allowed
      */
     default TraversalControl backRef(TraverserContext<T> context) {

--- a/src/test/groovy/graphql/Defer.java
+++ b/src/test/groovy/graphql/Defer.java
@@ -1,0 +1,305 @@
+package graphql;
+
+
+import graphql.execution.DeferringAsyncExecutionStrategy;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLSchema;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static graphql.Scalars.GraphQLString;
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
+import static graphql.schema.GraphQLObjectType.newObject;
+import static org.junit.Assert.assertEquals;
+
+public class Defer {
+
+    private static GraphQL buildSimpleGraphQL() {
+        GraphQLObjectType queryType = newObject()
+                .name("helloWorldQuery")
+                .field(newFieldDefinition()
+                        .type(GraphQLString)
+                        .name("hello")
+                        .staticValue("world"))
+                .field(newFieldDefinition()
+                        .type(GraphQLString)
+                        .name("hello2")
+                        .staticValue("mars")
+                )
+                .field(newFieldDefinition()
+                        .type(GraphQLString)
+                        .name("hello3")
+                        .staticValue("venus")
+                )
+                .build();
+
+        GraphQLSchema schema = GraphQLSchema.newSchema()
+                .query(queryType)
+                .build();
+
+        return GraphQL.newGraphQL(schema).build();
+    }
+
+    private Map<String, Object> doQuery(String query, GraphQL graphQL, String test ) {
+        ExecutionResult executionResult = graphQL.execute(query);
+        assertEquals(0, executionResult.getErrors().size());
+        Map<String, Object> result = executionResult.getData();
+//        System.out.println(test + ": " + result.toString());
+//        System.out.println(DeferringAsyncExecutionStrategy.getlastDeferredResults());
+        return result;
+    }
+
+    @Test
+    public void basicDeferLastTest() {
+        Map<String, Object> result = doQuery("{\n" +
+                "    hello\n" +
+                "    hello2 @defer\n" +
+                "}",
+            buildSimpleGraphQL(), "basicDeferLastTest" );
+        assertEquals(1, result.size());     // not 2, given @defer
+        assertEquals("world", result.get("hello"));
+    }
+
+    @Test
+    public void basicDeferFirstTest() {
+        Map<String, Object> result = doQuery("{\n" +
+                // test both variations (since one doesn't necessarily imply the other ...)
+                        "    hello @defer\n" +
+                        "    hello2\n" +
+                        "}",
+                buildSimpleGraphQL(), "basicDeferFirstTest" );
+        assertEquals(1, result.size());     // not 2, given @defer
+        assertEquals("mars", result.get("hello2"));
+    }
+
+    @Test
+    public void basicDeferMiddleTest() {
+        Map<String, Object> result = doQuery("{\n" +
+                        "    hello3\n" +
+                // another test that lays foundation for induction
+                        "    hello @defer\n" +
+                        "    hello2\n" +
+                        "}",
+                buildSimpleGraphQL(), "basicDeferMiddleTest" );
+        assertEquals(2, result.size());
+        assertEquals("mars", result.get("hello2"));
+        assertEquals("venus", result.get("hello3"));
+    }
+
+    @Test
+    public void basicDeferMiddleTest2() {
+        Map<String, Object> result = doQuery("{\n" +
+                // invert pattern of prior test
+                        "    hello3 @defer\n" +
+                        "    hello\n" +
+                        "    hello2 @defer\n" +
+                        "}",
+                buildSimpleGraphQL(), "basicDeferMiddleTest" );
+        assertEquals(1, result.size());
+        assertEquals("world", result.get("hello"));
+    }
+
+    @Test
+    public void emptyDeferTest() {
+        Map<String, Object> result = doQuery("{\n" +
+                "    hello @defer\n" +
+                "}",
+            buildSimpleGraphQL(), "emptyDeferTest" );
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    public void empty2DeferTest() {
+        Map<String, Object> result = doQuery("{\n" +
+                "    hello @defer\n" +
+                "    hello2 @defer\n" +
+                "}",
+            buildSimpleGraphQL(), "empty2DeferTest" );
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    public void nestedDeferTest() {
+        Map<String, Object> result = doQuery("query HeroNameAndFriendsQuery {\n" +
+                "    hero {\n" +
+                "        id\n" +
+                "        name @defer\n" +
+                "    }\n" +
+                "}",
+            GraphQL.newGraphQL(StarWarsSchema.starWarsSchema).build(), "nestedDeferTest" );
+        assertEquals(1, result.size());
+        Map<String, Object> hero = (Map<String, Object>) result.get("hero");
+        assertEquals("2001", hero.get("id"));
+        assertEquals(1, hero.size());
+    }
+
+    @Test
+    public void complexDeferFieldTest() {
+        Map<String, Object> result = doQuery("query HeroNameAndFriendsQuery {\n" +
+                "    hero {\n" +
+                "        id\n" +
+                "        name\n" +
+                "        friends {\n" +
+                // following will result in ..., friends=[{}, {}, {}]
+                // that is, current implementation does not trim
+                "            name @defer \n" +
+                "        }\n" +
+                "    }\n" +
+                "}",
+            GraphQL.newGraphQL(StarWarsSchema.starWarsSchema).build(), "complexDeferFieldTest" );
+        assertEquals(1, result.size());
+        Map<String, Object> hero = (Map<String, Object>) result.get("hero");
+        assertEquals("2001", hero.get("id"));
+        List<Object> friends = (List<Object>) hero.get("friends");
+        assertEquals(3, friends.size());
+        Map<String, Object> friend1 = (Map<String, Object>) friends.get(0);
+        // friends array that are each empty will be returned
+        assertEquals(0, friend1.size());
+        Map<String, Object> friend2 = (Map<String, Object>) friends.get(1);
+        assertEquals(0, friend2.size());
+        Map<String, Object> friend3 = (Map<String, Object>) friends.get(2);
+        assertEquals(0, friend3.size());
+    }
+
+    @Test
+    public void moreComplexDeferFieldTest() {
+        Map<String, Object> result = doQuery("query HeroNameAndFriendsQuery {\n" +
+                "   hero {\n" +
+                "       id\n" +
+                "       name\n" +
+                "       friends {\n" +
+                "           name @defer \n" +
+                "           id" +
+                "       }\n" +
+                "   }\n" +
+                "}",
+                GraphQL.newGraphQL(StarWarsSchema.starWarsSchema).build(), "moreComplexDeferFieldTest" );
+        assertEquals(1, result.size());
+        Map<String, Object> hero = (Map<String, Object>) result.get("hero");
+        assertEquals("2001", hero.get("id"));
+        List<Object> friends = (List<Object>) hero.get("friends");
+        assertEquals(3, friends.size());
+        Map<String, Object> friend1 = (Map<String, Object>) friends.get(0);
+        assertEquals(1, friend1.size());
+        assertEquals("1000", friend1.get("id"));
+        Map<String, Object> friend2 = (Map<String, Object>) friends.get(1);
+        assertEquals(1, friend2.size());
+        assertEquals("1002", friend2.get("id"));
+        Map<String, Object> friend3 = (Map<String, Object>) friends.get(2);
+        assertEquals(1, friend3.size());
+        assertEquals("1003", friend3.get("id"));
+    }
+
+    @Test
+    public void moreComplexDeferFieldTest2() {
+        Map<String, Object> result = doQuery("query HeroNameAndFriendsQuery {\n" +
+                        "   hero {\n" +
+                        "       id\n" +
+                        "       name\n" +
+                        "       friends {\n" +
+                // check both variations, like above
+                        "           name\n" +
+                        "           id @defer\n" +
+                        "       }\n" +
+                        "   }\n" +
+                        "}",
+                GraphQL.newGraphQL(StarWarsSchema.starWarsSchema).build(), "moreComplexDeferFieldTest2" );
+        assertEquals(1, result.size());
+        Map<String, Object> hero = (Map<String, Object>) result.get("hero");
+        assertEquals("2001", hero.get("id"));
+        List<Object> friends = (List<Object>) hero.get("friends");
+        assertEquals(3, friends.size());
+        Map<String, Object> friend1 = (Map<String, Object>) friends.get(0);
+        assertEquals(1, friend1.size());
+        assertEquals("Luke Skywalker", friend1.get("name"));
+        Map<String, Object> friend2 = (Map<String, Object>) friends.get(1);
+        assertEquals(1, friend2.size());
+        assertEquals("Han Solo", friend2.get("name"));
+        Map<String, Object> friend3 = (Map<String, Object>) friends.get(2);
+        assertEquals(1, friend3.size());
+        assertEquals("Leia Organa", friend3.get("name"));
+    }
+
+    @Test
+    public void moreComplexDeferFieldTest3() {
+        Map<String, Object> result = doQuery("query HeroNameAndFriendsQuery {\n" +
+                        "   hero {\n" +
+                        "       id\n" +
+                        "       name\n" +
+                        "       friends {\n" +
+                        "           name\n" +
+                        "           id @defer\n" +
+                        "           appearsIn\n" +
+                        "       }\n" +
+                        "   }\n" +
+                        "}",
+                GraphQL.newGraphQL(StarWarsSchema.starWarsSchema).build(), "moreComplexDeferFieldTest3" );
+        assertEquals(1, result.size());
+        Map<String, Object> hero = (Map<String, Object>) result.get("hero");
+        assertEquals("2001", hero.get("id"));
+        List<Object> friends = (List<Object>) hero.get("friends");
+        assertEquals(3, friends.size());
+        Map<String, Object> friend1 = (Map<String, Object>) friends.get(0);
+        assertEquals(2, friend1.size());
+        assertEquals("Luke Skywalker", friend1.get("name"));
+        Map<String, Object> friend2 = (Map<String, Object>) friends.get(1);
+        assertEquals(2, friend2.size());
+        assertEquals("Han Solo", friend2.get("name"));
+        Map<String, Object> friend3 = (Map<String, Object>) friends.get(2);
+        assertEquals(2, friend3.size());
+        assertEquals("Leia Organa", friend3.get("name"));
+    }
+
+    @Test
+    public void moreComplexDeferFieldTest4() {
+        Map<String, Object> result = doQuery("query HeroNameAndFriendsQuery {\n" +
+                        "   hero {\n" +
+                        "       id\n" +
+                        "       name\n" +
+                        "       friends {\n" +
+                        "           name @defer\n" +
+                        "           id\n" +
+                        "           appearsIn @defer\n" +
+                        "       }\n" +
+                        "   }\n" +
+                        "}",
+                GraphQL.newGraphQL(StarWarsSchema.starWarsSchema).build(), "moreComplexDeferFieldTest4" );
+        assertEquals(1, result.size());
+        Map<String, Object> hero = (Map<String, Object>) result.get("hero");
+        assertEquals("2001", hero.get("id"));
+        List<Object> friends = (List<Object>) hero.get("friends");
+        assertEquals(3, friends.size());
+        Map<String, Object> friend1 = (Map<String, Object>) friends.get(0);
+        assertEquals("1000", friend1.get("id"));
+        Map<String, Object> friend2 = (Map<String, Object>) friends.get(1);
+        assertEquals(1, friend2.size());
+        assertEquals("1002", friend2.get("id"));
+        Map<String, Object> friend3 = (Map<String, Object>) friends.get(2);
+        assertEquals(1, friend3.size());
+        assertEquals("1003", friend3.get("id"));
+    }
+
+    @Test
+    public void complexDeferObjectTest() {
+        Map<String, Object> result = doQuery("query HeroNameAndFriendsQuery {\n" +
+                "    hero {\n" +
+                "        id\n" +
+                "        name\n" +
+                "        friends @defer {\n" +
+                "            name\n" +
+                "            id\n" +
+                "        }\n" +
+                "    }\n" +
+                "}",
+            GraphQL.newGraphQL(StarWarsSchema.starWarsSchema).build(), "complexDeferObjectTest" );
+        assertEquals(1, result.size());
+        Map<String, Object> hero = (Map<String, Object>) result.get("hero");
+        assertEquals("2001", hero.get("id"));
+        List<Object> friends = (List<Object>) hero.get("friends");
+        //confirm there are no friends fields
+        assertEquals(null, friends);
+    }
+
+}

--- a/src/test/groovy/graphql/HelloWorld.java
+++ b/src/test/groovy/graphql/HelloWorld.java
@@ -14,7 +14,7 @@ import static org.junit.Assert.assertEquals;
 
 public class HelloWorld {
 
-    public static void main(String[] args) {
+    private static GraphQL buildGraphQL() {
         GraphQLObjectType queryType = newObject()
                 .name("helloWorldQuery")
                 .field(newFieldDefinition()
@@ -27,28 +27,31 @@ public class HelloWorld {
                 .query(queryType)
                 .build();
 
-        GraphQL graphQL = GraphQL.newGraphQL(schema).build();
+        return GraphQL.newGraphQL(schema).build();
+    }
 
-        Map<String, Object> result = graphQL.execute("{hello}").getData();
+    private static final String query ="{\n" +
+            "hello\n" +
+            "}";
+
+    public static void main(String[] args) {
+        GraphQL graphQL = buildGraphQL();
+        ExecutionResult executionResult = graphQL.execute(query);
+        if (executionResult.getErrors().size() != 0) {
+            System.err.println(executionResult.getErrors().toString());
+        }
+        Map<String, Object> result = executionResult.getData();
         System.out.println(result);
         // Prints: {hello=world}
     }
 
     @Test
     public void helloWorldTest() {
-        GraphQLObjectType queryType = newObject()
-                .name("helloWorldQuery")
-                .field(newFieldDefinition()
-                        .type(GraphQLString)
-                        .name("hello")
-                        .staticValue("world"))
-                .build();
-
-        GraphQLSchema schema = GraphQLSchema.newSchema()
-                .query(queryType)
-                .build();
-        GraphQL graphQL = GraphQL.newGraphQL(schema).build();
-        Map<String, Object> result = graphQL.execute("{hello}").getData();
+        GraphQL graphQL = buildGraphQL();
+        ExecutionResult executionResult = graphQL.execute(query);
+        assertEquals(0, executionResult.getErrors().size());
+        Map<String, Object> result = executionResult.getData();
+        assertEquals(1, result.size());
         assertEquals("world", result.get("hello"));
     }
 }

--- a/src/test/groovy/graphql/StarWarsIntrospectionTests.groovy
+++ b/src/test/groovy/graphql/StarWarsIntrospectionTests.groovy
@@ -426,6 +426,6 @@ class StarWarsIntrospectionTests extends Specification {
         schemaParts.get('mutationType') == null
         schemaParts.get('subscriptionType') == null
         schemaParts.get('types').size() == 15
-        schemaParts.get('directives').size() == 2
+        schemaParts.get('directives').size() == 3
     }
 }

--- a/src/test/groovy/graphql/execution/FieldCollectorTest.groovy
+++ b/src/test/groovy/graphql/execution/FieldCollectorTest.groovy
@@ -33,7 +33,7 @@ class FieldCollectorTest extends Specification {
                 }
                 """)
         def objectType = schema.getType("Query") as GraphQLObjectType
-        FieldCollector fieldCollector = new FieldCollector()
+        FieldCollector fieldCollector = new SimpleFieldCollector()
         FieldCollectorParameters fieldCollectorParameters = newParameters()
                 .schema(schema)
                 .objectType(objectType)
@@ -66,7 +66,7 @@ class FieldCollectorTest extends Specification {
             }
                 """)
         def object = schema.getType("TestImpl") as GraphQLObjectType
-        FieldCollector fieldCollector = new FieldCollector()
+        FieldCollector fieldCollector = new SimpleFieldCollector()
         FieldCollectorParameters fieldCollectorParameters = newParameters()
                 .schema(schema)
                 .objectType(object)

--- a/src/test/groovy/graphql/schema/DataFetcherSelectionTest.groovy
+++ b/src/test/groovy/graphql/schema/DataFetcherSelectionTest.groovy
@@ -5,6 +5,7 @@ import graphql.GraphQL
 import graphql.StarWarsData
 import graphql.TestUtil
 import graphql.execution.FieldCollector
+import graphql.execution.SimpleFieldCollector
 import graphql.language.AstPrinter
 import graphql.language.Field
 import graphql.schema.idl.MapEnumValuesProvider
@@ -30,7 +31,7 @@ class DataFetcherSelectionTest extends Specification {
 
         SelectionCapturingDataFetcher(DataFetcher delegate, Map<String, String> captureMap, List<Map<String, Map<String, Object>>> captureFieldArgs) {
             this.delegate = delegate
-            this.fieldCollector = new FieldCollector()
+            this.fieldCollector = new SimpleFieldCollector()
             this.captureMap = captureMap
             this.captureFieldArgs = captureFieldArgs;
         }

--- a/src/test/groovy/graphql/validation/rules/KnownDirectivesTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/KnownDirectivesTest.groovy
@@ -62,5 +62,41 @@ class KnownDirectivesTest extends Specification {
 
     }
 
+    def "defer test"() {
+        given:
+        def query = """
+          query Foo  {
+                name @defer
+              }
+        """
 
+        Document document = new Parser().parseDocument(query)
+        LanguageTraversal languageTraversal = new LanguageTraversal()
+
+        when:
+        languageTraversal.traverse(document, new RulesVisitor(validationContext, [knownDirectives]))
+
+        then:
+        errorCollector.errors.isEmpty()
+
+    }
+
+    def "junk directive test"() {
+        given:
+        def query = """
+          query Foo  {
+                name @junk
+              }
+        """
+
+        Document document = new Parser().parseDocument(query)
+        LanguageTraversal languageTraversal = new LanguageTraversal()
+
+        when:
+        languageTraversal.traverse(document, new RulesVisitor(validationContext, [knownDirectives]))
+
+        then:
+        errorCollector.containsValidationError(ValidationErrorType.UnknownDirective)
+
+    }
 }


### PR DESCRIPTION
DO NOT MERGE!  This is a draft for review purposes ONLY!!

It is based on master prior to the implementation of @defer that Brad Baker and Andreas Marek did in PR 967.  Specifically, it is based on master as of: commit 934ca19d3c3109e5690abe576ea4744aa926934e    Mon Mar 26 14:54:44 2018 -0700

This work was done as an initial attempt to add @defer support.  The essence of the approach taken was to create a `DeferringAsyncExecutionStrategy`.  The intention was to make alterations to existing classes be as minimal as possible.  `ExecutionStrategy` and `Execution` being two classes that were modified to support execution in the cases of skipping @defer nodes, or including them (in the execution.)

The implementation of `DeferringAsyncExecutionStrategy` is incomplete inasmuch as the original intention was to use reactivestreams in a manner analogous to how they are used in `SubscriptionExecutionStrategy`.  That work was not completed.

A couple of implementation notes: 
- `FieldCollector` and `FieldNodeFilter` became `Simple...` (which ignores the @defer directive) and `NonDeferred...` and `Deferred...`, which operate on non-@defer nodes and @defer nodes, respectively.  
- As part of that, `FieldCollector` became an `interface` that `SimpleFieldCollector` and `DeferredFieldCollector` implement.  
- Likewise, `FieldNodeFilter` interface was created, that `FieldNodeFilterImpl`, and `...FieldNodeFilter` implement.

A fairly robust test was created `src/test/groovy/graphql/Defer` to check various cases of usage patterns of @defer at a single level, and nesting.

The author acknowledges the absolutely wonderful support of Atlassian for allowing me to do the majority of this work as an Innovation Week project.