### PR TITLE
Fix Async.eachSequentiallyImpl is throwing NoSuchElement Exception

### DIFF
--- a/src/main/java/graphql/execution/Async.java
+++ b/src/main/java/graphql/execution/Async.java
@@ -66,6 +66,7 @@ public class Async {
     private static <T, U> void eachSequentiallyImpl(Iterator<T> iterator, CFFactory<T, U> cfFactory, int index, List<U> tmpResult, CompletableFuture<List<U>> overallResult) {
         if (!iterator.hasNext()) {
             overallResult.complete(tmpResult);
+            return;
         }
         CompletableFuture<U> cf;
         try {


### PR DESCRIPTION
    -Added return call to avoid un-necessarily throwing and catching the
    exception

fixes #992 