### PR TITLE
fix: Handling empty list in SimpleListCollection

### DIFF
--- a/src/main/java/graphql/relay/SimpleListConnection.java
+++ b/src/main/java/graphql/relay/SimpleListConnection.java
@@ -46,6 +46,10 @@ public class SimpleListConnection<T> implements DataFetcher<Connection<T>> {
 
         List<Edge<T>> edges = buildEdges();
 
+        if (edges.size() == 0) {
+            return emptyConnection();
+        }
+
         ConnectionCursor firstPresliceCursor = edges.get(0).getCursor();
         ConnectionCursor lastPresliceCursor = edges.get(edges.size() - 1).getCursor();
 

--- a/src/test/groovy/graphql/relay/SimpleListConnectionTest.groovy
+++ b/src/test/groovy/graphql/relay/SimpleListConnectionTest.groovy
@@ -81,4 +81,16 @@ class SimpleListConnectionTest extends Specification {
         connection.getEdges().size() == 3
         connection.getEdges().get(1).getNode() == null
     }
+    
+    def "can accept an empty list"() {
+        given:
+        def empty = []
+        def env = newDataFetchingEnvironment().executionContext(Mock(ExecutionContext)).build()
+
+        when:
+        def connection = new SimpleListConnection(empty).get(env)
+
+        then:
+        connection.getEdges().size() == 0
+    }
 }


### PR DESCRIPTION
If the list is empty, a NPE is triggered in the following `edges.get(0).getCursor()`.