### PR TITLE
make NodeTraverser public and improves it with preOder/postOrder methods

### DIFF
--- a/src/main/java/graphql/language/NodeVisitor.java
+++ b/src/main/java/graphql/language/NodeVisitor.java
@@ -1,10 +1,13 @@
 package graphql.language;
 
-import graphql.Internal;
+import graphql.PublicApi;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
-@Internal
+/**
+ * Used by {@link NodeTraverser} to visit {@link Node}.
+ */
+@PublicApi
 public interface NodeVisitor {
     TraversalControl visitArgument(Argument node, TraverserContext<Node> data);
 

--- a/src/main/java/graphql/language/NodeVisitorStub.java
+++ b/src/main/java/graphql/language/NodeVisitorStub.java
@@ -1,12 +1,14 @@
 package graphql.language;
 
-import graphql.Internal;
+import graphql.PublicApi;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
-@Internal
-public class NodeVisitorStub
-        implements NodeVisitor {
+/**
+ * Convenient implementation of {@link NodeVisitor} for easy subclassing methods handling different types of Nodes in one method.
+ */
+@PublicApi
+public class NodeVisitorStub implements NodeVisitor {
     @Override
     public TraversalControl visitArgument(Argument node, TraverserContext<Node> context) {
         return visitNode(node, context);

--- a/src/main/java/graphql/util/TraversalControl.java
+++ b/src/main/java/graphql/util/TraversalControl.java
@@ -1,13 +1,16 @@
 package graphql.util;
 
-import graphql.Internal;
+import graphql.PublicApi;
 
 /**
  * Special traversal control values
  */
-@Internal
+@PublicApi
 public enum TraversalControl {
 
+    /**
+     * When returned the traversal will continue as planned.
+     */
     CONTINUE,
     /**
      * When returned from a Visitor's method, indicates exiting the traversal
@@ -17,7 +20,6 @@ public enum TraversalControl {
      * When returned from a Visitor's method, indicates skipping traversal of a subtree.
      *
      * Not allowed to be returned from 'leave' or 'backRef' because it doesn't make sense.
-     *
      */
     ABORT
 }

--- a/src/main/java/graphql/util/TraverserContext.java
+++ b/src/main/java/graphql/util/TraverserContext.java
@@ -1,6 +1,6 @@
 package graphql.util;
 
-import graphql.Internal;
+import graphql.PublicApi;
 
 import java.util.Set;
 
@@ -9,7 +9,7 @@ import java.util.Set;
  *
  * @param <T> type of tree node
  */
-@Internal
+@PublicApi
 public interface TraverserContext<T> {
     /**
      * Returns current node being visited
@@ -25,13 +25,15 @@ public interface TraverserContext<T> {
      * the current path as well as the variables {@link #getVar(java.lang.Class) }
      * stored in every parent context.
      *
-     * Useful when it is difficult to organize a local Visitor's stack, when performing
-     * breadth-first or parallel traversal
-     *
      * @return context associated with the node parent
      */
     TraverserContext<T> getParentContext();
 
+    /**
+     * The result of the {@link #getParentContext()}.
+     *
+     * @return
+     */
     Object getParentResult();
 
     /**
@@ -71,10 +73,25 @@ public interface TraverserContext<T> {
     <S> TraverserContext<T> setVar(Class<? super S> key, S value);
 
 
+    /**
+     * Set the result for this TraverserContext.
+     *
+     * @param result
+     */
     void setResult(Object result);
 
+    /**
+     * The result of this TraverserContext..
+     *
+     * @return
+     */
     Object getResult();
 
+    /**
+     * Used to share something across all TraverserContext.
+     *
+     * @return
+     */
     Object getInitialData();
 
 }

--- a/src/test/groovy/graphql/language/NodeTraverserTest.groovy
+++ b/src/test/groovy/graphql/language/NodeTraverserTest.groovy
@@ -37,6 +37,50 @@ class NodeTraverserTest extends Specification {
         0 * nodeVisitor._
     }
 
+    def "traverse nodes in pre-order"() {
+        given:
+        Field leaf = new Field("leaf")
+        SelectionSet rootSelectionSet = new SelectionSet(Arrays.asList(leaf))
+        Field root = new Field("root")
+        root.setSelectionSet(rootSelectionSet)
+
+        NodeTraverser nodeTraverser = new NodeTraverser()
+        NodeVisitor nodeVisitor = Mock(NodeVisitor)
+        when:
+        nodeTraverser.preOrder(nodeVisitor, root)
+
+        then:
+        1 * nodeVisitor.visitField(root, { isEnter(it) }) >> TraversalControl.CONTINUE
+        then:
+        1 * nodeVisitor.visitSelectionSet(rootSelectionSet, { isEnter(it) }) >> TraversalControl.CONTINUE
+        then:
+        1 * nodeVisitor.visitField(leaf, { isEnter(it) }) >> TraversalControl.CONTINUE
+        then:
+        0 * nodeVisitor._
+    }
+
+    def "traverse nodes in post-order"() {
+        given:
+        Field leaf = new Field("leaf")
+        SelectionSet rootSelectionSet = new SelectionSet(Arrays.asList(leaf))
+        Field root = new Field("root")
+        root.setSelectionSet(rootSelectionSet)
+
+        NodeTraverser nodeTraverser = new NodeTraverser()
+        NodeVisitor nodeVisitor = Mock(NodeVisitor)
+        when:
+        nodeTraverser.postOrder(nodeVisitor, root)
+
+        then:
+        1 * nodeVisitor.visitField(leaf, { isLeave(it) }) >> TraversalControl.CONTINUE
+        then:
+        1 * nodeVisitor.visitSelectionSet(rootSelectionSet, { isLeave(it) }) >> TraversalControl.CONTINUE
+        then:
+        1 * nodeVisitor.visitField(root, { isLeave(it) }) >> TraversalControl.CONTINUE
+        then:
+        0 * nodeVisitor._
+    }
+
     def "uses root vars"() {
         given:
         Field root = new Field("root")


### PR DESCRIPTION
graphql-java should provide a good way to traverse a Document/Query. This makes the NodeTraverser public and adds special pre/post Order methods for easy usage.