### PR TITLE
add ignored chars to the AST

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ def getDevelopmentVersion() {
         println "git hash is empty: error: ${error.toString()}"
         throw new IllegalStateException("git hash could not be determined")
     }
-    new SimpleDateFormat('yyyy-MM-dd\'T\'HH-mm-ss').format(new Date()) + "-" + gitHash
+    new SimpleDateFormat('yyyy-MM-dd\'T\'HH-mm-ss').format(new Date()) + "-" + gitHash + "-ignored-chars"
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ def getDevelopmentVersion() {
         println "git hash is empty: error: ${error.toString()}"
         throw new IllegalStateException("git hash could not be determined")
     }
-    new SimpleDateFormat('yyyy-MM-dd\'T\'HH-mm-ss').format(new Date()) + "-" + gitHash + "-ignored-chars"
+    new SimpleDateFormat('yyyy-MM-dd\'T\'HH-mm-ss').format(new Date()) + "-" + gitHash
 }
 
 

--- a/src/main/antlr/GraphqlCommon.g4
+++ b/src/main/antlr/GraphqlCommon.g4
@@ -120,14 +120,17 @@ fragment SourceCharacter :[\u0009\u000A\u000D\u0020-\uFFFF];
 
 Comment: '#' ~[\n\r\u2028\u2029]* -> channel(2);
 
-Ignored: (UnicodeBOM|Whitespace|LineTerminator|Comma) -> skip;
+//Ignored: (UnicodeBOM|Whitespace|LineTerminator|Comma) -> channel(3);
 
 fragment EscapedChar :   '\\' (["\\/bfnrt] | Unicode) ;
 fragment Unicode : 'u' Hex Hex Hex Hex ;
 fragment Hex : [0-9a-fA-F] ;
 
-fragment LineTerminator: [\n\r\u2028\u2029];
+LF: [\n] -> channel(3);
+CR: [\r] -> channel(3);
+LineTerminator: [\u2028\u2029] -> channel(3);
 
-fragment Whitespace : [\u0009\u0020];
-fragment Comma : ',';
-fragment UnicodeBOM : [\ufeff];
+Space : [\u0020] -> channel(3);
+Tab : [\u0009] -> channel(3);
+Comma : ',' -> channel(3);
+UnicodeBOM : [\ufeff] -> channel(3);

--- a/src/main/antlr/GraphqlCommon.g4
+++ b/src/main/antlr/GraphqlCommon.g4
@@ -120,8 +120,6 @@ fragment SourceCharacter :[\u0009\u000A\u000D\u0020-\uFFFF];
 
 Comment: '#' ~[\n\r\u2028\u2029]* -> channel(2);
 
-//Ignored: (UnicodeBOM|Whitespace|LineTerminator|Comma) -> channel(3);
-
 fragment EscapedChar :   '\\' (["\\/bfnrt] | Unicode) ;
 fragment Unicode : 'u' Hex Hex Hex Hex ;
 fragment Hex : [0-9a-fA-F] ;

--- a/src/main/java/graphql/language/AbstractNode.java
+++ b/src/main/java/graphql/language/AbstractNode.java
@@ -13,11 +13,13 @@ public abstract class AbstractNode<T extends Node> implements Node<T> {
 
     private final SourceLocation sourceLocation;
     private final List<Comment> comments;
+    private final IgnoredChars ignoredChars;
 
-    public AbstractNode(SourceLocation sourceLocation, List<Comment> comments) {
+    public AbstractNode(SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars) {
         this.sourceLocation = sourceLocation;
         Assert.assertNotNull(comments, "comments can't be null");
         this.comments = new ArrayList<>(comments);
+        this.ignoredChars = Assert.assertNotNull(ignoredChars, "ignoredChars can't be null");
     }
 
     @Override
@@ -30,6 +32,10 @@ public abstract class AbstractNode<T extends Node> implements Node<T> {
         return new ArrayList<>(comments);
     }
 
+    @Override
+    public IgnoredChars getIgnoredChars() {
+        return ignoredChars;
+    }
 
     @SuppressWarnings("unchecked")
     protected <V extends Node> V deepCopy(V nullableObj) {

--- a/src/main/java/graphql/language/Argument.java
+++ b/src/main/java/graphql/language/Argument.java
@@ -17,8 +17,8 @@ public class Argument extends AbstractNode<Argument> implements NamedNode<Argume
     private Value value;
 
     @Internal
-    protected Argument(String name, Value value, SourceLocation sourceLocation, List<Comment> comments) {
-        super(sourceLocation, comments);
+    protected Argument(String name, Value value, SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
         this.name = name;
         this.value = value;
     }
@@ -26,11 +26,11 @@ public class Argument extends AbstractNode<Argument> implements NamedNode<Argume
     /**
      * alternative to using a Builder for convenience
      *
-     * @param name of the argument
+     * @param name  of the argument
      * @param value of the argument
      */
     public Argument(String name, Value value) {
-        this(name, value, null, new ArrayList<>());
+        this(name, value, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     @Override
@@ -60,8 +60,12 @@ public class Argument extends AbstractNode<Argument> implements NamedNode<Argume
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         Argument that = (Argument) o;
 
@@ -71,7 +75,7 @@ public class Argument extends AbstractNode<Argument> implements NamedNode<Argume
 
     @Override
     public Argument deepCopy() {
-        return new Argument(name, deepCopy(value), getSourceLocation(), getComments());
+        return new Argument(name, deepCopy(value), getSourceLocation(), getComments(), getIgnoredChars());
     }
 
     @Override
@@ -106,6 +110,7 @@ public class Argument extends AbstractNode<Argument> implements NamedNode<Argume
         private List<Comment> comments = new ArrayList<>();
         private String name;
         private Value value;
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -115,6 +120,7 @@ public class Argument extends AbstractNode<Argument> implements NamedNode<Argume
             this.comments = existing.getComments();
             this.name = existing.getName();
             this.value = existing.getValue();
+            this.ignoredChars = existing.getIgnoredChars();
         }
 
         public Builder sourceLocation(SourceLocation sourceLocation) {
@@ -137,8 +143,13 @@ public class Argument extends AbstractNode<Argument> implements NamedNode<Argume
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public Argument build() {
-            Argument argument = new Argument(name, value, sourceLocation, comments);
+            Argument argument = new Argument(name, value, sourceLocation, comments, ignoredChars);
             return argument;
         }
     }

--- a/src/main/java/graphql/language/ArrayValue.java
+++ b/src/main/java/graphql/language/ArrayValue.java
@@ -16,8 +16,8 @@ public class ArrayValue extends AbstractNode<ArrayValue> implements Value<ArrayV
     private final List<Value> values = new ArrayList<>();
 
     @Internal
-    protected ArrayValue(List<Value> values, SourceLocation sourceLocation, List<Comment> comments) {
-        super(sourceLocation, comments);
+    protected ArrayValue(List<Value> values, SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
         this.values.addAll(values);
     }
 
@@ -27,7 +27,7 @@ public class ArrayValue extends AbstractNode<ArrayValue> implements Value<ArrayV
      * @param values of the array
      */
     public ArrayValue(List<Value> values) {
-        this(values,null, new ArrayList<>());
+        this(values, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     public List<Value> getValues() {
@@ -41,8 +41,12 @@ public class ArrayValue extends AbstractNode<ArrayValue> implements Value<ArrayV
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         return true;
     }
@@ -56,7 +60,7 @@ public class ArrayValue extends AbstractNode<ArrayValue> implements Value<ArrayV
 
     @Override
     public ArrayValue deepCopy() {
-        return new ArrayValue(deepCopy(values), getSourceLocation(), getComments());
+        return new ArrayValue(deepCopy(values), getSourceLocation(), getComments(), getIgnoredChars());
     }
 
     @Override
@@ -78,6 +82,7 @@ public class ArrayValue extends AbstractNode<ArrayValue> implements Value<ArrayV
         private SourceLocation sourceLocation;
         private List<Value> values = new ArrayList<>();
         private List<Comment> comments = new ArrayList<>();
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -86,6 +91,7 @@ public class ArrayValue extends AbstractNode<ArrayValue> implements Value<ArrayV
             this.sourceLocation = existing.getSourceLocation();
             this.comments = existing.getComments();
             this.values = existing.getValues();
+            this.ignoredChars = existing.getIgnoredChars();
         }
 
         public Builder sourceLocation(SourceLocation sourceLocation) {
@@ -108,8 +114,13 @@ public class ArrayValue extends AbstractNode<ArrayValue> implements Value<ArrayV
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public ArrayValue build() {
-            ArrayValue arrayValue = new ArrayValue(values, sourceLocation, comments);
+            ArrayValue arrayValue = new ArrayValue(values, sourceLocation, comments, ignoredChars);
             return arrayValue;
         }
     }

--- a/src/main/java/graphql/language/BooleanValue.java
+++ b/src/main/java/graphql/language/BooleanValue.java
@@ -16,8 +16,8 @@ public class BooleanValue extends AbstractNode<BooleanValue> implements ScalarVa
     private final boolean value;
 
     @Internal
-    protected BooleanValue(boolean value, SourceLocation sourceLocation, List<Comment> comments) {
-        super(sourceLocation, comments);
+    protected BooleanValue(boolean value, SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
         this.value = value;
     }
 
@@ -27,7 +27,7 @@ public class BooleanValue extends AbstractNode<BooleanValue> implements ScalarVa
      * @param value of the Boolean
      */
     public BooleanValue(boolean value) {
-        this(value, null, new ArrayList<>());
+        this(value, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     public boolean isValue() {
@@ -41,8 +41,12 @@ public class BooleanValue extends AbstractNode<BooleanValue> implements ScalarVa
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         BooleanValue that = (BooleanValue) o;
 
@@ -52,7 +56,7 @@ public class BooleanValue extends AbstractNode<BooleanValue> implements ScalarVa
 
     @Override
     public BooleanValue deepCopy() {
-        return new BooleanValue(value, getSourceLocation(), getComments());
+        return new BooleanValue(value, getSourceLocation(), getComments(), getIgnoredChars());
     }
 
     @Override
@@ -86,6 +90,7 @@ public class BooleanValue extends AbstractNode<BooleanValue> implements ScalarVa
         private SourceLocation sourceLocation;
         private boolean value;
         private List<Comment> comments = new ArrayList<>();
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -94,6 +99,7 @@ public class BooleanValue extends AbstractNode<BooleanValue> implements ScalarVa
             this.sourceLocation = existing.getSourceLocation();
             this.comments = existing.getComments();
             this.value = existing.isValue();
+            this.ignoredChars = existing.getIgnoredChars();
         }
 
 
@@ -112,8 +118,13 @@ public class BooleanValue extends AbstractNode<BooleanValue> implements ScalarVa
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public BooleanValue build() {
-            BooleanValue booleanValue = new BooleanValue(value, sourceLocation, comments);
+            BooleanValue booleanValue = new BooleanValue(value, sourceLocation, comments, ignoredChars);
             return booleanValue;
         }
     }

--- a/src/main/java/graphql/language/Directive.java
+++ b/src/main/java/graphql/language/Directive.java
@@ -19,8 +19,8 @@ public class Directive extends AbstractNode<Directive> implements NamedNode<Dire
     private final List<Argument> arguments = new ArrayList<>();
 
     @Internal
-    protected Directive(String name, List<Argument> arguments, SourceLocation sourceLocation, List<Comment> comments) {
-        super(sourceLocation, comments);
+    protected Directive(String name, List<Argument> arguments, SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
         this.name = name;
         this.arguments.addAll(arguments);
     }
@@ -32,7 +32,7 @@ public class Directive extends AbstractNode<Directive> implements NamedNode<Dire
      * @param arguments of the directive
      */
     public Directive(String name, List<Argument> arguments) {
-        this(name, arguments, null, new ArrayList<>());
+        this(name, arguments, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
 
@@ -42,7 +42,7 @@ public class Directive extends AbstractNode<Directive> implements NamedNode<Dire
      * @param name of the directive
      */
     public Directive(String name) {
-        this(name, new ArrayList<>(), null, new ArrayList<>());
+        this(name, new ArrayList<>(), null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     public List<Argument> getArguments() {
@@ -71,8 +71,12 @@ public class Directive extends AbstractNode<Directive> implements NamedNode<Dire
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         Directive that = (Directive) o;
 
@@ -82,7 +86,7 @@ public class Directive extends AbstractNode<Directive> implements NamedNode<Dire
 
     @Override
     public Directive deepCopy() {
-        return new Directive(name, deepCopy(arguments), getSourceLocation(), getComments());
+        return new Directive(name, deepCopy(arguments), getSourceLocation(), getComments(), getIgnoredChars());
     }
 
     @Override
@@ -113,6 +117,7 @@ public class Directive extends AbstractNode<Directive> implements NamedNode<Dire
         private List<Comment> comments = new ArrayList<>();
         private String name;
         private List<Argument> arguments = new ArrayList<>();
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -122,6 +127,7 @@ public class Directive extends AbstractNode<Directive> implements NamedNode<Dire
             this.comments = existing.getComments();
             this.name = existing.getName();
             this.arguments = existing.getArguments();
+            this.ignoredChars = existing.getIgnoredChars();
         }
 
 
@@ -145,8 +151,13 @@ public class Directive extends AbstractNode<Directive> implements NamedNode<Dire
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public Directive build() {
-            Directive directive = new Directive(name, arguments, sourceLocation, comments);
+            Directive directive = new Directive(name, arguments, sourceLocation, comments, ignoredChars);
             return directive;
         }
     }

--- a/src/main/java/graphql/language/DirectiveDefinition.java
+++ b/src/main/java/graphql/language/DirectiveDefinition.java
@@ -22,9 +22,10 @@ public class DirectiveDefinition extends AbstractNode<DirectiveDefinition> imple
                                   List<InputValueDefinition> inputValueDefinitions,
                                   List<DirectiveLocation> directiveLocations,
                                   SourceLocation sourceLocation,
-                                  List<Comment> comments
+                                  List<Comment> comments,
+                                  IgnoredChars ignoredChars
     ) {
-        super(sourceLocation, comments);
+        super(sourceLocation, comments, ignoredChars);
         this.name = name;
         this.inputValueDefinitions = inputValueDefinitions;
         this.directiveLocations = directiveLocations;
@@ -36,7 +37,7 @@ public class DirectiveDefinition extends AbstractNode<DirectiveDefinition> imple
      * @param name of the directive definition
      */
     public DirectiveDefinition(String name) {
-        this(name, new ArrayList<>(), new ArrayList<>(), null, new ArrayList<>());
+        this(name, new ArrayList<>(), new ArrayList<>(), null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     @Override
@@ -70,8 +71,12 @@ public class DirectiveDefinition extends AbstractNode<DirectiveDefinition> imple
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         DirectiveDefinition that = (DirectiveDefinition) o;
 
@@ -84,7 +89,8 @@ public class DirectiveDefinition extends AbstractNode<DirectiveDefinition> imple
                 deepCopy(inputValueDefinitions),
                 deepCopy(directiveLocations),
                 getSourceLocation(),
-                getComments());
+                getComments(),
+                getIgnoredChars());
     }
 
     @Override
@@ -118,6 +124,7 @@ public class DirectiveDefinition extends AbstractNode<DirectiveDefinition> imple
         private Description description;
         private List<InputValueDefinition> inputValueDefinitions = new ArrayList<>();
         private List<DirectiveLocation> directiveLocations = new ArrayList<>();
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -129,6 +136,7 @@ public class DirectiveDefinition extends AbstractNode<DirectiveDefinition> imple
             this.description = existing.getDescription();
             this.inputValueDefinitions = existing.getInputValueDefinitions();
             this.directiveLocations = existing.getDirectiveLocations();
+            this.ignoredChars = existing.getIgnoredChars();
         }
 
         public Builder sourceLocation(SourceLocation sourceLocation) {
@@ -171,8 +179,13 @@ public class DirectiveDefinition extends AbstractNode<DirectiveDefinition> imple
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public DirectiveDefinition build() {
-            DirectiveDefinition directiveDefinition = new DirectiveDefinition(name, inputValueDefinitions, directiveLocations, sourceLocation, comments);
+            DirectiveDefinition directiveDefinition = new DirectiveDefinition(name, inputValueDefinitions, directiveLocations, sourceLocation, comments, ignoredChars);
             directiveDefinition.setDescription(description);
             return directiveDefinition;
         }

--- a/src/main/java/graphql/language/DirectiveLocation.java
+++ b/src/main/java/graphql/language/DirectiveLocation.java
@@ -23,8 +23,8 @@ public class DirectiveLocation extends AbstractNode<DirectiveLocation> implement
     private final String name;
 
     @Internal
-    protected DirectiveLocation(String name, SourceLocation sourceLocation, List<Comment> comments) {
-        super(sourceLocation, comments);
+    protected DirectiveLocation(String name, SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
         this.name = name;
     }
 
@@ -34,7 +34,7 @@ public class DirectiveLocation extends AbstractNode<DirectiveLocation> implement
      * @param name of the directive location
      */
     public DirectiveLocation(String name) {
-        this(name, null, new ArrayList<>());
+        this(name, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     @Override
@@ -49,8 +49,12 @@ public class DirectiveLocation extends AbstractNode<DirectiveLocation> implement
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         DirectiveLocation that = (DirectiveLocation) o;
 
@@ -59,7 +63,7 @@ public class DirectiveLocation extends AbstractNode<DirectiveLocation> implement
 
     @Override
     public DirectiveLocation deepCopy() {
-        return new DirectiveLocation(name, getSourceLocation(), getComments());
+        return new DirectiveLocation(name, getSourceLocation(), getComments(), getIgnoredChars());
     }
 
     @Override
@@ -88,6 +92,7 @@ public class DirectiveLocation extends AbstractNode<DirectiveLocation> implement
         private SourceLocation sourceLocation;
         private List<Comment> comments = new ArrayList<>();
         private String name;
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -113,8 +118,13 @@ public class DirectiveLocation extends AbstractNode<DirectiveLocation> implement
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public DirectiveLocation build() {
-            DirectiveLocation directiveLocation = new DirectiveLocation(name, sourceLocation, comments);
+            DirectiveLocation directiveLocation = new DirectiveLocation(name, sourceLocation, comments, ignoredChars);
             return directiveLocation;
         }
     }

--- a/src/main/java/graphql/language/Document.java
+++ b/src/main/java/graphql/language/Document.java
@@ -16,8 +16,8 @@ public class Document extends AbstractNode<Document> {
     private final List<Definition> definitions;
 
     @Internal
-    protected Document(List<Definition> definitions, SourceLocation sourceLocation, List<Comment> comments) {
-        super(sourceLocation, comments);
+    protected Document(List<Definition> definitions, SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
         this.definitions = definitions;
     }
 
@@ -27,7 +27,7 @@ public class Document extends AbstractNode<Document> {
      * @param definitions the definitions that make up this document
      */
     public Document(List<Definition> definitions) {
-        this(definitions, null, new ArrayList<>());
+        this(definitions, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     public List<Definition> getDefinitions() {
@@ -43,15 +43,19 @@ public class Document extends AbstractNode<Document> {
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         return true;
     }
 
     @Override
     public Document deepCopy() {
-        return new Document(deepCopy(definitions), getSourceLocation(), getComments());
+        return new Document(deepCopy(definitions), getSourceLocation(), getComments(), getIgnoredChars());
     }
 
     @Override
@@ -80,6 +84,7 @@ public class Document extends AbstractNode<Document> {
         private List<Definition> definitions = new ArrayList<>();
         private SourceLocation sourceLocation;
         private List<Comment> comments = new ArrayList<>();
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -88,6 +93,7 @@ public class Document extends AbstractNode<Document> {
             this.sourceLocation = existing.getSourceLocation();
             this.comments = existing.getComments();
             this.definitions = existing.getDefinitions();
+            this.ignoredChars = existing.getIgnoredChars();
         }
 
         public Builder definitions(List<Definition> definitions) {
@@ -110,8 +116,13 @@ public class Document extends AbstractNode<Document> {
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public Document build() {
-            Document document = new Document(definitions, sourceLocation, comments);
+            Document document = new Document(definitions, sourceLocation, comments, ignoredChars);
             return document;
         }
     }

--- a/src/main/java/graphql/language/EnumTypeDefinition.java
+++ b/src/main/java/graphql/language/EnumTypeDefinition.java
@@ -22,8 +22,9 @@ public class EnumTypeDefinition extends AbstractNode<EnumTypeDefinition> impleme
                                  List<Directive> directives,
                                  Description description,
                                  SourceLocation sourceLocation,
-                                 List<Comment> comments) {
-        super(sourceLocation, comments);
+                                 List<Comment> comments,
+                                 IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
         this.name = name;
         this.description = description;
         this.directives = (null == directives) ? new ArrayList<>() : directives;
@@ -36,7 +37,7 @@ public class EnumTypeDefinition extends AbstractNode<EnumTypeDefinition> impleme
      * @param name of the enum
      */
     public EnumTypeDefinition(String name) {
-        this(name, new ArrayList<>(), new ArrayList<>(), null, null, new ArrayList<>());
+        this(name, new ArrayList<>(), new ArrayList<>(), null, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     public List<EnumValueDefinition> getEnumValueDefinitions() {
@@ -67,8 +68,12 @@ public class EnumTypeDefinition extends AbstractNode<EnumTypeDefinition> impleme
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         EnumTypeDefinition that = (EnumTypeDefinition) o;
 
@@ -81,7 +86,9 @@ public class EnumTypeDefinition extends AbstractNode<EnumTypeDefinition> impleme
                 deepCopy(enumValueDefinitions),
                 deepCopy(directives),
                 description,
-                getSourceLocation(), getComments());
+                getSourceLocation(),
+                getComments(),
+                getIgnoredChars());
     }
 
     @Override
@@ -115,6 +122,7 @@ public class EnumTypeDefinition extends AbstractNode<EnumTypeDefinition> impleme
         private Description description;
         private List<EnumValueDefinition> enumValueDefinitions = new ArrayList<>();
         private List<Directive> directives = new ArrayList<>();
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -126,6 +134,7 @@ public class EnumTypeDefinition extends AbstractNode<EnumTypeDefinition> impleme
             this.description = existing.getDescription();
             this.directives = existing.getDirectives();
             this.enumValueDefinitions = existing.getEnumValueDefinitions();
+            this.ignoredChars = existing.getIgnoredChars();
         }
 
         public Builder sourceLocation(SourceLocation sourceLocation) {
@@ -168,8 +177,13 @@ public class EnumTypeDefinition extends AbstractNode<EnumTypeDefinition> impleme
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public EnumTypeDefinition build() {
-            EnumTypeDefinition enumTypeDefinition = new EnumTypeDefinition(name, enumValueDefinitions, directives, description, sourceLocation, comments);
+            EnumTypeDefinition enumTypeDefinition = new EnumTypeDefinition(name, enumValueDefinitions, directives, description, sourceLocation, comments, ignoredChars);
             return enumTypeDefinition;
         }
     }

--- a/src/main/java/graphql/language/EnumTypeExtensionDefinition.java
+++ b/src/main/java/graphql/language/EnumTypeExtensionDefinition.java
@@ -12,13 +12,14 @@ public class EnumTypeExtensionDefinition extends EnumTypeDefinition {
 
     @Internal
     protected EnumTypeExtensionDefinition(String name,
-                                        List<EnumValueDefinition> enumValueDefinitions,
-                                        List<Directive> directives,
-                                        Description description,
-                                        SourceLocation sourceLocation,
-                                        List<Comment> comments) {
+                                          List<EnumValueDefinition> enumValueDefinitions,
+                                          List<Directive> directives,
+                                          Description description,
+                                          SourceLocation sourceLocation,
+                                          List<Comment> comments,
+                                          IgnoredChars ignoredChars) {
         super(name, enumValueDefinitions, directives, description,
-                sourceLocation, comments);
+                sourceLocation, comments, ignoredChars);
     }
 
     @Override
@@ -28,7 +29,8 @@ public class EnumTypeExtensionDefinition extends EnumTypeDefinition {
                 deepCopy(getDirectives()),
                 getDescription(),
                 getSourceLocation(),
-                getComments());
+                getComments(),
+                getIgnoredChars());
     }
 
     @Override
@@ -57,6 +59,7 @@ public class EnumTypeExtensionDefinition extends EnumTypeDefinition {
         private Description description;
         private List<EnumValueDefinition> enumValueDefinitions;
         private List<Directive> directives;
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -68,6 +71,7 @@ public class EnumTypeExtensionDefinition extends EnumTypeDefinition {
             this.description = existing.getDescription();
             this.directives = existing.getDirectives();
             this.enumValueDefinitions = existing.getEnumValueDefinitions();
+            this.ignoredChars = existing.getIgnoredChars();
         }
 
         public Builder sourceLocation(SourceLocation sourceLocation) {
@@ -100,13 +104,19 @@ public class EnumTypeExtensionDefinition extends EnumTypeDefinition {
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public EnumTypeExtensionDefinition build() {
             EnumTypeExtensionDefinition enumTypeDefinition = new EnumTypeExtensionDefinition(name,
                     enumValueDefinitions,
                     directives,
                     description,
                     sourceLocation,
-                    comments);
+                    comments,
+                    ignoredChars);
             return enumTypeDefinition;
         }
     }

--- a/src/main/java/graphql/language/EnumValue.java
+++ b/src/main/java/graphql/language/EnumValue.java
@@ -16,8 +16,8 @@ public class EnumValue extends AbstractNode<EnumValue> implements Value<EnumValu
     private final String name;
 
     @Internal
-    protected EnumValue(String name, SourceLocation sourceLocation, List<Comment> comments) {
-        super(sourceLocation, comments);
+    protected EnumValue(String name, SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
         this.name = name;
     }
 
@@ -28,7 +28,7 @@ public class EnumValue extends AbstractNode<EnumValue> implements Value<EnumValu
      * @param name of the enum value
      */
     public EnumValue(String name) {
-        this(name, null, new ArrayList<>());
+        this(name, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     @Override
@@ -44,8 +44,12 @@ public class EnumValue extends AbstractNode<EnumValue> implements Value<EnumValu
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         EnumValue that = (EnumValue) o;
 
@@ -54,7 +58,7 @@ public class EnumValue extends AbstractNode<EnumValue> implements Value<EnumValu
 
     @Override
     public EnumValue deepCopy() {
-        return new EnumValue(name, getSourceLocation(), getComments());
+        return new EnumValue(name, getSourceLocation(), getComments(), getIgnoredChars());
     }
 
     @Override
@@ -87,6 +91,7 @@ public class EnumValue extends AbstractNode<EnumValue> implements Value<EnumValu
         private SourceLocation sourceLocation;
         private String name;
         private List<Comment> comments = new ArrayList<>();
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -113,8 +118,13 @@ public class EnumValue extends AbstractNode<EnumValue> implements Value<EnumValu
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public EnumValue build() {
-            EnumValue enumValue = new EnumValue(name, sourceLocation, comments);
+            EnumValue enumValue = new EnumValue(name, sourceLocation, comments, ignoredChars);
             return enumValue;
         }
     }

--- a/src/main/java/graphql/language/EnumValueDefinition.java
+++ b/src/main/java/graphql/language/EnumValueDefinition.java
@@ -22,8 +22,9 @@ public class EnumValueDefinition extends AbstractNode<EnumValueDefinition> imple
                                   List<Directive> directives,
                                   Description description,
                                   SourceLocation sourceLocation,
-                                  List<Comment> comments) {
-        super(sourceLocation, comments);
+                                  List<Comment> comments,
+                                  IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
         this.name = name;
         this.description = description;
         this.directives = (null == directives) ? new ArrayList<>() : directives;
@@ -35,7 +36,7 @@ public class EnumValueDefinition extends AbstractNode<EnumValueDefinition> imple
      * @param name of the enum value
      */
     public EnumValueDefinition(String name) {
-        this(name, new ArrayList<>(), null, null, new ArrayList<>());
+        this(name, new ArrayList<>(), null, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     /**
@@ -45,7 +46,7 @@ public class EnumValueDefinition extends AbstractNode<EnumValueDefinition> imple
      * @param directives the directives on the enum value
      */
     public EnumValueDefinition(String name, List<Directive> directives) {
-        this(name, directives, null, null, new ArrayList<>());
+        this(name, directives, null, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     @Override
@@ -71,8 +72,12 @@ public class EnumValueDefinition extends AbstractNode<EnumValueDefinition> imple
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         EnumValueDefinition that = (EnumValueDefinition) o;
 
@@ -82,7 +87,7 @@ public class EnumValueDefinition extends AbstractNode<EnumValueDefinition> imple
 
     @Override
     public EnumValueDefinition deepCopy() {
-        return new EnumValueDefinition(name, deepCopy(directives), description, getSourceLocation(), getComments());
+        return new EnumValueDefinition(name, deepCopy(directives), description, getSourceLocation(), getComments(), getIgnoredChars());
     }
 
     @Override
@@ -114,6 +119,7 @@ public class EnumValueDefinition extends AbstractNode<EnumValueDefinition> imple
         private String name;
         private Description description;
         private List<Directive> directives;
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -124,6 +130,7 @@ public class EnumValueDefinition extends AbstractNode<EnumValueDefinition> imple
             this.name = existing.getName();
             this.description = existing.getDescription();
             this.directives = existing.getDirectives();
+            this.ignoredChars = existing.getIgnoredChars();
         }
 
         public Builder sourceLocation(SourceLocation sourceLocation) {
@@ -151,8 +158,13 @@ public class EnumValueDefinition extends AbstractNode<EnumValueDefinition> imple
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public EnumValueDefinition build() {
-            EnumValueDefinition enumValueDefinition = new EnumValueDefinition(name, directives, description, sourceLocation, comments);
+            EnumValueDefinition enumValueDefinition = new EnumValueDefinition(name, directives, description, sourceLocation, comments, ignoredChars);
             return enumValueDefinition;
         }
     }

--- a/src/main/java/graphql/language/Field.java
+++ b/src/main/java/graphql/language/Field.java
@@ -30,8 +30,9 @@ public class Field extends AbstractNode<Field> implements Selection<Field>, Sele
                     List<Directive> directives,
                     SelectionSet selectionSet,
                     SourceLocation sourceLocation,
-                    List<Comment> comments) {
-        super(sourceLocation, comments);
+                    List<Comment> comments,
+                    IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
         this.name = name;
         this.alias = alias;
         this.arguments = arguments;
@@ -46,7 +47,7 @@ public class Field extends AbstractNode<Field> implements Selection<Field>, Sele
      * @param name of the field
      */
     public Field(String name) {
-        this(name, null, new ArrayList<>(), new ArrayList<>(), null, null, new ArrayList<>());
+        this(name, null, new ArrayList<>(), new ArrayList<>(), null, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     /**
@@ -56,7 +57,7 @@ public class Field extends AbstractNode<Field> implements Selection<Field>, Sele
      * @param arguments to the field
      */
     public Field(String name, List<Argument> arguments) {
-        this(name, null, arguments, new ArrayList<>(), null, null, new ArrayList<>());
+        this(name, null, arguments, new ArrayList<>(), null, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     /**
@@ -67,7 +68,7 @@ public class Field extends AbstractNode<Field> implements Selection<Field>, Sele
      * @param selectionSet of the field
      */
     public Field(String name, List<Argument> arguments, SelectionSet selectionSet) {
-        this(name, null, arguments, new ArrayList<>(), selectionSet, null, new ArrayList<>());
+        this(name, null, arguments, new ArrayList<>(), selectionSet, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     /**
@@ -77,7 +78,7 @@ public class Field extends AbstractNode<Field> implements Selection<Field>, Sele
      * @param selectionSet of the field
      */
     public Field(String name, SelectionSet selectionSet) {
-        this(name, null, new ArrayList<>(), new ArrayList<>(), selectionSet, null, new ArrayList<>());
+        this(name, null, new ArrayList<>(), new ArrayList<>(), selectionSet, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     @Override
@@ -157,7 +158,8 @@ public class Field extends AbstractNode<Field> implements Selection<Field>, Sele
                 deepCopy(directives),
                 deepCopy(selectionSet),
                 getSourceLocation(),
-                getComments()
+                getComments(),
+                getIgnoredChars()
         );
     }
 
@@ -203,6 +205,7 @@ public class Field extends AbstractNode<Field> implements Selection<Field>, Sele
         private List<Argument> arguments = new ArrayList<>();
         private List<Directive> directives = new ArrayList<>();
         private SelectionSet selectionSet;
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -215,6 +218,7 @@ public class Field extends AbstractNode<Field> implements Selection<Field>, Sele
             this.arguments = existing.getArguments();
             this.directives = existing.getDirectives();
             this.selectionSet = existing.getSelectionSet();
+            this.ignoredChars = existing.getIgnoredChars();
         }
 
 
@@ -253,8 +257,13 @@ public class Field extends AbstractNode<Field> implements Selection<Field>, Sele
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public Field build() {
-            Field field = new Field(name, alias, arguments, directives, selectionSet, sourceLocation, comments);
+            Field field = new Field(name, alias, arguments, directives, selectionSet, sourceLocation, comments, ignoredChars);
             return field;
         }
     }

--- a/src/main/java/graphql/language/FieldDefinition.java
+++ b/src/main/java/graphql/language/FieldDefinition.java
@@ -20,13 +20,14 @@ public class FieldDefinition extends AbstractNode<FieldDefinition> implements Di
 
     @Internal
     protected FieldDefinition(String name,
-                            Type type,
-                            List<InputValueDefinition> inputValueDefinitions,
-                            List<Directive> directives,
-                            Description description,
-                            SourceLocation sourceLocation,
-                            List<Comment> comments) {
-        super(sourceLocation, comments);
+                              Type type,
+                              List<InputValueDefinition> inputValueDefinitions,
+                              List<Directive> directives,
+                              Description description,
+                              SourceLocation sourceLocation,
+                              List<Comment> comments,
+                              IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
         this.description = description;
         this.name = name;
         this.type = type;
@@ -36,7 +37,7 @@ public class FieldDefinition extends AbstractNode<FieldDefinition> implements Di
 
     public FieldDefinition(String name,
                            Type type) {
-        this(name, type, new ArrayList<>(), new ArrayList<>(), null, null, new ArrayList<>());
+        this(name, type, new ArrayList<>(), new ArrayList<>(), null, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     public Type getType() {
@@ -72,8 +73,12 @@ public class FieldDefinition extends AbstractNode<FieldDefinition> implements Di
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         FieldDefinition that = (FieldDefinition) o;
 
@@ -88,7 +93,8 @@ public class FieldDefinition extends AbstractNode<FieldDefinition> implements Di
                 deepCopy(directives),
                 description,
                 getSourceLocation(),
-                getComments()
+                getComments(),
+                getIgnoredChars()
         );
     }
 
@@ -133,6 +139,7 @@ public class FieldDefinition extends AbstractNode<FieldDefinition> implements Di
         private Description description;
         private List<InputValueDefinition> inputValueDefinitions = new ArrayList<>();
         private List<Directive> directives = new ArrayList<>();
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -145,6 +152,7 @@ public class FieldDefinition extends AbstractNode<FieldDefinition> implements Di
             this.description = existing.getDescription();
             this.inputValueDefinitions = existing.getInputValueDefinitions();
             this.directives = existing.getDirectives();
+            this.ignoredChars = existing.getIgnoredChars();
         }
 
 
@@ -193,8 +201,13 @@ public class FieldDefinition extends AbstractNode<FieldDefinition> implements Di
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public FieldDefinition build() {
-            FieldDefinition fieldDefinition = new FieldDefinition(name, type, inputValueDefinitions, directives, description, sourceLocation, comments);
+            FieldDefinition fieldDefinition = new FieldDefinition(name, type, inputValueDefinitions, directives, description, sourceLocation, comments, ignoredChars);
             return fieldDefinition;
         }
     }

--- a/src/main/java/graphql/language/FloatValue.java
+++ b/src/main/java/graphql/language/FloatValue.java
@@ -17,8 +17,8 @@ public class FloatValue extends AbstractNode<FloatValue> implements ScalarValue<
     private final BigDecimal value;
 
     @Internal
-    protected FloatValue(BigDecimal value, SourceLocation sourceLocation, List<Comment> comments) {
-        super(sourceLocation, comments);
+    protected FloatValue(BigDecimal value, SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
         this.value = value;
     }
 
@@ -28,7 +28,7 @@ public class FloatValue extends AbstractNode<FloatValue> implements ScalarValue<
      * @param value of the Float
      */
     public FloatValue(BigDecimal value) {
-        this(value, null, new ArrayList<>());
+        this(value, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     public BigDecimal getValue() {
@@ -49,8 +49,12 @@ public class FloatValue extends AbstractNode<FloatValue> implements ScalarValue<
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         FloatValue that = (FloatValue) o;
 
@@ -60,7 +64,7 @@ public class FloatValue extends AbstractNode<FloatValue> implements ScalarValue<
 
     @Override
     public FloatValue deepCopy() {
-        return new FloatValue(value, getSourceLocation(), getComments());
+        return new FloatValue(value, getSourceLocation(), getComments(), getIgnoredChars());
     }
 
     public FloatValue transform(Consumer<Builder> builderConsumer) {
@@ -86,6 +90,7 @@ public class FloatValue extends AbstractNode<FloatValue> implements ScalarValue<
         private SourceLocation sourceLocation;
         private BigDecimal value;
         private List<Comment> comments = new ArrayList<>();
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -112,8 +117,13 @@ public class FloatValue extends AbstractNode<FloatValue> implements ScalarValue<
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public FloatValue build() {
-            FloatValue floatValue = new FloatValue(value, sourceLocation, comments);
+            FloatValue floatValue = new FloatValue(value, sourceLocation, comments, ignoredChars);
             return floatValue;
         }
     }

--- a/src/main/java/graphql/language/FragmentDefinition.java
+++ b/src/main/java/graphql/language/FragmentDefinition.java
@@ -23,12 +23,13 @@ public class FragmentDefinition extends AbstractNode<FragmentDefinition> impleme
 
     @Internal
     protected FragmentDefinition(String name,
-                               TypeName typeCondition,
-                               List<Directive> directives,
-                               SelectionSet selectionSet,
-                               SourceLocation sourceLocation,
-                               List<Comment> comments) {
-        super(sourceLocation, comments);
+                                 TypeName typeCondition,
+                                 List<Directive> directives,
+                                 SelectionSet selectionSet,
+                                 SourceLocation sourceLocation,
+                                 List<Comment> comments,
+                                 IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
         this.name = name;
         this.typeCondition = typeCondition;
         this.directives = directives;
@@ -67,8 +68,12 @@ public class FragmentDefinition extends AbstractNode<FragmentDefinition> impleme
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         FragmentDefinition that = (FragmentDefinition) o;
 
@@ -82,7 +87,8 @@ public class FragmentDefinition extends AbstractNode<FragmentDefinition> impleme
                 deepCopy(directives),
                 deepCopy(selectionSet),
                 getSourceLocation(),
-                getComments()
+                getComments(),
+                getIgnoredChars()
         );
     }
 
@@ -118,6 +124,7 @@ public class FragmentDefinition extends AbstractNode<FragmentDefinition> impleme
         private TypeName typeCondition;
         private List<Directive> directives = new ArrayList<>();
         private SelectionSet selectionSet;
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -129,6 +136,7 @@ public class FragmentDefinition extends AbstractNode<FragmentDefinition> impleme
             this.typeCondition = existing.getTypeCondition();
             this.directives = existing.getDirectives();
             this.selectionSet = existing.getSelectionSet();
+            this.ignoredChars = existing.getIgnoredChars();
         }
 
 
@@ -162,8 +170,13 @@ public class FragmentDefinition extends AbstractNode<FragmentDefinition> impleme
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public FragmentDefinition build() {
-            FragmentDefinition fragmentDefinition = new FragmentDefinition(name, typeCondition, directives, selectionSet, sourceLocation, comments);
+            FragmentDefinition fragmentDefinition = new FragmentDefinition(name, typeCondition, directives, selectionSet, sourceLocation, comments, ignoredChars);
             return fragmentDefinition;
         }
     }

--- a/src/main/java/graphql/language/FragmentSpread.java
+++ b/src/main/java/graphql/language/FragmentSpread.java
@@ -17,8 +17,8 @@ public class FragmentSpread extends AbstractNode<FragmentSpread> implements Sele
     private final List<Directive> directives;
 
     @Internal
-    protected FragmentSpread(String name, List<Directive> directives, SourceLocation sourceLocation, List<Comment> comments) {
-        super(sourceLocation, comments);
+    protected FragmentSpread(String name, List<Directive> directives, SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
         this.name = name;
         this.directives = new ArrayList<>(directives);
     }
@@ -29,7 +29,7 @@ public class FragmentSpread extends AbstractNode<FragmentSpread> implements Sele
      * @param name of the fragment
      */
     public FragmentSpread(String name) {
-        this(name, new ArrayList<>(), null, new ArrayList<>());
+        this(name, new ArrayList<>(), null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     @Override
@@ -44,8 +44,12 @@ public class FragmentSpread extends AbstractNode<FragmentSpread> implements Sele
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         FragmentSpread that = (FragmentSpread) o;
 
@@ -62,7 +66,7 @@ public class FragmentSpread extends AbstractNode<FragmentSpread> implements Sele
 
     @Override
     public FragmentSpread deepCopy() {
-        return new FragmentSpread(name, deepCopy(directives), getSourceLocation(), getComments());
+        return new FragmentSpread(name, deepCopy(directives), getSourceLocation(), getComments(), getIgnoredChars());
     }
 
     @Override
@@ -98,6 +102,7 @@ public class FragmentSpread extends AbstractNode<FragmentSpread> implements Sele
         private List<Comment> comments = new ArrayList<>();
         private String name;
         private List<Directive> directives = new ArrayList<>();
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -107,6 +112,7 @@ public class FragmentSpread extends AbstractNode<FragmentSpread> implements Sele
             this.comments = existing.getComments();
             this.name = existing.getName();
             this.directives = existing.getDirectives();
+            this.ignoredChars = existing.getIgnoredChars();
         }
 
         public Builder sourceLocation(SourceLocation sourceLocation) {
@@ -129,8 +135,13 @@ public class FragmentSpread extends AbstractNode<FragmentSpread> implements Sele
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public FragmentSpread build() {
-            FragmentSpread fragmentSpread = new FragmentSpread(name, directives, sourceLocation, comments);
+            FragmentSpread fragmentSpread = new FragmentSpread(name, directives, sourceLocation, comments, ignoredChars);
             return fragmentSpread;
         }
     }

--- a/src/main/java/graphql/language/IgnoredChar.java
+++ b/src/main/java/graphql/language/IgnoredChar.java
@@ -1,0 +1,65 @@
+package graphql.language;
+
+import graphql.PublicApi;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@PublicApi
+public class IgnoredChar implements Serializable {
+
+    public enum IgnoredCharKind {
+        SPACE, COMMA, TAB, CR, LF, OTHER
+    }
+
+    private final String value;
+    private final IgnoredCharKind kind;
+    private final SourceLocation sourceLocation;
+
+
+    public IgnoredChar(String value, IgnoredCharKind kind, SourceLocation sourceLocation) {
+        this.value = value;
+        this.kind = kind;
+        this.sourceLocation = sourceLocation;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public IgnoredCharKind getKind() {
+        return kind;
+    }
+
+    public SourceLocation getSourceLocation() {
+        return sourceLocation;
+    }
+
+    @Override
+    public String toString() {
+        return "IgnoredChar{" +
+                "value='" + value + '\'' +
+                ", kind=" + kind +
+                ", sourceLocation=" + sourceLocation +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IgnoredChar that = (IgnoredChar) o;
+        return Objects.equals(value, that.value) &&
+                kind == that.kind &&
+                Objects.equals(sourceLocation, that.sourceLocation);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value, kind, sourceLocation);
+    }
+}

--- a/src/main/java/graphql/language/IgnoredChars.java
+++ b/src/main/java/graphql/language/IgnoredChars.java
@@ -1,0 +1,31 @@
+package graphql.language;
+
+import graphql.PublicApi;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@PublicApi
+public class IgnoredChars implements Serializable {
+
+    private final List<IgnoredChar> left;
+    private final List<IgnoredChar> right;
+
+    public static final IgnoredChars EMPTY = new IgnoredChars(Collections.emptyList(), Collections.emptyList());
+
+    public IgnoredChars(List<IgnoredChar> left, List<IgnoredChar> right) {
+        this.left = new ArrayList<>(left);
+        this.right = new ArrayList<>(right);
+    }
+
+
+    public List<IgnoredChar> getLeft() {
+        return new ArrayList<>(left);
+    }
+
+    public List<IgnoredChar> getRight() {
+        return new ArrayList<>(right);
+    }
+}

--- a/src/main/java/graphql/language/InlineFragment.java
+++ b/src/main/java/graphql/language/InlineFragment.java
@@ -24,8 +24,9 @@ public class InlineFragment extends AbstractNode<InlineFragment> implements Sele
                              List<Directive> directives,
                              SelectionSet selectionSet,
                              SourceLocation sourceLocation,
-                             List<Comment> comments) {
-        super(sourceLocation, comments);
+                             List<Comment> comments,
+                             IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
         this.typeCondition = typeCondition;
         this.directives = directives;
         this.selectionSet = selectionSet;
@@ -37,7 +38,7 @@ public class InlineFragment extends AbstractNode<InlineFragment> implements Sele
      * @param typeCondition the type condition of the inline fragment
      */
     public InlineFragment(TypeName typeCondition) {
-        this(typeCondition, new ArrayList<>(), null, null, new ArrayList<>());
+        this(typeCondition, new ArrayList<>(), null, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     /**
@@ -47,7 +48,7 @@ public class InlineFragment extends AbstractNode<InlineFragment> implements Sele
      * @param selectionSet  of the inline fragment
      */
     public InlineFragment(TypeName typeCondition, SelectionSet selectionSet) {
-        this(typeCondition, new ArrayList<>(), selectionSet, null, new ArrayList<>());
+        this(typeCondition, new ArrayList<>(), selectionSet, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     public TypeName getTypeCondition() {
@@ -86,8 +87,12 @@ public class InlineFragment extends AbstractNode<InlineFragment> implements Sele
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         return true;
     }
@@ -99,7 +104,8 @@ public class InlineFragment extends AbstractNode<InlineFragment> implements Sele
                 deepCopy(directives),
                 deepCopy(selectionSet),
                 getSourceLocation(),
-                getComments()
+                getComments(),
+                getIgnoredChars()
         );
     }
 
@@ -133,6 +139,7 @@ public class InlineFragment extends AbstractNode<InlineFragment> implements Sele
         private TypeName typeCondition;
         private List<Directive> directives = new ArrayList<>();
         private SelectionSet selectionSet;
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -144,6 +151,7 @@ public class InlineFragment extends AbstractNode<InlineFragment> implements Sele
             this.typeCondition = existing.getTypeCondition();
             this.directives = existing.getDirectives();
             this.selectionSet = existing.getSelectionSet();
+            this.ignoredChars = existing.getIgnoredChars();
         }
 
 
@@ -172,8 +180,13 @@ public class InlineFragment extends AbstractNode<InlineFragment> implements Sele
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public InlineFragment build() {
-            InlineFragment inlineFragment = new InlineFragment(typeCondition, directives, selectionSet, sourceLocation, comments);
+            InlineFragment inlineFragment = new InlineFragment(typeCondition, directives, selectionSet, sourceLocation, comments, ignoredChars);
             return inlineFragment;
         }
     }

--- a/src/main/java/graphql/language/InputObjectTypeDefinition.java
+++ b/src/main/java/graphql/language/InputObjectTypeDefinition.java
@@ -20,12 +20,13 @@ public class InputObjectTypeDefinition extends AbstractNode<InputObjectTypeDefin
 
     @Internal
     protected InputObjectTypeDefinition(String name,
-                              List<Directive> directives,
-                              List<InputValueDefinition> inputValueDefinitions,
-                              Description description,
-                              SourceLocation sourceLocation,
-                              List<Comment> comments) {
-        super(sourceLocation, comments);
+                                        List<Directive> directives,
+                                        List<InputValueDefinition> inputValueDefinitions,
+                                        Description description,
+                                        SourceLocation sourceLocation,
+                                        List<Comment> comments,
+                                        IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
         this.name = name;
         this.description = description;
         this.directives = directives;
@@ -60,8 +61,12 @@ public class InputObjectTypeDefinition extends AbstractNode<InputObjectTypeDefin
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         InputObjectTypeDefinition that = (InputObjectTypeDefinition) o;
 
@@ -75,7 +80,8 @@ public class InputObjectTypeDefinition extends AbstractNode<InputObjectTypeDefin
                 deepCopy(inputValueDefinitions),
                 description,
                 getSourceLocation(),
-                getComments());
+                getComments(),
+                getIgnoredChars());
     }
 
     @Override
@@ -110,6 +116,7 @@ public class InputObjectTypeDefinition extends AbstractNode<InputObjectTypeDefin
         private Description description;
         private List<Directive> directives = new ArrayList<>();
         private List<InputValueDefinition> inputValueDefinitions = new ArrayList<>();
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -164,13 +171,19 @@ public class InputObjectTypeDefinition extends AbstractNode<InputObjectTypeDefin
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public InputObjectTypeDefinition build() {
             InputObjectTypeDefinition inputObjectTypeDefinition = new InputObjectTypeDefinition(name,
                     directives,
                     inputValueDefinitions,
                     description,
                     sourceLocation,
-                    comments);
+                    comments,
+                    ignoredChars);
             return inputObjectTypeDefinition;
         }
     }

--- a/src/main/java/graphql/language/InputObjectTypeExtensionDefinition.java
+++ b/src/main/java/graphql/language/InputObjectTypeExtensionDefinition.java
@@ -12,12 +12,13 @@ public class InputObjectTypeExtensionDefinition extends InputObjectTypeDefinitio
 
     @Internal
     protected InputObjectTypeExtensionDefinition(String name,
-                                               List<Directive> directives,
-                                               List<InputValueDefinition> inputValueDefinitions,
-                                               Description description,
-                                               SourceLocation sourceLocation,
-                                               List<Comment> comments) {
-        super(name, directives, inputValueDefinitions, description, sourceLocation, comments);
+                                                 List<Directive> directives,
+                                                 List<InputValueDefinition> inputValueDefinitions,
+                                                 Description description,
+                                                 SourceLocation sourceLocation,
+                                                 List<Comment> comments,
+                                                 IgnoredChars ignoredChars) {
+        super(name, directives, inputValueDefinitions, description, sourceLocation, comments, ignoredChars);
     }
 
     @Override
@@ -27,7 +28,8 @@ public class InputObjectTypeExtensionDefinition extends InputObjectTypeDefinitio
                 deepCopy(getInputValueDefinitions()),
                 getDescription(),
                 getSourceLocation(),
-                getComments());
+                getComments(),
+                getIgnoredChars());
     }
 
     @Override
@@ -57,6 +59,7 @@ public class InputObjectTypeExtensionDefinition extends InputObjectTypeDefinitio
         private Description description;
         private List<Directive> directives = new ArrayList<>();
         private List<InputValueDefinition> inputValueDefinitions = new ArrayList<>();
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -68,6 +71,7 @@ public class InputObjectTypeExtensionDefinition extends InputObjectTypeDefinitio
             this.description = existing.getDescription();
             this.directives = existing.getDirectives();
             this.inputValueDefinitions = existing.getInputValueDefinitions();
+            this.ignoredChars = existing.getIgnoredChars();
         }
 
 
@@ -101,13 +105,19 @@ public class InputObjectTypeExtensionDefinition extends InputObjectTypeDefinitio
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public InputObjectTypeExtensionDefinition build() {
             InputObjectTypeExtensionDefinition inputObjectTypeDefinition = new InputObjectTypeExtensionDefinition(name,
                     directives,
                     inputValueDefinitions,
                     description,
                     sourceLocation,
-                    comments);
+                    comments,
+                    ignoredChars);
             return inputObjectTypeDefinition;
         }
     }

--- a/src/main/java/graphql/language/InputValueDefinition.java
+++ b/src/main/java/graphql/language/InputValueDefinition.java
@@ -26,8 +26,9 @@ public class InputValueDefinition extends AbstractNode<InputValueDefinition> imp
                                    List<Directive> directives,
                                    Description description,
                                    SourceLocation sourceLocation,
-                                   List<Comment> comments) {
-        super(sourceLocation, comments);
+                                   List<Comment> comments,
+                                   IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
         this.name = name;
         this.type = type;
         this.defaultValue = defaultValue;
@@ -44,7 +45,7 @@ public class InputValueDefinition extends AbstractNode<InputValueDefinition> imp
      */
     public InputValueDefinition(String name,
                                 Type type) {
-        this(name, type, null, new ArrayList<>(), null, null, new ArrayList<>());
+        this(name, type, null, new ArrayList<>(), null, null, new ArrayList<>(), IgnoredChars.EMPTY);
 
     }
 
@@ -59,7 +60,7 @@ public class InputValueDefinition extends AbstractNode<InputValueDefinition> imp
     public InputValueDefinition(String name,
                                 Type type,
                                 Value defaultValue) {
-        this(name, type, defaultValue, new ArrayList<>(), null, null, new ArrayList<>());
+        this(name, type, defaultValue, new ArrayList<>(), null, null, new ArrayList<>(), IgnoredChars.EMPTY);
 
     }
 
@@ -97,8 +98,12 @@ public class InputValueDefinition extends AbstractNode<InputValueDefinition> imp
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         InputValueDefinition that = (InputValueDefinition) o;
 
@@ -113,7 +118,8 @@ public class InputValueDefinition extends AbstractNode<InputValueDefinition> imp
                 deepCopy(directives),
                 description,
                 getSourceLocation(),
-                getComments());
+                getComments(),
+                getIgnoredChars());
     }
 
     @Override
@@ -149,6 +155,7 @@ public class InputValueDefinition extends AbstractNode<InputValueDefinition> imp
         private Value defaultValue;
         private Description description;
         private List<Directive> directives = new ArrayList<>();
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -204,6 +211,11 @@ public class InputValueDefinition extends AbstractNode<InputValueDefinition> imp
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public InputValueDefinition build() {
             InputValueDefinition inputValueDefinition = new InputValueDefinition(name,
                     type,
@@ -211,7 +223,8 @@ public class InputValueDefinition extends AbstractNode<InputValueDefinition> imp
                     directives,
                     description,
                     sourceLocation,
-                    comments);
+                    comments,
+                    ignoredChars);
             return inputValueDefinition;
         }
     }

--- a/src/main/java/graphql/language/IntValue.java
+++ b/src/main/java/graphql/language/IntValue.java
@@ -17,8 +17,8 @@ public class IntValue extends AbstractNode<IntValue> implements ScalarValue<IntV
     private final BigInteger value;
 
     @Internal
-    protected IntValue(BigInteger value, SourceLocation sourceLocation, List<Comment> comments) {
-        super(sourceLocation, comments);
+    protected IntValue(BigInteger value, SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
         this.value = value;
     }
 
@@ -28,7 +28,7 @@ public class IntValue extends AbstractNode<IntValue> implements ScalarValue<IntV
      * @param value of the Int
      */
     public IntValue(BigInteger value) {
-        this(value, null, new ArrayList<>());
+        this(value, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     public BigInteger getValue() {
@@ -42,8 +42,12 @@ public class IntValue extends AbstractNode<IntValue> implements ScalarValue<IntV
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         IntValue that = (IntValue) o;
 
@@ -53,7 +57,7 @@ public class IntValue extends AbstractNode<IntValue> implements ScalarValue<IntV
 
     @Override
     public IntValue deepCopy() {
-        return new IntValue(value, getSourceLocation(), getComments());
+        return new IntValue(value, getSourceLocation(), getComments(), IgnoredChars.EMPTY);
     }
 
     @Override
@@ -86,6 +90,7 @@ public class IntValue extends AbstractNode<IntValue> implements ScalarValue<IntV
         private SourceLocation sourceLocation;
         private BigInteger value;
         private List<Comment> comments = new ArrayList<>();
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -111,8 +116,13 @@ public class IntValue extends AbstractNode<IntValue> implements ScalarValue<IntV
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public IntValue build() {
-            IntValue intValue = new IntValue(value, sourceLocation, comments);
+            IntValue intValue = new IntValue(value, sourceLocation, comments, ignoredChars);
             return intValue;
         }
     }

--- a/src/main/java/graphql/language/InterfaceTypeDefinition.java
+++ b/src/main/java/graphql/language/InterfaceTypeDefinition.java
@@ -24,8 +24,9 @@ public class InterfaceTypeDefinition extends AbstractNode<InterfaceTypeDefinitio
                                       List<Directive> directives,
                                       Description description,
                                       SourceLocation sourceLocation,
-                                      List<Comment> comments) {
-        super(sourceLocation, comments);
+                                      List<Comment> comments,
+                                      IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
         this.name = name;
         this.definitions = definitions;
         this.directives = directives;
@@ -38,7 +39,7 @@ public class InterfaceTypeDefinition extends AbstractNode<InterfaceTypeDefinitio
      * @param name of the interface
      */
     public InterfaceTypeDefinition(String name) {
-        this(name, new ArrayList<>(), new ArrayList<>(), null, null, new ArrayList<>());
+        this(name, new ArrayList<>(), new ArrayList<>(), null, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     public List<FieldDefinition> getFieldDefinitions() {
@@ -70,8 +71,12 @@ public class InterfaceTypeDefinition extends AbstractNode<InterfaceTypeDefinitio
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         InterfaceTypeDefinition that = (InterfaceTypeDefinition) o;
 
@@ -85,7 +90,8 @@ public class InterfaceTypeDefinition extends AbstractNode<InterfaceTypeDefinitio
                 deepCopy(directives),
                 description,
                 getSourceLocation(),
-                getComments()
+                getComments(),
+                getIgnoredChars()
         );
     }
 
@@ -121,6 +127,7 @@ public class InterfaceTypeDefinition extends AbstractNode<InterfaceTypeDefinitio
         private Description description;
         private List<FieldDefinition> definitions = new ArrayList<>();
         private List<Directive> directives = new ArrayList<>();
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -133,6 +140,7 @@ public class InterfaceTypeDefinition extends AbstractNode<InterfaceTypeDefinitio
             this.description = existing.getDescription();
             this.directives = existing.getDirectives();
             this.definitions = existing.getFieldDefinitions();
+            this.ignoredChars = existing.getIgnoredChars();
         }
 
 
@@ -176,13 +184,19 @@ public class InterfaceTypeDefinition extends AbstractNode<InterfaceTypeDefinitio
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public InterfaceTypeDefinition build() {
             InterfaceTypeDefinition interfaceTypeDefinition = new InterfaceTypeDefinition(name,
                     definitions,
                     directives,
                     description,
                     sourceLocation,
-                    comments);
+                    comments,
+                    ignoredChars);
             return interfaceTypeDefinition;
         }
     }

--- a/src/main/java/graphql/language/InterfaceTypeExtensionDefinition.java
+++ b/src/main/java/graphql/language/InterfaceTypeExtensionDefinition.java
@@ -12,12 +12,13 @@ public class InterfaceTypeExtensionDefinition extends InterfaceTypeDefinition {
 
     @Internal
     protected InterfaceTypeExtensionDefinition(String name,
-                                     List<FieldDefinition> definitions,
-                                     List<Directive> directives,
-                                     Description description,
-                                     SourceLocation sourceLocation,
-                                     List<Comment> comments) {
-        super(name, definitions, directives, description, sourceLocation, comments);
+                                               List<FieldDefinition> definitions,
+                                               List<Directive> directives,
+                                               Description description,
+                                               SourceLocation sourceLocation,
+                                               List<Comment> comments,
+                                               IgnoredChars ignoredChars) {
+        super(name, definitions, directives, description, sourceLocation, comments, ignoredChars);
     }
 
     @Override
@@ -27,7 +28,8 @@ public class InterfaceTypeExtensionDefinition extends InterfaceTypeDefinition {
                 deepCopy(getDirectives()),
                 getDescription(),
                 getSourceLocation(),
-                getComments()
+                getComments(),
+                getIgnoredChars()
         );
     }
 
@@ -58,6 +60,7 @@ public class InterfaceTypeExtensionDefinition extends InterfaceTypeDefinition {
         private Description description;
         private List<FieldDefinition> definitions = new ArrayList<>();
         private List<Directive> directives = new ArrayList<>();
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -69,6 +72,7 @@ public class InterfaceTypeExtensionDefinition extends InterfaceTypeDefinition {
             this.description = existing.getDescription();
             this.directives = existing.getDirectives();
             this.definitions = existing.getFieldDefinitions();
+            this.ignoredChars = existing.getIgnoredChars();
         }
 
         public Builder sourceLocation(SourceLocation sourceLocation) {
@@ -101,13 +105,19 @@ public class InterfaceTypeExtensionDefinition extends InterfaceTypeDefinition {
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public InterfaceTypeExtensionDefinition build() {
             InterfaceTypeExtensionDefinition interfaceTypeDefinition = new InterfaceTypeExtensionDefinition(name,
                     definitions,
                     directives,
                     description,
                     sourceLocation,
-                    comments);
+                    comments,
+                    ignoredChars);
             return interfaceTypeDefinition;
         }
     }

--- a/src/main/java/graphql/language/ListType.java
+++ b/src/main/java/graphql/language/ListType.java
@@ -16,8 +16,8 @@ public class ListType extends AbstractNode<ListType> implements Type<ListType> {
     private final Type type;
 
     @Internal
-    protected ListType(Type type, SourceLocation sourceLocation, List<Comment> comments) {
-        super(sourceLocation, comments);
+    protected ListType(Type type, SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
         this.type = type;
     }
 
@@ -27,7 +27,7 @@ public class ListType extends AbstractNode<ListType> implements Type<ListType> {
      * @param type the wrapped type
      */
     public ListType(Type type) {
-        this(type, null, new ArrayList<>());
+        this(type, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     public Type getType() {
@@ -43,15 +43,19 @@ public class ListType extends AbstractNode<ListType> implements Type<ListType> {
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         return true;
     }
 
     @Override
     public ListType deepCopy() {
-        return new ListType(deepCopy(type), getSourceLocation(), getComments());
+        return new ListType(deepCopy(type), getSourceLocation(), getComments(), getIgnoredChars());
     }
 
     @Override
@@ -84,6 +88,7 @@ public class ListType extends AbstractNode<ListType> implements Type<ListType> {
         private Type type;
         private SourceLocation sourceLocation;
         private List<Comment> comments = new ArrayList<>();
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -92,6 +97,7 @@ public class ListType extends AbstractNode<ListType> implements Type<ListType> {
             this.sourceLocation = existing.getSourceLocation();
             this.comments = existing.getComments();
             this.type = existing.getType();
+            this.ignoredChars = existing.getIgnoredChars();
         }
 
 
@@ -110,8 +116,13 @@ public class ListType extends AbstractNode<ListType> implements Type<ListType> {
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public ListType build() {
-            ListType listType = new ListType(type, sourceLocation, comments);
+            ListType listType = new ListType(type, sourceLocation, comments, ignoredChars);
             return listType;
         }
     }

--- a/src/main/java/graphql/language/Node.java
+++ b/src/main/java/graphql/language/Node.java
@@ -36,6 +36,8 @@ public interface Node<T extends Node> extends Serializable {
      */
     List<Comment> getComments();
 
+    IgnoredChars getIgnoredChars();
+
     /**
      * Compares just the content and not the children.
      *

--- a/src/main/java/graphql/language/NodeBuilder.java
+++ b/src/main/java/graphql/language/NodeBuilder.java
@@ -10,4 +10,7 @@ public interface NodeBuilder {
     NodeBuilder sourceLocation(SourceLocation sourceLocation);
 
     NodeBuilder comments(List<Comment> comments);
+
+    NodeBuilder ignoredChars(IgnoredChars ignoredChars);
+
 }

--- a/src/main/java/graphql/language/NonNullType.java
+++ b/src/main/java/graphql/language/NonNullType.java
@@ -16,8 +16,8 @@ public class NonNullType extends AbstractNode<NonNullType> implements Type<NonNu
     private final Type type;
 
     @Internal
-    protected NonNullType(Type type, SourceLocation sourceLocation, List<Comment> comments) {
-        super(sourceLocation, comments);
+    protected NonNullType(Type type, SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
         this.type = type;
     }
 
@@ -27,7 +27,7 @@ public class NonNullType extends AbstractNode<NonNullType> implements Type<NonNu
      * @param type the wrapped type
      */
     public NonNullType(Type type) {
-        this(type,null, new ArrayList<>());
+        this(type, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     public Type getType() {
@@ -43,8 +43,12 @@ public class NonNullType extends AbstractNode<NonNullType> implements Type<NonNu
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         return true;
 
@@ -52,7 +56,7 @@ public class NonNullType extends AbstractNode<NonNullType> implements Type<NonNu
 
     @Override
     public NonNullType deepCopy() {
-        return new NonNullType(deepCopy(type), getSourceLocation(), getComments());
+        return new NonNullType(deepCopy(type), getSourceLocation(), getComments(), getIgnoredChars());
     }
 
     @Override
@@ -85,6 +89,7 @@ public class NonNullType extends AbstractNode<NonNullType> implements Type<NonNu
         private SourceLocation sourceLocation;
         private Type type;
         private List<Comment> comments = new ArrayList<>();
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -93,6 +98,7 @@ public class NonNullType extends AbstractNode<NonNullType> implements Type<NonNu
             this.sourceLocation = existing.getSourceLocation();
             this.comments = existing.getComments();
             this.type = existing.getType();
+            this.ignoredChars = existing.getIgnoredChars();
         }
 
 
@@ -124,8 +130,13 @@ public class NonNullType extends AbstractNode<NonNullType> implements Type<NonNu
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public NonNullType build() {
-            NonNullType nonNullType = new NonNullType(type, sourceLocation, comments);
+            NonNullType nonNullType = new NonNullType(type, sourceLocation, comments, ignoredChars);
             return nonNullType;
         }
     }

--- a/src/main/java/graphql/language/NullValue.java
+++ b/src/main/java/graphql/language/NullValue.java
@@ -13,11 +13,11 @@ import java.util.List;
 @PublicApi
 public class NullValue extends AbstractNode<NullValue> implements Value<NullValue> {
 
-    public static final NullValue Null = new NullValue(null, Collections.emptyList());
+    public static final NullValue Null = new NullValue(null, Collections.emptyList(), IgnoredChars.EMPTY);
 
     @Internal
-    protected NullValue(SourceLocation sourceLocation, List<Comment> comments) {
-        super(sourceLocation, comments);
+    protected NullValue(SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
     }
 
     @Override
@@ -27,8 +27,12 @@ public class NullValue extends AbstractNode<NullValue> implements Value<NullValu
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         return true;
 
@@ -58,6 +62,7 @@ public class NullValue extends AbstractNode<NullValue> implements Value<NullValu
     public static final class Builder implements NodeBuilder {
         private SourceLocation sourceLocation;
         private List<Comment> comments = new ArrayList<>();
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -72,8 +77,13 @@ public class NullValue extends AbstractNode<NullValue> implements Value<NullValu
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public NullValue build() {
-            NullValue nullValue = new NullValue(sourceLocation, comments);
+            NullValue nullValue = new NullValue(sourceLocation, comments, ignoredChars);
             return nullValue;
         }
     }

--- a/src/main/java/graphql/language/ObjectField.java
+++ b/src/main/java/graphql/language/ObjectField.java
@@ -17,8 +17,8 @@ public class ObjectField extends AbstractNode<ObjectField> implements NamedNode<
     private final Value value;
 
     @Internal
-    protected ObjectField(String name, Value value, SourceLocation sourceLocation, List<Comment> comments) {
-        super(sourceLocation, comments);
+    protected ObjectField(String name, Value value, SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
         this.name = name;
         this.value = value;
     }
@@ -30,7 +30,7 @@ public class ObjectField extends AbstractNode<ObjectField> implements NamedNode<
      * @param value of the field
      */
     public ObjectField(String name, Value value) {
-        this(name, value, null, new ArrayList<>());
+        this(name, value, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     @Override
@@ -51,8 +51,12 @@ public class ObjectField extends AbstractNode<ObjectField> implements NamedNode<
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         ObjectField that = (ObjectField) o;
 
@@ -62,7 +66,7 @@ public class ObjectField extends AbstractNode<ObjectField> implements NamedNode<
 
     @Override
     public ObjectField deepCopy() {
-        return new ObjectField(name, deepCopy(this.value), getSourceLocation(), getComments());
+        return new ObjectField(name, deepCopy(this.value), getSourceLocation(), getComments(), getIgnoredChars());
     }
 
     @Override
@@ -93,6 +97,7 @@ public class ObjectField extends AbstractNode<ObjectField> implements NamedNode<
         private String name;
         private List<Comment> comments = new ArrayList<>();
         private Value value;
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -126,8 +131,13 @@ public class ObjectField extends AbstractNode<ObjectField> implements NamedNode<
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public ObjectField build() {
-            ObjectField objectField = new ObjectField(name, value, sourceLocation, comments);
+            ObjectField objectField = new ObjectField(name, value, sourceLocation, comments, ignoredChars);
             return objectField;
         }
     }

--- a/src/main/java/graphql/language/ObjectTypeDefinition.java
+++ b/src/main/java/graphql/language/ObjectTypeDefinition.java
@@ -25,8 +25,9 @@ public class ObjectTypeDefinition extends AbstractNode<ObjectTypeDefinition> imp
                                    List<FieldDefinition> fieldDefinitions,
                                    Description description,
                                    SourceLocation sourceLocation,
-                                   List<Comment> comments) {
-        super(sourceLocation, comments);
+                                   List<Comment> comments,
+                                   IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
         this.name = name;
         this.implementz = implementz;
         this.directives = directives;
@@ -40,7 +41,7 @@ public class ObjectTypeDefinition extends AbstractNode<ObjectTypeDefinition> imp
      * @param name of the object type
      */
     public ObjectTypeDefinition(String name) {
-        this(name, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), null, null, new ArrayList<>());
+        this(name, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), null, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     public List<Type> getImplements() {
@@ -76,8 +77,12 @@ public class ObjectTypeDefinition extends AbstractNode<ObjectTypeDefinition> imp
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         ObjectTypeDefinition that = (ObjectTypeDefinition) o;
         return NodeUtil.isEqualTo(this.name, that.name);
@@ -91,7 +96,8 @@ public class ObjectTypeDefinition extends AbstractNode<ObjectTypeDefinition> imp
                 deepCopy(fieldDefinitions),
                 description,
                 getSourceLocation(),
-                getComments()
+                getComments(),
+                getIgnoredChars()
         );
     }
 
@@ -128,6 +134,7 @@ public class ObjectTypeDefinition extends AbstractNode<ObjectTypeDefinition> imp
         private List<Type> implementz = new ArrayList<>();
         private List<Directive> directives = new ArrayList<>();
         private List<FieldDefinition> fieldDefinitions = new ArrayList<>();
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -140,6 +147,7 @@ public class ObjectTypeDefinition extends AbstractNode<ObjectTypeDefinition> imp
             this.directives = existing.getDirectives();
             this.implementz = existing.getImplements();
             this.fieldDefinitions = existing.getFieldDefinitions();
+            this.ignoredChars = existing.getIgnoredChars();
         }
 
         public Builder sourceLocation(SourceLocation sourceLocation) {
@@ -192,6 +200,11 @@ public class ObjectTypeDefinition extends AbstractNode<ObjectTypeDefinition> imp
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public ObjectTypeDefinition build() {
             ObjectTypeDefinition objectTypeDefinition = new ObjectTypeDefinition(name,
                     implementz,
@@ -199,7 +212,8 @@ public class ObjectTypeDefinition extends AbstractNode<ObjectTypeDefinition> imp
                     fieldDefinitions,
                     description,
                     sourceLocation,
-                    comments);
+                    comments,
+                    ignoredChars);
             return objectTypeDefinition;
         }
     }

--- a/src/main/java/graphql/language/ObjectTypeExtensionDefinition.java
+++ b/src/main/java/graphql/language/ObjectTypeExtensionDefinition.java
@@ -18,9 +18,10 @@ public class ObjectTypeExtensionDefinition extends ObjectTypeDefinition {
                                             List<FieldDefinition> fieldDefinitions,
                                             Description description,
                                             SourceLocation sourceLocation,
-                                            List<Comment> comments) {
+                                            List<Comment> comments,
+                                            IgnoredChars ignoredChars) {
         super(name, implementz, directives, fieldDefinitions,
-                description, sourceLocation, comments);
+                description, sourceLocation, comments, ignoredChars);
     }
 
     /**
@@ -29,7 +30,7 @@ public class ObjectTypeExtensionDefinition extends ObjectTypeDefinition {
      * @param name of the object type extension
      */
     public ObjectTypeExtensionDefinition(String name) {
-        this(name, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), null, null, new ArrayList<>());
+        this(name, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), null, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     @Override
@@ -40,7 +41,8 @@ public class ObjectTypeExtensionDefinition extends ObjectTypeDefinition {
                 deepCopy(getFieldDefinitions()),
                 getDescription(),
                 getSourceLocation(),
-                getComments()
+                getComments(),
+                getIgnoredChars()
         );
     }
 
@@ -73,6 +75,7 @@ public class ObjectTypeExtensionDefinition extends ObjectTypeDefinition {
         private List<Type> implementz = new ArrayList<>();
         private List<Directive> directives = new ArrayList<>();
         private List<FieldDefinition> fieldDefinitions = new ArrayList<>();
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -85,6 +88,7 @@ public class ObjectTypeExtensionDefinition extends ObjectTypeDefinition {
             this.directives = existing.getDirectives();
             this.implementz = existing.getImplements();
             this.fieldDefinitions = existing.getFieldDefinitions();
+            this.ignoredChars = existing.getIgnoredChars();
         }
 
         public Builder sourceLocation(SourceLocation sourceLocation) {
@@ -137,6 +141,11 @@ public class ObjectTypeExtensionDefinition extends ObjectTypeDefinition {
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public ObjectTypeExtensionDefinition build() {
             ObjectTypeExtensionDefinition objectTypeDefinition = new ObjectTypeExtensionDefinition(name,
                     implementz,
@@ -144,7 +153,8 @@ public class ObjectTypeExtensionDefinition extends ObjectTypeDefinition {
                     fieldDefinitions,
                     description,
                     sourceLocation,
-                    comments);
+                    comments,
+                    ignoredChars);
             return objectTypeDefinition;
         }
     }

--- a/src/main/java/graphql/language/ObjectValue.java
+++ b/src/main/java/graphql/language/ObjectValue.java
@@ -16,8 +16,8 @@ public class ObjectValue extends AbstractNode<ObjectValue> implements Value<Obje
     private final List<ObjectField> objectFields = new ArrayList<>();
 
     @Internal
-    protected ObjectValue(List<ObjectField> objectFields, SourceLocation sourceLocation, List<Comment> comments) {
-        super(sourceLocation, comments);
+    protected ObjectValue(List<ObjectField> objectFields, SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
         this.objectFields.addAll(objectFields);
     }
 
@@ -27,7 +27,7 @@ public class ObjectValue extends AbstractNode<ObjectValue> implements Value<Obje
      * @param objectFields the list of field that make up this object value
      */
     public ObjectValue(List<ObjectField> objectFields) {
-        this(objectFields, null, new ArrayList<>());
+        this(objectFields, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     public List<ObjectField> getObjectFields() {
@@ -43,8 +43,12 @@ public class ObjectValue extends AbstractNode<ObjectValue> implements Value<Obje
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         ObjectValue that = (ObjectValue) o;
 
@@ -54,7 +58,7 @@ public class ObjectValue extends AbstractNode<ObjectValue> implements Value<Obje
 
     @Override
     public ObjectValue deepCopy() {
-        return new ObjectValue(deepCopy(objectFields), getSourceLocation(), getComments());
+        return new ObjectValue(deepCopy(objectFields), getSourceLocation(), getComments(), getIgnoredChars());
     }
 
 
@@ -85,6 +89,7 @@ public class ObjectValue extends AbstractNode<ObjectValue> implements Value<Obje
         private SourceLocation sourceLocation;
         private List<ObjectField> objectFields = new ArrayList<>();
         private List<Comment> comments = new ArrayList<>();
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -115,8 +120,13 @@ public class ObjectValue extends AbstractNode<ObjectValue> implements Value<Obje
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public ObjectValue build() {
-            ObjectValue objectValue = new ObjectValue(objectFields, sourceLocation, comments);
+            ObjectValue objectValue = new ObjectValue(objectFields, sourceLocation, comments, ignoredChars);
             return objectValue;
         }
     }

--- a/src/main/java/graphql/language/OperationDefinition.java
+++ b/src/main/java/graphql/language/OperationDefinition.java
@@ -26,13 +26,14 @@ public class OperationDefinition extends AbstractNode<OperationDefinition> imple
 
     @Internal
     protected OperationDefinition(String name,
-                                Operation operation,
-                                List<VariableDefinition> variableDefinitions,
-                                List<Directive> directives,
-                                SelectionSet selectionSet,
-                                SourceLocation sourceLocation,
-                                List<Comment> comments) {
-        super(sourceLocation, comments);
+                                  Operation operation,
+                                  List<VariableDefinition> variableDefinitions,
+                                  List<Directive> directives,
+                                  SelectionSet selectionSet,
+                                  SourceLocation sourceLocation,
+                                  List<Comment> comments,
+                                  IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
         this.name = name;
         this.operation = operation;
         this.variableDefinitions = variableDefinitions;
@@ -42,11 +43,11 @@ public class OperationDefinition extends AbstractNode<OperationDefinition> imple
 
     public OperationDefinition(String name,
                                Operation operation) {
-        this(name, operation, new ArrayList<>(), new ArrayList<>(), null, null, new ArrayList<>());
+        this(name, operation, new ArrayList<>(), new ArrayList<>(), null, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     public OperationDefinition(String name) {
-        this(name, null, new ArrayList<>(), new ArrayList<>(), null, null, new ArrayList<>());
+        this(name, null, new ArrayList<>(), new ArrayList<>(), null, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     @Override
@@ -89,8 +90,12 @@ public class OperationDefinition extends AbstractNode<OperationDefinition> imple
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         OperationDefinition that = (OperationDefinition) o;
 
@@ -106,7 +111,8 @@ public class OperationDefinition extends AbstractNode<OperationDefinition> imple
                 deepCopy(directives),
                 deepCopy(selectionSet),
                 getSourceLocation(),
-                getComments()
+                getComments(),
+                getIgnoredChars()
         );
     }
 
@@ -144,6 +150,7 @@ public class OperationDefinition extends AbstractNode<OperationDefinition> imple
         private List<VariableDefinition> variableDefinitions = new ArrayList<>();
         private List<Directive> directives = new ArrayList<>();
         private SelectionSet selectionSet;
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -156,6 +163,7 @@ public class OperationDefinition extends AbstractNode<OperationDefinition> imple
             this.variableDefinitions = existing.getVariableDefinitions();
             this.directives = existing.getDirectives();
             this.selectionSet = existing.getSelectionSet();
+            this.ignoredChars = existing.getIgnoredChars();
         }
 
 
@@ -194,6 +202,11 @@ public class OperationDefinition extends AbstractNode<OperationDefinition> imple
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public OperationDefinition build() {
             OperationDefinition operationDefinition = new OperationDefinition(
                     name,
@@ -202,7 +215,8 @@ public class OperationDefinition extends AbstractNode<OperationDefinition> imple
                     directives,
                     selectionSet,
                     sourceLocation,
-                    comments
+                    comments,
+                    ignoredChars
             );
             return operationDefinition;
         }

--- a/src/main/java/graphql/language/OperationTypeDefinition.java
+++ b/src/main/java/graphql/language/OperationTypeDefinition.java
@@ -17,8 +17,8 @@ public class OperationTypeDefinition extends AbstractNode<OperationTypeDefinitio
     private final Type type;
 
     @Internal
-    protected OperationTypeDefinition(String name, Type type, SourceLocation sourceLocation, List<Comment> comments) {
-        super(sourceLocation, comments);
+    protected OperationTypeDefinition(String name, Type type, SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
         this.name = name;
         this.type = type;
     }
@@ -30,7 +30,7 @@ public class OperationTypeDefinition extends AbstractNode<OperationTypeDefinitio
      * @param type the type in play
      */
     public OperationTypeDefinition(String name, Type type) {
-        this(name, type, null, new ArrayList<>());
+        this(name, type, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     public Type getType() {
@@ -51,8 +51,12 @@ public class OperationTypeDefinition extends AbstractNode<OperationTypeDefinitio
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         OperationTypeDefinition that = (OperationTypeDefinition) o;
 
@@ -61,7 +65,7 @@ public class OperationTypeDefinition extends AbstractNode<OperationTypeDefinitio
 
     @Override
     public OperationTypeDefinition deepCopy() {
-        return new OperationTypeDefinition(name, deepCopy(type), getSourceLocation(), getComments());
+        return new OperationTypeDefinition(name, deepCopy(type), getSourceLocation(), getComments(), getIgnoredChars());
     }
 
     @Override
@@ -92,6 +96,7 @@ public class OperationTypeDefinition extends AbstractNode<OperationTypeDefinitio
         private List<Comment> comments = new ArrayList<>();
         private String name;
         private Type type;
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -102,6 +107,7 @@ public class OperationTypeDefinition extends AbstractNode<OperationTypeDefinitio
             this.comments = existing.getComments();
             this.name = existing.getName();
             this.type = existing.getType();
+            this.ignoredChars = existing.getIgnoredChars();
         }
 
 
@@ -125,8 +131,13 @@ public class OperationTypeDefinition extends AbstractNode<OperationTypeDefinitio
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public OperationTypeDefinition build() {
-            OperationTypeDefinition operationTypeDefinition = new OperationTypeDefinition(name, type, sourceLocation, comments);
+            OperationTypeDefinition operationTypeDefinition = new OperationTypeDefinition(name, type, sourceLocation, comments, ignoredChars);
             return operationTypeDefinition;
         }
     }

--- a/src/main/java/graphql/language/ScalarTypeDefinition.java
+++ b/src/main/java/graphql/language/ScalarTypeDefinition.java
@@ -18,8 +18,13 @@ public class ScalarTypeDefinition extends AbstractNode<ScalarTypeDefinition> imp
     private final List<Directive> directives;
 
     @Internal
-    protected ScalarTypeDefinition(String name, List<Directive> directives, Description description, SourceLocation sourceLocation, List<Comment> comments) {
-        super(sourceLocation, comments);
+    protected ScalarTypeDefinition(String name,
+                                   List<Directive> directives,
+                                   Description description,
+                                   SourceLocation sourceLocation,
+                                   List<Comment> comments,
+                                   IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
         this.name = name;
         this.directives = directives;
         this.description = description;
@@ -31,7 +36,7 @@ public class ScalarTypeDefinition extends AbstractNode<ScalarTypeDefinition> imp
      * @param name of the scalar
      */
     public ScalarTypeDefinition(String name) {
-        this(name, new ArrayList<>(), null, null, new ArrayList<>());
+        this(name, new ArrayList<>(), null, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     @Override
@@ -58,8 +63,12 @@ public class ScalarTypeDefinition extends AbstractNode<ScalarTypeDefinition> imp
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         ScalarTypeDefinition that = (ScalarTypeDefinition) o;
 
@@ -68,7 +77,7 @@ public class ScalarTypeDefinition extends AbstractNode<ScalarTypeDefinition> imp
 
     @Override
     public ScalarTypeDefinition deepCopy() {
-        return new ScalarTypeDefinition(name, deepCopy(directives), description, getSourceLocation(), getComments());
+        return new ScalarTypeDefinition(name, deepCopy(directives), description, getSourceLocation(), getComments(), getIgnoredChars());
     }
 
     @Override
@@ -100,6 +109,7 @@ public class ScalarTypeDefinition extends AbstractNode<ScalarTypeDefinition> imp
         private String name;
         private Description description;
         private List<Directive> directives = new ArrayList<>();
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -110,6 +120,7 @@ public class ScalarTypeDefinition extends AbstractNode<ScalarTypeDefinition> imp
             this.name = existing.getName();
             this.description = existing.getDescription();
             this.directives = existing.getDirectives();
+            this.ignoredChars = existing.getIgnoredChars();
         }
 
 
@@ -143,12 +154,18 @@ public class ScalarTypeDefinition extends AbstractNode<ScalarTypeDefinition> imp
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public ScalarTypeDefinition build() {
             ScalarTypeDefinition scalarTypeDefinition = new ScalarTypeDefinition(name,
                     directives,
                     description,
                     sourceLocation,
-                    comments);
+                    comments,
+                    ignoredChars);
             return scalarTypeDefinition;
         }
     }

--- a/src/main/java/graphql/language/ScalarTypeExtensionDefinition.java
+++ b/src/main/java/graphql/language/ScalarTypeExtensionDefinition.java
@@ -12,16 +12,17 @@ public class ScalarTypeExtensionDefinition extends ScalarTypeDefinition {
 
     @Internal
     protected ScalarTypeExtensionDefinition(String name,
-                                          List<Directive> directives,
-                                          Description description,
-                                          SourceLocation sourceLocation,
-                                          List<Comment> comments) {
-        super(name, directives, description, sourceLocation, comments);
+                                            List<Directive> directives,
+                                            Description description,
+                                            SourceLocation sourceLocation,
+                                            List<Comment> comments,
+                                            IgnoredChars ignoredChars) {
+        super(name, directives, description, sourceLocation, comments, ignoredChars);
     }
 
     @Override
     public ScalarTypeExtensionDefinition deepCopy() {
-        return new ScalarTypeExtensionDefinition(getName(), deepCopy(getDirectives()), getDescription(), getSourceLocation(), getComments());
+        return new ScalarTypeExtensionDefinition(getName(), deepCopy(getDirectives()), getDescription(), getSourceLocation(), getComments(), getIgnoredChars());
     }
 
     @Override
@@ -49,6 +50,7 @@ public class ScalarTypeExtensionDefinition extends ScalarTypeDefinition {
         private String name;
         private Description description;
         private List<Directive> directives = new ArrayList<>();
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -60,6 +62,7 @@ public class ScalarTypeExtensionDefinition extends ScalarTypeDefinition {
             this.name = existing.getName();
             this.description = existing.getDescription();
             this.directives = existing.getDirectives();
+            this.ignoredChars = existing.getIgnoredChars();
         }
 
 
@@ -88,12 +91,18 @@ public class ScalarTypeExtensionDefinition extends ScalarTypeDefinition {
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public ScalarTypeExtensionDefinition build() {
             ScalarTypeExtensionDefinition scalarTypeDefinition = new ScalarTypeExtensionDefinition(name,
                     directives,
                     description,
                     sourceLocation,
-                    comments);
+                    comments,
+                    ignoredChars);
             return scalarTypeDefinition;
         }
     }

--- a/src/main/java/graphql/language/SchemaDefinition.java
+++ b/src/main/java/graphql/language/SchemaDefinition.java
@@ -21,10 +21,11 @@ public class SchemaDefinition extends AbstractNode<SchemaDefinition> implements 
 
     @Internal
     protected SchemaDefinition(List<Directive> directives,
-                             List<OperationTypeDefinition> operationTypeDefinitions,
-                             SourceLocation sourceLocation,
-                             List<Comment> comments) {
-        super(sourceLocation, comments);
+                               List<OperationTypeDefinition> operationTypeDefinitions,
+                               SourceLocation sourceLocation,
+                               List<Comment> comments,
+                               IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
         this.directives = directives;
         this.operationTypeDefinitions = operationTypeDefinitions;
     }
@@ -56,8 +57,12 @@ public class SchemaDefinition extends AbstractNode<SchemaDefinition> implements 
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         SchemaDefinition that = (SchemaDefinition) o;
 
@@ -66,7 +71,8 @@ public class SchemaDefinition extends AbstractNode<SchemaDefinition> implements 
 
     @Override
     public SchemaDefinition deepCopy() {
-        return new SchemaDefinition(deepCopy(directives), deepCopy(operationTypeDefinitions), getSourceLocation(), getComments());
+        return new SchemaDefinition(deepCopy(directives), deepCopy(operationTypeDefinitions), getSourceLocation(), getComments(),
+                getIgnoredChars());
     }
 
     @Override
@@ -97,6 +103,7 @@ public class SchemaDefinition extends AbstractNode<SchemaDefinition> implements 
         private List<Comment> comments = new ArrayList<>();
         private List<Directive> directives = new ArrayList<>();
         private List<OperationTypeDefinition> operationTypeDefinitions = new ArrayList<>();
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -106,6 +113,7 @@ public class SchemaDefinition extends AbstractNode<SchemaDefinition> implements 
             this.comments = existing.getComments();
             this.directives = existing.getDirectives();
             this.operationTypeDefinitions = existing.getOperationTypeDefinitions();
+            this.ignoredChars = existing.getIgnoredChars();
         }
 
 
@@ -139,11 +147,17 @@ public class SchemaDefinition extends AbstractNode<SchemaDefinition> implements 
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public SchemaDefinition build() {
             SchemaDefinition schemaDefinition = new SchemaDefinition(directives,
                     operationTypeDefinitions,
                     sourceLocation,
-                    comments);
+                    comments,
+                    ignoredChars);
             return schemaDefinition;
         }
     }

--- a/src/main/java/graphql/language/SelectionSet.java
+++ b/src/main/java/graphql/language/SelectionSet.java
@@ -16,8 +16,8 @@ public class SelectionSet extends AbstractNode<SelectionSet> {
     private final List<Selection> selections = new ArrayList<>();
 
     @Internal
-    protected SelectionSet(List<Selection> selections, SourceLocation sourceLocation, List<Comment> comments) {
-        super(sourceLocation, comments);
+    protected SelectionSet(List<Selection> selections, SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
         this.selections.addAll(selections);
     }
 
@@ -27,7 +27,7 @@ public class SelectionSet extends AbstractNode<SelectionSet> {
      * @param selections the list of selection in this selection set
      */
     public SelectionSet(List<Selection> selections) {
-        this(selections, null, new ArrayList<>());
+        this(selections, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     public List<Selection> getSelections() {
@@ -44,8 +44,12 @@ public class SelectionSet extends AbstractNode<SelectionSet> {
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         SelectionSet that = (SelectionSet) o;
 
@@ -55,7 +59,7 @@ public class SelectionSet extends AbstractNode<SelectionSet> {
 
     @Override
     public SelectionSet deepCopy() {
-        return new SelectionSet(deepCopy(selections), getSourceLocation(), getComments());
+        return new SelectionSet(deepCopy(selections), getSourceLocation(), getComments(), getIgnoredChars());
     }
 
     @Override
@@ -89,6 +93,7 @@ public class SelectionSet extends AbstractNode<SelectionSet> {
         private List<Selection> selections = new ArrayList<>();
         private SourceLocation sourceLocation;
         private List<Comment> comments = new ArrayList<>();
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -97,6 +102,7 @@ public class SelectionSet extends AbstractNode<SelectionSet> {
             this.sourceLocation = existing.getSourceLocation();
             this.comments = existing.getComments();
             this.selections = existing.getSelections();
+            this.ignoredChars = existing.getIgnoredChars();
         }
 
         public Builder selections(List<Selection> selections) {
@@ -114,8 +120,13 @@ public class SelectionSet extends AbstractNode<SelectionSet> {
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public SelectionSet build() {
-            SelectionSet selectionSet = new SelectionSet(selections, sourceLocation, comments);
+            SelectionSet selectionSet = new SelectionSet(selections, sourceLocation, comments, ignoredChars);
             return selectionSet;
         }
     }

--- a/src/main/java/graphql/language/StringValue.java
+++ b/src/main/java/graphql/language/StringValue.java
@@ -16,8 +16,8 @@ public class StringValue extends AbstractNode<StringValue> implements ScalarValu
     private final String value;
 
     @Internal
-    protected StringValue(String value, SourceLocation sourceLocation, List<Comment> comments) {
-        super(sourceLocation, comments);
+    protected StringValue(String value, SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
         this.value = value;
     }
 
@@ -27,7 +27,7 @@ public class StringValue extends AbstractNode<StringValue> implements ScalarValu
      * @param value of the String
      */
     public StringValue(String value) {
-        this(value, null, new ArrayList<>());
+        this(value, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     public String getValue() {
@@ -49,8 +49,12 @@ public class StringValue extends AbstractNode<StringValue> implements ScalarValu
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         StringValue that = (StringValue) o;
 
@@ -60,7 +64,7 @@ public class StringValue extends AbstractNode<StringValue> implements ScalarValu
 
     @Override
     public StringValue deepCopy() {
-        return new StringValue(value, getSourceLocation(), getComments());
+        return new StringValue(value, getSourceLocation(), getComments(), getIgnoredChars());
     }
 
     @Override
@@ -86,6 +90,7 @@ public class StringValue extends AbstractNode<StringValue> implements ScalarValu
         private SourceLocation sourceLocation;
         private String value;
         private List<Comment> comments = new ArrayList<>();
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -94,6 +99,7 @@ public class StringValue extends AbstractNode<StringValue> implements ScalarValu
             this.sourceLocation = existing.getSourceLocation();
             this.comments = existing.getComments();
             this.value = existing.getValue();
+            this.ignoredChars = existing.getIgnoredChars();
         }
 
 
@@ -112,8 +118,13 @@ public class StringValue extends AbstractNode<StringValue> implements ScalarValu
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public StringValue build() {
-            StringValue stringValue = new StringValue(value, sourceLocation, comments);
+            StringValue stringValue = new StringValue(value, sourceLocation, comments, ignoredChars);
             return stringValue;
         }
     }

--- a/src/main/java/graphql/language/TypeName.java
+++ b/src/main/java/graphql/language/TypeName.java
@@ -16,8 +16,8 @@ public class TypeName extends AbstractNode<TypeName> implements Type<TypeName> {
     private final String name;
 
     @Internal
-    protected TypeName(String name, SourceLocation sourceLocation, List<Comment> comments) {
-        super(sourceLocation, comments);
+    protected TypeName(String name, SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
         this.name = name;
     }
 
@@ -27,7 +27,7 @@ public class TypeName extends AbstractNode<TypeName> implements Type<TypeName> {
      * @param name of the type
      */
     public TypeName(String name) {
-        this(name, null, new ArrayList<>());
+        this(name, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
 
@@ -42,8 +42,12 @@ public class TypeName extends AbstractNode<TypeName> implements Type<TypeName> {
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         TypeName that = (TypeName) o;
 
@@ -52,7 +56,7 @@ public class TypeName extends AbstractNode<TypeName> implements Type<TypeName> {
 
     @Override
     public TypeName deepCopy() {
-        return new TypeName(name, getSourceLocation(), getComments());
+        return new TypeName(name, getSourceLocation(), getComments(), getIgnoredChars());
     }
 
     @Override
@@ -86,6 +90,7 @@ public class TypeName extends AbstractNode<TypeName> implements Type<TypeName> {
         private String name;
         private SourceLocation sourceLocation;
         private List<Comment> comments = new ArrayList<>();
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -112,8 +117,13 @@ public class TypeName extends AbstractNode<TypeName> implements Type<TypeName> {
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public TypeName build() {
-            TypeName typeName = new TypeName(name, sourceLocation, comments);
+            TypeName typeName = new TypeName(name, sourceLocation, comments, ignoredChars);
             return typeName;
         }
     }

--- a/src/main/java/graphql/language/TypeName.java
+++ b/src/main/java/graphql/language/TypeName.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.function.Consumer;
 
 @PublicApi
-public class TypeName extends AbstractNode<TypeName> implements Type<TypeName> {
+public class TypeName extends AbstractNode<TypeName> implements Type<TypeName>, NamedNode<TypeName> {
 
     private final String name;
 

--- a/src/main/java/graphql/language/UnionTypeDefinition.java
+++ b/src/main/java/graphql/language/UnionTypeDefinition.java
@@ -24,8 +24,9 @@ public class UnionTypeDefinition extends AbstractNode<UnionTypeDefinition> imple
                                   List<Type> memberTypes,
                                   Description description,
                                   SourceLocation sourceLocation,
-                                  List<Comment> comments) {
-        super(sourceLocation, comments);
+                                  List<Comment> comments,
+                                  IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
         this.name = name;
         this.directives = directives;
         this.memberTypes = memberTypes;
@@ -40,7 +41,7 @@ public class UnionTypeDefinition extends AbstractNode<UnionTypeDefinition> imple
      */
     public UnionTypeDefinition(String name,
                                List<Directive> directives) {
-        this(name, directives, new ArrayList<>(), null, null, new ArrayList<>());
+        this(name, directives, new ArrayList<>(), null, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     /**
@@ -49,7 +50,7 @@ public class UnionTypeDefinition extends AbstractNode<UnionTypeDefinition> imple
      * @param name of the union
      */
     public UnionTypeDefinition(String name) {
-        this(name, new ArrayList<>(), new ArrayList<>(), null, null, new ArrayList<>());
+        this(name, new ArrayList<>(), new ArrayList<>(), null, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     @Override
@@ -80,8 +81,12 @@ public class UnionTypeDefinition extends AbstractNode<UnionTypeDefinition> imple
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         UnionTypeDefinition that = (UnionTypeDefinition) o;
 
@@ -95,7 +100,8 @@ public class UnionTypeDefinition extends AbstractNode<UnionTypeDefinition> imple
                 deepCopy(memberTypes),
                 description,
                 getSourceLocation(),
-                getComments()
+                getComments(),
+                getIgnoredChars()
         );
     }
 
@@ -130,6 +136,7 @@ public class UnionTypeDefinition extends AbstractNode<UnionTypeDefinition> imple
         private Description description;
         private List<Directive> directives = new ArrayList<>();
         private List<Type> memberTypes = new ArrayList<>();
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -141,6 +148,7 @@ public class UnionTypeDefinition extends AbstractNode<UnionTypeDefinition> imple
             this.description = existing.getDescription();
             this.directives = existing.getDirectives();
             this.memberTypes = existing.getMemberTypes();
+            this.ignoredChars = existing.getIgnoredChars();
         }
 
         public Builder sourceLocation(SourceLocation sourceLocation) {
@@ -183,13 +191,19 @@ public class UnionTypeDefinition extends AbstractNode<UnionTypeDefinition> imple
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public UnionTypeDefinition build() {
             UnionTypeDefinition unionTypeDefinition = new UnionTypeDefinition(name,
                     directives,
                     memberTypes,
                     description,
                     sourceLocation,
-                    comments);
+                    comments,
+                    ignoredChars);
             return unionTypeDefinition;
         }
     }

--- a/src/main/java/graphql/language/UnionTypeExtensionDefinition.java
+++ b/src/main/java/graphql/language/UnionTypeExtensionDefinition.java
@@ -12,17 +12,19 @@ public class UnionTypeExtensionDefinition extends UnionTypeDefinition {
 
     @Internal
     protected UnionTypeExtensionDefinition(String name,
-                                         List<Directive> directives,
-                                         List<Type> memberTypes,
-                                         Description description,
-                                         SourceLocation sourceLocation,
-                                         List<Comment> comments) {
+                                           List<Directive> directives,
+                                           List<Type> memberTypes,
+                                           Description description,
+                                           SourceLocation sourceLocation,
+                                           List<Comment> comments,
+                                           IgnoredChars ignoredChars) {
         super(name,
                 directives,
                 memberTypes,
                 description,
                 sourceLocation,
-                comments);
+                comments,
+                ignoredChars);
     }
 
     @Override
@@ -32,7 +34,8 @@ public class UnionTypeExtensionDefinition extends UnionTypeDefinition {
                 deepCopy(getMemberTypes()),
                 getDescription(),
                 getSourceLocation(),
-                getComments());
+                getComments(),
+                getIgnoredChars());
     }
 
     @Override
@@ -61,6 +64,7 @@ public class UnionTypeExtensionDefinition extends UnionTypeDefinition {
         private Description description;
         private List<Directive> directives = new ArrayList<>();
         private List<Type> memberTypes = new ArrayList<>();
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -73,6 +77,7 @@ public class UnionTypeExtensionDefinition extends UnionTypeDefinition {
             this.description = existing.getDescription();
             this.directives = existing.getDirectives();
             this.memberTypes = existing.getMemberTypes();
+            this.ignoredChars = existing.getIgnoredChars();
         }
 
         public Builder sourceLocation(SourceLocation sourceLocation) {
@@ -105,13 +110,19 @@ public class UnionTypeExtensionDefinition extends UnionTypeDefinition {
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public UnionTypeExtensionDefinition build() {
             UnionTypeExtensionDefinition unionTypeDefinition = new UnionTypeExtensionDefinition(name,
                     directives,
                     memberTypes,
                     description,
                     sourceLocation,
-                    comments
+                    comments,
+                    ignoredChars
             );
             return unionTypeDefinition;
         }

--- a/src/main/java/graphql/language/VariableDefinition.java
+++ b/src/main/java/graphql/language/VariableDefinition.java
@@ -22,8 +22,9 @@ public class VariableDefinition extends AbstractNode<VariableDefinition> impleme
                                  Type type,
                                  Value defaultValue,
                                  SourceLocation sourceLocation,
-                                 List<Comment> comments) {
-        super(sourceLocation, comments);
+                                 List<Comment> comments,
+                                 IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
         this.name = name;
         this.type = type;
         this.defaultValue = defaultValue;
@@ -39,7 +40,7 @@ public class VariableDefinition extends AbstractNode<VariableDefinition> impleme
     public VariableDefinition(String name,
                               Type type,
                               Value defaultValue) {
-        this(name, type, defaultValue, null, new ArrayList<>());
+        this(name, type, defaultValue, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     /**
@@ -50,7 +51,7 @@ public class VariableDefinition extends AbstractNode<VariableDefinition> impleme
      */
     public VariableDefinition(String name,
                               Type type) {
-        this(name, type, null, null, new ArrayList<>());
+        this(name, type, null, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
 
@@ -70,14 +71,20 @@ public class VariableDefinition extends AbstractNode<VariableDefinition> impleme
     public List<Node> getChildren() {
         List<Node> result = new ArrayList<>();
         result.add(type);
-        if (defaultValue != null) result.add(defaultValue);
+        if (defaultValue != null) {
+            result.add(defaultValue);
+        }
         return result;
     }
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         VariableDefinition that = (VariableDefinition) o;
 
@@ -91,7 +98,8 @@ public class VariableDefinition extends AbstractNode<VariableDefinition> impleme
                 deepCopy(type),
                 deepCopy(defaultValue),
                 getSourceLocation(),
-                getComments()
+                getComments(),
+                getIgnoredChars()
         );
     }
 
@@ -138,6 +146,7 @@ public class VariableDefinition extends AbstractNode<VariableDefinition> impleme
         private List<Comment> comments = new ArrayList<>();
         private Type type;
         private Value defaultValue;
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -148,6 +157,7 @@ public class VariableDefinition extends AbstractNode<VariableDefinition> impleme
             this.name = existing.getName();
             this.type = existing.getType();
             this.defaultValue = existing.getDefaultValue();
+            this.ignoredChars = existing.getIgnoredChars();
         }
 
         public Builder sourceLocation(SourceLocation sourceLocation) {
@@ -175,13 +185,19 @@ public class VariableDefinition extends AbstractNode<VariableDefinition> impleme
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public VariableDefinition build() {
             VariableDefinition variableDefinition = new VariableDefinition(
                     name,
                     type,
                     defaultValue,
                     sourceLocation,
-                    comments
+                    comments,
+                    ignoredChars
             );
             return variableDefinition;
         }

--- a/src/main/java/graphql/language/VariableReference.java
+++ b/src/main/java/graphql/language/VariableReference.java
@@ -16,8 +16,8 @@ public class VariableReference extends AbstractNode<VariableReference> implement
     private final String name;
 
     @Internal
-    protected VariableReference(String name, SourceLocation sourceLocation, List<Comment> comments) {
-        super(sourceLocation, comments);
+    protected VariableReference(String name, SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars) {
+        super(sourceLocation, comments, ignoredChars);
         this.name = name;
     }
 
@@ -27,7 +27,7 @@ public class VariableReference extends AbstractNode<VariableReference> implement
      * @param name of the variable
      */
     public VariableReference(String name) {
-        this(name,null, new ArrayList<>());
+        this(name, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
     @Override
@@ -42,8 +42,12 @@ public class VariableReference extends AbstractNode<VariableReference> implement
 
     @Override
     public boolean isEqualTo(Node o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         VariableReference that = (VariableReference) o;
 
@@ -52,7 +56,7 @@ public class VariableReference extends AbstractNode<VariableReference> implement
 
     @Override
     public VariableReference deepCopy() {
-        return new VariableReference(name, getSourceLocation(), getComments());
+        return new VariableReference(name, getSourceLocation(), getComments(), getIgnoredChars());
     }
 
     @Override
@@ -81,6 +85,7 @@ public class VariableReference extends AbstractNode<VariableReference> implement
         private SourceLocation sourceLocation;
         private List<Comment> comments = new ArrayList<>();
         private String name;
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
         }
@@ -89,6 +94,7 @@ public class VariableReference extends AbstractNode<VariableReference> implement
             this.sourceLocation = existing.getSourceLocation();
             this.comments = existing.getComments();
             this.name = existing.getName();
+            this.ignoredChars = existing.getIgnoredChars();
         }
 
         public Builder sourceLocation(SourceLocation sourceLocation) {
@@ -106,8 +112,13 @@ public class VariableReference extends AbstractNode<VariableReference> implement
             return this;
         }
 
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
         public VariableReference build() {
-            VariableReference variableReference = new VariableReference(name, sourceLocation, comments);
+            VariableReference variableReference = new VariableReference(name, sourceLocation, comments, ignoredChars);
             return variableReference;
         }
     }

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -3,8 +3,8 @@ set -ev
 echo "current git hash:"
 git rev-parse --short HEAD
 BUILD_COMMAND="./gradlew assemble && ./gradlew check --info"
-#if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_BRANCH}" = "master" ]; then
-#    echo "Building on master"
+if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_BRANCH}" = "master" ]; then
+    echo "Building on master"
     BUILD_COMMAND="./gradlew clean assemble && ./gradlew check  --info && ./gradlew bintrayUpload -x check --info"
-#fi
+fi
 docker run -it --rm -v `pwd .`:/build -e RELEASE_VERSION=$RELEASE_VERSION -e BINTRAY_USER=$BINTRAY_USER -e BINTRAY_API_KEY=$BINTRAY_API_KEY -e MAVEN_CENTRAL_USER=$MAVEN_CENTRAL_USER -e MAVEN_CENTRAL_PASSWORD=$MAVEN_CENTRAL_PASSWORD -w /build openjdk:8u131-jdk bash -c "${BUILD_COMMAND}"

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -3,8 +3,8 @@ set -ev
 echo "current git hash:"
 git rev-parse --short HEAD
 BUILD_COMMAND="./gradlew assemble && ./gradlew check --info"
-if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_BRANCH}" = "master" ]; then
-    echo "Building on master"
+#if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_BRANCH}" = "master" ]; then
+#    echo "Building on master"
     BUILD_COMMAND="./gradlew clean assemble && ./gradlew check  --info && ./gradlew bintrayUpload -x check --info"
-fi
+#fi
 docker run -it --rm -v `pwd .`:/build -e RELEASE_VERSION=$RELEASE_VERSION -e BINTRAY_USER=$BINTRAY_USER -e BINTRAY_API_KEY=$BINTRAY_API_KEY -e MAVEN_CENTRAL_USER=$MAVEN_CENTRAL_USER -e MAVEN_CENTRAL_PASSWORD=$MAVEN_CENTRAL_PASSWORD -w /build openjdk:8u131-jdk bash -c "${BUILD_COMMAND}"


### PR DESCRIPTION
This adds all the ignored chars to the Ast. Previously we would just skip them, now they are available on the AST.
This is allows for printing out the original Document (not implemented here) and also allows some analysing of the complete Document.