### PR TITLE
clean up second constructors to use the first ones

### DIFF
--- a/src/main/java/graphql/language/ArrayValue.java
+++ b/src/main/java/graphql/language/ArrayValue.java
@@ -27,8 +27,7 @@ public class ArrayValue extends AbstractNode<ArrayValue> implements Value<ArrayV
      * @param values of the array
      */
     public ArrayValue(List<Value> values) {
-        super(null, new ArrayList<>());
-        this.values.addAll(values);
+        this(values,null, new ArrayList<>());
     }
 
     public List<Value> getValues() {

--- a/src/main/java/graphql/language/BooleanValue.java
+++ b/src/main/java/graphql/language/BooleanValue.java
@@ -27,8 +27,7 @@ public class BooleanValue extends AbstractNode<BooleanValue> implements ScalarVa
      * @param value of the Boolean
      */
     public BooleanValue(boolean value) {
-        super(null, new ArrayList<>());
-        this.value = value;
+        this(value, null, new ArrayList<>());
     }
 
     public boolean isValue() {

--- a/src/main/java/graphql/language/EnumValue.java
+++ b/src/main/java/graphql/language/EnumValue.java
@@ -28,8 +28,7 @@ public class EnumValue extends AbstractNode<EnumValue> implements Value<EnumValu
      * @param name of the enum value
      */
     public EnumValue(String name) {
-        super(null, new ArrayList<>());
-        this.name = name;
+        this(name, null, new ArrayList<>());
     }
 
     @Override

--- a/src/main/java/graphql/language/IntValue.java
+++ b/src/main/java/graphql/language/IntValue.java
@@ -28,8 +28,7 @@ public class IntValue extends AbstractNode<IntValue> implements ScalarValue<IntV
      * @param value of the Int
      */
     public IntValue(BigInteger value) {
-        super(null, new ArrayList<>());
-        this.value = value;
+        this(value, null, new ArrayList<>());
     }
 
     public BigInteger getValue() {

--- a/src/main/java/graphql/language/ListType.java
+++ b/src/main/java/graphql/language/ListType.java
@@ -27,8 +27,7 @@ public class ListType extends AbstractNode<ListType> implements Type<ListType> {
      * @param type the wrapped type
      */
     public ListType(Type type) {
-        super(null, new ArrayList<>());
-        this.type = type;
+        this(type, null, new ArrayList<>());
     }
 
     public Type getType() {

--- a/src/main/java/graphql/language/NonNullType.java
+++ b/src/main/java/graphql/language/NonNullType.java
@@ -18,7 +18,6 @@ public class NonNullType extends AbstractNode<NonNullType> implements Type<NonNu
     @Internal
     protected NonNullType(Type type, SourceLocation sourceLocation, List<Comment> comments) {
         super(sourceLocation, comments);
-
         this.type = type;
     }
 
@@ -28,9 +27,7 @@ public class NonNullType extends AbstractNode<NonNullType> implements Type<NonNu
      * @param type the wrapped type
      */
     public NonNullType(Type type) {
-        super(null, new ArrayList<>());
-
-        this.type = type;
+        this(type,null, new ArrayList<>());
     }
 
     public Type getType() {

--- a/src/main/java/graphql/language/StringValue.java
+++ b/src/main/java/graphql/language/StringValue.java
@@ -27,8 +27,7 @@ public class StringValue extends AbstractNode<StringValue> implements ScalarValu
      * @param value of the String
      */
     public StringValue(String value) {
-        super(null, new ArrayList<>());
-        this.value = value;
+        this(value, null, new ArrayList<>());
     }
 
     public String getValue() {

--- a/src/main/java/graphql/language/TypeName.java
+++ b/src/main/java/graphql/language/TypeName.java
@@ -27,8 +27,7 @@ public class TypeName extends AbstractNode<TypeName> implements Type<TypeName> {
      * @param name of the type
      */
     public TypeName(String name) {
-        super(null, new ArrayList<>());
-        this.name = name;
+        this(name, null, new ArrayList<>());
     }
 
 

--- a/src/main/java/graphql/language/VariableReference.java
+++ b/src/main/java/graphql/language/VariableReference.java
@@ -27,8 +27,7 @@ public class VariableReference extends AbstractNode<VariableReference> implement
      * @param name of the variable
      */
     public VariableReference(String name) {
-        super(null, new ArrayList<>());
-        this.name = name;
+        this(name,null, new ArrayList<>());
     }
 
     @Override


### PR DESCRIPTION
some classes assign some fields and call parent constructor in all their own constructors instead of reuse them.