### PR TITLE
This makes @defer support first class, instead of being an experiment

### DIFF
--- a/docs/defer.rst
+++ b/docs/defer.rst
@@ -45,23 +45,7 @@ usual.  There will be the usual  ``ExecutionResult`` of initial data and then a 
 In the query above, the ``post`` data will be send out in the initial result and then the comments and review data will be sent (in query order)
 down a ``Publisher`` later.
 
-The first thing you need to put in place is including the ``defer`` directive into your schema.  It wont work without it and graphql-java will
-give you an error if you don't.
-
-
-.. code-block:: java
-
-    GraphQLSchema buildSchemaWithDirective() {
-
-        GraphQLSchema schema = buildSchema();
-        schema = schema.transform(builder ->
-                builder.additionalDirective(Directives.DeferDirective)
-        );
-        return schema;
-    }
-
-
-Then you execute your query as you would any other graphql query.  The deferred results ``Publisher`` will be given to you via
+You execute your query as you would any other graphql query.  The deferred results ``Publisher`` will be given to you via
 the ``extensions`` map
 
 

--- a/src/main/java/graphql/Directives.java
+++ b/src/main/java/graphql/Directives.java
@@ -1,7 +1,6 @@
 package graphql;
 
 
-import graphql.introspection.Introspection;
 import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLNonNull;
 
@@ -48,11 +47,10 @@ public class Directives {
             .validLocations(FIELD_DEFINITION)
             .build();
 
-    @ExperimentalApi
     public static final GraphQLDirective DeferDirective = GraphQLDirective.newDirective()
             .name("defer")
-            .description("This experimental directive allows results to be deferred during execution")
-            .validLocations(Introspection.DirectiveLocation.FIELD)
+            .description("This directive allows results to be deferred during execution")
+            .validLocations(FIELD)
             .build();
 
 }

--- a/src/main/java/graphql/schema/GraphQLSchema.java
+++ b/src/main/java/graphql/schema/GraphQLSchema.java
@@ -9,7 +9,6 @@ import graphql.schema.validation.SchemaValidator;
 import graphql.schema.visibility.GraphqlFieldVisibility;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -23,6 +22,7 @@ import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertTrue;
 import static graphql.schema.visibility.DefaultGraphqlFieldVisibility.DEFAULT_FIELD_VISIBILITY;
 import static java.lang.String.format;
+import static java.util.Arrays.asList;
 
 /**
  * The schema represents the combined type system of the graphql engine.  This is how the engine knows
@@ -69,7 +69,9 @@ public class GraphQLSchema {
         this.subscriptionType = subscriptionType;
         this.fieldVisibility = fieldVisibility;
         this.additionalTypes = additionalTypes;
-        this.directives = new LinkedHashSet<>(Arrays.asList(Directives.IncludeDirective, Directives.SkipDirective));
+        this.directives = new LinkedHashSet<>(
+                asList(Directives.IncludeDirective, Directives.SkipDirective, Directives.DeferDirective)
+        );
         this.directives.addAll(directives);
         this.typeMap = schemaUtil.allTypes(this, additionalTypes);
         this.byInterface = schemaUtil.groupImplementations(this);
@@ -242,6 +244,7 @@ public class GraphQLSchema {
             this.additionalTypes.addAll(additionalTypes);
             return this;
         }
+
         public Builder additionalType(GraphQLType additionalType) {
             this.additionalTypes.add(additionalType);
             return this;

--- a/src/test/groovy/graphql/StarWarsIntrospectionTests.groovy
+++ b/src/test/groovy/graphql/StarWarsIntrospectionTests.groovy
@@ -426,6 +426,6 @@ class StarWarsIntrospectionTests extends Specification {
         schemaParts.get('mutationType') == null
         schemaParts.get('subscriptionType') == null
         schemaParts.get('types').size() == 15
-        schemaParts.get('directives').size() == 2
+        schemaParts.get('directives').size() == 3
     }
 }

--- a/src/test/groovy/graphql/execution/defer/DeferSupportIntegrationTest.groovy
+++ b/src/test/groovy/graphql/execution/defer/DeferSupportIntegrationTest.groovy
@@ -1,6 +1,5 @@
 package graphql.execution.defer
 
-import graphql.Directives
 import graphql.ExecutionInput
 import graphql.ExecutionResult
 import graphql.GraphQL
@@ -127,9 +126,6 @@ class DeferSupportIntegrationTest extends Specification {
                 .type(newTypeWiring("Review").dataFetcher("comments", commentsFetcher))
                 .build()
         def schema = TestUtil.schema(schemaSpec, runtimeWiring)
-        schema = schema.transform({ builder ->
-            builder.additionalDirective(Directives.DeferDirective)
-        })
 
         graphQL = GraphQL.newGraphQL(schema).build()
     }


### PR DESCRIPTION
It means you don't have to add it explicitly to your schema to use it