### PR TITLE
Fix SimpleListConnection when acting on an empty list

### DIFF
--- a/src/main/java/graphql/relay/SimpleListConnection.java
+++ b/src/main/java/graphql/relay/SimpleListConnection.java
@@ -46,6 +46,10 @@ public class SimpleListConnection<T> implements DataFetcher<Connection<T>> {
 
         List<Edge<T>> edges = buildEdges();
 
+        if (edges.isEmpty()) {
+            return emptyConnection();
+        }
+
         ConnectionCursor firstPresliceCursor = edges.get(0).getCursor();
         ConnectionCursor lastPresliceCursor = edges.get(edges.size() - 1).getCursor();
 
@@ -57,7 +61,7 @@ public class SimpleListConnection<T> implements DataFetcher<Connection<T>> {
         if (begin > end) begin = end;
 
         edges = edges.subList(begin, end);
-        if (edges.size() == 0) {
+        if (edges.isEmpty()) {
             return emptyConnection();
         }
 

--- a/src/test/groovy/graphql/relay/SimpleListConnectionTest.groovy
+++ b/src/test/groovy/graphql/relay/SimpleListConnectionTest.groovy
@@ -81,4 +81,19 @@ class SimpleListConnectionTest extends Specification {
         connection.getEdges().size() == 3
         connection.getEdges().get(1).getNode() == null
     }
+
+    def "can accept an empty list"() {
+        given:
+        def env = newDataFetchingEnvironment().executionContext(Mock(ExecutionContext)).build()
+
+        when:
+        def connection = new SimpleListConnection([]).get(env)
+
+        then:
+        connection.getEdges().size() == 0
+        connection.getPageInfo().getEndCursor() == null
+        connection.getPageInfo().getStartCursor() == null
+        !connection.getPageInfo().isHasNextPage()
+        !connection.getPageInfo().isHasPreviousPage()
+    }
 }


### PR DESCRIPTION
### Issue
An `IndexOutOfBoundsException` is thrown by `graphql.relay.SimpleListConnection#get` when the `List` provided to the `SimpleListConnection` is empty

Code in develop at the time of writing:
https://github.com/graphql-java/graphql-java/blob/4485074df0be836253c7e1c52a8011cd4ffc26db/src/main/java/graphql/relay/SimpleListConnection.java#L47-L49

### Fix
Return an empty `Connection` if  `edges` is empty (obtained by calling `graphql.relay.SimpleListConnection#emptyConnection`)