### PR TITLE
WIP - Lazy list completion

### DIFF
--- a/src/main/java/graphql/execution/AbstractAsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AbstractAsyncExecutionStrategy.java
@@ -19,9 +19,10 @@ public abstract class AbstractAsyncExecutionStrategy extends ExecutionStrategy {
         super(dataFetcherExceptionHandler);
     }
 
-    protected BiConsumer<List<ExecutionResult>, Throwable> handleResults(ExecutionContext executionContext, List<String> fieldNames, CompletableFuture<ExecutionResult> overallResult) {
+    protected BiConsumer<List<ExecutionResult>, Throwable> handleResults(ExecutionContext executionContext, CompletionCancellationRegistry completionCancellationRegistry, List<String> fieldNames, CompletableFuture<ExecutionResult> overallResult) {
         return (List<ExecutionResult> results, Throwable exception) -> {
             if (exception != null) {
+                completionCancellationRegistry.dispatch();
                 handleNonNullException(executionContext, overallResult, exception);
                 return;
             }

--- a/src/main/java/graphql/execution/CompletionCancellationRegistry.java
+++ b/src/main/java/graphql/execution/CompletionCancellationRegistry.java
@@ -1,0 +1,38 @@
+package graphql.execution;
+
+import graphql.Internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Internal
+public class CompletionCancellationRegistry {
+    private final List<Runnable> callbacks = new ArrayList<>();
+    private final AtomicBoolean cancelled = new AtomicBoolean(false);
+
+    public CompletionCancellationRegistry(CompletionCancellationRegistry parent) {
+        parent.addCancellationCallback(this::dispatch);
+    }
+
+    public CompletionCancellationRegistry() {
+    }
+
+    public void addCancellationCallback(Runnable callback) {
+        synchronized (callbacks) {
+            if (cancelled.get()) {
+                callback.run();
+            } else {
+                callbacks.add(callback);
+            }
+        }
+    }
+
+    public void dispatch() {
+        cancelled.set(true);
+        synchronized (callbacks) {
+            callbacks.forEach(Runnable::run);
+            callbacks.clear();
+        }
+    }
+}

--- a/src/main/java/graphql/execution/ExecutionContext.java
+++ b/src/main/java/graphql/execution/ExecutionContext.java
@@ -1,11 +1,13 @@
 package graphql.execution;
 
 
+import graphql.ExperimentalApi;
 import graphql.GraphQLError;
 import graphql.PublicApi;
 import graphql.execution.defer.DeferSupport;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationState;
+import graphql.execution.lazy.LazySupport;
 import graphql.language.Document;
 import graphql.language.FragmentDefinition;
 import graphql.language.OperationDefinition;
@@ -35,13 +37,14 @@ public class ExecutionContext {
     private final Object context;
     private final Instrumentation instrumentation;
     private final List<GraphQLError> errors = new CopyOnWriteArrayList<>();
-    private final DeferSupport deferSupport = new DeferSupport();
+    private final LazySupport lazySupport;
+    private final DeferSupport deferSupport;
 
-    public ExecutionContext(Instrumentation instrumentation, ExecutionId executionId, GraphQLSchema graphQLSchema, InstrumentationState instrumentationState, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy, ExecutionStrategy subscriptionStrategy, Map<String, FragmentDefinition> fragmentsByName, Document document, OperationDefinition operationDefinition, Map<String, Object> variables, Object context, Object root) {
-        this(instrumentation, executionId, graphQLSchema, instrumentationState, queryStrategy, mutationStrategy, subscriptionStrategy, fragmentsByName, document, operationDefinition, variables, context, root, Collections.emptyList());
+    public ExecutionContext(Instrumentation instrumentation, ExecutionId executionId, GraphQLSchema graphQLSchema, InstrumentationState instrumentationState, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy, ExecutionStrategy subscriptionStrategy, Map<String, FragmentDefinition> fragmentsByName, Document document, OperationDefinition operationDefinition, Map<String, Object> variables, Object context, Object root, LazySupport lazySupport, DeferSupport deferSupport) {
+        this(instrumentation, executionId, graphQLSchema, instrumentationState, queryStrategy, mutationStrategy, subscriptionStrategy, fragmentsByName, document, operationDefinition, variables, context, root, Collections.emptyList(), lazySupport, deferSupport);
     }
 
-    ExecutionContext(Instrumentation instrumentation, ExecutionId executionId, GraphQLSchema graphQLSchema, InstrumentationState instrumentationState, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy, ExecutionStrategy subscriptionStrategy, Map<String, FragmentDefinition> fragmentsByName, Document document, OperationDefinition operationDefinition, Map<String, Object> variables, Object context, Object root, List<GraphQLError> startingErrors) {
+    ExecutionContext(Instrumentation instrumentation, ExecutionId executionId, GraphQLSchema graphQLSchema, InstrumentationState instrumentationState, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy, ExecutionStrategy subscriptionStrategy, Map<String, FragmentDefinition> fragmentsByName, Document document, OperationDefinition operationDefinition, Map<String, Object> variables, Object context, Object root, List<GraphQLError> startingErrors, LazySupport lazySupport, DeferSupport deferSupport) {
         this.graphQLSchema = graphQLSchema;
         this.executionId = executionId;
         this.instrumentationState = instrumentationState;
@@ -56,6 +59,8 @@ public class ExecutionContext {
         this.root = root;
         this.instrumentation = instrumentation;
         this.errors.addAll(startingErrors);
+        this.lazySupport = lazySupport;
+        this.deferSupport = deferSupport;
     }
 
 
@@ -161,6 +166,11 @@ public class ExecutionContext {
 
     public DeferSupport getDeferSupport() {
         return deferSupport;
+    }
+
+    @ExperimentalApi
+    public LazySupport getLazySupport() {
+        return lazySupport;
     }
 
     /**

--- a/src/main/java/graphql/execution/ExecutionContextBuilder.java
+++ b/src/main/java/graphql/execution/ExecutionContextBuilder.java
@@ -3,8 +3,10 @@ package graphql.execution;
 import graphql.GraphQLError;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.execution.defer.DeferSupport;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationState;
+import graphql.execution.lazy.LazySupport;
 import graphql.language.Document;
 import graphql.language.FragmentDefinition;
 import graphql.language.OperationDefinition;
@@ -34,6 +36,8 @@ public class ExecutionContextBuilder {
     private Map<String, Object> variables = new HashMap<>();
     private Map<String, FragmentDefinition> fragmentsByName = new HashMap<>();
     private List<GraphQLError> errors = new ArrayList<>();
+    private LazySupport lazySupport;
+    private DeferSupport deferSupport;
 
     /**
      * @return a new builder of {@link graphql.execution.ExecutionContext}s
@@ -55,6 +59,8 @@ public class ExecutionContextBuilder {
 
     @Internal
     public ExecutionContextBuilder() {
+        lazySupport = new LazySupport();
+        deferSupport = new DeferSupport(lazySupport);
     }
 
     @Internal
@@ -73,6 +79,8 @@ public class ExecutionContextBuilder {
         variables = new HashMap<>(other.getVariables());
         fragmentsByName = new HashMap<>(other.getFragmentsByName());
         errors = new ArrayList<>(other.getErrors());
+        lazySupport = other.getLazySupport();
+        deferSupport = other.getDeferSupport();
     }
 
     public ExecutionContextBuilder instrumentation(Instrumentation instrumentation) {
@@ -140,6 +148,11 @@ public class ExecutionContextBuilder {
         return this;
     }
 
+    public ExecutionContextBuilder errors(List<GraphQLError> errors) {
+        this.errors = errors;
+        return this;
+    }
+
 
     public ExecutionContext build() {
         // preconditions
@@ -159,6 +172,8 @@ public class ExecutionContextBuilder {
                 variables,
                 context,
                 root,
-                errors);
+                errors,
+                lazySupport,
+                deferSupport);
     }
 }

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -484,6 +484,10 @@ public abstract class ExecutionStrategy {
                 instrumentationParams
         );
 
+        CompletionCancellationRegistry completionCancellationRegistry = new CompletionCancellationRegistry(
+                parameters.getCompletionCancellationRegistry()
+        );
+
         List<FieldValueInfo> fieldValueInfos = new ArrayList<>();
         int index = 0;
         for (Object item : values) {
@@ -506,6 +510,7 @@ public abstract class ExecutionStrategy {
                             .currentListIndex(finalIndex)
                             .path(indexedPath)
                             .source(item)
+                            .completionCancellationRegistry(completionCancellationRegistry)
             );
             fieldValueInfos.add(completeValue(executionContext, newParameters));
             index++;
@@ -518,6 +523,7 @@ public abstract class ExecutionStrategy {
 
         resultsFuture.whenComplete((results, exception) -> {
             if (exception != null) {
+                completionCancellationRegistry.dispatch();
                 ExecutionResult executionResult = handleNonNullException(executionContext, overallResult, exception);
                 completeListCtx.onCompleted(executionResult, exception);
                 return;

--- a/src/main/java/graphql/execution/ExecutionStrategyParameters.java
+++ b/src/main/java/graphql/execution/ExecutionStrategyParameters.java
@@ -27,6 +27,7 @@ public class ExecutionStrategyParameters {
     private final int currentListIndex;
     private final ExecutionStrategyParameters parent;
     private final DeferredErrorSupport deferredErrorSupport;
+    private final CompletionCancellationRegistry completionCancellationRegistry;
 
     private ExecutionStrategyParameters(ExecutionTypeInfo typeInfo,
                                         Object source,
@@ -38,7 +39,8 @@ public class ExecutionStrategyParameters {
                                         int listSize,
                                         int currentListIndex,
                                         ExecutionStrategyParameters parent,
-                                        DeferredErrorSupport deferredErrorSupport) {
+                                        DeferredErrorSupport deferredErrorSupport,
+                                        CompletionCancellationRegistry completionCancellationRegistry) {
 
         this.typeInfo = assertNotNull(typeInfo, "typeInfo is null");
         this.fields = assertNotNull(fields, "fields is null");
@@ -51,6 +53,7 @@ public class ExecutionStrategyParameters {
         this.currentListIndex = currentListIndex;
         this.parent = parent;
         this.deferredErrorSupport = deferredErrorSupport;
+        this.completionCancellationRegistry = completionCancellationRegistry;
     }
 
     public ExecutionTypeInfo getTypeInfo() {
@@ -103,6 +106,10 @@ public class ExecutionStrategyParameters {
         return currentField;
     }
 
+    public CompletionCancellationRegistry getCompletionCancellationRegistry() {
+        return completionCancellationRegistry;
+    }
+
     public ExecutionStrategyParameters transform(Consumer<Builder> builderConsumer) {
         Builder builder = newParameters(this);
         builderConsumer.accept(builder);
@@ -135,6 +142,7 @@ public class ExecutionStrategyParameters {
         int currentListIndex;
         ExecutionStrategyParameters parent;
         DeferredErrorSupport deferredErrorSupport = new DeferredErrorSupport();
+        CompletionCancellationRegistry completionCancellationRegistry;
 
         /**
          * @see ExecutionStrategyParameters#newParameters()
@@ -157,6 +165,7 @@ public class ExecutionStrategyParameters {
             this.parent = oldParameters.parent;
             this.listSize = oldParameters.listSize;
             this.currentListIndex = oldParameters.currentListIndex;
+            this.completionCancellationRegistry = oldParameters.completionCancellationRegistry;
         }
 
         public Builder typeInfo(ExecutionTypeInfo type) {
@@ -219,8 +228,13 @@ public class ExecutionStrategyParameters {
             return this;
         }
 
+        public Builder completionCancellationRegistry(CompletionCancellationRegistry completionCancellationRegistry) {
+            this.completionCancellationRegistry = completionCancellationRegistry;
+            return this;
+        }
+
         public ExecutionStrategyParameters build() {
-            return new ExecutionStrategyParameters(typeInfo, source, fields, arguments, nonNullableFieldValidator, path, currentField, listSize, currentListIndex, parent, deferredErrorSupport);
+            return new ExecutionStrategyParameters(typeInfo, source, fields, arguments, nonNullableFieldValidator, path, currentField, listSize, currentListIndex, parent, deferredErrorSupport, completionCancellationRegistry);
         }
     }
 }

--- a/src/main/java/graphql/execution/FieldValueInfo.java
+++ b/src/main/java/graphql/execution/FieldValueInfo.java
@@ -14,7 +14,8 @@ public class FieldValueInfo {
         LIST,
         NULL,
         SCALAR,
-        ENUM
+        ENUM,
+        LAZY_LIST,
 
     }
 

--- a/src/main/java/graphql/execution/instrumentation/Instrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/Instrumentation.java
@@ -2,6 +2,7 @@ package graphql.execution.instrumentation;
 
 import graphql.ExecutionInput;
 import graphql.ExecutionResult;
+import graphql.ExperimentalApi;
 import graphql.execution.ExecutionContext;
 import graphql.execution.instrumentation.parameters.InstrumentationDeferredFieldParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationExecuteOperationParameters;
@@ -137,6 +138,18 @@ public interface Instrumentation {
      * @return a non null {@link InstrumentationContext} object that will be called back when the step ends
      */
     default InstrumentationContext<ExecutionResult> beginFieldListComplete(InstrumentationFieldCompleteParameters parameters) {
+        return new SimpleInstrumentationContext<>();
+    }
+
+    /**
+     * This is called just before the elements of a lazy list are being retrieved.
+     *
+     * @param parameters the parameters to this step
+     *
+     * @return a non null {@link InstrumentationContext} object that will be called back when the step ends
+     */
+    @ExperimentalApi
+    default InstrumentationContext<ExecutionResult> beginFieldLazyListComplete(InstrumentationFieldCompleteParameters parameters) {
         return new SimpleInstrumentationContext<>();
     }
 

--- a/src/main/java/graphql/execution/lazy/BlockingLazyList.java
+++ b/src/main/java/graphql/execution/lazy/BlockingLazyList.java
@@ -1,0 +1,35 @@
+package graphql.execution.lazy;
+
+import graphql.ExperimentalApi;
+import graphql.PublicSpi;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+/**
+ * A simplified lazy list that always passes {@literal true} as the boolean argument. See the documentation of
+ * {@link LazyList} for more details.
+ *
+ * This interface is useful because it can be assigned from {@literal stream::forAll} where {@literal stream} is an
+ * instance of {@link java.util.stream.Stream}.
+ *
+ * @param <T> the type of object passed to the callback
+ */
+@PublicSpi
+@ExperimentalApi
+@FunctionalInterface
+public interface BlockingLazyList<T> extends LazyList<T> {
+    /**
+     * This is called to retrieve the elements of the lazy list. The callback should be invoked once for each element in
+     * the list.
+     *
+     * If the callback throws an exception, the exception should be passed through.
+     *
+     * @param action the callback to invoke
+     */
+    void forEach(Consumer<? super T> action);
+
+    default void forEach(BiConsumer<Boolean, ? super T> action) {
+        forEach(item -> action.accept(true, item));
+    }
+}

--- a/src/main/java/graphql/execution/lazy/LazyExecutionResult.java
+++ b/src/main/java/graphql/execution/lazy/LazyExecutionResult.java
@@ -1,0 +1,63 @@
+package graphql.execution.lazy;
+
+import graphql.ExecutionResult;
+import graphql.GraphQL;
+import graphql.GraphQLError;
+import graphql.Internal;
+import graphql.execution.ExecutionContext;
+import graphql.execution.defer.DeferSupport;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An execution result used for executions that contain lazy objects. The major differences between this and
+ * {@link graphql.ExecutionResultImpl} are
+ *
+ * <ul>
+ * <li>{@link LazyExecutionResult#getErrors()} always returns the current errors from the execution context</li>
+ * <li>{@link LazyExecutionResult#getExtensions()} always returns all currently used extensions</li>
+ * <li>{@link LazyExecutionResult#toSpecification()} is not supported by this implementation</li>
+ * </ul>
+ */
+@Internal
+public class LazyExecutionResult implements ExecutionResult {
+    private final ExecutionResult delegate;
+    private final List<GraphQLError> contextErrors;
+    private final DeferSupport deferSupport;
+
+    public LazyExecutionResult(ExecutionResult delegate, List<GraphQLError> contextErrors, DeferSupport deferSupport) {
+        this.delegate = delegate;
+        this.contextErrors = contextErrors;
+        this.deferSupport = deferSupport;
+    }
+
+    @Override
+    public <T> T getData() {
+        return delegate.getData();
+    }
+
+    @Override
+    public List<GraphQLError> getErrors() {
+        return new ArrayList<>(contextErrors);
+    }
+
+    @Override
+    public Map<Object, Object> getExtensions() {
+        Map<Object, Object> extensions = delegate.getExtensions();
+        if (extensions == null) {
+            extensions = new LinkedHashMap<>();
+        }
+        if (deferSupport != null && deferSupport.isDeferDetected()) {
+            extensions.put(GraphQL.DEFERRED_RESULTS, deferSupport.getPublisher());
+        }
+        return extensions.isEmpty() ? null : extensions;
+    }
+
+    @Override
+    public Map<String, Object> toSpecification() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/graphql/execution/lazy/LazyList.java
+++ b/src/main/java/graphql/execution/lazy/LazyList.java
@@ -1,0 +1,39 @@
+package graphql.execution.lazy;
+
+import graphql.ExecutionResult;
+import graphql.ExperimentalApi;
+import graphql.PublicSpi;
+
+import java.util.function.BiConsumer;
+
+/**
+ * A lazy list can be returned by a data fetcher of a field of list type to defer the completion of the list until
+ * the elements are actually needed. Returning a lazy list from a data fetcher causes the execution result to contain a
+ * lazy list at the same place. In order to retrieve the completed list elements, the lazy list in the execution result
+ * must be invoked.
+ *
+ * Since the completion of the list elements is deferred, not all possible errors are known when the execution result is
+ * created. Therefore, the {@link ExecutionResult#toSpecification()} method cannot be used if lazy lists are used during
+ * the execution. Instead the user must manually serialize the execution result in accordance with the specification.
+ * The errors of the execution result must only be retrieved once all elements of all lazy lists have been completed.
+ *
+ * @param <T> the type of object passed to the callback
+ */
+@PublicSpi
+@ExperimentalApi
+@FunctionalInterface
+public interface LazyList<T> {
+
+    /**
+     * This is called to retrieve the elements of the lazy list. The callback should be invoked once for each element in
+     * the list. The boolean argument is only used for lazy lists returned by the data fetcher (in contrast to the lazy
+     * list contained in the execution result.) In this case, all elements passed to the callback are completed
+     * concurrently until the callback is invoked with the boolean argument true. Once it is invoked with true, the
+     * execution waits for all elements that have not yet been passed along to complete and then passes them along.
+     *
+     * If the callback throws an exception, the exception should be passed through.
+     *
+     * @param action the callback to invoke
+     */
+    void forEach(BiConsumer<Boolean, ? super T> action);
+}

--- a/src/main/java/graphql/execution/lazy/LazyListUtil.java
+++ b/src/main/java/graphql/execution/lazy/LazyListUtil.java
@@ -1,0 +1,31 @@
+package graphql.execution.lazy;
+
+import graphql.Internal;
+
+import java.util.function.Function;
+
+/**
+ * A utility for wrapping lazy lists in other lazy lists in a fluent style
+ *
+ * @param <T> the type parameter of the lazy list
+ */
+@Internal
+public class LazyListUtil<T> {
+    private final LazyList<T> delegate;
+
+    private LazyListUtil(LazyList<T> delegate) {
+        this.delegate = delegate;
+    }
+
+    public static <T> LazyListUtil<T> of(LazyList<T> delegate) {
+        return new LazyListUtil<>(delegate);
+    }
+
+    public <U> LazyListUtil<U> wrap(Function<LazyList<T>, LazyList<U>> f) {
+        return LazyListUtil.of(f.apply(delegate));
+    }
+
+    public LazyList<T> unwrap() {
+        return delegate;
+    }
+}

--- a/src/main/java/graphql/execution/lazy/LazySupport.java
+++ b/src/main/java/graphql/execution/lazy/LazySupport.java
@@ -1,0 +1,55 @@
+package graphql.execution.lazy;
+
+import graphql.Internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Internal
+public class LazySupport {
+    private final AtomicBoolean lazyFieldsDetected = new AtomicBoolean();
+    private final AtomicInteger numPendingCompletions = new AtomicInteger();
+    private final List<Runnable> callbacks = new ArrayList<>();
+
+    public class Token {
+        private final AtomicBoolean released = new AtomicBoolean(false);
+
+        public void release() {
+            if (!released.getAndSet(true)) {
+                if (numPendingCompletions.decrementAndGet() == 0) {
+                    synchronized (callbacks) {
+                        List<Runnable> tmp = new ArrayList<>(callbacks);
+                        callbacks.clear();
+                        tmp.forEach(Runnable::run);
+                    }
+                }
+            }
+        }
+    }
+
+    public Token addLazyCompletion() {
+        lazyFieldsDetected.set(true);
+        numPendingCompletions.incrementAndGet();
+        return new Token();
+    }
+
+    public boolean hasPendingCompletions() {
+        return numPendingCompletions.get() != 0;
+    }
+
+    public boolean lazyFieldsDetected() {
+        return lazyFieldsDetected.get();
+    }
+
+    public void addCompletionCallback(Runnable callback) {
+        synchronized (callbacks) {
+            if (hasPendingCompletions()) {
+                callbacks.add(callback);
+            } else {
+                callback.run();
+            }
+        }
+    }
+}

--- a/src/main/java/graphql/execution/reactive/SingleSubscriberPublisher.java
+++ b/src/main/java/graphql/execution/reactive/SingleSubscriberPublisher.java
@@ -59,7 +59,10 @@ public class SingleSubscriberPublisher<T> implements Publisher<T> {
      * @param data the data to offer
      */
     public void offer(T data) {
-        mutex.execute(() -> dataQ.offer(data));
+        mutex.execute(() -> {
+            dataQ.offer(data);
+            maybeReadInMutex();
+        });
     }
 
     /**

--- a/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy
@@ -80,6 +80,7 @@ class AsyncExecutionStrategyTest extends Specification {
                 .newParameters()
                 .typeInfo(typeInfo)
                 .fields(['hello': [new Field('hello')], 'hello2': [new Field('hello2')]])
+                .completionCancellationRegistry(new CompletionCancellationRegistry())
                 .build()
 
         AsyncExecutionStrategy asyncExecutionStrategy = new AsyncExecutionStrategy()
@@ -118,6 +119,7 @@ class AsyncExecutionStrategyTest extends Specification {
                 .newParameters()
                 .typeInfo(typeInfo)
                 .fields(['hello': [new Field('hello')], 'hello2': [new Field('hello2')]])
+                .completionCancellationRegistry(new CompletionCancellationRegistry())
                 .build()
 
         AsyncExecutionStrategy asyncExecutionStrategy = new AsyncExecutionStrategy()
@@ -158,6 +160,7 @@ class AsyncExecutionStrategyTest extends Specification {
                 .newParameters()
                 .typeInfo(typeInfo)
                 .fields(['hello': [new Field('hello')], 'hello2': [new Field('hello2')]])
+                .completionCancellationRegistry(new CompletionCancellationRegistry())
                 .build()
 
         AsyncExecutionStrategy asyncExecutionStrategy = new AsyncExecutionStrategy()
@@ -197,6 +200,7 @@ class AsyncExecutionStrategyTest extends Specification {
                 .newParameters()
                 .typeInfo(typeInfo)
                 .fields(['hello': [new Field('hello')], 'hello2': [new Field('hello2')]])
+                .completionCancellationRegistry(new CompletionCancellationRegistry())
                 .build()
 
         AsyncExecutionStrategy asyncExecutionStrategy = new AsyncExecutionStrategy()

--- a/src/test/groovy/graphql/execution/AsyncSerialExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/AsyncSerialExecutionStrategyTest.groovy
@@ -87,6 +87,7 @@ class AsyncSerialExecutionStrategyTest extends Specification {
                 .newParameters()
                 .typeInfo(typeInfo)
                 .fields(['hello': [new Field('hello')], 'hello2': [new Field('hello2')], 'hello3': [new Field('hello3')]])
+                .completionCancellationRegistry(new CompletionCancellationRegistry())
                 .build()
 
         AsyncSerialExecutionStrategy strategy = new AsyncSerialExecutionStrategy()
@@ -130,6 +131,7 @@ class AsyncSerialExecutionStrategyTest extends Specification {
                 .newParameters()
                 .typeInfo(typeInfo)
                 .fields(['hello': [new Field('hello')], 'hello2': [new Field('hello2')], 'hello3': [new Field('hello3')]])
+                .completionCancellationRegistry(new CompletionCancellationRegistry())
                 .build()
 
         AsyncSerialExecutionStrategy strategy = new AsyncSerialExecutionStrategy()

--- a/src/test/groovy/graphql/execution/CompletionCancellationRegistryTest.groovy
+++ b/src/test/groovy/graphql/execution/CompletionCancellationRegistryTest.groovy
@@ -1,0 +1,40 @@
+package graphql.execution
+
+import spock.lang.Specification
+
+/**
+ * @author jorth
+ */
+class CompletionCancellationRegistryTest extends Specification {
+    def "test callback is invoked immediately"() {
+        given:
+        def called = 0
+        def registry = new CompletionCancellationRegistry()
+        registry.dispatch()
+
+        when:
+        registry.addCancellationCallback({ called = 1 })
+
+        then:
+        called == 1
+    }
+
+    def "test parent cancels child"() {
+        given:
+        def called = 0
+        def parentRegistry = new CompletionCancellationRegistry()
+        def registry = new CompletionCancellationRegistry(parentRegistry)
+
+        when:
+        registry.addCancellationCallback({ called = 1 })
+
+        then:
+        called == 0
+
+        when:
+        parentRegistry.dispatch()
+
+        then:
+        called == 1
+    }
+}

--- a/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
@@ -7,7 +7,9 @@ import graphql.ExecutionResult
 import graphql.Scalars
 import graphql.SerializationError
 import graphql.TypeMismatchError
+import graphql.execution.defer.DeferSupport
 import graphql.execution.instrumentation.SimpleInstrumentation
+import graphql.execution.lazy.LazySupport
 import graphql.language.Argument
 import graphql.language.Field
 import graphql.language.OperationDefinition
@@ -56,10 +58,12 @@ class ExecutionStrategyTest extends Specification {
     def buildContext(GraphQLSchema schema = null) {
         ExecutionId executionId = ExecutionId.from("executionId123")
         def variables = [arg1: "value1"]
+        def lazySupport = new LazySupport()
+        def deferSupport = new DeferSupport(lazySupport)
         new ExecutionContext(SimpleInstrumentation.INSTANCE, executionId, schema, null,
                 executionStrategy, executionStrategy, executionStrategy,
                 null, null, null,
-                variables, "context", "root")
+                variables, "context", "root", lazySupport, deferSupport)
     }
 
     @SuppressWarnings("GroovyAssignabilityCheck")
@@ -123,6 +127,7 @@ class ExecutionStrategyTest extends Specification {
                 .source(result)
                 .nonNullFieldValidator(nullableFieldValidator)
                 .fields(["fld": []])
+                .completionCancellationRegistry(new CompletionCancellationRegistry())
                 .build()
 
         when:
@@ -337,6 +342,7 @@ class ExecutionStrategyTest extends Specification {
                 .source(result)
                 .nonNullFieldValidator(nullableFieldValidator)
                 .fields(["fld": []])
+                .completionCancellationRegistry(new CompletionCancellationRegistry())
                 .build()
 
         when:
@@ -664,6 +670,7 @@ class ExecutionStrategyTest extends Specification {
                 .nonNullFieldValidator(nullableFieldValidator)
                 .fields(["fld": [new Field()]])
                 .field([new Field()])
+                .completionCancellationRegistry(new CompletionCancellationRegistry())
                 .build()
 
         when:
@@ -744,6 +751,7 @@ class ExecutionStrategyTest extends Specification {
                 .nonNullFieldValidator(nullableFieldValidator)
                 .fields(["fld": [new Field()]])
                 .field([new Field()])
+                .completionCancellationRegistry(new CompletionCancellationRegistry())
                 .build()
 
         when:

--- a/src/test/groovy/graphql/execution/lazy/LazyListIntegrationTest.groovy
+++ b/src/test/groovy/graphql/execution/lazy/LazyListIntegrationTest.groovy
@@ -1,0 +1,498 @@
+package graphql.execution.lazy
+
+import graphql.ExecutionInput
+import graphql.ExecutionResult
+import graphql.GraphQL
+import graphql.TestUtil
+import graphql.execution.defer.BasicSubscriber
+import graphql.schema.DataFetcher
+import graphql.schema.DataFetchingEnvironment
+import graphql.schema.idl.RuntimeWiring
+import spock.lang.Specification
+
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.stream.IntStream
+
+import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring
+
+class LazyListIntegrationTest extends Specification {
+    def schemaSpec = '''
+            type Query {
+                items: [Item!]
+            }
+            
+            type Item {
+                field: Int!
+                exception: Int
+                items: [Item]
+            }
+        '''
+
+    def query = '''
+            query {
+                items {
+                    field
+                    items {
+                        field
+                    }
+                }
+            }
+        '''
+
+    def complex = false
+    def flushOn = null
+    def fieldNullOn = null
+    def fetchedValue = new AtomicInteger()
+    def lazyListsFetched = new AtomicInteger();
+
+    def itemsFetcher = new DataFetcher() {
+        @Override
+        LazyList get(DataFetchingEnvironment environment) {
+            lazyListsFetched.incrementAndGet();
+            def stream = IntStream.range(0, 3).mapToObj { i -> [i, fetchedValue.incrementAndGet()] }
+            return { action ->
+                stream.forEach({ orig, fetched ->
+                    def flush = flushOn == null || flushOn == orig
+                    action.accept(flush, fetched)
+                })
+            }
+        }
+    }
+
+    def fieldFetcher = new DataFetcher() {
+        @Override
+        Integer get(DataFetchingEnvironment environment) {
+            if (fieldNullOn == environment.source) {
+                null
+            } else {
+                environment.source
+            }
+        }
+    }
+
+    def exceptionFetcher = new DataFetcher() {
+        @Override
+        Object get(DataFetchingEnvironment environment) {
+            throw new RuntimeException("dummy")
+        }
+    }
+
+    GraphQL graphQL = null
+
+    def setup() {
+        def runtimeWiring = RuntimeWiring.newRuntimeWiring()
+                .type(newTypeWiring("Query").dataFetcher("items", itemsFetcher))
+                .type(newTypeWiring("Item")
+                .dataFetcher("field", fieldFetcher)
+                .dataFetcher("items", itemsFetcher)
+                .dataFetcher("exception", exceptionFetcher)
+        )
+                .build()
+        def schema = TestUtil.schema(schemaSpec, runtimeWiring)
+        graphQL = GraphQL.newGraphQL(schema).build()
+    }
+
+    def collectResults(def executionResult) {
+        def results = []
+        def items = executionResult.data
+        if (items instanceof Map) {
+            items = items.items
+        }
+        if (!items) {
+            return null
+        }
+        def fetch = { item ->
+            def outerResult = complex ? [item?.field, fetchedValue.get()] : item?.field
+            def innerResults = null
+            if (item && item.items) {
+                innerResults = []
+                item.items.forEach({ innerFlush, innerItem ->
+                    innerResults << (complex ? [innerItem?.field, fetchedValue.get()] : innerItem?.field)
+                })
+            }
+            results << [outerResult, innerResults]
+        }
+        if (!(items instanceof LazyList)) {
+            fetch(items)
+        } else {
+            items.forEach({ flush, item -> fetch(item) })
+        }
+        results
+    }
+
+    def "test lazy list simple"() {
+        complex = true
+
+        when:
+        def executionResult = graphQL.execute(ExecutionInput.newExecutionInput().query(query).build())
+
+        then:
+        executionResult.errors.isEmpty()
+        collectResults(executionResult) == [
+                [[1, 1], [
+                        [2, 2],
+                        [3, 3],
+                        [4, 4],
+                ]],
+                [[5, 5], [
+                        [6, 6],
+                        [7, 7],
+                        [8, 8],
+                ]],
+                [[9, 9], [
+                        [10, 10],
+                        [11, 11],
+                        [12, 12],
+                ]],
+        ]
+    }
+
+    def "test lazy list non-blocking"() {
+        flushOn = 1
+        complex = true
+
+        when:
+        def executionResult = graphQL.execute(ExecutionInput.newExecutionInput().query(query).build())
+
+        then:
+        executionResult.errors.isEmpty()
+        collectResults(executionResult) == [
+                [[1, 2], [
+                        [3, 4],
+                        [4, 4],
+                        [5, 5],
+                ]],
+                [[2, 5], [
+                        [6, 7],
+                        [7, 7],
+                        [8, 8],
+                ]],
+                [[9, 9], [
+                        [10, 11],
+                        [11, 11],
+                        [12, 12],
+                ]],
+        ]
+    }
+
+    def "test lazy list with inner null field"() {
+        fieldNullOn = 3
+        complex = true
+
+        when:
+        def executionResult = graphQL.execute(ExecutionInput.newExecutionInput().query(query).build())
+
+        then:
+        executionResult.errors.isEmpty()
+        collectResults(executionResult) == [
+                [[1, 1], [
+                        [2, 2],
+                        [null, 3],
+                        [4, 4],
+                ]],
+                [[5, 5], [
+                        [6, 6],
+                        [7, 7],
+                        [8, 8],
+                ]],
+                [[9, 9], [
+                        [10, 10],
+                        [11, 11],
+                        [12, 12],
+                ]],
+        ]
+        executionResult.errors*.path == [
+                ["items", 0, "items", 1, "field"],
+        ]
+    }
+
+    def "test lazy list with outer null field"() {
+        fieldNullOn = 5
+
+        when:
+        def executionResult = graphQL.execute(ExecutionInput.newExecutionInput().query(query).build())
+
+        then:
+        executionResult.errors.isEmpty()
+        collectResults(executionResult) == [[1, [2, 3, 4]]]
+        executionResult.errors*.path == [
+                ["items", 1, "field"],
+                ["items"]
+        ]
+    }
+
+    def "test lazy list with inner defer"() {
+        given:
+        def query = '''
+            query {
+                items {
+                    field
+                    items @defer {
+                        field
+                    }
+                }
+            }
+        '''
+
+        when:
+        def executionResult = graphQL.execute(ExecutionInput.newExecutionInput().query(query).build())
+
+        then:
+        executionResult.extensions == null
+        executionResult.errors.isEmpty()
+        collectResults(executionResult) == [
+                [1, null],
+                [2, null],
+                [3, null],
+        ]
+        executionResult.extensions != null
+
+        when:
+        def subResults = []
+        def subscriber = new BasicSubscriber() {
+            @Override
+            void onNext(ExecutionResult subExecutionResult) {
+                subResults << subExecutionResult
+                subscription.request(1)
+            }
+        }
+        executionResult.extensions.get(GraphQL.DEFERRED_RESULTS).subscribe(subscriber)
+
+        then:
+        collectResults(subResults[0]) == [
+                [4, null],
+                [5, null],
+                [6, null],
+        ]
+        collectResults(subResults[1]) == [
+                [7, null],
+                [8, null],
+                [9, null],
+        ]
+        collectResults(subResults[2]) == [
+                [10, null],
+                [11, null],
+                [12, null],
+        ]
+    }
+
+    def "test lazy list with outer defer"() {
+        given:
+        def query = '''
+            query {
+                items @defer {
+                    field
+                    items {
+                        field
+                    }
+                }
+            }
+        '''
+
+        when:
+        def executionResult = graphQL.execute(ExecutionInput.newExecutionInput().query(query).build())
+
+        then:
+        executionResult.errors.isEmpty()
+        collectResults(executionResult) == null
+        executionResult.extensions != null
+
+        when:
+        def subResults = []
+        def subscriber = new BasicSubscriber() {
+            @Override
+            void onNext(ExecutionResult subExecutionResult) {
+                subResults << subExecutionResult
+                subscription.request(1)
+            }
+        }
+        executionResult.extensions.get(GraphQL.DEFERRED_RESULTS).subscribe(subscriber)
+
+        then:
+        subResults.size() == 1
+        collectResults(subResults[0]) == [
+                [1, [2, 3, 4]],
+                [5, [6, 7, 8]],
+                [9, [10, 11, 12]]
+        ]
+    }
+
+    def "test lazy list with inner and outer defer"() {
+        given:
+        def query = '''
+            query {
+                items @defer {
+                    field
+                    items @defer {
+                        field
+                    }
+                }
+            }
+        '''
+
+        when:
+        def executionResult = graphQL.execute(ExecutionInput.newExecutionInput().query(query).build())
+
+        then:
+        executionResult.errors.isEmpty()
+        collectResults(executionResult) == null
+        executionResult.extensions != null
+
+        when:
+        def subResults = []
+        def subscriber = new BasicSubscriber() {
+            @Override
+            void onNext(ExecutionResult subExecutionResult) {
+                subResults << subExecutionResult
+                subscription.request(1)
+            }
+        }
+        executionResult.extensions.get(GraphQL.DEFERRED_RESULTS).subscribe(subscriber)
+
+        then:
+        subResults.size() == 1
+        collectResults(subResults[0]) == [
+                [1, null],
+                [2, null],
+                [3, null],
+        ]
+        subResults.size() == 4
+        collectResults(subResults[1]) == [
+                [4, null],
+                [5, null],
+                [6, null],
+        ]
+        collectResults(subResults[2]) == [
+                [7, null],
+                [8, null],
+                [9, null],
+        ]
+        collectResults(subResults[3]) == [
+                [10, null],
+                [11, null],
+                [12, null],
+        ]
+    }
+
+    def "test lazy list with inner defer and exceptions"() {
+        given:
+        schemaSpec = '''
+            type Query {
+                items: [Item!]
+            }
+            
+            type Item {
+                field: Int!
+                exception: Int
+                items: [Item]
+            }
+        '''
+
+        setup()
+
+        def query = '''
+            query {
+                items {
+                    field
+                    exception
+                    items @defer {
+                        field
+                        exception
+                    }
+                }
+            }
+        '''
+
+        when:
+        def executionResult = graphQL.execute(ExecutionInput.newExecutionInput().query(query).build())
+
+        then:
+        executionResult.errors.isEmpty()
+        collectResults(executionResult) == [ [1, null], [2, null], [3, null] ]
+        executionResult.errors*.path == [
+                [ "items", 0, "exception" ],
+                [ "items", 1, "exception" ],
+                [ "items", 2, "exception" ],
+        ]
+        executionResult.extensions != null
+
+        when:
+        List<ExecutionResult> subResults = []
+        def subscriber = new BasicSubscriber() {
+            @Override
+            void onNext(ExecutionResult subExecutionResult) {
+                subResults << subExecutionResult
+                subscription.request(1)
+            }
+        }
+        executionResult.extensions.get(GraphQL.DEFERRED_RESULTS).subscribe(subscriber)
+
+        then:
+        subResults.size() == 3
+        subResults[0].errors.isEmpty()
+        subResults[1].errors.isEmpty()
+        subResults[2].errors.isEmpty()
+        collectResults(subResults[0]) == [
+                [4, null],
+                [5, null],
+                [6, null],
+        ]
+        subResults[0].errors*.path == [
+                [ "items", 0, "items", 0, "exception" ],
+                [ "items", 0, "items", 1, "exception" ],
+                [ "items", 0, "items", 2, "exception" ],
+        ]
+        collectResults(subResults[1]) == [
+                [7, null],
+                [8, null],
+                [9, null],
+        ]
+        subResults[1].errors*.path == [
+                [ "items", 1, "items", 0, "exception" ],
+                [ "items", 1, "items", 1, "exception" ],
+                [ "items", 1, "items", 2, "exception" ],
+        ]
+        collectResults(subResults[2]) == [
+                [10, null],
+                [11, null],
+                [12, null],
+        ]
+        subResults[2].errors*.path == [
+                [ "items", 2, "items", 0, "exception" ],
+                [ "items", 2, "items", 1, "exception" ],
+                [ "items", 2, "items", 2, "exception" ],
+        ]
+
+        subResults*.extensions == [ null, null, null ]
+
+        executionResult.errors*.path == [
+                [ "items", 0, "exception" ],
+                [ "items", 1, "exception" ],
+                [ "items", 2, "exception" ],
+        ]
+    }
+
+    def "test lazy list cancellation"() {
+        given:
+        def query = '''
+            query {
+                items {
+                    items {
+                        field
+                    }
+                    field
+                }
+            }
+        '''
+        fieldNullOn = 1
+
+        when:
+        def executionResult = graphQL.execute(ExecutionInput.newExecutionInput().query(query).build())
+
+        then:
+        executionResult.errors.isEmpty()
+        collectResults(executionResult) == []
+        lazyListsFetched.get() == 2
+        !executionResult.deferSupport.lazySupport.hasPendingCompletions()
+    }
+}


### PR DESCRIPTION
Hi,

consider the following schema:

```graphql
type Query {
    items: [Item]
}

type Item {
    # fields omitted
}
```

It can happen that the list is too large to fit into memory--in particular if
multiple queries are running concurrently.

The obvious solution is to use paging, however,

1. Paging is inconvenient for the client.
2. Having the client execute multiple queries to get the whole list will
   increase the server load and increase the total response time.
3. If the problematic list is actually contained within another list, then it
   might be impossible to create a paging scheme that is both efficient and not
   overly complex.

Therefore we would like to

1. Fetch up to N elements of the list
2. Complete these elements
3. Send the completed elements to the client
4. Repeat unless all elements of the list have been processed

The intention of this PR is to allow the server to

1. Suspend the completion of fields of list type
2. Resume completion of the fields on-demand and after the overall GraphQL
   execution has completed
3. Stream the completed list elements so that no more than necessary have to be
   kept in memory

## Suspending a list completion

At the moment, the object returned by a `DataFetcher` of a field of list type
must be either

* `null`
* an array
* an instance of `Iterable`

This PR introduced the new functional interface `LazyList<T>` with the following
method:

```java
void forAll(BiConsumer<Boolean, ? super T> action);
```

If the `DataFetcher` of a field of list type returns an instance of this
interface, the completion of the list is suspended and the completion step
immediately returns a `completedFuture` with `data` equal to an instance of
`LazyList<Object>`.

The `LazyList<T>` returned by by the `DataFetcher` should, when invoked, call
the `action` once for each element of the list. (The meaning of the `Boolean`
argument will be explained below.) The `LazyList<Object>` returned by the
completion step will, when invoked, call the `action` once for each completed
element of the list.

This implies that the `Map<String, Object>` returned by the overall GraphQL
execution contains elements of type `LazyList<Object>` at its leaves.

## Serializing the overall execution result

Since the `Map<String, Object>` contains elements of type `LazyList<Object>`,
the server can no longer use stock Jackson to serialize the result. Instead,
they have to use a custom serializer to serialize the `LazyList<Object>`
objects.

This serializer has to

1. Write the opening `[`
2. Invoke `forAll` and serialize the objects passed to it via the callback
   in order
3. Write the closing `]`

Such a custom Jackson serializer is not part of this PR but it would not be too
hard to add, for example, a new `graphql-java-jackson-module` project that
contains such a serializer.

## Resuming the list completion

Once the `forAll` method of a `LazyList<Object>` is invoked, the completion of
the list resumes. This is quite similar to the usual list completion except that
we do not wait for the whole list to complete. Instead we pass the individual
elements of the list to the callback as soon as possible.

The server might not want completion to block on each element. Instead they
might want to complete, say, 10 elements concurrently and only then pass them to
the serializer. This is possible via the `Boolean` argument of the callback.

If the `Boolean` argument is `false`, then completion of the element will be
initiated but we don't wait for it to finish. Instead we add the
`CompletableFuture` to a list and proceed with the next element. Once the
`Boolean` argument becomes `true`, we wait for all `CompletableFutures` in the
list to complete and pass them on.

In the simplest case, the `Boolean` argument is always `true` and each element
is completed and serialized before we try to complete the next one.

## Error handling

Since the overall GraphQL execution completes before all fields have been
completed, the list of errors known at that point might not be complete.

Usually, the server is advised to call `toSpecification` on the overall
execution result to create a `Map<String, Object>` that is suitable for
serialization. However, since, in this map, the `error` element is not set if
there are no errors after the overall GraphQL execution completes, it is not
suitable for serializing trees that contain `LazyLists`.

Therefore, this PR introduces a new `ExecutionResult` implementation called
`LazyExecutionResult`. If the `Execution` class detects that `LazyLists` were
used during the execution, it wraps the overall execution result in a
`LazyExecutionResult`.

The `LazyExecutionResult` forwards the method `getData` to the wrapped delegate.
On the other hand, the `getErrors` method retrieves the current list of errors
from the `ExecutionContext` and `getExtensions` does something similar. The
`toSpecification` method is not supported if the server chooses to use
`LazyLists` and therefore throws an `UnsupportedOperationException`.

In order to serialize such an execution result, the server must

1. Write the opening `{`
2. Serialize the data (if any)
3. Serialize the errors (in the correct format) (if any at this point)
4. Serialize the extensions (if any)
5. Write the closing `}`

A custom Jackson serializer that knows how to serialize `ExecutionResult`
objects correctly would make the `toSpecification` method unnecessary (for
Jackson users) and could be added to a potential `graphql-java-jackson-module`
project.

## Compatibility with deferred results

In order to create compatibility with the @defer directive, I've added the
ability for fields to detect the cancellation of any of their parent fields.
For example, consider the following schema:

```graphql
type Query {
    value: Value
}

type Value {
    items: [Item]
    field: Int!
}
```

If `items` is a lazy list and the value fetched by `field` is null, then `value`
itself becomes null and `items` can never be completed. Therefore, it is now
possible for `items` to register a callback that is invoked when any parent
becomes null.

This is necessary because we want to start the deferred calls only after the
execution result of the overall GraphQL query has been fully completed. In order
to know when this is, we have to know when the number of pending lazy lists
becomes 0. This happens when each lazy list has either been fetched or
cancelled.

Since a lazy list might contain a @defer which itself might contain lazy
lists (and so on), the second commit in this series creates the necessary
framework to use both lazy completion and @defer in a single query.

## Incompatibility with the specification

`LazyLists` are incompatible with the GraphQL specification because we start
serializing the list before we know whether all elements can be retrieved and
completed. There are at least three cases that can cause this to fail:

1. The `forAll` method of the `LazyList<T>` throws an exception
2. The `forAll` method of the `LazyList<T>` passes a `null` element and the
   element type is non-null.
3. The `forAll` method of the `LazyList<T>` passes an element for which
   completion fails and the element type is non-null.

In these cases the whole list must be null according to the spec.