### PR TITLE
Fix improper quoting for post and comments

### DIFF
--- a/docs/defer.rst
+++ b/docs/defer.rst
@@ -3,7 +3,7 @@ Deferred Execution
 
 Often when executing a query you have two classes of data.  The data you need immediately and the data that could arrive little bit later.
 
-For example imagine this query that gets data on a ``post` and its ``comments`` and ``reviews``.
+For example imagine this query that gets data on a ``post`` and its ``comments`` and ``reviews``.
 
 
 .. code-block:: graphql


### PR DESCRIPTION
The words are not properly formatted because of improper quoting. Discovered while reading http://graphql-java.readthedocs.io/en/latest/defer.html