### PR TITLE
Added source location of where a type was used incorrectly in SDL

### DIFF
--- a/src/main/java/graphql/schema/idl/SchemaGenerator.java
+++ b/src/main/java/graphql/schema/idl/SchemaGenerator.java
@@ -307,7 +307,7 @@ public class SchemaGenerator {
             outputType = buildScalar(buildCtx, (ScalarTypeDefinition) typeDefinition);
         } else {
             // typeDefinition is not a valid output type
-            throw new NotAnOutputTypeError(typeDefinition);
+            throw new NotAnOutputTypeError(rawType, typeDefinition);
         }
 
         buildCtx.put(outputType);
@@ -340,7 +340,7 @@ public class SchemaGenerator {
             inputType = buildScalar(buildCtx, (ScalarTypeDefinition) typeDefinition);
         } else {
             // typeDefinition is not a valid InputType
-            throw new NotAnInputTypeError(typeDefinition);
+            throw new NotAnInputTypeError(rawType, typeDefinition);
         }
 
         buildCtx.put(inputType);

--- a/src/main/java/graphql/schema/idl/errors/NotAnInputTypeError.java
+++ b/src/main/java/graphql/schema/idl/errors/NotAnInputTypeError.java
@@ -1,12 +1,13 @@
 package graphql.schema.idl.errors;
 
+import graphql.language.Type;
 import graphql.language.TypeDefinition;
 
 import static java.lang.String.format;
 
 public class NotAnInputTypeError extends BaseError {
 
-    public NotAnInputTypeError(TypeDefinition typeDefinition) {
-        super(typeDefinition, format("expected InputType, but found %s type %s", typeDefinition.getName(), lineCol(typeDefinition)));
+    public NotAnInputTypeError(Type rawType, TypeDefinition typeDefinition) {
+        super(rawType, format("The type '%s' %s is not an input type, but was used as an input type %s", typeDefinition.getName(), lineCol(typeDefinition), lineCol(rawType)));
     }
 }

--- a/src/main/java/graphql/schema/idl/errors/NotAnOutputTypeError.java
+++ b/src/main/java/graphql/schema/idl/errors/NotAnOutputTypeError.java
@@ -1,12 +1,13 @@
 package graphql.schema.idl.errors;
 
+import graphql.language.Type;
 import graphql.language.TypeDefinition;
 
 import static java.lang.String.format;
 
 public class NotAnOutputTypeError extends BaseError {
 
-    public NotAnOutputTypeError(TypeDefinition typeDefinition) {
-        super(typeDefinition, format("expected OutputType, but found %s type %s", typeDefinition.getName(), lineCol(typeDefinition)));
+    public NotAnOutputTypeError(Type rawType, TypeDefinition typeDefinition) {
+        super(rawType, format("The type '%s' %s is not an output type, but was used to declare the output type of a field %s", typeDefinition.getName(), lineCol(typeDefinition), lineCol(rawType)));
     }
 }

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -634,7 +634,7 @@ class SchemaGeneratorTest extends Specification {
 
         then:
         def err = thrown(NotAnInputTypeError.class)
-        err.message == "expected InputType, but found CharacterInput type [@11:13]"
+        err.message == "The type 'CharacterInput' [@11:13] is not an input type, but was used as an input type [@7:42]"
     }
 
     def "InputType used as type should throw appropriate error #425"() {
@@ -659,7 +659,7 @@ class SchemaGeneratorTest extends Specification {
 
         then:
         def err = thrown(NotAnOutputTypeError.class)
-        err.message == "expected OutputType, but found CharacterInput type [@11:13]"
+        err.message == "The type 'CharacterInput' [@11:13] is not an output type, but was used to declare the output type of a field [@7:32]"
     }
 
     def "schema with subscription"() {


### PR DESCRIPTION
This PR adds the source location of where a type has been used incorrectly in addition to the existing location of the referenced type definition (#429).

Both locations are useful as the cause of the error is either the wrong use of a type, or the type was declared incorrectly.