### PR TITLE
Added query complexity and depth logging + added 'simulation' option

### DIFF
--- a/src/main/java/graphql/analysis/MaxQueryDepthInstrumentation.java
+++ b/src/main/java/graphql/analysis/MaxQueryDepthInstrumentation.java
@@ -6,6 +6,8 @@ import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.SimpleInstrumentation;
 import graphql.execution.instrumentation.parameters.InstrumentationValidationParameters;
 import graphql.validation.ValidationError;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
@@ -17,10 +19,29 @@ import static graphql.execution.instrumentation.SimpleInstrumentationContext.whe
 @PublicApi
 public class MaxQueryDepthInstrumentation extends SimpleInstrumentation {
 
-    private final int maxDepth;
+    private static final Logger log = LoggerFactory.getLogger(MaxQueryDepthInstrumentation.class);
 
+    private final int maxDepth;
+    private final boolean abortExecution;
+
+    /**
+     * new Instrumentation
+     *
+     * @param maxDepth max allowed depth, otherwise execution will be aborted
+     */
     public MaxQueryDepthInstrumentation(int maxDepth) {
+        this(maxDepth, true);
+    }
+
+    /**
+     * new Instrumentation
+     *
+     * @param maxDepth       max allowed depth, otherwise execution will be aborted
+     * @param abortExecution whether to abort execution or only log a warning
+     */
+    public MaxQueryDepthInstrumentation(int maxDepth, boolean abortExecution) {
         this.maxDepth = maxDepth;
+        this.abortExecution = abortExecution;
     }
 
     @Override
@@ -31,8 +52,13 @@ public class MaxQueryDepthInstrumentation extends SimpleInstrumentation {
             }
             QueryTraversal queryTraversal = newQueryTraversal(parameters);
             int depth = queryTraversal.reducePreOrder((env, acc) -> Math.max(getPathLength(env.getParentEnvironment()), acc), 0);
+            log.debug("Query depth: {}", depth);
             if (depth > maxDepth) {
-                throw mkAbortException(depth, maxDepth);
+                if (abortExecution) {
+                    throw mkAbortException(depth, maxDepth);
+                } else {
+                    log.warn("Maximum query depth exceeded {} > {}", depth, maxDepth);
+                }
             }
         });
     }

--- a/src/main/java/graphql/analysis/MaxQueryDepthInstrumentation.java
+++ b/src/main/java/graphql/analysis/MaxQueryDepthInstrumentation.java
@@ -29,7 +29,7 @@ public class MaxQueryDepthInstrumentation extends SimpleInstrumentation {
     private final Function<QueryDepthInfo, Boolean> maxQueryDepthExceededFunction;
 
     /**
-     * new Instrumentation
+     * Creates a new instrumentation that tracks the query depth.
      *
      * @param maxDepth max allowed depth, otherwise execution will be aborted
      */
@@ -38,7 +38,7 @@ public class MaxQueryDepthInstrumentation extends SimpleInstrumentation {
     }
 
     /**
-     * new Instrumentation
+     * Creates a new instrumentation that tracks the query depth.
      *
      * @param maxDepth                      max allowed depth, otherwise execution will be aborted
      * @param maxQueryDepthExceededFunction the function to perform when the max depth is exceeded

--- a/src/main/java/graphql/analysis/QueryComplexityInfo.java
+++ b/src/main/java/graphql/analysis/QueryComplexityInfo.java
@@ -1,0 +1,66 @@
+package graphql.analysis;
+
+import graphql.PublicApi;
+
+/**
+ * The query complexity info.
+ */
+@PublicApi
+public class QueryComplexityInfo {
+
+    private final int complexity;
+
+    private QueryComplexityInfo(int complexity) {
+        this.complexity = complexity;
+    }
+
+    /**
+     * This returns the query complexity.
+     *
+     * @return the query complexity
+     */
+    public int getComplexity() {
+        return complexity;
+    }
+
+    @Override
+    public String toString() {
+        return "QueryComplexityInfo{" +
+                "complexity=" + complexity +
+                '}';
+    }
+
+    /**
+     * @return a new {@link QueryComplexityInfo} builder
+     */
+    public static Builder newQueryComplexityInfo() {
+        return new Builder();
+    }
+
+    @PublicApi
+    public static class Builder {
+
+        private int complexity;
+
+        private Builder() {
+        }
+
+        /**
+         * The query complexity.
+         *
+         * @param complexity the query complexity
+         * @return this builder
+         */
+        public Builder complexity(int complexity) {
+            this.complexity = complexity;
+            return this;
+        }
+
+        /**
+         * @return a built {@link QueryComplexityInfo} object
+         */
+        public QueryComplexityInfo build() {
+            return new QueryComplexityInfo(complexity);
+        }
+    }
+}

--- a/src/main/java/graphql/analysis/QueryDepthInfo.java
+++ b/src/main/java/graphql/analysis/QueryDepthInfo.java
@@ -1,0 +1,66 @@
+package graphql.analysis;
+
+import graphql.PublicApi;
+
+/**
+ * The query depth info.
+ */
+@PublicApi
+public class QueryDepthInfo {
+
+    private final int depth;
+
+    private QueryDepthInfo(int depth) {
+        this.depth = depth;
+    }
+
+    /**
+     * This returns the query depth.
+     *
+     * @return the query depth
+     */
+    public int getDepth() {
+        return depth;
+    }
+
+    @Override
+    public String toString() {
+        return "QueryDepthInfo{" +
+                "depth=" + depth +
+                '}';
+    }
+
+    /**
+     * @return a new {@link QueryDepthInfo} builder
+     */
+    public static Builder newQueryDepthInfo() {
+        return new Builder();
+    }
+
+    @PublicApi
+    public static class Builder {
+
+        private int depth;
+
+        private Builder() {
+        }
+
+        /**
+         * The query depth.
+         *
+         * @param depth the depth complexity
+         * @return this builder
+         */
+        public Builder depth(int depth) {
+            this.depth = depth;
+            return this;
+        }
+
+        /**
+         * @return a built {@link QueryDepthInfo} object
+         */
+        public QueryDepthInfo build() {
+            return new QueryDepthInfo(depth);
+        }
+    }
+}

--- a/src/test/groovy/graphql/analysis/MaxQueryComplexityInstrumentationTest.groovy
+++ b/src/test/groovy/graphql/analysis/MaxQueryComplexityInstrumentationTest.groovy
@@ -11,6 +11,8 @@ import graphql.validation.ValidationError
 import graphql.validation.ValidationErrorType
 import spock.lang.Specification
 
+import java.util.function.Function
+
 class MaxQueryComplexityInstrumentationTest extends Specification {
 
     Document createQuery(String query) {
@@ -154,6 +156,39 @@ class MaxQueryComplexityInstrumentationTest extends Specification {
 
     }
 
+    def "custom max query complexity exceeded function"() {
+        given:
+        def schema = TestUtil.schema("""
+            type Query{
+                foo: Foo
+                bar: String
+            }
+            type Foo {
+                scalar: String  
+                foo: Foo
+            }
+        """)
+        def query = createQuery("""
+            {f2: foo {scalar foo{scalar}} f1: foo { foo {foo {foo {foo{foo{scalar}}}}}} }
+            """)
+        Boolean test = false
+        Function<QueryComplexityInfo, Boolean> maxQueryComplexityExceededFunction = new Function<QueryComplexityInfo, Boolean>() {
+            @Override
+            Boolean apply(final QueryComplexityInfo queryComplexityInfo) {
+                test = true
+                return false
+            }
+        }
+        MaxQueryComplexityInstrumentation queryComplexityInstrumentation = new MaxQueryComplexityInstrumentation(10, maxQueryComplexityExceededFunction)
+        ExecutionInput executionInput = Mock(ExecutionInput)
+        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, null)
+        InstrumentationContext instrumentationContext = queryComplexityInstrumentation.beginValidation(validationParameters)
+        when:
+        instrumentationContext.onCompleted(null, null)
+        then:
+        test == true
+        notThrown(Exception)
+    }
 }
 
 


### PR DESCRIPTION
This PR adds:

- Logging of query complexity and depth when instrumentation classes are used.
- A kind of 'simulation' option using a `boolean abortExecution` argument.

This is useful to get insights of the query complexity and depth users are performing against our GraphQL API.
The latter one can be used if we don't actually want to abort the execution (yet), but only log a warning when the query is above the max complexity / depth.