### PR TITLE
Support for list type in implicit directive argument values

### DIFF
--- a/src/main/java/graphql/Scalars.java
+++ b/src/main/java/graphql/Scalars.java
@@ -191,7 +191,7 @@ public class Scalars {
         public String parseLiteral(Object input) {
             if (!(input instanceof StringValue)) {
                 throw new CoercingParseLiteralException(
-                        "Expected AST type 'IntValue' but was '" + typeName(input) + "'."
+                        "Expected AST type 'StringValue' but was '" + typeName(input) + "'."
                 );
             }
             return ((StringValue) input).getValue();


### PR DESCRIPTION
## Description

**Current behavior**:
[The commit that added runtime directive support](https://github.com/graphql-java/graphql-java/commit/f40354e02fe34181d7cd3cd24c09d4705fd3015a#diff-7472121f90a7b71b41a1874204845666R743) restricted the types of arguments for implicit directives to strictly only primitives. By implicit directive, I mean a directive that is used on a schema which doesn't have a corresponding directive definition. 

**Expected behavior**:
While this code path is still supported but not recommended (customers should be spec compliant and use directive definitions instead), it is breaking for us when using arrays, so I added support for array of primitive types.

## Steps to reproduce 

I added a test to reproduce, the test below raises an `AssertException` for the array types:

```java
@Unroll
    def "when using implicit directive (w/o definition), #argumentName is supported"() {
        setup:
        def spec = """
            type Query @myDirective($argumentName: $argumentValue) {
                foo: String 
            }
        """
        when:
        def wiring = RuntimeWiring.newRuntimeWiring()
                .build()

        def schema = schema(spec, wiring)
        def queryType = schema.queryType

        then:
        def directive = queryType.getDirective("myDirective")
        directive.getArgument(argumentName).type == expectedArgumentType

        where:
        argumentName        | argumentValue     || expectedArgumentType
        "stringArg"         | '"a string"'      || GraphQLString
        "boolArg"           | "true"            || GraphQLBoolean
        "floatArg"          | "4.5"             || GraphQLFloat
        "intArg"            | "5"               || GraphQLInt
        "nullArg"           | "null"            || GraphQLString
        "emptyArrayArg"     | "[]"              || new GraphQLList(GraphQLString)
        "arrayNullsArg"     | "[null, null]"    || new GraphQLList(GraphQLString)
        "arrayArg"          | "[3,4,6]"         || new GraphQLList(GraphQLInt)
        "arrayWithNullsArg" | "[null,3,null,6]" || new GraphQLList(GraphQLInt)
    }
```

## Proposal 

I added support for arrays of primitives, Object values and Enum values are still not supported. If someone needs them we can add them later.
I added unit tests to cover negative and positive cases.
I fixed a typo in the `Scalars.parseLiteral` error message.

