### PR TITLE
Added sourceName to improve error reporting across multiple SDL documents

### DIFF
--- a/src/main/java/graphql/language/SourceLocation.java
+++ b/src/main/java/graphql/language/SourceLocation.java
@@ -37,14 +37,15 @@ public class SourceLocation {
         SourceLocation that = (SourceLocation) o;
 
         if (line != that.line) return false;
-        return column == that.column;
-
+        if (column != that.column) return false;
+        return sourceName != null ? sourceName.equals(that.sourceName) : that.sourceName == null;
     }
 
     @Override
     public int hashCode() {
         int result = line;
         result = 31 * result + column;
+        result = 31 * result + (sourceName != null ? sourceName.hashCode() : 0);
         return result;
     }
 
@@ -53,6 +54,7 @@ public class SourceLocation {
         return "SourceLocation{" +
                 "line=" + line +
                 ", column=" + column +
+                (sourceName != null ? ", sourceName=" + sourceName : "") +
                 '}';
     }
 }

--- a/src/main/java/graphql/language/SourceLocation.java
+++ b/src/main/java/graphql/language/SourceLocation.java
@@ -5,10 +5,16 @@ public class SourceLocation {
 
     private final int line;
     private final int column;
+    private final String sourceName;
 
     public SourceLocation(int line, int column) {
+        this(line, column, null);
+    }
+
+    public SourceLocation(int line, int column, String sourceName) {
         this.line = line;
         this.column = column;
+        this.sourceName = sourceName;
     }
 
     public int getLine() {
@@ -17,6 +23,10 @@ public class SourceLocation {
 
     public int getColumn() {
         return column;
+    }
+
+    public String getSourceName() {
+        return sourceName;
     }
 
     @Override

--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -53,6 +53,7 @@ import graphql.language.VariableReference;
 import graphql.parser.antlr.GraphqlBaseVisitor;
 import graphql.parser.antlr.GraphqlParser;
 import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.IntStream;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
 
@@ -831,6 +832,12 @@ public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
     private SourceLocation getSourceLocation(ParserRuleContext parserRuleContext) {
         Token startToken = parserRuleContext.getStart();
         String sourceName = startToken.getTokenSource().getSourceName();
+        if (IntStream.UNKNOWN_SOURCE_NAME.equals(sourceName)) {
+            // UNKNOWN_SOURCE_NAME is Antrl's way of indicating that no source name was given during parsing --
+            // which is the case when queries and other operations are parsed. We don't want this hardcoded
+            // '<unknown>' sourceName to leak to clients when the response is serialized as JSON, so we null it.
+            sourceName = null;
+        }
         return new SourceLocation(startToken.getLine(), startToken.getCharPositionInLine() + 1, sourceName);
     }
 

--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -829,7 +829,9 @@ public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
 
 
     private SourceLocation getSourceLocation(ParserRuleContext parserRuleContext) {
-        return new SourceLocation(parserRuleContext.getStart().getLine(), parserRuleContext.getStart().getCharPositionInLine() + 1);
+        Token startToken = parserRuleContext.getStart();
+        String sourceName = startToken.getTokenSource().getSourceName();
+        return new SourceLocation(startToken.getLine(), startToken.getCharPositionInLine() + 1, sourceName);
     }
 
     private List<Comment> getComments(ParserRuleContext ctx) {

--- a/src/main/java/graphql/parser/Parser.java
+++ b/src/main/java/graphql/parser/Parser.java
@@ -5,15 +5,14 @@ import graphql.language.Document;
 import graphql.parser.antlr.GraphqlLexer;
 import graphql.parser.antlr.GraphqlParser;
 import org.antlr.v4.runtime.BailErrorStrategy;
+import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
-import org.antlr.v4.runtime.IntStream;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.atn.PredictionMode;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 
 import java.util.List;
-import java.util.Optional;
 
 @Internal
 public class Parser {
@@ -24,7 +23,14 @@ public class Parser {
 
     public Document parseDocument(String input, String sourceName) {
 
-        GraphqlLexer lexer = new GraphqlLexer(CharStreams.fromString(input, Optional.ofNullable(sourceName).orElse(IntStream.UNKNOWN_SOURCE_NAME)));
+        CharStream charStream;
+        if(sourceName == null) {
+            charStream = CharStreams.fromString(input);
+        } else{
+            charStream = CharStreams.fromString(input, sourceName);
+        }
+
+        GraphqlLexer lexer = new GraphqlLexer(charStream);
 
         CommonTokenStream tokens = new CommonTokenStream(lexer);
 

--- a/src/main/java/graphql/parser/Parser.java
+++ b/src/main/java/graphql/parser/Parser.java
@@ -7,18 +7,24 @@ import graphql.parser.antlr.GraphqlParser;
 import org.antlr.v4.runtime.BailErrorStrategy;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.IntStream;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.atn.PredictionMode;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 
 import java.util.List;
+import java.util.Optional;
 
 @Internal
 public class Parser {
 
     public Document parseDocument(String input) {
+        return parseDocument(input, null);
+    }
 
-        GraphqlLexer lexer = new GraphqlLexer(CharStreams.fromString(input));
+    public Document parseDocument(String input, String sourceName) {
+
+        GraphqlLexer lexer = new GraphqlLexer(CharStreams.fromString(input, Optional.ofNullable(sourceName).orElse(IntStream.UNKNOWN_SOURCE_NAME)));
 
         CommonTokenStream tokens = new CommonTokenStream(lexer);
 

--- a/src/test/groovy/graphql/parser/IDLParserTest.groovy
+++ b/src/test/groovy/graphql/parser/IDLParserTest.groovy
@@ -34,6 +34,7 @@ import graphql.language.TypeName
 import graphql.language.UnionTypeDefinition
 import graphql.language.UnionTypeExtensionDefinition
 import graphql.language.VariableReference
+import org.antlr.v4.runtime.IntStream
 import spock.lang.Specification
 
 import java.util.stream.Collectors
@@ -794,6 +795,24 @@ input Gun {
         fromDoc(doc, 2, InputObjectTypeExtensionDefinition).getDirectives().size() == 1
         fromDoc(doc, 2, InputObjectTypeExtensionDefinition).getDirectivesByName().containsKey("directive")
         fromDoc(doc, 2, InputObjectTypeExtensionDefinition).inputValueDefinitions[0].name == 'inputField'
+    }
+
+    def "source name is available when specified"() {
+
+        def input = 'type Query { hello: String }'
+        def sourceName = 'named.graphql'
+
+        when:
+        def defaultDoc = new Parser().parseDocument(input)
+        def namedDocNull = new Parser().parseDocument(input, null)
+        def namedDoc = new Parser().parseDocument(input, sourceName)
+
+        then:
+
+        defaultDoc.definitions[0].sourceLocation.sourceName == IntStream.UNKNOWN_SOURCE_NAME
+        namedDocNull.definitions[0].sourceLocation.sourceName == IntStream.UNKNOWN_SOURCE_NAME
+        namedDoc.definitions[0].sourceLocation.sourceName == sourceName
+
     }
 
     static <T> T fromDoc(Document document, int index, Class<T> asClass) {

--- a/src/test/groovy/graphql/parser/IDLParserTest.groovy
+++ b/src/test/groovy/graphql/parser/IDLParserTest.groovy
@@ -34,7 +34,6 @@ import graphql.language.TypeName
 import graphql.language.UnionTypeDefinition
 import graphql.language.UnionTypeExtensionDefinition
 import graphql.language.VariableReference
-import org.antlr.v4.runtime.IntStream
 import spock.lang.Specification
 
 import java.util.stream.Collectors
@@ -809,8 +808,8 @@ input Gun {
 
         then:
 
-        defaultDoc.definitions[0].sourceLocation.sourceName == IntStream.UNKNOWN_SOURCE_NAME
-        namedDocNull.definitions[0].sourceLocation.sourceName == IntStream.UNKNOWN_SOURCE_NAME
+        defaultDoc.definitions[0].sourceLocation.sourceName == null
+        namedDocNull.definitions[0].sourceLocation.sourceName == null
         namedDoc.definitions[0].sourceLocation.sourceName == sourceName
 
     }


### PR DESCRIPTION
This PR adds sourceName as supported by Antlr TokenSource to the GraphQL SourceLocation class.

The sourceName is useful when schema errors are reported during schema validation, and the type registry was created by parsing multiple SDL documents.