### PR TITLE
Fix: invalid fragment target type triggers assertShouldNeverHappen

### DIFF
--- a/src/main/java/graphql/validation/TraversalContext.java
+++ b/src/main/java/graphql/validation/TraversalContext.java
@@ -129,9 +129,14 @@ public class TraversalContext implements DocumentVisitor {
         TypeName typeCondition = inlineFragment.getTypeCondition();
         GraphQLOutputType type;
         if (typeCondition != null) {
-            type = (GraphQLOutputType) schema.getType(typeCondition.getName());
+            GraphQLType typeConditionType = schema.getType(typeCondition.getName());
+            if (typeConditionType instanceof GraphQLOutputType) {
+                type = (GraphQLOutputType) typeConditionType;
+            } else {
+                type = null;
+            }
         } else {
-            type = (GraphQLOutputType) getParentType();
+            type = getParentType();
         }
         addOutputType(type);
     }
@@ -139,7 +144,7 @@ public class TraversalContext implements DocumentVisitor {
     private void enterImpl(FragmentDefinition fragmentDefinition) {
         enterName(fragmentDefinition.getName());
         GraphQLType type = schema.getType(fragmentDefinition.getTypeCondition().getName());
-        addOutputType((GraphQLOutputType) type);
+        addOutputType(type instanceof GraphQLOutputType ? (GraphQLOutputType) type : null);
     }
 
     private void enterImpl(VariableDefinition variableDefinition) {

--- a/src/main/java/graphql/validation/rules/PossibleFragmentSpreads.java
+++ b/src/main/java/graphql/validation/rules/PossibleFragmentSpreads.java
@@ -32,11 +32,11 @@ public class PossibleFragmentSpreads extends AbstractRule {
         GraphQLOutputType fragType = getValidationContext().getOutputType();
         GraphQLCompositeType parentType = getValidationContext().getParentType();
         if (fragType == null || parentType == null) return;
-        if (!doTypesOverlap(fragType, parentType)) {
+
+        if (isValidTargetCompositeType(fragType) && isValidTargetCompositeType(parentType) && !doTypesOverlap(fragType, parentType)) {
             String message = String.format("Fragment cannot be spread here as objects of " +
                     "type %s can never be of type %s", parentType.getName(), fragType.getName());
             addError(ValidationErrorType.InvalidFragmentType, inlineFragment.getSourceLocation(), message);
-
         }
     }
 
@@ -48,7 +48,7 @@ public class PossibleFragmentSpreads extends AbstractRule {
         GraphQLCompositeType parentType = getValidationContext().getParentType();
         if (typeCondition == null || parentType == null) return;
 
-        if (!doTypesOverlap(typeCondition, parentType)) {
+        if (isValidTargetCompositeType(typeCondition) && isValidTargetCompositeType(parentType) && !doTypesOverlap(typeCondition, parentType)) {
             String message = String.format("Fragment %s cannot be spread here as objects of " +
                     "type %s can never be of type %s", fragmentSpread.getName(), parentType.getName(), typeCondition.getName());
             addError(ValidationErrorType.InvalidFragmentType, fragmentSpread.getSourceLocation(), message);
@@ -79,5 +79,15 @@ public class PossibleFragmentSpreads extends AbstractRule {
             Assert.assertShouldNeverHappen();
         }
         return possibleConditionTypes;
+    }
+
+    /**
+     * Per spec: The target type of fragment (type condition)
+     * must have kind UNION, INTERFACE, or OBJECT.
+     * @param type GraphQLType
+     * @return true if it is a union, interface, or object.
+     */
+    private boolean isValidTargetCompositeType(GraphQLType type) {
+        return type instanceof GraphQLCompositeType;
     }
 }

--- a/src/test/groovy/graphql/StarWarsIntrospectionTests.groovy
+++ b/src/test/groovy/graphql/StarWarsIntrospectionTests.groovy
@@ -22,8 +22,10 @@ class StarWarsIntrospectionTests extends Specification {
                                    [[name: 'Human'],
                                     [name: '__TypeKind'],
                                     [name: '__Field'],
+                                    [name: 'MutationType'],
                                     [name: 'Character'],
                                     [name: '__Schema'],
+                                    [name: 'HumanInput'],
                                     [name: '__Type'],
                                     [name: '__EnumValue'],
                                     [name: '__DirectiveLocation'],
@@ -424,9 +426,9 @@ class StarWarsIntrospectionTests extends Specification {
         Map<String, Object> schemaParts = (Map<String, Map>) schema.get("__schema")
         schemaParts.size() == 5
         schemaParts.get('queryType').size() == 1
-        schemaParts.get('mutationType') == null
+        schemaParts.get('mutationType').size() == 1
         schemaParts.get('subscriptionType') == null
-        schemaParts.get('types').size() == 15
+        schemaParts.get('types').size() == 17
         schemaParts.get('directives').size() == 3
     }
 }

--- a/src/test/groovy/graphql/StarWarsSchema.java
+++ b/src/test/groovy/graphql/StarWarsSchema.java
@@ -2,6 +2,7 @@ package graphql;
 
 
 import graphql.schema.GraphQLEnumType;
+import graphql.schema.GraphQLInputObjectType;
 import graphql.schema.GraphQLInterfaceType;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
@@ -11,6 +12,8 @@ import static graphql.Scalars.GraphQLString;
 import static graphql.schema.GraphQLArgument.newArgument;
 import static graphql.schema.GraphQLEnumType.newEnum;
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
+import static graphql.schema.GraphQLInputObjectField.newInputObjectField;
+import static graphql.schema.GraphQLInputObjectType.newInputObject;
 import static graphql.schema.GraphQLInterfaceType.newInterface;
 import static graphql.schema.GraphQLList.list;
 import static graphql.schema.GraphQLNonNull.nonNull;
@@ -105,6 +108,14 @@ public class StarWarsSchema {
                     .type(GraphQLString))
             .build();
 
+    public static GraphQLInputObjectType inputHumanType = newInputObject()
+            .name("HumanInput")
+            .description("Input for A humanoid creature in the Star Wars universe.")
+            .field(newInputObjectField()
+                    .name("id")
+                    .description("The id of the human.")
+                    .type(nonNull(GraphQLString)))
+            .build();
 
     public static GraphQLObjectType queryType = newObject()
             .name("QueryType")
@@ -134,8 +145,19 @@ public class StarWarsSchema {
                     .dataFetcher(StarWarsData.getDroidDataFetcher()))
             .build();
 
+    public static GraphQLObjectType mutationType = newObject()
+            .name("MutationType")
+            .field(newFieldDefinition()
+                    .name("createHuman")
+                    .type(characterInterface)
+                    .argument(newArgument()
+                            .name("input")
+                            .type(inputHumanType))
+                    .dataFetcher(new StaticDataFetcher(StarWarsData.getArtoo())))
+            .build();
 
     public static GraphQLSchema starWarsSchema = GraphQLSchema.newSchema()
             .query(queryType)
+            .mutation(mutationType)
             .build();
 }

--- a/src/test/groovy/graphql/schema/SchemaUtilTest.groovy
+++ b/src/test/groovy/graphql/schema/SchemaUtilTest.groovy
@@ -12,6 +12,8 @@ import static graphql.StarWarsSchema.characterInterface
 import static graphql.StarWarsSchema.droidType
 import static graphql.StarWarsSchema.episodeEnum
 import static graphql.StarWarsSchema.humanType
+import static graphql.StarWarsSchema.mutationType
+import static graphql.StarWarsSchema.inputHumanType
 import static graphql.StarWarsSchema.queryType
 import static graphql.StarWarsSchema.starWarsSchema
 import static graphql.TypeReferenceSchema.SchemaWithReferences
@@ -29,11 +31,13 @@ class SchemaUtilTest extends Specification {
         when:
         Map<String, GraphQLType> types = new SchemaUtil().allTypes(starWarsSchema, Collections.emptySet())
         then:
-        types.size() == 15
+        types.size() == 17
         types == [(droidType.name)                        : droidType,
                   (humanType.name)                        : humanType,
                   (queryType.name)                        : queryType,
+                  (mutationType.name)                     : mutationType,
                   (characterInterface.name)               : characterInterface,
+                  (inputHumanType.name)                   : inputHumanType,
                   (episodeEnum.name)                      : episodeEnum,
                   (GraphQLString.name)                    : GraphQLString,
                   (Introspection.__Schema.name)           : Introspection.__Schema,

--- a/src/test/groovy/graphql/validation/TraversalContextTest.groovy
+++ b/src/test/groovy/graphql/validation/TraversalContextTest.groovy
@@ -23,6 +23,7 @@ import spock.lang.Specification
 import static graphql.Directives.IncludeDirective
 import static graphql.Scalars.GraphQLString
 import static graphql.StarWarsSchema.droidType
+import static graphql.StarWarsSchema.inputHumanType
 import static graphql.StarWarsSchema.queryType
 import static graphql.StarWarsSchema.starWarsSchema
 import static graphql.language.OperationDefinition.Operation.QUERY
@@ -134,6 +135,43 @@ class TraversalContextTest extends Specification {
 
         then:
         traversalContext.getOutputType() == droidType
+
+        when:
+        traversalContext.leave(fragmentDefinition, [])
+
+        then:
+        traversalContext.getOutputType() == null
+    }
+
+    def "inlineFragment that is not a GraphQLOutputType should result as null"() {
+        given:
+        InlineFragment inlineFragment = new InlineFragment(new TypeName(inputHumanType.getName()))
+
+        when:
+        traversalContext.enter(inlineFragment, [])
+
+        then:
+        traversalContext.getOutputType() == null
+
+        when:
+        traversalContext.leave(inlineFragment, [])
+
+        then:
+        traversalContext.getOutputType() == null
+    }
+
+    def "fragmentDefinition that is not a GraphQLOutputType should result as null"() {
+        given:
+        FragmentDefinition fragmentDefinition = FragmentDefinition.newFragmentDefinition()
+                .name("fragment")
+                .typeCondition(new TypeName(inputHumanType.getName()))
+                .build()
+
+        when:
+        traversalContext.enter(fragmentDefinition, [])
+
+        then:
+        traversalContext.getOutputType() == null
 
         when:
         traversalContext.leave(fragmentDefinition, [])

--- a/src/test/groovy/graphql/validation/rules/Harness.java
+++ b/src/test/groovy/graphql/validation/rules/Harness.java
@@ -1,6 +1,7 @@
 package graphql.validation.rules;
 
 import graphql.schema.GraphQLEnumType;
+import graphql.schema.GraphQLInputObjectType;
 import graphql.schema.GraphQLInterfaceType;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
@@ -13,6 +14,7 @@ import static graphql.Scalars.GraphQLString;
 import static graphql.schema.GraphQLArgument.newArgument;
 import static graphql.schema.GraphQLEnumType.newEnum;
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
+import static graphql.schema.GraphQLInputObjectField.newInputObjectField;
 import static graphql.schema.GraphQLInterfaceType.newInterface;
 import static graphql.schema.GraphQLList.list;
 import static graphql.schema.GraphQLObjectType.newObject;
@@ -175,6 +177,13 @@ public class Harness {
             .typeResolver(dummyTypeResolve)
             .build();
 
+    public static GraphQLInputObjectType Leash = GraphQLInputObjectType.newInputObject()
+            .name("LeashInput")
+            .field(newInputObjectField()
+                    .name("id")
+                    .type(GraphQLString))
+            .build();
+
     public static GraphQLObjectType QueryRoot = newObject()
             .name("QueryRoot")
             .field(newFieldDefinition()
@@ -192,6 +201,12 @@ public class Harness {
             .field(newFieldDefinition()
                     .name("catOrDog")
                     .type(CatOrDog))
+            .field(newFieldDefinition()
+                    .name("dogWithInput")
+                    .argument(newArgument()
+                            .name("leash")
+                            .type(Leash))
+                    .type(Dog))
 
             .field(newFieldDefinition()
                     .name("dogOrHuman")
@@ -204,7 +219,5 @@ public class Harness {
     public static GraphQLSchema Schema = newSchema()
             .query(QueryRoot)
             .build();
-
-
 }
 

--- a/src/test/groovy/graphql/validation/rules/PossibleFragmentSpreadsTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/PossibleFragmentSpreadsTest.groovy
@@ -297,4 +297,42 @@ class PossibleFragmentSpreadsTest extends Specification {
 
     }
 
+    def 'when fragment target type is not composite type do not error - FragmentsOnCompositeType takes care of the validation'() {
+        setup: "LeashInput is an input type so it shouldn't be target-able"
+        def query = """
+           query {
+            dogWithInput {
+             ...LeashInputFragment
+            }
+           }
+           
+           fragment LeashInputFragment on LeashInput {
+            id
+           }
+        """
+        when:
+        traverse(query)
+
+        then:
+        errorCollector.getErrors().isEmpty()
+    }
+
+    def 'when inline fragment target type is not composite type do not error - FragmentsOnCompositeType takes care of the validation'() {
+        setup: "LeashInput is an input type so it shouldn't be target-able"
+        def query = """
+           query {
+            dogWithInput {
+             ...on LeashInput {
+              id 
+             }
+            }
+           }           
+        """
+        when:
+        traverse(query)
+
+        then:
+        errorCollector.getErrors().isEmpty()
+    }
+
 }


### PR DESCRIPTION
## Description

When a fragment target type (or type condition) is not a composite type, `PossibleFragmentSpreads` rule validation errors with `assertShouldNeverHappen`. 
Note that the `FragmentOnCompositeType` rule already catches this use case and is the rule that emits the user validation error.

## Steps to reproduce
I created a test to reproduce the `AssertException` issue:

```java
    def 'when fragment target type is not composite type do not error - FragmentsOnCompositeType takes care of the validation'() {
        setup: "LeashInput is an input type so it shouldn't be target-able"
        def query = """
           query {
            dogWithInput {
             ...LeashInputFragment
            }
           }
           
           fragment LeashInputFragment on LeashInput {
            id
           }
        """
        when:
        traverse(query)
         then:
        errorCollector.getErrors().isEmpty()
    }
```

## Expected behavior
The `PossibleFragmentSpreads` rule should not error when a fragment fails the `FragmentOnCompositeType` rule validation.

## Proposed fix
[Like in GraphQL.js](https://github.com/graphql/graphql-js/blob/f4f15b386b6d5b8438a9a97b72f01c12c3c49964/src/validation/rules/PossibleFragmentSpreads.js#L54), the `PossibleFragmentSpreads` rule should re-check for composite type before applying its own validation.
Also, I noticed that the `TraversalContext` is not defensively checking before casting to a `GraphQLOutputType` which causes a `ClassCastException` instead for invalid inline fragments.

## Note
This is a patch and can be included on both 9.x and 10.x branches.