### PR TITLE
Use type names in PossibleFragmentSpreads message format

### DIFF
--- a/src/main/java/graphql/validation/rules/PossibleFragmentSpreads.java
+++ b/src/main/java/graphql/validation/rules/PossibleFragmentSpreads.java
@@ -34,7 +34,7 @@ public class PossibleFragmentSpreads extends AbstractRule {
         if (fragType == null || parentType == null) return;
         if (!doTypesOverlap(fragType, parentType)) {
             String message = String.format("Fragment cannot be spread here as objects of " +
-                    "type %s can never be of type %s", parentType, fragType);
+                    "type %s can never be of type %s", parentType.getName(), fragType.getName());
             addError(ValidationErrorType.InvalidFragmentType, inlineFragment.getSourceLocation(), message);
 
         }
@@ -50,7 +50,7 @@ public class PossibleFragmentSpreads extends AbstractRule {
 
         if (!doTypesOverlap(typeCondition, parentType)) {
             String message = String.format("Fragment %s cannot be spread here as objects of " +
-                    "type %s can never be of type %s", fragmentSpread.getName(), parentType, typeCondition);
+                    "type %s can never be of type %s", fragmentSpread.getName(), parentType.getName(), typeCondition.getName());
             addError(ValidationErrorType.InvalidFragmentType, fragmentSpread.getSourceLocation(), message);
         }
     }

--- a/src/test/groovy/graphql/validation/rules/PossibleFragmentSpreadsTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/PossibleFragmentSpreadsTest.groovy
@@ -179,6 +179,7 @@ class PossibleFragmentSpreadsTest extends Specification {
 
         then:
         errorCollector.getErrors().size() == 1
+        errorCollector.getErrors().get(0).message == 'Validation error of type InvalidFragmentType: Fragment cannot be spread here as objects of type Cat can never be of type Dog @ \'invalidObjectWithinObjectAnon\''
     }
 
     def 'object into not implementing interface'() {
@@ -191,6 +192,7 @@ class PossibleFragmentSpreadsTest extends Specification {
 
         then:
         errorCollector.getErrors().size() == 1
+        errorCollector.getErrors().get(0).message == 'Validation error of type InvalidFragmentType: Fragment humanFragment cannot be spread here as objects of type Pet can never be of type Human @ \'invalidObjectWithinInterface\''
     }
 
     def 'object into not containing union'() {


### PR DESCRIPTION
This PR contains the follow changes:

- Use type names in `PossibleFragmentSpreads` message format to make it more readable (it's currently being toString'ed which outputs the typeResolver etc. as part of the message)
- Updated `PossibleFragmentSpreadsTest.groovy` with assertions that the type names appear as expected for both inline fragments and named fragment spreads