### PR TITLE
Fix NPE and add ExecutableDefinitions Validation rule

### DIFF
--- a/src/main/java/graphql/validation/AbstractRule.java
+++ b/src/main/java/graphql/validation/AbstractRule.java
@@ -1,6 +1,9 @@
 package graphql.validation;
 
 
+import java.util.ArrayList;
+import java.util.List;
+
 import graphql.Internal;
 import graphql.language.Argument;
 import graphql.language.Directive;
@@ -16,9 +19,6 @@ import graphql.language.SourceLocation;
 import graphql.language.TypeName;
 import graphql.language.VariableDefinition;
 import graphql.language.VariableReference;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Internal
 public class AbstractRule {
@@ -76,6 +76,10 @@ public class AbstractRule {
 
     protected List<String> getQueryPath() {
         return validationContext.getQueryPath();
+    }
+
+    public void checkDocument(Document document) {
+
     }
 
     public void checkArgument(Argument argument) {

--- a/src/main/java/graphql/validation/LanguageTraversal.java
+++ b/src/main/java/graphql/validation/LanguageTraversal.java
@@ -1,11 +1,11 @@
 package graphql.validation;
 
 
-import graphql.Internal;
-import graphql.language.Node;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import graphql.Internal;
+import graphql.language.Node;
 
 @Internal
 public class LanguageTraversal {
@@ -32,8 +32,11 @@ public class LanguageTraversal {
     private void traverseImpl(Node<?> root, DocumentVisitor documentVisitor, List<Node> path) {
         documentVisitor.enter(root, path);
         path.add(root);
-        for (Node child : root.getChildren()) {
-            traverseImpl(child, documentVisitor, path);
+        List<Node> children = root.getChildren();
+        for (Node child : children) {
+            if (child != null) {
+                traverseImpl(child, documentVisitor, path);
+            }
         }
         path.remove(path.size() - 1);
         documentVisitor.leave(root, path);

--- a/src/main/java/graphql/validation/RulesVisitor.java
+++ b/src/main/java/graphql/validation/RulesVisitor.java
@@ -1,6 +1,13 @@
 package graphql.validation;
 
 
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import graphql.Internal;
 import graphql.language.Argument;
 import graphql.language.Directive;
@@ -15,13 +22,6 @@ import graphql.language.SelectionSet;
 import graphql.language.TypeName;
 import graphql.language.VariableDefinition;
 import graphql.language.VariableReference;
-
-import java.util.ArrayList;
-import java.util.IdentityHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 @Internal
 public class RulesVisitor implements DocumentVisitor {
@@ -59,7 +59,9 @@ public class RulesVisitor implements DocumentVisitor {
         Set<AbstractRule> tmpRulesSet = new LinkedHashSet<>(this.rules);
         tmpRulesSet.removeAll(rulesToSkip);
         List<AbstractRule> rulesToConsider = new ArrayList<>(tmpRulesSet);
-        if (node instanceof Argument) {
+        if (node instanceof Document){
+            checkDocument((Document) node, rulesToConsider);
+        } else if (node instanceof Argument) {
             checkArgument((Argument) node, rulesToConsider);
         } else if (node instanceof TypeName) {
             checkTypeName((TypeName) node, rulesToConsider);
@@ -82,7 +84,12 @@ public class RulesVisitor implements DocumentVisitor {
         } else if (node instanceof SelectionSet) {
             checkSelectionSet((SelectionSet) node, rulesToConsider);
         }
+    }
 
+    private void checkDocument(Document node, List<AbstractRule> rules) {
+        for (AbstractRule rule : rules) {
+            rule.checkDocument(node);
+        }
     }
 
 

--- a/src/main/java/graphql/validation/ValidationErrorType.java
+++ b/src/main/java/graphql/validation/ValidationErrorType.java
@@ -27,6 +27,7 @@ public enum ValidationErrorType {
     FragmentCycle,
     FieldsConflict,
     InvalidFragmentType,
-    LoneAnonymousOperationViolation
+    LoneAnonymousOperationViolation,
+    NonExecutableDefinition
 
 }

--- a/src/main/java/graphql/validation/Validator.java
+++ b/src/main/java/graphql/validation/Validator.java
@@ -1,10 +1,14 @@
 package graphql.validation;
 
 
+import java.util.ArrayList;
+import java.util.List;
+
 import graphql.Internal;
 import graphql.language.Document;
 import graphql.schema.GraphQLSchema;
 import graphql.validation.rules.ArgumentsOfCorrectType;
+import graphql.validation.rules.ExecutableDefinitions;
 import graphql.validation.rules.FieldsOnCorrectType;
 import graphql.validation.rules.FragmentsOnCompositeType;
 import graphql.validation.rules.KnownArgumentNames;
@@ -24,9 +28,6 @@ import graphql.validation.rules.VariableDefaultValuesOfCorrectType;
 import graphql.validation.rules.VariableTypesMatchRule;
 import graphql.validation.rules.VariablesAreInputTypes;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Internal
 public class Validator {
 
@@ -44,6 +45,9 @@ public class Validator {
 
     private List<AbstractRule> createRules(ValidationContext validationContext, ValidationErrorCollector validationErrorCollector) {
         List<AbstractRule> rules = new ArrayList<>();
+
+        ExecutableDefinitions executableDefinitions = new ExecutableDefinitions(validationContext, validationErrorCollector);
+        rules.add(executableDefinitions);
 
         ArgumentsOfCorrectType argumentsOfCorrectType = new ArgumentsOfCorrectType(validationContext, validationErrorCollector);
         rules.add(argumentsOfCorrectType);

--- a/src/main/java/graphql/validation/rules/ExecutableDefinitions.java
+++ b/src/main/java/graphql/validation/rules/ExecutableDefinitions.java
@@ -1,0 +1,55 @@
+package graphql.validation.rules;
+
+import graphql.language.Definition;
+import graphql.language.Document;
+import graphql.language.FragmentDefinition;
+import graphql.language.OperationDefinition;
+import graphql.language.SchemaDefinition;
+import graphql.language.TypeDefinition;
+import graphql.validation.AbstractRule;
+import graphql.validation.ValidationContext;
+import graphql.validation.ValidationErrorCollector;
+import graphql.validation.ValidationErrorType;
+
+public class ExecutableDefinitions extends AbstractRule {
+
+    public ExecutableDefinitions(ValidationContext validationContext, ValidationErrorCollector validationErrorCollector) {
+        super(validationContext, validationErrorCollector);
+    }
+
+    /**
+     * Executable definitions
+     *
+     * A GraphQL document is only valid for execution if all definitions are either
+     * operation or fragment definitions.
+     */
+    @Override
+    public void checkDocument(Document document) {
+        document.getDefinitions().forEach(definition -> {
+            if (!(definition instanceof OperationDefinition)
+                && !(definition instanceof FragmentDefinition)) {
+
+                String message = nonExecutableDefinitionMessage(definition);
+                addError(ValidationErrorType.NonExecutableDefinition, definition.getSourceLocation(), message);
+            }
+        });
+    }
+
+    private String nonExecutableDefinitionMessage(Definition definition) {
+
+        String definitionName;
+        if (definition instanceof TypeDefinition) {
+            definitionName = ((TypeDefinition) definition).getName();
+        } else if (definition instanceof SchemaDefinition) {
+            definitionName = "schema";
+        } else {
+            definitionName = "provided";
+        }
+
+        return nonExecutableDefinitionMessage(definitionName);
+    }
+
+    static String nonExecutableDefinitionMessage(String definitionName) {
+        return String.format("The %s definition is not executable.", definitionName);
+    }
+}

--- a/src/test/groovy/graphql/validation/rules/ExecutableDefinitionsTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/ExecutableDefinitionsTest.groovy
@@ -1,0 +1,122 @@
+package graphql.validation.rules
+
+import graphql.language.SourceLocation
+import graphql.parser.Parser
+import graphql.validation.ValidationError
+import graphql.validation.ValidationErrorType
+import graphql.validation.Validator
+import spock.lang.Specification
+
+import static graphql.validation.rules.ExecutableDefinitions.nonExecutableDefinitionMessage
+
+class ExecutableDefinitionsTest extends Specification {
+
+    def 'Executable Definitions with only operation'() {
+        def query = """\
+              query Foo {
+                dog {
+                  name
+                }
+              }
+            """.stripIndent()
+        when:
+        def validationErrors = validate(query)
+
+        then:
+        validationErrors.empty
+    }
+
+    def 'Executable Definitions with operation and fragment'() {
+        def query = """\
+              query Foo {
+                dog {
+                  name
+                  ...Frag
+                }
+              }
+        
+              fragment Frag on Dog {
+                name
+              }
+            """.stripIndent()
+        when:
+        def validationErrors = validate(query)
+
+        then:
+        validationErrors.empty
+    }
+
+    def 'Executable Definitions with type definition'() {
+        def query = """\
+              query Foo {
+                dog {
+                  name
+                }
+              }
+        
+              type Cow {
+                name: String
+              }
+        
+              extend type Dog {
+                color: String
+              }
+            """.stripIndent()
+        when:
+        def validationErrors = validate(query)
+
+        then:
+        !validationErrors.empty
+        validationErrors.size() == 2
+        validationErrors[0] == nonExecutableDefinition("Cow", 7, 1)
+        validationErrors[1] == nonExecutableDefinition("Dog", 11, 1)
+
+    }
+
+    def 'Executable Definitions with schema definition'() {
+        def query = """\
+              schema {
+                query: QueryRoot
+              }
+        
+              type QueryRoot {
+                test: String
+              }
+            """.stripIndent()
+        when:
+        def validationErrors = validate(query)
+
+        then:
+        !validationErrors.empty
+        validationErrors.size() == 2
+        validationErrors[0] == nonExecutableDefinition("schema", 1, 1)
+        validationErrors[1] == nonExecutableDefinition("QueryRoot", 5, 1)
+    }
+
+    def 'Executable Definitions with input value type definition'() {
+        def query = """\
+            type QueryRoot {               
+                getDog(id: String!): String
+            }
+            """.stripIndent()
+        when:
+        def validationErrors = validate(query)
+
+        then:
+        !validationErrors.empty
+        validationErrors.size() == 1
+        validationErrors[0] == nonExecutableDefinition("QueryRoot", 1, 1)
+    }
+
+
+    ValidationError nonExecutableDefinition(String defName, int line, int column) {
+        return new ValidationError(ValidationErrorType.NonExecutableDefinition,
+                [new SourceLocation(line, column)],
+                nonExecutableDefinitionMessage(defName))
+    }
+
+    List<ValidationError> validate(String query) {
+        def document = new Parser().parseDocument(query)
+        return new Validator().validateDocument(Harness.Schema, document)
+    }
+}


### PR DESCRIPTION
## Description

When a valid schema SDL definition is attempted to be executed, a validation rule
should catch that use case and display a human readable error. Instead the validation either passes and the query fails later at execution or an NPE is raised when traversing the syntax tree.

GraphQL-js correctly prevents non GraphQL queries to be executed by using the following validation rule [ExecutableDefinitions](https://github.com/graphql/graphql-js/blob/261b99b0a643561ccfb217fe8ac0c2ac16b2c5d3/src/validation/rules/ExecutableDefinitions.js ). This rule validates that the parsed Document is of either kind OperationDefinition or FragmentDefinition, so we don't attempt to mistakenly execute other kinds of definitions. 
GraphQL-java is currently missing this validation rule.

Also, if we attempt to execute the following SDL definition an NPE will be raised when traversing the tree.

```
type QueryRoot {               
    getDog(id: String!): String
}
```
will yield
```
java.lang.NullPointerException
	at graphql.validation.LanguageTraversal.traverseImpl(LanguageTraversal.java:35)
	at graphql.validation.LanguageTraversal.traverseImpl(LanguageTraversal.java:37)
	at graphql.validation.LanguageTraversal.traverseImpl(LanguageTraversal.java:37)
	at graphql.validation.LanguageTraversal.traverseImpl(LanguageTraversal.java:37)
	at graphql.validation.LanguageTraversal.traverseImpl(LanguageTraversal.java:37)
	at graphql.validation.LanguageTraversal.traverse(LanguageTraversal.java:28)
	at graphql.validation.Validator.validateDocument(Validator.java:41)
	at graphql.validation.rules.ExecutableDefinitionsTest.validate(ExecutableDefinitionsTest.groovy:120)
	at graphql.validation.rules.ExecutableDefinitionsTest.Executable Definitions with input value type definition(ExecutableDefinitionsTest.groovy:103)
```
This test showcases the NPE:

```
def "execute a definition should result in validation errors"() {
        given:
        GraphQLSchema schema = simpleSchema()

        when:
        def result = GraphQL.newGraphQL(schema).build().execute("""
        type Query {
            getEvent(id: String!): String
        }
        """.stripIndent())

        then:
        !result.errors.empty
    }
```

## Fixes

Added Null check in `LanguageTraversal.traverseImpl` and added the missing `ExecutionDefinitions` validation rule.

## Testing

Added all graphql-js unit tests for the new validation rule and for the null check.


