### PR TITLE
Fix quoting around "IBM" in the SDL sample in the Subscriptions page.

### DIFF
--- a/docs/subscriptions.rst
+++ b/docs/subscriptions.rst
@@ -16,7 +16,7 @@ Imagine you have an stock market pricing service and you make a graphql subscrip
 .. code-block:: graphql
 
     subscription StockCodeSubscription {
-        stockQuotes(stockCode:"IBM') {
+        stockQuotes(stockCode:"IBM") {
             dateTime
             stockCode
             stockPrice


### PR DESCRIPTION
I've stumbled on an improper quoting while reading http://graphql-java.readthedocs.io/en/latest/subscriptions.html