### PR TITLE
Fix ChainInstrumentation misses to pass down calls chained contexts causes hanging

### DIFF
--- a/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderPerformanceData.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderPerformanceData.groovy
@@ -1,0 +1,251 @@
+package graphql.execution.instrumentation.dataloader
+
+import graphql.Directives
+import graphql.GraphQL
+import graphql.execution.instrumentation.Instrumentation
+import graphql.schema.GraphQLSchema
+import org.dataloader.DataLoaderRegistry
+
+
+class DataLoaderPerformanceData {
+
+    static DataLoaderRegistry setupDataLoaderRegistry() {
+        DataLoaderRegistry dataLoaderRegistry = new DataLoaderRegistry()
+        dataLoaderRegistry.register("departments", BatchCompareDataFetchers.departmentsForShopDataLoader)
+        dataLoaderRegistry.register("products", BatchCompareDataFetchers.productsForDepartmentDataLoader)
+    }
+
+    static GraphQL setupGraphQL(Instrumentation instrumentation) {
+        BatchCompareDataFetchers.resetState()
+        GraphQLSchema schema = new BatchCompare().buildDataLoaderSchema()
+        schema = schema.transform({ bldr -> bldr.additionalDirective(Directives.DeferDirective) })
+
+        GraphQL.newGraphQL(schema)
+                .instrumentation(instrumentation)
+                .build()
+    }
+
+    static def expectedData = [
+            shops: [
+                    [id         : "shop-1", name: "Shop 1",
+                     departments: [[id: "department-1", name: "Department 1", products: [[id: "product-1", name: "Product 1"]]],
+                                   [id: "department-2", name: "Department 2", products: [[id: "product-2", name: "Product 2"]]],
+                                   [id: "department-3", name: "Department 3", products: [[id: "product-3", name: "Product 3"]]]
+                     ]],
+                    [id         : "shop-2", name: "Shop 2",
+                     departments: [[id: "department-4", name: "Department 4", products: [[id: "product-4", name: "Product 4"]]],
+                                   [id: "department-5", name: "Department 5", products: [[id: "product-5", name: "Product 5"]]],
+                                   [id: "department-6", name: "Department 6", products: [[id: "product-6", name: "Product 6"]]]
+                     ]],
+                    [id         : "shop-3", name: "Shop 3",
+                     departments: [[id: "department-7", name: "Department 7", products: [[id: "product-7", name: "Product 7"]]],
+                                   [id: "department-8", name: "Department 8", products: [[id: "product-8", name: "Product 8"]]],
+                                   [id: "department-9", name: "Department 9", products: [[id: "product-9", name: "Product 9"]]]]
+                    ]]
+    ]
+
+    static def query = """
+            query { 
+                shops { 
+                    id name 
+                    departments { 
+                        id name 
+                        products { 
+                            id name 
+                        } 
+                    } 
+                } 
+            }
+            """
+
+    static def expectedExpensiveData = [
+            shops         : [[name                : "Shop 1",
+                              departments         : [[name: "Department 1", products: [[name: "Product 1"]], expensiveProducts: [[name: "Product 1"]]],
+                                                     [name: "Department 2", products: [[name: "Product 2"]], expensiveProducts: [[name: "Product 2"]]],
+                                                     [name: "Department 3", products: [[name: "Product 3"]], expensiveProducts: [[name: "Product 3"]]]],
+                              expensiveDepartments: [[name: "Department 1", products: [[name: "Product 1"]], expensiveProducts: [[name: "Product 1"]]],
+                                                     [name: "Department 2", products: [[name: "Product 2"]], expensiveProducts: [[name: "Product 2"]]],
+                                                     [name: "Department 3", products: [[name: "Product 3"]], expensiveProducts: [[name: "Product 3"]]]]],
+                             [name                : "Shop 2",
+                              departments         : [[name: "Department 4", products: [[name: "Product 4"]], expensiveProducts: [[name: "Product 4"]]],
+                                                     [name: "Department 5", products: [[name: "Product 5"]], expensiveProducts: [[name: "Product 5"]]],
+                                                     [name: "Department 6", products: [[name: "Product 6"]], expensiveProducts: [[name: "Product 6"]]]],
+                              expensiveDepartments: [[name: "Department 4", products: [[name: "Product 4"]], expensiveProducts: [[name: "Product 4"]]],
+                                                     [name: "Department 5", products: [[name: "Product 5"]], expensiveProducts: [[name: "Product 5"]]],
+                                                     [name: "Department 6", products: [[name: "Product 6"]], expensiveProducts: [[name: "Product 6"]]]]],
+                             [name                : "Shop 3",
+                              departments         : [[name: "Department 7", products: [[name: "Product 7"]], expensiveProducts: [[name: "Product 7"]]],
+                                                     [name: "Department 8", products: [[name: "Product 8"]], expensiveProducts: [[name: "Product 8"]]],
+                                                     [name: "Department 9", products: [[name: "Product 9"]], expensiveProducts: [[name: "Product 9"]]]],
+                              expensiveDepartments: [[name: "Department 7", products: [[name: "Product 7"]], expensiveProducts: [[name: "Product 7"]]],
+                                                     [name: "Department 8", products: [[name: "Product 8"]], expensiveProducts: [[name: "Product 8"]]],
+                                                     [name: "Department 9", products: [[name: "Product 9"]], expensiveProducts: [[name: "Product 9"]]]]]],
+            expensiveShops: [[name                : "ExShop 1",
+                              departments         : [[name: "Department 1", products: [[name: "Product 1"]], expensiveProducts: [[name: "Product 1"]]],
+                                                     [name: "Department 2", products: [[name: "Product 2"]], expensiveProducts: [[name: "Product 2"]]],
+                                                     [name: "Department 3", products: [[name: "Product 3"]], expensiveProducts: [[name: "Product 3"]]]],
+                              expensiveDepartments: [[name: "Department 1", products: [[name: "Product 1"]], expensiveProducts: [[name: "Product 1"]]],
+                                                     [name: "Department 2", products: [[name: "Product 2"]], expensiveProducts: [[name: "Product 2"]]],
+                                                     [name: "Department 3", products: [[name: "Product 3"]], expensiveProducts: [[name: "Product 3"]]]]],
+                             [name                : "ExShop 2",
+                              departments         : [[name: "Department 4", products: [[name: "Product 4"]], expensiveProducts: [[name: "Product 4"]]],
+                                                     [name: "Department 5", products: [[name: "Product 5"]], expensiveProducts: [[name: "Product 5"]]],
+                                                     [name: "Department 6", products: [[name: "Product 6"]], expensiveProducts: [[name: "Product 6"]]]],
+                              expensiveDepartments: [[name: "Department 4", products: [[name: "Product 4"]], expensiveProducts: [[name: "Product 4"]]],
+                                                     [name: "Department 5", products: [[name: "Product 5"]], expensiveProducts: [[name: "Product 5"]]],
+                                                     [name: "Department 6", products: [[name: "Product 6"]], expensiveProducts: [[name: "Product 6"]]]]],
+                             [name                : "ExShop 3",
+                              departments         : [[name: "Department 7", products: [[name: "Product 7"]], expensiveProducts: [[name: "Product 7"]]],
+                                                     [name: "Department 8", products: [[name: "Product 8"]], expensiveProducts: [[name: "Product 8"]]],
+                                                     [name: "Department 9", products: [[name: "Product 9"]], expensiveProducts: [[name: "Product 9"]]]],
+                              expensiveDepartments: [[name: "Department 7", products: [[name: "Product 7"]], expensiveProducts: [[name: "Product 7"]]],
+                                                     [name: "Department 8", products: [[name: "Product 8"]], expensiveProducts: [[name: "Product 8"]]],
+                                                     [name: "Department 9", products: [[name: "Product 9"]], expensiveProducts: [[name: "Product 9"]]]]]]
+
+    ]
+
+
+    static def expensiveQuery = """
+            query { 
+                shops { 
+                    name 
+                    departments { 
+                        name 
+                        products { 
+                            name 
+                        } 
+                        expensiveProducts { 
+                            name 
+                        } 
+                    } 
+                    expensiveDepartments { 
+                        name 
+                        products { 
+                            name 
+                        } 
+                        expensiveProducts { 
+                            name 
+                        } 
+                    } 
+                } 
+                expensiveShops { 
+                    name 
+                    departments { 
+                        name 
+                        products { 
+                            name 
+                        } 
+                        expensiveProducts { 
+                            name 
+                        } 
+                    } 
+                    expensiveDepartments { 
+                        name 
+                        products { 
+                            name 
+                        } 
+                        expensiveProducts { 
+                            name 
+                        } 
+                    } 
+                } 
+            }
+            """
+
+    static def expectedDeferredData = [
+            shops: [
+                    [id: "shop-1", name: "Shop 1"],
+                    [id: "shop-2", name: "Shop 2"],
+                    [id: "shop-3", name: "Shop 3"],
+            ]
+    ]
+
+    static def expectedListOfDeferredData = [
+            [[id: "department-1", name: "Department 1", products: [[id: "product-1", name: "Product 1"]]],
+             [id: "department-2", name: "Department 2", products: [[id: "product-2", name: "Product 2"]]],
+             [id: "department-3", name: "Department 3", products: [[id: "product-3", name: "Product 3"]]]]
+            ,
+
+            [[id: "department-4", name: "Department 4", products: [[id: "product-4", name: "Product 4"]]],
+             [id: "department-5", name: "Department 5", products: [[id: "product-5", name: "Product 5"]]],
+             [id: "department-6", name: "Department 6", products: [[id: "product-6", name: "Product 6"]]]]
+            ,
+            [[id: "department-7", name: "Department 7", products: [[id: "product-7", name: "Product 7"]]],
+             [id: "department-8", name: "Department 8", products: [[id: "product-8", name: "Product 8"]]],
+             [id: "department-9", name: "Department 9", products: [[id: "product-9", name: "Product 9"]]]]
+            ,
+
+    ]
+
+
+    static def deferredQuery = """
+            query { 
+                shops { 
+                    id name 
+                    departments @defer { 
+                        id name 
+                        products { 
+                            id name 
+                        } 
+                    } 
+                } 
+            }
+            """
+
+    static def expensiveDeferredQuery = """
+            query { 
+                shops { 
+                    id name 
+                    departments @defer { 
+                        name 
+                        products @defer { 
+                            name 
+                        } 
+                        expensiveProducts @defer { 
+                            name 
+                        } 
+                    } 
+                    expensiveDepartments @defer { 
+                        name 
+                        products { 
+                            name 
+                        } 
+                        expensiveProducts { 
+                            name 
+                        } 
+                    } 
+                } 
+                expensiveShops @defer { 
+                    id name
+                } 
+            }
+            """
+
+    static def expectedExpensiveDeferredData = [
+            [[id: "exshop-1", name: "ExShop 1"], [id: "exshop-2", name: "ExShop 2"], [id: "exshop-3", name: "ExShop 3"]],
+            [[name: "Department 1"], [name: "Department 2"], [name: "Department 3"]],
+            [[name: "Department 1", products: [[name: "Product 1"]], expensiveProducts: [[name: "Product 1"]]], [name: "Department 2", products: [[name: "Product 2"]], expensiveProducts: [[name: "Product 2"]]], [name: "Department 3", products: [[name: "Product 3"]], expensiveProducts: [[name: "Product 3"]]]],
+            [[name: "Department 4"], [name: "Department 5"], [name: "Department 6"]],
+            [[name: "Department 4", products: [[name: "Product 4"]], expensiveProducts: [[name: "Product 4"]]], [name: "Department 5", products: [[name: "Product 5"]], expensiveProducts: [[name: "Product 5"]]], [name: "Department 6", products: [[name: "Product 6"]], expensiveProducts: [[name: "Product 6"]]]],
+            [[name: "Department 7"], [name: "Department 8"], [name: "Department 9"]],
+            [[name: "Department 7", products: [[name: "Product 7"]], expensiveProducts: [[name: "Product 7"]]], [name: "Department 8", products: [[name: "Product 8"]], expensiveProducts: [[name: "Product 8"]]], [name: "Department 9", products: [[name: "Product 9"]], expensiveProducts: [[name: "Product 9"]]]],
+            [[name: "Product 1"]],
+            [[name: "Product 1"]],
+            [[name: "Product 2"]],
+            [[name: "Product 2"]],
+            [[name: "Product 3"]],
+            [[name: "Product 3"]],
+            [[name: "Product 4"]],
+            [[name: "Product 4"]],
+            [[name: "Product 5"]],
+            [[name: "Product 5"]],
+            [[name: "Product 6"]],
+            [[name: "Product 6"]],
+            [[name: "Product 7"]],
+            [[name: "Product 7"]],
+            [[name: "Product 8"]],
+            [[name: "Product 8"]],
+            [[name: "Product 9"]],
+            [[name: "Product 9"]],
+    ]
+}

--- a/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderPerformanceWithChainedInstrumentationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderPerformanceWithChainedInstrumentationTest.groovy
@@ -4,27 +4,30 @@ import graphql.ExecutionInput
 import graphql.ExecutionResult
 import graphql.GraphQL
 import graphql.execution.defer.CapturingSubscriber
+import graphql.execution.instrumentation.ChainedInstrumentation
 import graphql.execution.instrumentation.Instrumentation
 import org.awaitility.Awaitility
 import org.dataloader.DataLoaderRegistry
 import org.reactivestreams.Publisher
 import spock.lang.Specification
 
-
 import static graphql.execution.instrumentation.dataloader.DataLoaderPerformanceData.*
 
-class DataLoaderPerformanceTest extends Specification {
+
+class DataLoaderPerformanceWithChainedInstrumentationTest extends Specification {
 
     GraphQL graphQL
-
+    
     void setup() {
         DataLoaderRegistry dataLoaderRegistry = setupDataLoaderRegistry()
-        Instrumentation instrumentation = new DataLoaderDispatcherInstrumentation(dataLoaderRegistry)
+        Instrumentation instrumentation = new ChainedInstrumentation(
+                Collections.singletonList(new DataLoaderDispatcherInstrumentation(dataLoaderRegistry)))
         graphQL = setupGraphQL(instrumentation)
     }
 
-    def "760 ensure data loader is performant for lists"() {
+    def "chainedInstrumentation: 760 ensure data loader is performant for lists"() {
         when:
+
         ExecutionInput executionInput = ExecutionInput.newExecutionInput().query(query).build()
         def result = graphQL.execute(executionInput)
 
@@ -36,7 +39,7 @@ class DataLoaderPerformanceTest extends Specification {
         BatchCompareDataFetchers.productsForDepartmentsBatchLoaderCounter.get() == 1
     }
 
-    def "970 ensure data loader is performant for multiple field with lists"() {
+    def "chainedInstrumentation: 970 ensure data loader is performant for multiple field with lists"() {
 
         when:
 
@@ -50,7 +53,7 @@ class DataLoaderPerformanceTest extends Specification {
         BatchCompareDataFetchers.productsForDepartmentsBatchLoaderCounter.get() == 1
     }
 
-    def "ensure data loader is performant for lists using async batch loading"() {
+    def "chainedInstrumentation: ensure data loader is performant for lists using async batch loading"() {
 
         when:
 
@@ -68,7 +71,7 @@ class DataLoaderPerformanceTest extends Specification {
 
     }
 
-    def "970 ensure data loader is performant for multiple field with lists using async batch loading"() {
+    def "chainedInstrumentation: 970 ensure data loader is performant for multiple field with lists using async batch loading"() {
 
         when:
 
@@ -84,7 +87,7 @@ class DataLoaderPerformanceTest extends Specification {
         BatchCompareDataFetchers.productsForDepartmentsBatchLoaderCounter.get() == 1
     }
 
-    def "data loader will work with deferred queries"() {
+    def "chainedInstrumentation: data loader will work with deferred queries"() {
 
         when:
 
@@ -111,7 +114,7 @@ class DataLoaderPerformanceTest extends Specification {
         BatchCompareDataFetchers.productsForDepartmentsBatchLoaderCounter.get() == 3
     }
 
-    def "data loader will work with deferred queries on multiple levels deep"() {
+    def "chainedInstrumentation: data loader will work with deferred queries on multiple levels deep"() {
 
         when:
 


### PR DESCRIPTION
## Description

When using the `ChainedInstrumentation` along with the `DataLoaderInstrumentation` any GraphQL query containing lists of lists will hang indefinitely. The reason is, the chained instrumentation is not correctly passing calls back to the chained contexts, which will cause to never trigger dispatches. For reference [this is the offending line/commit](https://github.com/graphql-java/graphql-java/commit/ca6f7fa01b516b75efc292f7e673973b0d9572f3#diff-5e8eee6bb7ce89c537845070d52e704aR107) 

## Steps to reproduce

I reused the `DataLoaderPerformanceTest` but instead with a `ChainedInstrumentation` to reproduce the issue/hanging.
Note the use of `ChainedInstrumentation` below.

```java
    void setup() {
        DataLoaderRegistry dataLoaderRegistry = setupDataLoaderRegistry()
        Instrumentation instrumentation = new ChainedInstrumentation(
                Collections.singletonList(new DataLoaderDispatcherInstrumentation(dataLoaderRegistry)))
        graphQL = setupGraphQL(instrumentation)
    }

    def "chainedInstrumentation: 760 ensure data loader is performant for lists"() {
        when:

        ExecutionInput executionInput = ExecutionInput.newExecutionInput().query(query).build()
        def result = graphQL.execute(executionInput)

        then:
        result.data == expectedData
        //
        //  eg 1 for shops-->departments and one for departments --> products
        BatchCompareDataFetchers.departmentsForShopsBatchLoaderCounter.get() == 1
        BatchCompareDataFetchers.productsForDepartmentsBatchLoaderCounter.get() == 1
    }
```

## Fix & Testing

I created custom `InstrumentationContext`s that override `onFieldValuesInfo` and  `onDeferredField`, `onFieldValueInfo`respectively and passed down the calls to the instrumentations.

Regarding the tests, I did not want to parameterize every single existing test (using spock `where:`) inside the `DataLoaderPerformanceTest` specification as I believe would increase the already cognitive load of these tests. Instead, I duplicated them and I separated them while extracting the common logic. Let me know if that's ok. 
