### PR TITLE
Handle array values in SchemaPrinter

### DIFF
--- a/src/main/java/graphql/language/AstValueHelper.java
+++ b/src/main/java/graphql/language/AstValueHelper.java
@@ -14,6 +14,7 @@ import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLScalarType;
 import graphql.schema.GraphQLType;
+import graphql.util.FpKit;
 
 import java.beans.BeanInfo;
 import java.beans.IntrospectionException;
@@ -142,8 +143,9 @@ public class AstValueHelper {
 
     private static Value handleList(Object _value, GraphQLList type) {
         GraphQLType itemType = type.getWrappedType();
-        if (_value instanceof Iterable) {
-            Iterable iterable = (Iterable) _value;
+        boolean isIterable = _value instanceof Iterable;
+        if (isIterable || (_value != null && _value.getClass().isArray())) {
+            Iterable iterable = isIterable ? (Iterable) _value : FpKit.toCollection(_value);
             List<Value> valuesNodes = new ArrayList<>();
             for (Object item : iterable) {
                 Value itemNode = astFromValue(item, itemType);


### PR DESCRIPTION
Make SchemaPrinter able to deal with array values for `GraphQLList`

Fixes #1326