### PR TITLE
Add directive argument type validation

### DIFF
--- a/src/main/java/graphql/schema/idl/ArgValueOfAllowedTypeChecker.java
+++ b/src/main/java/graphql/schema/idl/ArgValueOfAllowedTypeChecker.java
@@ -1,0 +1,270 @@
+package graphql.schema.idl;
+
+import graphql.AssertException;
+import graphql.GraphQLError;
+import graphql.Internal;
+import graphql.language.Argument;
+import graphql.language.ArrayValue;
+import graphql.language.Directive;
+import graphql.language.EnumTypeDefinition;
+import graphql.language.EnumValue;
+import graphql.language.EnumValueDefinition;
+import graphql.language.InputObjectTypeDefinition;
+import graphql.language.InputValueDefinition;
+import graphql.language.ListType;
+import graphql.language.Node;
+import graphql.language.NonNullType;
+import graphql.language.NullValue;
+import graphql.language.ObjectField;
+import graphql.language.ObjectValue;
+import graphql.language.ScalarTypeDefinition;
+import graphql.language.Type;
+import graphql.language.TypeDefinition;
+import graphql.language.TypeName;
+import graphql.language.Value;
+import graphql.schema.CoercingParseLiteralException;
+import graphql.schema.GraphQLScalarType;
+import graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static graphql.Assert.assertShouldNeverHappen;
+import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.DUPLICATED_KEYS_MESSAGE;
+import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.EXPECTED_ENUM_MESSAGE;
+import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.EXPECTED_LIST_MESSAGE;
+import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.EXPECTED_NON_NULL_MESSAGE;
+import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.EXPECTED_OBJECT_MESSAGE;
+import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.EXPECTED_SCALAR_MESSAGE;
+import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.MISSING_REQUIRED_FIELD_MESSAGE;
+import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.MUST_BE_VALID_ENUM_VALUE_MESSAGE;
+import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.NOT_A_VALID_SCALAR_LITERAL_MESSAGE;
+import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.UNKNOWN_FIELDS_MESSAGE;
+
+/**
+ * Class to check whether a given directive argument value
+ * matches a given directive definition.
+ *
+ */
+@Internal
+class ArgValueOfAllowedTypeChecker {
+
+    private static final Logger log = LoggerFactory.getLogger(ArgValueOfAllowedTypeChecker.class);
+
+    private final Directive directive;
+    private final Node element;
+    private final String elementName;
+    private final Argument argument;
+    private final TypeDefinitionRegistry typeRegistry;
+    private final RuntimeWiring runtimeWiring;
+
+    ArgValueOfAllowedTypeChecker(final Directive directive,
+                                 final Node element,
+                                 final String elementName,
+                                 final Argument argument,
+                                 final TypeDefinitionRegistry typeRegistry,
+                                 final RuntimeWiring runtimeWiring) {
+        this.directive = directive;
+        this.element = element;
+        this.elementName = elementName;
+        this.argument = argument;
+        this.typeRegistry = typeRegistry;
+        this.runtimeWiring = runtimeWiring;
+    }
+
+    /**
+     * Recursively inspects an argument value given an allowed type.
+     * Given the (invalid) SDL below:
+     *
+     *      directive @myDirective(arg: [[String]] ) on FIELD_DEFINITION
+     *
+     *      query {
+     *          f: String @myDirective(arg: ["A String"])
+     *      }
+     *
+     * it will first check that the `myDirective.arg` type is an array
+     * and fail when finding "A String" as it expected a nested array ([[String]]).
+     * @param errors validation error collector
+     * @param instanceValue directive argument value
+     * @param allowedArgType directive definition argument allowed type
+     */
+    void checkArgValueMatchesAllowedType(List<GraphQLError> errors, Value instanceValue, Type allowedArgType) {
+        if (allowedArgType instanceof TypeName) {
+            checkArgValueMatchesAllowedTypeName(errors, instanceValue, allowedArgType);
+        } else if (allowedArgType instanceof ListType) {
+            checkArgValueMatchesAllowedListType(errors, instanceValue, (ListType) allowedArgType);
+        } else if (allowedArgType instanceof NonNullType) {
+            checkArgValueMatchesAllowedNonNullType(errors, instanceValue, (NonNullType) allowedArgType);
+        } else {
+            assertShouldNeverHappen("Unsupported Type '%s' was added. ", allowedArgType);
+        }
+    }
+
+    private void addValidationError(List<GraphQLError> errors, String message, Object... args) {
+        errors.add(new DirectiveIllegalArgumentTypeError(element, elementName, directive.getName(), argument.getName(), String.format(message, args)));
+    }
+
+    private void checkArgValueMatchesAllowedTypeName(List<GraphQLError> errors, Value instanceValue, Type allowedArgType) {
+        if (instanceValue instanceof NullValue) {
+            return;
+        }
+
+        String allowedTypeName = ((TypeName) allowedArgType).getName();
+        TypeDefinition allowedTypeDefinition = typeRegistry.getType(allowedTypeName)
+                .orElseThrow(() -> new AssertException("Directive unknown argument type '%s'. This should have been validated before."));
+
+        if (allowedTypeDefinition instanceof ScalarTypeDefinition) {
+            checkArgValueMatchesAllowedScalar(errors, instanceValue, allowedTypeName);
+        } else if (allowedTypeDefinition instanceof EnumTypeDefinition) {
+            checkArgValueMatchesAllowedEnum(errors, instanceValue, (EnumTypeDefinition) allowedTypeDefinition);
+        } else if (allowedTypeDefinition instanceof InputObjectTypeDefinition) {
+            checkArgValueMatchesAllowedInputType(errors, instanceValue, (InputObjectTypeDefinition) allowedTypeDefinition);
+        } else {
+            assertShouldNeverHappen("'%s' must be an input type. It is %s instead. ", allowedTypeName, allowedTypeDefinition.getClass());
+        }
+    }
+
+    private void checkArgValueMatchesAllowedInputType(List<GraphQLError> errors, Value instanceValue, InputObjectTypeDefinition allowedTypeDefinition) {
+        if (!(instanceValue instanceof ObjectValue)) {
+            addValidationError(errors, EXPECTED_OBJECT_MESSAGE, instanceValue.getClass().getSimpleName());
+            return;
+        }
+
+        ObjectValue objectValue = ((ObjectValue) instanceValue);
+        // duck typing validation, if it looks like the definition
+        // then it must be the same type as the definition
+
+        List<ObjectField> fields = objectValue.getObjectFields();
+        List<InputValueDefinition> inputValueDefinitions = allowedTypeDefinition.getInputValueDefinitions();
+
+        // check for duplicated fields
+        Map<String, Long> fieldsToOccurrenceMap = fields.stream().map(ObjectField::getName)
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+
+        if (fieldsToOccurrenceMap.values().stream().anyMatch(count -> count > 1)) {
+            addValidationError(errors, DUPLICATED_KEYS_MESSAGE, fieldsToOccurrenceMap.entrySet().stream()
+                    .filter(entry -> entry.getValue() > 1)
+                    .map(Map.Entry::getKey)
+                    .collect(Collectors.joining(",")));
+            return;
+        }
+
+        // check for unknown fields
+        Map<String, InputValueDefinition> nameToInputValueDefMap = inputValueDefinitions.stream()
+                .collect(Collectors.toMap(InputValueDefinition::getName, inputValueDef -> inputValueDef));
+
+        List<ObjectField> unknownFields = fields.stream()
+                .filter(field -> !nameToInputValueDefMap.containsKey(field.getName()))
+                .collect(Collectors.toList());
+
+        if (!unknownFields.isEmpty()) {
+            addValidationError(errors, UNKNOWN_FIELDS_MESSAGE,
+                    unknownFields.stream()
+                            .map(ObjectField::getName)
+                            .collect(Collectors.joining(",")),
+                    allowedTypeDefinition.getName());
+            return;
+        }
+
+        // fields to map for easy access
+        Map<String, ObjectField> nameToFieldsMap = fields.stream()
+                .collect(Collectors.toMap(ObjectField::getName, objectField -> objectField));
+        // check each single field with its definition
+        inputValueDefinitions.forEach(allowedValueDef -> {
+            ObjectField objectField = nameToFieldsMap.get(allowedValueDef.getName());
+            checkArgInputObjectValueFieldMatchesAllowedDefinition(errors, objectField, allowedValueDef);
+        });
+    }
+
+    private void checkArgValueMatchesAllowedEnum(List<GraphQLError> errors, Value instanceValue, EnumTypeDefinition allowedTypeDefinition) {
+        if (!(instanceValue instanceof EnumValue)) {
+            addValidationError(errors, EXPECTED_ENUM_MESSAGE, instanceValue.getClass().getSimpleName());
+            return;
+        }
+
+        EnumValue enumValue = ((EnumValue) instanceValue);
+
+        boolean noneMatchAllowedEnumValue = allowedTypeDefinition.getEnumValueDefinitions().stream()
+                .noneMatch(enumAllowedValue -> enumAllowedValue.getName().equals(enumValue.getName()));
+
+        if (noneMatchAllowedEnumValue) {
+            addValidationError(errors, MUST_BE_VALID_ENUM_VALUE_MESSAGE, enumValue.getName(), allowedTypeDefinition.getEnumValueDefinitions().stream()
+                            .map(EnumValueDefinition::getName)
+                            .collect(Collectors.joining(",")));
+        }
+    }
+
+    private void checkArgValueMatchesAllowedScalar(List<GraphQLError> errors, Value instanceValue, String allowedTypeName) {
+        if (instanceValue instanceof ArrayValue
+                || instanceValue instanceof EnumValue
+                || instanceValue instanceof ObjectValue) {
+            addValidationError(errors, EXPECTED_SCALAR_MESSAGE, instanceValue.getClass().getSimpleName());
+            return;
+        }
+
+        GraphQLScalarType scalarType = runtimeWiring.getScalars().get(allowedTypeName);
+        // scalarType will always be present as
+        // scalar implementation validation has been performed earlier
+        if (!isArgumentValueScalarLiteral(scalarType, instanceValue)) {
+            addValidationError(errors, NOT_A_VALID_SCALAR_LITERAL_MESSAGE, allowedTypeName);
+        }
+    }
+
+    private void checkArgInputObjectValueFieldMatchesAllowedDefinition(List<GraphQLError> errors, ObjectField objectField, InputValueDefinition allowedValueDef) {
+
+        if (objectField != null) {
+            checkArgValueMatchesAllowedType(errors, objectField.getValue(), allowedValueDef.getType());
+            return;
+        }
+
+        // check if field definition is required and has no default value
+        if (allowedValueDef.getType() instanceof NonNullType && allowedValueDef.getDefaultValue() == null) {
+            addValidationError(errors, MISSING_REQUIRED_FIELD_MESSAGE, allowedValueDef.getName());
+        }
+
+        // other cases are
+        // - field definition is marked as non-null but has a default value, so the default value can be used
+        // - field definition is nullable hence null can be used
+    }
+
+    private void checkArgValueMatchesAllowedNonNullType(List<GraphQLError> errors, Value instanceValue, NonNullType allowedArgType) {
+        if (instanceValue instanceof NullValue) {
+            addValidationError(errors, EXPECTED_NON_NULL_MESSAGE);
+            return;
+        }
+
+        Type unwrappedAllowedType = allowedArgType.getType();
+        checkArgValueMatchesAllowedType(errors, instanceValue, unwrappedAllowedType);
+    }
+
+    private void checkArgValueMatchesAllowedListType(List<GraphQLError> errors, Value instanceValue, ListType allowedArgType) {
+        if (instanceValue instanceof NullValue) {
+            return;
+        }
+
+        if (!(instanceValue instanceof ArrayValue)) {
+            addValidationError(errors, EXPECTED_LIST_MESSAGE, instanceValue.getClass().getSimpleName());
+            return;
+        }
+
+        ArrayValue arrayValue = ((ArrayValue) instanceValue);
+        Type unwrappedAllowedType = allowedArgType.getType();
+
+        // validate each instance value in the list, all instances must match for the list to match
+        arrayValue.getValues().forEach(value -> checkArgValueMatchesAllowedType(errors, value, unwrappedAllowedType));
+    }
+
+    private boolean isArgumentValueScalarLiteral(GraphQLScalarType scalarType, Value instanceValue) {
+        try {
+            scalarType.getCoercing().parseLiteral(instanceValue);
+            return true;
+        } catch (CoercingParseLiteralException ex) {
+            log.debug("Attempted parsing literal into '{}' but got the following error: ", scalarType.getName(), ex);
+            return false;
+        }
+    }
+}

--- a/src/main/java/graphql/schema/idl/SchemaTypeChecker.java
+++ b/src/main/java/graphql/schema/idl/SchemaTypeChecker.java
@@ -82,12 +82,13 @@ public class SchemaTypeChecker {
 
         checkFieldsAreSensible(errors, typeRegistry);
 
-        if (enforceSchemaDirectives) {
-            SchemaTypeDirectivesChecker directivesChecker = new SchemaTypeDirectivesChecker();
-            directivesChecker.checkTypeDirectives(errors, typeRegistry);
-        }
-
+        //check directive definitions before checking directive usages
         checkDirectiveDefinitions(typeRegistry, errors);
+
+        if (enforceSchemaDirectives) {
+            SchemaTypeDirectivesChecker directivesChecker = new SchemaTypeDirectivesChecker(typeRegistry, wiring);
+            directivesChecker.checkTypeDirectives(errors);
+        }
 
         return errors;
     }

--- a/src/main/java/graphql/schema/idl/SchemaTypeDirectivesChecker.java
+++ b/src/main/java/graphql/schema/idl/SchemaTypeDirectivesChecker.java
@@ -1,35 +1,50 @@
 package graphql.schema.idl;
 
+import graphql.AssertException;
 import graphql.GraphQLError;
 import graphql.Internal;
 import graphql.introspection.Introspection.DirectiveLocation;
 import graphql.language.Argument;
+import graphql.language.ArrayValue;
 import graphql.language.Directive;
 import graphql.language.DirectiveDefinition;
 import graphql.language.EnumTypeDefinition;
+import graphql.language.EnumValue;
 import graphql.language.EnumValueDefinition;
 import graphql.language.FieldDefinition;
 import graphql.language.InputObjectTypeDefinition;
 import graphql.language.InputValueDefinition;
 import graphql.language.InterfaceTypeDefinition;
+import graphql.language.ListType;
 import graphql.language.Node;
 import graphql.language.NonNullType;
+import graphql.language.NullValue;
+import graphql.language.ObjectField;
 import graphql.language.ObjectTypeDefinition;
+import graphql.language.ObjectValue;
+import graphql.language.ScalarTypeDefinition;
 import graphql.language.Type;
 import graphql.language.TypeDefinition;
+import graphql.language.TypeName;
 import graphql.language.UnionTypeDefinition;
 import graphql.language.Value;
+import graphql.schema.CoercingParseLiteralException;
+import graphql.schema.GraphQLScalarType;
 import graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError;
 import graphql.schema.idl.errors.DirectiveIllegalLocationError;
 import graphql.schema.idl.errors.DirectiveMissingNonNullArgumentError;
 import graphql.schema.idl.errors.DirectiveUndeclaredError;
 import graphql.schema.idl.errors.DirectiveUnknownArgumentError;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static graphql.Assert.assertShouldNeverHappen;
 import static graphql.introspection.Introspection.DirectiveLocation.ARGUMENT_DEFINITION;
 import static graphql.introspection.Introspection.DirectiveLocation.ENUM;
 import static graphql.introspection.Introspection.DirectiveLocation.ENUM_VALUE;
@@ -40,6 +55,16 @@ import static graphql.introspection.Introspection.DirectiveLocation.INTERFACE;
 import static graphql.introspection.Introspection.DirectiveLocation.OBJECT;
 import static graphql.introspection.Introspection.DirectiveLocation.SCALAR;
 import static graphql.introspection.Introspection.DirectiveLocation.UNION;
+import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.DUPLICATED_KEYS_MESSAGE;
+import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.EXPECTED_ENUM_MESSAGE;
+import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.EXPECTED_LIST_MESSAGE;
+import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.EXPECTED_NON_NULL_MESSAGE;
+import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.EXPECTED_OBJECT_MESSAGE;
+import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.EXPECTED_SCALAR_MESSAGE;
+import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.MISSING_REQUIRED_FIELD_MESSAGE;
+import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.MUST_BE_VALID_ENUM_VALUE_MESSAGE;
+import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.NOT_A_VALID_SCALAR_LITERAL_MESSAGE;
+import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.UNKNOWN_FIELDS_MESSAGE;
 import static graphql.util.FpKit.getByName;
 import static graphql.util.FpKit.mergeFirst;
 
@@ -51,39 +76,49 @@ import static graphql.util.FpKit.mergeFirst;
 @Internal
 class SchemaTypeDirectivesChecker {
 
-    void checkTypeDirectives(List<GraphQLError> errors, TypeDefinitionRegistry typeRegistry) {
+    private static final Logger log = LoggerFactory.getLogger(SchemaTypeDirectivesChecker.class);
 
+    private final TypeDefinitionRegistry typeRegistry;
+    private final RuntimeWiring runtimeWiring;
+
+    public SchemaTypeDirectivesChecker(final TypeDefinitionRegistry typeRegistry,
+                                       final RuntimeWiring runtimeWiring) {
+        this.typeRegistry = typeRegistry;
+        this.runtimeWiring = runtimeWiring;
+    }
+
+    void checkTypeDirectives(List<GraphQLError> errors) {
         typeRegistry.objectTypeExtensions().values()
-                .forEach(extDefinitions -> extDefinitions.forEach(ext -> checkDirectives(OBJECT, errors, typeRegistry, ext)));
+                .forEach(extDefinitions -> extDefinitions.forEach(ext -> checkDirectives(OBJECT, errors, ext)));
         typeRegistry.interfaceTypeExtensions().values()
-                .forEach(extDefinitions -> extDefinitions.forEach(ext -> checkDirectives(INTERFACE, errors, typeRegistry, ext)));
+                .forEach(extDefinitions -> extDefinitions.forEach(ext -> checkDirectives(INTERFACE, errors, ext)));
         typeRegistry.unionTypeExtensions().values()
-                .forEach(extDefinitions -> extDefinitions.forEach(ext -> checkDirectives(UNION, errors, typeRegistry, ext)));
+                .forEach(extDefinitions -> extDefinitions.forEach(ext -> checkDirectives(UNION, errors, ext)));
         typeRegistry.enumTypeExtensions().values()
-                .forEach(extDefinitions -> extDefinitions.forEach(ext -> checkDirectives(ENUM, errors, typeRegistry, ext)));
+                .forEach(extDefinitions -> extDefinitions.forEach(ext -> checkDirectives(ENUM, errors, ext)));
         typeRegistry.scalarTypeExtensions().values()
-                .forEach(extDefinitions -> extDefinitions.forEach(ext -> checkDirectives(SCALAR, errors, typeRegistry, ext)));
+                .forEach(extDefinitions -> extDefinitions.forEach(ext -> checkDirectives(SCALAR, errors, ext)));
         typeRegistry.inputObjectTypeExtensions().values()
-                .forEach(extDefinitions -> extDefinitions.forEach(ext -> checkDirectives(INPUT_OBJECT, errors, typeRegistry, ext)));
+                .forEach(extDefinitions -> extDefinitions.forEach(ext -> checkDirectives(INPUT_OBJECT, errors, ext)));
 
         typeRegistry.getTypes(ObjectTypeDefinition.class)
-                .forEach(typeDef -> checkDirectives(OBJECT, errors, typeRegistry, typeDef));
+                .forEach(typeDef -> checkDirectives(OBJECT, errors, typeDef));
         typeRegistry.getTypes(InterfaceTypeDefinition.class)
-                .forEach(typeDef -> checkDirectives(INTERFACE, errors, typeRegistry, typeDef));
+                .forEach(typeDef -> checkDirectives(INTERFACE, errors, typeDef));
         typeRegistry.getTypes(UnionTypeDefinition.class)
-                .forEach(typeDef -> checkDirectives(UNION, errors, typeRegistry, typeDef));
+                .forEach(typeDef -> checkDirectives(UNION, errors, typeDef));
         typeRegistry.getTypes(EnumTypeDefinition.class)
-                .forEach(typeDef -> checkDirectives(ENUM, errors, typeRegistry, typeDef));
+                .forEach(typeDef -> checkDirectives(ENUM, errors, typeDef));
         typeRegistry.getTypes(InputObjectTypeDefinition.class)
-                .forEach(typeDef -> checkDirectives(INPUT_OBJECT, errors, typeRegistry, typeDef));
+                .forEach(typeDef -> checkDirectives(INPUT_OBJECT, errors, typeDef));
 
         typeRegistry.scalars().values()
-                .forEach(typeDef -> checkDirectives(SCALAR, errors, typeRegistry, typeDef));
+                .forEach(typeDef -> checkDirectives(SCALAR, errors, typeDef));
 
     }
 
 
-    private void checkDirectives(DirectiveLocation expectedLocation, List<GraphQLError> errors, TypeDefinitionRegistry typeRegistry, TypeDefinition<?> typeDef) {
+    private void checkDirectives(DirectiveLocation expectedLocation, List<GraphQLError> errors, TypeDefinition<?> typeDef) {
         checkDirectives(expectedLocation, errors, typeRegistry, typeDef, typeDef.getName(), typeDef.getDirectives());
 
         if (typeDef instanceof ObjectTypeDefinition) {
@@ -143,8 +178,9 @@ class SchemaTypeDirectivesChecker {
             InputValueDefinition allowedArg = allowedArgs.get(argument.getName());
             if (allowedArg == null) {
                 errors.add(new DirectiveUnknownArgumentError(element, elementName, directive.getName(), argument.getName()));
-            } else if (!argValueMatchesAllowedType(typeRegistry, argument.getValue(), allowedArg.getType())) {
-                errors.add(new DirectiveIllegalArgumentTypeError(element, elementName, directive.getName(), argument.getName()));
+            } else {
+                ArgValueOfAllowedTypeChecker argValueOfAllowedTypeChecker = new ArgValueOfAllowedTypeChecker(directive, element, elementName, argument);
+                argValueOfAllowedTypeChecker.checkArgValueMatchesAllowedType(errors, argument.getValue(), allowedArg.getType());
             }
         });
         allowedArgs.forEach((argName, definitionArgument) -> {
@@ -160,8 +196,219 @@ class SchemaTypeDirectivesChecker {
         return definitionArgument.getType() instanceof NonNullType && definitionArgument.getDefaultValue() == null;
     }
 
-    private boolean argValueMatchesAllowedType(TypeDefinitionRegistry typeRegistry, Value instanceValue, Type allowedArgType) {
-        // this code is not written yet and is tricky.
-        return true;
+
+    /**
+     * Class to check whether a given directive argument value
+     * matches a given directive definition.
+     *
+     */
+    private class ArgValueOfAllowedTypeChecker {
+
+        private final Directive directive;
+        private final Node element;
+        private final String elementName;
+        private final Argument argument;
+
+        ArgValueOfAllowedTypeChecker(Directive directive,
+                                     Node element,
+                                     String elementName,
+                                     Argument argument) {
+            this.directive = directive;
+            this.element = element;
+            this.elementName = elementName;
+            this.argument = argument;
+        }
+
+        /**
+         * Recursively inspects an argument value given an allowed type.
+         * Given the (invalid) SDL below:
+         *
+         *      directive @myDirective(arg: [[String]] ) on FIELD_DEFINITION
+         *
+         *      query {
+         *          f: String @myDirective(arg: ["A String"])
+         *      }
+         *
+         * it will first check that the `myDirective.arg` type is an array
+         * and fail when finding "A String" as it expected a nested array ([[String]]).
+         * @param errors validation error collector
+         * @param instanceValue directive argument value
+         * @param allowedArgType directive definition argument allowed type
+         */
+        void checkArgValueMatchesAllowedType(List<GraphQLError> errors, Value instanceValue, Type allowedArgType) {
+            if (allowedArgType instanceof TypeName) {
+                checkArgValueMatchesAllowedTypeName(errors, instanceValue, allowedArgType);
+            } else if (allowedArgType instanceof ListType) {
+                checkArgValueMatchesAllowedListType(errors, instanceValue, (ListType) allowedArgType);
+            } else if (allowedArgType instanceof NonNullType) {
+                checkArgValueMatchesAllowedNonNullType(errors, instanceValue, (NonNullType) allowedArgType);
+            } else {
+                assertShouldNeverHappen("Unsupported Type '%s' was added. ", allowedArgType);
+            }
+        }
+
+        private void addValidationError(List<GraphQLError> errors, String message, Object... args) {
+            errors.add(new DirectiveIllegalArgumentTypeError(element, elementName, directive.getName(), argument.getName(), String.format(message, args)));
+        }
+
+        private void checkArgValueMatchesAllowedTypeName(List<GraphQLError> errors, Value instanceValue, Type allowedArgType) {
+            if (instanceValue instanceof NullValue) {
+                return;
+            }
+
+            String allowedTypeName = ((TypeName) allowedArgType).getName();
+            TypeDefinition allowedTypeDefinition = typeRegistry.getType(allowedTypeName)
+                    .orElseThrow(() -> new AssertException("Directive unknown argument type '%s'. This should have been validated before."));
+
+            if (allowedTypeDefinition instanceof ScalarTypeDefinition) {
+                checkArgValueMatchesAllowedScalar(errors, instanceValue, allowedTypeName);
+            } else if (allowedTypeDefinition instanceof EnumTypeDefinition) {
+                checkArgValueMatchesAllowedEnum(errors, instanceValue, (EnumTypeDefinition) allowedTypeDefinition);
+            } else if (allowedTypeDefinition instanceof InputObjectTypeDefinition) {
+                checkArgValueMatchesAllowedInputType(errors, instanceValue, (InputObjectTypeDefinition) allowedTypeDefinition);
+            } else {
+                assertShouldNeverHappen("'%s' must be an input type. It is %s instead. ", allowedTypeName, allowedTypeDefinition.getClass());
+            }
+        }
+
+        private void checkArgValueMatchesAllowedInputType(List<GraphQLError> errors, Value instanceValue, InputObjectTypeDefinition allowedTypeDefinition) {
+            if (!(instanceValue instanceof ObjectValue)) {
+                addValidationError(errors, EXPECTED_OBJECT_MESSAGE, instanceValue.getClass().getSimpleName());
+                return;
+            }
+
+            ObjectValue objectValue = ((ObjectValue) instanceValue);
+            // duck typing validation, if it looks like the definition
+            // then it must be the same type as the definition
+
+            List<ObjectField> fields = objectValue.getObjectFields();
+            List<InputValueDefinition> inputValueDefinitions = allowedTypeDefinition.getInputValueDefinitions();
+
+            // check for duplicated fields
+            Map<String, Long> fieldsToOccurrenceMap = fields.stream().map(ObjectField::getName)
+                    .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+
+            if (fieldsToOccurrenceMap.values().stream().anyMatch(count -> count > 1)) {
+                addValidationError(errors, DUPLICATED_KEYS_MESSAGE, fieldsToOccurrenceMap.entrySet().stream()
+                        .filter(entry -> entry.getValue() > 1)
+                        .map(Map.Entry::getKey)
+                        .collect(Collectors.joining(",")));
+                return;
+            }
+
+            // check for unknown fields
+            Map<String, InputValueDefinition> nameToInputValueDefMap = inputValueDefinitions.stream()
+                    .collect(Collectors.toMap(InputValueDefinition::getName, inputValueDef -> inputValueDef));
+
+            List<ObjectField> unknownFields = fields.stream()
+                    .filter(field -> !nameToInputValueDefMap.containsKey(field.getName()))
+                    .collect(Collectors.toList());
+
+            if (!unknownFields.isEmpty()) {
+                addValidationError(errors, UNKNOWN_FIELDS_MESSAGE,
+                        unknownFields.stream()
+                                .map(ObjectField::getName)
+                                .collect(Collectors.joining(",")),
+                        allowedTypeDefinition.getName());
+                return;
+            }
+
+            // fields to map for easy access
+            Map<String, ObjectField> nameToFieldsMap = fields.stream()
+                    .collect(Collectors.toMap(ObjectField::getName, objectField -> objectField));
+            // check each single field with its definition
+            inputValueDefinitions.forEach(allowedValueDef -> {
+                ObjectField objectField = nameToFieldsMap.get(allowedValueDef.getName());
+                checkArgInputObjectValueFieldMatchesAllowedDefinition(errors, objectField, allowedValueDef);
+            });
+        }
+
+        private void checkArgValueMatchesAllowedEnum(List<GraphQLError> errors, Value instanceValue, EnumTypeDefinition allowedTypeDefinition) {
+            if (!(instanceValue instanceof EnumValue)) {
+                addValidationError(errors, EXPECTED_ENUM_MESSAGE, instanceValue.getClass().getSimpleName());
+                return;
+            }
+
+            EnumValue enumValue = ((EnumValue) instanceValue);
+
+            boolean noneMatchAllowedEnumValue = allowedTypeDefinition.getEnumValueDefinitions().stream()
+                    .noneMatch(enumAllowedValue -> enumAllowedValue.getName().equals(enumValue.getName()));
+
+            if (noneMatchAllowedEnumValue) {
+                addValidationError(errors, MUST_BE_VALID_ENUM_VALUE_MESSAGE, enumValue.getName(), allowedTypeDefinition.getEnumValueDefinitions().stream()
+                                .map(EnumValueDefinition::getName)
+                                .collect(Collectors.joining(",")));
+            }
+        }
+
+        private void checkArgValueMatchesAllowedScalar(List<GraphQLError> errors, Value instanceValue, String allowedTypeName) {
+            if (instanceValue instanceof ArrayValue
+                    || instanceValue instanceof EnumValue
+                    || instanceValue instanceof ObjectValue) {
+                addValidationError(errors, EXPECTED_SCALAR_MESSAGE, instanceValue.getClass().getSimpleName());
+                return;
+            }
+
+            GraphQLScalarType scalarType = runtimeWiring.getScalars().get(allowedTypeName);
+            // scalarType will always be present as
+            // scalar implementation validation has been performed earlier
+            if (!isArgumentValueScalarLiteral(scalarType, instanceValue)) {
+                addValidationError(errors, NOT_A_VALID_SCALAR_LITERAL_MESSAGE, allowedTypeName);
+            }
+        }
+
+        private void checkArgInputObjectValueFieldMatchesAllowedDefinition(List<GraphQLError> errors, ObjectField objectField, InputValueDefinition allowedValueDef) {
+
+            if (objectField != null) {
+                checkArgValueMatchesAllowedType(errors, objectField.getValue(), allowedValueDef.getType());
+                return;
+            }
+
+            // check if field definition is required and has no default value
+            if (allowedValueDef.getType() instanceof NonNullType && allowedValueDef.getDefaultValue() == null) {
+                addValidationError(errors, MISSING_REQUIRED_FIELD_MESSAGE, allowedValueDef.getName());
+            }
+
+            // other cases are
+            // - field definition is marked as non-null but has a default value, so the default value can be used
+            // - field definition is nullable hence null can be used
+        }
+
+        private void checkArgValueMatchesAllowedNonNullType(List<GraphQLError> errors, Value instanceValue, NonNullType allowedArgType) {
+            if (instanceValue instanceof NullValue) {
+                addValidationError(errors, EXPECTED_NON_NULL_MESSAGE);
+                return;
+            }
+
+            Type unwrappedAllowedType = allowedArgType.getType();
+            checkArgValueMatchesAllowedType(errors, instanceValue, unwrappedAllowedType);
+        }
+
+        private void checkArgValueMatchesAllowedListType(List<GraphQLError> errors, Value instanceValue, ListType allowedArgType) {
+            if (instanceValue instanceof NullValue) {
+                return;
+            }
+
+            if (!(instanceValue instanceof ArrayValue)) {
+                addValidationError(errors, EXPECTED_LIST_MESSAGE, instanceValue.getClass().getSimpleName());
+                return;
+            }
+
+            ArrayValue arrayValue = ((ArrayValue) instanceValue);
+            Type unwrappedAllowedType = allowedArgType.getType();
+
+            // validate each instance value in the list, all instances must match for the list to match
+            arrayValue.getValues().forEach(value -> checkArgValueMatchesAllowedType(errors, value, unwrappedAllowedType));
+        }
+
+        private boolean isArgumentValueScalarLiteral(GraphQLScalarType scalarType, Value instanceValue) {
+            try {
+                scalarType.getCoercing().parseLiteral(instanceValue);
+                return true;
+            } catch (CoercingParseLiteralException ex) {
+                log.debug("Attempted parsing literal into '{}' but got the following error: ", scalarType.getName(), ex);
+                return false;
+            }
+        }
     }
 }

--- a/src/main/java/graphql/schema/idl/SchemaTypeDirectivesChecker.java
+++ b/src/main/java/graphql/schema/idl/SchemaTypeDirectivesChecker.java
@@ -1,50 +1,32 @@
 package graphql.schema.idl;
 
-import graphql.AssertException;
 import graphql.GraphQLError;
 import graphql.Internal;
 import graphql.introspection.Introspection.DirectiveLocation;
 import graphql.language.Argument;
-import graphql.language.ArrayValue;
 import graphql.language.Directive;
 import graphql.language.DirectiveDefinition;
 import graphql.language.EnumTypeDefinition;
-import graphql.language.EnumValue;
 import graphql.language.EnumValueDefinition;
 import graphql.language.FieldDefinition;
 import graphql.language.InputObjectTypeDefinition;
 import graphql.language.InputValueDefinition;
 import graphql.language.InterfaceTypeDefinition;
-import graphql.language.ListType;
 import graphql.language.Node;
 import graphql.language.NonNullType;
-import graphql.language.NullValue;
-import graphql.language.ObjectField;
 import graphql.language.ObjectTypeDefinition;
-import graphql.language.ObjectValue;
-import graphql.language.ScalarTypeDefinition;
-import graphql.language.Type;
 import graphql.language.TypeDefinition;
-import graphql.language.TypeName;
 import graphql.language.UnionTypeDefinition;
-import graphql.language.Value;
-import graphql.schema.CoercingParseLiteralException;
-import graphql.schema.GraphQLScalarType;
-import graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError;
 import graphql.schema.idl.errors.DirectiveIllegalLocationError;
 import graphql.schema.idl.errors.DirectiveMissingNonNullArgumentError;
 import graphql.schema.idl.errors.DirectiveUndeclaredError;
 import graphql.schema.idl.errors.DirectiveUnknownArgumentError;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static graphql.Assert.assertShouldNeverHappen;
 import static graphql.introspection.Introspection.DirectiveLocation.ARGUMENT_DEFINITION;
 import static graphql.introspection.Introspection.DirectiveLocation.ENUM;
 import static graphql.introspection.Introspection.DirectiveLocation.ENUM_VALUE;
@@ -55,16 +37,6 @@ import static graphql.introspection.Introspection.DirectiveLocation.INTERFACE;
 import static graphql.introspection.Introspection.DirectiveLocation.OBJECT;
 import static graphql.introspection.Introspection.DirectiveLocation.SCALAR;
 import static graphql.introspection.Introspection.DirectiveLocation.UNION;
-import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.DUPLICATED_KEYS_MESSAGE;
-import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.EXPECTED_ENUM_MESSAGE;
-import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.EXPECTED_LIST_MESSAGE;
-import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.EXPECTED_NON_NULL_MESSAGE;
-import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.EXPECTED_OBJECT_MESSAGE;
-import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.EXPECTED_SCALAR_MESSAGE;
-import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.MISSING_REQUIRED_FIELD_MESSAGE;
-import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.MUST_BE_VALID_ENUM_VALUE_MESSAGE;
-import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.NOT_A_VALID_SCALAR_LITERAL_MESSAGE;
-import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.UNKNOWN_FIELDS_MESSAGE;
 import static graphql.util.FpKit.getByName;
 import static graphql.util.FpKit.mergeFirst;
 
@@ -75,8 +47,6 @@ import static graphql.util.FpKit.mergeFirst;
  */
 @Internal
 class SchemaTypeDirectivesChecker {
-
-    private static final Logger log = LoggerFactory.getLogger(SchemaTypeDirectivesChecker.class);
 
     private final TypeDefinitionRegistry typeRegistry;
     private final RuntimeWiring runtimeWiring;
@@ -179,7 +149,7 @@ class SchemaTypeDirectivesChecker {
             if (allowedArg == null) {
                 errors.add(new DirectiveUnknownArgumentError(element, elementName, directive.getName(), argument.getName()));
             } else {
-                ArgValueOfAllowedTypeChecker argValueOfAllowedTypeChecker = new ArgValueOfAllowedTypeChecker(directive, element, elementName, argument);
+                ArgValueOfAllowedTypeChecker argValueOfAllowedTypeChecker = new ArgValueOfAllowedTypeChecker(directive, element, elementName, argument, typeRegistry, runtimeWiring);
                 argValueOfAllowedTypeChecker.checkArgValueMatchesAllowedType(errors, argument.getValue(), allowedArg.getType());
             }
         });
@@ -194,221 +164,5 @@ class SchemaTypeDirectivesChecker {
 
     private boolean isNoNullArgWithoutDefaultValue(InputValueDefinition definitionArgument) {
         return definitionArgument.getType() instanceof NonNullType && definitionArgument.getDefaultValue() == null;
-    }
-
-
-    /**
-     * Class to check whether a given directive argument value
-     * matches a given directive definition.
-     *
-     */
-    private class ArgValueOfAllowedTypeChecker {
-
-        private final Directive directive;
-        private final Node element;
-        private final String elementName;
-        private final Argument argument;
-
-        ArgValueOfAllowedTypeChecker(Directive directive,
-                                     Node element,
-                                     String elementName,
-                                     Argument argument) {
-            this.directive = directive;
-            this.element = element;
-            this.elementName = elementName;
-            this.argument = argument;
-        }
-
-        /**
-         * Recursively inspects an argument value given an allowed type.
-         * Given the (invalid) SDL below:
-         *
-         *      directive @myDirective(arg: [[String]] ) on FIELD_DEFINITION
-         *
-         *      query {
-         *          f: String @myDirective(arg: ["A String"])
-         *      }
-         *
-         * it will first check that the `myDirective.arg` type is an array
-         * and fail when finding "A String" as it expected a nested array ([[String]]).
-         * @param errors validation error collector
-         * @param instanceValue directive argument value
-         * @param allowedArgType directive definition argument allowed type
-         */
-        void checkArgValueMatchesAllowedType(List<GraphQLError> errors, Value instanceValue, Type allowedArgType) {
-            if (allowedArgType instanceof TypeName) {
-                checkArgValueMatchesAllowedTypeName(errors, instanceValue, allowedArgType);
-            } else if (allowedArgType instanceof ListType) {
-                checkArgValueMatchesAllowedListType(errors, instanceValue, (ListType) allowedArgType);
-            } else if (allowedArgType instanceof NonNullType) {
-                checkArgValueMatchesAllowedNonNullType(errors, instanceValue, (NonNullType) allowedArgType);
-            } else {
-                assertShouldNeverHappen("Unsupported Type '%s' was added. ", allowedArgType);
-            }
-        }
-
-        private void addValidationError(List<GraphQLError> errors, String message, Object... args) {
-            errors.add(new DirectiveIllegalArgumentTypeError(element, elementName, directive.getName(), argument.getName(), String.format(message, args)));
-        }
-
-        private void checkArgValueMatchesAllowedTypeName(List<GraphQLError> errors, Value instanceValue, Type allowedArgType) {
-            if (instanceValue instanceof NullValue) {
-                return;
-            }
-
-            String allowedTypeName = ((TypeName) allowedArgType).getName();
-            TypeDefinition allowedTypeDefinition = typeRegistry.getType(allowedTypeName)
-                    .orElseThrow(() -> new AssertException("Directive unknown argument type '%s'. This should have been validated before."));
-
-            if (allowedTypeDefinition instanceof ScalarTypeDefinition) {
-                checkArgValueMatchesAllowedScalar(errors, instanceValue, allowedTypeName);
-            } else if (allowedTypeDefinition instanceof EnumTypeDefinition) {
-                checkArgValueMatchesAllowedEnum(errors, instanceValue, (EnumTypeDefinition) allowedTypeDefinition);
-            } else if (allowedTypeDefinition instanceof InputObjectTypeDefinition) {
-                checkArgValueMatchesAllowedInputType(errors, instanceValue, (InputObjectTypeDefinition) allowedTypeDefinition);
-            } else {
-                assertShouldNeverHappen("'%s' must be an input type. It is %s instead. ", allowedTypeName, allowedTypeDefinition.getClass());
-            }
-        }
-
-        private void checkArgValueMatchesAllowedInputType(List<GraphQLError> errors, Value instanceValue, InputObjectTypeDefinition allowedTypeDefinition) {
-            if (!(instanceValue instanceof ObjectValue)) {
-                addValidationError(errors, EXPECTED_OBJECT_MESSAGE, instanceValue.getClass().getSimpleName());
-                return;
-            }
-
-            ObjectValue objectValue = ((ObjectValue) instanceValue);
-            // duck typing validation, if it looks like the definition
-            // then it must be the same type as the definition
-
-            List<ObjectField> fields = objectValue.getObjectFields();
-            List<InputValueDefinition> inputValueDefinitions = allowedTypeDefinition.getInputValueDefinitions();
-
-            // check for duplicated fields
-            Map<String, Long> fieldsToOccurrenceMap = fields.stream().map(ObjectField::getName)
-                    .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
-
-            if (fieldsToOccurrenceMap.values().stream().anyMatch(count -> count > 1)) {
-                addValidationError(errors, DUPLICATED_KEYS_MESSAGE, fieldsToOccurrenceMap.entrySet().stream()
-                        .filter(entry -> entry.getValue() > 1)
-                        .map(Map.Entry::getKey)
-                        .collect(Collectors.joining(",")));
-                return;
-            }
-
-            // check for unknown fields
-            Map<String, InputValueDefinition> nameToInputValueDefMap = inputValueDefinitions.stream()
-                    .collect(Collectors.toMap(InputValueDefinition::getName, inputValueDef -> inputValueDef));
-
-            List<ObjectField> unknownFields = fields.stream()
-                    .filter(field -> !nameToInputValueDefMap.containsKey(field.getName()))
-                    .collect(Collectors.toList());
-
-            if (!unknownFields.isEmpty()) {
-                addValidationError(errors, UNKNOWN_FIELDS_MESSAGE,
-                        unknownFields.stream()
-                                .map(ObjectField::getName)
-                                .collect(Collectors.joining(",")),
-                        allowedTypeDefinition.getName());
-                return;
-            }
-
-            // fields to map for easy access
-            Map<String, ObjectField> nameToFieldsMap = fields.stream()
-                    .collect(Collectors.toMap(ObjectField::getName, objectField -> objectField));
-            // check each single field with its definition
-            inputValueDefinitions.forEach(allowedValueDef -> {
-                ObjectField objectField = nameToFieldsMap.get(allowedValueDef.getName());
-                checkArgInputObjectValueFieldMatchesAllowedDefinition(errors, objectField, allowedValueDef);
-            });
-        }
-
-        private void checkArgValueMatchesAllowedEnum(List<GraphQLError> errors, Value instanceValue, EnumTypeDefinition allowedTypeDefinition) {
-            if (!(instanceValue instanceof EnumValue)) {
-                addValidationError(errors, EXPECTED_ENUM_MESSAGE, instanceValue.getClass().getSimpleName());
-                return;
-            }
-
-            EnumValue enumValue = ((EnumValue) instanceValue);
-
-            boolean noneMatchAllowedEnumValue = allowedTypeDefinition.getEnumValueDefinitions().stream()
-                    .noneMatch(enumAllowedValue -> enumAllowedValue.getName().equals(enumValue.getName()));
-
-            if (noneMatchAllowedEnumValue) {
-                addValidationError(errors, MUST_BE_VALID_ENUM_VALUE_MESSAGE, enumValue.getName(), allowedTypeDefinition.getEnumValueDefinitions().stream()
-                                .map(EnumValueDefinition::getName)
-                                .collect(Collectors.joining(",")));
-            }
-        }
-
-        private void checkArgValueMatchesAllowedScalar(List<GraphQLError> errors, Value instanceValue, String allowedTypeName) {
-            if (instanceValue instanceof ArrayValue
-                    || instanceValue instanceof EnumValue
-                    || instanceValue instanceof ObjectValue) {
-                addValidationError(errors, EXPECTED_SCALAR_MESSAGE, instanceValue.getClass().getSimpleName());
-                return;
-            }
-
-            GraphQLScalarType scalarType = runtimeWiring.getScalars().get(allowedTypeName);
-            // scalarType will always be present as
-            // scalar implementation validation has been performed earlier
-            if (!isArgumentValueScalarLiteral(scalarType, instanceValue)) {
-                addValidationError(errors, NOT_A_VALID_SCALAR_LITERAL_MESSAGE, allowedTypeName);
-            }
-        }
-
-        private void checkArgInputObjectValueFieldMatchesAllowedDefinition(List<GraphQLError> errors, ObjectField objectField, InputValueDefinition allowedValueDef) {
-
-            if (objectField != null) {
-                checkArgValueMatchesAllowedType(errors, objectField.getValue(), allowedValueDef.getType());
-                return;
-            }
-
-            // check if field definition is required and has no default value
-            if (allowedValueDef.getType() instanceof NonNullType && allowedValueDef.getDefaultValue() == null) {
-                addValidationError(errors, MISSING_REQUIRED_FIELD_MESSAGE, allowedValueDef.getName());
-            }
-
-            // other cases are
-            // - field definition is marked as non-null but has a default value, so the default value can be used
-            // - field definition is nullable hence null can be used
-        }
-
-        private void checkArgValueMatchesAllowedNonNullType(List<GraphQLError> errors, Value instanceValue, NonNullType allowedArgType) {
-            if (instanceValue instanceof NullValue) {
-                addValidationError(errors, EXPECTED_NON_NULL_MESSAGE);
-                return;
-            }
-
-            Type unwrappedAllowedType = allowedArgType.getType();
-            checkArgValueMatchesAllowedType(errors, instanceValue, unwrappedAllowedType);
-        }
-
-        private void checkArgValueMatchesAllowedListType(List<GraphQLError> errors, Value instanceValue, ListType allowedArgType) {
-            if (instanceValue instanceof NullValue) {
-                return;
-            }
-
-            if (!(instanceValue instanceof ArrayValue)) {
-                addValidationError(errors, EXPECTED_LIST_MESSAGE, instanceValue.getClass().getSimpleName());
-                return;
-            }
-
-            ArrayValue arrayValue = ((ArrayValue) instanceValue);
-            Type unwrappedAllowedType = allowedArgType.getType();
-
-            // validate each instance value in the list, all instances must match for the list to match
-            arrayValue.getValues().forEach(value -> checkArgValueMatchesAllowedType(errors, value, unwrappedAllowedType));
-        }
-
-        private boolean isArgumentValueScalarLiteral(GraphQLScalarType scalarType, Value instanceValue) {
-            try {
-                scalarType.getCoercing().parseLiteral(instanceValue);
-                return true;
-            } catch (CoercingParseLiteralException ex) {
-                log.debug("Attempted parsing literal into '{}' but got the following error: ", scalarType.getName(), ex);
-                return false;
-            }
-        }
     }
 }

--- a/src/main/java/graphql/schema/idl/errors/DirectiveIllegalArgumentTypeError.java
+++ b/src/main/java/graphql/schema/idl/errors/DirectiveIllegalArgumentTypeError.java
@@ -6,10 +6,27 @@ import static java.lang.String.format;
 
 public class DirectiveIllegalArgumentTypeError extends BaseError {
 
-    public DirectiveIllegalArgumentTypeError(Node element, String elementName, String directiveName, String argumentName) {
-        super(element,
-                format("'%s' %s use an illegal value for the argument '%s' on directive '%s'",
-                        elementName, BaseError.lineCol(element), argumentName, directiveName
-                ));
+    public static final String DUPLICATED_KEYS_MESSAGE = "Argument value object keys [%s] appear more than once.";
+    public static final String UNKNOWN_FIELDS_MESSAGE = "Fields ['%s'] not present in type '%s'.";
+    public static final String EXPECTED_ENUM_MESSAGE = "Argument value is of type '%s', expected an enum value.";
+    public static final String MUST_BE_VALID_ENUM_VALUE_MESSAGE = "Argument value '%s' doesn't match any of the allowed enum values ['%s']";
+    public static final String EXPECTED_SCALAR_MESSAGE = "Argument value is of type '%s', expected a scalar.";
+    public static final String NOT_A_VALID_SCALAR_LITERAL_MESSAGE = "Argument value is not a valid value of scalar '%s'.";
+    public static final String MISSING_REQUIRED_FIELD_MESSAGE = "Missing required field '%s'.";
+    public static final String EXPECTED_NON_NULL_MESSAGE = "Argument value is 'null', expected a non-null value.";
+    public static final String EXPECTED_LIST_MESSAGE = "Argument value is '%s', expected a list value.";
+    public static final String EXPECTED_OBJECT_MESSAGE = "Argument value is of type '%s', expected an Object value.";
+
+    public DirectiveIllegalArgumentTypeError(Node element, String elementName, String directiveName, String argumentName, String detailedMessaged) {
+        super(element, mkDirectiveIllegalArgumentTypeErrorMessage(element, elementName, directiveName, argumentName, detailedMessaged));
+    }
+
+    static String mkDirectiveIllegalArgumentTypeErrorMessage(Node element,
+                                                             String elementName,
+                                                             String directiveName,
+                                                             String argumentName,
+                                                             String detailedMessage) {
+        return format("'%s' %s uses an illegal value for the argument '%s' on directive '%s'. %s",
+                elementName, BaseError.lineCol(element), argumentName, directiveName, detailedMessage);
     }
 }

--- a/src/test/groovy/graphql/schema/idl/SchemaTypeCheckerTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaTypeCheckerTest.groovy
@@ -1397,9 +1397,7 @@ class SchemaTypeCheckerTest extends Specification {
     }
 
     @Unroll
-    @SuppressWarnings("GroovyPointlessBoolean")
-    def "directive definition allowed argument type '#allowedArgType' does not match argument value '#argValue'"(
-            String allowedArgType, String argValue, String detailedMessage) {
+    def "directive definition allowed argument type '#allowedArgType' does not match argument value '#argValue'"() {
         def spec = """
             directive @testDirective(knownArg : $allowedArgType) on FIELD_DEFINITION
 
@@ -1463,9 +1461,7 @@ class SchemaTypeCheckerTest extends Specification {
     }
 
     @Unroll
-    @SuppressWarnings("GroovyPointlessBoolean")
-    def "directive definition allowed argument type '#allowedArgType' matches argument value '#argValue'"(
-            String allowedArgType, String argValue) {
+    def "directive definition allowed argument type '#allowedArgType' matches argument value '#argValue'"() {
         def spec = """
             directive @testDirective(knownArg : $allowedArgType) on FIELD_DEFINITION
 

--- a/src/test/groovy/graphql/schema/idl/SchemaTypeCheckerTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaTypeCheckerTest.groovy
@@ -2,17 +2,24 @@ package graphql.schema.idl
 
 import graphql.GraphQLError
 import graphql.TypeResolutionEnvironment
+import graphql.language.StringValue
 import graphql.schema.Coercing
+import graphql.schema.CoercingParseLiteralException
 import graphql.schema.DataFetcher
 import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLScalarType
 import graphql.schema.TypeResolver
+import graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError
 import graphql.schema.idl.errors.DirectiveIllegalLocationError
 import graphql.schema.idl.errors.DirectiveUndeclaredError
 import graphql.schema.idl.errors.MissingTypeError
 import graphql.schema.idl.errors.NonUniqueNameError
 import graphql.schema.idl.errors.SchemaMissingError
 import spock.lang.Specification
+import spock.lang.Unroll
+
+import static java.lang.String.format
+import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.*
 
 class SchemaTypeCheckerTest extends Specification {
 
@@ -94,9 +101,29 @@ class SchemaTypeCheckerTest extends Specification {
                 return null
             }
         })
+        def aCustomDateScalar = new GraphQLScalarType("ACustomDate", "", new Coercing() {
+            @Override
+            Object serialize(Object dataFetcherResult) {
+                return null
+            }
+
+            @Override
+            Object parseValue(Object input) {
+                return null
+            }
+
+            @Override
+            Object parseLiteral(Object input) {
+                if (input instanceof StringValue && "AFailingDate" == input.value) {
+                    throw new CoercingParseLiteralException("Failed!")
+                }
+                return null
+            }
+        })
         def runtimeBuilder = RuntimeWiring.newRuntimeWiring()
                 .wiringFactory(wiringFactory)
                 .scalar(scalesScalar)
+                .scalar(aCustomDateScalar)
                 .type(TypeRuntimeWiring.newTypeWiring("InterfaceType1").typeResolver(resolver))
                 .type(TypeRuntimeWiring.newTypeWiring("InterfaceType2").typeResolver(resolver))
                 .type(TypeRuntimeWiring.newTypeWiring("FooBar").typeResolver(resolver))
@@ -1367,6 +1394,131 @@ class SchemaTypeCheckerTest extends Specification {
         expect:
 
         result.isEmpty()
+    }
+
+    @Unroll
+    @SuppressWarnings("GroovyPointlessBoolean")
+    def "directive definition allowed argument type '#allowedArgType' does not match argument value '#argValue'"(
+            String allowedArgType, String argValue, String detailedMessage) {
+        def spec = """
+            directive @testDirective(knownArg : $allowedArgType) on FIELD_DEFINITION
+
+            type Query {
+                f : String @testDirective(knownArg: $argValue)
+            }
+            
+            scalar ACustomDate
+            
+            enum WEEKDAY {
+                MONDAY
+                TUESDAY
+            }
+            
+            input UserInput {
+                field: String
+                fieldNonNull: String!
+                fieldWithDefault: String = "default"
+                # not sure if below makes sense
+                fieldNonNullWithDefault: String! = "default"
+                fieldArray: [String]
+                fieldArrayOfArray: [[String]]
+                fieldNestedInput: AddressInput
+            }
+            
+            input AddressInput {
+                street: String
+            }
+
+        """
+
+        enforceSchemaDirectives = true
+        def result = check(spec)
+
+        expect:
+
+        !result.empty
+        result.get(0) instanceof DirectiveIllegalArgumentTypeError
+        errorContaining(result, "'f' [@n:n] uses an illegal value for the argument 'knownArg' on directive 'testDirective'. $detailedMessage")
+
+        where:
+
+        allowedArgType | argValue                                                                               | detailedMessage
+        "String"       | 'MONDAY'                                                                               | format(EXPECTED_SCALAR_MESSAGE, "EnumValue")
+        "String"       | '{ an: "object" }'                                                                     | format(EXPECTED_SCALAR_MESSAGE, "ObjectValue")
+        "String"       | '["str", "str2"]'                                                                      | format(EXPECTED_SCALAR_MESSAGE, "ArrayValue")
+        "ACustomDate"  | '"AFailingDate"'                                                                       | format(NOT_A_VALID_SCALAR_LITERAL_MESSAGE, "ACustomDate")
+        "[String]"     | '"str"'                                                                                | format(EXPECTED_LIST_MESSAGE, "StringValue")
+        "[String]!"    | '"str"'                                                                                | format(EXPECTED_LIST_MESSAGE, "StringValue")
+        "[String!]"    | '["str", null]'                                                                        | format(EXPECTED_NON_NULL_MESSAGE)
+        "[[String!]!]" | '[["str"], ["str2", null]]'                                                            | format(EXPECTED_NON_NULL_MESSAGE)
+        "WEEKDAY"      | '"somestr"'                                                                            | format(EXPECTED_ENUM_MESSAGE, "StringValue")
+        "WEEKDAY"      | 'SATURDAY'                                                                             | format(MUST_BE_VALID_ENUM_VALUE_MESSAGE, "SATURDAY", "MONDAY,TUESDAY")
+        "UserInput"    | '{ fieldNonNull: "str", fieldNonNull: "dupeKey" }'                                     | format(DUPLICATED_KEYS_MESSAGE, "fieldNonNull")
+        "UserInput"    | '{ fieldNonNull: "str", unknown: "field" }'                                            | format(UNKNOWN_FIELDS_MESSAGE, "unknown", "UserInput")
+        "UserInput"    | '{ fieldNonNull: "str", fieldArray: "strInsteadOfArray" }'                             | format(EXPECTED_LIST_MESSAGE, "StringValue")
+        "UserInput"    | '{ fieldNonNull: "str", fieldArrayOfArray: ["ArrayInsteadOfArrayOfArray"] }'           | format(EXPECTED_LIST_MESSAGE, "StringValue")
+        "UserInput"    | '{ fieldNonNull: "str", fieldNestedInput: "strInsteadOfObject" }'                      | format(EXPECTED_OBJECT_MESSAGE, "StringValue")
+        "UserInput"    | '{ fieldNonNull: "str", fieldNestedInput: { street: { s: "objectInsteadOfString" }} }' | format(EXPECTED_SCALAR_MESSAGE, "ObjectValue")
+        "UserInput"    | '{ field: "missing the `fieldNonNull` entry"}'                                         | format(MISSING_REQUIRED_FIELD_MESSAGE, "fieldNonNull")
+    }
+
+    @Unroll
+    @SuppressWarnings("GroovyPointlessBoolean")
+    def "directive definition allowed argument type '#allowedArgType' matches argument value '#argValue'"(
+            String allowedArgType, String argValue) {
+        def spec = """
+            directive @testDirective(knownArg : $allowedArgType) on FIELD_DEFINITION
+
+            type Query {
+                f : String @testDirective(knownArg: $argValue)
+            }
+            
+            scalar ACustomDate
+           
+            enum WEEKDAY {
+                MONDAY
+            }
+            
+            input UserInput {
+                fieldString: String
+                fieldNonNull: String!
+                fieldWithDefault: String = "default"
+                fieldArray: [String]
+                fieldArrayOfArray: [[String]]
+                fieldNestedInput: AddressInput
+            }
+            
+            input AddressInput {
+                street: String
+            }
+        """
+
+        enforceSchemaDirectives = true
+        def result = check(spec)
+
+        expect:
+
+        result.empty
+
+        where:
+
+        allowedArgType | argValue
+        "String"       | '"str"'
+        "Boolean"      | 'false'
+        "String"       | 'null'
+        "ACustomDate"  | '"TwoThousand-June-Six"'
+        "ACustomDate"  | '2002'
+        "[String]"     | '["str", null]'
+        "[String]"     | 'null'
+        "[String!]!"   | '["str"]'
+        "[[String!]!]" | '[["str"], ["str2", "str3"]]'
+        "WEEKDAY"      | 'MONDAY'
+        "UserInput"    | '{ fieldNonNull: "str" }'
+        "UserInput"    | '{ fieldNonNull: "str", fieldString: "Hey" }'
+        "UserInput"    | '{ fieldNonNull: "str", fieldWithDefault: "notDefault" }'
+        "UserInput"    | '{ fieldNonNull: "str", fieldArray: ["Hey", "Low"] }'
+        "UserInput"    | '{ fieldNonNull: "str", fieldArrayOfArray: [["Hey"], ["Low"]] }'
+        "UserInput"    | '{ fieldNonNull: "str", fieldNestedInput: { street: "nestedStr"} }'
     }
 
 }

--- a/src/test/groovy/graphql/schema/idl/SchemaTypeDirectivesCheckerTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaTypeDirectivesCheckerTest.groovy
@@ -49,7 +49,7 @@ class SchemaTypeDirectivesCheckerTest extends Specification {
         def errors = []
 
         when:
-        new SchemaTypeDirectivesChecker().checkTypeDirectives(errors, registry)
+        new SchemaTypeDirectivesChecker(registry, RuntimeWiring.newRuntimeWiring().build()).checkTypeDirectives(errors)
 
         then:
         errors.size() == 0
@@ -86,7 +86,7 @@ class SchemaTypeDirectivesCheckerTest extends Specification {
         def errors = []
 
         when:
-        new SchemaTypeDirectivesChecker().checkTypeDirectives(errors, registry)
+        new SchemaTypeDirectivesChecker(registry, RuntimeWiring.newRuntimeWiring().build()).checkTypeDirectives(errors)
 
         then:
         errors.each { assert it instanceof DirectiveUndeclaredError }
@@ -130,7 +130,7 @@ class SchemaTypeDirectivesCheckerTest extends Specification {
         def errors = []
 
         when:
-        new SchemaTypeDirectivesChecker().checkTypeDirectives(errors, registry)
+        new SchemaTypeDirectivesChecker(registry, RuntimeWiring.newRuntimeWiring().build()).checkTypeDirectives(errors)
 
         then:
         errors.each { assert it instanceof DirectiveUnknownArgumentError }
@@ -169,7 +169,7 @@ class SchemaTypeDirectivesCheckerTest extends Specification {
         def errors = []
 
         when:
-        new SchemaTypeDirectivesChecker().checkTypeDirectives(errors, registry)
+        new SchemaTypeDirectivesChecker(registry, RuntimeWiring.newRuntimeWiring().build()).checkTypeDirectives(errors)
 
         then:
         errors.each { assert it instanceof DirectiveIllegalLocationError }
@@ -197,7 +197,7 @@ class SchemaTypeDirectivesCheckerTest extends Specification {
         def errors = []
 
         when:
-        new SchemaTypeDirectivesChecker().checkTypeDirectives(errors, registry)
+        new SchemaTypeDirectivesChecker(registry, RuntimeWiring.newRuntimeWiring().build()).checkTypeDirectives(errors)
 
         then:
         errors.size() == 1


### PR DESCRIPTION
## Description

**Current behavior:**
This PR adds support for validating directive definitions against directive argument types.
In the example below, while the directive definition declares `arg` as being of type `[String]`, the directive improperly uses a `String`.

```
directive @myDirective(arg: [String]) on FIELD_DEFINITION
query {
    f: String @myDirective(arg: "A String")
}
```
graphql-java does not currently catch this use case as the implementation was implicitly marked as TODO:

```
 private boolean argValueMatchesAllowedType(TypeDefinitionRegistry typeRegistry, Value instanceValue, Type allowedArgType) {
        // this code is not written yet and is tricky.
        return true;
}
```
**Expected behavior:**
graphql-java should validate directive argument values matches the allowed types defined in the directive definition. To be fair, [the validation logic does not seem to be implemented in graphql-js](https://github.com/graphql/graphql-js/blob/9925e5022162b681c7647a147c47ca8e6124a930/src/type/validate.js#L171) either. I ran a similar test with graphql-js and the validation wrongly passed.

## Steps to reproduce

I wrote a test to reproduce the issue and to cover all the plausible negative use cases:

```java
@Unroll
    @SuppressWarnings("GroovyPointlessBoolean")
    def "directive definition allowed argument type '#allowedArgType' does not match argument value '#argValue'"(
            String allowedArgType, String argValue, String detailedMessage) {
        def spec = """
            directive @testDirective(knownArg : $allowedArgType) on FIELD_DEFINITION

            type Query {
                f : String @testDirective(knownArg: $argValue)
            }
            
            scalar ACustomDate
            
            enum WEEKDAY {
                MONDAY
                TUESDAY
            }
            
            input UserInput {
                field: String
                fieldNonNull: String!
                fieldWithDefault: String = "default"
                # not sure if below makes sense
                fieldNonNullWithDefault: String! = "default"
                fieldArray: [String]
                fieldArrayOfArray: [[String]]
                fieldNestedInput: AddressInput
            }
            
            input AddressInput {
                street: String
            }

        """

        enforceSchemaDirectives = true
        def result = check(spec)

        expect:

        !result.empty
        result.get(0) instanceof DirectiveIllegalArgumentTypeError
        errorContaining(result, "'f' [@n:n] uses an illegal value for the argument 'knownArg' on directive 'testDirective'. $detailedMessage")

        where:

        allowedArgType | argValue                                                                               | detailedMessage
        "String"       | 'MONDAY'                                                                               | format(EXPECTED_SCALAR_MESSAGE, "EnumValue")
        "String"       | '{ an: "object" }'                                                                     | format(EXPECTED_SCALAR_MESSAGE, "ObjectValue")
        "String"       | '["str", "str2"]'                                                                      | format(EXPECTED_SCALAR_MESSAGE, "ArrayValue")
        "ACustomDate"  | '"AFailingDate"'                                                                       | format(NOT_A_VALID_SCALAR_LITERAL_MESSAGE, "ACustomDate")
        "[String]"     | '"str"'                                                                                | format(EXPECTED_LIST_MESSAGE, "StringValue")
        "[String]!"    | '"str"'                                                                                | format(EXPECTED_LIST_MESSAGE, "StringValue")
        "[String!]"    | '["str", null]'                                                                        | format(EXPECTED_NON_NULL_MESSAGE)
        "[[String!]!]" | '[["str"], ["str2", null]]'                                                            | format(EXPECTED_NON_NULL_MESSAGE)
        "WEEKDAY"      | '"somestr"'                                                                            | format(EXPECTED_ENUM_MESSAGE, "StringValue")
        "WEEKDAY"      | 'SATURDAY'                                                                             | format(MUST_BE_VALID_ENUM_VALUE_MESSAGE, "SATURDAY", "MONDAY,TUESDAY")
        "UserInput"    | '{ fieldNonNull: "str", fieldNonNull: "dupeKey" }'                                     | format(DUPLICATED_KEYS_MESSAGE, "fieldNonNull")
        "UserInput"    | '{ fieldNonNull: "str", unknown: "field" }'                                            | format(UNKNOWN_FIELDS_MESSAGE, "unknown", "UserInput")
        "UserInput"    | '{ fieldNonNull: "str", fieldArray: "strInsteadOfArray" }'                             | format(EXPECTED_LIST_MESSAGE, "StringValue")
        "UserInput"    | '{ fieldNonNull: "str", fieldArrayOfArray: ["ArrayInsteadOfArrayOfArray"] }'           | format(EXPECTED_LIST_MESSAGE, "StringValue")
        "UserInput"    | '{ fieldNonNull: "str", fieldNestedInput: "strInsteadOfObject" }'                      | format(EXPECTED_OBJECT_MESSAGE, "StringValue")
        "UserInput"    | '{ fieldNonNull: "str", fieldNestedInput: { street: { s: "objectInsteadOfString" }} }' | format(EXPECTED_SCALAR_MESSAGE, "ObjectValue")
        "UserInput"    | '{ field: "missing the `fieldNonNull` entry"}'                                         | format(MISSING_REQUIRED_FIELD_MESSAGE, "fieldNonNull")
    }
```

## Proposal & Testing

_Notes:_
- I created an `ArgValueOfAllowedTypeChecker` to encapsulate the comparison of a given directive argument value with its allowed definition. 
- I added the `RuntimeWiring` to the `SchemaTypeDirectivesChecker ` in order to parse eventual scalar values passed in arguments. 
- I also took the liberty of extracting `TypeRegistry` and `RuntimeWiring` from method parameters to instance variables to keep the methods signatures short. 
- Unit tests to cover scenarios