### PR TITLE
types fields and args are sorted

### DIFF
--- a/src/main/java/graphql/TypeMismatchError.java
+++ b/src/main/java/graphql/TypeMismatchError.java
@@ -1,9 +1,5 @@
 package graphql;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import graphql.execution.ExecutionPath;
 import graphql.introspection.Introspection;
 import graphql.language.SourceLocation;
@@ -16,6 +12,10 @@ import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLScalarType;
 import graphql.schema.GraphQLType;
 import graphql.schema.GraphQLUnionType;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 import static graphql.Assert.assertNotNull;
 import static java.lang.String.format;
@@ -40,7 +40,7 @@ public class TypeMismatchError implements GraphQLError {
 
     static class GraphQLTypeToTypeKindMapping {
 
-        private static final Map<Class<? extends GraphQLType>, Introspection.TypeKind> registry = new HashMap<Class<? extends GraphQLType>, Introspection.TypeKind>() {{
+        private static final Map<Class<? extends GraphQLType>, Introspection.TypeKind> registry = new LinkedHashMap<Class<? extends GraphQLType>, Introspection.TypeKind>() {{
             put(GraphQLEnumType.class, Introspection.TypeKind.ENUM);
             put(GraphQLList.class, Introspection.TypeKind.LIST);
             put(GraphQLObjectType.class, Introspection.TypeKind.OBJECT);

--- a/src/main/java/graphql/execution/AbsoluteGraphQLError.java
+++ b/src/main/java/graphql/execution/AbsoluteGraphQLError.java
@@ -1,18 +1,18 @@
 package graphql.execution;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
 import graphql.ErrorType;
 import graphql.GraphQLError;
 import graphql.language.Field;
 import graphql.language.SourceLocation;
 import graphql.schema.DataFetcher;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static graphql.Assert.assertNotNull;
 
@@ -35,7 +35,7 @@ class AbsoluteGraphQLError implements GraphQLError {
         this.message = relativeError.getMessage();
         this.errorType = relativeError.getErrorType();
         if (relativeError.getExtensions() != null) {
-            this.extensions = new HashMap<>();
+            this.extensions = new LinkedHashMap<>();
             this.extensions.putAll(relativeError.getExtensions());
         } else {
             this.extensions = null;
@@ -69,11 +69,13 @@ class AbsoluteGraphQLError implements GraphQLError {
 
     /**
      * Creating absolute paths follows the following logic:
-     *  Relative path is null -> Absolute path null
-     *  Relative path is empty -> Absolute paths is path up to the field.
-     *  Relative path is not empty -> Absolute paths [base Path, relative Path]
-     * @param relativeError relative error
+     * Relative path is null -> Absolute path null
+     * Relative path is empty -> Absolute paths is path up to the field.
+     * Relative path is not empty -> Absolute paths [base Path, relative Path]
+     *
+     * @param relativeError               relative error
      * @param executionStrategyParameters execution strategy params.
+     *
      * @return List of paths from the root.
      */
     private List<Object> createAbsolutePath(ExecutionStrategyParameters executionStrategyParameters,
@@ -91,11 +93,13 @@ class AbsoluteGraphQLError implements GraphQLError {
 
     /**
      * Creating absolute locations follows the following logic:
-     *  Relative locations is null -> Absolute locations null
-     *  Relative locations is empty -> Absolute locations base locations of the field.
-     *  Relative locations is not empty -> Absolute locations [base line + relative line location]
+     * Relative locations is null -> Absolute locations null
+     * Relative locations is empty -> Absolute locations base locations of the field.
+     * Relative locations is not empty -> Absolute locations [base line + relative line location]
+     *
      * @param relativeError relative error
-     * @param fields fields on the current field.
+     * @param fields        fields on the current field.
+     *
      * @return List of locations from the root.
      */
     private List<SourceLocation> createAbsoluteLocations(GraphQLError relativeError, List<Field> fields) {

--- a/src/main/java/graphql/execution/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncExecutionStrategy.java
@@ -13,7 +13,7 @@ import graphql.language.Field;
 import graphql.schema.GraphQLFieldDefinition;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -100,7 +100,7 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
             DeferredErrorSupport errorSupport = new DeferredErrorSupport();
 
             // with a deferred field we are really resetting where we execute from, that is from this current field onwards
-            Map<String, List<Field>> fields = new HashMap<>();
+            Map<String, List<Field>> fields = new LinkedHashMap<>();
             fields.put(currentField.get(0).getName(), currentField);
 
             ExecutionStrategyParameters callParameters = parameters.transform(builder ->

--- a/src/main/java/graphql/execution/ExecutionContextBuilder.java
+++ b/src/main/java/graphql/execution/ExecutionContextBuilder.java
@@ -13,6 +13,7 @@ import org.dataloader.DataLoaderRegistry;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -32,8 +33,8 @@ public class ExecutionContextBuilder {
     private Object root;
     private Document document;
     private OperationDefinition operationDefinition;
-    private Map<String, Object> variables = new HashMap<>();
-    private Map<String, FragmentDefinition> fragmentsByName = new HashMap<>();
+    private Map<String, Object> variables = new LinkedHashMap<>();
+    private Map<String, FragmentDefinition> fragmentsByName = new LinkedHashMap<>();
     private DataLoaderRegistry dataLoaderRegistry;
     private List<GraphQLError> errors = new ArrayList<>();
 

--- a/src/main/java/graphql/language/AstValueHelper.java
+++ b/src/main/java/graphql/language/AstValueHelper.java
@@ -24,7 +24,7 @@ import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -223,7 +223,7 @@ public class AstValueHelper {
             return (Map) value;
         }
         // java bean inspector
-        Map<String, Object> result = new HashMap<>();
+        Map<String, Object> result = new LinkedHashMap<>();
         try {
             BeanInfo info = Introspector.getBeanInfo(value.getClass());
             for (PropertyDescriptor pd : info.getPropertyDescriptors()) {

--- a/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
@@ -10,7 +10,7 @@ import graphql.language.FragmentDefinition;
 import org.dataloader.DataLoader;
 
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -71,7 +71,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
 
     @Override
     public Map<String, Object> getArguments() {
-        return new HashMap<>(arguments);
+        return new LinkedHashMap<>(arguments);
     }
 
     @Override
@@ -126,7 +126,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
 
     @Override
     public Map<String, FragmentDefinition> getFragmentsByName() {
-        return new HashMap<>(fragmentsByName);
+        return new LinkedHashMap<>(fragmentsByName);
     }
 
     @Override

--- a/src/main/java/graphql/schema/GraphQLArgument.java
+++ b/src/main/java/graphql/schema/GraphQLArgument.java
@@ -70,7 +70,7 @@ public class GraphQLArgument implements GraphQLDirectiveContainer {
         this.defaultValue = defaultValue;
         this.value = value;
         this.definition = definition;
-        this.directives = sortGraphQLTypes(directives);
+        this.directives = directives;
     }
 
 

--- a/src/main/java/graphql/schema/GraphQLArgument.java
+++ b/src/main/java/graphql/schema/GraphQLArgument.java
@@ -16,6 +16,7 @@ import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
+import static graphql.schema.GraphqlTypeComparators.sortGraphQLTypes;
 import static graphql.util.FpKit.valuesToList;
 
 /**
@@ -69,7 +70,7 @@ public class GraphQLArgument implements GraphQLDirectiveContainer {
         this.defaultValue = defaultValue;
         this.value = value;
         this.definition = definition;
-        this.directives = directives;
+        this.directives = sortGraphQLTypes(directives);
     }
 
 

--- a/src/main/java/graphql/schema/GraphQLArgument.java
+++ b/src/main/java/graphql/schema/GraphQLArgument.java
@@ -16,7 +16,6 @@ import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
-import static graphql.schema.GraphqlTypeComparators.sortGraphQLTypes;
 import static graphql.util.FpKit.valuesToList;
 
 /**

--- a/src/main/java/graphql/schema/GraphQLDirective.java
+++ b/src/main/java/graphql/schema/GraphQLDirective.java
@@ -18,6 +18,7 @@ import java.util.function.UnaryOperator;
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
 import static graphql.introspection.Introspection.DirectiveLocation;
+import static graphql.schema.GraphqlTypeComparators.sortGraphQLTypes;
 import static graphql.util.FpKit.getByName;
 import static graphql.util.FpKit.valuesToList;
 
@@ -45,7 +46,7 @@ public class GraphQLDirective implements GraphQLType {
         this.name = name;
         this.description = description;
         this.locations = locations;
-        this.arguments.addAll(arguments);
+        this.arguments.addAll(sortGraphQLTypes(arguments));
         this.onOperation = onOperation;
         this.onFragment = onFragment;
         this.onField = onField;

--- a/src/main/java/graphql/schema/GraphQLEnumType.java
+++ b/src/main/java/graphql/schema/GraphQLEnumType.java
@@ -17,6 +17,7 @@ import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
+import static graphql.schema.GraphqlTypeComparators.sortGraphQLTypes;
 import static graphql.util.FpKit.getByName;
 import static graphql.util.FpKit.valuesToList;
 import static java.util.Collections.emptyList;
@@ -88,8 +89,8 @@ public class GraphQLEnumType implements GraphQLType, GraphQLInputType, GraphQLOu
         this.name = name;
         this.description = description;
         this.definition = definition;
-        this.directives = directives;
-        buildMap(values);
+        this.directives = GraphqlTypeComparators.sortGraphQLTypes(directives);
+        buildMap(sortGraphQLTypes(values));
     }
 
     public List<GraphQLEnumValueDefinition> getValues() {

--- a/src/main/java/graphql/schema/GraphQLEnumType.java
+++ b/src/main/java/graphql/schema/GraphQLEnumType.java
@@ -89,7 +89,7 @@ public class GraphQLEnumType implements GraphQLType, GraphQLInputType, GraphQLOu
         this.name = name;
         this.description = description;
         this.definition = definition;
-        this.directives = GraphqlTypeComparators.sortGraphQLTypes(directives);
+        this.directives = directives;
         buildMap(sortGraphQLTypes(values));
     }
 

--- a/src/main/java/graphql/schema/GraphQLEnumValueDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLEnumValueDefinition.java
@@ -55,7 +55,7 @@ public class GraphQLEnumValueDefinition implements GraphQLDirectiveContainer {
         this.description = description;
         this.value = value;
         this.deprecationReason = deprecationReason;
-        this.directives = sortGraphQLTypes(directives);
+        this.directives = directives;
     }
 
     @Override

--- a/src/main/java/graphql/schema/GraphQLEnumValueDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLEnumValueDefinition.java
@@ -15,6 +15,7 @@ import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
+import static graphql.schema.GraphqlTypeComparators.sortGraphQLTypes;
 import static graphql.util.FpKit.getByName;
 import static graphql.util.FpKit.valuesToList;
 import static java.util.Collections.emptyList;
@@ -54,7 +55,7 @@ public class GraphQLEnumValueDefinition implements GraphQLDirectiveContainer {
         this.description = description;
         this.value = value;
         this.deprecationReason = deprecationReason;
-        this.directives = directives;
+        this.directives = sortGraphQLTypes(directives);
     }
 
     @Override

--- a/src/main/java/graphql/schema/GraphQLFieldDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLFieldDefinition.java
@@ -62,7 +62,7 @@ public class GraphQLFieldDefinition implements GraphQLDirectiveContainer {
         this.type = type;
         this.dataFetcherFactory = dataFetcherFactory;
         this.arguments = Collections.unmodifiableList(sortGraphQLTypes(arguments));
-        this.directives = sortGraphQLTypes(directives);
+        this.directives = directives;
         this.deprecationReason = deprecationReason;
         this.definition = definition;
     }

--- a/src/main/java/graphql/schema/GraphQLFieldDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLFieldDefinition.java
@@ -18,6 +18,7 @@ import java.util.function.UnaryOperator;
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
 import static graphql.schema.DataFetcherFactoryEnvironment.newDataFetchingFactoryEnvironment;
+import static graphql.schema.GraphqlTypeComparators.sortGraphQLTypes;
 import static graphql.util.FpKit.getByName;
 import static graphql.util.FpKit.valuesToList;
 
@@ -52,7 +53,6 @@ public class GraphQLFieldDefinition implements GraphQLDirectiveContainer {
 
     @Internal
     public GraphQLFieldDefinition(String name, String description, GraphQLOutputType type, DataFetcherFactory dataFetcherFactory, List<GraphQLArgument> arguments, String deprecationReason, List<GraphQLDirective> directives, FieldDefinition definition) {
-        this.directives = directives;
         assertValidName(name);
         assertNotNull(dataFetcherFactory, "you have to provide a DataFetcher (or DataFetcherFactory)");
         assertNotNull(type, "type can't be null");
@@ -61,7 +61,8 @@ public class GraphQLFieldDefinition implements GraphQLDirectiveContainer {
         this.description = description;
         this.type = type;
         this.dataFetcherFactory = dataFetcherFactory;
-        this.arguments = Collections.unmodifiableList(new ArrayList<>(arguments));
+        this.arguments = Collections.unmodifiableList(sortGraphQLTypes(arguments));
+        this.directives = sortGraphQLTypes(directives);
         this.deprecationReason = deprecationReason;
         this.definition = definition;
     }
@@ -152,7 +153,7 @@ public class GraphQLFieldDefinition implements GraphQLDirectiveContainer {
 
     @Override
     public List<GraphQLType> getChildren() {
-        List<GraphQLType> children =  new ArrayList<>();
+        List<GraphQLType> children = new ArrayList<>();
         children.add(type);
         children.addAll(arguments);
         children.addAll(directives);

--- a/src/main/java/graphql/schema/GraphQLInputObjectField.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectField.java
@@ -58,7 +58,7 @@ public class GraphQLInputObjectField implements GraphQLDirectiveContainer {
         this.type = type;
         this.defaultValue = defaultValue;
         this.description = description;
-        this.directives = sortGraphQLTypes(directives);
+        this.directives = directives;
         this.definition = definition;
     }
 

--- a/src/main/java/graphql/schema/GraphQLInputObjectField.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectField.java
@@ -15,7 +15,6 @@ import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
-import static graphql.schema.GraphqlTypeComparators.sortGraphQLTypes;
 import static graphql.util.FpKit.getByName;
 import static graphql.util.FpKit.valuesToList;
 import static java.util.Collections.emptyList;

--- a/src/main/java/graphql/schema/GraphQLInputObjectField.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectField.java
@@ -8,7 +8,6 @@ import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -16,6 +15,7 @@ import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
+import static graphql.schema.GraphqlTypeComparators.sortGraphQLTypes;
 import static graphql.util.FpKit.getByName;
 import static graphql.util.FpKit.valuesToList;
 import static java.util.Collections.emptyList;
@@ -58,7 +58,7 @@ public class GraphQLInputObjectField implements GraphQLDirectiveContainer {
         this.type = type;
         this.defaultValue = defaultValue;
         this.description = description;
-        this.directives = directives;
+        this.directives = sortGraphQLTypes(directives);
         this.definition = definition;
     }
 

--- a/src/main/java/graphql/schema/GraphQLInputObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectType.java
@@ -50,7 +50,7 @@ public class GraphQLInputObjectType implements GraphQLType, GraphQLInputType, Gr
         this.name = name;
         this.description = description;
         this.definition = definition;
-        this.directives = sortGraphQLTypes(directives);
+        this.directives = directives;
         buildMap(sortGraphQLTypes(fields));
     }
 

--- a/src/main/java/graphql/schema/GraphQLInputObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectType.java
@@ -16,6 +16,7 @@ import java.util.function.UnaryOperator;
 
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
+import static graphql.schema.GraphqlTypeComparators.sortGraphQLTypes;
 import static graphql.util.FpKit.getByName;
 import static graphql.util.FpKit.valuesToList;
 import static java.util.Collections.emptyList;
@@ -49,8 +50,8 @@ public class GraphQLInputObjectType implements GraphQLType, GraphQLInputType, Gr
         this.name = name;
         this.description = description;
         this.definition = definition;
-        this.directives = directives;
-        buildMap(fields);
+        this.directives = sortGraphQLTypes(directives);
+        buildMap(sortGraphQLTypes(fields));
     }
 
     private void buildMap(List<GraphQLInputObjectField> fields) {

--- a/src/main/java/graphql/schema/GraphQLInterfaceType.java
+++ b/src/main/java/graphql/schema/GraphQLInterfaceType.java
@@ -59,7 +59,7 @@ public class GraphQLInterfaceType implements GraphQLType, GraphQLOutputType, Gra
         buildDefinitionMap(sortGraphQLTypes(fieldDefinitions));
         this.typeResolver = typeResolver;
         this.definition = definition;
-        this.directives = sortGraphQLTypes(directives);
+        this.directives = directives;
     }
 
     private void buildDefinitionMap(List<GraphQLFieldDefinition> fieldDefinitions) {

--- a/src/main/java/graphql/schema/GraphQLInterfaceType.java
+++ b/src/main/java/graphql/schema/GraphQLInterfaceType.java
@@ -17,6 +17,7 @@ import java.util.function.UnaryOperator;
 
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
+import static graphql.schema.GraphqlTypeComparators.sortGraphQLTypes;
 import static graphql.util.FpKit.getByName;
 import static graphql.util.FpKit.valuesToList;
 import static java.lang.String.format;
@@ -55,10 +56,10 @@ public class GraphQLInterfaceType implements GraphQLType, GraphQLOutputType, Gra
 
         this.name = name;
         this.description = description;
-        buildDefinitionMap(fieldDefinitions);
+        buildDefinitionMap(sortGraphQLTypes(fieldDefinitions));
         this.typeResolver = typeResolver;
         this.definition = definition;
-        this.directives = directives;
+        this.directives = sortGraphQLTypes(directives);
     }
 
     private void buildDefinitionMap(List<GraphQLFieldDefinition> fieldDefinitions) {

--- a/src/main/java/graphql/schema/GraphQLObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLObjectType.java
@@ -13,10 +13,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
-import java.util.stream.Collectors;
 
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
+import static graphql.schema.GraphqlTypeComparators.sortGraphQLTypes;
 import static graphql.util.FpKit.getByName;
 import static graphql.util.FpKit.valuesToList;
 import static java.lang.String.format;
@@ -56,10 +56,10 @@ public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQ
         assertNotNull(interfaces, "interfaces can't be null");
         this.name = name;
         this.description = description;
-        this.interfaces = interfaces;
+        this.interfaces = sortGraphQLTypes(interfaces);
         this.definition = definition;
         this.directives = assertNotNull(directives);
-        buildDefinitionMap(fieldDefinitions);
+        buildDefinitionMap(sortGraphQLTypes(fieldDefinitions));
     }
 
     void replaceInterfaces(List<GraphQLOutputType> interfaces) {

--- a/src/main/java/graphql/schema/GraphQLScalarType.java
+++ b/src/main/java/graphql/schema/GraphQLScalarType.java
@@ -58,7 +58,7 @@ public class GraphQLScalarType implements GraphQLType, GraphQLInputType, GraphQL
         this.description = description;
         this.coercing = coercing;
         this.definition = definition;
-        this.directives = sortGraphQLTypes(directives);
+        this.directives = directives;
     }
 
     @Override

--- a/src/main/java/graphql/schema/GraphQLScalarType.java
+++ b/src/main/java/graphql/schema/GraphQLScalarType.java
@@ -15,6 +15,7 @@ import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
+import static graphql.schema.GraphqlTypeComparators.sortGraphQLTypes;
 import static graphql.util.FpKit.getByName;
 import static graphql.util.FpKit.valuesToList;
 import static java.util.Collections.emptyList;
@@ -57,7 +58,7 @@ public class GraphQLScalarType implements GraphQLType, GraphQLInputType, GraphQL
         this.description = description;
         this.coercing = coercing;
         this.definition = definition;
-        this.directives = directives;
+        this.directives = sortGraphQLTypes(directives);
     }
 
     @Override

--- a/src/main/java/graphql/schema/GraphQLSchema.java
+++ b/src/main/java/graphql/schema/GraphQLSchema.java
@@ -11,7 +11,6 @@ import graphql.schema.visibility.GraphqlFieldVisibility;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -236,7 +235,7 @@ public class GraphQLSchema {
         private GraphQLObjectType mutationType;
         private GraphQLObjectType subscriptionType;
         private GraphqlFieldVisibility fieldVisibility = DEFAULT_FIELD_VISIBILITY;
-        private Set<GraphQLType> additionalTypes = new HashSet<>();
+        private Set<GraphQLType> additionalTypes = new LinkedHashSet<>();
         // we default these in
         private Set<GraphQLDirective> additionalDirectives = new LinkedHashSet<>(
                 asList(Directives.IncludeDirective, Directives.SkipDirective, Directives.DeferDirective)

--- a/src/main/java/graphql/schema/GraphQLSchema.java
+++ b/src/main/java/graphql/schema/GraphQLSchema.java
@@ -21,6 +21,7 @@ import java.util.function.Consumer;
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertShouldNeverHappen;
 import static graphql.Assert.assertTrue;
+import static graphql.schema.GraphqlTypeComparators.sortGraphQLTypes;
 import static graphql.schema.visibility.DefaultGraphqlFieldVisibility.DEFAULT_FIELD_VISIBILITY;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
@@ -107,7 +108,7 @@ public class GraphQLSchema {
     }
 
     public List<GraphQLType> getAllTypesAsList() {
-        return new ArrayList<>(typeMap.values());
+        return sortGraphQLTypes(typeMap.values());
     }
 
     /**
@@ -122,7 +123,7 @@ public class GraphQLSchema {
         List<GraphQLObjectType> implementations = byInterface.get(type.getName());
         return (implementations == null)
                 ? Collections.emptyList()
-                : Collections.unmodifiableList(implementations);
+                : Collections.unmodifiableList(sortGraphQLTypes(implementations));
     }
 
     /**
@@ -167,7 +168,7 @@ public class GraphQLSchema {
     }
 
     public List<GraphQLDirective> getDirectives() {
-        return new ArrayList<>(directives);
+        return sortGraphQLTypes(directives);
     }
 
     public GraphQLDirective getDirective(String name) {

--- a/src/main/java/graphql/schema/GraphQLSchema.java
+++ b/src/main/java/graphql/schema/GraphQLSchema.java
@@ -16,6 +16,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
@@ -72,9 +73,10 @@ public class GraphQLSchema {
         this.subscriptionType = subscriptionType;
         this.fieldVisibility = fieldVisibility;
         this.additionalTypes.addAll(additionalTypes);
-        this.directives.addAll(directives);
-        this.typeMap = schemaUtil.allTypes(this, additionalTypes);
-        this.byInterface = schemaUtil.groupImplementations(this);
+        this.directives.addAll(sortGraphQLTypes(directives));
+        // sorted by type name
+        this.typeMap = new TreeMap<>(schemaUtil.allTypes(this, additionalTypes));
+        this.byInterface = new TreeMap<>(schemaUtil.groupImplementations(this));
     }
 
     public Set<GraphQLType> getAdditionalTypes() {
@@ -168,7 +170,7 @@ public class GraphQLSchema {
     }
 
     public List<GraphQLDirective> getDirectives() {
-        return sortGraphQLTypes(directives);
+        return new ArrayList<>(directives);
     }
 
     public GraphQLDirective getDirective(String name) {

--- a/src/main/java/graphql/schema/GraphQLTypeCollectingVisitor.java
+++ b/src/main/java/graphql/schema/GraphQLTypeCollectingVisitor.java
@@ -7,6 +7,7 @@ import graphql.util.TraverserContext;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 import static java.lang.String.format;
 
@@ -87,13 +88,13 @@ public class GraphQLTypeCollectingVisitor extends GraphQLTypeVisitorStub {
 
 
     /*
-From http://facebook.github.io/graphql/#sec-Type-System
+        From http://facebook.github.io/graphql/#sec-Type-System
 
-   All types within a GraphQL schema must have unique names. No two provided types may have the same name.
-   No provided type may have a name which conflicts with any built in types (including Scalar and Introspection types).
+           All types within a GraphQL schema must have unique names. No two provided types may have the same name.
+           No provided type may have a name which conflicts with any built in types (including Scalar and Introspection types).
 
-Enforcing this helps avoid problems later down the track fo example https://github.com/graphql-java/graphql-java/issues/373
-*/
+        Enforcing this helps avoid problems later down the track fo example https://github.com/graphql-java/graphql-java/issues/373
+    */
     private void assertTypeUniqueness(GraphQLType type, Map<String, GraphQLType> result) {
         GraphQLType existingType = result.get(type.getName());
         // do we have an existing definition
@@ -111,8 +112,7 @@ Enforcing this helps avoid problems later down the track fo example https://gith
     }
 
     public Map<String, GraphQLType> getResult() {
-        return result;
+        // sorted by type name
+        return new TreeMap<>(result);
     }
-
-
 }

--- a/src/main/java/graphql/schema/GraphQLTypeCollectingVisitor.java
+++ b/src/main/java/graphql/schema/GraphQLTypeCollectingVisitor.java
@@ -5,7 +5,7 @@ import graphql.Internal;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static java.lang.String.format;
@@ -13,7 +13,7 @@ import static java.lang.String.format;
 @Internal
 public class GraphQLTypeCollectingVisitor extends GraphQLTypeVisitorStub {
 
-    private final Map<String, GraphQLType> result = new HashMap<>();
+    private final Map<String, GraphQLType> result = new LinkedHashMap<>();
 
     public GraphQLTypeCollectingVisitor() {
     }

--- a/src/main/java/graphql/schema/GraphQLTypeCollectingVisitor.java
+++ b/src/main/java/graphql/schema/GraphQLTypeCollectingVisitor.java
@@ -7,7 +7,6 @@ import graphql.util.TraverserContext;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.TreeMap;
 
 import static java.lang.String.format;
 
@@ -112,7 +111,6 @@ public class GraphQLTypeCollectingVisitor extends GraphQLTypeVisitorStub {
     }
 
     public Map<String, GraphQLType> getResult() {
-        // sorted by type name
-        return new TreeMap<>(result);
+        return result;
     }
 }

--- a/src/main/java/graphql/schema/GraphQLUnionType.java
+++ b/src/main/java/graphql/schema/GraphQLUnionType.java
@@ -12,11 +12,11 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import static graphql.Assert.assertNotEmpty;
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
+import static graphql.schema.GraphqlTypeComparators.sortGraphQLTypes;
 import static graphql.util.FpKit.getByName;
 import static graphql.util.FpKit.valuesToList;
 import static java.util.Collections.emptyList;
@@ -57,10 +57,10 @@ public class GraphQLUnionType implements GraphQLType, GraphQLOutputType, GraphQL
 
         this.name = name;
         this.description = description;
-        this.types = types;
+        this.types = sortGraphQLTypes(types);
         this.typeResolver = typeResolver;
         this.definition = definition;
-        this.directives = directives;
+        this.directives = sortGraphQLTypes(directives);
     }
 
     void replaceTypes(List<GraphQLOutputType> types) {

--- a/src/main/java/graphql/schema/GraphQLUnionType.java
+++ b/src/main/java/graphql/schema/GraphQLUnionType.java
@@ -60,7 +60,7 @@ public class GraphQLUnionType implements GraphQLType, GraphQLOutputType, GraphQL
         this.types = sortGraphQLTypes(types);
         this.typeResolver = typeResolver;
         this.definition = definition;
-        this.directives = sortGraphQLTypes(directives);
+        this.directives = directives;
     }
 
     void replaceTypes(List<GraphQLOutputType> types) {

--- a/src/main/java/graphql/schema/GraphqlTypeComparators.java
+++ b/src/main/java/graphql/schema/GraphqlTypeComparators.java
@@ -1,0 +1,37 @@
+package graphql.schema;
+
+import graphql.PublicApi;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+
+@PublicApi
+public class GraphqlTypeComparators {
+
+    /**
+     * This sorts the list of {@link graphql.schema.GraphQLType} objects (by name) and allocates a new sorted
+     * list back.
+     *
+     * @param types the types to sort
+     * @param <T>   the type of type
+     *
+     * @return a new allocated list of sorted things
+     */
+    public static <T extends GraphQLType> List<T> sortGraphQLTypes(Collection<T> types) {
+        ArrayList<T> sorted = new ArrayList<>(types);
+        sorted.sort(graphQLTypeComparator());
+        return sorted;
+    }
+
+    /**
+     * Returns a comparator that compares {@link graphql.schema.GraphQLType} objects by ascending name
+     *
+     * @return a comparator that compares {@link graphql.schema.GraphQLType} objects by ascending name
+     */
+    public static <T extends GraphQLType> Comparator<? super GraphQLType> graphQLTypeComparator() {
+        return Comparator.comparing(GraphQLType::getName);
+    }
+
+}

--- a/src/main/java/graphql/schema/GraphqlTypeComparators.java
+++ b/src/main/java/graphql/schema/GraphqlTypeComparators.java
@@ -1,13 +1,13 @@
 package graphql.schema;
 
-import graphql.PublicApi;
+import graphql.Internal;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 
-@PublicApi
+@Internal
 public class GraphqlTypeComparators {
 
     /**
@@ -20,7 +20,7 @@ public class GraphqlTypeComparators {
      * @return a new allocated list of sorted things
      */
     public static <T extends GraphQLType> List<T> sortGraphQLTypes(Collection<T> types) {
-        ArrayList<T> sorted = new ArrayList<>(types);
+        List<T> sorted = new ArrayList<>(types);
         sorted.sort(graphQLTypeComparator());
         return sorted;
     }

--- a/src/main/java/graphql/schema/GraphqlTypeComparators.java
+++ b/src/main/java/graphql/schema/GraphqlTypeComparators.java
@@ -28,6 +28,8 @@ public class GraphqlTypeComparators {
     /**
      * Returns a comparator that compares {@link graphql.schema.GraphQLType} objects by ascending name
      *
+     * @param <T> the type of type
+     *
      * @return a comparator that compares {@link graphql.schema.GraphQLType} objects by ascending name
      */
     public static <T extends GraphQLType> Comparator<? super GraphQLType> graphQLTypeComparator() {

--- a/src/main/java/graphql/schema/SchemaUtil.java
+++ b/src/main/java/graphql/schema/SchemaUtil.java
@@ -5,7 +5,7 @@ import graphql.Internal;
 import graphql.introspection.Introspection;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -53,7 +53,7 @@ public class SchemaUtil {
      *
      */
     Map<String, List<GraphQLObjectType>> groupImplementations(GraphQLSchema schema) {
-        Map<String, List<GraphQLObjectType>> result = new HashMap<>();
+        Map<String, List<GraphQLObjectType>> result = new LinkedHashMap<>();
         for (GraphQLType type : schema.getAllTypesAsList()) {
             if (type instanceof GraphQLObjectType) {
                 for (GraphQLOutputType interfaceType : ((GraphQLObjectType) type).getInterfaces()) {

--- a/src/main/java/graphql/schema/diff/SchemaDiff.java
+++ b/src/main/java/graphql/schema/diff/SchemaDiff.java
@@ -24,7 +24,7 @@ import graphql.schema.diff.reporting.DifferenceReporter;
 import graphql.schema.idl.TypeInfo;
 
 import java.util.Arrays;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -273,7 +273,7 @@ public class SchemaDiff {
         return typeName.startsWith("__");
     }
 
-    private final static Set<String> SYSTEM_SCALARS = new HashSet<>();
+    private final static Set<String> SYSTEM_SCALARS = new LinkedHashSet<>();
 
     static {
         SYSTEM_SCALARS.add("ID");

--- a/src/main/java/graphql/schema/idl/SchemaGenerator.java
+++ b/src/main/java/graphql/schema/idl/SchemaGenerator.java
@@ -59,9 +59,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -139,10 +138,10 @@ public class SchemaGenerator {
         private final Deque<String> typeStack = new ArrayDeque<>();
         private final Deque<Node> nodeStack = new ArrayDeque<>();
 
-        private final Map<String, GraphQLOutputType> outputGTypes = new HashMap<>();
-        private final Map<String, GraphQLInputType> inputGTypes = new HashMap<>();
-        private final Map<String, Object> directiveBehaviourContext = new HashMap<>();
-        private final Set<GraphQLDirective> directiveDefinitions = new HashSet<>();
+        private final Map<String, GraphQLOutputType> outputGTypes = new LinkedHashMap<>();
+        private final Map<String, GraphQLInputType> inputGTypes = new LinkedHashMap<>();
+        private final Map<String, Object> directiveBehaviourContext = new LinkedHashMap<>();
+        private final Set<GraphQLDirective> directiveDefinitions = new LinkedHashSet<>();
 
         BuildContext(TypeDefinitionRegistry typeRegistry, RuntimeWiring wiring) {
             this.typeRegistry = typeRegistry;
@@ -352,7 +351,7 @@ public class SchemaGenerator {
      * @return the additional types not referenced from the top level operations
      */
     private Set<GraphQLType> buildAdditionalTypes(BuildContext buildCtx) {
-        Set<GraphQLType> additionalTypes = new HashSet<>();
+        Set<GraphQLType> additionalTypes = new LinkedHashSet<>();
         TypeDefinitionRegistry typeRegistry = buildCtx.getTypeRegistry();
         typeRegistry.types().values().forEach(typeDefinition -> {
             TypeName typeName = TypeName.newTypeName().name(typeDefinition.getName()).build();
@@ -370,7 +369,7 @@ public class SchemaGenerator {
     }
 
     private Set<GraphQLDirective> buildAdditionalDirectives(BuildContext buildCtx) {
-        Set<GraphQLDirective> additionalDirectives = new HashSet<>();
+        Set<GraphQLDirective> additionalDirectives = new LinkedHashSet<>();
         TypeDefinitionRegistry typeRegistry = buildCtx.getTypeRegistry();
         typeRegistry.getDirectiveDefinitions().values().forEach(directiveDefinition -> {
             Function<Type, GraphQLInputType> inputTypeFactory = inputType -> buildInputType(buildCtx, inputType);
@@ -508,14 +507,14 @@ public class SchemaGenerator {
         }));
 
         interfaces.values().forEach(interfaze -> {
-          if (interfaze instanceof GraphQLInterfaceType) {
-            builder.withInterface((GraphQLInterfaceType) interfaze);
-            return;
-          }
-          if (interfaze instanceof GraphQLTypeReference) {
-            builder.withInterface((GraphQLTypeReference) interfaze);
-            return;
-          }
+            if (interfaze instanceof GraphQLInterfaceType) {
+                builder.withInterface((GraphQLInterfaceType) interfaze);
+                return;
+            }
+            if (interfaze instanceof GraphQLTypeReference) {
+                builder.withInterface((GraphQLTypeReference) interfaze);
+                return;
+            }
         });
     }
 
@@ -886,7 +885,7 @@ public class SchemaGenerator {
     private GraphQLDirective[] buildDirectives(List<Directive> directives, List<Directive> extensionDirectives, DirectiveLocation directiveLocation, Set<GraphQLDirective> directiveDefinitions) {
         directives = directives == null ? emptyList() : directives;
         extensionDirectives = extensionDirectives == null ? emptyList() : extensionDirectives;
-        Set<String> names = new HashSet<>();
+        Set<String> names = new LinkedHashSet<>();
 
         List<GraphQLDirective> output = new ArrayList<>();
         for (Directive directive : directives) {

--- a/src/main/java/graphql/schema/idl/SchemaTypeChecker.java
+++ b/src/main/java/graphql/schema/idl/SchemaTypeChecker.java
@@ -44,7 +44,7 @@ import graphql.schema.idl.errors.SchemaProblem;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -208,7 +208,7 @@ public class SchemaTypeChecker {
                     errors.add(new DirectiveIllegalLocationError(directiveDefinition, locationName));
                 }
             });
-            });
+        });
     }
 
     private void checkScalarImplementationsArePresent(List<GraphQLError> errors, TypeDefinitionRegistry typeRegistry, RuntimeWiring wiring) {
@@ -373,7 +373,7 @@ public class SchemaTypeChecker {
      * @param errorFunction     the function producing an error
      */
     static <T, E extends GraphQLError> void checkNamedUniqueness(List<GraphQLError> errors, List<T> listOfNamedThings, Function<T, String> namer, BiFunction<String, T, E> errorFunction) {
-        Set<String> names = new HashSet<>();
+        Set<String> names = new LinkedHashSet<>();
         listOfNamedThings.forEach(thing -> {
             String name = namer.apply(thing);
             if (names.contains(name)) {

--- a/src/main/java/graphql/schema/validation/NoUnbrokenInputCycles.java
+++ b/src/main/java/graphql/schema/validation/NoUnbrokenInputCycles.java
@@ -8,10 +8,9 @@ import graphql.schema.GraphQLInputType;
 import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLType;
-import graphql.schema.GraphQLTypeUtil;
 
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -36,7 +35,7 @@ public class NoUnbrokenInputCycles implements SchemaValidationRule {
             if (argumentType instanceof GraphQLInputObjectType) {
                 List<String> path = new ArrayList<>();
                 path.add(argumentType.getName());
-                check((GraphQLInputObjectType) argumentType, new HashSet<>(), path, validationErrorCollector);
+                check((GraphQLInputObjectType) argumentType, new LinkedHashSet<>(), path, validationErrorCollector);
             }
         }
     }
@@ -54,7 +53,7 @@ public class NoUnbrokenInputCycles implements SchemaValidationRule {
                 if (unwrapped instanceof GraphQLInputObjectType) {
                     path = new ArrayList<>(path);
                     path.add(field.getName() + "!");
-                    check((GraphQLInputObjectType) unwrapped, new HashSet<>(seen), path, validationErrorCollector);
+                    check((GraphQLInputObjectType) unwrapped, new LinkedHashSet<>(seen), path, validationErrorCollector);
                 }
             }
         }

--- a/src/main/java/graphql/schema/validation/SchemaValidator.java
+++ b/src/main/java/graphql/schema/validation/SchemaValidator.java
@@ -8,14 +8,14 @@ import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
 
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
 @Internal
 public class SchemaValidator {
 
-    private final Set<GraphQLOutputType> processed = new HashSet<>();
+    private final Set<GraphQLOutputType> processed = new LinkedHashSet<>();
 
     private List<SchemaValidationRule> rules = new ArrayList<>();
 

--- a/src/main/java/graphql/validation/rules/UniqueOperationNames.java
+++ b/src/main/java/graphql/validation/rules/UniqueOperationNames.java
@@ -6,7 +6,7 @@ import graphql.validation.ValidationContext;
 import graphql.validation.ValidationErrorCollector;
 import graphql.validation.ValidationErrorType;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
@@ -15,7 +15,7 @@ import java.util.Set;
  */
 public class UniqueOperationNames extends AbstractRule {
 
-    private Set<String> operationNames = new HashSet<>();
+    private Set<String> operationNames = new LinkedHashSet<>();
 
     public UniqueOperationNames(ValidationContext validationContext, ValidationErrorCollector validationErrorCollector) {
         super(validationContext, validationErrorCollector);

--- a/src/test/groovy/graphql/RelaySchemaTest.groovy
+++ b/src/test/groovy/graphql/RelaySchemaTest.groovy
@@ -90,7 +90,7 @@ class RelaySchemaTest extends Specification {
 
         then:
         def fields = result.data["__type"]["fields"]
-        fields == [[name: "node", type: [name: "Stuff", kind: "OBJECT", ofType: null]], [name: "cursor", type: [name: null, kind: "NON_NULL", ofType: [name: "String", kind: "SCALAR"]]]]
+        fields == [[name: "cursor", type: [name: null, kind: "NON_NULL", ofType: [name: "String", kind: "SCALAR"]]], [name: "node", type: [name: "Stuff", kind: "OBJECT", ofType: null]]]
     }
 
 }

--- a/src/test/groovy/graphql/StarWarsIntrospectionTests.groovy
+++ b/src/test/groovy/graphql/StarWarsIntrospectionTests.groovy
@@ -7,6 +7,30 @@ import spock.lang.Specification
 class StarWarsIntrospectionTests extends Specification {
 
     def "Allows querying the schema for types"() {
+        def expected = [
+                __schema: [types:
+                                   [
+                                           [name: 'Boolean'],
+                                           [name: 'Character'],
+                                           [name: 'Droid'],
+                                           [name: 'Episode'],
+                                           [name: 'Human'],
+                                           [name: 'HumanInput'],
+                                           [name: 'MutationType'],
+                                           [name: 'QueryType'],
+                                           [name: 'String'],
+                                           [name: '__Directive'],
+                                           [name: '__DirectiveLocation'],
+                                           [name: '__EnumValue'],
+                                           [name: '__Field'],
+                                           [name: '__InputValue'],
+                                           [name: '__Schema'],
+                                           [name: '__Type'],
+                                           [name: '__TypeKind'],
+                                   ]
+                ]
+
+        ]
         given:
         def query = """
         query IntrospectionTypeQuery {
@@ -17,29 +41,6 @@ class StarWarsIntrospectionTests extends Specification {
             }
         }
         """
-        def expected = [
-                __schema: [types:
-                                   [[name: 'Human'],
-                                    [name: '__TypeKind'],
-                                    [name: '__Field'],
-                                    [name: 'MutationType'],
-                                    [name: 'Character'],
-                                    [name: '__Schema'],
-                                    [name: 'HumanInput'],
-                                    [name: '__Type'],
-                                    [name: '__EnumValue'],
-                                    [name: '__DirectiveLocation'],
-                                    [name: 'String'],
-                                    [name: 'Droid'],
-                                    [name: 'Episode'],
-                                    [name: '__InputValue'],
-                                    [name: 'Boolean'],
-                                    [name: 'QueryType'],
-                                    [name: '__Directive']
-                                   ]
-                ]
-
-        ]
 
         when:
         def result = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema).build().execute(query).data
@@ -165,6 +166,20 @@ class StarWarsIntrospectionTests extends Specification {
                         name  : 'Droid',
                         fields: [
                                 [
+                                        name: 'appearsIn',
+                                        type: [
+                                                name: null,
+                                                kind: 'LIST'
+                                        ]
+                                ],
+                                [
+                                        name: 'friends',
+                                        type: [
+                                                name: null,
+                                                kind: 'LIST'
+                                        ]
+                                ],
+                                [
                                         name: 'id',
                                         type: [
                                                 name: null,
@@ -176,20 +191,6 @@ class StarWarsIntrospectionTests extends Specification {
                                         type: [
                                                 name: 'String',
                                                 kind: 'SCALAR'
-                                        ]
-                                ],
-                                [
-                                        name: 'friends',
-                                        type: [
-                                                name: null,
-                                                kind: 'LIST'
-                                        ]
-                                ],
-                                [
-                                        name: 'appearsIn',
-                                        type: [
-                                                name: null,
-                                                kind: 'LIST'
                                         ]
                                 ],
                                 [
@@ -234,6 +235,28 @@ class StarWarsIntrospectionTests extends Specification {
                         name  : 'Droid',
                         fields: [
                                 [
+                                        name: 'appearsIn',
+                                        type: [
+                                                name  : null,
+                                                kind  : 'LIST',
+                                                ofType: [
+                                                        name: 'Episode',
+                                                        kind: 'ENUM'
+                                                ]
+                                        ]
+                                ],
+                                [
+                                        name: 'friends',
+                                        type: [
+                                                name  : null,
+                                                kind  : 'LIST',
+                                                ofType: [
+                                                        name: 'Character',
+                                                        kind: 'INTERFACE'
+                                                ]
+                                        ]
+                                ],
+                                [
                                         name: 'id',
                                         type: [
                                                 name  : null,
@@ -250,28 +273,6 @@ class StarWarsIntrospectionTests extends Specification {
                                                 name  : 'String',
                                                 kind  : 'SCALAR',
                                                 ofType: null
-                                        ]
-                                ],
-                                [
-                                        name: 'friends',
-                                        type: [
-                                                name  : null,
-                                                kind  : 'LIST',
-                                                ofType: [
-                                                        name: 'Character',
-                                                        kind: 'INTERFACE'
-                                                ]
-                                        ]
-                                ],
-                                [
-                                        name: 'appearsIn',
-                                        type: [
-                                                name  : null,
-                                                kind  : 'LIST',
-                                                ofType: [
-                                                        name: 'Episode',
-                                                        kind: 'ENUM'
-                                                ]
                                         ]
                                 ],
                                 [
@@ -323,6 +324,24 @@ class StarWarsIntrospectionTests extends Specification {
                         queryType: [
                                 fields: [
                                         [
+                                                name: 'droid',
+                                                args: [
+                                                        [
+                                                                name        : 'id',
+                                                                description : 'id of the droid',
+                                                                type        : [
+                                                                        kind  : 'NON_NULL',
+                                                                        name  : null,
+                                                                        ofType: [
+                                                                                kind: 'SCALAR',
+                                                                                name: 'String'
+                                                                        ]
+                                                                ],
+                                                                defaultValue: null
+                                                        ]
+                                                ]
+                                        ],
+                                        [
                                                 name: 'hero',
                                                 args: [
                                                         [
@@ -359,24 +378,6 @@ class StarWarsIntrospectionTests extends Specification {
                                                         ]
                                                 ]
                                         ],
-                                        [
-                                                name: 'droid',
-                                                args: [
-                                                        [
-                                                                name        : 'id',
-                                                                description : 'id of the droid',
-                                                                type        : [
-                                                                        kind  : 'NON_NULL',
-                                                                        name  : null,
-                                                                        ofType: [
-                                                                                kind: 'SCALAR',
-                                                                                name: 'String'
-                                                                        ]
-                                                                ],
-                                                                defaultValue: null
-                                                        ]
-                                                ]
-                                        ]
                                 ]
                         ]
                 ]

--- a/src/test/groovy/graphql/UnionTest.groovy
+++ b/src/test/groovy/graphql/UnionTest.groovy
@@ -38,8 +38,8 @@ class UnionTest extends Specification {
                 interfaces   : null,
                 possibleTypes: [
                         [name: 'Cat'],
+                        [name: 'Dog'],
                         [name: 'Person'],
-                        [name: 'Dog']
                 ],
                 enumValues   : null,
                 inputFields  : null

--- a/src/test/groovy/graphql/schema/GraphQLSchemaTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLSchemaTest.groovy
@@ -28,7 +28,7 @@ class GraphQLSchemaTest extends Specification {
         then:
         objectTypes.size() == 2
         objectTypes == [
-                humanType, droidType
+                droidType, humanType
         ]
 
     }

--- a/src/test/groovy/graphql/schema/GraphqlTypeComparatorsTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphqlTypeComparatorsTest.groovy
@@ -1,0 +1,149 @@
+package graphql.schema
+
+import graphql.TestUtil
+import spock.lang.Specification
+
+class GraphqlTypeComparatorsTest extends Specification {
+
+    def spec = '''
+            type Query {
+                zField(zArg : String, yArg : String, xArg : InputType) : ZType
+                yField : YInterface
+                xField : XUnion
+            }
+            
+            type ZType {
+                enumField : EnumType
+            }
+            
+            interface YInterface {
+                zField : String
+                yField : String
+                xField : String
+            } 
+            
+            interface XInterface {
+                zField : String
+                yField : String
+                xField : String
+            }
+
+            interface ZInterface {
+                zField : String
+                yField : String
+                xField : String
+            }
+            
+            union XUnion = Foo | Bar
+            
+            type Foo implements YInterface, XInterface, ZInterface {
+                zField : String
+                yField : String
+                xField : String
+            }
+            
+            type Bar implements YInterface {
+                zField : String
+                yField : String
+                xField : String
+            }
+            
+            enum EnumType {
+                z
+                y
+                x
+            }
+            
+            input InputType {
+                zInput : String
+                xInput : String
+                yInput : String
+            }
+        '''
+
+    def schema = TestUtil.schema(spec)
+
+    def "test that types sorted from the schema"() {
+        def expectedNames = ["Bar", "Boolean", "EnumType", "Foo", "InputType", "Query", "String", "XInterface", "XUnion", "YInterface", "ZInterface", "ZType",
+                             "__Directive", "__DirectiveLocation", "__EnumValue", "__Field", "__InputValue", "__Schema", "__Type", "__TypeKind"]
+        when:
+        def names = schema.getAllTypesAsList().collect({ thing -> thing.getName() })
+
+        then:
+        names == expectedNames
+
+        when:
+        names = schema.getTypeMap().values().collect({ thing -> thing.getName() })
+
+        then:
+        names == expectedNames
+
+        when:
+        names = schema.getTypeMap().keySet().toList()
+
+        then:
+        names == expectedNames
+
+    }
+
+    def "test that fields in a type are sorted"() {
+        when:
+        def names = schema.getObjectType("Query").getFieldDefinitions().collect({ thing -> thing.getName() })
+
+        then:
+        names == ["xField", "yField", "zField"]
+
+        when:
+        def interfaceType = schema.getType("YInterface") as GraphQLInterfaceType
+        names = interfaceType.getFieldDefinitions().collect({ thing -> thing.getName() })
+
+        then:
+        names == ["xField", "yField", "zField"]
+    }
+
+    def "test that members in a union are sorted"() {
+        when:
+        def unionType = schema.getType("XUnion") as GraphQLUnionType
+        def names = unionType.getTypes().collect({ thing -> thing.getName() })
+
+        then:
+        names == ["Bar", "Foo"]
+    }
+
+    def "test that implementations in a object type are sorted"() {
+        when:
+        def objectType = schema.getObjectType("Foo")
+        def names = objectType.getInterfaces().collect({ thing -> thing.getName() })
+
+        then:
+        names == ["XInterface", "YInterface", "ZInterface"]
+    }
+
+    def "test that args in a field in a type are sorted"() {
+        when:
+        def names = schema.getObjectType("Query").getFieldDefinition("zField").getArguments().collect({ thing -> thing.getName() })
+
+        then:
+        names == ["xArg", "yArg", "zArg"]
+
+    }
+
+    def "test that enum values in a enum are sorted"() {
+        def enumType = schema.getType("EnumType") as GraphQLEnumType
+        when:
+        def names = enumType.getValues().collect({ thing -> thing.getName() })
+
+        then:
+        names == ["x", "y", "z"]
+
+    }
+
+    def "test that input fields in a input type are sorted"() {
+        def inputType = schema.getType("InputType") as GraphQLInputObjectType
+        when:
+        def names = inputType.getFieldDefinitions().collect({ thing -> thing.getName() })
+
+        then:
+        names == ["xInput", "yInput", "zInput"]
+    }
+}

--- a/src/test/groovy/graphql/schema/SchemaUtilTest.groovy
+++ b/src/test/groovy/graphql/schema/SchemaUtilTest.groovy
@@ -111,7 +111,7 @@ class SchemaUtilTest extends Specification {
         byInterface.size() == 1
         byInterface[characterInterface.getName()].size() == 2
         byInterface == [
-                (characterInterface.getName()): [humanType, droidType]
+                (characterInterface.getName()): [ droidType, humanType]
         ]
     }
 

--- a/src/test/groovy/graphql/schema/TypeTraverserTest.groovy
+++ b/src/test/groovy/graphql/schema/TypeTraverserTest.groovy
@@ -58,8 +58,8 @@ class TypeTraverserTest extends Specification {
                 .build())
         then:
         visitor.getStack() == ["enum: foo", "fallback: foo",
-                               "enum value: bar", "fallback: bar",
-                               "enum value: abc", "fallback: abc"]
+                               "enum value: abc", "fallback: abc",
+                               "enum value: bar", "fallback: bar"]
 
     }
 

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorDirectiveHelperTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorDirectiveHelperTest.groovy
@@ -204,7 +204,7 @@ class SchemaGeneratorDirectiveHelperTest extends Specification {
         targetList.contains("ScalarType")
     }
 
-    def "can modify the existing behaviour"() {
+    def     "can modify the existing behaviour"() {
         def spec = '''
             type Query {
                 lowerCaseValue : String @uppercase

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -301,8 +301,8 @@ class SchemaGeneratorTest extends Specification {
         types.size() == 2
         types[0] instanceof GraphQLObjectType
         types[1] instanceof GraphQLObjectType
-        types[0].name == "Foo"
-        types[1].name == "Bar"
+        types[0].name == "Bar"
+        types[1].name == "Foo"
 
     }
 
@@ -338,8 +338,8 @@ class SchemaGeneratorTest extends Specification {
         types.size() == 2
         types[0] instanceof GraphQLObjectType
         types[1] instanceof GraphQLObjectType
-        types[0].name == "Foo"
-        types[1].name == "Bar"
+        types[0].name == "Bar"
+        types[1].name == "Foo"
 
     }
 
@@ -374,8 +374,8 @@ class SchemaGeneratorTest extends Specification {
         types.size() == 2
         types[0] instanceof GraphQLObjectType
         types[1] instanceof GraphQLObjectType
-        types[0].name == "Foo"
-        types[1].name == "Bar"
+        types[0].name == "Bar"
+        types[1].name == "Foo"
 
     }
 
@@ -447,9 +447,9 @@ class SchemaGeneratorTest extends Specification {
         enumType.getName() == "RGB"
         enumType.getDefinition().getName() == "RGB"
 
-        enumType.values.get(0).getValue() == "RED"
+        enumType.values.get(0).getValue() == "BLUE"
         enumType.values.get(1).getValue() == "GREEN"
-        enumType.values.get(2).getValue() == "BLUE"
+        enumType.values.get(2).getValue() == "RED"
 
     }
 
@@ -482,9 +482,9 @@ class SchemaGeneratorTest extends Specification {
         interfaceType.name == "Foo"
         interfaceType.getDefinition().getName() == "Foo"
 
-        schema.queryType.fieldDefinitions[0].name == "is_foo"
+        schema.queryType.fieldDefinitions[0].name == "is_bar"
         schema.queryType.fieldDefinitions[0].type.name == "Boolean"
-        schema.queryType.fieldDefinitions[1].name == "is_bar"
+        schema.queryType.fieldDefinitions[1].name == "is_foo"
         schema.queryType.fieldDefinitions[1].type.name == "Boolean"
 
     }
@@ -607,11 +607,11 @@ class SchemaGeneratorTest extends Specification {
         GraphQLObjectType type = schema.getQueryType()
 
         type.name == "Human"
-        type.fieldDefinitions[0].name == "id"
-        type.fieldDefinitions[1].name == "name"
-        type.fieldDefinitions[2].name == "friends"
-        type.fieldDefinitions[3].name == "appearsIn"
-        type.fieldDefinitions[4].name == "homePlanet"
+        type.fieldDefinitions[0].name == "appearsIn"
+        type.fieldDefinitions[1].name == "friends"
+        type.fieldDefinitions[2].name == "homePlanet"
+        type.fieldDefinitions[3].name == "id"
+        type.fieldDefinitions[4].name == "name"
 
         type.interfaces.size() == 1
         type.interfaces[0].name == "Character"
@@ -1183,13 +1183,14 @@ class SchemaGeneratorTest extends Specification {
         directive.arguments[argIndex].type == argType
         directive.arguments[argIndex].value == argValue
 
+        // arguments are sorted
         where:
         argIndex | argName    | argType        | argValue
-        0        | "strArg"   | GraphQLString  | "String"
-        1        | "intArg"   | GraphQLInt     | 1
-        2        | "boolArg"  | GraphQLBoolean | true
-        3        | "floatArg" | GraphQLFloat   | 1.1
-        4        | "nullArg"  | GraphQLString  | null
+        0        | "boolArg"  | GraphQLBoolean | true
+        1        | "floatArg" | GraphQLFloat   | 1.1
+        2        | "intArg"   | GraphQLInt     | 1
+        3        | "nullArg"  | GraphQLString  | null
+        4        | "strArg"   | GraphQLString  | "String"
 
     }
 

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -413,8 +413,8 @@ class SchemaGeneratorTest extends Specification {
         types.size() == 2
         types[0] instanceof GraphQLObjectType
         types[1] instanceof GraphQLObjectType
-        types[0].name == "Foo"
-        types[1].name == "Bar"
+        types[0].name == "Bar"
+        types[1].name == "Foo"
 
     }
 

--- a/src/test/groovy/graphql/schema/visibility/BlockedFieldsTest.groovy
+++ b/src/test/groovy/graphql/schema/visibility/BlockedFieldsTest.groovy
@@ -43,12 +43,12 @@ class BlockedFieldsTest extends Specification {
 
         where:
         why                              | type                              | patterns                                       | expectedFieldList
-        "partial field name match"       | StarWarsSchema.characterInterface | [".*\\.name"]                                  | ["id", "friends", "appearsIn"]
-        "no match"                       | StarWarsSchema.characterInterface | ["Character.mismatched"]                       | ["id", "name", "friends", "appearsIn"]
+        "partial field name match"       | StarWarsSchema.characterInterface | [".*\\.name"]                                  | ["appearsIn", "friends", "id"]
+        "no match"                       | StarWarsSchema.characterInterface | ["Character.mismatched"]                       | ["appearsIn", "friends", "id", "name",]
         "all blocked"                    | StarWarsSchema.characterInterface | [".*"]                                         | []
-        "needs FQN to match"             | StarWarsSchema.characterInterface | ["name"]                                       | ["id", "name", "friends", "appearsIn"]
-        "FQN"                            | StarWarsSchema.characterInterface | ["Character.name"]                             | ["id", "friends", "appearsIn"]
-        "multiple patterns"              | StarWarsSchema.characterInterface | ["Character.name", ".*.id"]                    | ["friends", "appearsIn"]
+        "needs FQN to match"             | StarWarsSchema.characterInterface | ["name"]                                       | ["appearsIn", "friends", "id", "name",]
+        "FQN"                            | StarWarsSchema.characterInterface | ["Character.name"]                             | ["appearsIn", "friends", "id",]
+        "multiple patterns"              | StarWarsSchema.characterInterface | ["Character.name", ".*.id"]                    | ["appearsIn", "friends", ]
 
         "input partial field name match" | accessInputType                   | [".*\\.secretRoles"]                           | ["openRoles", "questionableRoles"]
         "input no match"                 | accessInputType                   | ["Access.mismatched"]                          | ["openRoles", "questionableRoles", "secretRoles"]


### PR DESCRIPTION
See #1314 

Now when  a the schema is asked for all types, it is named sorted.

When an object is asked for its fields, they are name sorted

When the arguments of a field is asked for, they are name sorted.

This will mean that Introspection stays stable and make it that much easier to build "contract tooling"