### PR TITLE
Fix Json string escaping

### DIFF
--- a/src/main/java/graphql/language/AstValueHelper.java
+++ b/src/main/java/graphql/language/AstValueHelper.java
@@ -157,13 +157,13 @@ public class AstValueHelper {
     }
 
     private static String jsonStringify(String stringValue) {
-        stringValue = stringValue.replace("\"", "\\\"");
         stringValue = stringValue.replace("\\", "\\\\");
-        stringValue = stringValue.replace("/", "\\/");
+        stringValue = stringValue.replace("\"", "\\\"");
         stringValue = stringValue.replace("\f", "\\f");
         stringValue = stringValue.replace("\n", "\\n");
         stringValue = stringValue.replace("\r", "\\r");
         stringValue = stringValue.replace("\t", "\\t");
+        stringValue = stringValue.replace("\b", "\\b");
         return stringValue;
     }
 

--- a/src/test/groovy/graphql/language/AstValueHelperTest.groovy
+++ b/src/test/groovy/graphql/language/AstValueHelperTest.groovy
@@ -60,7 +60,11 @@ class AstValueHelperTest extends Specification {
 
         astFromValue('VALUE', GraphQLString).isEqualTo(new StringValue('VALUE'))
 
-        astFromValue('VA\n\t\\LUE', GraphQLString).isEqualTo(new StringValue('VA\\n\\t\\\\LUE'))
+        astFromValue('VA\n\t\f\r\b\\LUE', GraphQLString).isEqualTo(new StringValue('VA\\n\\t\\f\\r\\b\\\\LUE'))
+
+        astFromValue('VA/LUE', GraphQLString).isEqualTo(new StringValue('VA/LUE'))
+
+        astFromValue('VA\\L\"UE', GraphQLString).isEqualTo(new StringValue('VA\\\\L\\"UE'))
 
         astFromValue(123, GraphQLString).isEqualTo(new StringValue('123'))
 


### PR DESCRIPTION
https://github.com/graphql-java/graphql-java/issues/1030

I included three fixes here:
- `\b` was not being escaped
- if escaping both `\` and `\"` in the same string, the slash before the doublequotes will be re-escaped
- not a bug, just an improvement: my understanding is that the forward slash `/` *can* be escaped in a json string, but it doesn't have to. i suggest not escaping it to generate cleaner output.

note that unicode chars `\uXXXX` are still unescaped, not sure if those should be escaped though. I'm also wondering if [`StringEscapeUtils.html.escapeEcmaScript(String)` from apache comons-lang](https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/StringEscapeUtils.html#escapeEcmaScript-java.lang.String-) should be used instead. 