### PR TITLE
Add specific UnknownOperationException when operation name is missing

### DIFF
--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -42,6 +42,11 @@ These are not graphql errors in execution but rather totally unacceptable condit
  is thrown if the schema is not valid when built via
   graphql.schema.GraphQLSchema.Builder#build()`
 
+ -  `graphql.execution.UnknownOperationException`
+
+if multiple operations are defined in the query and
+the operation name is missing or there is no matching operation name
+contained in the GraphQL query.
 
  -  `graphql.GraphQLException`
 

--- a/src/main/java/graphql/execution/UnknownOperationException.java
+++ b/src/main/java/graphql/execution/UnknownOperationException.java
@@ -1,0 +1,17 @@
+package graphql.execution;
+
+import graphql.GraphQLException;
+import graphql.PublicApi;
+
+/**
+ * This is thrown if multiple operations are defined in the query and
+ * the operation name is missing or there is no matching operation name
+ * contained in the GraphQL query.
+ */
+@PublicApi
+public class UnknownOperationException extends GraphQLException {
+
+    public UnknownOperationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/graphql/language/NodeUtil.java
+++ b/src/main/java/graphql/language/NodeUtil.java
@@ -1,7 +1,7 @@
 package graphql.language;
 
-import graphql.GraphQLException;
 import graphql.Internal;
+import graphql.execution.UnknownOperationException;
 import graphql.util.FpKit;
 
 import java.util.LinkedHashMap;
@@ -59,7 +59,7 @@ public class NodeUtil {
             }
         }
         if (operationName == null && operationsByName.size() > 1) {
-            throw new GraphQLException("missing operation name");
+            throw new UnknownOperationException("Must provide operation name if query contains multiple operations.");
         }
         OperationDefinition operation;
 
@@ -69,7 +69,7 @@ public class NodeUtil {
             operation = operationsByName.get(operationName);
         }
         if (operation == null) {
-            throw new GraphQLException("no operation found");
+            throw new UnknownOperationException(String.format("Unknown operation named '%s'.", operationName));
         }
         GetOperationResult result = new GetOperationResult();
         result.fragmentsByName = fragmentsByName;

--- a/src/test/groovy/graphql/language/NodeUtilTest.groovy
+++ b/src/test/groovy/graphql/language/NodeUtilTest.groovy
@@ -1,0 +1,38 @@
+package graphql.language
+
+import graphql.TestUtil
+import graphql.execution.UnknownOperationException
+import spock.lang.Specification
+
+class NodeUtilTest extends Specification {
+
+    def "getOperation: when multiple operations are defined in the query and operation name is missing then it should throw UnknownOperationException"() {
+        setup:
+        def doc = TestUtil.parseQuery('''
+            query Q1 { id }
+            query Q2 { id }
+        ''')
+
+        when:
+        NodeUtil.getOperation(doc, null)
+
+        then:
+        def ex = thrown(UnknownOperationException)
+        ex.message == "Must provide operation name if query contains multiple operations."
+    }
+
+    def "getOperation: when multiple operations are defined in the query and operation name doesn't match any of the query operations then it should throw UnknownOperationException"() {
+        setup:
+        def doc = TestUtil.parseQuery('''
+            query Q1 { id }
+            query Q2 { id }
+        ''')
+
+        when:
+        NodeUtil.getOperation(doc, 'Unknown')
+
+        then:
+        def ex = thrown(UnknownOperationException)
+        ex.message == "Unknown operation named 'Unknown'."
+    }
+}


### PR DESCRIPTION
## Description

When executing a GraphQL query, if multiple operations are defined in the query and the operation name is missing or there is no matching operation name contained in the GraphQL query, then GraphQL-java throws the general purpose `GraphQLException`. 

The problem with throwing `GraphQLException` is it's hard for the library consumer to catch for that specific use case and translate to a customer error. To do so we currently have to catch all `GraphQLException` and match on the exception message.

## Proposal

I added a new `UnknownOperationException` that is to be used specifically for this kind of errors, whether the operation name is missing or not matching the operation name provided in the query.
I also added it to the documentation for completeness.

## Testing 

I added unit tests in `NodeUtil` to cover the failure scenarios.