### PR TITLE
Query traversal improvments

### DIFF
--- a/src/main/java/graphql/analysis/MaxQueryComplexityInstrumentation.java
+++ b/src/main/java/graphql/analysis/MaxQueryComplexityInstrumentation.java
@@ -59,9 +59,8 @@ public class MaxQueryComplexityInstrumentation extends SimpleInstrumentation {
                 @Override
                 public void visitField(QueryVisitorFieldEnvironment env) {
                     int childsComplexity = 0;
-                    QueryVisitorFieldEnvironment thisNodeAsParent = new QueryVisitorFieldEnvironmentImpl(env.getField(), env.getFieldDefinition(), env.getParentType(), env.getParentEnvironment(), env.getArguments(), env.getSelectionSetContainer());
-                    if (valuesByParent.containsKey(thisNodeAsParent)) {
-                        childsComplexity = valuesByParent.get(thisNodeAsParent).stream().mapToInt(Integer::intValue).sum();
+                    if (valuesByParent.containsKey(env)) {
+                        childsComplexity = valuesByParent.get(env).stream().mapToInt(Integer::intValue).sum();
                     }
                     int value = calculateComplexity(env, childsComplexity);
                     valuesByParent.putIfAbsent(env.getParentEnvironment(), new ArrayList<>());
@@ -101,16 +100,16 @@ public class MaxQueryComplexityInstrumentation extends SimpleInstrumentation {
         return fieldComplexityCalculator.calculate(fieldComplexityEnvironment, childsComplexity);
     }
 
-    private FieldComplexityEnvironment convertEnv(QueryVisitorFieldEnvironment QueryVisitorFieldEnvironment) {
+    private FieldComplexityEnvironment convertEnv(QueryVisitorFieldEnvironment queryVisitorFieldEnvironment) {
         FieldComplexityEnvironment parentEnv = null;
-        if (QueryVisitorFieldEnvironment.getParentEnvironment() != null) {
-            parentEnv = convertEnv(QueryVisitorFieldEnvironment.getParentEnvironment());
+        if (queryVisitorFieldEnvironment.getParentEnvironment() != null) {
+            parentEnv = convertEnv(queryVisitorFieldEnvironment.getParentEnvironment());
         }
         return new FieldComplexityEnvironment(
-                QueryVisitorFieldEnvironment.getField(),
-                QueryVisitorFieldEnvironment.getFieldDefinition(),
-                QueryVisitorFieldEnvironment.getParentType(),
-                QueryVisitorFieldEnvironment.getArguments(),
+                queryVisitorFieldEnvironment.getField(),
+                queryVisitorFieldEnvironment.getFieldDefinition(),
+                queryVisitorFieldEnvironment.getUnmodifiedParentType(),
+                queryVisitorFieldEnvironment.getArguments(),
                 parentEnv
         );
     }

--- a/src/main/java/graphql/analysis/QueryTraversalContext.java
+++ b/src/main/java/graphql/analysis/QueryTraversalContext.java
@@ -3,6 +3,7 @@ package graphql.analysis;
 import graphql.Internal;
 import graphql.language.SelectionSetContainer;
 import graphql.schema.GraphQLCompositeType;
+import graphql.schema.GraphQLOutputType;
 
 /**
  * QueryTraversal helper class that maintains traversal context as
@@ -10,19 +11,29 @@ import graphql.schema.GraphQLCompositeType;
  */
 @Internal
 class QueryTraversalContext {
-    
-    private final GraphQLCompositeType type;
+
+    private final GraphQLOutputType outputType;
+    private final GraphQLCompositeType rawType;
     private final QueryVisitorFieldEnvironment environment;
     private final SelectionSetContainer selectionSetContainer;
 
-    QueryTraversalContext(GraphQLCompositeType type, QueryVisitorFieldEnvironment environment, SelectionSetContainer selectionSetContainer) {
-        this.type = type;
+    QueryTraversalContext(GraphQLOutputType outputType,
+                          GraphQLCompositeType rawType
+            ,
+                          QueryVisitorFieldEnvironment environment,
+                          SelectionSetContainer selectionSetContainer) {
+        this.outputType = outputType;
+        this.rawType = rawType;
         this.environment = environment;
         this.selectionSetContainer = selectionSetContainer;
     }
 
-    public GraphQLCompositeType getType() {
-        return type;
+    public GraphQLOutputType getOutputType() {
+        return outputType;
+    }
+
+    public GraphQLCompositeType getRawType() {
+        return rawType;
     }
 
     public QueryVisitorFieldEnvironment getEnvironment() {

--- a/src/main/java/graphql/analysis/QueryVisitor.java
+++ b/src/main/java/graphql/analysis/QueryVisitor.java
@@ -10,7 +10,7 @@ import graphql.PublicApi;
 @PublicApi
 public interface QueryVisitor {
 
-    void visitField(QueryVisitorFieldEnvironment QueryVisitorFieldEnvironment);
+    void visitField(QueryVisitorFieldEnvironment queryVisitorFieldEnvironment);
 
     void visitInlineFragment(QueryVisitorInlineFragmentEnvironment queryVisitorInlineFragmentEnvironment);
 

--- a/src/main/java/graphql/analysis/QueryVisitorFieldEnvironment.java
+++ b/src/main/java/graphql/analysis/QueryVisitorFieldEnvironment.java
@@ -17,10 +17,16 @@ public interface QueryVisitorFieldEnvironment {
      */
     boolean isTypeNameIntrospectionField();
 
+    /**
+     * @return the current Field
+     */
     Field getField();
 
     GraphQLFieldDefinition getFieldDefinition();
 
+    /**
+     * @return the parent output type of the current field.
+     */
     GraphQLOutputType getParentType();
 
     /**

--- a/src/main/java/graphql/analysis/QueryVisitorFieldEnvironment.java
+++ b/src/main/java/graphql/analysis/QueryVisitorFieldEnvironment.java
@@ -3,19 +3,32 @@ package graphql.analysis;
 import graphql.PublicApi;
 import graphql.language.Field;
 import graphql.language.SelectionSetContainer;
-import graphql.schema.GraphQLCompositeType;
 import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLFieldsContainer;
+import graphql.schema.GraphQLOutputType;
 
 import java.util.Map;
 
 @PublicApi
 public interface QueryVisitorFieldEnvironment {
 
+    /**
+     * @return true if the current field is __typename
+     */
+    boolean isTypeNameIntrospectionField();
+
     Field getField();
 
     GraphQLFieldDefinition getFieldDefinition();
 
-    GraphQLCompositeType getParentType();
+    GraphQLOutputType getParentType();
+
+    /**
+     * @return the unmodified fields container fot the current type
+     *
+     * @throws IllegalStateException if the current field is __typename see {@link #isTypeNameIntrospectionField()}
+     */
+    GraphQLFieldsContainer getUnmodifiedParentType();
 
     QueryVisitorFieldEnvironment getParentEnvironment();
 

--- a/src/main/java/graphql/analysis/QueryVisitorFieldEnvironmentImpl.java
+++ b/src/main/java/graphql/analysis/QueryVisitorFieldEnvironmentImpl.java
@@ -3,29 +3,38 @@ package graphql.analysis;
 import graphql.Internal;
 import graphql.language.Field;
 import graphql.language.SelectionSetContainer;
-import graphql.schema.GraphQLCompositeType;
 import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLFieldsContainer;
+import graphql.schema.GraphQLOutputType;
 
 import java.util.Map;
+import java.util.Objects;
 
 @Internal
 public class QueryVisitorFieldEnvironmentImpl implements QueryVisitorFieldEnvironment {
+
+    private final boolean typeNameIntrospectionField;
     private final Field field;
     private final GraphQLFieldDefinition fieldDefinition;
-    private final GraphQLCompositeType parentType;
+    private final GraphQLOutputType parentType;
+    private final GraphQLFieldsContainer unmodifiedParentType;
     private final Map<String, Object> arguments;
     private final QueryVisitorFieldEnvironment parentEnvironment;
     private final SelectionSetContainer selectionSetContainer;
 
-    public QueryVisitorFieldEnvironmentImpl(Field field,
+    public QueryVisitorFieldEnvironmentImpl(boolean typeNameIntrospectionField,
+                                            Field field,
                                             GraphQLFieldDefinition fieldDefinition,
-                                            GraphQLCompositeType parentType,
+                                            GraphQLOutputType parentType,
+                                            GraphQLFieldsContainer unmodifiedParentType,
                                             QueryVisitorFieldEnvironment parentEnvironment,
                                             Map<String, Object> arguments,
                                             SelectionSetContainer selectionSetContainer) {
+        this.typeNameIntrospectionField = typeNameIntrospectionField;
         this.field = field;
         this.fieldDefinition = fieldDefinition;
         this.parentType = parentType;
+        this.unmodifiedParentType = unmodifiedParentType;
         this.parentEnvironment = parentEnvironment;
         this.arguments = arguments;
         this.selectionSetContainer = selectionSetContainer;
@@ -42,7 +51,7 @@ public class QueryVisitorFieldEnvironmentImpl implements QueryVisitorFieldEnviro
     }
 
     @Override
-    public GraphQLCompositeType getParentType() {
+    public GraphQLOutputType getParentType() {
         return parentType;
     }
 
@@ -62,29 +71,37 @@ public class QueryVisitorFieldEnvironmentImpl implements QueryVisitorFieldEnviro
     }
 
     @Override
+    public GraphQLFieldsContainer getUnmodifiedParentType() {
+        if (isTypeNameIntrospectionField()) {
+            throw new IllegalStateException("introspection field __typename doesn't have a fields container");
+        }
+        return unmodifiedParentType;
+    }
+
+    @Override
+    public boolean isTypeNameIntrospectionField() {
+        return typeNameIntrospectionField;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
         QueryVisitorFieldEnvironmentImpl that = (QueryVisitorFieldEnvironmentImpl) o;
-
-        if (field != null ? !field.equals(that.field) : that.field != null) return false;
-        if (fieldDefinition != null ? !fieldDefinition.equals(that.fieldDefinition) : that.fieldDefinition != null)
-            return false;
-        if (parentType != null ? !parentType.equals(that.parentType) : that.parentType != null) return false;
-        if (parentEnvironment != null ? !parentEnvironment.equals(that.parentEnvironment) : that.parentEnvironment != null)
-            return false;
-        return arguments != null ? arguments.equals(that.arguments) : that.arguments == null;
+        return typeNameIntrospectionField == that.typeNameIntrospectionField &&
+                Objects.equals(field, that.field) &&
+                Objects.equals(fieldDefinition, that.fieldDefinition) &&
+                Objects.equals(parentType, that.parentType) &&
+                Objects.equals(unmodifiedParentType, that.unmodifiedParentType) &&
+                Objects.equals(arguments, that.arguments) &&
+                Objects.equals(parentEnvironment, that.parentEnvironment) &&
+                Objects.equals(selectionSetContainer, that.selectionSetContainer);
     }
 
     @Override
     public int hashCode() {
-        int result = field != null ? field.hashCode() : 0;
-        result = 31 * result + (fieldDefinition != null ? fieldDefinition.hashCode() : 0);
-        result = 31 * result + (parentType != null ? parentType.hashCode() : 0);
-        result = 31 * result + (parentEnvironment != null ? parentEnvironment.hashCode() : 0);
-        result = 31 * result + (arguments != null ? arguments.hashCode() : 0);
-        return result;
+
+        return Objects.hash(typeNameIntrospectionField, field, fieldDefinition, parentType, unmodifiedParentType, arguments, parentEnvironment, selectionSetContainer);
     }
 
     @Override

--- a/src/main/java/graphql/analysis/QueryVisitorStub.java
+++ b/src/main/java/graphql/analysis/QueryVisitorStub.java
@@ -7,7 +7,7 @@ public class QueryVisitorStub implements QueryVisitor {
 
 
     @Override
-    public void visitField(QueryVisitorFieldEnvironment QueryVisitorFieldEnvironment) {
+    public void visitField(QueryVisitorFieldEnvironment queryVisitorFieldEnvironment) {
 
     }
 

--- a/src/main/java/graphql/execution/instrumentation/fieldvalidation/FieldValidationSupport.java
+++ b/src/main/java/graphql/execution/instrumentation/fieldvalidation/FieldValidationSupport.java
@@ -106,7 +106,7 @@ class FieldValidationSupport {
 
         @Override
         public GraphQLCompositeType getParentType() {
-            return traversalEnv.getParentType();
+            return traversalEnv.getUnmodifiedParentType();
         }
 
         @Override

--- a/src/main/java/graphql/introspection/Introspection.java
+++ b/src/main/java/graphql/introspection/Introspection.java
@@ -2,6 +2,7 @@ package graphql.introspection;
 
 
 import graphql.Assert;
+import graphql.PublicApi;
 import graphql.language.AstPrinter;
 import graphql.language.AstValueHelper;
 import graphql.schema.DataFetcher;
@@ -40,6 +41,7 @@ import static graphql.schema.GraphQLNonNull.nonNull;
 import static graphql.schema.GraphQLObjectType.newObject;
 import static graphql.schema.GraphQLTypeReference.typeRef;
 
+@PublicApi
 public class Introspection {
 
     public enum TypeKind {

--- a/src/main/java/graphql/schema/GraphQLCompositeType.java
+++ b/src/main/java/graphql/schema/GraphQLCompositeType.java
@@ -1,5 +1,8 @@
 package graphql.schema;
 
 
-public interface GraphQLCompositeType extends GraphQLType {
+import graphql.PublicApi;
+
+@PublicApi
+public interface GraphQLCompositeType extends GraphQLOutputType {
 }

--- a/src/main/java/graphql/schema/GraphQLFieldsContainer.java
+++ b/src/main/java/graphql/schema/GraphQLFieldsContainer.java
@@ -1,5 +1,7 @@
 package graphql.schema;
 
+import graphql.PublicApi;
+
 import java.util.List;
 
 
@@ -9,7 +11,8 @@ import java.util.List;
  * @see graphql.schema.GraphQLObjectType
  * @see graphql.schema.GraphQLInterfaceType
  */
-public interface GraphQLFieldsContainer extends GraphQLType {
+@PublicApi
+public interface GraphQLFieldsContainer extends GraphQLCompositeType {
 
     GraphQLFieldDefinition getFieldDefinition(String name);
 

--- a/src/main/java/graphql/schema/GraphQLTypeReference.java
+++ b/src/main/java/graphql/schema/GraphQLTypeReference.java
@@ -1,12 +1,15 @@
 package graphql.schema;
 
 
+import graphql.PublicApi;
+
 import static graphql.Assert.assertValidName;
 
 /**
  * A special type to allow a object/interface types to reference itself. It's replaced with the real type
  * object when the schema is built.
  */
+@PublicApi
 public class GraphQLTypeReference implements GraphQLType, GraphQLOutputType, GraphQLInputType {
 
     /**


### PR DESCRIPTION
This improves the query traversal features by improving QueryVisitorFieldEnvironment and making it more clear what the parent type of the field is and if the field is the special introspection field __typename.

It also changes the GraphqlType hierarchy by making it more cleat that FieldsContainer < CompositeType < OutputType.

This is a breaking change because QueryVisitorFieldEnvironment.getParentType() returns now the possible modified type and not the unmodified type. 

@bbakerman What are your thoughts about that breaking change? It seems rather small, but I am not sure how easy it can be detected by everyone: the behaviour was changed without always breaking at compile time.