### PR TITLE
Make DataLoaderDispatcherInstrumentation support request scope for servlet usage

### DIFF
--- a/src/main/java/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentationState.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentationState.java
@@ -1,12 +1,29 @@
 package graphql.execution.instrumentation.dataloader;
 
+import org.dataloader.DataLoaderRegistry;
+import org.slf4j.Logger;
+
 import graphql.execution.instrumentation.InstrumentationState;
 
 /**
  * A base class that keeps track of whether aggressive batching can be used
  */
 public class DataLoaderDispatcherInstrumentationState implements InstrumentationState {
+
+    private final FieldLevelTrackingApproach approach;
+
+    private final DataLoaderRegistry dataLoaderRegistry;
+
+    private final InstrumentationState state;
+
     private boolean aggressivelyBatching = true;
+
+    public DataLoaderDispatcherInstrumentationState(Logger log, DataLoaderRegistry dataLoaderRegistry) {
+
+        this.dataLoaderRegistry = dataLoaderRegistry;
+        this.approach = new FieldLevelTrackingApproach(log, dataLoaderRegistry);
+        this.state = approach.createState();
+    }
 
     boolean isAggressivelyBatching() {
         return aggressivelyBatching;
@@ -16,5 +33,18 @@ public class DataLoaderDispatcherInstrumentationState implements Instrumentation
         this.aggressivelyBatching = aggressivelyBatching;
     }
 
+    FieldLevelTrackingApproach getApproach() {
+        return approach;
+    }
+
+    DataLoaderRegistry getDataLoaderRegistry() {
+        return dataLoaderRegistry;
+    }
+
+    InstrumentationState getState() {
+        return state;
+    }
+    
+    
 
 }

--- a/src/main/java/graphql/execution/instrumentation/dataloader/FieldLevelTrackingApproach.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/FieldLevelTrackingApproach.java
@@ -33,7 +33,7 @@ public class FieldLevelTrackingApproach {
     private final DataLoaderRegistry dataLoaderRegistry;
     private final Logger log;
 
-    private static class CallStack extends DataLoaderDispatcherInstrumentationState {
+    private static class CallStack implements InstrumentationState {
 
         private final Map<Integer, Integer> expectedFetchCountPerLevel = new LinkedHashMap<>();
         private final Map<Integer, Integer> fetchCountPerLevel = new LinkedHashMap<>();


### PR DESCRIPTION
according to https://github.com/graphql-java/graphql-java-tools/issues/58#issuecomment-407335274

for Spring-Boot usage example

```
    @Bean
    Instrumentation dataloaderInstrumentation() {
            return new DataLoaderDispatcherInstrumentation(
                  ()->new DataLoaderRegistry().register("characters", characterDataLoader)
            );
    }
```