### PR TITLE
Add validation rule for unique operation names.

### DIFF
--- a/src/main/java/graphql/validation/ValidationErrorType.java
+++ b/src/main/java/graphql/validation/ValidationErrorType.java
@@ -28,6 +28,7 @@ public enum ValidationErrorType {
     FieldsConflict,
     InvalidFragmentType,
     LoneAnonymousOperationViolation,
-    NonExecutableDefinition
+    NonExecutableDefinition,
+    DuplicateOperationName
 
 }

--- a/src/main/java/graphql/validation/Validator.java
+++ b/src/main/java/graphql/validation/Validator.java
@@ -1,9 +1,6 @@
 package graphql.validation;
 
 
-import java.util.ArrayList;
-import java.util.List;
-
 import graphql.Internal;
 import graphql.language.Document;
 import graphql.schema.GraphQLSchema;
@@ -24,9 +21,13 @@ import graphql.validation.rules.OverlappingFieldsCanBeMerged;
 import graphql.validation.rules.PossibleFragmentSpreads;
 import graphql.validation.rules.ProvidedNonNullArguments;
 import graphql.validation.rules.ScalarLeafs;
+import graphql.validation.rules.UniqueOperationNames;
 import graphql.validation.rules.VariableDefaultValuesOfCorrectType;
 import graphql.validation.rules.VariableTypesMatchRule;
 import graphql.validation.rules.VariablesAreInputTypes;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Internal
 public class Validator {
@@ -95,6 +96,9 @@ public class Validator {
 
         LoneAnonymousOperation loneAnonymousOperation = new LoneAnonymousOperation(validationContext, validationErrorCollector);
         rules.add(loneAnonymousOperation);
+
+        UniqueOperationNames uniqueOperationNames = new UniqueOperationNames(validationContext, validationErrorCollector);
+        rules.add(uniqueOperationNames);
 
         return rules;
     }

--- a/src/main/java/graphql/validation/rules/UniqueOperationNames.java
+++ b/src/main/java/graphql/validation/rules/UniqueOperationNames.java
@@ -1,0 +1,44 @@
+package graphql.validation.rules;
+
+import graphql.language.OperationDefinition;
+import graphql.validation.AbstractRule;
+import graphql.validation.ValidationContext;
+import graphql.validation.ValidationErrorCollector;
+import graphql.validation.ValidationErrorType;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * A GraphQL document is only valid if all defined operations have unique names.
+ * http://facebook.github.io/graphql/October2016/#sec-Operation-Name-Uniqueness
+ */
+public class UniqueOperationNames extends AbstractRule {
+
+    private Set<String> operationNames = new HashSet<>();
+
+    public UniqueOperationNames(ValidationContext validationContext, ValidationErrorCollector validationErrorCollector) {
+        super(validationContext, validationErrorCollector);
+    }
+
+    @Override
+    public void checkOperationDefinition(OperationDefinition operationDefinition) {
+        super.checkOperationDefinition(operationDefinition);
+        String name = operationDefinition.getName();
+
+        // skip validation for anonymous operations
+        if (name == null) {
+            return;
+        }
+
+        if (operationNames.contains(name)) {
+            addError(ValidationErrorType.DuplicateOperationName, operationDefinition.getSourceLocation(), duplicateOperationNameMessage(name));
+        } else {
+            operationNames.add(name);
+        }
+    }
+
+    static String duplicateOperationNameMessage(String definitionName) {
+        return String.format("There can be only one operation named '%s'", definitionName);
+    }
+}

--- a/src/test/groovy/graphql/validation/SpecValidation51Test.groovy
+++ b/src/test/groovy/graphql/validation/SpecValidation51Test.groovy
@@ -1,7 +1,4 @@
 package graphql.validation
-
-import spock.lang.Requires
-
 /**
  * validation examples used in the spec in given section
  * http://facebook.github.io/graphql/#sec-Validation
@@ -33,7 +30,6 @@ query getOwnerName {
         validationErrors.empty
     }
 
-    @Requires({ SpecValidationBase.enableStrictValidation })
     def '5.1.1.1 Operation Name Uniqueness Not Valid'() {
         def query = """
 query getName {
@@ -52,13 +48,11 @@ query getName {
 """
         when:
         def validationErrors = validate(query)
-        //def result = new GraphQL(SpecValidationSchema.specValidationSchema).execute(query)
 
         then:
         !validationErrors.empty
     }
 
-    @Requires({ SpecValidationBase.enableStrictValidation })
     def '5.1.1.1 Operation Name Uniqueness Not Valid Different Operations'() {
         def query = """
 query dogOperation {

--- a/src/test/groovy/graphql/validation/SpecValidationBase.groovy
+++ b/src/test/groovy/graphql/validation/SpecValidationBase.groovy
@@ -11,8 +11,6 @@ import spock.lang.Specification
  */
 class SpecValidationBase extends Specification {
 
-    public static final boolean enableStrictValidation = false
-
     List<ValidationError> validate(String query) {
         def document = new Parser().parseDocument(query)
         return new Validator().validateDocument(SpecValidationSchema.specValidationSchema, document)

--- a/src/test/groovy/graphql/validation/rules/UniqueOperationNamesTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/UniqueOperationNamesTest.groovy
@@ -1,0 +1,73 @@
+package graphql.validation.rules
+
+import graphql.language.SourceLocation
+import graphql.parser.Parser
+import graphql.validation.SpecValidationSchema
+import graphql.validation.ValidationError
+import graphql.validation.ValidationErrorType
+import graphql.validation.Validator
+import spock.lang.Specification
+
+import static graphql.validation.rules.UniqueOperationNames.duplicateOperationNameMessage
+
+class UniqueOperationNamesTest extends Specification {
+
+    def '5.1.1.1 Operation Name Uniqueness Not Valid'() {
+        def query = """\
+        query getName {
+            dog {
+                name
+            }
+        }
+
+        query getName {
+            dog {
+                owner {
+                    name
+                }
+            }
+        }
+        """.stripIndent()
+        when:
+        def validationErrors = validate(query)
+
+        then:
+        !validationErrors.empty
+        validationErrors.size() == 1
+        validationErrors[0] == duplicateOperationName("getName", 7, 1)
+    }
+
+    def '5.1.1.1 Operation Name Uniqueness Not Valid Different Operations'() {
+        def query = """\
+        query dogOperation {
+            dog {
+                name
+            }
+        }
+
+        mutation dogOperation {
+            mutateDog {
+                id
+            }
+        }
+        """.stripIndent()
+        when:
+        def validationErrors = validate(query)
+
+        then:
+        !validationErrors.empty
+        validationErrors.size() == 1
+        validationErrors[0] == duplicateOperationName("dogOperation", 7, 1)
+    }
+
+    ValidationError duplicateOperationName(String defName, int line, int column) {
+        return new ValidationError(ValidationErrorType.DuplicateOperationName,
+                [new SourceLocation(line, column)],
+                duplicateOperationNameMessage(defName))
+    }
+
+    List<ValidationError> validate(String query) {
+        def document = new Parser().parseDocument(query)
+        return new Validator().validateDocument(SpecValidationSchema.specValidationSchema, document)
+    }
+}


### PR DESCRIPTION
### Description

**Current behavior:**
When a query contains duplicate operation names, graphql-java execute one of the two operations instead of raising a validation error.

**Expected behavior:**
The graphql-js implementation complies to the [spec](http://facebook.github.io/graphql/October2016/#sec-Operation-Name-Uniqueness) by executing the [UniqueOperationNames](https://github.com/graphql/graphql-js/blob/master/src/validation/rules/UniqueOperationNames.js#L15) rule and raising a GraphQLError.

### Steps to reproduce

After digging through the existing tests in graphql-java I found [two tests](https://github.com/graphql-java/graphql-java/blob/master/src/test/groovy/graphql/validation/SpecValidation51Test.groovy#L37) covering this use case but they are currently disabled.

See one of them below: (_SpecValidationBase.enableStrictValidation_ turns out to be always false)
```java
    @Requires({ SpecValidationBase.enableStrictValidation })
    def '5.1.1.1 Operation Name Uniqueness Not Valid'() {
        def query = """
query getName {
  dog {
    name
  }
}
query getName {
  dog {
    owner {
      name
    }
  }
}
"""
        when:
        def validationErrors = validate(query)
        //def result = new GraphQL(SpecValidationSchema.specValidationSchema).execute(query)

        then:
        !validationErrors.empty
    }
```

### Fix & Testing

I added the missing **UniqueOperationNames** validation rule and covered it using its own specification class.
I also removed the _SpecValidationBase.enableStrictValidation_ flag, let me know if that was kept for another purpose.