### PR TITLE
Pass wrappedType name through in GraphQLNonNull

### DIFF
--- a/src/main/java/graphql/schema/GraphQLNonNull.java
+++ b/src/main/java/graphql/schema/GraphQLNonNull.java
@@ -80,7 +80,7 @@ public class GraphQLNonNull implements GraphQLType, GraphQLInputType, GraphQLOut
 
     @Override
     public String getName() {
-        return null;
+        return wrappedType != null ? wrappedType.getName() : null;
     }
 
     @Override

--- a/src/test/groovy/graphql/RelaySchemaTest.groovy
+++ b/src/test/groovy/graphql/RelaySchemaTest.groovy
@@ -63,7 +63,7 @@ class RelaySchemaTest extends Specification {
 
         then:
         def fields = result.data["__type"]["fields"]
-        fields == [[name: "edges", type: [name: null, kind: "LIST", ofType: [name: "StuffEdge", kind: "OBJECT"]]], [name: "pageInfo", type: [name: null, kind: "NON_NULL", ofType: [name: "PageInfo", kind: "OBJECT"]]]]
+        fields == [[name: "edges", type: [name: null, kind: "LIST", ofType: [name: "StuffEdge", kind: "OBJECT"]]], [name: "pageInfo", type: [name: "PageInfo", kind: "NON_NULL", ofType: [name: "PageInfo", kind: "OBJECT"]]]]
     }
 
     def "Validate Relay StuffEdge schema"() {
@@ -90,7 +90,7 @@ class RelaySchemaTest extends Specification {
 
         then:
         def fields = result.data["__type"]["fields"]
-        fields == [[name: "node", type: [name: "Stuff", kind: "OBJECT", ofType: null]], [name: "cursor", type: [name: null, kind: "NON_NULL", ofType: [name: "String", kind: "SCALAR"]]]]
+        fields == [[name: "node", type: [name: "Stuff", kind: "OBJECT", ofType: null]], [name: "cursor", type: [name: "String", kind: "NON_NULL", ofType: [name: "String", kind: "SCALAR"]]]]
     }
 
 }

--- a/src/test/groovy/graphql/StarWarsIntrospectionTests.groovy
+++ b/src/test/groovy/graphql/StarWarsIntrospectionTests.groovy
@@ -167,7 +167,7 @@ class StarWarsIntrospectionTests extends Specification {
                                 [
                                         name: 'id',
                                         type: [
-                                                name: null,
+                                                name: 'String',
                                                 kind: 'NON_NULL'
                                         ]
                                 ],
@@ -236,7 +236,7 @@ class StarWarsIntrospectionTests extends Specification {
                                 [
                                         name: 'id',
                                         type: [
-                                                name  : null,
+                                                name  : 'String',
                                                 kind  : 'NON_NULL',
                                                 ofType: [
                                                         name: 'String',
@@ -349,7 +349,7 @@ class StarWarsIntrospectionTests extends Specification {
                                                                 description : 'id of the human',
                                                                 type        : [
                                                                         kind  : 'NON_NULL',
-                                                                        name  : null,
+                                                                        name  : 'String',
                                                                         ofType: [
                                                                                 kind: 'SCALAR',
                                                                                 name: 'String'
@@ -367,7 +367,7 @@ class StarWarsIntrospectionTests extends Specification {
                                                                 description : 'id of the droid',
                                                                 type        : [
                                                                         kind  : 'NON_NULL',
-                                                                        name  : null,
+                                                                        name  : 'String',
                                                                         ofType: [
                                                                                 kind: 'SCALAR',
                                                                                 name: 'String'

--- a/src/test/groovy/graphql/schema/TypeTraverserTest.groovy
+++ b/src/test/groovy/graphql/schema/TypeTraverserTest.groovy
@@ -135,7 +135,7 @@ class TypeTraverserTest extends Specification {
         def visitor = new GraphQLTestingVisitor()
         new TypeTraverser().depthFirst(visitor, GraphQLNonNull.nonNull(Scalars.GraphQLString))
         then:
-        visitor.getStack() == ["nonNull: String", "fallback: null",
+        visitor.getStack() == ["nonNull: String", "fallback: String",
                                "scalar: String", "fallback: String"]
     }
 


### PR DESCRIPTION
I was surprised to see GraphQLNonNull always returning null for getName(); it seems like this should pass through the name of the wrapped type.