### PR TITLE
Add support to PropertyDataFetcher for aliased props from a Map Datasource

### DIFF
--- a/src/main/java/graphql/schema/PropertyDataFetcher.java
+++ b/src/main/java/graphql/schema/PropertyDataFetcher.java
@@ -131,9 +131,22 @@ public class PropertyDataFetcher<T> implements DataFetcher<T> {
         }
 
         if (source instanceof Map) {
-            return (T) ((Map<?, ?>) source).get(propertyName);
+            return (T) getPropertyFromMap(propertyName, environment);
         }
         return (T) getPropertyViaGetter(source, environment.getFieldType());
+    }
+
+    private Object getPropertyFromMap(String propertyName, DataFetchingEnvironment env) {
+        Map<?, ?> source = env.getSource();
+        // First check if an alias was defined for the lookup field, if so, use that instead of the propertyName
+        if (env.getFields() != null && env.getFields().size() > 0) {
+            graphql.language.Field field = env.getField();
+            String alias = field.getAlias();
+            if (alias != null && !alias.isEmpty()) {
+                return source.get(alias);
+            }
+        }
+        return source.get(propertyName);
     }
 
     private Object getPropertyViaGetter(Object object, GraphQLOutputType outputType) {

--- a/src/test/groovy/graphql/schema/PropertyDataFetcherTest.groovy
+++ b/src/test/groovy/graphql/schema/PropertyDataFetcherTest.groovy
@@ -1,6 +1,7 @@
 package graphql.schema
 
 import graphql.execution.ExecutionContext
+import graphql.language.Field
 import graphql.schema.somepackage.TestClass
 import graphql.schema.somepackage.TwoClassesDown
 import spock.lang.Specification
@@ -11,10 +12,16 @@ import static graphql.schema.DataFetchingEnvironmentBuilder.newDataFetchingEnvir
 
 class PropertyDataFetcherTest extends Specification {
 
-    def env(obj) {
-        newDataFetchingEnvironment()
+    def env(obj, Field field=null) {
+        def env = newDataFetchingEnvironment()
                 .executionContext(Mock(ExecutionContext))
-                .source(obj).build()
+                .source(obj)
+        if (field != null) {
+            List<Field> fields = new ArrayList<>()
+            fields.add(field)
+            env.fields(fields)
+        }
+        env.build()
     }
 
     class SomeObject {
@@ -46,6 +53,14 @@ class PropertyDataFetcherTest extends Specification {
 
     def "fetch via map lookup"() {
         def environment = env(["mapProperty": "aValue"])
+        def fetcher = PropertyDataFetcher.fetching("mapProperty")
+        expect:
+        fetcher.get(environment) == "aValue"
+    }
+
+    def "fetch via map lookup_with_alias"() {
+        Field f = new Field("mapProperty", "mapPropertyAlias", null, null, null)
+        def environment = env(["mapPropertyAlias": "aValue"], f)
         def fetcher = PropertyDataFetcher.fetching("mapProperty")
         expect:
         fetcher.get(environment) == "aValue"


### PR DESCRIPTION
When the data source for the PropertyDataFetcher is a Map the keys will either be the property name or the aliased property name if the query specified an alias. Currently the PropertyDataFetcher only attempts to lookup the value by the property name which means aliased values will resolve as null.
This change checks if a field has been aliased when doing a Map lookup and attempts to retrieve the value with the alias vs the property name.

In this query case, the map for the PropertyDataFetcher will be mapped by the alias (nameAlias) not name.
```graphql
query($id: String!) {
  foo(id: $id) {
    id
    nameAlias: name
  }
}
```

I'm not sure if I should have the logic fall back to fetching by the propertyName if no value is found for the alias, this seems like it would be reasonable, but I don't have enough context to be sure if that's the correct behavior.