### PR TITLE
Add failing test to reproduce issue 1072

### DIFF
--- a/src/test/groovy/graphql/execution/ExecutionStrategyExceptionHandlingEquivalenceTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategyExceptionHandlingEquivalenceTest.groovy
@@ -1,0 +1,63 @@
+package graphql.execution
+
+import graphql.ExecutionInput
+import graphql.GraphQL
+import graphql.StarWarsSchema
+import graphql.execution.instrumentation.InstrumentationContext
+import graphql.execution.instrumentation.SimpleInstrumentation
+import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters
+import graphql.validation.ValidationError
+import graphql.validation.ValidationErrorType
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * This allows the testing of different execution strategies that handle exceptions during data fetching in the same way
+ */
+class ExecutionStrategyExceptionHandlingEquivalenceTest extends Specification {
+
+  class TestInstrumentation extends SimpleInstrumentation {
+
+    @Override
+    InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters) {
+      throw new AbortExecutionException(Arrays.asList(new ValidationError(ValidationErrorType.UnknownType)))
+    }
+  }
+
+  /**
+   * @return a simple set of queries and expected results that each execution strategy should
+   * return the same result for, even if they use a different strategy
+   */
+  @Unroll
+  def "execution strategy exception handling equivalence ()"() {
+
+    def query = """
+        {
+            hero {
+                id
+                appearsIn
+            }
+        }
+        """
+    def graphQL = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema)
+      .instrumentation(new TestInstrumentation())
+      .queryExecutionStrategy(strategyUnderTest)
+      .build()
+
+
+    expect:
+
+    def executionInput = ExecutionInput.newExecutionInput().query(query).build()
+    def result = graphQL.execute(executionInput)
+
+    assert result.errors[0].message.equals(
+      "Validation error of type UnknownType: null"): "${strategyType} did not pass through the underlying error from AbortExecutionException"
+
+    where:
+
+    strategyType  | strategyUnderTest
+    // "async"      | new AsyncExecutionStrategy()
+    "asyncSerial" | new AsyncSerialExecutionStrategy()
+  }
+}
+


### PR DESCRIPTION
AsyncExecutionStrategy vs AsyncSerialExecutionStrategy error handling of AbortExecutionException in custom instrumentation.

Unit test requested in https://github.com/graphql-java/graphql-java/issues/1072#issuecomment-395330513. Hopefully this is helpful!

Stepping through the code, it looks like in
https://github.com/graphql-java/graphql-java/blob/ac30ed132b0aae3efda52c86b58e542c17dd1fd6/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java#L37
the `AbortExecutionException` is [caught and a new `CompletionException` is thrown](https://github.com/graphql-java/graphql-java/blob/ac30ed132b0aae3efda52c86b58e542c17dd1fd6/src/main/java/graphql/execution/Async.java#L78), without grabbing the underlying errors (as happens with the AsyncExecutionStrategy later, [here](https://github.com/graphql-java/graphql-java/blob/ac30ed132b0aae3efda52c86b58e542c17dd1fd6/src/main/java/graphql/GraphQL.java#L478)).