### PR TITLE
Added SchemaTransformers as a post processing step in the schema build

### DIFF
--- a/src/main/java/graphql/schema/SchemaTransformer.java
+++ b/src/main/java/graphql/schema/SchemaTransformer.java
@@ -1,0 +1,17 @@
+package graphql.schema;
+
+/**
+ * These are called by the {@link graphql.schema.idl.SchemaGenerator} after a valid schema has been built
+ * and they can then adjust it accordingly with some sort of post processing.
+ */
+public interface SchemaTransformer {
+
+    /**
+     * Called to transform the schema from its built state into something else
+     *
+     * @param originalSchema the original built schema
+     *
+     * @return a non null schema
+     */
+    GraphQLSchema transform(GraphQLSchema originalSchema);
+}

--- a/src/main/java/graphql/schema/idl/RuntimeWiring.java
+++ b/src/main/java/graphql/schema/idl/RuntimeWiring.java
@@ -4,9 +4,12 @@ import graphql.PublicApi;
 import graphql.schema.DataFetcher;
 import graphql.schema.GraphQLScalarType;
 import graphql.schema.GraphQLSchema;
+import graphql.schema.SchemaTransformer;
 import graphql.schema.TypeResolver;
 import graphql.schema.visibility.GraphqlFieldVisibility;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.UnaryOperator;
@@ -28,9 +31,10 @@ public class RuntimeWiring {
     private final Map<String, SchemaDirectiveWiring> directiveWiring;
     private final WiringFactory wiringFactory;
     private final Map<String, EnumValuesProvider> enumValuesProviders;
+    private final Collection<SchemaTransformer> schemaTransformers;
     private final GraphqlFieldVisibility fieldVisibility;
 
-    private RuntimeWiring(Map<String, Map<String, DataFetcher>> dataFetchers, Map<String, DataFetcher> defaultDataFetchers, Map<String, GraphQLScalarType> scalars, Map<String, TypeResolver> typeResolvers, Map<String, SchemaDirectiveWiring> directiveWiring, Map<String, EnumValuesProvider> enumValuesProviders, WiringFactory wiringFactory, GraphqlFieldVisibility fieldVisibility) {
+    private RuntimeWiring(Map<String, Map<String, DataFetcher>> dataFetchers, Map<String, DataFetcher> defaultDataFetchers, Map<String, GraphQLScalarType> scalars, Map<String, TypeResolver> typeResolvers, Map<String, SchemaDirectiveWiring> directiveWiring, Map<String, EnumValuesProvider> enumValuesProviders, WiringFactory wiringFactory, Collection<SchemaTransformer> schemaTransformers, GraphqlFieldVisibility fieldVisibility) {
         this.dataFetchers = dataFetchers;
         this.defaultDataFetchers = defaultDataFetchers;
         this.scalars = scalars;
@@ -38,6 +42,7 @@ public class RuntimeWiring {
         this.directiveWiring = directiveWiring;
         this.wiringFactory = wiringFactory;
         this.enumValuesProviders = enumValuesProviders;
+        this.schemaTransformers = schemaTransformers;
         this.fieldVisibility = fieldVisibility;
     }
 
@@ -84,6 +89,10 @@ public class RuntimeWiring {
         return directiveWiring;
     }
 
+    public Collection<SchemaTransformer> getSchemaTransformers() {
+        return schemaTransformers;
+    }
+
     @PublicApi
     public static class Builder {
         private final Map<String, Map<String, DataFetcher>> dataFetchers = new LinkedHashMap<>();
@@ -92,6 +101,7 @@ public class RuntimeWiring {
         private final Map<String, TypeResolver> typeResolvers = new LinkedHashMap<>();
         private final Map<String, EnumValuesProvider> enumValuesProviders = new LinkedHashMap<>();
         private final Map<String, SchemaDirectiveWiring> directiveWiring = new LinkedHashMap<>();
+        private final Collection<SchemaTransformer> schemaTransformers = new ArrayList<>();
         private WiringFactory wiringFactory = new NoopWiringFactory();
         private GraphqlFieldVisibility fieldVisibility = DEFAULT_FIELD_VISIBILITY;
 
@@ -204,14 +214,24 @@ public class RuntimeWiring {
         }
 
         /**
+         * Adds a schema transformer into the mix
+         *
+         * @param schemaTransformer the non null schema transformer to add
+         *
+         * @return the runtime wiring builder
+         */
+        public Builder transformer(SchemaTransformer schemaTransformer) {
+            this.schemaTransformers.add(assertNotNull(schemaTransformer));
+            return this;
+        }
+
+        /**
          * @return the built runtime wiring
          */
         public RuntimeWiring build() {
-            return new RuntimeWiring(dataFetchers, defaultDataFetchers, scalars, typeResolvers, directiveWiring, enumValuesProviders, wiringFactory, fieldVisibility);
+            return new RuntimeWiring(dataFetchers, defaultDataFetchers, scalars, typeResolvers, directiveWiring, enumValuesProviders, wiringFactory, schemaTransformers, fieldVisibility);
         }
 
     }
-
-
 }
 

--- a/src/main/java/graphql/schema/idl/SchemaGenerator.java
+++ b/src/main/java/graphql/schema/idl/SchemaGenerator.java
@@ -48,6 +48,7 @@ import graphql.schema.GraphQLType;
 import graphql.schema.GraphQLTypeReference;
 import graphql.schema.GraphQLUnionType;
 import graphql.schema.PropertyDataFetcher;
+import graphql.schema.SchemaTransformer;
 import graphql.schema.TypeResolver;
 import graphql.schema.TypeResolverProxy;
 import graphql.schema.idl.errors.NotAnInputTypeError;
@@ -57,6 +58,7 @@ import graphql.schema.idl.errors.SchemaProblem;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.LinkedHashMap;
@@ -333,7 +335,13 @@ public class SchemaGenerator {
 
         schemaBuilder.fieldVisibility(buildCtx.getWiring().getFieldVisibility());
 
-        return schemaBuilder.build();
+        GraphQLSchema graphQLSchema = schemaBuilder.build();
+
+        Collection<SchemaTransformer> schemaTransformers = buildCtx.getWiring().getSchemaTransformers();
+        for (SchemaTransformer schemaTransformer : schemaTransformers) {
+            graphQLSchema = schemaTransformer.transform(graphQLSchema);
+        }
+        return graphQLSchema;
     }
 
     private GraphQLObjectType buildOperation(BuildContext buildCtx, OperationTypeDefinition operation) {


### PR DESCRIPTION
This allows for post processing code to be specified in the RuntimeWiring so that the build schema can be automatically transformed into something else.

I intend it to be used for the "validation post processing" so that we can run the entire schema and find validation directives and generate code that goes into the CodeRegistry.