### PR TITLE
Add validation after type resolution to check if concrete type is a possible type of abstract type

### DIFF
--- a/src/main/java/graphql/UnresolvedTypeError.java
+++ b/src/main/java/graphql/UnresolvedTypeError.java
@@ -1,0 +1,78 @@
+package graphql;
+
+import graphql.execution.ExecutionPath;
+import graphql.execution.ExecutionTypeInfo;
+import graphql.execution.UnresolvedTypeException;
+import graphql.language.SourceLocation;
+
+import java.util.List;
+
+import static graphql.Assert.assertNotNull;
+import static java.lang.String.format;
+
+@PublicApi
+public class UnresolvedTypeError implements GraphQLError {
+
+    private final String message;
+    private final List<Object> path;
+    private final UnresolvedTypeException exception;
+
+    public UnresolvedTypeError(ExecutionPath path, ExecutionTypeInfo info,
+                               UnresolvedTypeException exception) {
+        this.path = assertNotNull(path).toList();
+        this.exception = assertNotNull(exception);
+        this.message = mkMessage(path, exception, assertNotNull(info));
+    }
+
+    private String mkMessage(ExecutionPath path, UnresolvedTypeException exception, ExecutionTypeInfo info) {
+        return format("Can't resolve '%s'. Abstract type '%s' must resolve to an Object type at runtime for field '%s.%s'. %s",
+                path,
+                exception.getInterfaceOrUnionType().getName(),
+                info.getParentTypeInfo().getType().getName(),
+                info.getFieldDefinition().getName(),
+                exception.getMessage());
+    }
+
+    public UnresolvedTypeException getException() {
+        return exception;
+    }
+
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public List<SourceLocation> getLocations() {
+        return null;
+    }
+
+    @Override
+    public ErrorType getErrorType() {
+        return ErrorType.DataFetchingException;
+    }
+
+    public List<Object> getPath() {
+        return path;
+    }
+
+    @Override
+    public String toString() {
+        return "UnresolvedTypeError{" +
+                "path=" + path +
+                "exception=" + exception +
+                '}';
+    }
+
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
+    @Override
+    public boolean equals(Object o) {
+        return GraphqlErrorHelper.equals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return GraphqlErrorHelper.hashCode(this);
+    }
+}

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -667,6 +667,7 @@ public abstract class ExecutionStrategy {
         } else {
             resolvedType = (GraphQLObjectType) fieldType;
         }
+
         return resolvedType;
     }
 
@@ -684,6 +685,11 @@ public abstract class ExecutionStrategy {
         if (result == null) {
             throw new UnresolvedTypeException(abstractType);
         }
+
+        if (!params.getSchema().isPossibleType(abstractType, result)) {
+            throw new UnresolvedTypeException(abstractType, result);
+        }
+
         return result;
     }
 
@@ -701,6 +707,11 @@ public abstract class ExecutionStrategy {
         if (result == null) {
             throw new UnresolvedTypeException(abstractType);
         }
+
+        if (!params.getSchema().isPossibleType(abstractType, result)) {
+            throw new UnresolvedTypeException(abstractType, result);
+        }
+
         return result;
     }
 

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -6,6 +6,7 @@ import graphql.PublicSpi;
 import graphql.SerializationError;
 import graphql.TypeMismatchError;
 import graphql.TypeResolutionEnvironment;
+import graphql.UnresolvedTypeError;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldCompleteParameters;
@@ -366,13 +367,32 @@ public abstract class ExecutionStrategy {
         } else if (fieldType instanceof GraphQLEnumType) {
             return completeValueForEnum(executionContext, parameters, (GraphQLEnumType) fieldType, result);
         }
+
         //
         // when we are here, we have a complex type: Interface, Union or Object
         // and we must go deeper
         //
-        GraphQLObjectType resolvedObjectType = resolveType(executionContext, parameters, fieldType);
+        GraphQLObjectType resolvedObjectType;
+        try {
+            resolvedObjectType = resolveType(executionContext, parameters, fieldType);
+        } catch (UnresolvedTypeException ex) {
+            // consider the result to be null and add the error on the context
+            handleUnresolvedTypeProblem(executionContext, parameters, ex);
+            // and validate the field is nullable, if non-nullable throw exception
+            parameters.getNonNullFieldValidator().validate(parameters.getPath(), null);
+            // complete the field
+            return completedFuture(new ExecutionResultImpl(null, null));
+        }
 
         return completeValueForObject(executionContext, parameters, resolvedObjectType, result);
+    }
+
+    private void handleUnresolvedTypeProblem(ExecutionContext context, ExecutionStrategyParameters parameters, UnresolvedTypeException e) {
+        UnresolvedTypeError error = new UnresolvedTypeError(parameters.getPath(), parameters.getTypeInfo(), e);
+        log.warn(error.getMessage(), e);
+        context.addError(error);
+
+        parameters.deferredErrorSupport().onError(error);
     }
 
     private CompletableFuture<ExecutionResult> completeValueForNull(ExecutionStrategyParameters parameters) {
@@ -659,9 +679,10 @@ public abstract class ExecutionStrategy {
      */
     protected GraphQLObjectType resolveTypeForInterface(TypeResolutionParameters params) {
         TypeResolutionEnvironment env = new TypeResolutionEnvironment(params.getValue(), params.getArgumentValues(), params.getField(), params.getGraphQLInterfaceType(), params.getSchema(), params.getContext());
-        GraphQLObjectType result = params.getGraphQLInterfaceType().getTypeResolver().getType(env);
+        GraphQLInterfaceType abstractType = params.getGraphQLInterfaceType();
+        GraphQLObjectType result = abstractType.getTypeResolver().getType(env);
         if (result == null) {
-            throw new UnresolvedTypeException(params.getGraphQLInterfaceType());
+            throw new UnresolvedTypeException(abstractType);
         }
         return result;
     }
@@ -675,9 +696,10 @@ public abstract class ExecutionStrategy {
      */
     protected GraphQLObjectType resolveTypeForUnion(TypeResolutionParameters params) {
         TypeResolutionEnvironment env = new TypeResolutionEnvironment(params.getValue(), params.getArgumentValues(), params.getField(), params.getGraphQLUnionType(), params.getSchema(), params.getContext());
-        GraphQLObjectType result = params.getGraphQLUnionType().getTypeResolver().getType(env);
+        GraphQLUnionType abstractType = params.getGraphQLUnionType();
+        GraphQLObjectType result = abstractType.getTypeResolver().getType(env);
         if (result == null) {
-            throw new UnresolvedTypeException(params.getGraphQLUnionType());
+            throw new UnresolvedTypeException(abstractType);
         }
         return result;
     }

--- a/src/main/java/graphql/execution/UnresolvedTypeException.java
+++ b/src/main/java/graphql/execution/UnresolvedTypeException.java
@@ -3,10 +3,11 @@ package graphql.execution;
 import graphql.GraphQLException;
 import graphql.PublicApi;
 import graphql.schema.GraphQLOutputType;
+import graphql.schema.GraphQLType;
 
 /**
  * This is thrown if a {@link graphql.schema.TypeResolver} fails to give back a concrete type
- * for an interface or union type at runtime.
+ * or provides a type that doesn't implement the given interface or union.
  */
 @PublicApi
 public class UnresolvedTypeException extends GraphQLException {
@@ -27,6 +28,11 @@ public class UnresolvedTypeException extends GraphQLException {
 
     public UnresolvedTypeException(GraphQLOutputType interfaceOrUnionType) {
         this("Could not determine the exact type of '" + interfaceOrUnionType.getName() + "'", interfaceOrUnionType);
+    }
+
+    public UnresolvedTypeException(GraphQLOutputType interfaceOrUnionType, GraphQLType providedType) {
+        this("Runtime Object type '" + providedType.getName() + "' is not a possible type for "
+                + "'" + interfaceOrUnionType.getName() + "'.", interfaceOrUnionType);
     }
 
     public GraphQLOutputType getInterfaceOrUnionType() {

--- a/src/main/java/graphql/execution/UnresolvedTypeException.java
+++ b/src/main/java/graphql/execution/UnresolvedTypeException.java
@@ -13,12 +13,24 @@ public class UnresolvedTypeException extends GraphQLException {
 
     private final GraphQLOutputType interfaceOrUnionType;
 
-    public UnresolvedTypeException(GraphQLOutputType interfaceOrUnionType) {
-        super("Could not determine the exact type of '" + interfaceOrUnionType.getName() + "'");
+    /**
+     * Constructor to use a custom error message
+     * for an error that happened during type resolution.
+     *
+     * @param message              custom error message.
+     * @param interfaceOrUnionType expected type.
+     */
+    public UnresolvedTypeException(String message, GraphQLOutputType interfaceOrUnionType) {
+        super(message);
         this.interfaceOrUnionType = interfaceOrUnionType;
+    }
+
+    public UnresolvedTypeException(GraphQLOutputType interfaceOrUnionType) {
+        this("Could not determine the exact type of '" + interfaceOrUnionType.getName() + "'", interfaceOrUnionType);
     }
 
     public GraphQLOutputType getInterfaceOrUnionType() {
         return interfaceOrUnionType;
     }
+
 }

--- a/src/test/groovy/graphql/GraphQLTest.groovy
+++ b/src/test/groovy/graphql/GraphQLTest.groovy
@@ -812,6 +812,7 @@ class GraphQLTest extends Specification {
 
         GraphQLSchema schema = newSchema()
                 .query(query)
+                .additionalType(foo)
                 .build()
 
         GraphQL graphQL = GraphQL.newGraphQL(schema)

--- a/src/test/groovy/graphql/TestUtil.groovy
+++ b/src/test/groovy/graphql/TestUtil.groovy
@@ -25,8 +25,6 @@ import graphql.schema.idl.UnionWiringEnvironment
 import graphql.schema.idl.WiringFactory
 import graphql.schema.idl.errors.SchemaProblem
 
-import java.util.EnumSet
-import java.util.Collections
 import java.util.stream.Collectors
 
 import static graphql.Scalars.GraphQLString

--- a/src/test/groovy/graphql/TypeResolverExecutionTest.groovy
+++ b/src/test/groovy/graphql/TypeResolverExecutionTest.groovy
@@ -1,0 +1,301 @@
+package graphql
+
+import graphql.schema.DataFetcher
+import graphql.schema.GraphQLInterfaceType
+import graphql.schema.GraphQLObjectType
+import graphql.schema.GraphQLUnionType
+import graphql.schema.TypeResolver
+import graphql.schema.idl.FieldWiringEnvironment
+import graphql.schema.idl.InterfaceWiringEnvironment
+import graphql.schema.idl.RuntimeWiring
+import graphql.schema.idl.UnionWiringEnvironment
+import graphql.schema.idl.WiringFactory
+import spock.lang.Specification
+
+import static graphql.Assert.assertShouldNeverHappen
+import static graphql.execution.ExecutionTypeInfo.unwrapBaseType
+
+class TypeResolverExecutionTest extends Specification {
+
+    def simpleTypeResolver = new TypeResolver() {
+        @Override
+        GraphQLObjectType getType(TypeResolutionEnvironment env) {
+            // returns based on fields
+            Map obj = env.object as Map
+            if (obj.containsKey('topic')) {
+                return env.getSchema().getObjectType('Conference')
+            } else if (obj.containsKey('name')) {
+                return env.getSchema().getObjectType('Concert')
+            }
+            return null
+        }
+    }
+
+    def nullTypeResolver = new TypeResolver() {
+        @Override
+        GraphQLObjectType getType(TypeResolutionEnvironment env) {
+            // it couldn't find an appropriate type
+            return null
+        }
+    }
+
+    class SimpleTestWiringFactory implements WiringFactory {
+
+        TypeResolver typeResolver
+
+        SimpleTestWiringFactory(TypeResolver typeResolver) {
+            this.typeResolver = typeResolver
+        }
+
+        @Override
+        boolean providesTypeResolver(InterfaceWiringEnvironment environment) {
+            return true
+        }
+
+        @Override
+        TypeResolver getTypeResolver(InterfaceWiringEnvironment environment) {
+            return typeResolver
+        }
+
+        @Override
+        boolean providesTypeResolver(UnionWiringEnvironment environment) {
+            return true
+        }
+
+        @Override
+        TypeResolver getTypeResolver(UnionWiringEnvironment environment) {
+            return typeResolver
+        }
+
+        @Override
+        boolean providesDataFetcher(FieldWiringEnvironment environment) {
+            if (unwrapBaseType(environment.fieldType) instanceof GraphQLInterfaceType ||
+                    unwrapBaseType(environment.fieldType) instanceof GraphQLUnionType) {
+                return true
+            }
+            return false
+        }
+
+        @Override
+        DataFetcher getDataFetcher(FieldWiringEnvironment environment) {
+            if (unwrapBaseType(environment.fieldType) instanceof GraphQLInterfaceType) {
+                return { [id: 'confOne', topic: 'Front-End technologies'] }
+            } else if (unwrapBaseType(environment.fieldType) instanceof GraphQLUnionType) {
+                return { [id: 'getLucky', name: 'Daft Punk Anniversary'] }
+            }
+            assertShouldNeverHappen()
+        }
+    }
+
+    def "happy case, type resolution should work"() {
+        def idl = """
+            type Query {
+                event: Event
+            }
+            
+            interface Event {
+                id: String
+            }
+            
+            type Concert implements Event {
+                id: String
+                name: String
+            }
+            
+            type Conference implements Event {
+                id: String
+                topic: String    
+            }
+        """
+
+        def runTimeWiring = RuntimeWiring.newRuntimeWiring()
+                .wiringFactory(new SimpleTestWiringFactory(simpleTypeResolver))
+        def schema = TestUtil.schema(idl, runTimeWiring)
+        def graphql = new GraphQL(schema)
+
+        when:
+        def res = graphql.execute('''
+            { 
+                event { 
+                    id 
+                    ...on Conference { 
+                        topic 
+                    } 
+                } 
+            }''')
+
+        then:
+        def event = (res.data as Map)['event'] as Map
+        event['id'] == 'confOne'
+        event['topic'] == 'Front-End technologies'
+        res.errors.empty
+    }
+
+    def "interface: when typeResolver returns null (meaning it couldn't find an appropriate type), it should yield a UnresolvedTypeError GraphQL error"() {
+        def idl = """
+            type Query {
+                event: Event
+            }
+            
+            interface Event {
+                id: String
+            }
+            
+            type Concert implements Event {
+                id: String
+                name: String
+            }
+            
+            type Conference implements Event {
+                id: String
+                topic: String    
+            }
+           
+        """
+
+        def runTimeWiring = RuntimeWiring.newRuntimeWiring()
+                .wiringFactory(new SimpleTestWiringFactory(nullTypeResolver))
+        def schema = TestUtil.schema(idl, runTimeWiring)
+        def graphql = new GraphQL(schema)
+
+        when:
+        def res = graphql.execute('''
+            { 
+                event { 
+                    id 
+                    ...on Conference { 
+                        topic 
+                    } 
+                } 
+            }''')
+
+        then:
+        (res.data as Map)['event'] == null
+        res.errors[0] instanceof UnresolvedTypeError
+    }
+
+
+    def "interface: when typeResolver returns null and the field is non-nullable, it should yield an UnresolvedTypeError GraphQL error"() {
+        def idl = """
+            type Query {
+                event: Event!
+            }
+            
+            interface Event {
+                id: String
+            }
+            
+            type Concert implements Event {
+                id: String
+                name: String
+            }
+            
+            type Conference implements Event {
+                id: String
+                topic: String    
+            }
+           
+        """
+
+        def runTimeWiring = RuntimeWiring.newRuntimeWiring()
+                .wiringFactory(new SimpleTestWiringFactory(nullTypeResolver))
+        def schema = TestUtil.schema(idl, runTimeWiring)
+        def graphql = new GraphQL(schema)
+
+        when:
+        def res = graphql.execute('''
+            { 
+                event { 
+                    id 
+                    ...on Conference { 
+                        topic 
+                    } 
+                } 
+            }''')
+
+        then:
+        res.data == null
+        res.errors[0] instanceof UnresolvedTypeError
+    }
+
+    def "union: when typeResolver returns null (meaning it couldn't find an appropriate type), it should yield a UnresolvedTypeError GraphQL error"() {
+        def idl = """
+            type Query {
+                event: Event
+            }
+                        
+            type Concert {
+                id: String
+                name: String
+            }
+            
+            type Conference {
+                id: String
+                topic: String    
+            }
+            
+            union Event = Concert | Conference
+        """
+
+        def runTimeWiring = RuntimeWiring.newRuntimeWiring()
+                .wiringFactory(new SimpleTestWiringFactory(nullTypeResolver))
+        def schema = TestUtil.schema(idl, runTimeWiring)
+        def graphql = new GraphQL(schema)
+
+        when:
+        def res = graphql.execute('''
+            { 
+                event { 
+                    ...on Conference { 
+                        id
+                        topic 
+                    } 
+                } 
+            }''')
+
+        then:
+        (res.data as Map)['event'] == null
+        res.errors[0] instanceof UnresolvedTypeError
+    }
+
+
+    def "union: when typeResolver returns null and the field is non-nullable, it should yield an UnresolvedTypeError GraphQL error"() {
+        def idl = """
+            type Query {
+                event: Event!
+            }
+                        
+            type Concert {
+                id: String
+                name: String
+            }
+            
+            type Conference {
+                id: String
+                topic: String    
+            }
+            
+            union Event = Concert | Conference
+        """
+
+        def runTimeWiring = RuntimeWiring.newRuntimeWiring()
+                .wiringFactory(new SimpleTestWiringFactory(nullTypeResolver))
+        def schema = TestUtil.schema(idl, runTimeWiring)
+        def graphql = new GraphQL(schema)
+
+        when:
+        def res = graphql.execute('''
+            { 
+                event { 
+                    ...on Conference { 
+                        id
+                        topic 
+                    } 
+                } 
+            }''')
+
+        then:
+        res.data == null
+        res.errors[0] instanceof UnresolvedTypeError
+    }
+}

--- a/src/test/groovy/graphql/execution/batched/FunWithStringsSchemaFactory.java
+++ b/src/test/groovy/graphql/execution/batched/FunWithStringsSchemaFactory.java
@@ -26,6 +26,7 @@ import static graphql.schema.GraphQLEnumType.newEnum;
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 import static graphql.schema.GraphQLInterfaceType.newInterface;
 import static graphql.schema.GraphQLObjectType.newObject;
+import static graphql.schema.GraphQLTypeReference.typeRef;
 
 public class FunWithStringsSchemaFactory {
 
@@ -389,6 +390,7 @@ public class FunWithStringsSchemaFactory {
 
         GraphQLObjectType simpleObjectType = newObject()
                 .name("SimpleObject")
+                .withInterface(typeRef("InterfaceType"))
                 .field(newFieldDefinition()
                         .name("value")
                         .type(GraphQLString))
@@ -434,6 +436,7 @@ public class FunWithStringsSchemaFactory {
 
         return GraphQLSchema.newSchema()
                 .query(queryType)
+                .additionalType(simpleObjectType)
                 .build();
 
     }

--- a/src/test/groovy/graphql/schema/GraphQLSchemaTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLSchemaTest.groovy
@@ -1,5 +1,6 @@
 package graphql.schema
 
+import graphql.AssertException
 import graphql.ExecutionInput
 import graphql.GraphQL
 import graphql.TestUtil
@@ -23,6 +24,18 @@ class GraphQLSchemaTest extends Specification {
                 humanType, droidType
         ]
 
+    }
+
+    def "isPossibleType works as expected"() {
+        expect:
+        starWarsSchema.isPossibleType(characterInterface, humanType)
+    }
+
+    def "isPossibleType when wrong abstract type is passed expect exception"() {
+        when:
+        starWarsSchema.isPossibleType(humanType, humanType)
+        then:
+        thrown(AssertException)
     }
 
     def "#698 interfaces copied as expected"() {


### PR DESCRIPTION
### Description

#1050 is a pre-requisite to this PR. 

**Current behavior:**
After calling the user defined `TypeResolver`, `graphql-java` doesn't validate that the returned `resolvedType` is a possible type of the resolved abstract type (interface or union). If the user `TypeResolver` happens to return an aberrant type, (i.e a type that doesn't implement the given interface), `graphql-java` still attempts to complete the fetched value with that type and can lead to unexpected behavior.

**Expected behavior:**
`graphq-java` should behave like `graphql-js` which validates [the `resolvedType` and throws a `GraphQLError` if it isn't valid.](https://github.com/graphql/graphql-js/blob/ef585e9db8d161e715dfaa4e70c1ed2efa58294c/src/execution/execute.js#L1057)

### Steps to reproduce

I wrote a test to showcase the issue, by using an `aberrantTypeResolver` that returns a type that doesn't implement the wanted abstract type.

```java
def "interface:  when typeResolver returns an aberrant type it should yield a GraphQL error"() {
        def idl = """
            type Query {
                event: Event
            }
            
            interface Event {
                id: String
            }
            
            type Concert implements Event {
                id: String
                name: String
            }
            
            type Conference implements Event {
                id: String
                topic: String    
            }
            
            type OtherType {
                id: String
            }
        """

        def runTimeWiring = RuntimeWiring.newRuntimeWiring()
                .wiringFactory(new SimpleTestWiringFactory(aberrantTypeResolver))
        def schema = TestUtil.schema(idl, runTimeWiring)
        def graphql = new GraphQL(schema)

        when:
        def res = graphql.execute('''
            { 
                event { 
                    id 
                    ...on Conference { 
                        topic 
                    } 
                } 
            }''')

        then:
        (res.data as Map)['event'] == null
        res.errors[0] instanceof UnresolvedTypeError
    }
```

### Fix 

I added a public `isPossibleType` method inside the `GraphQLSchema` class so it can be used both internally and externally (`graphql-js` offers it too) . I added the `isPossibleType` check inside the `ExecutionStrategy` for the validation and reused the `UnresolvedTypeException`. 

### Testing

Fixed a few breaking unit tests, and added new unit tests to cover the validation and the new public `isPossibleType` method.