### PR TITLE
SchemaPrinter to print directives in all locations

### DIFF
--- a/src/main/java/graphql/schema/idl/SchemaPrinter.java
+++ b/src/main/java/graphql/schema/idl/SchemaPrinter.java
@@ -210,7 +210,7 @@ public class SchemaPrinter {
             }
             if (printScalar) {
                 printComments(out, type, "");
-                out.format("scalar %s\n\n", type.getName());
+                out.format("scalar %s%s\n\n", type.getName(), directivesString(type.getDirectives()));
             }
         };
     }
@@ -221,14 +221,14 @@ public class SchemaPrinter {
                 return;
             }
             printComments(out, type, "");
-            out.format("enum %s {\n", type.getName());
+            out.format("enum %s%s {\n", type.getName(), directivesString(type.getDirectives()));
             List<GraphQLEnumValueDefinition> values = type.getValues()
                     .stream()
                     .sorted(Comparator.comparing(GraphQLEnumValueDefinition::getName))
                     .collect(toList());
             for (GraphQLEnumValueDefinition enumValueDefinition : values) {
                 printComments(out, enumValueDefinition, "  ");
-                out.format("  %s\n", enumValueDefinition.getName());
+                out.format("  %s%s\n", enumValueDefinition.getName(), directivesString(enumValueDefinition.getDirectives()));
             }
             out.format("}\n\n");
         };
@@ -240,14 +240,14 @@ public class SchemaPrinter {
                 return;
             }
             printComments(out, type, "");
-            out.format("interface %s {\n", type.getName());
+            out.format("interface %s%s {\n", type.getName(), directivesString(type.getDirectives()));
             visibility.getFieldDefinitions(type)
                     .stream()
                     .sorted(Comparator.comparing(GraphQLFieldDefinition::getName))
                     .forEach(fd -> {
                         printComments(out, fd, "  ");
-                        out.format("  %s%s: %s\n",
-                                fd.getName(), argsString(fd.getArguments()), typeString(fd.getType()));
+                        out.format("  %s%s: %s%s\n",
+                                fd.getName(), argsString(fd.getArguments()), typeString(fd.getType()), directivesString(fd.getDirectives()));
                     });
             out.format("}\n\n");
         };
@@ -259,7 +259,7 @@ public class SchemaPrinter {
                 return;
             }
             printComments(out, type, "");
-            out.format("union %s = ", type.getName());
+            out.format("union %s%s = ", type.getName(), directivesString(type.getDirectives()));
             List<GraphQLOutputType> types = type.getTypes()
                     .stream()
                     .sorted(Comparator.comparing(GraphQLOutputType::getName))
@@ -289,9 +289,10 @@ public class SchemaPrinter {
                         .stream()
                         .map(GraphQLType::getName)
                         .sorted(Comparator.naturalOrder());
-                out.format("type %s implements %s {\n",
+                out.format("type %s implements %s%s {\n",
                         type.getName(),
-                        interfaceNames.collect(joining(" & ")));
+                        interfaceNames.collect(joining(" & ")),
+                        directivesString(type.getDirectives()));
             }
 
             visibility.getFieldDefinitions(type)
@@ -313,7 +314,7 @@ public class SchemaPrinter {
                 return;
             }
             printComments(out, type, "");
-            out.format("input %s {\n", type.getName());
+            out.format("input %s%s {\n", type.getName(), directivesString(type.getDirectives()));
             visibility.getFieldDefinitions(type)
                     .stream()
                     .sorted(Comparator.comparing(GraphQLInputObjectField::getName))
@@ -326,6 +327,7 @@ public class SchemaPrinter {
                             String astValue = printAst(defaultValue, fd.getType());
                             out.format(" = %s", astValue);
                         }
+                        out.format(directivesString(fd.getDirectives()));
                         out.format("\n");
                     });
             out.format("}\n\n");

--- a/src/test/groovy/graphql/TestUtil.groovy
+++ b/src/test/groovy/graphql/TestUtil.groovy
@@ -1,10 +1,13 @@
 package graphql
 
+import graphql.introspection.Introspection.DirectiveLocation
 import graphql.language.Document
+import graphql.language.ScalarTypeDefinition
 import graphql.parser.Parser
 import graphql.schema.Coercing
 import graphql.schema.DataFetcher
 import graphql.schema.GraphQLArgument
+import graphql.schema.GraphQLDirective
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLInputType
 import graphql.schema.GraphQLObjectType
@@ -21,6 +24,10 @@ import graphql.schema.idl.TypeRuntimeWiring
 import graphql.schema.idl.UnionWiringEnvironment
 import graphql.schema.idl.WiringFactory
 import graphql.schema.idl.errors.SchemaProblem
+
+import java.util.EnumSet
+import java.util.Collections
+import java.util.stream.Collectors
 
 import static graphql.Scalars.GraphQLString
 import static graphql.schema.GraphQLArgument.newArgument
@@ -126,7 +133,11 @@ class TestUtil {
     }
 
     static GraphQLScalarType mockScalar(String name) {
-        new GraphQLScalarType(name, name, new Coercing() {
+        new GraphQLScalarType(name, name, mockCoercing());
+    }
+
+    private static Coercing mockCoercing() {
+        new Coercing() {
             @Override
             Object serialize(Object dataFetcherResult) {
                 return null
@@ -141,7 +152,33 @@ class TestUtil {
             Object parseLiteral(Object input) {
                 return null
             }
-        })
+        }
+    }
+
+    static GraphQLScalarType mockScalar(ScalarTypeDefinition definition) {
+        new GraphQLScalarType(
+            definition.getName(),
+            definition.getDescription(),
+            mockCoercing(),
+            definition.getDirectives().stream().map({ mockDirective(it.getName()) }).collect(Collectors.toList()),
+            definition);
+    }
+
+    static GraphQLDirective mockDirective(String name) {
+        new GraphQLDirective(name, name, EnumSet.noneOf(DirectiveLocation.class), Collections.emptyList(), false, false, false)
+    }
+
+    static TypeRuntimeWiring mockTypeRuntimeWiring(String typeName, boolean withResolver) {
+        def builder = TypeRuntimeWiring.newTypeWiring(typeName)
+        if (withResolver) {
+            builder.typeResolver(new TypeResolver() {
+                @Override
+                GraphQLObjectType getType(TypeResolutionEnvironment env) {
+                    return null
+                }
+            })
+        }
+        return builder.build();
     }
 
 


### PR DESCRIPTION
https://github.com/graphql-java/graphql-java/issues/1029

I found that the schema printer was not printing directives for the following items:
- enum types
- enum values
- interface types
- interface fields
- union types
- input types
- input fields
- regular object types when implementing interfaces
- directives are also missing for field arguments, however that is not easily resolvable because while the schema definition uses `InputValueDefinition` to represent field args (which contains `Directive`s), the executable schema uses `GraphQLArgument` (which doesn't contain `GraphQLDirective`, neither it implements `GraphQLDirectiveContainer`)

I'm also a bit confused about how `Directive` and `DirectiveDefinition` are mapped into the executable schema, is that distinction lost or am I missing something? i only see `GraphQLDirective` and it seems to merge information from both.

let me know if it needs changes, thanks!