### PR TITLE
Fix SchemaPrinter generating invalid values for directives

### DIFF
--- a/src/main/java/graphql/schema/idl/SchemaPrinter.java
+++ b/src/main/java/graphql/schema/idl/SchemaPrinter.java
@@ -478,9 +478,8 @@ public class SchemaPrinter {
                 if (arg.getValue() != null) {
                     sb.append(" : ");
                     sb.append(printAst(arg.getValue(), arg.getType()));
-                }
-                if (arg.getDefaultValue() != null) {
-                    sb.append(" = ");
+                } else if (arg.getDefaultValue() != null) {
+                    sb.append(" : ");
                     sb.append(printAst(arg.getDefaultValue(), arg.getType()));
                 }
                 if (i < args.size() - 1) {


### PR DESCRIPTION
Steps to reproduce:

Add a `@deprecated` directive to a field or a value and then run it through both `SchemaParser` and `SchemaPrinter`, it will be transformed into `@deprecated(reason : "No longer supported" = "No longer supported")` which is invalid GraphQL according to the [spec](http://facebook.github.io/graphql/June2018/#sec-Language.Directives).