### PR TITLE
moves the info if a DF is trivial out of the DF itself into a marker

### DIFF
--- a/src/main/java/graphql/TrivialDataFetcher.java
+++ b/src/main/java/graphql/TrivialDataFetcher.java
@@ -1,0 +1,13 @@
+package graphql;
+
+import graphql.schema.DataFetcher;
+
+
+/**
+ * Mark a DataFetcher as trivial:
+ * If a data fetcher is simply mapping data from an object to a field, it can be considered a trivial data fetcher for the purposes
+ * of tracing and so on.
+ */
+@PublicSpi
+public interface TrivialDataFetcher<T> extends DataFetcher<T> {
+}

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -6,6 +6,7 @@ import graphql.GraphQLError;
 import graphql.Internal;
 import graphql.PublicSpi;
 import graphql.SerializationError;
+import graphql.TrivialDataFetcher;
 import graphql.TypeMismatchError;
 import graphql.TypeResolutionEnvironment;
 import graphql.UnresolvedTypeError;
@@ -251,7 +252,7 @@ public abstract class ExecutionStrategy {
 
         Instrumentation instrumentation = executionContext.getInstrumentation();
 
-        InstrumentationFieldFetchParameters instrumentationFieldFetchParams = new InstrumentationFieldFetchParameters(executionContext, fieldDef, environment, parameters, dataFetcher.isTrivialDataFetcher());
+        InstrumentationFieldFetchParameters instrumentationFieldFetchParams = new InstrumentationFieldFetchParameters(executionContext, fieldDef, environment, parameters, dataFetcher instanceof TrivialDataFetcher);
         InstrumentationContext<Object> fetchCtx = instrumentation.beginFieldFetch(instrumentationFieldFetchParams);
 
         CompletableFuture<Object> fetchedValue;

--- a/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
+++ b/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
@@ -4,6 +4,7 @@ import graphql.Assert;
 import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.PublicApi;
+import graphql.TrivialDataFetcher;
 import graphql.execution.Async;
 import graphql.execution.DataFetcherExceptionHandler;
 import graphql.execution.DataFetcherExceptionHandlerParameters;
@@ -258,7 +259,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
                 .build();
 
         DataFetcher supplied = fieldDef.getDataFetcher();
-        boolean trivialDataFetcher = supplied.isTrivialDataFetcher();
+        boolean trivialDataFetcher = supplied instanceof TrivialDataFetcher;
         BatchedDataFetcher batchedDataFetcher = batchingFactory.create(supplied);
 
         Instrumentation instrumentation = executionContext.getInstrumentation();

--- a/src/main/java/graphql/relay/SimpleListConnection.java
+++ b/src/main/java/graphql/relay/SimpleListConnection.java
@@ -1,6 +1,7 @@
 package graphql.relay;
 
 import graphql.PublicApi;
+import graphql.TrivialDataFetcher;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 
@@ -16,7 +17,7 @@ import static java.util.Base64.getDecoder;
 import static java.util.Base64.getEncoder;
 
 @PublicApi
-public class SimpleListConnection<T> implements DataFetcher<Connection<T>> {
+public class SimpleListConnection<T> implements DataFetcher<Connection<T>>, TrivialDataFetcher<Connection<T>> {
 
     static final String DUMMY_CURSOR_PREFIX = "simple-cursor";
     private final String prefix;
@@ -39,11 +40,6 @@ public class SimpleListConnection<T> implements DataFetcher<Connection<T>> {
             edges.add(new DefaultEdge<>(object, new DefaultConnectionCursor(createCursor(ix++))));
         }
         return edges;
-    }
-
-    @Override
-    public boolean isTrivialDataFetcher() {
-        return true;
     }
 
     @Override

--- a/src/main/java/graphql/schema/DataFetcher.java
+++ b/src/main/java/graphql/schema/DataFetcher.java
@@ -31,13 +31,4 @@ public interface DataFetcher<T> {
     T get(DataFetchingEnvironment environment) throws Exception;
 
 
-    /**
-     * If a data fetcher is simply mapping data from an object to a field, it can be considered a trivial data fetcher for the purposes
-     * of tracing and so on.
-     *
-     * @return true if the data fetcher can be considered a trivial data fetcher.
-     */
-    default boolean isTrivialDataFetcher() {
-        return false;
-    }
 }

--- a/src/main/java/graphql/schema/PropertyDataFetcher.java
+++ b/src/main/java/graphql/schema/PropertyDataFetcher.java
@@ -4,6 +4,7 @@ package graphql.schema;
 import graphql.Assert;
 import graphql.GraphQLException;
 import graphql.PublicApi;
+import graphql.TrivialDataFetcher;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -46,7 +47,7 @@ import static graphql.schema.GraphQLTypeUtil.unwrapOne;
  * @see graphql.schema.DataFetcher
  */
 @PublicApi
-public class PropertyDataFetcher<T> implements DataFetcher<T> {
+public class PropertyDataFetcher<T> implements DataFetcher<T>, TrivialDataFetcher<T> {
 
     private final String propertyName;
     private final Function<Object, Object> function;
@@ -120,14 +121,6 @@ public class PropertyDataFetcher<T> implements DataFetcher<T> {
      */
     public String getPropertyName() {
         return propertyName;
-    }
-
-    /**
-     * @return true - because PropertyDataFetcher is one the most trivial fetchers
-     */
-    @Override
-    public boolean isTrivialDataFetcher() {
-        return true;
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/graphql/schema/StaticDataFetcher.java
+++ b/src/main/java/graphql/schema/StaticDataFetcher.java
@@ -2,12 +2,13 @@ package graphql.schema;
 
 
 import graphql.PublicApi;
+import graphql.TrivialDataFetcher;
 
 /**
  * A {@link graphql.schema.DataFetcher} that always returns the same value
  */
 @PublicApi
-public class StaticDataFetcher implements DataFetcher {
+public class StaticDataFetcher implements DataFetcher, TrivialDataFetcher {
 
 
     private final Object value;
@@ -21,8 +22,4 @@ public class StaticDataFetcher implements DataFetcher {
         return value;
     }
 
-    @Override
-    public boolean isTrivialDataFetcher() {
-        return true;
-    }
 }


### PR DESCRIPTION
@bbakerman this is an alternative to #1300: What do u think?

My main motivation was to keep the info out of the DF interface itself: being the most important Interface we have I think our goal should be to keep it as simple as possible.

The trivial info is not needed in a lot of cased and will distract/confuse especially beginners who look at GraphQL Java the first time more than it helps. IMHO 