### PR TITLE
improve query traversal and make it public

### DIFF
--- a/src/main/java/graphql/analysis/MaxQueryComplexityInstrumentation.java
+++ b/src/main/java/graphql/analysis/MaxQueryComplexityInstrumentation.java
@@ -59,7 +59,7 @@ public class MaxQueryComplexityInstrumentation extends SimpleInstrumentation {
                 @Override
                 public void visitField(QueryVisitorFieldEnvironment env) {
                     int childsComplexity = 0;
-                    QueryVisitorFieldEnvironment thisNodeAsParent = new QueryVisitorFieldEnvironment(env.getField(), env.getFieldDefinition(), env.getParentType(), env.getParentEnvironment(), env.getArguments(), env.getSelectionSetContainer());
+                    QueryVisitorFieldEnvironment thisNodeAsParent = new QueryVisitorFieldEnvironmentImpl(env.getField(), env.getFieldDefinition(), env.getParentType(), env.getParentEnvironment(), env.getArguments(), env.getSelectionSetContainer());
                     if (valuesByParent.containsKey(thisNodeAsParent)) {
                         childsComplexity = valuesByParent.get(thisNodeAsParent).stream().mapToInt(Integer::intValue).sum();
                     }
@@ -96,21 +96,21 @@ public class MaxQueryComplexityInstrumentation extends SimpleInstrumentation {
         );
     }
 
-    private int calculateComplexity(QueryVisitorFieldEnvironment queryVisitorFieldEnvironment, int childsComplexity) {
-        FieldComplexityEnvironment fieldComplexityEnvironment = convertEnv(queryVisitorFieldEnvironment);
+    private int calculateComplexity(QueryVisitorFieldEnvironment QueryVisitorFieldEnvironment, int childsComplexity) {
+        FieldComplexityEnvironment fieldComplexityEnvironment = convertEnv(QueryVisitorFieldEnvironment);
         return fieldComplexityCalculator.calculate(fieldComplexityEnvironment, childsComplexity);
     }
 
-    private FieldComplexityEnvironment convertEnv(QueryVisitorFieldEnvironment queryVisitorFieldEnvironment) {
+    private FieldComplexityEnvironment convertEnv(QueryVisitorFieldEnvironment QueryVisitorFieldEnvironment) {
         FieldComplexityEnvironment parentEnv = null;
-        if (queryVisitorFieldEnvironment.getParentEnvironment() != null) {
-            parentEnv = convertEnv(queryVisitorFieldEnvironment.getParentEnvironment());
+        if (QueryVisitorFieldEnvironment.getParentEnvironment() != null) {
+            parentEnv = convertEnv(QueryVisitorFieldEnvironment.getParentEnvironment());
         }
         return new FieldComplexityEnvironment(
-                queryVisitorFieldEnvironment.getField(),
-                queryVisitorFieldEnvironment.getFieldDefinition(),
-                queryVisitorFieldEnvironment.getParentType(),
-                queryVisitorFieldEnvironment.getArguments(),
+                QueryVisitorFieldEnvironment.getField(),
+                QueryVisitorFieldEnvironment.getFieldDefinition(),
+                QueryVisitorFieldEnvironment.getParentType(),
+                QueryVisitorFieldEnvironment.getArguments(),
                 parentEnv
         );
     }

--- a/src/main/java/graphql/analysis/MaxQueryComplexityInstrumentation.java
+++ b/src/main/java/graphql/analysis/MaxQueryComplexityInstrumentation.java
@@ -57,7 +57,7 @@ public class MaxQueryComplexityInstrumentation extends SimpleInstrumentation {
             Map<QueryVisitorEnvironment, List<Integer>> valuesByParent = new LinkedHashMap<>();
             queryTraversal.visitPostOrder(env -> {
                 int childsComplexity = 0;
-                QueryVisitorEnvironment thisNodeAsParent = new QueryVisitorEnvironment(env.getField(), env.getFieldDefinition(), env.getParentType(), env.getParentEnvironment(), env.getArguments());
+                QueryVisitorEnvironment thisNodeAsParent = new QueryVisitorEnvironment(env.getField(), env.getFieldDefinition(), env.getParentType(), env.getParentEnvironment(), env.getArguments(), env.getSelectionSetContainer());
                 if (valuesByParent.containsKey(thisNodeAsParent)) {
                     childsComplexity = valuesByParent.get(thisNodeAsParent).stream().mapToInt(Integer::intValue).sum();
                 }

--- a/src/main/java/graphql/analysis/MaxQueryComplexityInstrumentation.java
+++ b/src/main/java/graphql/analysis/MaxQueryComplexityInstrumentation.java
@@ -88,12 +88,12 @@ public class MaxQueryComplexityInstrumentation extends SimpleInstrumentation {
     }
 
     QueryTraversal newQueryTraversal(InstrumentationValidationParameters parameters) {
-        return new QueryTraversal(
-                parameters.getSchema(),
-                parameters.getDocument(),
-                parameters.getOperation(),
-                parameters.getVariables()
-        );
+        return QueryTraversal.newQueryTraversal()
+                .schema(parameters.getSchema())
+                .document(parameters.getDocument())
+                .operationName(parameters.getOperation())
+                .variables(parameters.getVariables())
+                .build();
     }
 
     private int calculateComplexity(QueryVisitorFieldEnvironment QueryVisitorFieldEnvironment, int childsComplexity) {

--- a/src/main/java/graphql/analysis/MaxQueryComplexityInstrumentation.java
+++ b/src/main/java/graphql/analysis/MaxQueryComplexityInstrumentation.java
@@ -54,10 +54,10 @@ public class MaxQueryComplexityInstrumentation extends SimpleInstrumentation {
             }
             QueryTraversal queryTraversal = newQueryTraversal(parameters);
 
-            Map<QueryVisitorEnvironment, List<Integer>> valuesByParent = new LinkedHashMap<>();
+            Map<QueryVisitorFieldEnvironment, List<Integer>> valuesByParent = new LinkedHashMap<>();
             queryTraversal.visitPostOrder(env -> {
                 int childsComplexity = 0;
-                QueryVisitorEnvironment thisNodeAsParent = new QueryVisitorEnvironment(env.getField(), env.getFieldDefinition(), env.getParentType(), env.getParentEnvironment(), env.getArguments(), env.getSelectionSetContainer());
+                QueryVisitorFieldEnvironment thisNodeAsParent = new QueryVisitorFieldEnvironment(env.getField(), env.getFieldDefinition(), env.getParentType(), env.getParentEnvironment(), env.getArguments(), env.getSelectionSetContainer());
                 if (valuesByParent.containsKey(thisNodeAsParent)) {
                     childsComplexity = valuesByParent.get(thisNodeAsParent).stream().mapToInt(Integer::intValue).sum();
                 }
@@ -93,21 +93,21 @@ public class MaxQueryComplexityInstrumentation extends SimpleInstrumentation {
         );
     }
 
-    private int calculateComplexity(QueryVisitorEnvironment queryVisitorEnvironment, int childsComplexity) {
-        FieldComplexityEnvironment fieldComplexityEnvironment = convertEnv(queryVisitorEnvironment);
+    private int calculateComplexity(QueryVisitorFieldEnvironment queryVisitorFieldEnvironment, int childsComplexity) {
+        FieldComplexityEnvironment fieldComplexityEnvironment = convertEnv(queryVisitorFieldEnvironment);
         return fieldComplexityCalculator.calculate(fieldComplexityEnvironment, childsComplexity);
     }
 
-    private FieldComplexityEnvironment convertEnv(QueryVisitorEnvironment queryVisitorEnvironment) {
+    private FieldComplexityEnvironment convertEnv(QueryVisitorFieldEnvironment queryVisitorFieldEnvironment) {
         FieldComplexityEnvironment parentEnv = null;
-        if (queryVisitorEnvironment.getParentEnvironment() != null) {
-            parentEnv = convertEnv(queryVisitorEnvironment.getParentEnvironment());
+        if (queryVisitorFieldEnvironment.getParentEnvironment() != null) {
+            parentEnv = convertEnv(queryVisitorFieldEnvironment.getParentEnvironment());
         }
         return new FieldComplexityEnvironment(
-                queryVisitorEnvironment.getField(),
-                queryVisitorEnvironment.getFieldDefinition(),
-                queryVisitorEnvironment.getParentType(),
-                queryVisitorEnvironment.getArguments(),
+                queryVisitorFieldEnvironment.getField(),
+                queryVisitorFieldEnvironment.getFieldDefinition(),
+                queryVisitorFieldEnvironment.getParentType(),
+                queryVisitorFieldEnvironment.getArguments(),
                 parentEnv
         );
     }

--- a/src/main/java/graphql/analysis/MaxQueryDepthInstrumentation.java
+++ b/src/main/java/graphql/analysis/MaxQueryDepthInstrumentation.java
@@ -4,13 +4,12 @@ import graphql.PublicApi;
 import graphql.execution.AbortExecutionException;
 import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.SimpleInstrumentation;
-import graphql.execution.instrumentation.SimpleInstrumentationContext;
 import graphql.execution.instrumentation.parameters.InstrumentationValidationParameters;
 import graphql.validation.ValidationError;
 
 import java.util.List;
 
-import static graphql.execution.instrumentation.SimpleInstrumentationContext.*;
+import static graphql.execution.instrumentation.SimpleInstrumentationContext.whenCompleted;
 
 /**
  * Prevents execution if the query depth is greater than the specified maxDepth
@@ -59,7 +58,7 @@ public class MaxQueryDepthInstrumentation extends SimpleInstrumentation {
         );
     }
 
-    private int getPathLength(QueryVisitorEnvironment path) {
+    private int getPathLength(QueryVisitorFieldEnvironment path) {
         int length = 1;
         while (path != null) {
             path = path.getParentEnvironment();

--- a/src/main/java/graphql/analysis/MaxQueryDepthInstrumentation.java
+++ b/src/main/java/graphql/analysis/MaxQueryDepthInstrumentation.java
@@ -50,12 +50,12 @@ public class MaxQueryDepthInstrumentation extends SimpleInstrumentation {
     }
 
     QueryTraversal newQueryTraversal(InstrumentationValidationParameters parameters) {
-        return new QueryTraversal(
-                parameters.getSchema(),
-                parameters.getDocument(),
-                parameters.getOperation(),
-                parameters.getVariables()
-        );
+        return QueryTraversal.newQueryTraversal()
+                .schema(parameters.getSchema())
+                .document(parameters.getDocument())
+                .operationName(parameters.getOperation())
+                .variables(parameters.getVariables())
+                .build();
     }
 
     private int getPathLength(QueryVisitorFieldEnvironment path) {

--- a/src/main/java/graphql/analysis/QueryReducer.java
+++ b/src/main/java/graphql/analysis/QueryReducer.java
@@ -2,9 +2,26 @@ package graphql.analysis;
 
 import graphql.PublicApi;
 
+/**
+ * Used by {@link QueryTraversal} to reduce the fields of a Document (or part of it) to a single value.
+ * <p/>
+ * How this happens in detail (pre vs post-order for example) is defined by {@link QueryTraversal}.
+ * <p/>
+ * See {@link QueryTraversal#reducePostOrder(QueryReducer, Object)} and {@link QueryTraversal#reducePreOrder(QueryReducer, Object)}
+ *
+ * @param <T>
+ */
 @PublicApi
 @FunctionalInterface
 public interface QueryReducer<T> {
 
-    T reduceField(QueryVisitorFieldEnvironment reducerEnvironment, T acc);
+    /**
+     * Called each time a field is visited.
+     *
+     * @param fieldEnvironment
+     * @param acc              the previous result
+     *
+     * @return the new result
+     */
+    T reduceField(QueryVisitorFieldEnvironment fieldEnvironment, T acc);
 }

--- a/src/main/java/graphql/analysis/QueryReducer.java
+++ b/src/main/java/graphql/analysis/QueryReducer.java
@@ -6,5 +6,5 @@ import graphql.Internal;
 @FunctionalInterface
 public interface QueryReducer<T> {
 
-    T reduceField(QueryVisitorEnvironment reducerEnvironment, T acc);
+    T reduceField(QueryVisitorFieldEnvironment reducerEnvironment, T acc);
 }

--- a/src/main/java/graphql/analysis/QueryReducer.java
+++ b/src/main/java/graphql/analysis/QueryReducer.java
@@ -1,8 +1,8 @@
 package graphql.analysis;
 
-import graphql.Internal;
+import graphql.PublicApi;
 
-@Internal
+@PublicApi
 @FunctionalInterface
 public interface QueryReducer<T> {
 

--- a/src/main/java/graphql/analysis/QueryTraversal.java
+++ b/src/main/java/graphql/analysis/QueryTraversal.java
@@ -101,7 +101,12 @@ public class QueryTraversal {
     public <T> T reducePostOrder(QueryReducer<T> queryReducer, T initialValue) {
         // compiler hack to make acc final and mutable :-)
         final Object[] acc = {initialValue};
-        visitPostOrder((env) -> acc[0] = queryReducer.reduceField(env, (T) acc[0]));
+        visitPostOrder(new QueryVisitorStub() {
+            @Override
+            public void visitField(QueryVisitorFieldEnvironment env) {
+                acc[0] = queryReducer.reduceField(env, (T) acc[0]);
+            }
+        });
         return (T) acc[0];
     }
 
@@ -109,7 +114,12 @@ public class QueryTraversal {
     public <T> T reducePreOrder(QueryReducer<T> queryReducer, T initialValue) {
         // compiler hack to make acc final and mutable :-)
         final Object[] acc = {initialValue};
-        visitPreOrder((env) -> acc[0] = queryReducer.reduceField(env, (T) acc[0]));
+        visitPreOrder(new QueryVisitorStub() {
+            @Override
+            public void visitField(QueryVisitorFieldEnvironment env) {
+                acc[0] = queryReducer.reduceField(env, (T) acc[0]);
+            }
+        });
         return (T) acc[0];
     }
 
@@ -121,8 +131,7 @@ public class QueryTraversal {
         Map<Class<?>, Object> rootVars = new LinkedHashMap<>();
         rootVars.put(QueryTraversalContext.class, new QueryTraversalContext(rootParentType, null, null));
 
-        QueryVisitor noOp = notUsed -> {
-        };
+        QueryVisitor noOp = new QueryVisitorStub();
         QueryVisitor preOrderCallback = preOrder ? visitFieldCallback : noOp;
         QueryVisitor postOrderCallback = !preOrder ? visitFieldCallback : noOp;
 

--- a/src/main/java/graphql/analysis/QueryTraversal.java
+++ b/src/main/java/graphql/analysis/QueryTraversal.java
@@ -154,7 +154,7 @@ public class QueryTraversal {
             if (!conditionalNodes.shouldInclude(variables, inlineFragment.getDirectives()))
                 return TraversalControl.ABORT;
 
-            QueryVisitorInlineFragmentEnvironment inlineFragmentEnvironment = new QueryVisitorInlineFragmentEnvironment(inlineFragment);
+            QueryVisitorInlineFragmentEnvironment inlineFragmentEnvironment = new QueryVisitorInlineFragmentEnvironmentImpl(inlineFragment);
 
             if (context.getVar(LeaveOrEnter.class) == LEAVE) {
                 postOrderCallback.visitInlineFragment(inlineFragmentEnvironment);
@@ -189,7 +189,7 @@ public class QueryTraversal {
             if (!conditionalNodes.shouldInclude(variables, fragmentDefinition.getDirectives()))
                 return TraversalControl.ABORT;
 
-            QueryVisitorFragmentSpreadEnvironment fragmentSpreadEnvironment = new QueryVisitorFragmentSpreadEnvironment(fragmentSpread, fragmentDefinition);
+            QueryVisitorFragmentSpreadEnvironment fragmentSpreadEnvironment = new QueryVisitorFragmentSpreadEnvironmentImpl(fragmentSpread, fragmentDefinition);
             if (context.getVar(LeaveOrEnter.class) == LEAVE) {
                 postOrderCallback.visitFragmentSpread(fragmentSpreadEnvironment);
                 return TraversalControl.CONTINUE;

--- a/src/main/java/graphql/analysis/QueryTraversal.java
+++ b/src/main/java/graphql/analysis/QueryTraversal.java
@@ -76,11 +76,11 @@ public class QueryTraversal {
         this.childrenOfSelectionProvider = new ChildrenOfSelectionProvider(fragmentsByName);
     }
 
-    public void visitPostOrder(FieldVisitor visitor) {
+    public void visitPostOrder(QueryVisitor visitor) {
         visitImpl(visitor, false);
     }
 
-    public void visitPreOrder(FieldVisitor visitor) {
+    public void visitPreOrder(QueryVisitor visitor) {
         visitImpl(visitor, true);
     }
 
@@ -117,14 +117,14 @@ public class QueryTraversal {
         return childrenOfSelectionProvider.getSelections((Selection) selection);
     }
 
-    private void visitImpl(FieldVisitor visitFieldCallback, boolean preOrder) {
+    private void visitImpl(QueryVisitor visitFieldCallback, boolean preOrder) {
         Map<Class<?>, Object> rootVars = new LinkedHashMap<>();
         rootVars.put(QueryTraversalContext.class, new QueryTraversalContext(rootParentType, null, null));
 
-        FieldVisitor noOp = notUsed -> {
+        QueryVisitor noOp = notUsed -> {
         };
-        FieldVisitor preOrderCallback = preOrder ? visitFieldCallback : noOp;
-        FieldVisitor postOrderCallback = !preOrder ? visitFieldCallback : noOp;
+        QueryVisitor preOrderCallback = preOrder ? visitFieldCallback : noOp;
+        QueryVisitor postOrderCallback = !preOrder ? visitFieldCallback : noOp;
 
         NodeTraverser nodeTraverser = new NodeTraverser(rootVars, this::childrenOf);
         nodeTraverser.depthFirst(new NodeVisitorImpl(preOrderCallback, postOrderCallback), roots);
@@ -132,10 +132,10 @@ public class QueryTraversal {
 
     private class NodeVisitorImpl extends NodeVisitorStub {
 
-        final FieldVisitor preOrderCallback;
-        final FieldVisitor postOrderCallback;
+        final QueryVisitor preOrderCallback;
+        final QueryVisitor postOrderCallback;
 
-        NodeVisitorImpl(FieldVisitor preOrderCallback, FieldVisitor postOrderCallback) {
+        NodeVisitorImpl(QueryVisitor preOrderCallback, QueryVisitor postOrderCallback) {
             this.preOrderCallback = preOrderCallback;
             this.postOrderCallback = postOrderCallback;
         }

--- a/src/main/java/graphql/analysis/QueryTraversal.java
+++ b/src/main/java/graphql/analysis/QueryTraversal.java
@@ -189,6 +189,14 @@ public class QueryTraversal {
             if (!conditionalNodes.shouldInclude(variables, fragmentDefinition.getDirectives()))
                 return TraversalControl.ABORT;
 
+            QueryVisitorFragmentSpreadEnvironment fragmentSpreadEnvironment = new QueryVisitorFragmentSpreadEnvironment(fragmentSpread, fragmentDefinition);
+            if (context.getVar(LeaveOrEnter.class) == LEAVE) {
+                postOrderCallback.visitFragmentSpread(fragmentSpreadEnvironment);
+                return TraversalControl.CONTINUE;
+            }
+
+            preOrderCallback.visitFragmentSpread(fragmentSpreadEnvironment);
+
             QueryTraversalContext parentEnv = context
                     .getParentContext()
                     .getVar(QueryTraversalContext.class);

--- a/src/main/java/graphql/analysis/QueryTraversal.java
+++ b/src/main/java/graphql/analysis/QueryTraversal.java
@@ -151,11 +151,17 @@ public class QueryTraversal {
 
         @Override
         public TraversalControl visitInlineFragment(InlineFragment inlineFragment, TraverserContext<Node> context) {
-            if (context.getVar(LeaveOrEnter.class) == LEAVE) {
-                return TraversalControl.CONTINUE;
-            }
             if (!conditionalNodes.shouldInclude(variables, inlineFragment.getDirectives()))
                 return TraversalControl.ABORT;
+
+            QueryVisitorInlineFragmentEnvironment inlineFragmentEnvironment = new QueryVisitorInlineFragmentEnvironment(inlineFragment);
+
+            if (context.getVar(LeaveOrEnter.class) == LEAVE) {
+                postOrderCallback.visitInlineFragment(inlineFragmentEnvironment);
+                return TraversalControl.CONTINUE;
+            }
+
+            preOrderCallback.visitInlineFragment(inlineFragmentEnvironment);
 
             // inline fragments are allowed not have type conditions, if so the parent type counts
             QueryTraversalContext parentEnv = context
@@ -176,9 +182,6 @@ public class QueryTraversal {
 
         @Override
         public TraversalControl visitFragmentSpread(FragmentSpread fragmentSpread, TraverserContext<Node> context) {
-            if (context.getVar(LeaveOrEnter.class) == LEAVE) {
-                return TraversalControl.CONTINUE;
-            }
             if (!conditionalNodes.shouldInclude(variables, fragmentSpread.getDirectives()))
                 return TraversalControl.ABORT;
 

--- a/src/main/java/graphql/analysis/QueryTraversal.java
+++ b/src/main/java/graphql/analysis/QueryTraversal.java
@@ -196,7 +196,7 @@ public class QueryTraversal {
 
             GraphQLFieldDefinition fieldDefinition = Introspection.getFieldDef(schema, parentEnv.getType(), field.getName());
             Map<String, Object> argumentValues = valuesResolver.getArgumentValues(schema.getFieldVisibility(), fieldDefinition.getArguments(), field.getArguments(), variables);
-            QueryVisitorEnvironment environment = new QueryVisitorEnvironment(field, fieldDefinition, parentEnv.getType(), parentEnv.getEnvironment(), argumentValues, parentEnv.getSelectionSetContainer());
+            QueryVisitorFieldEnvironment environment = new QueryVisitorFieldEnvironment(field, fieldDefinition, parentEnv.getType(), parentEnv.getEnvironment(), argumentValues, parentEnv.getSelectionSetContainer());
 
             LeaveOrEnter leaveOrEnter = context.getVar(LeaveOrEnter.class);
             if (leaveOrEnter == LEAVE) {

--- a/src/main/java/graphql/analysis/QueryTraversal.java
+++ b/src/main/java/graphql/analysis/QueryTraversal.java
@@ -216,7 +216,7 @@ public class QueryTraversal {
 
             GraphQLFieldDefinition fieldDefinition = Introspection.getFieldDef(schema, parentEnv.getType(), field.getName());
             Map<String, Object> argumentValues = valuesResolver.getArgumentValues(schema.getFieldVisibility(), fieldDefinition.getArguments(), field.getArguments(), variables);
-            QueryVisitorFieldEnvironment environment = new QueryVisitorFieldEnvironment(field, fieldDefinition, parentEnv.getType(), parentEnv.getEnvironment(), argumentValues, parentEnv.getSelectionSetContainer());
+            QueryVisitorFieldEnvironment environment = new QueryVisitorFieldEnvironmentImpl(field, fieldDefinition, parentEnv.getType(), parentEnv.getEnvironment(), argumentValues, parentEnv.getSelectionSetContainer());
 
             LeaveOrEnter leaveOrEnter = context.getVar(LeaveOrEnter.class);
             if (leaveOrEnter == LEAVE) {

--- a/src/main/java/graphql/analysis/QueryTraversal.java
+++ b/src/main/java/graphql/analysis/QueryTraversal.java
@@ -43,7 +43,7 @@ import static graphql.language.NodeTraverser.LeaveOrEnter.LEAVE;
  * defined type. See {@link QueryVisitorFieldEnvironment}.
  * <p/>
  * Further are the built in Directives skip/include automatically evaluated: if parts of the Document should be ignored they will not
- * be visited.
+ * be visited. But this is not a full evaluation of a Query: every fragment will be visited/followed regardless of the type condition.
  */
 @PublicApi
 public class QueryTraversal {

--- a/src/main/java/graphql/analysis/QueryTraversalContext.java
+++ b/src/main/java/graphql/analysis/QueryTraversalContext.java
@@ -12,10 +12,10 @@ import graphql.schema.GraphQLCompositeType;
 class QueryTraversalContext {
     
     private final GraphQLCompositeType type;
-    private final QueryVisitorEnvironment environment;
+    private final QueryVisitorFieldEnvironment environment;
     private final SelectionSetContainer selectionSetContainer;
 
-    QueryTraversalContext(GraphQLCompositeType type, QueryVisitorEnvironment environment, SelectionSetContainer selectionSetContainer) {
+    QueryTraversalContext(GraphQLCompositeType type, QueryVisitorFieldEnvironment environment, SelectionSetContainer selectionSetContainer) {
         this.type = type;
         this.environment = environment;
         this.selectionSetContainer = selectionSetContainer;
@@ -25,7 +25,7 @@ class QueryTraversalContext {
         return type;
     }
 
-    public QueryVisitorEnvironment getEnvironment() {
+    public QueryVisitorFieldEnvironment getEnvironment() {
         return environment;
     }
 

--- a/src/main/java/graphql/analysis/QueryTraversalContext.java
+++ b/src/main/java/graphql/analysis/QueryTraversalContext.java
@@ -1,6 +1,7 @@
 package graphql.analysis;
 
 import graphql.Internal;
+import graphql.language.SelectionSetContainer;
 import graphql.schema.GraphQLCompositeType;
 
 /**
@@ -12,10 +13,12 @@ class QueryTraversalContext {
     
     private final GraphQLCompositeType type;
     private final QueryVisitorEnvironment environment;
+    private final SelectionSetContainer selectionSetContainer;
 
-    QueryTraversalContext(GraphQLCompositeType type, QueryVisitorEnvironment environment) {
+    QueryTraversalContext(GraphQLCompositeType type, QueryVisitorEnvironment environment, SelectionSetContainer selectionSetContainer) {
         this.type = type;
         this.environment = environment;
+        this.selectionSetContainer = selectionSetContainer;
     }
 
     public GraphQLCompositeType getType() {
@@ -24,5 +27,10 @@ class QueryTraversalContext {
 
     public QueryVisitorEnvironment getEnvironment() {
         return environment;
-    }    
+    }
+
+    public SelectionSetContainer getSelectionSetContainer() {
+
+        return selectionSetContainer;
+    }
 }

--- a/src/main/java/graphql/analysis/QueryVisitor.java
+++ b/src/main/java/graphql/analysis/QueryVisitor.java
@@ -2,6 +2,11 @@ package graphql.analysis;
 
 import graphql.PublicApi;
 
+/**
+ * User by {@link QueryTraversal} to visit the nodes of a Query.
+ * <p/>
+ * How this happens in detail (pre vs post-order for example) is defined by {@link QueryTraversal}.
+ */
 @PublicApi
 public interface QueryVisitor {
 

--- a/src/main/java/graphql/analysis/QueryVisitor.java
+++ b/src/main/java/graphql/analysis/QueryVisitor.java
@@ -1,9 +1,9 @@
 package graphql.analysis;
 
-import graphql.Internal;
+import graphql.PublicApi;
 
-@Internal
-public interface FieldVisitor {
+@PublicApi
+public interface QueryVisitor {
 
     void visitField(QueryVisitorEnvironment queryVisitorEnvironment);
 

--- a/src/main/java/graphql/analysis/QueryVisitor.java
+++ b/src/main/java/graphql/analysis/QueryVisitor.java
@@ -5,7 +5,7 @@ import graphql.PublicApi;
 @PublicApi
 public interface QueryVisitor {
 
-    void visitField(QueryVisitorFieldEnvironment queryVisitorFieldEnvironment);
+    void visitField(QueryVisitorFieldEnvironment QueryVisitorFieldEnvironment);
 
     void visitInlineFragment(QueryVisitorInlineFragmentEnvironment queryVisitorInlineFragmentEnvironment);
 

--- a/src/main/java/graphql/analysis/QueryVisitor.java
+++ b/src/main/java/graphql/analysis/QueryVisitor.java
@@ -5,6 +5,8 @@ import graphql.PublicApi;
 @PublicApi
 public interface QueryVisitor {
 
-    void visitField(QueryVisitorEnvironment queryVisitorEnvironment);
+    void visitField(QueryVisitorFieldEnvironment queryVisitorFieldEnvironment);
+
+
 
 }

--- a/src/main/java/graphql/analysis/QueryVisitor.java
+++ b/src/main/java/graphql/analysis/QueryVisitor.java
@@ -7,6 +7,8 @@ public interface QueryVisitor {
 
     void visitField(QueryVisitorFieldEnvironment queryVisitorFieldEnvironment);
 
+    void visitInlineFragment(QueryVisitorInlineFragmentEnvironment queryVisitorInlineFragmentEnvironment);
 
+    void visitFragmentSpread(QueryVisitorInlineFragmentEnvironment queryVisitorInlineFragmentEnvironment);
 
 }

--- a/src/main/java/graphql/analysis/QueryVisitor.java
+++ b/src/main/java/graphql/analysis/QueryVisitor.java
@@ -9,6 +9,6 @@ public interface QueryVisitor {
 
     void visitInlineFragment(QueryVisitorInlineFragmentEnvironment queryVisitorInlineFragmentEnvironment);
 
-    void visitFragmentSpread(QueryVisitorInlineFragmentEnvironment queryVisitorInlineFragmentEnvironment);
+    void visitFragmentSpread(QueryVisitorFragmentSpreadEnvironment queryVisitorFragmentSpreadEnvironment);
 
 }

--- a/src/main/java/graphql/analysis/QueryVisitorEnvironment.java
+++ b/src/main/java/graphql/analysis/QueryVisitorEnvironment.java
@@ -1,30 +1,34 @@
 package graphql.analysis;
 
-import graphql.Internal;
+import graphql.PublicApi;
 import graphql.language.Field;
+import graphql.language.SelectionSetContainer;
 import graphql.schema.GraphQLCompositeType;
 import graphql.schema.GraphQLFieldDefinition;
 
 import java.util.Map;
 
-@Internal
+@PublicApi
 public class QueryVisitorEnvironment {
     private final Field field;
     private final GraphQLFieldDefinition fieldDefinition;
     private final GraphQLCompositeType parentType;
     private final Map<String, Object> arguments;
     private final QueryVisitorEnvironment parentEnvironment;
+    private final SelectionSetContainer selectionSetContainer;
 
     public QueryVisitorEnvironment(Field field,
                                    GraphQLFieldDefinition fieldDefinition,
                                    GraphQLCompositeType parentType,
                                    QueryVisitorEnvironment parentEnvironment,
-                                   Map<String, Object> arguments) {
+                                   Map<String, Object> arguments,
+                                   SelectionSetContainer selectionSetContainer) {
         this.field = field;
         this.fieldDefinition = fieldDefinition;
         this.parentType = parentType;
         this.parentEnvironment = parentEnvironment;
         this.arguments = arguments;
+        this.selectionSetContainer = selectionSetContainer;
     }
 
     public Field getField() {
@@ -45,6 +49,10 @@ public class QueryVisitorEnvironment {
 
     public Map<String, Object> getArguments() {
         return arguments;
+    }
+
+    public SelectionSetContainer getSelectionSetContainer() {
+        return selectionSetContainer;
     }
 
     @Override

--- a/src/main/java/graphql/analysis/QueryVisitorFieldEnvironment.java
+++ b/src/main/java/graphql/analysis/QueryVisitorFieldEnvironment.java
@@ -9,20 +9,20 @@ import graphql.schema.GraphQLFieldDefinition;
 import java.util.Map;
 
 @PublicApi
-public class QueryVisitorEnvironment {
+public class QueryVisitorFieldEnvironment {
     private final Field field;
     private final GraphQLFieldDefinition fieldDefinition;
     private final GraphQLCompositeType parentType;
     private final Map<String, Object> arguments;
-    private final QueryVisitorEnvironment parentEnvironment;
+    private final QueryVisitorFieldEnvironment parentEnvironment;
     private final SelectionSetContainer selectionSetContainer;
 
-    public QueryVisitorEnvironment(Field field,
-                                   GraphQLFieldDefinition fieldDefinition,
-                                   GraphQLCompositeType parentType,
-                                   QueryVisitorEnvironment parentEnvironment,
-                                   Map<String, Object> arguments,
-                                   SelectionSetContainer selectionSetContainer) {
+    public QueryVisitorFieldEnvironment(Field field,
+                                        GraphQLFieldDefinition fieldDefinition,
+                                        GraphQLCompositeType parentType,
+                                        QueryVisitorFieldEnvironment parentEnvironment,
+                                        Map<String, Object> arguments,
+                                        SelectionSetContainer selectionSetContainer) {
         this.field = field;
         this.fieldDefinition = fieldDefinition;
         this.parentType = parentType;
@@ -43,7 +43,7 @@ public class QueryVisitorEnvironment {
         return parentType;
     }
 
-    public QueryVisitorEnvironment getParentEnvironment() {
+    public QueryVisitorFieldEnvironment getParentEnvironment() {
         return parentEnvironment;
     }
 
@@ -60,7 +60,7 @@ public class QueryVisitorEnvironment {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        QueryVisitorEnvironment that = (QueryVisitorEnvironment) o;
+        QueryVisitorFieldEnvironment that = (QueryVisitorFieldEnvironment) o;
 
         if (field != null ? !field.equals(that.field) : that.field != null) return false;
         if (fieldDefinition != null ? !fieldDefinition.equals(that.fieldDefinition) : that.fieldDefinition != null)
@@ -83,7 +83,7 @@ public class QueryVisitorEnvironment {
 
     @Override
     public String toString() {
-        return "QueryVisitorEnvironment{" +
+        return "QueryVisitorFieldEnvironment{" +
                 "field=" + field +
                 ", fieldDefinition=" + fieldDefinition +
                 ", parentType=" + parentType +

--- a/src/main/java/graphql/analysis/QueryVisitorFieldEnvironment.java
+++ b/src/main/java/graphql/analysis/QueryVisitorFieldEnvironment.java
@@ -9,86 +9,17 @@ import graphql.schema.GraphQLFieldDefinition;
 import java.util.Map;
 
 @PublicApi
-public class QueryVisitorFieldEnvironment {
-    private final Field field;
-    private final GraphQLFieldDefinition fieldDefinition;
-    private final GraphQLCompositeType parentType;
-    private final Map<String, Object> arguments;
-    private final QueryVisitorFieldEnvironment parentEnvironment;
-    private final SelectionSetContainer selectionSetContainer;
+public interface QueryVisitorFieldEnvironment {
 
-    public QueryVisitorFieldEnvironment(Field field,
-                                        GraphQLFieldDefinition fieldDefinition,
-                                        GraphQLCompositeType parentType,
-                                        QueryVisitorFieldEnvironment parentEnvironment,
-                                        Map<String, Object> arguments,
-                                        SelectionSetContainer selectionSetContainer) {
-        this.field = field;
-        this.fieldDefinition = fieldDefinition;
-        this.parentType = parentType;
-        this.parentEnvironment = parentEnvironment;
-        this.arguments = arguments;
-        this.selectionSetContainer = selectionSetContainer;
-    }
+    Field getField();
 
-    public Field getField() {
-        return field;
-    }
+    GraphQLFieldDefinition getFieldDefinition();
 
-    public GraphQLFieldDefinition getFieldDefinition() {
-        return fieldDefinition;
-    }
+    GraphQLCompositeType getParentType();
 
-    public GraphQLCompositeType getParentType() {
-        return parentType;
-    }
+    QueryVisitorFieldEnvironment getParentEnvironment();
 
-    public QueryVisitorFieldEnvironment getParentEnvironment() {
-        return parentEnvironment;
-    }
+    Map<String, Object> getArguments();
 
-    public Map<String, Object> getArguments() {
-        return arguments;
-    }
-
-    public SelectionSetContainer getSelectionSetContainer() {
-        return selectionSetContainer;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        QueryVisitorFieldEnvironment that = (QueryVisitorFieldEnvironment) o;
-
-        if (field != null ? !field.equals(that.field) : that.field != null) return false;
-        if (fieldDefinition != null ? !fieldDefinition.equals(that.fieldDefinition) : that.fieldDefinition != null)
-            return false;
-        if (parentType != null ? !parentType.equals(that.parentType) : that.parentType != null) return false;
-        if (parentEnvironment != null ? !parentEnvironment.equals(that.parentEnvironment) : that.parentEnvironment != null)
-            return false;
-        return arguments != null ? arguments.equals(that.arguments) : that.arguments == null;
-    }
-
-    @Override
-    public int hashCode() {
-        int result = field != null ? field.hashCode() : 0;
-        result = 31 * result + (fieldDefinition != null ? fieldDefinition.hashCode() : 0);
-        result = 31 * result + (parentType != null ? parentType.hashCode() : 0);
-        result = 31 * result + (parentEnvironment != null ? parentEnvironment.hashCode() : 0);
-        result = 31 * result + (arguments != null ? arguments.hashCode() : 0);
-        return result;
-    }
-
-    @Override
-    public String toString() {
-        return "QueryVisitorFieldEnvironment{" +
-                "field=" + field +
-                ", fieldDefinition=" + fieldDefinition +
-                ", parentType=" + parentType +
-                ", parentEnvironment=" + parentEnvironment +
-                ", arguments=" + arguments +
-                '}';
-    }
+    SelectionSetContainer getSelectionSetContainer();
 }

--- a/src/main/java/graphql/analysis/QueryVisitorFieldEnvironmentImpl.java
+++ b/src/main/java/graphql/analysis/QueryVisitorFieldEnvironmentImpl.java
@@ -1,0 +1,100 @@
+package graphql.analysis;
+
+import graphql.Internal;
+import graphql.language.Field;
+import graphql.language.SelectionSetContainer;
+import graphql.schema.GraphQLCompositeType;
+import graphql.schema.GraphQLFieldDefinition;
+
+import java.util.Map;
+
+@Internal
+public class QueryVisitorFieldEnvironmentImpl implements QueryVisitorFieldEnvironment {
+    private final Field field;
+    private final GraphQLFieldDefinition fieldDefinition;
+    private final GraphQLCompositeType parentType;
+    private final Map<String, Object> arguments;
+    private final QueryVisitorFieldEnvironment parentEnvironment;
+    private final SelectionSetContainer selectionSetContainer;
+
+    public QueryVisitorFieldEnvironmentImpl(Field field,
+                                            GraphQLFieldDefinition fieldDefinition,
+                                            GraphQLCompositeType parentType,
+                                            QueryVisitorFieldEnvironment parentEnvironment,
+                                            Map<String, Object> arguments,
+                                            SelectionSetContainer selectionSetContainer) {
+        this.field = field;
+        this.fieldDefinition = fieldDefinition;
+        this.parentType = parentType;
+        this.parentEnvironment = parentEnvironment;
+        this.arguments = arguments;
+        this.selectionSetContainer = selectionSetContainer;
+    }
+
+    @Override
+    public Field getField() {
+        return field;
+    }
+
+    @Override
+    public GraphQLFieldDefinition getFieldDefinition() {
+        return fieldDefinition;
+    }
+
+    @Override
+    public GraphQLCompositeType getParentType() {
+        return parentType;
+    }
+
+    @Override
+    public QueryVisitorFieldEnvironment getParentEnvironment() {
+        return parentEnvironment;
+    }
+
+    @Override
+    public Map<String, Object> getArguments() {
+        return arguments;
+    }
+
+    @Override
+    public SelectionSetContainer getSelectionSetContainer() {
+        return selectionSetContainer;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        QueryVisitorFieldEnvironmentImpl that = (QueryVisitorFieldEnvironmentImpl) o;
+
+        if (field != null ? !field.equals(that.field) : that.field != null) return false;
+        if (fieldDefinition != null ? !fieldDefinition.equals(that.fieldDefinition) : that.fieldDefinition != null)
+            return false;
+        if (parentType != null ? !parentType.equals(that.parentType) : that.parentType != null) return false;
+        if (parentEnvironment != null ? !parentEnvironment.equals(that.parentEnvironment) : that.parentEnvironment != null)
+            return false;
+        return arguments != null ? arguments.equals(that.arguments) : that.arguments == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = field != null ? field.hashCode() : 0;
+        result = 31 * result + (fieldDefinition != null ? fieldDefinition.hashCode() : 0);
+        result = 31 * result + (parentType != null ? parentType.hashCode() : 0);
+        result = 31 * result + (parentEnvironment != null ? parentEnvironment.hashCode() : 0);
+        result = 31 * result + (arguments != null ? arguments.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "QueryVisitorFieldEnvironmentImpl{" +
+                "field=" + field +
+                ", fieldDefinition=" + fieldDefinition +
+                ", parentType=" + parentType +
+                ", parentEnvironment=" + parentEnvironment +
+                ", arguments=" + arguments +
+                '}';
+    }
+}

--- a/src/main/java/graphql/analysis/QueryVisitorFragmentSpreadEnvironment.java
+++ b/src/main/java/graphql/analysis/QueryVisitorFragmentSpreadEnvironment.java
@@ -1,20 +1,28 @@
 package graphql.analysis;
 
 import graphql.PublicApi;
+import graphql.language.FragmentDefinition;
 import graphql.language.FragmentSpread;
 
 import java.util.Objects;
 
 @PublicApi
 public class QueryVisitorFragmentSpreadEnvironment {
-    private final FragmentSpread fragmentSpread;
 
-    public QueryVisitorFragmentSpreadEnvironment(FragmentSpread fragmentSpread) {
+    private final FragmentSpread fragmentSpread;
+    private final FragmentDefinition fragmentDefinition;
+
+    public QueryVisitorFragmentSpreadEnvironment(FragmentSpread fragmentSpread, FragmentDefinition fragmentDefinition) {
         this.fragmentSpread = fragmentSpread;
+        this.fragmentDefinition = fragmentDefinition;
     }
 
     public FragmentSpread getFragmentSpread() {
         return fragmentSpread;
+    }
+
+    public FragmentDefinition getFragmentDefinition() {
+        return fragmentDefinition;
     }
 
     @Override
@@ -27,7 +35,6 @@ public class QueryVisitorFragmentSpreadEnvironment {
 
     @Override
     public int hashCode() {
-
         return Objects.hash(fragmentSpread);
     }
 }

--- a/src/main/java/graphql/analysis/QueryVisitorFragmentSpreadEnvironment.java
+++ b/src/main/java/graphql/analysis/QueryVisitorFragmentSpreadEnvironment.java
@@ -4,38 +4,9 @@ import graphql.PublicApi;
 import graphql.language.FragmentDefinition;
 import graphql.language.FragmentSpread;
 
-import java.util.Objects;
-
 @PublicApi
-public class QueryVisitorFragmentSpreadEnvironment {
+public interface QueryVisitorFragmentSpreadEnvironment {
+    FragmentSpread getFragmentSpread();
 
-    private final FragmentSpread fragmentSpread;
-    private final FragmentDefinition fragmentDefinition;
-
-    public QueryVisitorFragmentSpreadEnvironment(FragmentSpread fragmentSpread, FragmentDefinition fragmentDefinition) {
-        this.fragmentSpread = fragmentSpread;
-        this.fragmentDefinition = fragmentDefinition;
-    }
-
-    public FragmentSpread getFragmentSpread() {
-        return fragmentSpread;
-    }
-
-    public FragmentDefinition getFragmentDefinition() {
-        return fragmentDefinition;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        QueryVisitorFragmentSpreadEnvironment that = (QueryVisitorFragmentSpreadEnvironment) o;
-        return Objects.equals(fragmentSpread, that.fragmentSpread);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(fragmentSpread);
-    }
+    FragmentDefinition getFragmentDefinition();
 }
-

--- a/src/main/java/graphql/analysis/QueryVisitorFragmentSpreadEnvironment.java
+++ b/src/main/java/graphql/analysis/QueryVisitorFragmentSpreadEnvironment.java
@@ -1,0 +1,34 @@
+package graphql.analysis;
+
+import graphql.PublicApi;
+import graphql.language.FragmentSpread;
+
+import java.util.Objects;
+
+@PublicApi
+public class QueryVisitorFragmentSpreadEnvironment {
+    private final FragmentSpread fragmentSpread;
+
+    public QueryVisitorFragmentSpreadEnvironment(FragmentSpread fragmentSpread) {
+        this.fragmentSpread = fragmentSpread;
+    }
+
+    public FragmentSpread getFragmentSpread() {
+        return fragmentSpread;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        QueryVisitorFragmentSpreadEnvironment that = (QueryVisitorFragmentSpreadEnvironment) o;
+        return Objects.equals(fragmentSpread, that.fragmentSpread);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(fragmentSpread);
+    }
+}
+

--- a/src/main/java/graphql/analysis/QueryVisitorFragmentSpreadEnvironmentImpl.java
+++ b/src/main/java/graphql/analysis/QueryVisitorFragmentSpreadEnvironmentImpl.java
@@ -1,0 +1,43 @@
+package graphql.analysis;
+
+import graphql.Internal;
+import graphql.language.FragmentDefinition;
+import graphql.language.FragmentSpread;
+
+import java.util.Objects;
+
+@Internal
+public class QueryVisitorFragmentSpreadEnvironmentImpl implements QueryVisitorFragmentSpreadEnvironment {
+
+    private final FragmentSpread fragmentSpread;
+    private final FragmentDefinition fragmentDefinition;
+
+    public QueryVisitorFragmentSpreadEnvironmentImpl(FragmentSpread fragmentSpread, FragmentDefinition fragmentDefinition) {
+        this.fragmentSpread = fragmentSpread;
+        this.fragmentDefinition = fragmentDefinition;
+    }
+
+    @Override
+    public FragmentSpread getFragmentSpread() {
+        return fragmentSpread;
+    }
+
+    @Override
+    public FragmentDefinition getFragmentDefinition() {
+        return fragmentDefinition;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        QueryVisitorFragmentSpreadEnvironmentImpl that = (QueryVisitorFragmentSpreadEnvironmentImpl) o;
+        return Objects.equals(fragmentSpread, that.fragmentSpread);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fragmentSpread);
+    }
+}
+

--- a/src/main/java/graphql/analysis/QueryVisitorInlineFragmentEnvironment.java
+++ b/src/main/java/graphql/analysis/QueryVisitorInlineFragmentEnvironment.java
@@ -1,0 +1,41 @@
+package graphql.analysis;
+
+import graphql.PublicApi;
+import graphql.language.InlineFragment;
+import graphql.schema.GraphQLObjectType;
+
+import java.util.Objects;
+
+@PublicApi
+public class QueryVisitorInlineFragmentEnvironment {
+    private final InlineFragment inlineFragment;
+    private final GraphQLObjectType typeCondition;
+
+    public QueryVisitorInlineFragmentEnvironment(InlineFragment inlineFragment, GraphQLObjectType typeCondition) {
+        this.inlineFragment = inlineFragment;
+        this.typeCondition = typeCondition;
+    }
+
+    public InlineFragment getInlineFragment() {
+        return inlineFragment;
+    }
+
+    public GraphQLObjectType getTypeCondition() {
+        return typeCondition;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        QueryVisitorInlineFragmentEnvironment that = (QueryVisitorInlineFragmentEnvironment) o;
+        return Objects.equals(inlineFragment, that.inlineFragment) &&
+                Objects.equals(typeCondition, that.typeCondition);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(inlineFragment, typeCondition);
+    }
+}

--- a/src/main/java/graphql/analysis/QueryVisitorInlineFragmentEnvironment.java
+++ b/src/main/java/graphql/analysis/QueryVisitorInlineFragmentEnvironment.java
@@ -2,26 +2,19 @@ package graphql.analysis;
 
 import graphql.PublicApi;
 import graphql.language.InlineFragment;
-import graphql.schema.GraphQLObjectType;
 
 import java.util.Objects;
 
 @PublicApi
 public class QueryVisitorInlineFragmentEnvironment {
     private final InlineFragment inlineFragment;
-    private final GraphQLObjectType typeCondition;
 
-    public QueryVisitorInlineFragmentEnvironment(InlineFragment inlineFragment, GraphQLObjectType typeCondition) {
+    public QueryVisitorInlineFragmentEnvironment(InlineFragment inlineFragment) {
         this.inlineFragment = inlineFragment;
-        this.typeCondition = typeCondition;
     }
 
     public InlineFragment getInlineFragment() {
         return inlineFragment;
-    }
-
-    public GraphQLObjectType getTypeCondition() {
-        return typeCondition;
     }
 
     @Override
@@ -29,13 +22,19 @@ public class QueryVisitorInlineFragmentEnvironment {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         QueryVisitorInlineFragmentEnvironment that = (QueryVisitorInlineFragmentEnvironment) o;
-        return Objects.equals(inlineFragment, that.inlineFragment) &&
-                Objects.equals(typeCondition, that.typeCondition);
+        return Objects.equals(inlineFragment, that.inlineFragment);
     }
 
     @Override
     public int hashCode() {
 
-        return Objects.hash(inlineFragment, typeCondition);
+        return Objects.hash(inlineFragment);
+    }
+
+    @Override
+    public String toString() {
+        return "QueryVisitorInlineFragmentEnvironment{" +
+                "inlineFragment=" + inlineFragment +
+                '}';
     }
 }

--- a/src/main/java/graphql/analysis/QueryVisitorInlineFragmentEnvironment.java
+++ b/src/main/java/graphql/analysis/QueryVisitorInlineFragmentEnvironment.java
@@ -3,38 +3,7 @@ package graphql.analysis;
 import graphql.PublicApi;
 import graphql.language.InlineFragment;
 
-import java.util.Objects;
-
 @PublicApi
-public class QueryVisitorInlineFragmentEnvironment {
-    private final InlineFragment inlineFragment;
-
-    public QueryVisitorInlineFragmentEnvironment(InlineFragment inlineFragment) {
-        this.inlineFragment = inlineFragment;
-    }
-
-    public InlineFragment getInlineFragment() {
-        return inlineFragment;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        QueryVisitorInlineFragmentEnvironment that = (QueryVisitorInlineFragmentEnvironment) o;
-        return Objects.equals(inlineFragment, that.inlineFragment);
-    }
-
-    @Override
-    public int hashCode() {
-
-        return Objects.hash(inlineFragment);
-    }
-
-    @Override
-    public String toString() {
-        return "QueryVisitorInlineFragmentEnvironment{" +
-                "inlineFragment=" + inlineFragment +
-                '}';
-    }
+public interface QueryVisitorInlineFragmentEnvironment {
+    InlineFragment getInlineFragment();
 }

--- a/src/main/java/graphql/analysis/QueryVisitorInlineFragmentEnvironmentImpl.java
+++ b/src/main/java/graphql/analysis/QueryVisitorInlineFragmentEnvironmentImpl.java
@@ -1,0 +1,41 @@
+package graphql.analysis;
+
+import graphql.Internal;
+import graphql.language.InlineFragment;
+
+import java.util.Objects;
+
+@Internal
+public class QueryVisitorInlineFragmentEnvironmentImpl implements QueryVisitorInlineFragmentEnvironment {
+    private final InlineFragment inlineFragment;
+
+    public QueryVisitorInlineFragmentEnvironmentImpl(InlineFragment inlineFragment) {
+        this.inlineFragment = inlineFragment;
+    }
+
+    @Override
+    public InlineFragment getInlineFragment() {
+        return inlineFragment;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        QueryVisitorInlineFragmentEnvironmentImpl that = (QueryVisitorInlineFragmentEnvironmentImpl) o;
+        return Objects.equals(inlineFragment, that.inlineFragment);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(inlineFragment);
+    }
+
+    @Override
+    public String toString() {
+        return "QueryVisitorInlineFragmentEnvironmentImpl{" +
+                "inlineFragment=" + inlineFragment +
+                '}';
+    }
+}

--- a/src/main/java/graphql/analysis/QueryVisitorStub.java
+++ b/src/main/java/graphql/analysis/QueryVisitorStub.java
@@ -7,7 +7,7 @@ public class QueryVisitorStub implements QueryVisitor {
 
 
     @Override
-    public void visitField(QueryVisitorFieldEnvironment queryVisitorFieldEnvironment) {
+    public void visitField(QueryVisitorFieldEnvironment QueryVisitorFieldEnvironment) {
 
     }
 

--- a/src/main/java/graphql/analysis/QueryVisitorStub.java
+++ b/src/main/java/graphql/analysis/QueryVisitorStub.java
@@ -17,7 +17,7 @@ public class QueryVisitorStub implements QueryVisitor {
     }
 
     @Override
-    public void visitFragmentSpread(QueryVisitorInlineFragmentEnvironment queryVisitorInlineFragmentEnvironment) {
+    public void visitFragmentSpread(QueryVisitorFragmentSpreadEnvironment queryVisitorFragmentSpreadEnvironment) {
 
     }
 }

--- a/src/main/java/graphql/analysis/QueryVisitorStub.java
+++ b/src/main/java/graphql/analysis/QueryVisitorStub.java
@@ -1,0 +1,23 @@
+package graphql.analysis;
+
+import graphql.PublicApi;
+
+@PublicApi
+public class QueryVisitorStub implements QueryVisitor {
+
+
+    @Override
+    public void visitField(QueryVisitorFieldEnvironment queryVisitorFieldEnvironment) {
+
+    }
+
+    @Override
+    public void visitInlineFragment(QueryVisitorInlineFragmentEnvironment queryVisitorInlineFragmentEnvironment) {
+
+    }
+
+    @Override
+    public void visitFragmentSpread(QueryVisitorInlineFragmentEnvironment queryVisitorInlineFragmentEnvironment) {
+
+    }
+}

--- a/src/main/java/graphql/execution/instrumentation/fieldvalidation/FieldValidationSupport.java
+++ b/src/main/java/graphql/execution/instrumentation/fieldvalidation/FieldValidationSupport.java
@@ -5,6 +5,7 @@ import graphql.GraphQLError;
 import graphql.Internal;
 import graphql.analysis.QueryTraversal;
 import graphql.analysis.QueryVisitorFieldEnvironment;
+import graphql.analysis.QueryVisitorStub;
 import graphql.execution.ExecutionContext;
 import graphql.execution.ExecutionPath;
 import graphql.language.Field;
@@ -33,17 +34,20 @@ class FieldValidationSupport {
                 executionContext.getOperationDefinition().getName(),
                 executionContext.getVariables()
         );
-        queryTraversal.visitPreOrder(traversalEnv -> {
-            Field field = traversalEnv.getField();
-            if (field.getArguments() != null && !field.getArguments().isEmpty()) {
-                //
-                // only fields that have arguments make any sense to placed in play
-                // since only they have variable input
-                FieldAndArguments fieldArguments = new FieldAndArgumentsImpl(traversalEnv);
-                ExecutionPath path = fieldArguments.getPath();
-                List<FieldAndArguments> list = fieldArgumentsMap.getOrDefault(path, new ArrayList<>());
-                list.add(fieldArguments);
-                fieldArgumentsMap.put(path, list);
+        queryTraversal.visitPreOrder(new QueryVisitorStub() {
+            @Override
+            public void visitField(QueryVisitorFieldEnvironment env) {
+                Field field = env.getField();
+                if (field.getArguments() != null && !field.getArguments().isEmpty()) {
+                    //
+                    // only fields that have arguments make any sense to placed in play
+                    // since only they have variable input
+                    FieldAndArguments fieldArguments = new FieldAndArgumentsImpl(env);
+                    ExecutionPath path = fieldArguments.getPath();
+                    List<FieldAndArguments> list = fieldArgumentsMap.getOrDefault(path, new ArrayList<>());
+                    list.add(fieldArguments);
+                    fieldArgumentsMap.put(path, list);
+                }
             }
         });
 

--- a/src/main/java/graphql/execution/instrumentation/fieldvalidation/FieldValidationSupport.java
+++ b/src/main/java/graphql/execution/instrumentation/fieldvalidation/FieldValidationSupport.java
@@ -28,12 +28,13 @@ class FieldValidationSupport {
 
         Map<ExecutionPath, List<FieldAndArguments>> fieldArgumentsMap = new LinkedHashMap<>();
 
-        QueryTraversal queryTraversal = new QueryTraversal(
-                executionContext.getGraphQLSchema(),
-                executionContext.getDocument(),
-                executionContext.getOperationDefinition().getName(),
-                executionContext.getVariables()
-        );
+        QueryTraversal queryTraversal = QueryTraversal.newQueryTraversal()
+                .schema(executionContext.getGraphQLSchema())
+                .document(executionContext.getDocument())
+                .operationName(executionContext.getOperationDefinition().getName())
+                .variables(executionContext.getVariables())
+                .build();
+
         queryTraversal.visitPreOrder(new QueryVisitorStub() {
             @Override
             public void visitField(QueryVisitorFieldEnvironment env) {

--- a/src/main/java/graphql/execution/instrumentation/fieldvalidation/FieldValidationSupport.java
+++ b/src/main/java/graphql/execution/instrumentation/fieldvalidation/FieldValidationSupport.java
@@ -4,7 +4,7 @@ import graphql.ErrorType;
 import graphql.GraphQLError;
 import graphql.Internal;
 import graphql.analysis.QueryTraversal;
-import graphql.analysis.QueryVisitorEnvironment;
+import graphql.analysis.QueryVisitorFieldEnvironment;
 import graphql.execution.ExecutionContext;
 import graphql.execution.ExecutionPath;
 import graphql.language.Field;
@@ -54,26 +54,26 @@ class FieldValidationSupport {
     }
 
     private static class FieldAndArgumentsImpl implements FieldAndArguments {
-        private final QueryVisitorEnvironment traversalEnv;
+        private final QueryVisitorFieldEnvironment traversalEnv;
         private final FieldAndArguments parentArgs;
         private final ExecutionPath path;
 
-        FieldAndArgumentsImpl(QueryVisitorEnvironment traversalEnv) {
+        FieldAndArgumentsImpl(QueryVisitorFieldEnvironment traversalEnv) {
             this.traversalEnv = traversalEnv;
             this.parentArgs = mkParentArgs(traversalEnv);
             this.path = mkPath(traversalEnv);
         }
 
-        private FieldAndArguments mkParentArgs(QueryVisitorEnvironment traversalEnv) {
+        private FieldAndArguments mkParentArgs(QueryVisitorFieldEnvironment traversalEnv) {
             return traversalEnv.getParentEnvironment() != null ? new FieldAndArgumentsImpl(traversalEnv.getParentEnvironment()) : null;
         }
 
-        private ExecutionPath mkPath(QueryVisitorEnvironment traversalEnv) {
-            QueryVisitorEnvironment parentEnvironment = traversalEnv.getParentEnvironment();
+        private ExecutionPath mkPath(QueryVisitorFieldEnvironment traversalEnv) {
+            QueryVisitorFieldEnvironment parentEnvironment = traversalEnv.getParentEnvironment();
             if (parentEnvironment == null) {
                 return ExecutionPath.rootPath().segment(traversalEnv.getField().getName());
             } else {
-                Stack<QueryVisitorEnvironment> stack = new Stack<>();
+                Stack<QueryVisitorFieldEnvironment> stack = new Stack<>();
                 stack.push(traversalEnv);
                 while (parentEnvironment != null) {
                     stack.push(parentEnvironment);
@@ -81,7 +81,7 @@ class FieldValidationSupport {
                 }
                 ExecutionPath path = ExecutionPath.rootPath();
                 while (!stack.isEmpty()) {
-                    QueryVisitorEnvironment environment = stack.pop();
+                    QueryVisitorFieldEnvironment environment = stack.pop();
                     path = path.segment(environment.getField().getName());
                 }
                 return path;

--- a/src/main/java/graphql/language/Field.java
+++ b/src/main/java/graphql/language/Field.java
@@ -16,7 +16,7 @@ import static graphql.language.NodeUtil.directivesByName;
  * This might change in the future.
  */
 @PublicApi
-public class Field extends AbstractNode<Field> implements Selection<Field>, SelectionSetContainer {
+public class Field extends AbstractNode<Field> implements Selection<Field>, SelectionSetContainer<Field> {
 
     private String name;
     private String alias;

--- a/src/main/java/graphql/language/Field.java
+++ b/src/main/java/graphql/language/Field.java
@@ -12,11 +12,11 @@ import java.util.Map;
 import static graphql.language.NodeUtil.directivesByName;
 
 /*
-* This is provided to a DataFetcher, therefore it is a public API.
-* This might change in the future.
+ * This is provided to a DataFetcher, therefore it is a public API.
+ * This might change in the future.
  */
 @PublicApi
-public class Field extends AbstractNode<Field> implements Selection<Field> {
+public class Field extends AbstractNode<Field> implements Selection<Field>, SelectionSetContainer {
 
     private String name;
     private String alias;

--- a/src/main/java/graphql/language/FragmentDefinition.java
+++ b/src/main/java/graphql/language/FragmentDefinition.java
@@ -15,7 +15,7 @@ import static graphql.language.NodeUtil.directivesByName;
  * Provided to the DataFetcher, therefore public API
  */
 @PublicApi
-public class FragmentDefinition extends AbstractNode<FragmentDefinition> implements Definition<FragmentDefinition>, SelectionSetContainer {
+public class FragmentDefinition extends AbstractNode<FragmentDefinition> implements Definition<FragmentDefinition>, SelectionSetContainer<FragmentDefinition> {
 
     private String name;
     private TypeName typeCondition;

--- a/src/main/java/graphql/language/FragmentDefinition.java
+++ b/src/main/java/graphql/language/FragmentDefinition.java
@@ -15,7 +15,7 @@ import static graphql.language.NodeUtil.directivesByName;
  * Provided to the DataFetcher, therefore public API
  */
 @PublicApi
-public class FragmentDefinition extends AbstractNode<FragmentDefinition> implements Definition<FragmentDefinition> {
+public class FragmentDefinition extends AbstractNode<FragmentDefinition> implements Definition<FragmentDefinition>, SelectionSetContainer {
 
     private String name;
     private TypeName typeCondition;

--- a/src/main/java/graphql/language/InlineFragment.java
+++ b/src/main/java/graphql/language/InlineFragment.java
@@ -10,7 +10,7 @@ import java.util.Map;
 
 import static graphql.language.NodeUtil.directivesByName;
 
-public class InlineFragment extends AbstractNode<InlineFragment> implements Selection<InlineFragment>, SelectionSetContainer {
+public class InlineFragment extends AbstractNode<InlineFragment> implements Selection<InlineFragment>, SelectionSetContainer<InlineFragment> {
     private TypeName typeCondition;
     private List<Directive> directives;
     private SelectionSet selectionSet;

--- a/src/main/java/graphql/language/InlineFragment.java
+++ b/src/main/java/graphql/language/InlineFragment.java
@@ -10,7 +10,7 @@ import java.util.Map;
 
 import static graphql.language.NodeUtil.directivesByName;
 
-public class InlineFragment extends AbstractNode<InlineFragment> implements Selection<InlineFragment> {
+public class InlineFragment extends AbstractNode<InlineFragment> implements Selection<InlineFragment>, SelectionSetContainer {
     private TypeName typeCondition;
     private List<Directive> directives;
     private SelectionSet selectionSet;

--- a/src/main/java/graphql/language/NodeUtil.java
+++ b/src/main/java/graphql/language/NodeUtil.java
@@ -42,6 +42,18 @@ public class NodeUtil {
         public Map<String, FragmentDefinition> fragmentsByName;
     }
 
+    public static Map<String, FragmentDefinition> getFragmentsByName(Document document) {
+        Map<String, FragmentDefinition> fragmentsByName = new LinkedHashMap<>();
+
+        for (Definition definition : document.getDefinitions()) {
+            if (definition instanceof FragmentDefinition) {
+                FragmentDefinition fragmentDefinition = (FragmentDefinition) definition;
+                fragmentsByName.put(fragmentDefinition.getName(), fragmentDefinition);
+            }
+        }
+        return fragmentsByName;
+    }
+
     public static GetOperationResult getOperation(Document document, String operationName) {
 
 

--- a/src/main/java/graphql/language/OperationDefinition.java
+++ b/src/main/java/graphql/language/OperationDefinition.java
@@ -10,7 +10,7 @@ import java.util.Map;
 
 import static graphql.language.NodeUtil.directivesByName;
 
-public class OperationDefinition extends AbstractNode<OperationDefinition> implements Definition<OperationDefinition>, SelectionSetContainer {
+public class OperationDefinition extends AbstractNode<OperationDefinition> implements Definition<OperationDefinition>, SelectionSetContainer<OperationDefinition> {
 
     public enum Operation {
         QUERY, MUTATION, SUBSCRIPTION

--- a/src/main/java/graphql/language/OperationDefinition.java
+++ b/src/main/java/graphql/language/OperationDefinition.java
@@ -10,7 +10,7 @@ import java.util.Map;
 
 import static graphql.language.NodeUtil.directivesByName;
 
-public class OperationDefinition extends AbstractNode<OperationDefinition> implements Definition<OperationDefinition> {
+public class OperationDefinition extends AbstractNode<OperationDefinition> implements Definition<OperationDefinition>, SelectionSetContainer {
 
     public enum Operation {
         QUERY, MUTATION, SUBSCRIPTION

--- a/src/main/java/graphql/language/Selection.java
+++ b/src/main/java/graphql/language/Selection.java
@@ -2,9 +2,4 @@ package graphql.language;
 
 
 public interface Selection<T extends Selection> extends Node<T> {
-
-    /**
-     * @return a deep copy of this selection
-     */
-    T deepCopy();
 }

--- a/src/main/java/graphql/language/SelectionSetContainer.java
+++ b/src/main/java/graphql/language/SelectionSetContainer.java
@@ -1,0 +1,5 @@
+package graphql.language;
+
+public interface SelectionSetContainer {
+    SelectionSet getSelectionSet();
+}

--- a/src/main/java/graphql/language/SelectionSetContainer.java
+++ b/src/main/java/graphql/language/SelectionSetContainer.java
@@ -1,5 +1,6 @@
 package graphql.language;
 
-public interface SelectionSetContainer {
+
+public interface SelectionSetContainer<T extends Node> extends Node<T> {
     SelectionSet getSelectionSet();
 }

--- a/src/test/groovy/graphql/analysis/QueryTraversalTest.groovy
+++ b/src/test/groovy/graphql/analysis/QueryTraversalTest.groovy
@@ -133,11 +133,11 @@ class QueryTraversalTest extends Specification {
         queryTraversal.visitPreOrder(visitor)
 
         then:
-        1 * visitor.visitInlineFragment({ QueryVisitorInlineFragmentEnvironment env -> env.inlineFragment == inlineFragmentRoot })
+        1 * visitor.visitInlineFragment({ QueryVisitorInlineFragmentEnvironmentImpl env -> env.inlineFragment == inlineFragmentRoot })
         then:
-        1 * visitor.visitInlineFragment({ QueryVisitorInlineFragmentEnvironment env -> env.inlineFragment == inlineFragmentLeft })
+        1 * visitor.visitInlineFragment({ QueryVisitorInlineFragmentEnvironmentImpl env -> env.inlineFragment == inlineFragmentLeft })
         then:
-        1 * visitor.visitInlineFragment({ QueryVisitorInlineFragmentEnvironment env -> env.inlineFragment == inlineFragmentRight })
+        1 * visitor.visitInlineFragment({ QueryVisitorInlineFragmentEnvironmentImpl env -> env.inlineFragment == inlineFragmentRight })
 
     }
 
@@ -177,11 +177,11 @@ class QueryTraversalTest extends Specification {
         queryTraversal.visitPostOrder(visitor)
 
         then:
-        1 * visitor.visitInlineFragment({ QueryVisitorInlineFragmentEnvironment env -> env.inlineFragment == inlineFragmentLeft })
+        1 * visitor.visitInlineFragment({ QueryVisitorInlineFragmentEnvironmentImpl env -> env.inlineFragment == inlineFragmentLeft })
         then:
-        1 * visitor.visitInlineFragment({ QueryVisitorInlineFragmentEnvironment env -> env.inlineFragment == inlineFragmentRight })
+        1 * visitor.visitInlineFragment({ QueryVisitorInlineFragmentEnvironmentImpl env -> env.inlineFragment == inlineFragmentRight })
         then:
-        1 * visitor.visitInlineFragment({ QueryVisitorInlineFragmentEnvironment env -> env.inlineFragment == inlineFragmentRoot })
+        1 * visitor.visitInlineFragment({ QueryVisitorInlineFragmentEnvironmentImpl env -> env.inlineFragment == inlineFragmentRoot })
 
     }
 
@@ -231,11 +231,11 @@ class QueryTraversalTest extends Specification {
         queryTraversal.visitPreOrder(visitor)
 
         then:
-        1 * visitor.visitFragmentSpread({ QueryVisitorFragmentSpreadEnvironment env -> env.fragmentSpread == fragmentSpreadRoot && env.fragmentDefinition == fragmentF1})
+        1 * visitor.visitFragmentSpread({ QueryVisitorFragmentSpreadEnvironmentImpl env -> env.fragmentSpread == fragmentSpreadRoot && env.fragmentDefinition == fragmentF1 })
         then:
-        1 * visitor.visitFragmentSpread({ QueryVisitorFragmentSpreadEnvironment env -> env.fragmentSpread == fragmentSpreadLeft && env.fragmentDefinition == fragmentF2 })
+        1 * visitor.visitFragmentSpread({ QueryVisitorFragmentSpreadEnvironmentImpl env -> env.fragmentSpread == fragmentSpreadLeft && env.fragmentDefinition == fragmentF2 })
         then:
-        1 * visitor.visitFragmentSpread({ QueryVisitorFragmentSpreadEnvironment env -> env.fragmentSpread == fragmentSpreadRight && env.fragmentDefinition == fragmentF3 })
+        1 * visitor.visitFragmentSpread({ QueryVisitorFragmentSpreadEnvironmentImpl env -> env.fragmentSpread == fragmentSpreadRight && env.fragmentDefinition == fragmentF3 })
 
     }
 
@@ -285,11 +285,11 @@ class QueryTraversalTest extends Specification {
         queryTraversal.visitPostOrder(visitor)
 
         then:
-        1 * visitor.visitFragmentSpread({ QueryVisitorFragmentSpreadEnvironment env -> env.fragmentSpread == fragmentSpreadLeft && env.fragmentDefinition == fragmentF2 })
+        1 * visitor.visitFragmentSpread({ QueryVisitorFragmentSpreadEnvironmentImpl env -> env.fragmentSpread == fragmentSpreadLeft && env.fragmentDefinition == fragmentF2 })
         then:
-        1 * visitor.visitFragmentSpread({ QueryVisitorFragmentSpreadEnvironment env -> env.fragmentSpread == fragmentSpreadRight && env.fragmentDefinition == fragmentF3 })
+        1 * visitor.visitFragmentSpread({ QueryVisitorFragmentSpreadEnvironmentImpl env -> env.fragmentSpread == fragmentSpreadRight && env.fragmentDefinition == fragmentF3 })
         then:
-        1 * visitor.visitFragmentSpread({ QueryVisitorFragmentSpreadEnvironment env -> env.fragmentSpread == fragmentSpreadRoot && env.fragmentDefinition == fragmentF1})
+        1 * visitor.visitFragmentSpread({ QueryVisitorFragmentSpreadEnvironmentImpl env -> env.fragmentSpread == fragmentSpreadRoot && env.fragmentDefinition == fragmentF1 })
 
     }
 

--- a/src/test/groovy/graphql/analysis/QueryTraversalTest.groovy
+++ b/src/test/groovy/graphql/analysis/QueryTraversalTest.groovy
@@ -39,7 +39,7 @@ class QueryTraversalTest extends Specification {
                 subFoo: String  
             }
         """)
-        def visitor = Mock(FieldVisitor)
+        def visitor = Mock(QueryVisitor)
         def query = createQuery("""
             {foo { subFoo} bar }
             """)
@@ -74,7 +74,7 @@ class QueryTraversalTest extends Specification {
                 subFoo: String  
             }
         """)
-        def visitor = Mock(FieldVisitor)
+        def visitor = Mock(QueryVisitor)
         def query = createQuery("""
             {foo { subFoo} bar }
             """)
@@ -110,7 +110,7 @@ class QueryTraversalTest extends Specification {
             }
             schema {mutation: Mutation, query: Query}
         """)
-        def visitor = Mock(FieldVisitor)
+        def visitor = Mock(QueryVisitor)
         def query = createQuery("""
             mutation M{bar foo { subFoo} }
             """)
@@ -149,7 +149,7 @@ class QueryTraversalTest extends Specification {
             }
             schema {subscription: Subscription, query: Query}
         """)
-        def visitor = Mock(FieldVisitor)
+        def visitor = Mock(QueryVisitor)
         def query = createQuery("""
             subscription S{bar foo { subFoo} }
             """)
@@ -181,7 +181,7 @@ class QueryTraversalTest extends Specification {
                 foo(arg1: String, arg2: Boolean): String
             }
         """)
-        def visitor = Mock(FieldVisitor)
+        def visitor = Mock(QueryVisitor)
         def query = createQuery("""
             query myQuery(\$myVar: String){foo(arg1: \$myVar, arg2: true)} 
             """)
@@ -213,7 +213,7 @@ class QueryTraversalTest extends Specification {
                 subFoo: String  
             }
         """)
-        def visitor = Mock(FieldVisitor)
+        def visitor = Mock(QueryVisitor)
         def query = createQuery("""
             {bar foo { subFoo} }
             """)
@@ -250,7 +250,7 @@ class QueryTraversalTest extends Specification {
                 subFoo: String  
             }
         """)
-        def visitor = Mock(FieldVisitor)
+        def visitor = Mock(QueryVisitor)
         def query = createQuery("""
             {bar foo { subFoo} foo2 { subFoo} foo3 { subFoo}}
             """)
@@ -286,7 +286,7 @@ class QueryTraversalTest extends Specification {
                 subFoo: String  
             }
         """)
-        def visitor = Mock(FieldVisitor)
+        def visitor = Mock(QueryVisitor)
         def query = createQuery("""
             {
                 bar 
@@ -331,7 +331,7 @@ class QueryTraversalTest extends Specification {
                 subFoo: String  
             }
         """)
-        def visitor = Mock(FieldVisitor)
+        def visitor = Mock(QueryVisitor)
         def query = createQuery("""
             {
                 bar 
@@ -374,7 +374,7 @@ class QueryTraversalTest extends Specification {
                 subFoo: String  
             }
         """)
-        def visitor = Mock(FieldVisitor)
+        def visitor = Mock(QueryVisitor)
         def query = createQuery("""
             {
                 bar 
@@ -421,7 +421,7 @@ class QueryTraversalTest extends Specification {
                 subFoo: String  
             }
         """)
-        def visitor = Mock(FieldVisitor)
+        def visitor = Mock(QueryVisitor)
         def query = createQuery("""
             {
                 bar 
@@ -460,7 +460,7 @@ class QueryTraversalTest extends Specification {
                 subFoo: String  
             }
         """)
-        def visitor = Mock(FieldVisitor)
+        def visitor = Mock(QueryVisitor)
         def query = createQuery("""
             query MyQuery(\$variableFoo: Boolean) {
                 bar 
@@ -503,7 +503,7 @@ class QueryTraversalTest extends Specification {
                 otherString: String
             }
         """)
-        def visitor = Mock(FieldVisitor)
+        def visitor = Mock(QueryVisitor)
         def query = createQuery("""
             query MyQuery(\$variableFoo: Boolean) {
                 bar 
@@ -565,7 +565,7 @@ class QueryTraversalTest extends Specification {
                 otherString: String
             }
         """)
-        def visitor = Mock(FieldVisitor)
+        def visitor = Mock(QueryVisitor)
         def query = createQuery("""
             query MyQuery(\$variableFoo: Boolean) {
                 bar 
@@ -606,7 +606,7 @@ class QueryTraversalTest extends Specification {
                 otherString: String
             }
         """)
-        def visitor = Mock(FieldVisitor)
+        def visitor = Mock(QueryVisitor)
         def query = createQuery("""
             query MyQuery(\$variableFoo: Boolean) {
                 bar 
@@ -646,7 +646,7 @@ class QueryTraversalTest extends Specification {
                 otherString: String
             }
         """)
-        def visitor = Mock(FieldVisitor)
+        def visitor = Mock(QueryVisitor)
         def query = createQuery("""
             query MyQuery(\$variableFoo: Boolean) {
                 bar 
@@ -746,7 +746,7 @@ class QueryTraversalTest extends Specification {
             
             schema {query: Query}
         """)
-        def visitor = Mock(FieldVisitor)
+        def visitor = Mock(QueryVisitor)
         def query = createQuery("""
             {a {id... on Person {name}}}
         """)
@@ -784,7 +784,7 @@ class QueryTraversalTest extends Specification {
             
             schema {query: Query}
         """)
-        def visitor = Mock(FieldVisitor)
+        def visitor = Mock(QueryVisitor)
         def query = createQuery("""
             {foo {... on Cat {catName} ... on Dog {dogName}} }
         """)
@@ -814,7 +814,7 @@ class QueryTraversalTest extends Specification {
                 subFoo: String  
             }
         """)
-        def visitor = Mock(FieldVisitor)
+        def visitor = Mock(QueryVisitor)
         def query = createQuery("""
             {foo {__typename subFoo} 
             __schema{  types { name } }
@@ -859,7 +859,7 @@ class QueryTraversalTest extends Specification {
                 field2 : String
             }
         """)
-        def visitor = Mock(FieldVisitor)
+        def visitor = Mock(QueryVisitor)
         def query = createQuery("""
             {
             someObject {
@@ -907,7 +907,7 @@ class QueryTraversalTest extends Specification {
                id: String 
             }
         """)
-        def visitor = Mock(FieldVisitor)
+        def visitor = Mock(QueryVisitor)
         def query = createQuery("""
             {foo { subFoo {id}} }
             """)

--- a/src/test/groovy/graphql/analysis/QueryTraversalTest.groovy
+++ b/src/test/groovy/graphql/analysis/QueryTraversalTest.groovy
@@ -1137,13 +1137,8 @@ class QueryTraversalTest extends Specification {
 
     @Unroll
     def "builder doesn't allow ambiguous arguments"() {
-//        def document = createQuery("""
-//            {foo}
-//            """)
-//        def root = new Field()
-
         when:
-        def queryTraversal = QueryTraversal.newQueryTraversal()
+        QueryTraversal.newQueryTraversal()
                 .document(document)
                 .operationName(operationName)
                 .root(root)

--- a/src/test/groovy/graphql/analysis/QueryTraversalTest.groovy
+++ b/src/test/groovy/graphql/analysis/QueryTraversalTest.groovy
@@ -1,7 +1,11 @@
 package graphql.analysis
 
 import graphql.TestUtil
-import graphql.language.*
+import graphql.language.Document
+import graphql.language.Field
+import graphql.language.FragmentDefinition
+import graphql.language.FragmentSpread
+import graphql.language.InlineFragment
 import graphql.parser.Parser
 import graphql.schema.GraphQLSchema
 import spock.lang.Specification
@@ -45,10 +49,11 @@ class QueryTraversalTest extends Specification {
         queryTraversal.visitPreOrder(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Query" &&
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it ->
+            it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Query" &&
         it.selectionSetContainer == null})
         then:
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it ->
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it ->
             it.field.name == "subFoo" && it.fieldDefinition.type.name == "String" &&
                     it.parentType.name == "Foo" &&
                     it.parentEnvironment.field.name == "foo" && it.parentEnvironment.fieldDefinition.type.name == "Foo" &&
@@ -56,7 +61,7 @@ class QueryTraversalTest extends Specification {
 
         })
         then:
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
 
     }
 
@@ -80,15 +85,15 @@ class QueryTraversalTest extends Specification {
         queryTraversal.visitPostOrder(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it ->
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it ->
             it.field.name == "subFoo" && it.fieldDefinition.type.name == "String" &&
                     it.parentType.name == "Foo" &&
                     it.parentEnvironment.field.name == "foo" && it.parentEnvironment.fieldDefinition.type.name == "Foo"
         })
         then:
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Query" })
         then:
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
 
     }
 
@@ -312,9 +317,9 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Mutation" })
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Mutation" })
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it ->
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Mutation" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Mutation" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it ->
             it.field.name == "subFoo" && it.fieldDefinition.type.name == "String" &&
                     it.parentType.name == "Foo" &&
                     it.parentEnvironment.field.name == "foo" && it.parentEnvironment.fieldDefinition.type.name == "Foo"
@@ -351,9 +356,9 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Subscription" })
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Subscription" })
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it ->
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Subscription" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Subscription" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it ->
             it.field.name == "subFoo" && it.fieldDefinition.type.name == "String" &&
                     it.parentType.name == "Foo" &&
                     it.parentEnvironment.field.name == "foo" && it.parentEnvironment.fieldDefinition.type.name == "Foo"
@@ -383,7 +388,7 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it ->
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it ->
             it.field.name == "foo" &&
                     it.arguments == ['arg1': 'hello', 'arg2': true]
         })
@@ -415,9 +420,9 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Query" })
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it ->
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it ->
             it.field.name == "subFoo" && it.fieldDefinition.type.name == "String" &&
                     it.parentType.name == "Foo" &&
                     it.parentEnvironment.field.name == "foo" && it.parentEnvironment.fieldDefinition.type.name == "Foo"
@@ -452,14 +457,14 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.wrappedType.name == "Foo" && it.parentType.name == "Query" })
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it ->
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "foo" && it.fieldDefinition.type.wrappedType.name == "Foo" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it ->
             it.field.name == "subFoo" && it.fieldDefinition.type.name == "String" &&
                     it.parentType.name == "Foo" &&
                     it.parentEnvironment.field.name == "foo" && it.parentEnvironment.fieldDefinition.type.wrappedType.name == "Foo"
         })
-        2 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "subFoo" })
+        2 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "subFoo" })
 
         where:
         order       | visitFn
@@ -497,9 +502,9 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Query" && it.selectionSetContainer == inlineFragment })
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it ->
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Query" && it.selectionSetContainer == inlineFragment })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it ->
             it.field.name == "subFoo" && it.fieldDefinition.type.name == "String" &&
                     it.parentType.name == "Foo" &&
                     it.parentEnvironment.field.name == "foo" && it.parentEnvironment.fieldDefinition.type.name == "Foo"
@@ -540,9 +545,9 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Query" })
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it ->
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it ->
             it.field.name == "subFoo" && it.fieldDefinition.type.name == "String" &&
                     it.parentType.name == "Foo" &&
                     it.parentEnvironment.field.name == "foo" && it.parentEnvironment.fieldDefinition.type.name == "Foo"
@@ -587,9 +592,9 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Query" && it.selectionSetContainer == fragmentDefinition })
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it ->
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Query" && it.selectionSetContainer == fragmentDefinition })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it ->
             it.field.name == "subFoo" && it.fieldDefinition.type.name == "String" &&
                     it.parentType.name == "Foo" &&
                     it.parentEnvironment.field.name == "foo" && it.parentEnvironment.fieldDefinition.type.name == "Foo"
@@ -632,7 +637,7 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
         0 * visitor.visitField(*_)
 
         where:
@@ -671,7 +676,7 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
         0 * visitor.visitField(*_)
 
         where:
@@ -724,12 +729,12 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        2 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo1" && it.parentType.name == "Query" })
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "string" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Foo1" })
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "subFoo" && it.fieldDefinition.type.name == "Foo2" && it.parentType.name == "Foo1" })
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it ->
-            QueryVisitorFieldEnvironment secondParent = it.parentEnvironment.parentEnvironment
+        2 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo1" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "string" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Foo1" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "subFoo" && it.fieldDefinition.type.name == "Foo2" && it.parentType.name == "Foo1" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it ->
+            QueryVisitorFieldEnvironmentImpl secondParent = it.parentEnvironment.parentEnvironment
             it.field.name == "otherString" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Foo2" &&
                     it.parentEnvironment.field.name == "subFoo" && it.parentEnvironment.fieldDefinition.type.name == "Foo2" && it.parentEnvironment.parentType.name == "Foo1" &&
                     secondParent.field.name == "foo" && secondParent.fieldDefinition.type.name == "Foo1" && secondParent.parentType.name == "Query"
@@ -773,7 +778,7 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
         0 * visitor.visitField(_)
 
         where:
@@ -813,7 +818,7 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
         0 * visitor.visitField(_)
 
         where:
@@ -851,7 +856,7 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
         0 * visitor.visitField(_)
 
         where:
@@ -948,9 +953,9 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "a" && it.fieldDefinition.type.name == "Node" && it.parentType.name == "Query" })
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "name" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Person" })
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "id" && it.fieldDefinition.type.wrappedType.name == "ID" && it.parentType.name == "Node" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "a" && it.fieldDefinition.type.name == "Node" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "name" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Person" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "id" && it.fieldDefinition.type.wrappedType.name == "ID" && it.parentType.name == "Node" })
 
         where:
         order       | visitFn
@@ -986,9 +991,9 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.name == "CatOrDog" && it.parentType.name == "Query" })
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "catName" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Cat" })
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "dogName" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Dog" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "foo" && it.fieldDefinition.type.name == "CatOrDog" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "catName" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Cat" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "dogName" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Dog" })
 
         where:
         order       | visitFn
@@ -1019,11 +1024,11 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Query" })
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "__schema" && it.fieldDefinition.type.wrappedType.name == "__Schema" && it.parentType.name == "Query" })
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "__type" && it.fieldDefinition.type.name == "__Type" && it.parentType.name == "Query" })
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "types" })
-        2 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "name" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "__schema" && it.fieldDefinition.type.wrappedType.name == "__Schema" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "__type" && it.fieldDefinition.type.name == "__Type" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "types" })
+        2 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "name" })
 
         where:
         order       | visitFn
@@ -1073,11 +1078,11 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "someObject" && it.fieldDefinition.type.name == "SomeObject" && it.parentType.name == "Query" })
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "someUnionType" && it.fieldDefinition.type.name == "SomeUnionType" && it.parentType.name == "SomeObject" })
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "__typename" && it.fieldDefinition.type.wrappedType.name == "String" })
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "field1" && it.fieldDefinition.type.name == "String" && it.parentType.name == "TypeX" })
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "field2" && it.fieldDefinition.type.name == "String" && it.parentType.name == "TypeY" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "someObject" && it.fieldDefinition.type.name == "SomeObject" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "someUnionType" && it.fieldDefinition.type.name == "SomeUnionType" && it.parentType.name == "SomeObject" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "__typename" && it.fieldDefinition.type.wrappedType.name == "String" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "field1" && it.fieldDefinition.type.name == "String" && it.parentType.name == "TypeX" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "field2" && it.fieldDefinition.type.name == "String" && it.parentType.name == "TypeY" })
 
         where:
         order       | visitFn
@@ -1119,11 +1124,11 @@ class QueryTraversalTest extends Specification {
         queryTraversal.visitPreOrder(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it ->
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it ->
             it.field.name == "subFoo" && it.fieldDefinition.type.name == "SubFoo"
         })
         then:
-        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "id" && it.fieldDefinition.type.name == "String" && it.parentType.name == "SubFoo" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it -> it.field.name == "id" && it.fieldDefinition.type.name == "String" && it.parentType.name == "SubFoo" })
 
     }
 

--- a/src/test/groovy/graphql/analysis/QueryTraversalTest.groovy
+++ b/src/test/groovy/graphql/analysis/QueryTraversalTest.groovy
@@ -48,10 +48,10 @@ class QueryTraversalTest extends Specification {
         queryTraversal.visitPreOrder(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Query" &&
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Query" &&
         it.selectionSetContainer == null})
         then:
-        1 * visitor.visitField({ QueryVisitorEnvironment it ->
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it ->
             it.field.name == "subFoo" && it.fieldDefinition.type.name == "String" &&
                     it.parentType.name == "Foo" &&
                     it.parentEnvironment.field.name == "foo" && it.parentEnvironment.fieldDefinition.type.name == "Foo" &&
@@ -59,7 +59,7 @@ class QueryTraversalTest extends Specification {
 
         })
         then:
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
 
     }
 
@@ -83,15 +83,15 @@ class QueryTraversalTest extends Specification {
         queryTraversal.visitPostOrder(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorEnvironment it ->
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it ->
             it.field.name == "subFoo" && it.fieldDefinition.type.name == "String" &&
                     it.parentType.name == "Foo" &&
                     it.parentEnvironment.field.name == "foo" && it.parentEnvironment.fieldDefinition.type.name == "Foo"
         })
         then:
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Query" })
         then:
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
 
     }
 
@@ -119,9 +119,9 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Mutation" })
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Mutation" })
-        1 * visitor.visitField({ QueryVisitorEnvironment it ->
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Mutation" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Mutation" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it ->
             it.field.name == "subFoo" && it.fieldDefinition.type.name == "String" &&
                     it.parentType.name == "Foo" &&
                     it.parentEnvironment.field.name == "foo" && it.parentEnvironment.fieldDefinition.type.name == "Foo"
@@ -158,9 +158,9 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Subscription" })
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Subscription" })
-        1 * visitor.visitField({ QueryVisitorEnvironment it ->
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Subscription" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Subscription" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it ->
             it.field.name == "subFoo" && it.fieldDefinition.type.name == "String" &&
                     it.parentType.name == "Foo" &&
                     it.parentEnvironment.field.name == "foo" && it.parentEnvironment.fieldDefinition.type.name == "Foo"
@@ -190,7 +190,7 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorEnvironment it ->
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it ->
             it.field.name == "foo" &&
                     it.arguments == ['arg1': 'hello', 'arg2': true]
         })
@@ -222,9 +222,9 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Query" })
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
-        1 * visitor.visitField({ QueryVisitorEnvironment it ->
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it ->
             it.field.name == "subFoo" && it.fieldDefinition.type.name == "String" &&
                     it.parentType.name == "Foo" &&
                     it.parentEnvironment.field.name == "foo" && it.parentEnvironment.fieldDefinition.type.name == "Foo"
@@ -259,14 +259,14 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.wrappedType.name == "Foo" && it.parentType.name == "Query" })
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
-        1 * visitor.visitField({ QueryVisitorEnvironment it ->
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.wrappedType.name == "Foo" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it ->
             it.field.name == "subFoo" && it.fieldDefinition.type.name == "String" &&
                     it.parentType.name == "Foo" &&
                     it.parentEnvironment.field.name == "foo" && it.parentEnvironment.fieldDefinition.type.wrappedType.name == "Foo"
         })
-        2 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "subFoo" })
+        2 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "subFoo" })
 
         where:
         order       | visitFn
@@ -304,9 +304,9 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Query" && it.selectionSetContainer == inlineFragment })
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
-        1 * visitor.visitField({ QueryVisitorEnvironment it ->
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Query" && it.selectionSetContainer == inlineFragment })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it ->
             it.field.name == "subFoo" && it.fieldDefinition.type.name == "String" &&
                     it.parentType.name == "Foo" &&
                     it.parentEnvironment.field.name == "foo" && it.parentEnvironment.fieldDefinition.type.name == "Foo"
@@ -347,9 +347,9 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Query" })
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
-        1 * visitor.visitField({ QueryVisitorEnvironment it ->
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it ->
             it.field.name == "subFoo" && it.fieldDefinition.type.name == "String" &&
                     it.parentType.name == "Foo" &&
                     it.parentEnvironment.field.name == "foo" && it.parentEnvironment.fieldDefinition.type.name == "Foo"
@@ -394,9 +394,9 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Query"  && it.selectionSetContainer == fragmentDefinition})
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
-        1 * visitor.visitField({ QueryVisitorEnvironment it ->
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Query"  && it.selectionSetContainer == fragmentDefinition})
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it ->
             it.field.name == "subFoo" && it.fieldDefinition.type.name == "String" &&
                     it.parentType.name == "Foo" &&
                     it.parentEnvironment.field.name == "foo" && it.parentEnvironment.fieldDefinition.type.name == "Foo"
@@ -439,7 +439,7 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
         0 * visitor.visitField(*_)
 
         where:
@@ -478,7 +478,7 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
         0 * visitor.visitField(*_)
 
         where:
@@ -531,12 +531,12 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        2 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo1" && it.parentType.name == "Query" })
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "string" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Foo1" })
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "subFoo" && it.fieldDefinition.type.name == "Foo2" && it.parentType.name == "Foo1" })
-        1 * visitor.visitField({ QueryVisitorEnvironment it ->
-            QueryVisitorEnvironment secondParent = it.parentEnvironment.parentEnvironment
+        2 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo1" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "string" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Foo1" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "subFoo" && it.fieldDefinition.type.name == "Foo2" && it.parentType.name == "Foo1" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it ->
+            QueryVisitorFieldEnvironment secondParent = it.parentEnvironment.parentEnvironment
             it.field.name == "otherString" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Foo2" &&
                     it.parentEnvironment.field.name == "subFoo" && it.parentEnvironment.fieldDefinition.type.name == "Foo2" && it.parentEnvironment.parentType.name == "Foo1" &&
                     secondParent.field.name == "foo" && secondParent.fieldDefinition.type.name == "Foo1" && secondParent.parentType.name == "Query"
@@ -580,7 +580,7 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
         0 * visitor.visitField(_)
 
         where:
@@ -620,7 +620,7 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
         0 * visitor.visitField(_)
 
         where:
@@ -658,7 +658,7 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "bar" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Query" })
         0 * visitor.visitField(_)
 
         where:
@@ -755,9 +755,9 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "a" && it.fieldDefinition.type.name == "Node" && it.parentType.name == "Query" })
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "name" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Person" })
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "id" && it.fieldDefinition.type.wrappedType.name == "ID" && it.parentType.name == "Node" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "a" && it.fieldDefinition.type.name == "Node" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "name" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Person" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "id" && it.fieldDefinition.type.wrappedType.name == "ID" && it.parentType.name == "Node" })
 
         where:
         order       | visitFn
@@ -793,9 +793,9 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.name == "CatOrDog" && it.parentType.name == "Query" })
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "catName" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Cat" })
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "dogName" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Dog" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.name == "CatOrDog" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "catName" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Cat" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "dogName" && it.fieldDefinition.type.name == "String" && it.parentType.name == "Dog" })
 
         where:
         order       | visitFn
@@ -826,11 +826,11 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Query" })
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "__schema" && it.fieldDefinition.type.wrappedType.name == "__Schema" && it.parentType.name == "Query" })
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "__type" && it.fieldDefinition.type.name == "__Type" && it.parentType.name == "Query" })
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "types" })
-        2 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "name" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "foo" && it.fieldDefinition.type.name == "Foo" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "__schema" && it.fieldDefinition.type.wrappedType.name == "__Schema" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "__type" && it.fieldDefinition.type.name == "__Type" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "types" })
+        2 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "name" })
 
         where:
         order       | visitFn
@@ -880,11 +880,11 @@ class QueryTraversalTest extends Specification {
         queryTraversal."$visitFn"(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "someObject" && it.fieldDefinition.type.name == "SomeObject" && it.parentType.name == "Query" })
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "someUnionType" && it.fieldDefinition.type.name == "SomeUnionType" && it.parentType.name == "SomeObject" })
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "__typename" && it.fieldDefinition.type.wrappedType.name == "String" })
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "field1" && it.fieldDefinition.type.name == "String" && it.parentType.name == "TypeX" })
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "field2" && it.fieldDefinition.type.name == "String" && it.parentType.name == "TypeY" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "someObject" && it.fieldDefinition.type.name == "SomeObject" && it.parentType.name == "Query" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "someUnionType" && it.fieldDefinition.type.name == "SomeUnionType" && it.parentType.name == "SomeObject" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "__typename" && it.fieldDefinition.type.wrappedType.name == "String" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "field1" && it.fieldDefinition.type.name == "String" && it.parentType.name == "TypeX" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "field2" && it.fieldDefinition.type.name == "String" && it.parentType.name == "TypeY" })
 
         where:
         order       | visitFn
@@ -926,11 +926,11 @@ class QueryTraversalTest extends Specification {
         queryTraversal.visitPreOrder(visitor)
 
         then:
-        1 * visitor.visitField({ QueryVisitorEnvironment it ->
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it ->
             it.field.name == "subFoo" && it.fieldDefinition.type.name == "SubFoo"
         })
         then:
-        1 * visitor.visitField({ QueryVisitorEnvironment it -> it.field.name == "id" && it.fieldDefinition.type.name == "String" && it.parentType.name == "SubFoo" })
+        1 * visitor.visitField({ QueryVisitorFieldEnvironment it -> it.field.name == "id" && it.fieldDefinition.type.name == "String" && it.parentType.name == "SubFoo" })
 
     }
 


### PR DESCRIPTION
This makes QueryTraversal public (it was internal before)
and improves it by having an arbitrary Node as root (not only the DocumentDefintion) and adds the `SelectionSetContainer` to the environment. 