### PR TITLE
Support building from a different CWD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ docs/_build/
 \.classpath
 \.project
 \.settings/
+/.nb-gradle/

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'osgi'
 def getDevelopmentVersion() {
     def output = new StringBuilder()
     def error = new StringBuilder()
-    def gitShortHash = 'git rev-parse --short HEAD'.execute()
+    def gitShortHash = "git -C ${projectDir} rev-parse --short HEAD".execute()
     gitShortHash.waitForProcessOutput(output, error)
     def gitHash = output.toString().trim()
     if (gitHash.isEmpty()) {


### PR DESCRIPTION
Netbeans runs with a different CWD compared to the project causing the git command to break.

Adding -C to tell git the location of the repository to get the hash from.

Also added Netbeans gradle directory in.gitignore