### PR TITLE
Added serialisation support to graphql language nodes

### DIFF
--- a/src/main/java/graphql/GraphQLError.java
+++ b/src/main/java/graphql/GraphQLError.java
@@ -3,14 +3,22 @@ package graphql;
 
 import graphql.language.SourceLocation;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
 /**
+ * The interface describing graphql errors
+ *
+ * NOTE: This class implements {@link java.io.Serializable} and hence it can be serialised and placed into a distributed cache.  However we
+ * are not aiming to provide long term compatibility and do not intend for you to place this serialised data into permanent storage,
+ * with times frames that cross graphql-java versions.  While we don't change things unnecessarily,  we may inadvertently break
+ * the serialised compatibility across versions.
+ *
  * @see <a href="https://facebook.github.io/graphql/#sec-Errors">GraphQL Spec - 7.2.2 Errors</a>
  */
 @PublicApi
-public interface GraphQLError {
+public interface GraphQLError extends Serializable {
 
     /**
      * @return a description of the error intended for the developer as a guide to understand and correct the error

--- a/src/main/java/graphql/execution/preparsed/PreparsedDocumentEntry.java
+++ b/src/main/java/graphql/execution/preparsed/PreparsedDocumentEntry.java
@@ -3,6 +3,7 @@ package graphql.execution.preparsed;
 import graphql.GraphQLError;
 import graphql.language.Document;
 
+import java.io.Serializable;
 import java.util.List;
 
 import static graphql.Assert.assertNotNull;
@@ -11,8 +12,13 @@ import static java.util.Collections.singletonList;
 /**
  * An instance of a preparsed document entry represents the result of a query parse and validation, like
  * an either implementation it contains either the correct result in th document property or the errors.
+ *
+ * NOTE: This class implements {@link java.io.Serializable} and hence it can be serialised and placed into a distributed cache.  However we
+ * are not aiming to provide long term compatibility and do not intend for you to place this serialised data into permanent storage,
+ * with times frames that cross graphql-java versions.  While we don't change things unnecessarily,  we may inadvertently break
+ * the serialised compatibility across versions.
  */
-public class PreparsedDocumentEntry {
+public class PreparsedDocumentEntry implements Serializable {
     private final Document document;
     private final List<? extends GraphQLError> errors;
 

--- a/src/main/java/graphql/language/Comment.java
+++ b/src/main/java/graphql/language/Comment.java
@@ -1,6 +1,8 @@
 package graphql.language;
 
-public class Comment {
+import java.io.Serializable;
+
+public class Comment implements Serializable {
     public final String content;
     public final SourceLocation sourceLocation;
 

--- a/src/main/java/graphql/language/Description.java
+++ b/src/main/java/graphql/language/Description.java
@@ -1,6 +1,8 @@
 package graphql.language;
 
-public class Description {
+import java.io.Serializable;
+
+public class Description implements Serializable {
     public final String content;
     public final SourceLocation sourceLocation;
     public final boolean multiLine;

--- a/src/main/java/graphql/language/Node.java
+++ b/src/main/java/graphql/language/Node.java
@@ -4,9 +4,18 @@ package graphql.language;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
+import java.io.Serializable;
 import java.util.List;
 
-public interface Node<T extends Node> {
+/**
+ * The base interface for virtually all graphql language elements
+ *
+ * NOTE: This class implements {@link java.io.Serializable} and hence it can be serialised and placed into a distributed cache.  However we
+ * are not aiming to provide long term compatibility and do not intend for you to place this serialised data into permanent storage,
+ * with times frames that cross graphql-java versions.  While we don't change things unnecessarily,  we may inadvertently break
+ * the serialised compatibility across versions.
+ */
+public interface Node<T extends Node> extends Serializable {
 
     /**
      * @return a list of the children of this node

--- a/src/main/java/graphql/language/SourceLocation.java
+++ b/src/main/java/graphql/language/SourceLocation.java
@@ -1,7 +1,9 @@
 package graphql.language;
 
 
-public class SourceLocation {
+import java.io.Serializable;
+
+public class SourceLocation implements Serializable {
 
     private final int line;
     private final int column;

--- a/src/test/groovy/graphql/language/SerialisationTest.groovy
+++ b/src/test/groovy/graphql/language/SerialisationTest.groovy
@@ -1,0 +1,129 @@
+package graphql.language
+
+import graphql.GraphQLError
+import graphql.InvalidSyntaxError
+import graphql.TestUtil
+import graphql.execution.preparsed.PreparsedDocumentEntry
+import graphql.validation.ValidationError
+import graphql.validation.ValidationErrorType
+import spock.lang.Specification
+
+class SerialisationTest extends Specification {
+
+    static <T> T serialisedDownAndBack(T inputObj) {
+        def file = File.createTempFile("serialised", ".bin")
+
+        FileOutputStream f = new FileOutputStream(file)
+        ObjectOutputStream o = new ObjectOutputStream(f)
+
+        o.writeObject(inputObj)
+        o.close()
+
+        FileInputStream fi = new FileInputStream(file)
+        ObjectInputStream oi = new ObjectInputStream(fi)
+
+        T object = oi.readObject() as T
+        oi.close()
+
+        return object
+    }
+
+    static SourceLocation srcLoc(int line, int col) {
+        new SourceLocation(line, col)
+    }
+
+    def query = '''
+                #comment
+                query HeroForEpisode($ep: Episode!) {
+                  hero(episode: $ep) {
+                    name
+                    ... on Droid {
+                      primaryFunction
+                    }
+                    ... on Human {
+                      height
+                    }
+                  }
+                  
+                  rightComparison: hero(episode: JEDI) {
+                     ...comparisonFields
+                  }
+                  
+                  differentArgObjects( s : "s", int : 1, b : true, list : [{a : "s"}, 1, "s"], obj : {x : "s", y : true} )
+                  
+                  directiveOnField @skip(if:true)
+                }
+                
+                fragment comparisonFields on Character {
+                  name
+                  appearsIn
+                  friends {
+                    name
+                  }
+                }
+        '''
+
+    def "#1071 basic document serialisation"() {
+
+        // this helps prove that we can serialise a query document
+        // and hence allow caching of that parsed document via
+        // systems that require serializable objects
+
+        when:
+        Document originalDoc = TestUtil.parseQuery(query)
+        def originalAst = AstPrinter.printAst(originalDoc)
+
+        Document newDocument = serialisedDownAndBack(originalDoc)
+        def newAst = AstPrinter.printAst(newDocument)
+
+        then:
+
+        originalAst == newAst
+    }
+
+    def "basic error serialisation"() {
+        when:
+        GraphQLError syntaxError = new InvalidSyntaxError(srcLoc(1, 2), "Bad Syntax")
+
+        GraphQLError serialisedError = serialisedDownAndBack(syntaxError)
+
+        then:
+
+        syntaxError.getMessage() == serialisedError.getMessage()
+        syntaxError.getLocations() == serialisedError.getLocations()
+    }
+
+    def "PreparsedDocumentEntry with document is serializable"() {
+
+        when:
+        Document originalDoc = TestUtil.parseQuery(query)
+        def originalEntry = new PreparsedDocumentEntry(originalDoc)
+        def originalAst = AstPrinter.printAst(originalEntry.getDocument())
+
+        PreparsedDocumentEntry newEntry = serialisedDownAndBack(originalEntry)
+        def newAst = AstPrinter.printAst(newEntry.getDocument())
+
+        then:
+
+        originalAst == newAst
+    }
+
+    def "PreparsedDocumentEntry with errors is serializable"() {
+
+        when:
+        GraphQLError syntaxError1 = new InvalidSyntaxError(srcLoc(1, 1), "Bad Syntax 1")
+        GraphQLError validationError2 = new ValidationError(ValidationErrorType.FieldUndefined, srcLoc(2, 2), "Bad Query 2")
+        def originalEntry = new PreparsedDocumentEntry([syntaxError1, validationError2])
+
+        PreparsedDocumentEntry newEntry = serialisedDownAndBack(originalEntry)
+
+        then:
+
+        newEntry.getErrors().size() == 2
+        newEntry.getErrors().get(0).getMessage() == syntaxError1.getMessage()
+        newEntry.getErrors().get(0).getLocations() == syntaxError1.getLocations()
+
+        newEntry.getErrors().get(1).getMessage() == validationError2.getMessage()
+        newEntry.getErrors().get(1).getLocations() == validationError2.getLocations()
+    }
+}


### PR DESCRIPTION
See #1071 

Today you cant place a Document into a distributed cache because of missing serialisation

This puts serialisation on the graphql language nodes and errors so they can be cached