### PR TITLE
Fix race condition dispatch in FieldLevelTrackingApproach

### DIFF
--- a/src/main/java/graphql/execution/instrumentation/dataloader/FieldLevelTrackingApproach.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/FieldLevelTrackingApproach.java
@@ -163,7 +163,7 @@ public class FieldLevelTrackingApproach {
         };
     }
 
-    private void handleOnFieldValuesInfo(List<FieldValueInfo> fieldValueInfoList, CallStack callStack, int curLevel) {
+    private synchronized void handleOnFieldValuesInfo(List<FieldValueInfo> fieldValueInfoList, CallStack callStack, int curLevel) {
         callStack.increaseHappenedOnFieldValueCalls(curLevel);
         int expectedStrategyCalls = 0;
         for (FieldValueInfo fieldValueInfo : fieldValueInfoList) {

--- a/src/main/java/graphql/execution/instrumentation/dataloader/FieldLevelTrackingApproach.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/FieldLevelTrackingApproach.java
@@ -163,7 +163,7 @@ public class FieldLevelTrackingApproach {
         };
     }
 
-    private synchronized void handleOnFieldValuesInfo(List<FieldValueInfo> fieldValueInfoList, CallStack callStack, int curLevel) {
+    private void handleOnFieldValuesInfo(List<FieldValueInfo> fieldValueInfoList, CallStack callStack, int curLevel) {
         callStack.increaseHappenedOnFieldValueCalls(curLevel);
         int expectedStrategyCalls = 0;
         for (FieldValueInfo fieldValueInfo : fieldValueInfoList) {
@@ -230,7 +230,7 @@ public class FieldLevelTrackingApproach {
     }
 
 
-    private void dispatchIfNeeded(CallStack callStack, int level) {
+    private synchronized void dispatchIfNeeded(CallStack callStack, int level) {
         if (levelReady(callStack, level)) {
             callStack.dispatchIfNotDispatchedBefore(level, this::dispatch);
         }

--- a/src/test/groovy/graphql/execution/instrumentation/dataloader/Issue1178DataLoaderDispatchTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/dataloader/Issue1178DataLoaderDispatchTest.groovy
@@ -1,0 +1,133 @@
+package graphql.execution.instrumentation.dataloader
+
+import graphql.GraphQL
+import graphql.TestUtil
+import graphql.schema.DataFetcher
+import graphql.schema.DataFetchingEnvironment
+import graphql.schema.StaticDataFetcher
+import graphql.schema.idl.RuntimeWiring
+import org.dataloader.BatchLoader
+import org.dataloader.DataLoader
+import org.dataloader.DataLoaderRegistry
+import spock.lang.Specification
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+import java.util.concurrent.Executors
+
+import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring
+
+class Issue1178DataLoaderDispatchTest extends Specification {
+
+    def "shouldn't dispatch twice in multithreaded env"() {
+        setup:
+        def sdl = """
+        type Todo {
+           id: ID!
+           related: Todo
+           related2: Todo
+        }
+
+        type Query {
+           getTodos: [Todo]
+        }
+
+        schema {
+           query: Query
+        }"""
+
+        def executor = Executors.newFixedThreadPool(5)
+
+        def dataLoader = new DataLoader<Object, Object>(new BatchLoader<Object, Object>() {
+            @Override
+            CompletionStage<List<Object>> load(List<Object> keys) {
+                return CompletableFuture.supplyAsync({
+                    return keys.collect({ [id: 'r'+ it]})
+                }, executor)
+            }
+        })
+        def dataLoader2 = new DataLoader<Object, Object>(new BatchLoader<Object, Object>() {
+            @Override
+            CompletionStage<List<Object>> load(List<Object> keys) {
+                return CompletableFuture.supplyAsync({
+                    return keys.collect({ [id: 'r'+ it]})
+                }, executor)
+            }
+        })
+
+        def dataLoaderRegistry = new DataLoaderRegistry()
+        dataLoaderRegistry.register("todo.related", dataLoader)
+        dataLoaderRegistry.register("todo.related2", dataLoader2)
+
+        def relatedDf = new MyDataFetcher(dataLoader)
+        def relatedDf2 = new MyDataFetcher(dataLoader2)
+
+        def wiring = RuntimeWiring.newRuntimeWiring()
+                .type(newTypeWiring("Query")
+                .dataFetcher("getTodos", new StaticDataFetcher([[id: '1'], [id: '2'], [id: '3'], [id: '4'], [id: '5']])))
+                .type(newTypeWiring("Todo")
+                .dataFetcher("related", relatedDf)
+                .dataFetcher("related2", relatedDf2))
+                .build()
+
+        def schema = TestUtil.schema(sdl, wiring)
+
+        when:
+        def graphql = GraphQL.newGraphQL(schema)
+                .instrumentation(new DataLoaderDispatcherInstrumentation(dataLoaderRegistry))
+                .build()
+
+        then: "execution shouldn't error"
+        for (int i = 0; i < 100; i++) {
+            def result = graphql.execute("""
+                query { 
+                    getTodos { __typename id 
+                        related { id __typename 
+                            related { id __typename 
+                                related2 { id __typename 
+                                    related2 { id __typename 
+                                        related { id __typename }
+                                    }
+                                }
+                            } 
+                        }
+                        related2 { id __typename 
+                            related2 { id __typename 
+                                related { id __typename 
+                                    related { id __typename 
+                                        related2 { id __typename 
+                                            related2 { id __typename 
+                                                related { id __typename }
+                                                related2 { id __typename 
+                                                    related2 { id __typename 
+                                                        related { id __typename }
+                                                    }
+                                                }
+                                            }
+                                            related { id __typename }
+                                        }
+                                    } 
+                                }
+                            } 
+                        }
+                    } 
+                }""")
+            assert result.errors.empty
+        }
+    }
+
+    static class MyDataFetcher implements DataFetcher<CompletableFuture<Object>> {
+
+        private final DataLoader dataLoader
+
+        public MyDataFetcher(DataLoader dataLoader) {
+            this.dataLoader = dataLoader
+        }
+
+        @Override
+        CompletableFuture<Object> get(DataFetchingEnvironment environment) {
+            def todo = environment.source as Map
+            return dataLoader.load(todo['id'])
+        }
+    }
+}


### PR DESCRIPTION
## Description
Attempt to reproduce and fix #1178.

## Steps to reproduce
The step below throws the `AssertException:  Internal error: should never happen: level 3 already dispatched` outlined in #1178. 
```java
def "shouldn't dispatch twice in multithreaded env"() {
        setup:
        def sdl = """
        type Todo {
           id: ID!
           related: Todo
           related2: Todo
        }

        type Query {
           getTodos: [Todo]
        }

        schema {
           query: Query
        }"""

        def executor = Executors.newFixedThreadPool(5)

        def dataLoader = new DataLoader<Object, Object>(new BatchLoader<Object, Object>() {
            @Override
            CompletionStage<List<Object>> load(List<Object> keys) {
                return CompletableFuture.supplyAsync({
                    return keys.collect({ [id: 'r'+ it]})
                }, executor)
            }
        })
        def dataLoader2 = new DataLoader<Object, Object>(new BatchLoader<Object, Object>() {
            @Override
            CompletionStage<List<Object>> load(List<Object> keys) {
                return CompletableFuture.supplyAsync({
                    return keys.collect({ [id: 'r'+ it]})
                }, executor)
            }
        })

        def dataLoaderRegistry = new DataLoaderRegistry()
        dataLoaderRegistry.register("todo.related", dataLoader)
        dataLoaderRegistry.register("todo.related2", dataLoader2)

        def relatedDf = new MyDataFetcher(dataLoader)
        def relatedDf2 = new MyDataFetcher(dataLoader2)

        def wiring = RuntimeWiring.newRuntimeWiring()
                .type(newTypeWiring("Query")
                .dataFetcher("getTodos", new StaticDataFetcher([[id: '1'], [id: '2'], [id: '3'], [id: '4'], [id: '5']])))
                .type(newTypeWiring("Todo")
                .dataFetcher("related", relatedDf)
                .dataFetcher("related2", relatedDf2))
                .build()

        def schema = TestUtil.schema(sdl, wiring)

        when:
        def graphql = GraphQL.newGraphQL(schema)
                .instrumentation(new DataLoaderDispatcherInstrumentation(dataLoaderRegistry))
                .build()

        then: "execution shouldn't error"
        for (int i = 0; i < 100; i++) {
            def result = graphql.execute("""
                query { 
                    getTodos { __typename id 
                        related { id __typename 
                            related { id __typename 
                                related2 { id __typename 
                                    related2 { id __typename 
                                        related { id __typename }
                                    }
                                }
                            } 
                        }
                        related2 { id __typename 
                            related2 { id __typename 
                                related { id __typename 
                                    related { id __typename 
                                        related2 { id __typename 
                                            related2 { id __typename 
                                                related { id __typename }
                                                related2 { id __typename 
                                                    related2 { id __typename 
                                                        related { id __typename }
                                                    }
                                                }
                                            }
                                            related { id __typename }
                                        }
                                    } 
                                }
                            } 
                        }
                    } 
                }""")
            assert result.errors.empty
        }
    }
```
## Fix attempt
I'm not very familiar with the `FieldLevelTrackingApproach` logic but it seems that the condition happens because `handleOnFieldValuesInfo` can be executed across threads. I added a `synchronized` to prevent that behavior but I would prefer @andimarek to look at it.

Note: The unit test runs 100 executions to consistently reproduce the issue but we should probably avoid merging as is as it will slow down builds. (takes ~3s to run) 