### PR TITLE
restrict add to SDLDefinitions

### DIFF
--- a/src/main/java/graphql/schema/idl/SchemaParser.java
+++ b/src/main/java/graphql/schema/idl/SchemaParser.java
@@ -5,6 +5,7 @@ import graphql.InvalidSyntaxError;
 import graphql.PublicApi;
 import graphql.language.Definition;
 import graphql.language.Document;
+import graphql.language.SDLDefinition;
 import graphql.parser.Parser;
 import graphql.schema.idl.errors.SchemaProblem;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
@@ -101,7 +102,9 @@ public class SchemaParser {
         TypeDefinitionRegistry typeRegistry = new TypeDefinitionRegistry();
         List<Definition> definitions = document.getDefinitions();
         for (Definition definition : definitions) {
-            typeRegistry.add(definition).ifPresent(errors::add);
+            if (definition instanceof SDLDefinition) {
+                typeRegistry.add((SDLDefinition) definition).ifPresent(errors::add);
+            }
         }
         if (errors.size() > 0) {
             throw new SchemaProblem(errors);

--- a/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java
+++ b/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java
@@ -1,8 +1,8 @@
 package graphql.schema.idl;
 
+import graphql.Assert;
 import graphql.GraphQLError;
 import graphql.PublicApi;
-import graphql.language.Definition;
 import graphql.language.DirectiveDefinition;
 import graphql.language.EnumTypeExtensionDefinition;
 import graphql.language.InputObjectTypeExtensionDefinition;
@@ -10,6 +10,7 @@ import graphql.language.InterfaceTypeDefinition;
 import graphql.language.InterfaceTypeExtensionDefinition;
 import graphql.language.ObjectTypeDefinition;
 import graphql.language.ObjectTypeExtensionDefinition;
+import graphql.language.SDLDefinition;
 import graphql.language.ScalarTypeDefinition;
 import graphql.language.ScalarTypeExtensionDefinition;
 import graphql.language.SchemaDefinition;
@@ -139,7 +140,7 @@ public class TypeDefinitionRegistry {
      *
      * @return an optional error
      */
-    public Optional<GraphQLError> add(Definition definition) {
+    public Optional<GraphQLError> add(SDLDefinition definition) {
         // extensions
         if (definition instanceof ObjectTypeExtensionDefinition) {
             ObjectTypeExtensionDefinition newEntry = (ObjectTypeExtensionDefinition) definition;
@@ -177,6 +178,8 @@ public class TypeDefinitionRegistry {
             } else {
                 schema = newSchema;
             }
+        } else {
+            return Assert.assertShouldNeverHappen();
         }
         return Optional.empty();
     }


### PR DESCRIPTION
use the new SDLDefinitions Interface to make it more clear that only SDL Types are accepted.