### PR TITLE
Fix NPE in FieldLevelTrackingApproach when type mismatch error

### DIFF
--- a/src/main/java/graphql/execution/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncExecutionStrategy.java
@@ -82,6 +82,12 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
             List<CompletableFuture<ExecutionResult>> executionResultFuture = completeValueInfos.stream().map(FieldValueInfo::getFieldValue).collect(Collectors.toList());
             executionStrategyCtx.onFieldValuesInfo(completeValueInfos);
             Async.each(executionResultFuture).whenComplete(handleResultsConsumer);
+        }).exceptionally((ex) -> {
+            // if there are any issues with combining/handling the field results,
+            // complete the future at all costs and bubble up any thrown exception so
+            // the execution does not hang.
+            overallResult.completeExceptionally(ex);
+            return null;
         });
 
         overallResult.whenComplete(executionStrategyCtx::onCompleted);

--- a/src/main/java/graphql/execution/FieldValueInfo.java
+++ b/src/main/java/graphql/execution/FieldValueInfo.java
@@ -3,8 +3,11 @@ package graphql.execution;
 import graphql.ExecutionResult;
 import graphql.PublicApi;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+
+import static graphql.Assert.assertNotNull;
 
 @PublicApi
 public class FieldValueInfo {
@@ -23,6 +26,7 @@ public class FieldValueInfo {
     private final List<FieldValueInfo> fieldValueInfos;
 
     private FieldValueInfo(CompleteValueType completeValueType, CompletableFuture<ExecutionResult> fieldValue, List<FieldValueInfo> fieldValueInfos) {
+        assertNotNull(fieldValueInfos, "fieldValueInfos can't be null");
         this.completeValueType = completeValueType;
         this.fieldValue = fieldValue;
         this.fieldValueInfos = fieldValueInfos;
@@ -57,7 +61,7 @@ public class FieldValueInfo {
     public static class Builder {
         private CompleteValueType completeValueType;
         private CompletableFuture<ExecutionResult> executionResultFuture;
-        private List<FieldValueInfo> listInfos;
+        private List<FieldValueInfo> listInfos = new ArrayList<>();
 
         public Builder(CompleteValueType completeValueType) {
             this.completeValueType = completeValueType;
@@ -74,6 +78,7 @@ public class FieldValueInfo {
         }
 
         public Builder fieldValueInfos(List<FieldValueInfo> listInfos) {
+            assertNotNull(listInfos, "fieldValueInfos can't be null");
             this.listInfos = listInfos;
             return this;
         }

--- a/src/test/groovy/graphql/execution/FieldValueInfoTest.groovy
+++ b/src/test/groovy/graphql/execution/FieldValueInfoTest.groovy
@@ -1,0 +1,30 @@
+package graphql.execution
+
+import graphql.AssertException
+import spock.lang.Specification
+
+
+class FieldValueInfoTest extends Specification{
+
+    def "simple constructor test"() {
+        when:
+        def fieldValueInfo = FieldValueInfo.newFieldValueInfo().build()
+
+        then: "fieldValueInfos to be empty list"
+        fieldValueInfo.fieldValueInfos == [] as List
+
+        and: "other fields to be null "
+        fieldValueInfo.fieldValue == null
+        fieldValueInfo.completeValueType == null
+    }
+
+    def "negative constructor test"() {
+        when:
+        FieldValueInfo.newFieldValueInfo()
+                .fieldValueInfos(null)
+                .build()
+        then:
+        def assEx = thrown(AssertException)
+        assEx.message.contains("fieldValueInfos")
+    }
+}

--- a/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderTypeMismatchTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderTypeMismatchTest.groovy
@@ -1,0 +1,74 @@
+package graphql.execution.instrumentation.dataloader
+
+import graphql.GraphQL
+import graphql.schema.DataFetcher
+import graphql.schema.DataFetchingEnvironment
+import graphql.schema.idl.RuntimeWiring
+import graphql.schema.idl.SchemaGenerator
+import graphql.schema.idl.SchemaParser
+import org.dataloader.BatchLoader
+import org.dataloader.DataLoader
+import org.dataloader.DataLoaderRegistry
+import spock.lang.Specification
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+
+import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring
+
+class DataLoaderTypeMismatchTest extends Specification {
+
+    def "when actual field value return type is different from expected return type, then it should not hang execution"() {
+        setup:
+        def sdl = """
+        type Todo {
+           id: ID!
+        }
+
+        type Query {
+           getTodos: [Todo]
+        }
+
+        schema {
+           query: Query
+        }"""
+
+        def typeDefinitionRegistry = new SchemaParser().parse(sdl)
+
+        def dataLoader = new DataLoader<Object, Object>(new BatchLoader<Object, Object>() {
+            @Override
+            CompletionStage<List<Object>> load(List<Object> keys) {
+                return CompletableFuture.completedFuture([
+                        [a: "map instead of a list of todos"]
+                ])
+            }
+        })
+        def dataLoaderRegistry = new DataLoaderRegistry()
+        dataLoaderRegistry.register("getTodos", dataLoader)
+
+        def todosDef = new DataFetcher<CompletableFuture<Object>>() {
+            @Override
+            CompletableFuture<Object> get(DataFetchingEnvironment environment) {
+                return dataLoader.load(environment)
+            }
+        }
+
+        def wiring = RuntimeWiring.newRuntimeWiring()
+                .type(newTypeWiring("Query")
+                    .dataFetcher("getTodos", todosDef))
+                .build()
+
+        def schema = new SchemaGenerator().makeExecutableSchema(typeDefinitionRegistry, wiring)
+
+        def graphql = GraphQL.newGraphQL(schema)
+                .instrumentation(new DataLoaderDispatcherInstrumentation(dataLoaderRegistry))
+                .build()
+
+        when:
+        def result = graphql.execute("query { getTodos { id } }")
+
+        then: "execution shouldn't hang"
+        !result.errors.empty
+        result.errors[0].message == "Can't resolve value (/getTodos) : type mismatch error, expected type LIST"
+    }
+}


### PR DESCRIPTION
## Description 
When using the `DataLoaderInstrumentation` and a type mismatch error happens, a NPE is thrown in the [`FieldLevelTrackingApproach.`](https://github.com/graphql-java/graphql-java/blob/ca6f7fa01b516b75efc292f7e673973b0d9572f3/src/main/java/graphql/execution/instrumentation/dataloader/FieldLevelTrackingApproach.java#L182) which will result in leaving the overall completable future result un-completed hence hanging the execution thread. 

## Steps to reproduce
I wrote an integration test to reproduce the issue, not the `Query.getTodos` returns a list of Todo objects `[Todo]` and our data-fetcher only returns a Todo.
This will trigger a type mismatch error that will then hang the execution.

```java
    def "when actual field value return type is different from expected return type, then it should not hang execution"() {
        setup:
        def sdl = """
        type Todo {
           id: ID!
        }

        type Query {
           getTodos: [Todo]
        }

        schema {
           query: Query
        }"""

        def typeDefinitionRegistry = new SchemaParser().parse(sdl)

        def dataLoader = new DataLoader<Object, Object>(new BatchLoader<Object, Object>() {
            @Override
            CompletionStage<List<Object>> load(List<Object> keys) {
                return CompletableFuture.completedFuture([
                        [a: "map instead of a list of todos"]
                ])
            }
        })
        def dataLoaderRegistry = new DataLoaderRegistry()
        dataLoaderRegistry.register("getTodos", dataLoader)

        def todosDef = new DataFetcher<CompletableFuture<Object>>() {
            @Override
            CompletableFuture<Object> get(DataFetchingEnvironment environment) {
                return dataLoader.load(environment)
            }
        }

        def wiring = RuntimeWiring.newRuntimeWiring()
                .type(newTypeWiring("Query")
                    .dataFetcher("getTodos", todosDef))
                .build()

        def schema = new SchemaGenerator().makeExecutableSchema(typeDefinitionRegistry, wiring)

        def graphql = GraphQL.newGraphQL(schema)
                .instrumentation(new DataLoaderDispatcherInstrumentation(dataLoaderRegistry))
                .build()

        when:
        def result = graphql.execute("query { getTodos { id } }")

        then: "execution shouldn't hang"
        !result.errors.empty
        result.errors[0].message == "Can't resolve value (/getTodos) : type mismatch error, expected type LIST"
    }
```

## Fixes
This PR fixes the NPE by enforcing that `FieldValueInfo.fieldValueInfos` will never be null. It also adds a safety measure in `AsyncExecutionStrategy.execute` to make sure any exception thrown will be bubbled up and will not result in un-completed futures.

## Testing
In addition to the test above, I added proper individual unit tests to cover the separate changes.