### PR TITLE
Fix UnresolvedTypeException not being propagated as GraphQLError

### DIFF
--- a/src/main/java/graphql/UnresolvedTypeError.java
+++ b/src/main/java/graphql/UnresolvedTypeError.java
@@ -1,0 +1,78 @@
+package graphql;
+
+import graphql.execution.ExecutionPath;
+import graphql.execution.ExecutionTypeInfo;
+import graphql.execution.UnresolvedTypeException;
+import graphql.language.SourceLocation;
+
+import java.util.List;
+
+import static graphql.Assert.assertNotNull;
+import static java.lang.String.format;
+
+@PublicApi
+public class UnresolvedTypeError implements GraphQLError {
+
+    private final String message;
+    private final List<Object> path;
+    private final UnresolvedTypeException exception;
+
+    public UnresolvedTypeError(ExecutionPath path, ExecutionTypeInfo info,
+                               UnresolvedTypeException exception) {
+        this.path = assertNotNull(path).toList();
+        this.exception = assertNotNull(exception);
+        this.message = mkMessage(path, exception, assertNotNull(info));
+    }
+
+    private String mkMessage(ExecutionPath path, UnresolvedTypeException exception, ExecutionTypeInfo info) {
+        return format("Can't resolve '%s'. Abstract type '%s' must resolve to an Object type at runtime for field '%s.%s'. %s",
+                path,
+                exception.getInterfaceOrUnionType().getName(),
+                info.getParentTypeInfo().getType().getName(),
+                info.getFieldDefinition().getName(),
+                exception.getMessage());
+    }
+
+    public UnresolvedTypeException getException() {
+        return exception;
+    }
+
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public List<SourceLocation> getLocations() {
+        return null;
+    }
+
+    @Override
+    public ErrorType getErrorType() {
+        return ErrorType.DataFetchingException;
+    }
+
+    public List<Object> getPath() {
+        return path;
+    }
+
+    @Override
+    public String toString() {
+        return "UnresolvedTypeError{" +
+                "path=" + path +
+                "exception=" + exception +
+                '}';
+    }
+
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
+    @Override
+    public boolean equals(Object o) {
+        return GraphqlErrorHelper.equals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return GraphqlErrorHelper.hashCode(this);
+    }
+}

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -6,6 +6,7 @@ import graphql.PublicSpi;
 import graphql.SerializationError;
 import graphql.TypeMismatchError;
 import graphql.TypeResolutionEnvironment;
+import graphql.UnresolvedTypeError;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldCompleteParameters;
@@ -366,13 +367,32 @@ public abstract class ExecutionStrategy {
         } else if (fieldType instanceof GraphQLEnumType) {
             return completeValueForEnum(executionContext, parameters, (GraphQLEnumType) fieldType, result);
         }
+
         //
         // when we are here, we have a complex type: Interface, Union or Object
         // and we must go deeper
         //
-        GraphQLObjectType resolvedObjectType = resolveType(executionContext, parameters, fieldType);
+        GraphQLObjectType resolvedObjectType;
+        try {
+            resolvedObjectType = resolveType(executionContext, parameters, fieldType);
+        } catch (UnresolvedTypeException ex) {
+            // consider the result to be null and add the error on the context
+            handleUnresolvedTypeProblem(executionContext, parameters, ex);
+            // and validate the field is nullable, if non-nullable throw exception
+            parameters.getNonNullFieldValidator().validate(parameters.getPath(), null);
+            // complete the field
+            return completedFuture(new ExecutionResultImpl(null, null));
+        }
 
         return completeValueForObject(executionContext, parameters, resolvedObjectType, result);
+    }
+
+    private void handleUnresolvedTypeProblem(ExecutionContext context, ExecutionStrategyParameters parameters, UnresolvedTypeException e) {
+        UnresolvedTypeError error = new UnresolvedTypeError(parameters.getPath(), parameters.getTypeInfo(), e);
+        log.warn(error.getMessage(), e);
+        context.addError(error);
+
+        parameters.deferredErrorSupport().onError(error);
     }
 
     private CompletableFuture<ExecutionResult> completeValueForNull(ExecutionStrategyParameters parameters) {
@@ -659,9 +679,10 @@ public abstract class ExecutionStrategy {
      */
     protected GraphQLObjectType resolveTypeForInterface(TypeResolutionParameters params) {
         TypeResolutionEnvironment env = new TypeResolutionEnvironment(params.getValue(), params.getArgumentValues(), params.getField(), params.getGraphQLInterfaceType(), params.getSchema(), params.getContext());
-        GraphQLObjectType result = params.getGraphQLInterfaceType().getTypeResolver().getType(env);
+        GraphQLInterfaceType abstractType = params.getGraphQLInterfaceType();
+        GraphQLObjectType result = abstractType.getTypeResolver().getType(env);
         if (result == null) {
-            throw new UnresolvedTypeException(params.getGraphQLInterfaceType());
+            throw new UnresolvedTypeException(abstractType);
         }
         return result;
     }
@@ -675,9 +696,10 @@ public abstract class ExecutionStrategy {
      */
     protected GraphQLObjectType resolveTypeForUnion(TypeResolutionParameters params) {
         TypeResolutionEnvironment env = new TypeResolutionEnvironment(params.getValue(), params.getArgumentValues(), params.getField(), params.getGraphQLUnionType(), params.getSchema(), params.getContext());
-        GraphQLObjectType result = params.getGraphQLUnionType().getTypeResolver().getType(env);
+        GraphQLUnionType abstractType = params.getGraphQLUnionType();
+        GraphQLObjectType result = abstractType.getTypeResolver().getType(env);
         if (result == null) {
-            throw new UnresolvedTypeException(params.getGraphQLUnionType());
+            throw new UnresolvedTypeException(abstractType);
         }
         return result;
     }

--- a/src/main/java/graphql/execution/UnresolvedTypeException.java
+++ b/src/main/java/graphql/execution/UnresolvedTypeException.java
@@ -13,12 +13,24 @@ public class UnresolvedTypeException extends GraphQLException {
 
     private final GraphQLOutputType interfaceOrUnionType;
 
-    public UnresolvedTypeException(GraphQLOutputType interfaceOrUnionType) {
-        super("Could not determine the exact type of '" + interfaceOrUnionType.getName() + "'");
+    /**
+     * Constructor to use a custom error message
+     * for an error that happened during type resolution.
+     *
+     * @param message              custom error message.
+     * @param interfaceOrUnionType expected type.
+     */
+    public UnresolvedTypeException(String message, GraphQLOutputType interfaceOrUnionType) {
+        super(message);
         this.interfaceOrUnionType = interfaceOrUnionType;
+    }
+
+    public UnresolvedTypeException(GraphQLOutputType interfaceOrUnionType) {
+        this("Could not determine the exact type of '" + interfaceOrUnionType.getName() + "'", interfaceOrUnionType);
     }
 
     public GraphQLOutputType getInterfaceOrUnionType() {
         return interfaceOrUnionType;
     }
+
 }

--- a/src/test/groovy/graphql/TypeResolverExecutionTest.groovy
+++ b/src/test/groovy/graphql/TypeResolverExecutionTest.groovy
@@ -1,0 +1,301 @@
+package graphql
+
+import graphql.schema.DataFetcher
+import graphql.schema.GraphQLInterfaceType
+import graphql.schema.GraphQLObjectType
+import graphql.schema.GraphQLUnionType
+import graphql.schema.TypeResolver
+import graphql.schema.idl.FieldWiringEnvironment
+import graphql.schema.idl.InterfaceWiringEnvironment
+import graphql.schema.idl.RuntimeWiring
+import graphql.schema.idl.UnionWiringEnvironment
+import graphql.schema.idl.WiringFactory
+import spock.lang.Specification
+
+import static graphql.Assert.assertShouldNeverHappen
+import static graphql.execution.ExecutionTypeInfo.unwrapBaseType
+
+class TypeResolverExecutionTest extends Specification {
+
+    def simpleTypeResolver = new TypeResolver() {
+        @Override
+        GraphQLObjectType getType(TypeResolutionEnvironment env) {
+            // returns based on fields
+            Map obj = env.object as Map
+            if (obj.containsKey('topic')) {
+                return env.getSchema().getObjectType('Conference')
+            } else if (obj.containsKey('name')) {
+                return env.getSchema().getObjectType('Concert')
+            }
+            return null
+        }
+    }
+
+    def nullTypeResolver = new TypeResolver() {
+        @Override
+        GraphQLObjectType getType(TypeResolutionEnvironment env) {
+            // it couldn't find an appropriate type
+            return null
+        }
+    }
+
+    class SimpleTestWiringFactory implements WiringFactory {
+
+        TypeResolver typeResolver
+
+        SimpleTestWiringFactory(TypeResolver typeResolver) {
+            this.typeResolver = typeResolver
+        }
+
+        @Override
+        boolean providesTypeResolver(InterfaceWiringEnvironment environment) {
+            return true
+        }
+
+        @Override
+        TypeResolver getTypeResolver(InterfaceWiringEnvironment environment) {
+            return typeResolver
+        }
+
+        @Override
+        boolean providesTypeResolver(UnionWiringEnvironment environment) {
+            return true
+        }
+
+        @Override
+        TypeResolver getTypeResolver(UnionWiringEnvironment environment) {
+            return typeResolver
+        }
+
+        @Override
+        boolean providesDataFetcher(FieldWiringEnvironment environment) {
+            if (unwrapBaseType(environment.fieldType) instanceof GraphQLInterfaceType ||
+                    unwrapBaseType(environment.fieldType) instanceof GraphQLUnionType) {
+                return true
+            }
+            return false
+        }
+
+        @Override
+        DataFetcher getDataFetcher(FieldWiringEnvironment environment) {
+            if (unwrapBaseType(environment.fieldType) instanceof GraphQLInterfaceType) {
+                return { [id: 'confOne', topic: 'Front-End technologies'] }
+            } else if (unwrapBaseType(environment.fieldType) instanceof GraphQLUnionType) {
+                return { [id: 'getLucky', name: 'Daft Punk Anniversary'] }
+            }
+            assertShouldNeverHappen()
+        }
+    }
+
+    def "happy case, type resolution should work"() {
+        def idl = """
+            type Query {
+                event: Event
+            }
+            
+            interface Event {
+                id: String
+            }
+            
+            type Concert implements Event {
+                id: String
+                name: String
+            }
+            
+            type Conference implements Event {
+                id: String
+                topic: String    
+            }
+        """
+
+        def runTimeWiring = RuntimeWiring.newRuntimeWiring()
+                .wiringFactory(new SimpleTestWiringFactory(simpleTypeResolver))
+        def schema = TestUtil.schema(idl, runTimeWiring)
+        def graphql = new GraphQL(schema)
+
+        when:
+        def res = graphql.execute('''
+            { 
+                event { 
+                    id 
+                    ...on Conference { 
+                        topic 
+                    } 
+                } 
+            }''')
+
+        then:
+        def event = (res.data as Map)['event'] as Map
+        event['id'] == 'confOne'
+        event['topic'] == 'Front-End technologies'
+        res.errors.empty
+    }
+
+    def "interface: when typeResolver returns null (meaning it couldn't find an appropriate type), it should yield a UnresolvedTypeError GraphQL error"() {
+        def idl = """
+            type Query {
+                event: Event
+            }
+            
+            interface Event {
+                id: String
+            }
+            
+            type Concert implements Event {
+                id: String
+                name: String
+            }
+            
+            type Conference implements Event {
+                id: String
+                topic: String    
+            }
+           
+        """
+
+        def runTimeWiring = RuntimeWiring.newRuntimeWiring()
+                .wiringFactory(new SimpleTestWiringFactory(nullTypeResolver))
+        def schema = TestUtil.schema(idl, runTimeWiring)
+        def graphql = new GraphQL(schema)
+
+        when:
+        def res = graphql.execute('''
+            { 
+                event { 
+                    id 
+                    ...on Conference { 
+                        topic 
+                    } 
+                } 
+            }''')
+
+        then:
+        (res.data as Map)['event'] == null
+        res.errors[0] instanceof UnresolvedTypeError
+    }
+
+
+    def "interface: when typeResolver returns null and the field is non-nullable, it should yield an UnresolvedTypeError GraphQL error"() {
+        def idl = """
+            type Query {
+                event: Event!
+            }
+            
+            interface Event {
+                id: String
+            }
+            
+            type Concert implements Event {
+                id: String
+                name: String
+            }
+            
+            type Conference implements Event {
+                id: String
+                topic: String    
+            }
+           
+        """
+
+        def runTimeWiring = RuntimeWiring.newRuntimeWiring()
+                .wiringFactory(new SimpleTestWiringFactory(nullTypeResolver))
+        def schema = TestUtil.schema(idl, runTimeWiring)
+        def graphql = new GraphQL(schema)
+
+        when:
+        def res = graphql.execute('''
+            { 
+                event { 
+                    id 
+                    ...on Conference { 
+                        topic 
+                    } 
+                } 
+            }''')
+
+        then:
+        res.data == null
+        res.errors[0] instanceof UnresolvedTypeError
+    }
+
+    def "union: when typeResolver returns null (meaning it couldn't find an appropriate type), it should yield a UnresolvedTypeError GraphQL error"() {
+        def idl = """
+            type Query {
+                event: Event
+            }
+                        
+            type Concert {
+                id: String
+                name: String
+            }
+            
+            type Conference {
+                id: String
+                topic: String    
+            }
+            
+            union Event = Concert | Conference
+        """
+
+        def runTimeWiring = RuntimeWiring.newRuntimeWiring()
+                .wiringFactory(new SimpleTestWiringFactory(nullTypeResolver))
+        def schema = TestUtil.schema(idl, runTimeWiring)
+        def graphql = new GraphQL(schema)
+
+        when:
+        def res = graphql.execute('''
+            { 
+                event { 
+                    ...on Conference { 
+                        id
+                        topic 
+                    } 
+                } 
+            }''')
+
+        then:
+        (res.data as Map)['event'] == null
+        res.errors[0] instanceof UnresolvedTypeError
+    }
+
+
+    def "union: when typeResolver returns null and the field is non-nullable, it should yield an UnresolvedTypeError GraphQL error"() {
+        def idl = """
+            type Query {
+                event: Event!
+            }
+                        
+            type Concert {
+                id: String
+                name: String
+            }
+            
+            type Conference {
+                id: String
+                topic: String    
+            }
+            
+            union Event = Concert | Conference
+        """
+
+        def runTimeWiring = RuntimeWiring.newRuntimeWiring()
+                .wiringFactory(new SimpleTestWiringFactory(nullTypeResolver))
+        def schema = TestUtil.schema(idl, runTimeWiring)
+        def graphql = new GraphQL(schema)
+
+        when:
+        def res = graphql.execute('''
+            { 
+                event { 
+                    ...on Conference { 
+                        id
+                        topic 
+                    } 
+                } 
+            }''')
+
+        then:
+        res.data == null
+        res.errors[0] instanceof UnresolvedTypeError
+    }
+}


### PR DESCRIPTION
### Description

**Current behavior:**
When a type resolver fails to find an appropriate concrete type for a given abstract type (interface or union), an `UnresolvedTypeException` is thrown, the execution is aborted and the exception is bubbled up as is back to the caller.

**Expected behavior:**
Instead, the corresponding GraphQL field should be set to `null` (if nullable) and the `UnresolvedTypeException` should be translated to a GraphQLError to be placed in the errors block of the GraphQL response. `graphql-js` handles this correctly [by validating the resolved type](https://github.com/graphql/graphql-js/blob/ef585e9db8d161e715dfaa4e70c1ed2efa58294c/src/execution/execute.js#L1016) and [throwing a GraphQLError](https://github.com/graphql/graphql-js/blob/ef585e9db8d161e715dfaa4e70c1ed2efa58294c/src/execution/execute.js#L1045) if the returned concrete type isn't valid.

### Steps to reproduce

I wrote a test to showcase the issue by simply using a TypeResolver that returns `null` for all type resolutions.

```java
def "interface: when typeResolver returns null (meaning it couldn't find an appropriate type), it should yield a UnresolvedTypeError GraphQL error"() {
        def idl = """
            type Query {
                event: Event
            }
            
            interface Event {
                id: String
            }
            
            type Concert implements Event {
                id: String
                name: String
            }
            
            type Conference implements Event {
                id: String
                topic: String    
            }
           
        """
        def runTimeWiring = RuntimeWiring.newRuntimeWiring()
                .wiringFactory(new SimpleTestWiringFactory(nullTypeResolver))
        def schema = TestUtil.schema(idl, runTimeWiring)
        def graphql = new GraphQL(schema)
        when:
        def res = graphql.execute('''
            { 
                event { 
                    id 
                    ...on Conference { 
                        topic 
                    } 
                } 
            }''')
        then:
        (res.data as Map)['event'] == null
        res.errors[0] instanceof UnresolvedTypeError
    }
```

### Fix & Testing

I added a try/catch block to handle the `UnresolvedTypeException` and "handle" it the same way we handle Serialization or Coercion errors.
Unit tests added to cover non-nullable field scenarios as well.

### Notes

While looking at the `graphql-js` implementation, I found out `graphql-java` is also not validating that the returned concrete type from the `TypeResolver` is actually a possible type of the abstract type. By "possible" it means that in case of an interface the returned concrete type must be implementing the interface type, and in case of a union, the concrete type must be one of the possible types of that union. 
The code changes are ready, but I prefer submitting a single fix per PR.