### PR TITLE
Fix classCastException when a query variable is not a GraphQLInputType

### DIFF
--- a/src/main/java/graphql/validation/TraversalContext.java
+++ b/src/main/java/graphql/validation/TraversalContext.java
@@ -142,7 +142,7 @@ public class TraversalContext implements DocumentVisitor {
 
     private void enterImpl(VariableDefinition variableDefinition) {
         GraphQLType type = TypeFromAST.getTypeFromAST(schema, variableDefinition.getType());
-        addInputType(type != null ? (GraphQLInputType) type : null);
+        addInputType(type instanceof GraphQLInputType ? (GraphQLInputType) type : null);
     }
 
     private void enterImpl(Argument argument) {

--- a/src/test/groovy/graphql/validation/TraversalContextTest.groovy
+++ b/src/test/groovy/graphql/validation/TraversalContextTest.groovy
@@ -158,6 +158,23 @@ class TraversalContextTest extends Specification {
         traversalContext.getInputType() == null
     }
 
+    def "variableDefinition that is not a GraphQLInputType should result as null"() {
+        given: "a GraphQLObjectType instead of a GraphQLInputType"
+        VariableDefinition variableDefinition = new VariableDefinition("var", new TypeName("Human"))
+
+        when:
+        traversalContext.enter(variableDefinition, [])
+
+        then:
+        traversalContext.getInputType() == null
+
+        when:
+        traversalContext.leave(variableDefinition, [])
+
+        then:
+        traversalContext.getInputType() == null
+    }
+
     def "field argument saves argument and input type"() {
         given:
         Argument argument = new Argument("id", new StringValue("string"))

--- a/src/test/groovy/graphql/validation/rules/VariablesAreInputTypesTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/VariablesAreInputTypesTest.groovy
@@ -1,6 +1,7 @@
 package graphql.validation.rules
 
 import graphql.StarWarsSchema
+import graphql.TestUtil
 import graphql.language.ListType
 import graphql.language.NonNullType
 import graphql.language.TypeName
@@ -8,6 +9,7 @@ import graphql.language.VariableDefinition
 import graphql.validation.ValidationContext
 import graphql.validation.ValidationErrorCollector
 import graphql.validation.ValidationErrorType
+import graphql.validation.Validator
 import spock.lang.Specification
 
 class VariablesAreInputTypesTest extends Specification {
@@ -28,5 +30,47 @@ class VariablesAreInputTypesTest extends Specification {
 
         then:
         errorCollector.containsValidationError(ValidationErrorType.NonInputTypeOnVariable)
+    }
+
+    def "when a variable is of type GraphQLObjectType then it should not throw ClassCastException and validate with errors"() {
+        setup:
+        def schema = '''
+            type User {
+                id: String
+            }
+            
+            input UserInput {
+                id: String
+            }
+            
+            type Mutation {
+                createUser(user: UserInput): User
+            }
+            
+            type Query {
+                getUser: User
+            }
+        '''
+
+        def query = '''
+            mutation createUser($user: User){
+                createUser(user: $user) {
+                    id
+                } 
+            }
+        '''
+
+        def graphQlSchema = TestUtil.schema(schema)
+        def document = TestUtil.parseQuery(query)
+        def validator = new Validator()
+
+        when:
+        def validationErrors = validator.validateDocument(graphQlSchema, document)
+
+        then:
+        !validationErrors.empty
+        validationErrors.size() == 2
+        validationErrors.validationErrorType as Set ==
+                [ValidationErrorType.VariableTypeMismatch, ValidationErrorType.NonInputTypeOnVariable] as Set
     }
 }


### PR DESCRIPTION
## Description

**Current Behavior:**
If a GraphQL query contains a variable that is of type `GraphQLObjectType`, `graphql-java` throws a `ClassCastException`. 

**Expected Behavior:**
The library should catch that behavior and return a validation error using the `VariablesAreInputTypes` rule. 

## Steps to reproduce 

I wrote an integration test to showcase the issue, (integration test below):

```java
def "when a variable is of type GraphQLObjectType then it should not throw ClassCastException and validate with errors"() {
        setup:
        def schema = '''
            type User {
                id: String
            }
            
            input UserInput {
                id: String
            }
            
            type Mutation {
                createUser(user: UserInput): User
            }
            
            type Query {
                getUser: User
            }
        '''

        def query = '''
            mutation createUser($user: User){
                createUser(user: $user) {
                    id
                } 
            }
        '''

        def graphQlSchema = TestUtil.schema(schema)
        def document = TestUtil.parseQuery(query)
        def validator = new Validator()

        when:
        def validationErrors = validator.validateDocument(graphQlSchema, document)

        then:
        !validationErrors.empty
        validationErrors.size() == 2
        validationErrors.validationErrorType as Set ==
                [ValidationErrorType.VariableTypeMismatch, ValidationErrorType.NonInputTypeOnVariable] as Set
    }
```

## Fix/Testing

I replaced the check using `instanceOf` in [`TraversalContext`](https://github.com/graphql-java/graphql-java/blob/5be76471b892daf57baf7f754537d20defd23407/src/main/java/graphql/validation/TraversalContext.java#L145)
I also added a proper unit test in addition to the integration test shown above.