### PR TITLE
Remove errors from response when they are empty

### DIFF
--- a/src/main/java/graphql/ExecutionResultImpl.java
+++ b/src/main/java/graphql/ExecutionResultImpl.java
@@ -41,7 +41,7 @@ public class ExecutionResultImpl implements ExecutionResult {
         if (errors != null && !errors.isEmpty()) {
             this.errors = Collections.unmodifiableList(new ArrayList<>(errors));
         } else {
-            this.errors = Collections.emptyList();
+            this.errors = null;
         }
 
         this.extensions = extensions;


### PR DESCRIPTION
The [GraphQL specification](https://facebook.github.io/graphql/June2018/#sec-Errors) states that the error field shouldn't be there if no error occurred.

> If no errors were encountered during the requested operation, the errors entry should not be present in the result.