### PR TITLE
Improves errormsg for nested fields

### DIFF
--- a/src/main/java/graphql/execution/NonNullableValueCoercedAsNullException.java
+++ b/src/main/java/graphql/execution/NonNullableValueCoercedAsNullException.java
@@ -28,6 +28,12 @@ public class NonNullableValueCoercedAsNullException extends GraphQLException imp
         this.sourceLocations = Collections.singletonList(variableDefinition.getSourceLocation());
     }
 
+    public NonNullableValueCoercedAsNullException(VariableDefinition variableDefinition, String fieldName, GraphQLType graphQLType) {
+        super(format("Field '%s' of variable '%s' has coerced Null value for NonNull type '%s'",
+                fieldName, variableDefinition.getName(), GraphQLTypeUtil.getUnwrappedTypeName(graphQLType)));
+        this.sourceLocations = Collections.singletonList(variableDefinition.getSourceLocation());
+    }
+
     public NonNullableValueCoercedAsNullException(GraphQLInputObjectField inputTypeField) {
         super(format("Input field '%s' has coerced Null value for NonNull type '%s'",
                 inputTypeField.getName(), GraphQLTypeUtil.getUnwrappedTypeName(inputTypeField.getType())));

--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -151,7 +151,7 @@ public class ValuesResolver {
                 Object returnValue =
                         coerceValue(fieldVisibility, variableDefinition, inputName, unwrapOne(graphQLType), value);
                 if (returnValue == null) {
-                    throw new NonNullableValueCoercedAsNullException(variableDefinition, graphQLType);
+                    throw new NonNullableValueCoercedAsNullException(variableDefinition, inputName, graphQLType);
                 }
                 return returnValue;
             }

--- a/src/test/groovy/graphql/NullVariableCoercionTest.groovy
+++ b/src/test/groovy/graphql/NullVariableCoercionTest.groovy
@@ -69,7 +69,7 @@ class NullVariableCoercionTest extends Specification {
         varResult.data == null
         varResult.errors.size() == 1
         varResult.errors[0].errorType == ErrorType.ValidationError
-        varResult.errors[0].message == "Variable 'input' has coerced Null value for NonNull type 'String!'"
+        varResult.errors[0].message == "Field 'baz' of variable 'input' has coerced Null value for NonNull type 'String!'"
         varResult.errors[0].locations == [new SourceLocation(1, 11)]
     }
 }


### PR DESCRIPTION
When using graphql variables for nested mandatory fields the error message in case of a missing value was not specifying the name of the field. This commit adds the field name to the message so that finding the problem is much easier.
Resolves #1183