### PR TITLE
rename ExecutionInfo to ExecutionStepInfo

### DIFF
--- a/src/main/java/graphql/UnresolvedTypeError.java
+++ b/src/main/java/graphql/UnresolvedTypeError.java
@@ -1,7 +1,7 @@
 package graphql;
 
-import graphql.execution.ExecutionInfo;
 import graphql.execution.ExecutionPath;
+import graphql.execution.ExecutionStepInfo;
 import graphql.execution.UnresolvedTypeException;
 import graphql.language.SourceLocation;
 
@@ -17,14 +17,14 @@ public class UnresolvedTypeError implements GraphQLError {
     private final List<Object> path;
     private final UnresolvedTypeException exception;
 
-    public UnresolvedTypeError(ExecutionPath path, ExecutionInfo info,
+    public UnresolvedTypeError(ExecutionPath path, ExecutionStepInfo info,
                                UnresolvedTypeException exception) {
         this.path = assertNotNull(path).toList();
         this.exception = assertNotNull(exception);
         this.message = mkMessage(path, exception, assertNotNull(info));
     }
 
-    private String mkMessage(ExecutionPath path, UnresolvedTypeException exception, ExecutionInfo info) {
+    private String mkMessage(ExecutionPath path, UnresolvedTypeException exception, ExecutionStepInfo info) {
         return format("Can't resolve '%s'. Abstract type '%s' must resolve to an Object type at runtime for field '%s.%s'. %s",
                 path,
                 exception.getInterfaceOrUnionType().getName(),

--- a/src/main/java/graphql/execution/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncExecutionStrategy.java
@@ -126,7 +126,7 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
 
             Instrumentation instrumentation = executionContext.getInstrumentation();
             DeferredFieldInstrumentationContext fieldCtx = instrumentation.beginDeferredField(
-                    new InstrumentationDeferredFieldParameters(executionContext, parameters, fieldDef, executionInfo(executionContext, parameters, fieldDef))
+                    new InstrumentationDeferredFieldParameters(executionContext, parameters, fieldDef, createExecutionStepInfo(executionContext, parameters, fieldDef))
             );
             CompletableFuture<ExecutionResult> result = new CompletableFuture<>();
             fieldCtx.onDispatched(result);

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -32,8 +32,8 @@ import java.util.concurrent.CompletableFuture;
 
 import static graphql.Assert.assertShouldNeverHappen;
 import static graphql.execution.ExecutionContextBuilder.newExecutionContextBuilder;
+import static graphql.execution.ExecutionStepInfo.newExecutionStepInfo;
 import static graphql.execution.ExecutionStrategyParameters.newParameters;
-import static graphql.execution.ExecutionInfo.newExecutionInfo;
 import static graphql.language.OperationDefinition.Operation.MUTATION;
 import static graphql.language.OperationDefinition.Operation.QUERY;
 import static graphql.language.OperationDefinition.Operation.SUBSCRIPTION;
@@ -134,11 +134,11 @@ public class Execution {
         Map<String, List<Field>> fields = fieldCollector.collectFields(collectorParameters, operationDefinition.getSelectionSet());
 
         ExecutionPath path = ExecutionPath.rootPath();
-        ExecutionInfo executionInfo = newExecutionInfo().type(operationRootType).path(path).build();
-        NonNullableFieldValidator nonNullableFieldValidator = new NonNullableFieldValidator(executionContext, executionInfo);
+        ExecutionStepInfo executionStepInfo = newExecutionStepInfo().type(operationRootType).path(path).build();
+        NonNullableFieldValidator nonNullableFieldValidator = new NonNullableFieldValidator(executionContext, executionStepInfo);
 
         ExecutionStrategyParameters parameters = newParameters()
-                .executionInfo(executionInfo)
+                .executionStepInfo(executionStepInfo)
                 .source(root)
                 .fields(fields)
                 .nonNullFieldValidator(nonNullableFieldValidator)

--- a/src/main/java/graphql/execution/ExecutionStepInfo.java
+++ b/src/main/java/graphql/execution/ExecutionStepInfo.java
@@ -30,7 +30,7 @@ import static graphql.schema.GraphQLTypeUtil.unwrapOne;
  * type instances, so this helper class adds this information during query execution.
  */
 @PublicApi
-public class ExecutionInfo {
+public class ExecutionStepInfo {
 
     private final GraphQLType type;
     private final Field field;
@@ -38,13 +38,13 @@ public class ExecutionInfo {
     private final ExecutionPath path;
     private final boolean typeIsNonNull;
     private final Map<String, Object> arguments;
-    private final ExecutionInfo parentInfo;
+    private final ExecutionStepInfo parent;
 
-    private ExecutionInfo(GraphQLType type, GraphQLFieldDefinition fieldDefinition, Field field, ExecutionPath path, ExecutionInfo parentInfo, boolean nonNull, Map<String, Object> arguments) {
+    private ExecutionStepInfo(GraphQLType type, GraphQLFieldDefinition fieldDefinition, Field field, ExecutionPath path, ExecutionStepInfo parent, boolean nonNull, Map<String, Object> arguments) {
         this.fieldDefinition = fieldDefinition;
         this.field = field;
         this.path = path;
-        this.parentInfo = parentInfo;
+        this.parent = parent;
         this.type = type;
         this.typeIsNonNull = nonNull;
         this.arguments = arguments;
@@ -137,15 +137,15 @@ public class ExecutionInfo {
     /**
      * @return the parent type information
      */
-    public ExecutionInfo getParent() {
-        return parentInfo;
+    public ExecutionStepInfo getParent() {
+        return parent;
     }
 
     /**
      * @return true if the type has a parent (most do)
      */
     public boolean hasParent() {
-        return parentInfo != null;
+        return parent != null;
     }
 
     /**
@@ -158,8 +158,8 @@ public class ExecutionInfo {
      *
      * @return a new type info with the same
      */
-    public ExecutionInfo treatAs(GraphQLType newType) {
-        return new ExecutionInfo(unwrapNonNull(newType), fieldDefinition, field, path, this.parentInfo, this.typeIsNonNull, arguments);
+    public ExecutionStepInfo treatAs(GraphQLType newType) {
+        return new ExecutionStepInfo(unwrapNonNull(newType), fieldDefinition, field, path, this.parent, this.typeIsNonNull, arguments);
     }
 
 
@@ -213,10 +213,10 @@ public class ExecutionInfo {
 
     @Override
     public String toString() {
-        return "ExecutionInfo{" +
+        return "ExecutionStepInfo{" +
                 " path=" + path +
                 ", type=" + type +
-                ", parentInfo=" + parentInfo +
+                ", parentInfo=" + parent +
                 ", typeIsNonNull=" + typeIsNonNull +
                 ", fieldDefinition=" + fieldDefinition +
                 '}';
@@ -233,20 +233,20 @@ public class ExecutionInfo {
     /**
      * @return a builder of type info
      */
-    public static ExecutionInfo.Builder newExecutionInfo() {
+    public static ExecutionStepInfo.Builder newExecutionStepInfo() {
         return new Builder();
     }
 
     public static class Builder {
         GraphQLType type;
-        ExecutionInfo parentInfo;
+        ExecutionStepInfo parentInfo;
         GraphQLFieldDefinition fieldDefinition;
         Field field;
         ExecutionPath executionPath;
         Map<String, Object> arguments = new LinkedHashMap<>();
 
         /**
-         * @see ExecutionInfo#newExecutionInfo()
+         * @see ExecutionStepInfo#newExecutionStepInfo()
          */
         private Builder() {
         }
@@ -256,8 +256,8 @@ public class ExecutionInfo {
             return this;
         }
 
-        public Builder parentInfo(ExecutionInfo executionInfo) {
-            this.parentInfo = executionInfo;
+        public Builder parentInfo(ExecutionStepInfo executionStepInfo) {
+            this.parentInfo = executionStepInfo;
             return this;
         }
 
@@ -281,11 +281,11 @@ public class ExecutionInfo {
             return this;
         }
 
-        public ExecutionInfo build() {
+        public ExecutionStepInfo build() {
             if (isNonNull(type)) {
-                return new ExecutionInfo(unwrapNonNull(type), fieldDefinition, field, executionPath, parentInfo, true, arguments);
+                return new ExecutionStepInfo(unwrapNonNull(type), fieldDefinition, field, executionPath, parentInfo, true, arguments);
             }
-            return new ExecutionInfo(type, fieldDefinition, field, executionPath, parentInfo, false, arguments);
+            return new ExecutionStepInfo(type, fieldDefinition, field, executionPath, parentInfo, false, arguments);
         }
     }
 }

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -50,7 +50,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
 import static graphql.execution.Async.exceptionallyCompletedFuture;
-import static graphql.execution.ExecutionInfo.newExecutionInfo;
+import static graphql.execution.ExecutionStepInfo.newExecutionStepInfo;
 import static graphql.execution.FieldCollectorParameters.newParameters;
 import static graphql.execution.FieldValueInfo.CompleteValueType.ENUM;
 import static graphql.execution.FieldValueInfo.CompleteValueType.LIST;
@@ -196,7 +196,7 @@ public abstract class ExecutionStrategy {
 
         Instrumentation instrumentation = executionContext.getInstrumentation();
         InstrumentationContext<ExecutionResult> fieldCtx = instrumentation.beginField(
-                new InstrumentationFieldParameters(executionContext, fieldDef, executionInfo(executionContext, parameters, fieldDef))
+                new InstrumentationFieldParameters(executionContext, fieldDef, createExecutionStepInfo(executionContext, parameters, fieldDef))
         );
 
         CompletableFuture<Object> fetchFieldFuture = fetchField(executionContext, parameters);
@@ -226,7 +226,7 @@ public abstract class ExecutionStrategy {
      */
     protected CompletableFuture<Object> fetchField(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
         Field field = parameters.getField().get(0);
-        GraphQLObjectType parentType = parameters.getExecutionInfo().castType(GraphQLObjectType.class);
+        GraphQLObjectType parentType = parameters.getExecutionStepInfo().castType(GraphQLObjectType.class);
         GraphQLFieldDefinition fieldDef = getFieldDef(executionContext.getGraphQLSchema(), parentType, field);
 
         GraphqlFieldVisibility fieldVisibility = executionContext.getGraphQLSchema().getFieldVisibility();
@@ -234,7 +234,7 @@ public abstract class ExecutionStrategy {
 
         GraphQLOutputType fieldType = fieldDef.getType();
         DataFetchingFieldSelectionSet fieldCollector = DataFetchingFieldSelectionSetImpl.newCollector(executionContext, fieldType, parameters.getField());
-        ExecutionInfo executionInfo = executionInfo(executionContext, parameters, fieldDef);
+        ExecutionStepInfo executionStepInfo = createExecutionStepInfo(executionContext, parameters, fieldDef);
 
         DataFetchingEnvironment environment = newDataFetchingEnvironment(executionContext)
                 .source(parameters.getSource())
@@ -242,7 +242,7 @@ public abstract class ExecutionStrategy {
                 .fieldDefinition(fieldDef)
                 .fields(parameters.getField())
                 .fieldType(fieldType)
-                .executionInfo(executionInfo)
+                .executionStepInfo(executionStepInfo)
                 .parentType(parentType)
                 .selectionSet(fieldCollector)
                 .build();
@@ -257,13 +257,13 @@ public abstract class ExecutionStrategy {
         dataFetcher = instrumentation.instrumentDataFetcher(dataFetcher, instrumentationFieldFetchParams);
         ExecutionId executionId = executionContext.getExecutionId();
         try {
-            log.debug("'{}' fetching field '{}' using data fetcher '{}'...", executionId, executionInfo.getPath(), dataFetcher.getClass().getName());
+            log.debug("'{}' fetching field '{}' using data fetcher '{}'...", executionId, executionStepInfo.getPath(), dataFetcher.getClass().getName());
             Object fetchedValueRaw = dataFetcher.get(environment);
-            log.debug("'{}' field '{}' fetch returned '{}'", executionId, executionInfo.getPath(), fetchedValueRaw == null ? "null" : fetchedValueRaw.getClass().getName());
+            log.debug("'{}' field '{}' fetch returned '{}'", executionId, executionStepInfo.getPath(), fetchedValueRaw == null ? "null" : fetchedValueRaw.getClass().getName());
 
             fetchedValue = Async.toCompletableFuture(fetchedValueRaw);
         } catch (Exception e) {
-            log.debug(String.format("'%s', field '%s' fetch threw exception", executionId, executionInfo.getPath()), e);
+            log.debug(String.format("'%s', field '%s' fetch threw exception", executionId, executionStepInfo.getPath()), e);
 
             fetchedValue = new CompletableFuture<>();
             fetchedValue.completeExceptionally(e);
@@ -339,12 +339,12 @@ public abstract class ExecutionStrategy {
      */
     protected FieldValueInfo completeField(ExecutionContext executionContext, ExecutionStrategyParameters parameters, Object fetchedValue) {
         Field field = parameters.getField().get(0);
-        GraphQLObjectType parentType = parameters.getExecutionInfo().castType(GraphQLObjectType.class);
+        GraphQLObjectType parentType = parameters.getExecutionStepInfo().castType(GraphQLObjectType.class);
         GraphQLFieldDefinition fieldDef = getFieldDef(executionContext.getGraphQLSchema(), parentType, field);
-        ExecutionInfo executionInfo = executionInfo(executionContext, parameters, fieldDef);
+        ExecutionStepInfo executionStepInfo = createExecutionStepInfo(executionContext, parameters, fieldDef);
 
         Instrumentation instrumentation = executionContext.getInstrumentation();
-        InstrumentationFieldCompleteParameters instrumentationParams = new InstrumentationFieldCompleteParameters(executionContext, parameters, fieldDef, executionInfo, fetchedValue);
+        InstrumentationFieldCompleteParameters instrumentationParams = new InstrumentationFieldCompleteParameters(executionContext, parameters, fieldDef, executionStepInfo, fetchedValue);
         InstrumentationContext<ExecutionResult> ctxCompleteField = instrumentation.beginFieldComplete(
                 instrumentationParams
         );
@@ -352,16 +352,16 @@ public abstract class ExecutionStrategy {
         GraphqlFieldVisibility fieldVisibility = executionContext.getGraphQLSchema().getFieldVisibility();
         Map<String, Object> argumentValues = valuesResolver.getArgumentValues(fieldVisibility, fieldDef.getArguments(), field.getArguments(), executionContext.getVariables());
 
-        NonNullableFieldValidator nonNullableFieldValidator = new NonNullableFieldValidator(executionContext, executionInfo);
+        NonNullableFieldValidator nonNullableFieldValidator = new NonNullableFieldValidator(executionContext, executionStepInfo);
 
         ExecutionStrategyParameters newParameters = parameters.transform(builder ->
-                builder.executionInfo(executionInfo)
+                builder.executionStepInfo(executionStepInfo)
                         .arguments(argumentValues)
                         .source(fetchedValue)
                         .nonNullFieldValidator(nonNullableFieldValidator)
         );
 
-        log.debug("'{}' completing field '{}'...", executionContext.getExecutionId(), executionInfo.getPath());
+        log.debug("'{}' completing field '{}'...", executionContext.getExecutionId(), executionStepInfo.getPath());
 
         FieldValueInfo fieldValueInfo = completeValue(executionContext, newParameters);
 
@@ -389,9 +389,9 @@ public abstract class ExecutionStrategy {
      * @throws NonNullableFieldWasNullException if a non null field resolves to a null value
      */
     protected FieldValueInfo completeValue(ExecutionContext executionContext, ExecutionStrategyParameters parameters) throws NonNullableFieldWasNullException {
-        ExecutionInfo executionInfo = parameters.getExecutionInfo();
+        ExecutionStepInfo executionStepInfo = parameters.getExecutionStepInfo();
         Object result = unboxPossibleOptional(parameters.getSource());
-        GraphQLType fieldType = executionInfo.getType();
+        GraphQLType fieldType = executionStepInfo.getType();
         CompletableFuture<ExecutionResult> fieldValue;
 
         if (result == null) {
@@ -426,7 +426,7 @@ public abstract class ExecutionStrategy {
     }
 
     private void handleUnresolvedTypeProblem(ExecutionContext context, ExecutionStrategyParameters parameters, UnresolvedTypeException e) {
-        UnresolvedTypeError error = new UnresolvedTypeError(parameters.getPath(), parameters.getExecutionInfo(), e);
+        UnresolvedTypeError error = new UnresolvedTypeError(parameters.getPath(), parameters.getExecutionStepInfo(), e);
         log.warn(error.getMessage(), e);
         context.addError(error);
 
@@ -476,12 +476,12 @@ public abstract class ExecutionStrategy {
     protected FieldValueInfo completeValueForList(ExecutionContext executionContext, ExecutionStrategyParameters parameters, Iterable<Object> iterableValues) {
 
         Collection<Object> values = FpKit.toCollection(iterableValues);
-        ExecutionInfo executionInfo = parameters.getExecutionInfo();
-        GraphQLList fieldType = executionInfo.castType(GraphQLList.class);
-        GraphQLFieldDefinition fieldDef = parameters.getExecutionInfo().getFieldDefinition();
-        Field field = parameters.getExecutionInfo().getField();
+        ExecutionStepInfo executionStepInfo = parameters.getExecutionStepInfo();
+        GraphQLList fieldType = executionStepInfo.castType(GraphQLList.class);
+        GraphQLFieldDefinition fieldDef = parameters.getExecutionStepInfo().getFieldDefinition();
+        Field field = parameters.getExecutionStepInfo().getField();
 
-        InstrumentationFieldCompleteParameters instrumentationParams = new InstrumentationFieldCompleteParameters(executionContext, parameters, fieldDef, executionInfo(executionContext, parameters, fieldDef), values);
+        InstrumentationFieldCompleteParameters instrumentationParams = new InstrumentationFieldCompleteParameters(executionContext, parameters, fieldDef, createExecutionStepInfo(executionContext, parameters, fieldDef), values);
         Instrumentation instrumentation = executionContext.getInstrumentation();
 
         InstrumentationContext<ExecutionResult> completeListCtx = instrumentation.beginFieldListComplete(
@@ -493,19 +493,19 @@ public abstract class ExecutionStrategy {
         for (Object item : values) {
             ExecutionPath indexedPath = parameters.getPath().segment(index);
 
-            ExecutionInfo wrappedExecutionInfo = ExecutionInfo.newExecutionInfo()
-                    .parentInfo(executionInfo)
+            ExecutionStepInfo wrappedExecutionStepInfo = ExecutionStepInfo.newExecutionStepInfo()
+                    .parentInfo(executionStepInfo)
                     .type(fieldType.getWrappedType())
                     .path(indexedPath)
                     .fieldDefinition(fieldDef)
                     .field(field)
                     .build();
 
-            NonNullableFieldValidator nonNullableFieldValidator = new NonNullableFieldValidator(executionContext, wrappedExecutionInfo);
+            NonNullableFieldValidator nonNullableFieldValidator = new NonNullableFieldValidator(executionContext, wrappedExecutionStepInfo);
 
             int finalIndex = index;
             ExecutionStrategyParameters newParameters = parameters.transform(builder ->
-                    builder.executionInfo(wrappedExecutionInfo)
+                    builder.executionStepInfo(wrappedExecutionStepInfo)
                             .nonNullFieldValidator(nonNullableFieldValidator)
                             .listSize(values.size())
                             .currentListIndex(finalIndex)
@@ -610,7 +610,7 @@ public abstract class ExecutionStrategy {
      * @return a promise to an {@link ExecutionResult}
      */
     protected CompletableFuture<ExecutionResult> completeValueForObject(ExecutionContext executionContext, ExecutionStrategyParameters parameters, GraphQLObjectType resolvedObjectType, Object result) {
-        ExecutionInfo executionInfo = parameters.getExecutionInfo();
+        ExecutionStepInfo executionStepInfo = parameters.getExecutionStepInfo();
 
         FieldCollectorParameters collectorParameters = newParameters()
                 .schema(executionContext.getGraphQLSchema())
@@ -621,11 +621,11 @@ public abstract class ExecutionStrategy {
 
         Map<String, List<Field>> subFields = fieldCollector.collectFields(collectorParameters, parameters.getField());
 
-        ExecutionInfo newExecutionInfo = executionInfo.treatAs(resolvedObjectType);
-        NonNullableFieldValidator nonNullableFieldValidator = new NonNullableFieldValidator(executionContext, newExecutionInfo);
+        ExecutionStepInfo newExecutionStepInfo = executionStepInfo.treatAs(resolvedObjectType);
+        NonNullableFieldValidator nonNullableFieldValidator = new NonNullableFieldValidator(executionContext, newExecutionStepInfo);
 
         ExecutionStrategyParameters newParameters = parameters.transform(builder ->
-                builder.executionInfo(newExecutionInfo)
+                builder.executionStepInfo(newExecutionStepInfo)
                         .fields(subFields)
                         .nonNullFieldValidator(nonNullableFieldValidator)
                         .source(result)
@@ -786,7 +786,7 @@ public abstract class ExecutionStrategy {
     }
 
     private void handleTypeMismatchProblem(ExecutionContext context, ExecutionStrategyParameters parameters, Object result) {
-        TypeMismatchError error = new TypeMismatchError(parameters.getPath(), parameters.getExecutionInfo().getType());
+        TypeMismatchError error = new TypeMismatchError(parameters.getPath(), parameters.getExecutionStepInfo().getType());
         log.warn("{} got {}", error.getMessage(), result.getClass());
         context.addError(error);
 
@@ -804,7 +804,7 @@ public abstract class ExecutionStrategy {
      * @return a {@link GraphQLFieldDefinition}
      */
     protected GraphQLFieldDefinition getFieldDef(ExecutionContext executionContext, ExecutionStrategyParameters parameters, Field field) {
-        GraphQLObjectType parentType = parameters.getExecutionInfo().castType(GraphQLObjectType.class);
+        GraphQLObjectType parentType = parameters.getExecutionStepInfo().castType(GraphQLObjectType.class);
         return getFieldDef(executionContext.getGraphQLSchema(), parentType, field);
     }
 
@@ -836,15 +836,15 @@ public abstract class ExecutionStrategy {
      * @throws NonNullableFieldWasNullException if a non null field resolves to a null value
      */
     protected void assertNonNullFieldPrecondition(NonNullableFieldWasNullException e) throws NonNullableFieldWasNullException {
-        ExecutionInfo executionInfo = e.getExecutionInfo();
-        if (executionInfo.hasParent() && executionInfo.getParent().isNonNullType()) {
+        ExecutionStepInfo executionStepInfo = e.getExecutionStepInfo();
+        if (executionStepInfo.hasParent() && executionStepInfo.getParent().isNonNullType()) {
             throw new NonNullableFieldWasNullException(e);
         }
     }
 
     protected void assertNonNullFieldPrecondition(NonNullableFieldWasNullException e, CompletableFuture<?> completableFuture) throws NonNullableFieldWasNullException {
-        ExecutionInfo executionInfo = e.getExecutionInfo();
-        if (executionInfo.hasParent() && executionInfo.getParent().isNonNullType()) {
+        ExecutionStepInfo executionStepInfo = e.getExecutionStepInfo();
+        if (executionStepInfo.hasParent() && executionStepInfo.getParent().isNonNullType()) {
             completableFuture.completeExceptionally(new NonNullableFieldWasNullException(e));
         }
     }
@@ -882,7 +882,7 @@ public abstract class ExecutionStrategy {
      *
      * @return a new type info
      */
-    protected ExecutionInfo executionInfo(ExecutionContext executionContext, ExecutionStrategyParameters parameters, GraphQLFieldDefinition fieldDefinition) {
+    protected ExecutionStepInfo createExecutionStepInfo(ExecutionContext executionContext, ExecutionStrategyParameters parameters, GraphQLFieldDefinition fieldDefinition) {
         GraphQLOutputType fieldType = fieldDefinition.getType();
         Field field = null;
         List<Argument> fieldArgs = Collections.emptyList();
@@ -893,12 +893,12 @@ public abstract class ExecutionStrategy {
         GraphqlFieldVisibility fieldVisibility = executionContext.getGraphQLSchema().getFieldVisibility();
         Map<String, Object> argumentValues = valuesResolver.getArgumentValues(fieldVisibility, fieldDefinition.getArguments(), fieldArgs, executionContext.getVariables());
 
-        return newExecutionInfo()
+        return newExecutionStepInfo()
                 .type(fieldType)
                 .fieldDefinition(fieldDefinition)
                 .field(field)
                 .path(parameters.getPath())
-                .parentInfo(parameters.getExecutionInfo())
+                .parentInfo(parameters.getExecutionStepInfo())
                 .arguments(argumentValues)
                 .build();
 

--- a/src/main/java/graphql/execution/ExecutionStrategyParameters.java
+++ b/src/main/java/graphql/execution/ExecutionStrategyParameters.java
@@ -16,7 +16,7 @@ import static graphql.Assert.assertNotNull;
  */
 @PublicApi
 public class ExecutionStrategyParameters {
-    private final ExecutionInfo executionInfo;
+    private final ExecutionStepInfo executionStepInfo;
     private final Object source;
     private final Map<String, Object> arguments;
     private final Map<String, List<Field>> fields;
@@ -28,7 +28,7 @@ public class ExecutionStrategyParameters {
     private final ExecutionStrategyParameters parent;
     private final DeferredErrorSupport deferredErrorSupport;
 
-    private ExecutionStrategyParameters(ExecutionInfo executionInfo,
+    private ExecutionStrategyParameters(ExecutionStepInfo executionStepInfo,
                                         Object source,
                                         Map<String, List<Field>> fields,
                                         Map<String, Object> arguments,
@@ -40,7 +40,7 @@ public class ExecutionStrategyParameters {
                                         ExecutionStrategyParameters parent,
                                         DeferredErrorSupport deferredErrorSupport) {
 
-        this.executionInfo = assertNotNull(executionInfo, "executionInfo is null");
+        this.executionStepInfo = assertNotNull(executionStepInfo, "executionStepInfo is null");
         this.fields = assertNotNull(fields, "fields is null");
         this.source = source;
         this.arguments = arguments;
@@ -53,8 +53,8 @@ public class ExecutionStrategyParameters {
         this.deferredErrorSupport = deferredErrorSupport;
     }
 
-    public ExecutionInfo getExecutionInfo() {
-        return executionInfo;
+    public ExecutionStepInfo getExecutionStepInfo() {
+        return executionStepInfo;
     }
 
     public Object getSource() {
@@ -112,8 +112,8 @@ public class ExecutionStrategyParameters {
 
     @Override
     public String toString() {
-        return String.format("ExecutionStrategyParameters { path=%s, executionInfo=%s, source=%s, fields=%s }",
-                path, executionInfo, source, fields);
+        return String.format("ExecutionStrategyParameters { path=%s, executionStepInfo=%s, source=%s, fields=%s }",
+                path, executionStepInfo, source, fields);
     }
 
     public static Builder newParameters() {
@@ -125,7 +125,7 @@ public class ExecutionStrategyParameters {
     }
 
     public static class Builder {
-        ExecutionInfo executionInfo;
+        ExecutionStepInfo executionStepInfo;
         Object source;
         Map<String, List<Field>> fields;
         Map<String, Object> arguments;
@@ -147,7 +147,7 @@ public class ExecutionStrategyParameters {
          * @see ExecutionStrategyParameters#newParameters(ExecutionStrategyParameters)
          */
         private Builder(ExecutionStrategyParameters oldParameters) {
-            this.executionInfo = oldParameters.executionInfo;
+            this.executionStepInfo = oldParameters.executionStepInfo;
             this.source = oldParameters.source;
             this.fields = oldParameters.fields;
             this.arguments = oldParameters.arguments;
@@ -160,13 +160,13 @@ public class ExecutionStrategyParameters {
             this.currentListIndex = oldParameters.currentListIndex;
         }
 
-        public Builder executionInfo(ExecutionInfo type) {
-            this.executionInfo = type;
+        public Builder executionStepInfo(ExecutionStepInfo executionStepInfo) {
+            this.executionStepInfo = executionStepInfo;
             return this;
         }
 
-        public Builder executionInfo(ExecutionInfo.Builder type) {
-            this.executionInfo = type.build();
+        public Builder executionStepInfo(ExecutionStepInfo.Builder executionStepInfoBuilder) {
+            this.executionStepInfo = executionStepInfoBuilder.build();
             return this;
         }
 
@@ -221,7 +221,7 @@ public class ExecutionStrategyParameters {
         }
 
         public ExecutionStrategyParameters build() {
-            return new ExecutionStrategyParameters(executionInfo, source, fields, arguments, nonNullableFieldValidator, path, currentField, listSize, currentListIndex, parent, deferredErrorSupport);
+            return new ExecutionStrategyParameters(executionStepInfo, source, fields, arguments, nonNullableFieldValidator, path, currentField, listSize, currentListIndex, parent, deferredErrorSupport);
         }
     }
 }

--- a/src/main/java/graphql/execution/NonNullableFieldValidator.java
+++ b/src/main/java/graphql/execution/NonNullableFieldValidator.java
@@ -13,11 +13,11 @@ import graphql.Internal;
 public class NonNullableFieldValidator {
 
     private final ExecutionContext executionContext;
-    private final ExecutionInfo executionInfo;
+    private final ExecutionStepInfo executionStepInfo;
 
-    public NonNullableFieldValidator(ExecutionContext executionContext, ExecutionInfo executionInfo) {
+    public NonNullableFieldValidator(ExecutionContext executionContext, ExecutionStepInfo executionStepInfo) {
         this.executionContext = executionContext;
-        this.executionInfo = executionInfo;
+        this.executionStepInfo = executionStepInfo;
     }
 
     /**
@@ -33,7 +33,7 @@ public class NonNullableFieldValidator {
      */
     public <T> T validate(ExecutionPath path, T result) throws NonNullableFieldWasNullException {
         if (result == null) {
-            if (executionInfo.isNonNullType()) {
+            if (executionStepInfo.isNonNullType()) {
                 // see http://facebook.github.io/graphql/#sec-Errors-and-Non-Nullability
                 //
                 //    > If the field returns null because of an error which has already been added to the "errors" list in the response,
@@ -46,7 +46,7 @@ public class NonNullableFieldValidator {
                 //
                 // We will do this until the spec makes this more explicit.
                 //
-                NonNullableFieldWasNullException nonNullException = new NonNullableFieldWasNullException(executionInfo, path);
+                NonNullableFieldWasNullException nonNullException = new NonNullableFieldWasNullException(executionStepInfo, path);
                 executionContext.addError(new NonNullableFieldWasNullError(nonNullException), path);
                 throw nonNullException;
             }

--- a/src/main/java/graphql/execution/NonNullableFieldWasNullException.java
+++ b/src/main/java/graphql/execution/NonNullableFieldWasNullException.java
@@ -9,41 +9,41 @@ import static graphql.Assert.assertNotNull;
  */
 public class NonNullableFieldWasNullException extends RuntimeException {
 
-    private final ExecutionInfo executionInfo;
+    private final ExecutionStepInfo executionStepInfo;
     private final ExecutionPath path;
 
 
-    public NonNullableFieldWasNullException(ExecutionInfo executionInfo, ExecutionPath path) {
+    public NonNullableFieldWasNullException(ExecutionStepInfo executionStepInfo, ExecutionPath path) {
         super(
-                mkMessage(assertNotNull(executionInfo),
+                mkMessage(assertNotNull(executionStepInfo),
                         assertNotNull(path))
         );
-        this.executionInfo = executionInfo;
+        this.executionStepInfo = executionStepInfo;
         this.path = path;
     }
 
     public NonNullableFieldWasNullException(NonNullableFieldWasNullException previousException) {
         super(
                 mkMessage(
-                        assertNotNull(previousException.executionInfo.getParent()),
-                        assertNotNull(previousException.executionInfo.getParent().getPath())
+                        assertNotNull(previousException.executionStepInfo.getParent()),
+                        assertNotNull(previousException.executionStepInfo.getParent().getPath())
                 ),
                 previousException
         );
-        this.executionInfo = previousException.executionInfo.getParent();
-        this.path = previousException.executionInfo.getParent().getPath();
+        this.executionStepInfo = previousException.executionStepInfo.getParent();
+        this.path = previousException.executionStepInfo.getParent().getPath();
     }
 
 
-    private static String mkMessage(ExecutionInfo executionInfo, ExecutionPath path) {
-        if (executionInfo.hasParent()) {
-            return String.format("Cannot return null for non-nullable type: '%s' within parent '%s' (%s)", executionInfo.getType().getName(), executionInfo.getParent().getType().getName(), path);
+    private static String mkMessage(ExecutionStepInfo executionStepInfo, ExecutionPath path) {
+        if (executionStepInfo.hasParent()) {
+            return String.format("Cannot return null for non-nullable type: '%s' within parent '%s' (%s)", executionStepInfo.getType().getName(), executionStepInfo.getParent().getType().getName(), path);
         }
-        return String.format("Cannot return null for non-nullable type: '%s' (%s)", executionInfo.getType().getName(), path);
+        return String.format("Cannot return null for non-nullable type: '%s' (%s)", executionStepInfo.getType().getName(), path);
     }
 
-    public ExecutionInfo getExecutionInfo() {
-        return executionInfo;
+    public ExecutionStepInfo getExecutionStepInfo() {
+        return executionStepInfo;
     }
 
     public ExecutionPath getPath() {
@@ -54,7 +54,7 @@ public class NonNullableFieldWasNullException extends RuntimeException {
     public String toString() {
         return "NonNullableFieldWasNullException{" +
                 " path=" + path +
-                " executionInfo=" + executionInfo +
+                " executionStepInfo=" + executionStepInfo +
                 '}';
     }
 }

--- a/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
+++ b/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
@@ -8,8 +8,8 @@ import graphql.execution.Async;
 import graphql.execution.DataFetcherExceptionHandler;
 import graphql.execution.DataFetcherExceptionHandlerParameters;
 import graphql.execution.ExecutionContext;
-import graphql.execution.ExecutionInfo;
 import graphql.execution.ExecutionPath;
+import graphql.execution.ExecutionStepInfo;
 import graphql.execution.ExecutionStrategy;
 import graphql.execution.ExecutionStrategyParameters;
 import graphql.execution.FieldCollectorParameters;
@@ -51,7 +51,7 @@ import java.util.concurrent.CompletionException;
 import java.util.function.BiFunction;
 import java.util.stream.IntStream;
 
-import static graphql.execution.ExecutionInfo.newExecutionInfo;
+import static graphql.execution.ExecutionStepInfo.newExecutionStepInfo;
 import static graphql.execution.FieldCollectorParameters.newParameters;
 import static graphql.schema.DataFetchingEnvironmentBuilder.newDataFetchingEnvironment;
 import static java.util.Collections.singletonList;
@@ -103,10 +103,10 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
         InstrumentationContext<ExecutionResult> executionStrategyCtx = executionContext.getInstrumentation()
                 .beginExecutionStrategy(new InstrumentationExecutionStrategyParameters(executionContext, parameters));
 
-        GraphQLObjectType type = parameters.getExecutionInfo().castType(GraphQLObjectType.class);
+        GraphQLObjectType type = parameters.getExecutionStepInfo().castType(GraphQLObjectType.class);
 
         ExecutionNode root = new ExecutionNode(type,
-                parameters.getExecutionInfo(),
+                parameters.getExecutionStepInfo(),
                 parameters.getFields(),
                 singletonList(MapOrList.createMap(new LinkedHashMap<>())),
                 Collections.singletonList(parameters.getSource())
@@ -154,31 +154,31 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
         // once an object is resolved from a interface / union to a node with an object type, the
         // parent type info has effectively changed (it has got more specific), even though the path etc...
         // has not changed
-        ExecutionInfo currentParentExecutionInfo = parameters.getExecutionInfo();
-        ExecutionInfo newParentExecutionInfo = newExecutionInfo()
+        ExecutionStepInfo currentParentExecutionStepInfo = parameters.getExecutionStepInfo();
+        ExecutionStepInfo newParentExecutionStepInfo = newExecutionStepInfo()
                 .type(curNode.getType())
-                .fieldDefinition(currentParentExecutionInfo.getFieldDefinition())
-                .field(currentParentExecutionInfo.getField())
-                .path(currentParentExecutionInfo.getPath())
-                .parentInfo(currentParentExecutionInfo.getParent())
+                .fieldDefinition(currentParentExecutionStepInfo.getFieldDefinition())
+                .field(currentParentExecutionStepInfo.getField())
+                .path(currentParentExecutionStepInfo.getPath())
+                .parentInfo(currentParentExecutionStepInfo.getParent())
                 .build();
 
-        ExecutionPath fieldPath = curNode.getExecutionInfo().getPath().segment(mkNameForPath(currentField));
+        ExecutionPath fieldPath = curNode.getExecutionStepInfo().getPath().segment(mkNameForPath(currentField));
         GraphQLFieldDefinition fieldDefinition = getFieldDef(executionContext.getGraphQLSchema(), curNode.getType(), currentField.get(0));
 
-        ExecutionInfo executionInfo = newExecutionInfo()
+        ExecutionStepInfo executionStepInfo = newExecutionStepInfo()
                 .type(fieldDefinition.getType())
                 .fieldDefinition(fieldDefinition)
                 .field(currentField.get(0))
                 .path(fieldPath)
-                .parentInfo(newParentExecutionInfo)
+                .parentInfo(newParentExecutionStepInfo)
                 .build();
 
         ExecutionStrategyParameters newParameters = parameters
                 .transform(builder -> builder
                         .path(fieldPath)
                         .field(currentField)
-                        .executionInfo(executionInfo)
+                        .executionStepInfo(executionStepInfo)
                 );
 
         ExecutionNode finalCurNode = curNode;
@@ -206,9 +206,9 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
         GraphQLFieldDefinition fieldDef = getFieldDef(executionContext.getGraphQLSchema(), parentType, fields.get(0));
 
         Instrumentation instrumentation = executionContext.getInstrumentation();
-        ExecutionInfo executionInfo = parameters.getExecutionInfo();
+        ExecutionStepInfo executionStepInfo = parameters.getExecutionStepInfo();
         InstrumentationContext<ExecutionResult> fieldCtx = instrumentation.beginField(
-                new InstrumentationFieldParameters(executionContext, fieldDef, executionInfo)
+                new InstrumentationFieldParameters(executionContext, fieldDef, executionStepInfo)
         );
 
         CompletableFuture<FetchedValues> fetchedData = fetchData(executionContext, parameters, fieldName, node, fieldDef);
@@ -220,7 +220,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
                     fieldVisibility,
                     fieldDef.getArguments(), fields.get(0).getArguments(), executionContext.getVariables());
 
-            return completeValues(executionContext, fetchedValues, executionInfo, fieldName, fields, argumentValues);
+            return completeValues(executionContext, fetchedValues, executionStepInfo, fieldName, fields, argumentValues);
         });
         fieldCtx.onDispatched(null);
         result = result.whenComplete((nodes, throwable) -> fieldCtx.onCompleted(null, throwable));
@@ -251,7 +251,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
                 .fieldDefinition(fieldDef)
                 .fields(fields)
                 .fieldType(fieldDef.getType())
-                .executionInfo(parameters.getExecutionInfo())
+                .executionStepInfo(parameters.getExecutionStepInfo())
                 .parentType(parentType)
                 .selectionSet(fieldCollector)
                 .build();
@@ -301,7 +301,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
                 Object value = unboxPossibleOptional(values.get(i));
                 retVal.add(new FetchedValue(parentResults.get(i), value));
             }
-            return new FetchedValues(retVal, parameters.getExecutionInfo(), parameters.getPath());
+            return new FetchedValues(retVal, parameters.getExecutionStepInfo(), parameters.getPath());
         };
     }
 
@@ -326,21 +326,21 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
     }
 
     private List<ExecutionNode> completeValues(ExecutionContext executionContext,
-                                               FetchedValues fetchedValues, ExecutionInfo executionInfo,
+                                               FetchedValues fetchedValues, ExecutionStepInfo executionStepInfo,
                                                String fieldName, List<Field> fields,
                                                Map<String, Object> argumentValues) {
 
         handleNonNullType(executionContext, fetchedValues);
 
-        GraphQLType unwrappedFieldType = executionInfo.getType();
+        GraphQLType unwrappedFieldType = executionStepInfo.getType();
 
         if (isPrimitive(unwrappedFieldType)) {
             handlePrimitives(fetchedValues, fieldName, unwrappedFieldType);
             return Collections.emptyList();
         } else if (isObject(unwrappedFieldType)) {
-            return handleObject(executionContext, argumentValues, fetchedValues, fieldName, fields, executionInfo);
+            return handleObject(executionContext, argumentValues, fetchedValues, fieldName, fields, executionStepInfo);
         } else if (isList(unwrappedFieldType)) {
-            return handleList(executionContext, argumentValues, fetchedValues, fieldName, fields, executionInfo);
+            return handleList(executionContext, argumentValues, fetchedValues, fieldName, fields, executionStepInfo);
         } else {
             return Assert.assertShouldNeverHappen("can't handle type: %s", unwrappedFieldType);
         }
@@ -349,9 +349,9 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
     @SuppressWarnings("unchecked")
     private List<ExecutionNode> handleList(ExecutionContext executionContext, Map<String, Object> argumentValues,
                                            FetchedValues fetchedValues, String fieldName, List<Field> fields,
-                                           ExecutionInfo executionInfo) {
+                                           ExecutionStepInfo executionStepInfo) {
 
-        GraphQLList listType = (GraphQLList) executionInfo.getType();
+        GraphQLList listType = (GraphQLList) executionStepInfo.getType();
         List<FetchedValue> flattenedValues = new ArrayList<>();
 
         for (FetchedValue value : fetchedValues.getValues()) {
@@ -369,16 +369,16 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
             }
         }
         GraphQLOutputType innerSubType = (GraphQLOutputType) listType.getWrappedType();
-        ExecutionInfo newExecutionInfo = executionInfo.treatAs(innerSubType);
-        FetchedValues flattenedFetchedValues = new FetchedValues(flattenedValues, newExecutionInfo, fetchedValues.getPath());
+        ExecutionStepInfo newExecutionStepInfo = executionStepInfo.treatAs(innerSubType);
+        FetchedValues flattenedFetchedValues = new FetchedValues(flattenedValues, newExecutionStepInfo, fetchedValues.getPath());
 
-        return completeValues(executionContext, flattenedFetchedValues, newExecutionInfo, fieldName, fields, argumentValues);
+        return completeValues(executionContext, flattenedFetchedValues, newExecutionStepInfo, fieldName, fields, argumentValues);
     }
 
     @SuppressWarnings("UnnecessaryLocalVariable")
     private List<ExecutionNode> handleObject(ExecutionContext executionContext, Map<String, Object> argumentValues,
                                              FetchedValues fetchedValues, String fieldName, List<Field> fields,
-                                             ExecutionInfo executionInfo) {
+                                             ExecutionStepInfo executionStepInfo) {
 
         // collect list of values by actual type (needed because of interfaces and unions)
         Map<GraphQLObjectType, List<MapOrList>> resultsByType = new LinkedHashMap<>();
@@ -392,7 +392,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
             }
             MapOrList childResult = mapOrList.createAndPutMap(fieldName);
 
-            GraphQLObjectType resolvedType = getGraphQLObjectType(executionContext, fields.get(0), executionInfo.getType(), value.getValue(), argumentValues);
+            GraphQLObjectType resolvedType = getGraphQLObjectType(executionContext, fields.get(0), executionStepInfo.getType(), value.getValue(), argumentValues);
             resultsByType.putIfAbsent(resolvedType, new ArrayList<>());
             resultsByType.get(resolvedType).add(childResult);
 
@@ -406,9 +406,9 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
             List<Object> sources = sourceByType.get(resolvedType);
             Map<String, List<Field>> childFields = getChildFields(executionContext, resolvedType, fields);
 
-            ExecutionInfo newExecutionInfo = executionInfo.treatAs(resolvedType);
+            ExecutionStepInfo newExecutionStepInfo = executionStepInfo.treatAs(resolvedType);
 
-            childNodes.add(new ExecutionNode(resolvedType, newExecutionInfo, childFields, results, sources));
+            childNodes.add(new ExecutionNode(resolvedType, newExecutionStepInfo, childFields, results, sources));
         }
         return childNodes;
     }
@@ -416,8 +416,8 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
 
     private void handleNonNullType(ExecutionContext executionContext, FetchedValues fetchedValues) {
 
-        ExecutionInfo executionInfo = fetchedValues.getExecutionInfo();
-        NonNullableFieldValidator nonNullableFieldValidator = new NonNullableFieldValidator(executionContext, executionInfo);
+        ExecutionStepInfo executionStepInfo = fetchedValues.getExecutionStepInfo();
+        NonNullableFieldValidator nonNullableFieldValidator = new NonNullableFieldValidator(executionContext, executionStepInfo);
         ExecutionPath path = fetchedValues.getPath();
         for (FetchedValue value : fetchedValues.getValues()) {
             nonNullableFieldValidator.validate(path, value.getValue());

--- a/src/main/java/graphql/execution/batched/ExecutionNode.java
+++ b/src/main/java/graphql/execution/batched/ExecutionNode.java
@@ -1,6 +1,6 @@
 package graphql.execution.batched;
 
-import graphql.execution.ExecutionInfo;
+import graphql.execution.ExecutionStepInfo;
 import graphql.language.Field;
 import graphql.schema.GraphQLObjectType;
 
@@ -11,18 +11,18 @@ import java.util.Map;
 class ExecutionNode {
 
     private final GraphQLObjectType type;
-    private final ExecutionInfo executionInfo;
+    private final ExecutionStepInfo executionStepInfo;
     private final Map<String, List<Field>> fields;
     private final List<MapOrList> parentResults;
     private final List<Object> sources;
 
     public ExecutionNode(GraphQLObjectType type,
-                         ExecutionInfo executionInfo,
+                         ExecutionStepInfo executionStepInfo,
                          Map<String, List<Field>> fields,
                          List<MapOrList> parentResults,
                          List<Object> sources) {
         this.type = type;
-        this.executionInfo = executionInfo;
+        this.executionStepInfo = executionStepInfo;
         this.fields = fields;
         this.parentResults = parentResults;
         this.sources = sources;
@@ -32,8 +32,8 @@ class ExecutionNode {
         return type;
     }
 
-    public ExecutionInfo getExecutionInfo() {
-        return executionInfo;
+    public ExecutionStepInfo getExecutionStepInfo() {
+        return executionStepInfo;
     }
 
     public Map<String, List<Field>> getFields() {

--- a/src/main/java/graphql/execution/batched/FetchedValues.java
+++ b/src/main/java/graphql/execution/batched/FetchedValues.java
@@ -1,7 +1,7 @@
 package graphql.execution.batched;
 
 import graphql.execution.ExecutionPath;
-import graphql.execution.ExecutionInfo;
+import graphql.execution.ExecutionStepInfo;
 
 import java.util.List;
 
@@ -9,12 +9,12 @@ import java.util.List;
 public class FetchedValues {
 
     private final List<FetchedValue> fetchedValues;
-    private final ExecutionInfo executionInfo;
+    private final ExecutionStepInfo executionStepInfo;
     private final ExecutionPath path;
 
-    public FetchedValues(List<FetchedValue> fetchedValues, ExecutionInfo executionInfo, ExecutionPath path) {
+    public FetchedValues(List<FetchedValue> fetchedValues, ExecutionStepInfo executionStepInfo, ExecutionPath path) {
         this.fetchedValues = fetchedValues;
-        this.executionInfo = executionInfo;
+        this.executionStepInfo = executionStepInfo;
         this.path = path;
     }
 
@@ -22,8 +22,8 @@ public class FetchedValues {
         return fetchedValues;
     }
 
-    public ExecutionInfo getExecutionInfo() {
-        return executionInfo;
+    public ExecutionStepInfo getExecutionStepInfo() {
+        return executionStepInfo;
     }
 
     public ExecutionPath getPath() {

--- a/src/main/java/graphql/execution/instrumentation/dataloader/FieldLevelTrackingApproach.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/FieldLevelTrackingApproach.java
@@ -236,7 +236,7 @@ public class FieldLevelTrackingApproach {
 
     public InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters) {
         CallStack callStack = parameters.getInstrumentationState();
-        ExecutionPath path = parameters.getEnvironment().getExecutionInfo().getPath();
+        ExecutionPath path = parameters.getEnvironment().getExecutionStepInfo().getPath();
         int level = path.getLevel();
         return new InstrumentationContext<Object>() {
 

--- a/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationDeferredFieldParameters.java
+++ b/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationDeferredFieldParameters.java
@@ -1,7 +1,7 @@
 package graphql.execution.instrumentation.parameters;
 
 import graphql.execution.ExecutionContext;
-import graphql.execution.ExecutionInfo;
+import graphql.execution.ExecutionStepInfo;
 import graphql.execution.ExecutionStrategyParameters;
 import graphql.execution.instrumentation.InstrumentationState;
 import graphql.schema.GraphQLFieldDefinition;
@@ -13,12 +13,12 @@ public class InstrumentationDeferredFieldParameters extends InstrumentationField
 
     private final ExecutionStrategyParameters executionStrategyParameters;
 
-    public InstrumentationDeferredFieldParameters(ExecutionContext executionContext, ExecutionStrategyParameters executionStrategyParameters, GraphQLFieldDefinition fieldDef, ExecutionInfo executionInfo) {
-        this(executionContext, executionStrategyParameters, fieldDef, executionInfo, executionContext.getInstrumentationState());
+    public InstrumentationDeferredFieldParameters(ExecutionContext executionContext, ExecutionStrategyParameters executionStrategyParameters, GraphQLFieldDefinition fieldDef, ExecutionStepInfo executionStepInfo) {
+        this(executionContext, executionStrategyParameters, fieldDef, executionStepInfo, executionContext.getInstrumentationState());
     }
 
-    InstrumentationDeferredFieldParameters(ExecutionContext executionContext, ExecutionStrategyParameters executionStrategyParameters, GraphQLFieldDefinition fieldDef, ExecutionInfo executionInfo, InstrumentationState instrumentationState) {
-        super(executionContext,fieldDef,executionInfo,instrumentationState);
+    InstrumentationDeferredFieldParameters(ExecutionContext executionContext, ExecutionStrategyParameters executionStrategyParameters, GraphQLFieldDefinition fieldDef, ExecutionStepInfo executionStepInfo, InstrumentationState instrumentationState) {
+        super(executionContext, fieldDef, executionStepInfo, instrumentationState);
         this.executionStrategyParameters = executionStrategyParameters;
     }
 
@@ -32,7 +32,7 @@ public class InstrumentationDeferredFieldParameters extends InstrumentationField
     @Override
     public InstrumentationDeferredFieldParameters withNewState(InstrumentationState instrumentationState) {
         return new InstrumentationDeferredFieldParameters(
-                this.getExecutionContext(), this.executionStrategyParameters, this.getField(), this.getExecutionInfo(), instrumentationState);
+                this.getExecutionContext(), this.executionStrategyParameters, this.getField(), this.getExecutionStepInfo(), instrumentationState);
     }
 
     public ExecutionStrategyParameters getExecutionStrategyParameters() {

--- a/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationFieldCompleteParameters.java
+++ b/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationFieldCompleteParameters.java
@@ -1,7 +1,7 @@
 package graphql.execution.instrumentation.parameters;
 
 import graphql.execution.ExecutionContext;
-import graphql.execution.ExecutionInfo;
+import graphql.execution.ExecutionStepInfo;
 import graphql.execution.ExecutionStrategyParameters;
 import graphql.execution.instrumentation.InstrumentationState;
 import graphql.schema.GraphQLFieldDefinition;
@@ -12,16 +12,16 @@ import graphql.schema.GraphQLFieldDefinition;
 public class InstrumentationFieldCompleteParameters {
     private final ExecutionContext executionContext;
     private final GraphQLFieldDefinition fieldDef;
-    private final ExecutionInfo typeInfo;
+    private final ExecutionStepInfo typeInfo;
     private final Object fetchedValue;
     private final InstrumentationState instrumentationState;
     private final ExecutionStrategyParameters executionStrategyParameters;
 
-    public InstrumentationFieldCompleteParameters(ExecutionContext executionContext, ExecutionStrategyParameters executionStrategyParameters, GraphQLFieldDefinition fieldDef, ExecutionInfo typeInfo, Object fetchedValue) {
+    public InstrumentationFieldCompleteParameters(ExecutionContext executionContext, ExecutionStrategyParameters executionStrategyParameters, GraphQLFieldDefinition fieldDef, ExecutionStepInfo typeInfo, Object fetchedValue) {
         this(executionContext, executionStrategyParameters, fieldDef, typeInfo, fetchedValue, executionContext.getInstrumentationState());
     }
 
-    InstrumentationFieldCompleteParameters(ExecutionContext executionContext, ExecutionStrategyParameters executionStrategyParameters, GraphQLFieldDefinition fieldDef, ExecutionInfo typeInfo, Object fetchedValue, InstrumentationState instrumentationState) {
+    InstrumentationFieldCompleteParameters(ExecutionContext executionContext, ExecutionStrategyParameters executionStrategyParameters, GraphQLFieldDefinition fieldDef, ExecutionStepInfo typeInfo, Object fetchedValue, InstrumentationState instrumentationState) {
         this.executionContext = executionContext;
         this.executionStrategyParameters = executionStrategyParameters;
         this.fieldDef = fieldDef;
@@ -55,7 +55,7 @@ public class InstrumentationFieldCompleteParameters {
         return fieldDef;
     }
 
-    public ExecutionInfo getTypeInfo() {
+    public ExecutionStepInfo getTypeInfo() {
         return typeInfo;
     }
 

--- a/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationFieldFetchParameters.java
+++ b/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationFieldFetchParameters.java
@@ -15,13 +15,13 @@ public class InstrumentationFieldFetchParameters extends InstrumentationFieldPar
     private final ExecutionStrategyParameters executionStrategyParameters;
 
     public InstrumentationFieldFetchParameters(ExecutionContext getExecutionContext, GraphQLFieldDefinition fieldDef, DataFetchingEnvironment environment, ExecutionStrategyParameters executionStrategyParameters) {
-        super(getExecutionContext, fieldDef, environment.getExecutionInfo());
+        super(getExecutionContext, fieldDef, environment.getExecutionStepInfo());
         this.environment = environment;
         this.executionStrategyParameters = executionStrategyParameters;
     }
 
     private InstrumentationFieldFetchParameters(ExecutionContext getExecutionContext, GraphQLFieldDefinition fieldDef, DataFetchingEnvironment environment, InstrumentationState instrumentationState, ExecutionStrategyParameters executionStrategyParameters) {
-        super(getExecutionContext, fieldDef, environment.getExecutionInfo(), instrumentationState);
+        super(getExecutionContext, fieldDef, environment.getExecutionStepInfo(), instrumentationState);
         this.environment = environment;
         this.executionStrategyParameters = executionStrategyParameters;
     }

--- a/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationFieldParameters.java
+++ b/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationFieldParameters.java
@@ -1,7 +1,7 @@
 package graphql.execution.instrumentation.parameters;
 
 import graphql.execution.ExecutionContext;
-import graphql.execution.ExecutionInfo;
+import graphql.execution.ExecutionStepInfo;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationState;
 import graphql.schema.GraphQLFieldDefinition;
@@ -12,17 +12,17 @@ import graphql.schema.GraphQLFieldDefinition;
 public class InstrumentationFieldParameters {
     private final ExecutionContext executionContext;
     private final graphql.schema.GraphQLFieldDefinition fieldDef;
-    private final ExecutionInfo executionInfo;
+    private final ExecutionStepInfo executionStepInfo;
     private final InstrumentationState instrumentationState;
 
-    public InstrumentationFieldParameters(ExecutionContext executionContext, GraphQLFieldDefinition fieldDef, ExecutionInfo executionInfo) {
-        this(executionContext, fieldDef, executionInfo, executionContext.getInstrumentationState());
+    public InstrumentationFieldParameters(ExecutionContext executionContext, GraphQLFieldDefinition fieldDef, ExecutionStepInfo executionStepInfo) {
+        this(executionContext, fieldDef, executionStepInfo, executionContext.getInstrumentationState());
     }
 
-    InstrumentationFieldParameters(ExecutionContext executionContext, GraphQLFieldDefinition fieldDef, ExecutionInfo executionInfo, InstrumentationState instrumentationState) {
+    InstrumentationFieldParameters(ExecutionContext executionContext, GraphQLFieldDefinition fieldDef, ExecutionStepInfo executionStepInfo, InstrumentationState instrumentationState) {
         this.executionContext = executionContext;
         this.fieldDef = fieldDef;
-        this.executionInfo = executionInfo;
+        this.executionStepInfo = executionStepInfo;
         this.instrumentationState = instrumentationState;
     }
 
@@ -35,7 +35,7 @@ public class InstrumentationFieldParameters {
      */
     public InstrumentationFieldParameters withNewState(InstrumentationState instrumentationState) {
         return new InstrumentationFieldParameters(
-                this.executionContext, this.fieldDef, this.executionInfo, instrumentationState);
+                this.executionContext, this.fieldDef, this.executionStepInfo, instrumentationState);
     }
 
 
@@ -47,8 +47,8 @@ public class InstrumentationFieldParameters {
         return fieldDef;
     }
 
-    public ExecutionInfo getExecutionInfo() {
-        return executionInfo;
+    public ExecutionStepInfo getExecutionStepInfo() {
+        return executionStepInfo;
     }
 
     @SuppressWarnings("TypeParameterUnusedInFormals")

--- a/src/main/java/graphql/execution/instrumentation/tracing/TracingSupport.java
+++ b/src/main/java/graphql/execution/instrumentation/tracing/TracingSupport.java
@@ -1,7 +1,7 @@
 package graphql.execution.instrumentation.tracing;
 
 import graphql.PublicApi;
-import graphql.execution.ExecutionInfo;
+import graphql.execution.ExecutionStepInfo;
 import graphql.execution.instrumentation.InstrumentationState;
 import graphql.schema.DataFetchingEnvironment;
 
@@ -62,13 +62,13 @@ public class TracingSupport implements InstrumentationState {
             long now = System.nanoTime();
             long duration = now - startFieldFetch;
             long startOffset = startFieldFetch - startRequestNanos;
-            ExecutionInfo executionInfo = dataFetchingEnvironment.getExecutionInfo();
+            ExecutionStepInfo executionStepInfo = dataFetchingEnvironment.getExecutionStepInfo();
 
             Map<String, Object> fetchMap = new LinkedHashMap<>();
-            fetchMap.put("path", executionInfo.getPath().toList());
-            fetchMap.put("parentType", executionInfo.getParent().getType().getName());
-            fetchMap.put("returnType", executionInfo.toAst());
-            fetchMap.put("fieldName", executionInfo.getFieldDefinition().getName());
+            fetchMap.put("path", executionStepInfo.getPath().toList());
+            fetchMap.put("parentType", executionStepInfo.getParent().getType().getName());
+            fetchMap.put("returnType", executionStepInfo.toAst());
+            fetchMap.put("fieldName", executionStepInfo.getFieldDefinition().getName());
             fetchMap.put("startOffset", startOffset);
             fetchMap.put("duration", duration);
 

--- a/src/main/java/graphql/schema/DataFetchingEnvironment.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironment.java
@@ -3,7 +3,7 @@ package graphql.schema;
 import graphql.PublicApi;
 import graphql.execution.ExecutionContext;
 import graphql.execution.ExecutionId;
-import graphql.execution.ExecutionInfo;
+import graphql.execution.ExecutionStepInfo;
 import graphql.language.Field;
 import graphql.language.FragmentDefinition;
 import org.dataloader.DataLoader;
@@ -123,9 +123,9 @@ public interface DataFetchingEnvironment {
 
 
     /**
-     * @return the field {@link graphql.execution.ExecutionInfo} for the current data fetch operation
+     * @return the field {@link ExecutionStepInfo} for the current data fetch operation
      */
-    ExecutionInfo getExecutionInfo();
+    ExecutionStepInfo getExecutionStepInfo();
 
     /**
      * @return the type of the parent of the current field

--- a/src/main/java/graphql/schema/DataFetchingEnvironmentBuilder.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironmentBuilder.java
@@ -3,7 +3,7 @@ package graphql.schema;
 import graphql.PublicApi;
 import graphql.execution.ExecutionContext;
 import graphql.execution.ExecutionId;
-import graphql.execution.ExecutionInfo;
+import graphql.execution.ExecutionStepInfo;
 import graphql.language.Field;
 import graphql.language.FragmentDefinition;
 
@@ -33,7 +33,7 @@ public class DataFetchingEnvironmentBuilder {
                 .root(environment.getRoot())
                 .fields(environment.getFields())
                 .fieldType(environment.getFieldType())
-                .executionInfo(environment.getExecutionInfo())
+                .executionStepInfo(environment.getExecutionStepInfo())
                 .parentType(environment.getParentType())
                 .graphQLSchema(environment.getGraphQLSchema())
                 .fragmentsByName(environment.getFragmentsByName())
@@ -67,7 +67,7 @@ public class DataFetchingEnvironmentBuilder {
     private Map<String, FragmentDefinition> fragmentsByName = Collections.emptyMap();
     private ExecutionId executionId;
     private DataFetchingFieldSelectionSet selectionSet;
-    private ExecutionInfo executionInfo;
+    private ExecutionStepInfo executionStepInfo;
     private ExecutionContext executionContext;
 
     public DataFetchingEnvironmentBuilder source(Object source) {
@@ -130,8 +130,8 @@ public class DataFetchingEnvironmentBuilder {
         return this;
     }
 
-    public DataFetchingEnvironmentBuilder executionInfo(ExecutionInfo executionInfo) {
-        this.executionInfo = executionInfo;
+    public DataFetchingEnvironmentBuilder executionStepInfo(ExecutionStepInfo executionStepInfo) {
+        this.executionStepInfo = executionStepInfo;
         return this;
     }
 
@@ -143,7 +143,7 @@ public class DataFetchingEnvironmentBuilder {
     public DataFetchingEnvironment build() {
         return new DataFetchingEnvironmentImpl(source, arguments, context, root,
                 fieldDefinition, fields, fieldType, parentType, graphQLSchema, fragmentsByName, executionId, selectionSet,
-                executionInfo,
+                executionStepInfo,
                 executionContext);
     }
 }

--- a/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
@@ -4,7 +4,7 @@ package graphql.schema;
 import graphql.Internal;
 import graphql.execution.ExecutionContext;
 import graphql.execution.ExecutionId;
-import graphql.execution.ExecutionInfo;
+import graphql.execution.ExecutionStepInfo;
 import graphql.language.Field;
 import graphql.language.FragmentDefinition;
 import org.dataloader.DataLoader;
@@ -31,7 +31,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
     private final Map<String, FragmentDefinition> fragmentsByName;
     private final ExecutionId executionId;
     private final DataFetchingFieldSelectionSet selectionSet;
-    private final ExecutionInfo executionInfo;
+    private final ExecutionStepInfo executionStepInfo;
     private ExecutionContext executionContext;
 
     public DataFetchingEnvironmentImpl(Object source,
@@ -46,7 +46,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
                                        Map<String, FragmentDefinition> fragmentsByName,
                                        ExecutionId executionId,
                                        DataFetchingFieldSelectionSet selectionSet,
-                                       ExecutionInfo executionInfo,
+                                       ExecutionStepInfo executionStepInfo,
                                        ExecutionContext executionContext) {
         this.source = source;
         this.arguments = arguments == null ? Collections.emptyMap() : arguments;
@@ -60,7 +60,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
         this.graphQLSchema = graphQLSchema;
         this.executionId = executionId;
         this.selectionSet = selectionSet;
-        this.executionInfo = executionInfo;
+        this.executionStepInfo = executionStepInfo;
         this.executionContext = assertNotNull(executionContext);
     }
 
@@ -140,8 +140,8 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
     }
 
     @Override
-    public ExecutionInfo getExecutionInfo() {
-        return executionInfo;
+    public ExecutionStepInfo getExecutionStepInfo() {
+        return executionStepInfo;
     }
 
     @Override
@@ -157,7 +157,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
     @Override
     public String toString() {
         return "DataFetchingEnvironmentImpl{" +
-                "executionInfo=" + executionInfo +
+                "executionStepInfo=" + executionStepInfo +
                 '}';
     }
 }

--- a/src/main/java/graphql/schema/DataFetchingFieldSelectionSetImpl.java
+++ b/src/main/java/graphql/schema/DataFetchingFieldSelectionSetImpl.java
@@ -2,7 +2,7 @@ package graphql.schema;
 
 import graphql.Internal;
 import graphql.execution.ExecutionContext;
-import graphql.execution.ExecutionInfo;
+import graphql.execution.ExecutionStepInfo;
 import graphql.execution.FieldCollector;
 import graphql.execution.FieldCollectorParameters;
 import graphql.execution.ValuesResolver;
@@ -66,7 +66,7 @@ public class DataFetchingFieldSelectionSetImpl implements DataFetchingFieldSelec
     };
 
     public static DataFetchingFieldSelectionSet newCollector(ExecutionContext executionContext, GraphQLType fieldType, List<Field> fields) {
-        GraphQLType unwrappedType = ExecutionInfo.unwrapBaseType(fieldType);
+        GraphQLType unwrappedType = ExecutionStepInfo.unwrapBaseType(fieldType);
         if (unwrappedType instanceof GraphQLFieldsContainer) {
             return new DataFetchingFieldSelectionSetImpl(executionContext, (GraphQLFieldsContainer) unwrappedType, fields);
         } else {
@@ -192,7 +192,7 @@ public class DataFetchingFieldSelectionSetImpl implements DataFetchingFieldSelec
             this.name = parentFields.get(0).getName();
             this.fieldDefinition = fieldDefinition;
             this.arguments = arguments;
-            GraphQLType unwrappedType = ExecutionInfo.unwrapBaseType(fieldDefinition.getType());
+            GraphQLType unwrappedType = ExecutionStepInfo.unwrapBaseType(fieldDefinition.getType());
             if (unwrappedType instanceof GraphQLFieldsContainer) {
                 this.selectionSet = new DataFetchingFieldSelectionSetImpl(parentFields, (GraphQLFieldsContainer) unwrappedType, graphQLSchema, variables, fragmentsByName);
             } else {
@@ -267,7 +267,7 @@ public class DataFetchingFieldSelectionSetImpl implements DataFetchingFieldSelec
 
             Field field = collectedFieldList.get(0);
             GraphQLFieldDefinition fieldDef = Introspection.getFieldDef(graphQLSchema, parentFieldType, field.getName());
-            GraphQLType unwrappedType = ExecutionInfo.unwrapBaseType(fieldDef.getType());
+            GraphQLType unwrappedType = ExecutionStepInfo.unwrapBaseType(fieldDef.getType());
             Map<String, Object> argumentValues = valuesResolver.getArgumentValues(fieldDef.getArguments(), field.getArguments(), variables);
 
             selectionSetFieldArgs.put(fieldName, argumentValues);

--- a/src/test/groovy/example/http/ExecutionResultJSONTesting.java
+++ b/src/test/groovy/example/http/ExecutionResultJSONTesting.java
@@ -1,21 +1,16 @@
 package example.http;
 
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-
 import graphql.ExceptionWhileDataFetching;
 import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.GraphQLError;
 import graphql.InvalidSyntaxError;
 import graphql.SerializationError;
-import graphql.execution.ExecutionInfo;
 import graphql.execution.ExecutionPath;
+import graphql.execution.ExecutionStepInfo;
 import graphql.execution.MissingRootTypeException;
 import graphql.execution.NonNullableFieldWasNullError;
 import graphql.execution.NonNullableFieldWasNullException;
@@ -24,6 +19,11 @@ import graphql.language.SourceLocation;
 import graphql.schema.CoercingSerializeException;
 import graphql.validation.ValidationError;
 import graphql.validation.ValidationErrorType;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.toList;
@@ -92,8 +92,8 @@ public class ExecutionResultJSONTesting {
         return ExecutionPath.rootPath().segment("heroes").segment(0).segment("abilities").segment("speed").segment(4);
     }
 
-    private ExecutionInfo mkExecutionInfo() {
-        return ExecutionInfo.newExecutionInfo()
+    private ExecutionStepInfo mkExecutionInfo() {
+        return ExecutionStepInfo.newExecutionStepInfo()
                 .type(Introspection.__Schema)
                 .path(mkPath())
                 .build();

--- a/src/test/groovy/graphql/GraphQLErrorTest.groovy
+++ b/src/test/groovy/graphql/GraphQLErrorTest.groovy
@@ -1,7 +1,7 @@
 package graphql
 
 import graphql.execution.ExecutionPath
-import graphql.execution.ExecutionInfo
+import graphql.execution.ExecutionStepInfo
 import graphql.execution.MissingRootTypeException
 import graphql.execution.NonNullableFieldWasNullError
 import graphql.execution.NonNullableFieldWasNullException
@@ -116,8 +116,8 @@ class GraphQLErrorTest extends Specification {
                 .segment(4)
     }
 
-    ExecutionInfo mkTypeInfo() {
-        return ExecutionInfo.newExecutionInfo()
+    ExecutionStepInfo mkTypeInfo() {
+        return ExecutionStepInfo.newExecutionStepInfo()
                 .type(Introspection.__Schema)
                 .path(mkPath())
                 .build()

--- a/src/test/groovy/graphql/TypeResolverExecutionTest.groovy
+++ b/src/test/groovy/graphql/TypeResolverExecutionTest.groovy
@@ -13,7 +13,7 @@ import graphql.schema.idl.WiringFactory
 import spock.lang.Specification
 
 import static graphql.Assert.assertShouldNeverHappen
-import static graphql.execution.ExecutionInfo.unwrapBaseType
+import static graphql.execution.ExecutionStepInfo.unwrapBaseType
 
 class TypeResolverExecutionTest extends Specification {
 

--- a/src/test/groovy/graphql/execution/AbsoluteGraphQLErrorTest.groovy
+++ b/src/test/groovy/graphql/execution/AbsoluteGraphQLErrorTest.groovy
@@ -27,7 +27,7 @@ class AbsoluteGraphQLErrorTest extends Specification {
         def field = Field.newField().name("test").sourceLocation(new SourceLocation(4, 5)).build()
 
         def parameters = newParameters()
-                .executionInfo(ExecutionInfo.newExecutionInfo().type(objectType))
+                .executionStepInfo(ExecutionStepInfo.newExecutionStepInfo().type(objectType))
                 .source(new Object())
                 .fields(["fld": [Field.newField().build()]])
                 .field([field])
@@ -62,7 +62,7 @@ class AbsoluteGraphQLErrorTest extends Specification {
         def field = Field.newField().name("test").sourceLocation(new SourceLocation(4, 5)).build()
 
         def parameters = newParameters()
-                .executionInfo(ExecutionInfo.newExecutionInfo().type(objectType))
+                .executionStepInfo(ExecutionStepInfo.newExecutionStepInfo().type(objectType))
                 .source(new Object())
                 .fields(["fld": [Field.newField().build()]])
                 .field([field])
@@ -86,7 +86,7 @@ class AbsoluteGraphQLErrorTest extends Specification {
         def field = Field.newField().name("test").sourceLocation(new SourceLocation(4, 5)).build()
 
         def parameters = newParameters()
-                .executionInfo(ExecutionInfo.newExecutionInfo().type(objectType))
+                .executionStepInfo(ExecutionStepInfo.newExecutionStepInfo().type(objectType))
                 .source(new Object())
                 .fields(["fld": [Field.newField().build()]])
                 .field([field])
@@ -111,7 +111,7 @@ class AbsoluteGraphQLErrorTest extends Specification {
         def field = Field.newField().name("test").build()
 
         def parameters = newParameters()
-                .executionInfo(ExecutionInfo.newExecutionInfo().type(objectType))
+                .executionStepInfo(ExecutionStepInfo.newExecutionStepInfo().type(objectType))
                 .source(new Object())
                 .fields(["fld": [Field.newField().build()]])
                 .field([field])
@@ -136,7 +136,7 @@ class AbsoluteGraphQLErrorTest extends Specification {
         def field = Field.newField().name("test").sourceLocation(expectedSourceLocation).build()
 
         def parameters = newParameters()
-                .executionInfo(ExecutionInfo.newExecutionInfo().type(objectType))
+                .executionStepInfo(ExecutionStepInfo.newExecutionStepInfo().type(objectType))
                 .source(new Object())
                 .fields(["fld": [Field.newField().build()]])
                 .field([field])
@@ -160,7 +160,7 @@ class AbsoluteGraphQLErrorTest extends Specification {
         def field = Field.newField().name("test").sourceLocation(new SourceLocation(4, 5)).build()
 
         def parameters = newParameters()
-                .executionInfo(ExecutionInfo.newExecutionInfo().type(objectType))
+                .executionStepInfo(ExecutionStepInfo.newExecutionStepInfo().type(objectType))
                 .source(new Object())
                 .fields(["fld": [Field.newField().build()]])
                 .field([field])

--- a/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy
@@ -70,7 +70,7 @@ class AsyncExecutionStrategyTest extends Specification {
         def document = new Parser().parseDocument(query)
         def operation = document.definitions[0] as OperationDefinition
 
-        def typeInfo = ExecutionInfo.newExecutionInfo()
+        def typeInfo = ExecutionStepInfo.newExecutionStepInfo()
                 .type(schema.getQueryType())
                 .build()
 
@@ -82,7 +82,7 @@ class AsyncExecutionStrategyTest extends Specification {
                 .build()
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
-                .executionInfo(typeInfo)
+                .executionStepInfo(typeInfo)
                 .fields(['hello': [Field.newField('hello').build()], 'hello2': [Field.newField('hello2').build()]])
                 .build()
 
@@ -108,7 +108,7 @@ class AsyncExecutionStrategyTest extends Specification {
         def document = new Parser().parseDocument(query)
         def operation = document.definitions[0] as OperationDefinition
 
-        def typeInfo = ExecutionInfo.newExecutionInfo()
+        def typeInfo = ExecutionStepInfo.newExecutionStepInfo()
                 .type(schema.getQueryType())
                 .build()
 
@@ -120,7 +120,7 @@ class AsyncExecutionStrategyTest extends Specification {
                 .build()
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
-                .executionInfo(typeInfo)
+                .executionStepInfo(typeInfo)
                 .fields(['hello': [Field.newField('hello').build()], 'hello2': [Field.newField('hello2').build()]])
                 .build()
 
@@ -148,7 +148,7 @@ class AsyncExecutionStrategyTest extends Specification {
         def document = new Parser().parseDocument(query)
         def operation = document.definitions[0] as OperationDefinition
 
-        def typeInfo = ExecutionInfo.newExecutionInfo()
+        def typeInfo = ExecutionStepInfo.newExecutionStepInfo()
                 .type(schema.getQueryType())
                 .build()
 
@@ -160,7 +160,7 @@ class AsyncExecutionStrategyTest extends Specification {
                 .build()
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
-                .executionInfo(typeInfo)
+                .executionStepInfo(typeInfo)
                 .fields(['hello': [Field.newField('hello').build()], 'hello2': [Field.newField('hello2').build()]])
                 .build()
 
@@ -187,7 +187,7 @@ class AsyncExecutionStrategyTest extends Specification {
         def document = new Parser().parseDocument(query)
         def operation = document.definitions[0] as OperationDefinition
 
-        def typeInfo = ExecutionInfo.newExecutionInfo()
+        def typeInfo = ExecutionStepInfo.newExecutionStepInfo()
                 .type(schema.getQueryType())
                 .build()
 
@@ -199,7 +199,7 @@ class AsyncExecutionStrategyTest extends Specification {
                 .build()
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
-                .executionInfo(typeInfo)
+                .executionStepInfo(typeInfo)
                 .fields(['hello': [Field.newField('hello').build()], 'hello2': [Field.newField('hello2').build()]])
                 .build()
 
@@ -225,7 +225,7 @@ class AsyncExecutionStrategyTest extends Specification {
         def document = new Parser().parseDocument(query)
         def operation = document.definitions[0] as OperationDefinition
 
-        def typeInfo = ExecutionInfo.newExecutionInfo()
+        def typeInfo = ExecutionStepInfo.newExecutionStepInfo()
                 .type(schema.getQueryType())
                 .build()
 
@@ -258,7 +258,7 @@ class AsyncExecutionStrategyTest extends Specification {
                 .build()
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
-                .executionInfo(typeInfo)
+                .executionStepInfo(typeInfo)
                 .fields(['hello': [new Field('hello')], 'hello2': [new Field('hello2')]])
                 .build()
 

--- a/src/test/groovy/graphql/execution/AsyncSerialExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/AsyncSerialExecutionStrategyTest.groovy
@@ -73,7 +73,7 @@ class AsyncSerialExecutionStrategyTest extends Specification {
         def document = new Parser().parseDocument(query)
         def operation = document.definitions[0] as OperationDefinition
 
-        def typeInfo = ExecutionInfo.newExecutionInfo()
+        def typeInfo = ExecutionStepInfo.newExecutionStepInfo()
                 .type(schema.getQueryType())
                 .build()
 
@@ -85,7 +85,7 @@ class AsyncSerialExecutionStrategyTest extends Specification {
                 .build()
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
-                .executionInfo(typeInfo)
+                .executionStepInfo(typeInfo)
                 .fields(['hello': [new Field('hello')], 'hello2': [new Field('hello2')], 'hello3': [new Field('hello3')]])
                 .build()
 
@@ -116,7 +116,7 @@ class AsyncSerialExecutionStrategyTest extends Specification {
         def document = new Parser().parseDocument(query)
         def operation = document.definitions[0] as OperationDefinition
 
-        def typeInfo = ExecutionInfo.newExecutionInfo()
+        def typeInfo = ExecutionStepInfo.newExecutionStepInfo()
                 .type(schema.getQueryType())
                 .build()
 
@@ -128,7 +128,7 @@ class AsyncSerialExecutionStrategyTest extends Specification {
                 .build()
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
-                .executionInfo(typeInfo)
+                .executionStepInfo(typeInfo)
                 .fields(['hello': [new Field('hello')], 'hello2': [new Field('hello2')], 'hello3': [new Field('hello3')]])
                 .build()
 

--- a/src/test/groovy/graphql/execution/ExecutionStepInfoTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStepInfoTest.groovy
@@ -14,7 +14,7 @@ import spock.lang.Specification
 
 import java.util.function.Function
 
-import static ExecutionInfo.newExecutionInfo
+import static ExecutionStepInfo.newExecutionStepInfo
 import static graphql.Scalars.GraphQLString
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
 import static graphql.schema.GraphQLList.list
@@ -23,7 +23,7 @@ import static graphql.schema.GraphQLTypeUtil.unwrapAll
 import static graphql.schema.idl.RuntimeWiring.newRuntimeWiring
 import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring
 
-class ExecutionInfoTest extends Specification {
+class ExecutionStepInfoTest extends Specification {
 
     def field = new Field("someAstField")
 
@@ -47,10 +47,10 @@ class ExecutionInfoTest extends Specification {
 
     def "basic hierarchy"() {
         given:
-        def rootTypeInfo = newExecutionInfo().type(rootType).build()
-        def fieldTypeInfo = newExecutionInfo().type(fieldType).fieldDefinition(field1Def).field(field).parentInfo(rootTypeInfo).build()
-        def nonNullFieldTypeInfo = newExecutionInfo().type(nonNull(fieldType)).parentInfo(rootTypeInfo).build()
-        def listTypeInfo = newExecutionInfo().type(list(fieldType)).parentInfo(rootTypeInfo).build()
+        def rootTypeInfo = newExecutionStepInfo().type(rootType).build()
+        def fieldTypeInfo = newExecutionStepInfo().type(fieldType).fieldDefinition(field1Def).field(field).parentInfo(rootTypeInfo).build()
+        def nonNullFieldTypeInfo = newExecutionStepInfo().type(nonNull(fieldType)).parentInfo(rootTypeInfo).build()
+        def listTypeInfo = newExecutionStepInfo().type(list(fieldType)).parentInfo(rootTypeInfo).build()
 
         expect:
         rootTypeInfo.type == rootType
@@ -78,8 +78,8 @@ class ExecutionInfoTest extends Specification {
 
     def "morphing type works"() {
         given:
-        def rootTypeInfo = newExecutionInfo().type(rootType).build()
-        def interfaceTypeInfo = newExecutionInfo().type(interfaceType).parentInfo(rootTypeInfo).build()
+        def rootTypeInfo = newExecutionStepInfo().type(rootType).build()
+        def interfaceTypeInfo = newExecutionStepInfo().type(interfaceType).parentInfo(rootTypeInfo).build()
         def morphedTypeInfo = interfaceTypeInfo.treatAs(fieldType)
 
         expect:
@@ -93,7 +93,7 @@ class ExecutionInfoTest extends Specification {
         given:
         // [[String!]!]
         GraphQLType wrappedType = list(nonNull(list(nonNull(GraphQLString))))
-        def stack = ExecutionInfo.unwrapType(wrappedType)
+        def stack = ExecutionStepInfo.unwrapType(wrappedType)
 
         expect:
         stack.pop() == GraphQLString
@@ -104,18 +104,18 @@ class ExecutionInfoTest extends Specification {
         stack.isEmpty()
     }
 
-    List<ExecutionInfo> executionTypeInfos = []
+    List<ExecutionStepInfo> executionTypeInfos = []
 
-    class ExecutionInfoCapturingDF implements DataFetcher {
+    class ExecutionStepInfoCapturingDF implements DataFetcher {
         Function function
 
-        ExecutionInfoCapturingDF(function) {
+        ExecutionStepInfoCapturingDF(function) {
             this.function = function
         }
 
         @Override
         Object get(DataFetchingEnvironment environment) {
-            executionTypeInfos.add(environment.getExecutionInfo())
+            executionTypeInfos.add(environment.getExecutionStepInfo())
             def val = function.apply(environment)
             return val
         }
@@ -151,8 +151,8 @@ class ExecutionInfoTest extends Specification {
         def frodo = new User("frodo", [bilbo, gandalf])
         def samwise = new User("samwise", [bilbo, gandalf, frodo])
 
-        DataFetcher samwiseDF = new ExecutionInfoCapturingDF({ env -> env.getSource() })
-        DataFetcher friendsDF = new ExecutionInfoCapturingDF({ env -> (env.getSource() as User).friends })
+        DataFetcher samwiseDF = new ExecutionStepInfoCapturingDF({ env -> env.getSource() })
+        DataFetcher friendsDF = new ExecutionStepInfoCapturingDF({ env -> (env.getSource() as User).friends })
 
         def runtimeWiring = newRuntimeWiring()
                 .type(newTypeWiring("Query").dataFetcher("hero", samwiseDF))

--- a/src/test/groovy/graphql/execution/ExecutionStrategyParametersTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategyParametersTest.groovy
@@ -2,7 +2,7 @@ package graphql.execution
 
 import spock.lang.Specification
 
-import static ExecutionInfo.newExecutionInfo
+import static ExecutionStepInfo.newExecutionStepInfo
 import static graphql.Scalars.GraphQLString
 import static graphql.execution.ExecutionStrategyParameters.newParameters
 
@@ -11,7 +11,7 @@ class ExecutionStrategyParametersTest extends Specification {
     def "ExecutionParameters can be transformed"() {
         given:
         def parameters = newParameters()
-                .executionInfo(newExecutionInfo().type(GraphQLString))
+                .executionStepInfo(newExecutionStepInfo().type(GraphQLString))
                 .source(new Object())
                 .fields("a": [])
                 .build()
@@ -20,7 +20,7 @@ class ExecutionStrategyParametersTest extends Specification {
         def newParameters = parameters.transform { it -> it.source(123) }
 
         then:
-        newParameters.getExecutionInfo() == parameters.getExecutionInfo()
+        newParameters.getExecutionStepInfo() == parameters.getExecutionStepInfo()
         newParameters.getFields() == parameters.getFields()
 
         newParameters.getSource() != parameters.getSource()

--- a/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
@@ -95,7 +95,7 @@ class ExecutionStrategyTest extends Specification {
         def executionContext = builder.build()
         def result = new Object()
         def parameters = newParameters()
-                .executionInfo(ExecutionInfo.newExecutionInfo().type(objectType))
+                .executionStepInfo(ExecutionStepInfo.newExecutionStepInfo().type(objectType))
                 .source(result)
                 .fields(["fld": [Field.newField().build()]])
                 .field([Field.newField().build()])
@@ -116,13 +116,13 @@ class ExecutionStrategyTest extends Specification {
         ExecutionContext executionContext = buildContext()
         def fieldType = list(GraphQLString)
         def fldDef = newFieldDefinition().name("test").type(fieldType).build()
-        def typeInfo = ExecutionInfo.newExecutionInfo().type(fieldType).fieldDefinition(fldDef).build()
+        def typeInfo = ExecutionStepInfo.newExecutionStepInfo().type(fieldType).fieldDefinition(fldDef).build()
         NonNullableFieldValidator nullableFieldValidator = new NonNullableFieldValidator(executionContext, typeInfo)
 
 
         def result = ["test", "1", "2", "3"]
         def parameters = newParameters()
-                .executionInfo(typeInfo)
+                .executionStepInfo(typeInfo)
                 .source(result)
                 .nonNullFieldValidator(nullableFieldValidator)
                 .fields(["fld": []])
@@ -140,10 +140,10 @@ class ExecutionStrategyTest extends Specification {
         ExecutionContext executionContext = buildContext()
         def fieldType = GraphQLString
         def fldDef = newFieldDefinition().name("test").type(fieldType).build()
-        def typeInfo = ExecutionInfo.newExecutionInfo().type(fieldType).fieldDefinition(fldDef).build()
+        def typeInfo = ExecutionStepInfo.newExecutionStepInfo().type(fieldType).fieldDefinition(fldDef).build()
         NonNullableFieldValidator nullableFieldValidator = new NonNullableFieldValidator(executionContext, typeInfo)
         def parameters = newParameters()
-                .executionInfo(typeInfo)
+                .executionStepInfo(typeInfo)
                 .nonNullFieldValidator(nullableFieldValidator)
                 .source(result)
                 .fields(["fld": []])
@@ -166,10 +166,10 @@ class ExecutionStrategyTest extends Specification {
         ExecutionContext executionContext = buildContext()
         def fieldType = nonNull(GraphQLString)
         def fldDef = newFieldDefinition().name("test").type(fieldType).build()
-        def typeInfo = ExecutionInfo.newExecutionInfo().type(fieldType).fieldDefinition(fldDef).build()
+        def typeInfo = ExecutionStepInfo.newExecutionStepInfo().type(fieldType).fieldDefinition(fldDef).build()
         NonNullableFieldValidator nullableFieldValidator = new NonNullableFieldValidator(executionContext, typeInfo)
         def parameters = newParameters()
-                .executionInfo(typeInfo)
+                .executionStepInfo(typeInfo)
                 .nonNullFieldValidator(nullableFieldValidator)
                 .source(Optional.ofNullable(null))
                 .fields(["fld": []])
@@ -188,10 +188,10 @@ class ExecutionStrategyTest extends Specification {
         ExecutionContext executionContext = buildContext()
         def fieldType = GraphQLString
         def fldDef = newFieldDefinition().name("test").type(fieldType).build()
-        def typeInfo = ExecutionInfo.newExecutionInfo().type(fieldType).fieldDefinition(fldDef).build()
+        def typeInfo = ExecutionStepInfo.newExecutionStepInfo().type(fieldType).fieldDefinition(fldDef).build()
         NonNullableFieldValidator nullableFieldValidator = new NonNullableFieldValidator(executionContext, typeInfo)
         def parameters = newParameters()
-                .executionInfo(typeInfo)
+                .executionStepInfo(typeInfo)
                 .nonNullFieldValidator(nullableFieldValidator)
                 .source(result)
                 .fields(["fld": []])
@@ -214,10 +214,10 @@ class ExecutionStrategyTest extends Specification {
         ExecutionContext executionContext = buildContext()
         def fieldType = nonNull(GraphQLString)
         def fldDef = newFieldDefinition().name("test").type(fieldType).build()
-        def typeInfo = ExecutionInfo.newExecutionInfo().type(fieldType).fieldDefinition(fldDef).build()
+        def typeInfo = ExecutionStepInfo.newExecutionStepInfo().type(fieldType).fieldDefinition(fldDef).build()
         NonNullableFieldValidator nullableFieldValidator = new NonNullableFieldValidator(executionContext, typeInfo)
         def parameters = newParameters()
-                .executionInfo(typeInfo)
+                .executionStepInfo(typeInfo)
                 .nonNullFieldValidator(nullableFieldValidator)
                 .source(OptionalInt.empty())
                 .fields(["fld": []])
@@ -236,10 +236,10 @@ class ExecutionStrategyTest extends Specification {
         ExecutionContext executionContext = buildContext()
         def fieldType = GraphQLString
         def fldDef = newFieldDefinition().name("test").type(fieldType).build()
-        def typeInfo = ExecutionInfo.newExecutionInfo().type(fieldType).fieldDefinition(fldDef).build()
+        def typeInfo = ExecutionStepInfo.newExecutionStepInfo().type(fieldType).fieldDefinition(fldDef).build()
         NonNullableFieldValidator nullableFieldValidator = new NonNullableFieldValidator(executionContext, typeInfo)
         def parameters = newParameters()
-                .executionInfo(typeInfo)
+                .executionStepInfo(typeInfo)
                 .nonNullFieldValidator(nullableFieldValidator)
                 .source(result)
                 .fields(["fld": []])
@@ -262,10 +262,10 @@ class ExecutionStrategyTest extends Specification {
         ExecutionContext executionContext = buildContext()
         def fieldType = nonNull(GraphQLString)
         def fldDef = newFieldDefinition().name("test").type(fieldType).build()
-        def typeInfo = ExecutionInfo.newExecutionInfo().type(fieldType).fieldDefinition(fldDef).build()
+        def typeInfo = ExecutionStepInfo.newExecutionStepInfo().type(fieldType).fieldDefinition(fldDef).build()
         NonNullableFieldValidator nullableFieldValidator = new NonNullableFieldValidator(executionContext, typeInfo)
         def parameters = newParameters()
-                .executionInfo(typeInfo)
+                .executionStepInfo(typeInfo)
                 .nonNullFieldValidator(nullableFieldValidator)
                 .source(OptionalDouble.empty())
                 .fields(["fld": []])
@@ -284,10 +284,10 @@ class ExecutionStrategyTest extends Specification {
         ExecutionContext executionContext = buildContext()
         def fieldType = GraphQLString
         def fldDef = newFieldDefinition().name("test").type(fieldType).build()
-        def typeInfo = ExecutionInfo.newExecutionInfo().type(fieldType).fieldDefinition(fldDef).build()
+        def typeInfo = ExecutionStepInfo.newExecutionStepInfo().type(fieldType).fieldDefinition(fldDef).build()
         NonNullableFieldValidator nullableFieldValidator = new NonNullableFieldValidator(executionContext, typeInfo)
         def parameters = newParameters()
-                .executionInfo(typeInfo)
+                .executionStepInfo(typeInfo)
                 .nonNullFieldValidator(nullableFieldValidator)
                 .source(result)
                 .fields(["fld": []])
@@ -310,10 +310,10 @@ class ExecutionStrategyTest extends Specification {
         ExecutionContext executionContext = buildContext()
         def fieldType = nonNull(GraphQLString)
         def fldDef = newFieldDefinition().name("test").type(fieldType).build()
-        def typeInfo = ExecutionInfo.newExecutionInfo().type(fieldType).fieldDefinition(fldDef).build()
+        def typeInfo = ExecutionStepInfo.newExecutionStepInfo().type(fieldType).fieldDefinition(fldDef).build()
         NonNullableFieldValidator nullableFieldValidator = new NonNullableFieldValidator(executionContext, typeInfo)
         def parameters = newParameters()
-                .executionInfo(typeInfo)
+                .executionStepInfo(typeInfo)
                 .nonNullFieldValidator(nullableFieldValidator)
                 .source(OptionalLong.empty())
                 .fields(["fld": []])
@@ -332,11 +332,11 @@ class ExecutionStrategyTest extends Specification {
         ExecutionContext executionContext = buildContext()
         def fieldType = list(GraphQLString)
         def fldDef = newFieldDefinition().name("test").type(fieldType).build()
-        def typeInfo = ExecutionInfo.newExecutionInfo().type(fieldType).fieldDefinition(fldDef).build()
+        def typeInfo = ExecutionStepInfo.newExecutionStepInfo().type(fieldType).fieldDefinition(fldDef).build()
         NonNullableFieldValidator nullableFieldValidator = new NonNullableFieldValidator(executionContext, typeInfo)
         def result = ["test", "1", "2", "3"]
         def parameters = newParameters()
-                .executionInfo(typeInfo)
+                .executionStepInfo(typeInfo)
                 .source(result)
                 .nonNullFieldValidator(nullableFieldValidator)
                 .fields(["fld": []])
@@ -353,12 +353,12 @@ class ExecutionStrategyTest extends Specification {
         given:
         ExecutionContext executionContext = buildContext()
         def fieldType = Scalars.GraphQLInt
-        def typeInfo = ExecutionInfo.newExecutionInfo().type(fieldType).build()
+        def typeInfo = ExecutionStepInfo.newExecutionStepInfo().type(fieldType).build()
         NonNullableFieldValidator nullableFieldValidator = new NonNullableFieldValidator(executionContext, typeInfo)
         String result = "not a number"
 
         def parameters = newParameters()
-                .executionInfo(typeInfo)
+                .executionStepInfo(typeInfo)
                 .source(result)
                 .nonNullFieldValidator(nullableFieldValidator)
                 .fields(["dummy": []])
@@ -378,12 +378,12 @@ class ExecutionStrategyTest extends Specification {
         given:
         ExecutionContext executionContext = buildContext()
         GraphQLEnumType enumType = newEnum().name("Enum").value("value").build()
-        def typeInfo = ExecutionInfo.newExecutionInfo().type(enumType).build()
+        def typeInfo = ExecutionStepInfo.newExecutionStepInfo().type(enumType).build()
         NonNullableFieldValidator nullableFieldValidator = new NonNullableFieldValidator(executionContext, typeInfo)
         String result = "not a enum number"
 
         def parameters = newParameters()
-                .executionInfo(typeInfo)
+                .executionStepInfo(typeInfo)
                 .source(result)
                 .nonNullFieldValidator(nullableFieldValidator)
                 .fields(["dummy": []])
@@ -424,12 +424,12 @@ class ExecutionStrategyTest extends Specification {
 
         ExecutionContext executionContext = buildContext()
         def fieldType = NullProducingScalar
-        def typeInfo = ExecutionInfo.newExecutionInfo().type(nonNull(fieldType)).build()
+        def typeInfo = ExecutionStepInfo.newExecutionStepInfo().type(nonNull(fieldType)).build()
         NonNullableFieldValidator nullableFieldValidator = new NonNullableFieldValidator(executionContext, typeInfo)
 
         when:
         def parameters = newParameters()
-                .executionInfo(ExecutionInfo.newExecutionInfo().type(fieldType))
+                .executionStepInfo(ExecutionStepInfo.newExecutionStepInfo().type(fieldType))
                 .source(result)
                 .fields(["dummy": []])
                 .nonNullFieldValidator(nullableFieldValidator)
@@ -475,14 +475,14 @@ class ExecutionStrategyTest extends Specification {
 
         GraphQLSchema schema = GraphQLSchema.newSchema().query(objectType).build()
         ExecutionContext executionContext = buildContext(schema)
-        ExecutionInfo typeInfo = ExecutionInfo.newExecutionInfo().type(objectType).build()
+        ExecutionStepInfo typeInfo = ExecutionStepInfo.newExecutionStepInfo().type(objectType).build()
         NonNullableFieldValidator nullableFieldValidator = new NonNullableFieldValidator(executionContext, typeInfo)
         Argument argument = new Argument("arg1", new StringValue("argVal"))
         Field field = new Field("someField", [argument])
         ExecutionPath executionPath = ExecutionPath.rootPath().segment("test")
 
         def parameters = newParameters()
-                .executionInfo(typeInfo)
+                .executionStepInfo(typeInfo)
                 .source("source")
                 .fields(["someField": [field]])
                 .field([field])
@@ -504,9 +504,9 @@ class ExecutionStrategyTest extends Specification {
         environment.root == "root"
         environment.parentType == objectType
         environment.arguments == ["arg1": "argVal"]
-        environment.executionInfo.type == GraphQLString
-        environment.executionInfo.path == executionPath
-        environment.executionInfo.parent.type == objectType
+        environment.executionStepInfo.type == GraphQLString
+        environment.executionStepInfo.path == executionPath
+        environment.executionStepInfo.parent.type == objectType
         environment.executionId == ExecutionId.from("executionId123")
     }
 
@@ -524,14 +524,14 @@ class ExecutionStrategyTest extends Specification {
                 .build()
         def schema = GraphQLSchema.newSchema().query(objectType).build()
         ExecutionContext executionContext = buildContext(schema)
-        def typeInfo = ExecutionInfo.newExecutionInfo().type(objectType).build()
+        def typeInfo = ExecutionStepInfo.newExecutionStepInfo().type(objectType).build()
         NonNullableFieldValidator nullableFieldValidator = new NonNullableFieldValidator(executionContext, typeInfo)
         ExecutionPath expectedPath = ExecutionPath.rootPath().segment("someField")
 
         SourceLocation sourceLocation = new SourceLocation(666, 999)
         Field field = Field.newField("someField").sourceLocation(sourceLocation).build()
         def parameters = newParameters()
-                .executionInfo(typeInfo)
+                .executionStepInfo(typeInfo)
                 .source("source")
                 .fields(["someField": [field]])
                 .field([field])
@@ -629,12 +629,12 @@ class ExecutionStrategyTest extends Specification {
         GraphQLSchema schema = GraphQLSchema.newSchema().query(objectType).build()
         ExecutionContext executionContext = buildContext(schema)
 
-        def typeInfo = ExecutionInfo.newExecutionInfo().type(objectType).build()
+        def typeInfo = ExecutionStepInfo.newExecutionStepInfo().type(objectType).build()
         NonNullableFieldValidator nullableFieldValidator = new NonNullableFieldValidator(executionContext, typeInfo)
         Field field = new Field("someField")
 
         def parameters = newParameters()
-                .executionInfo(typeInfo)
+                .executionStepInfo(typeInfo)
                 .source(null)
                 .nonNullFieldValidator(nullableFieldValidator)
                 .field([field])
@@ -657,11 +657,11 @@ class ExecutionStrategyTest extends Specification {
         long[] result = [1L, 2L, 3L]
         def fieldType = list(Scalars.GraphQLLong)
         def fldDef = newFieldDefinition().name("test").type(fieldType).build()
-        def typeInfo = ExecutionInfo.newExecutionInfo().type(fieldType).fieldDefinition(fldDef).build()
+        def typeInfo = ExecutionStepInfo.newExecutionStepInfo().type(fieldType).fieldDefinition(fldDef).build()
         NonNullableFieldValidator nullableFieldValidator = new NonNullableFieldValidator(executionContext, typeInfo)
 
         def parameters = newParameters()
-                .executionInfo(typeInfo)
+                .executionStepInfo(typeInfo)
                 .source(result)
                 .nonNullFieldValidator(nullableFieldValidator)
                 .fields(["fld": [Field.newField().build()]])
@@ -681,13 +681,13 @@ class ExecutionStrategyTest extends Specification {
         ExecutionContext executionContext = buildContext()
         def fieldType = list(Scalars.GraphQLLong)
         def fldDef = newFieldDefinition().name("test").type(fieldType).build()
-        def typeInfo = ExecutionInfo.newExecutionInfo().type(fieldType).fieldDefinition(fldDef).build()
+        def typeInfo = ExecutionStepInfo.newExecutionStepInfo().type(fieldType).fieldDefinition(fldDef).build()
         def field = Field.newField("parent").sourceLocation(new SourceLocation(5, 10)).build()
         def parameters = newParameters()
                 .path(ExecutionPath.fromList(["parent"]))
                 .field([field])
                 .fields(["parent": [field]])
-                .executionInfo(typeInfo)
+                .executionStepInfo(typeInfo)
                 .build()
 
         def executionData = ["child": [:]]
@@ -708,13 +708,13 @@ class ExecutionStrategyTest extends Specification {
         ExecutionContext executionContext = buildContext()
         def fieldType = list(Scalars.GraphQLLong)
         def fldDef = newFieldDefinition().name("test").type(fieldType).build()
-        def typeInfo = ExecutionInfo.newExecutionInfo().type(fieldType).fieldDefinition(fldDef).build()
+        def typeInfo = ExecutionStepInfo.newExecutionStepInfo().type(fieldType).fieldDefinition(fldDef).build()
         def field = Field.newField("parent").sourceLocation(new SourceLocation(5, 10)).build()
         def parameters = newParameters()
                 .path(ExecutionPath.fromList(["parent"]))
                 .field([field])
                 .fields(["parent": [field]])
-                .executionInfo(typeInfo)
+                .executionStepInfo(typeInfo)
                 .build()
 
         def executionData = ["child": [:]]
@@ -735,11 +735,11 @@ class ExecutionStrategyTest extends Specification {
         List<Long> result = [1L, 2L, 3L]
         def fieldType = list(Scalars.GraphQLLong)
         def fldDef = newFieldDefinition().name("test").type(fieldType).build()
-        def typeInfo = ExecutionInfo.newExecutionInfo().type(fieldType).fieldDefinition(fldDef).build()
+        def typeInfo = ExecutionStepInfo.newExecutionStepInfo().type(fieldType).fieldDefinition(fldDef).build()
         NonNullableFieldValidator nullableFieldValidator = new NonNullableFieldValidator(executionContext, typeInfo)
 
         def parameters = newParameters()
-                .executionInfo(typeInfo)
+                .executionStepInfo(typeInfo)
                 .source(result)
                 .nonNullFieldValidator(nullableFieldValidator)
                 .fields(["fld": [Field.newField().build()]])
@@ -759,11 +759,11 @@ class ExecutionStrategyTest extends Specification {
         Map<String, Object> result = new HashMap<>()
         def fieldType = list(Scalars.GraphQLLong)
         def fldDef = newFieldDefinition().name("test").type(fieldType).build()
-        def typeInfo = ExecutionInfo.newExecutionInfo().type(fieldType).fieldDefinition(fldDef).build()
+        def typeInfo = ExecutionStepInfo.newExecutionStepInfo().type(fieldType).fieldDefinition(fldDef).build()
         NonNullableFieldValidator nullableFieldValidator = new NonNullableFieldValidator(executionContext, typeInfo)
 
         def parameters = newParameters()
-                .executionInfo(typeInfo)
+                .executionStepInfo(typeInfo)
                 .source(result)
                 .nonNullFieldValidator(nullableFieldValidator)
                 .fields(["fld": [Field.newField().build()]])

--- a/src/test/groovy/graphql/execution/NonNullableFieldValidatorTest.groovy
+++ b/src/test/groovy/graphql/execution/NonNullableFieldValidatorTest.groovy
@@ -10,7 +10,7 @@ class NonNullableFieldValidatorTest extends Specification {
     ExecutionContext context = Mock(ExecutionContext)
 
     def "non nullable field throws exception"() {
-        ExecutionInfo typeInfo = ExecutionInfo.newExecutionInfo().type(nonNull(GraphQLString)).build()
+        ExecutionStepInfo typeInfo = ExecutionStepInfo.newExecutionStepInfo().type(nonNull(GraphQLString)).build()
 
         NonNullableFieldValidator validator = new NonNullableFieldValidator(context, typeInfo)
 
@@ -23,7 +23,7 @@ class NonNullableFieldValidatorTest extends Specification {
     }
 
     def "nullable field does not throw exception"() {
-        ExecutionInfo typeInfo = ExecutionInfo.newExecutionInfo().type(GraphQLString).build()
+        ExecutionStepInfo typeInfo = ExecutionStepInfo.newExecutionStepInfo().type(GraphQLString).build()
 
         NonNullableFieldValidator validator = new NonNullableFieldValidator(context, typeInfo)
 

--- a/src/test/groovy/graphql/execution/instrumentation/ChainedInstrumentationStateTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/ChainedInstrumentationStateTest.groovy
@@ -207,14 +207,14 @@ class ChainedInstrumentationStateTest extends Specification {
 
     private void assertCalls(NamedInstrumentation instrumentation) {
         assert instrumentation.dfInvocations[0].getFieldDefinition().name == 'hero'
-        assert instrumentation.dfInvocations[0].getExecutionInfo().getPath().toList() == ['hero']
-        assert instrumentation.dfInvocations[0].getExecutionInfo().getType().name == 'Character'
-        assert !instrumentation.dfInvocations[0].getExecutionInfo().isNonNullType()
+        assert instrumentation.dfInvocations[0].getExecutionStepInfo().getPath().toList() == ['hero']
+        assert instrumentation.dfInvocations[0].getExecutionStepInfo().getType().name == 'Character'
+        assert !instrumentation.dfInvocations[0].getExecutionStepInfo().isNonNullType()
 
         assert instrumentation.dfInvocations[1].getFieldDefinition().name == 'id'
-        assert instrumentation.dfInvocations[1].getExecutionInfo().getPath().toList() == ['hero', 'id']
-        assert instrumentation.dfInvocations[1].getExecutionInfo().getType().name == 'String'
-        assert instrumentation.dfInvocations[1].getExecutionInfo().isNonNullType()
+        assert instrumentation.dfInvocations[1].getExecutionStepInfo().getPath().toList() == ['hero', 'id']
+        assert instrumentation.dfInvocations[1].getExecutionStepInfo().getType().name == 'String'
+        assert instrumentation.dfInvocations[1].getExecutionStepInfo().isNonNullType()
     }
 
 }

--- a/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
@@ -98,14 +98,14 @@ class InstrumentationTest extends Specification {
         instrumentation.dfInvocations.size() == 2
 
         instrumentation.dfInvocations[0].getFieldDefinition().name == 'hero'
-        instrumentation.dfInvocations[0].getExecutionInfo().getPath().toList() == ['hero']
-        instrumentation.dfInvocations[0].getExecutionInfo().getType().name == 'Character'
-        !instrumentation.dfInvocations[0].getExecutionInfo().isNonNullType()
+        instrumentation.dfInvocations[0].getExecutionStepInfo().getPath().toList() == ['hero']
+        instrumentation.dfInvocations[0].getExecutionStepInfo().getType().name == 'Character'
+        !instrumentation.dfInvocations[0].getExecutionStepInfo().isNonNullType()
 
         instrumentation.dfInvocations[1].getFieldDefinition().name == 'id'
-        instrumentation.dfInvocations[1].getExecutionInfo().getPath().toList() == ['hero', 'id']
-        instrumentation.dfInvocations[1].getExecutionInfo().getType().name == 'String'
-        instrumentation.dfInvocations[1].getExecutionInfo().isNonNullType()
+        instrumentation.dfInvocations[1].getExecutionStepInfo().getPath().toList() == ['hero', 'id']
+        instrumentation.dfInvocations[1].getExecutionStepInfo().getType().name == 'String'
+        instrumentation.dfInvocations[1].getExecutionStepInfo().isNonNullType()
     }
 
     def '#630 - Instrumentation of batched execution strategy is called'() {
@@ -229,7 +229,7 @@ class InstrumentationTest extends Specification {
 
         @Override
         DataFetcher<?> instrumentDataFetcher(DataFetcher<?> dataFetcher, InstrumentationFieldFetchParameters parameters) {
-            System.out.println(String.format("t%s instrument DF for %s", Thread.currentThread().getId(), parameters.environment.getExecutionInfo().getPath()))
+            System.out.println(String.format("t%s instrument DF for %s", Thread.currentThread().getId(), parameters.environment.getExecutionStepInfo().getPath()))
 
             return new DataFetcher<Object>() {
                 @Override
@@ -237,9 +237,9 @@ class InstrumentationTest extends Specification {
                     // off thread call - that waits
                     return CompletableFuture.supplyAsync({
                         def value = dataFetcher.get(environment)
-                        System.out.println(String.format("   t%s awaiting %s", Thread.currentThread().getId(), environment.getExecutionInfo().getPath()))
+                        System.out.println(String.format("   t%s awaiting %s", Thread.currentThread().getId(), environment.getExecutionStepInfo().getPath()))
                         Awaitility.await().atMost(20, TimeUnit.SECONDS).untilTrue(goSignal)
-                        System.out.println(String.format("      t%s returning value %s", Thread.currentThread().getId(), environment.getExecutionInfo().getPath()))
+                        System.out.println(String.format("      t%s returning value %s", Thread.currentThread().getId(), environment.getExecutionStepInfo().getPath()))
                         return value
                     })
                 }


### PR DESCRIPTION
Breaking change: renaming ExecutionInfo to ExecutionStepInfo (before 11.0 release it was ExecutionTypeInfo)