### PR TITLE
Field coordinates for specifying data fetchers

### DIFF
--- a/src/main/java/graphql/analysis/QueryTraversal.java
+++ b/src/main/java/graphql/analysis/QueryTraversal.java
@@ -256,7 +256,7 @@ public class QueryTraversal {
             GraphQLFieldDefinition fieldDefinition = Introspection.getFieldDef(schema, parentEnv.getRawType(), field.getName());
             boolean isTypeNameIntrospectionField = fieldDefinition == Introspection.TypeNameMetaFieldDef;
             GraphQLFieldsContainer fieldsContainer = !isTypeNameIntrospectionField ? (GraphQLFieldsContainer) unwrapAll(parentEnv.getOutputType()) : null;
-            Map<String, Object> argumentValues = valuesResolver.getArgumentValues(schema.getFieldVisibility(), fieldDefinition.getArguments(), field.getArguments(), variables);
+            Map<String, Object> argumentValues = valuesResolver.getArgumentValues(schema.getCodeRegistry().getFieldVisibility(), fieldDefinition.getArguments(), field.getArguments(), variables);
             QueryVisitorFieldEnvironment environment = new QueryVisitorFieldEnvironmentImpl(isTypeNameIntrospectionField,
                     field,
                     fieldDefinition,

--- a/src/main/java/graphql/introspection/Introspection.java
+++ b/src/main/java/graphql/introspection/Introspection.java
@@ -8,6 +8,7 @@ import graphql.language.AstPrinter;
 import graphql.language.AstValueHelper;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.FieldCoordinates;
 import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLCodeRegistry;
 import graphql.schema.GraphQLCompositeType;
@@ -38,6 +39,8 @@ import java.util.Map;
 import static graphql.Assert.assertTrue;
 import static graphql.Scalars.GraphQLBoolean;
 import static graphql.Scalars.GraphQLString;
+import static graphql.schema.FieldCoordinates.coordinates;
+import static graphql.schema.FieldCoordinates.systemCoordinates;
 import static graphql.schema.GraphQLArgument.newArgument;
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 import static graphql.schema.GraphQLList.list;
@@ -47,18 +50,18 @@ import static graphql.schema.GraphQLTypeReference.typeRef;
 
 @PublicApi
 public class Introspection {
-    private static final Map<GraphQLCodeRegistry.TypeAndFieldKey, DataFetcher> introspectionDataFetchers = new LinkedHashMap<>();
+    private static final Map<FieldCoordinates, DataFetcher> introspectionDataFetchers = new LinkedHashMap<>();
 
     private static void register(GraphQLFieldsContainer parentType, String fieldName, DataFetcher dataFetcher) {
-        introspectionDataFetchers.put(GraphQLCodeRegistry.TypeAndFieldKey.mkKey(parentType.getName(), fieldName), dataFetcher);
+        introspectionDataFetchers.put(coordinates(parentType.getName(), fieldName), dataFetcher);
     }
 
     @Internal
     public static void addCodeForIntrospectionTypes(GraphQLCodeRegistry.Builder codeRegistry) {
         // place the system __ fields into the mix.  They have no parent types
-        codeRegistry.systemDataFetcher(SchemaMetaFieldDef, SchemaMetaFieldDefDataFetcher);
-        codeRegistry.systemDataFetcher(TypeNameMetaFieldDef, TypeNameMetaFieldDefDataFetcher);
-        codeRegistry.systemDataFetcher(TypeMetaFieldDef, TypeMetaFieldDefDataFetcher);
+        codeRegistry.systemDataFetcher(systemCoordinates(SchemaMetaFieldDef.getName()), SchemaMetaFieldDefDataFetcher);
+        codeRegistry.systemDataFetcher(systemCoordinates(TypeNameMetaFieldDef.getName()), TypeNameMetaFieldDefDataFetcher);
+        codeRegistry.systemDataFetcher(systemCoordinates(TypeMetaFieldDef.getName()), TypeMetaFieldDefDataFetcher);
 
         introspectionDataFetchers.forEach(codeRegistry::dataFetcher);
     }

--- a/src/main/java/graphql/schema/CodeRegistryVisitor.java
+++ b/src/main/java/graphql/schema/CodeRegistryVisitor.java
@@ -5,6 +5,7 @@ import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
 import static graphql.Assert.assertTrue;
+import static graphql.schema.FieldCoordinates.coordinates;
 import static graphql.util.TraversalControl.CONTINUE;
 
 /**
@@ -25,7 +26,8 @@ class CodeRegistryVisitor extends GraphQLTypeVisitorStub {
         if (dataFetcher == null) {
             dataFetcher = new PropertyDataFetcher<>(node.getName());
         }
-        codeRegistry.dataFetcherIfAbsent(parentContainerType, node, dataFetcher);
+        FieldCoordinates coordinates = coordinates(parentContainerType, node);
+        codeRegistry.dataFetcherIfAbsent(coordinates, dataFetcher);
         return CONTINUE;
     }
 

--- a/src/main/java/graphql/schema/FieldCoordinates.java
+++ b/src/main/java/graphql/schema/FieldCoordinates.java
@@ -1,0 +1,95 @@
+package graphql.schema;
+
+import graphql.PublicApi;
+
+import java.util.Objects;
+
+import static graphql.Assert.assertTrue;
+import static graphql.Assert.assertValidName;
+
+/**
+ * A field in graphql is uniquely located within a parent type and hence code elements
+ * like {@link graphql.schema.DataFetcher} need to be specified using those coordinates.
+ */
+@PublicApi
+public class FieldCoordinates {
+
+    private final String typeName;
+    private final String fieldName;
+
+    private FieldCoordinates(String typeName, String fieldName) {
+        this.typeName = typeName;
+        this.fieldName = fieldName;
+    }
+
+    public String getTypeName() {
+        return typeName;
+    }
+
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FieldCoordinates that = (FieldCoordinates) o;
+        return Objects.equals(typeName, that.typeName) &&
+                Objects.equals(fieldName, that.fieldName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(typeName, fieldName);
+    }
+
+    @Override
+    public String toString() {
+        return typeName + ':' + fieldName + '\'';
+    }
+
+    /**
+     * Creates new field coordinates
+     *
+     * @param parentType      the container of the field
+     * @param fieldDefinition the field definition
+     *
+     * @return new field coordinates represented by the two parameters
+     */
+    public static FieldCoordinates coordinates(GraphQLFieldsContainer parentType, GraphQLFieldDefinition fieldDefinition) {
+        return new FieldCoordinates(parentType.getName(), fieldDefinition.getName());
+    }
+
+    /**
+     * Creates new field coordinates
+     *
+     * @param parentType the container of the field
+     * @param fieldName  the field name
+     *
+     * @return new field coordinates represented by the two parameters
+     */
+    public static FieldCoordinates coordinates(String parentType, String fieldName) {
+        assertValidName(parentType);
+        assertValidName(fieldName);
+        return new FieldCoordinates(parentType, fieldName);
+    }
+
+    /**
+     * The exception to the general rule is the system __xxxx Introspection fields which have no parent type and
+     * are able to be specified on any type
+     *
+     * @param fieldName the name of the system field which MUST start with __
+     *
+     * @return the coordinates
+     */
+    public static FieldCoordinates systemCoordinates(String fieldName) {
+        assertTrue(fieldName.startsWith("__"), "Only __ system fields can be addressed without a parent type");
+        assertValidName(fieldName);
+        return new FieldCoordinates(null, fieldName);
+    }
+}

--- a/src/main/java/graphql/schema/GraphQLCodeRegistry.java
+++ b/src/main/java/graphql/schema/GraphQLCodeRegistry.java
@@ -6,14 +6,13 @@ import graphql.schema.visibility.GraphqlFieldVisibility;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertTrue;
 import static graphql.Assert.assertValidName;
 import static graphql.schema.DataFetcherFactoryEnvironment.newDataFetchingFactoryEnvironment;
-import static graphql.schema.GraphQLCodeRegistry.TypeAndFieldKey.mkKey;
+import static graphql.schema.FieldCoordinates.coordinates;
 import static graphql.schema.visibility.DefaultGraphqlFieldVisibility.DEFAULT_FIELD_VISIBILITY;
 
 
@@ -28,12 +27,12 @@ import static graphql.schema.visibility.DefaultGraphqlFieldVisibility.DEFAULT_FI
 @PublicApi
 public class GraphQLCodeRegistry {
 
-    private final Map<TypeAndFieldKey, DataFetcherFactory> dataFetcherMap;
+    private final Map<FieldCoordinates, DataFetcherFactory> dataFetcherMap;
     private final Map<String, DataFetcherFactory> systemDataFetcherMap;
     private final Map<String, TypeResolver> typeResolverMap;
     private final GraphqlFieldVisibility fieldVisibility;
 
-    private GraphQLCodeRegistry(Map<TypeAndFieldKey, DataFetcherFactory> dataFetcherMap, Map<String, DataFetcherFactory> systemDataFetcherMap, Map<String, TypeResolver> typeResolverMap, GraphqlFieldVisibility fieldVisibility) {
+    private GraphQLCodeRegistry(Map<FieldCoordinates, DataFetcherFactory> dataFetcherMap, Map<String, DataFetcherFactory> systemDataFetcherMap, Map<String, TypeResolver> typeResolverMap, GraphqlFieldVisibility fieldVisibility) {
         this.dataFetcherMap = dataFetcherMap;
         this.systemDataFetcherMap = systemDataFetcherMap;
         this.typeResolverMap = typeResolverMap;
@@ -59,13 +58,13 @@ public class GraphQLCodeRegistry {
         return getDataFetcherImpl(parentType, fieldDefinition, dataFetcherMap, systemDataFetcherMap);
     }
 
-    private static DataFetcher getDataFetcherImpl(GraphQLFieldsContainer parentType, GraphQLFieldDefinition fieldDefinition, Map<TypeAndFieldKey, DataFetcherFactory> dataFetcherMap, Map<String, DataFetcherFactory> systemDataFetcherMap) {
+    private static DataFetcher getDataFetcherImpl(GraphQLFieldsContainer parentType, GraphQLFieldDefinition fieldDefinition, Map<FieldCoordinates, DataFetcherFactory> dataFetcherMap, Map<String, DataFetcherFactory> systemDataFetcherMap) {
         assertNotNull(parentType);
         assertNotNull(fieldDefinition);
 
         DataFetcherFactory dataFetcherFactory = systemDataFetcherMap.get(fieldDefinition.getName());
         if (dataFetcherFactory == null) {
-            dataFetcherFactory = dataFetcherMap.get(mkKey(parentType, fieldDefinition));
+            dataFetcherFactory = dataFetcherMap.get(FieldCoordinates.coordinates(parentType, fieldDefinition));
             if (dataFetcherFactory == null) {
                 dataFetcherFactory = DataFetcherFactories.useDataFetcher(new PropertyDataFetcher<>(fieldDefinition.getName()));
             }
@@ -75,13 +74,12 @@ public class GraphQLCodeRegistry {
                 .build());
     }
 
-    private static boolean hasDataFetcherImpl(String parentTypeName, String fieldName, Map<TypeAndFieldKey, DataFetcherFactory> dataFetcherMap, Map<String, DataFetcherFactory> systemDataFetcherMap) {
-        assertNotNull(parentTypeName);
-        assertNotNull(fieldName);
+    private static boolean hasDataFetcherImpl(FieldCoordinates coords, Map<FieldCoordinates, DataFetcherFactory> dataFetcherMap, Map<String, DataFetcherFactory> systemDataFetcherMap) {
+        assertNotNull(coords);
 
-        DataFetcherFactory dataFetcherFactory = systemDataFetcherMap.get(fieldName);
+        DataFetcherFactory dataFetcherFactory = systemDataFetcherMap.get(coords.getFieldName());
         if (dataFetcherFactory == null) {
-            dataFetcherFactory = dataFetcherMap.get(mkKey(parentTypeName, fieldName));
+            dataFetcherFactory = dataFetcherMap.get(coords);
         }
         return dataFetcherFactory != null;
     }
@@ -128,48 +126,6 @@ public class GraphQLCodeRegistry {
         return assertNotNull(typeResolver, "There must be a type resolver for union " + parentType.getName());
     }
 
-    public static class TypeAndFieldKey {
-
-        private final String typeName;
-        private final String fieldName;
-
-        private TypeAndFieldKey(String typeName, String fieldName) {
-            this.typeName = typeName;
-            this.fieldName = fieldName;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-            TypeAndFieldKey that = (TypeAndFieldKey) o;
-            return Objects.equals(typeName, that.typeName) &&
-                    Objects.equals(fieldName, that.fieldName);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(typeName, fieldName);
-        }
-
-        @Override
-        public String toString() {
-            return typeName + ':' + fieldName + '\'';
-        }
-
-        public static TypeAndFieldKey mkKey(GraphQLFieldsContainer parentType, GraphQLFieldDefinition fieldDefinition) {
-            return new TypeAndFieldKey(parentType.getName(), fieldDefinition.getName());
-        }
-
-        public static TypeAndFieldKey mkKey(String parentType, String fieldName) {
-            return new TypeAndFieldKey(parentType, fieldName);
-        }
-    }
-
 
     /**
      * This helps you transform the current {@link graphql.schema.GraphQLCodeRegistry} object into another one by starting a builder with all
@@ -204,7 +160,7 @@ public class GraphQLCodeRegistry {
     }
 
     public static class Builder {
-        private final Map<TypeAndFieldKey, DataFetcherFactory> dataFetcherMap = new LinkedHashMap<>();
+        private final Map<FieldCoordinates, DataFetcherFactory> dataFetcherMap = new LinkedHashMap<>();
         private final Map<String, DataFetcherFactory> systemDataFetcherMap = new LinkedHashMap<>();
         private final Map<String, TypeResolver> typeResolverMap = new HashMap<>();
         private GraphqlFieldVisibility fieldVisibility = DEFAULT_FIELD_VISIBILITY;
@@ -234,13 +190,12 @@ public class GraphQLCodeRegistry {
         /**
          * Returns a data fetcher associated with a field within a container type
          *
-         * @param parentTypeName the container type name
-         * @param fieldName      the field definition name
+         * @param coordinates the field coordinates
          *
          * @return the true if there is a data fetcher already for this field
          */
-        public boolean hasDataFetcher(String parentTypeName, String fieldName) {
-            return hasDataFetcherImpl(parentTypeName, fieldName, dataFetcherMap, systemDataFetcherMap);
+        public boolean hasDataFetcher(FieldCoordinates coordinates) {
+            return hasDataFetcherImpl(coordinates, dataFetcherMap, systemDataFetcherMap);
         }
 
         /**
@@ -279,105 +234,57 @@ public class GraphQLCodeRegistry {
         /**
          * Sets the data fetcher for a specific field inside a container type
          *
-         * @param parentTypeContainer the parent container type
-         * @param fieldDefinition     the field definition
-         * @param dataFetcher         the data fetcher code for that field
+         * @param coordinates the field coordinates
+         * @param dataFetcher the data fetcher code for that field
          *
          * @return this builder
          */
-        public Builder dataFetcher(GraphQLFieldsContainer parentTypeContainer, GraphQLFieldDefinition fieldDefinition, DataFetcher<?> dataFetcher) {
+        public Builder dataFetcher(FieldCoordinates coordinates, DataFetcher<?> dataFetcher) {
             assertNotNull(dataFetcher);
-            return dataFetcher(parentTypeContainer, fieldDefinition, DataFetcherFactories.useDataFetcher(dataFetcher));
+            return dataFetcher(assertNotNull(coordinates), DataFetcherFactories.useDataFetcher(dataFetcher));
         }
 
         /**
          * Called to place system data fetchers (eg Introspection fields) into the mix
          *
-         * @param fieldDefinition the field definition
-         * @param dataFetcher     the data fetcher code for that field
+         * @param coordinates the field coordinates
+         * @param dataFetcher the data fetcher code for that field
          *
          * @return this builder
          */
-        public Builder systemDataFetcher(GraphQLFieldDefinition fieldDefinition, DataFetcher<?> dataFetcher) {
+        public Builder systemDataFetcher(FieldCoordinates coordinates, DataFetcher<?> dataFetcher) {
             assertNotNull(dataFetcher);
-            assertTrue(fieldDefinition.getName().startsWith("__"), "Only __ fields can be named as system data fetchers");
-            systemDataFetcherMap.put(fieldDefinition.getName(), DataFetcherFactories.useDataFetcher(dataFetcher));
+            assertNotNull(coordinates);
+            assertTrue(coordinates.getFieldName().startsWith("__"), "Only __ system fields can be used here");
+            systemDataFetcherMap.put(coordinates.getFieldName(), DataFetcherFactories.useDataFetcher(dataFetcher));
             return this;
         }
 
         /**
          * Sets the data fetcher factory for a specific field inside a container type
          *
-         * @param parentTypeContainer the parent container type
-         * @param fieldDefinition     the field definition
-         * @param dataFetcherFactory  the data fetcher factory code for that field
+         * @param coordinates        the field coordinates
+         * @param dataFetcherFactory the data fetcher factory code for that field
          *
          * @return this builder
          */
-        public Builder dataFetcher(GraphQLFieldsContainer parentTypeContainer, GraphQLFieldDefinition fieldDefinition, DataFetcherFactory<?> dataFetcherFactory) {
+        public Builder dataFetcher(FieldCoordinates coordinates, DataFetcherFactory<?> dataFetcherFactory) {
             assertNotNull(dataFetcherFactory);
-            dataFetcherMap.put(mkKey(parentTypeContainer, fieldDefinition), dataFetcherFactory);
+            dataFetcherMap.put(assertNotNull(coordinates), dataFetcherFactory);
             return this;
         }
 
         /**
          * Sets the data fetcher factory for a specific field inside a container type ONLY if not mapping has already been made
          *
-         * @param parentTypeContainer the parent container type
-         * @param fieldDefinition     the field definition
-         * @param dataFetcher         the data fetcher code for that field
+         * @param coordinates the field coordinates
+         * @param dataFetcher the data fetcher code for that field
          *
          * @return this builder
          */
-        public Builder dataFetcherIfAbsent(GraphQLFieldsContainer parentTypeContainer, GraphQLFieldDefinition fieldDefinition, DataFetcher<?> dataFetcher) {
-            dataFetcherMap.putIfAbsent(mkKey(parentTypeContainer, fieldDefinition), DataFetcherFactories.useDataFetcher(dataFetcher));
+        public Builder dataFetcherIfAbsent(FieldCoordinates coordinates, DataFetcher<?> dataFetcher) {
+            dataFetcherMap.putIfAbsent(assertNotNull(coordinates), DataFetcherFactories.useDataFetcher(dataFetcher));
             return this;
-        }
-
-        /**
-         * Sets the data fetcher for a specific field inside a container type
-         *
-         * @param parentTypeName the parent container type
-         * @param fieldName      the field name
-         * @param dataFetcher    the data fetcher code for that field
-         *
-         * @return this builder
-         */
-        public Builder dataFetcher(String parentTypeName, String fieldName, DataFetcher<?> dataFetcher) {
-            return dataFetcher(parentTypeName, fieldName, DataFetcherFactories.useDataFetcher(dataFetcher));
-        }
-
-        /**
-         * Sets the data fetcher factory for a specific field inside a container type
-         *
-         * @param parentTypeName     the parent container type
-         * @param fieldName          the field name
-         * @param dataFetcherFactory the data fetcher factory code for that field
-         *
-         * @return this builder
-         */
-        public Builder dataFetcher(String parentTypeName, String fieldName, DataFetcherFactory<?> dataFetcherFactory) {
-            assertNotNull(dataFetcherFactory);
-            dataFetcherMap.put(mkKey(assertValidName(parentTypeName), assertValidName(fieldName)), dataFetcherFactory);
-            return this;
-        }
-
-        public Builder dataFetcher(TypeAndFieldKey key, DataFetcher<?> dataFetcher) {
-            assertNotNull(dataFetcher);
-            dataFetcherMap.put(key, DataFetcherFactories.useDataFetcher(dataFetcher));
-            return this;
-        }
-
-        /**
-         * This allows you you to build all the data fetchers for the fields of a container type.
-         *
-         * @param parentTypeContainer the parent container type
-         * @param fieldDataFetchers   the map of field names to data fetchers
-         *
-         * @return this builder
-         */
-        public Builder dataFetchers(GraphQLFieldsContainer parentTypeContainer, Map<String, DataFetcher> fieldDataFetchers) {
-            return dataFetchers(parentTypeContainer.getName(), fieldDataFetchers);
         }
 
         /**
@@ -391,7 +298,7 @@ public class GraphQLCodeRegistry {
         public Builder dataFetchers(String parentTypeName, Map<String, DataFetcher> fieldDataFetchers) {
             assertNotNull(fieldDataFetchers);
             fieldDataFetchers.forEach((fieldName, dataFetcher) -> {
-                dataFetcher(parentTypeName, fieldName, dataFetcher);
+                dataFetcher(coordinates(parentTypeName, fieldName), dataFetcher);
             });
             return this;
         }

--- a/src/main/java/graphql/schema/idl/FetchSchemaDirectiveWiring.java
+++ b/src/main/java/graphql/schema/idl/FetchSchemaDirectiveWiring.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static graphql.DirectivesUtil.directiveWithArg;
+import static graphql.schema.FieldCoordinates.coordinates;
 
 /**
  * This adds ' @fetch(from : "otherName") ' support so you can rename what property is read for a given field
@@ -26,7 +27,7 @@ public class FetchSchemaDirectiveWiring implements SchemaDirectiveWiring {
         String fetchName = atFetchFromSupport(field.getName(), field.getDirectives());
         DataFetcher dataFetcher = new PropertyDataFetcher(fetchName);
 
-        environment.getCodeRegistry().dataFetcher(environment.getFieldsContainer(), field, dataFetcher);
+        environment.getCodeRegistry().dataFetcher(coordinates(environment.getFieldsContainer(), field), dataFetcher);
         return field;
     }
 

--- a/src/main/java/graphql/schema/idl/SchemaGenerator.java
+++ b/src/main/java/graphql/schema/idl/SchemaGenerator.java
@@ -31,6 +31,7 @@ import graphql.language.Value;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetcherFactories;
 import graphql.schema.DataFetcherFactory;
+import graphql.schema.FieldCoordinates;
 import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLCodeRegistry;
 import graphql.schema.GraphQLDirective;
@@ -761,9 +762,10 @@ public class SchemaGenerator {
 
         GraphQLFieldDefinition fieldDefinition = builder.build();
         // if they have already wired in a fetcher - then leave it alone
-        if (!buildCtx.codeRegistry.hasDataFetcher(parentType.getName(), fieldDefinition.getName())) {
+        FieldCoordinates coordinates = FieldCoordinates.coordinates(parentType.getName(), fieldDefinition.getName());
+        if (!buildCtx.codeRegistry.hasDataFetcher(coordinates)) {
             DataFetcherFactory dataFetcherFactory = buildDataFetcherFactory(buildCtx, parentType, fieldDef, fieldType, Arrays.asList(directives));
-            buildCtx.getCodeRegistry().dataFetcher(parentType.getName(), fieldDefinition.getName(), dataFetcherFactory);
+            buildCtx.getCodeRegistry().dataFetcher(coordinates, dataFetcherFactory);
         }
 
         return buildCtx.exitNode(new FieldDefAndDirectiveParams(fieldDefinition, buildCtx.mkBehaviourParams()));

--- a/src/main/java/graphql/schema/idl/SchemaPrinter.java
+++ b/src/main/java/graphql/schema/idl/SchemaPrinter.java
@@ -181,7 +181,7 @@ public class SchemaPrinter {
         StringWriter sw = new StringWriter();
         PrintWriter out = new PrintWriter(sw);
 
-        GraphqlFieldVisibility visibility = schema.getFieldVisibility();
+        GraphqlFieldVisibility visibility = schema.getCodeRegistry().getFieldVisibility();
 
         printer(schema.getClass()).print(out, schema, visibility);
 

--- a/src/main/java/graphql/validation/ValidationUtil.java
+++ b/src/main/java/graphql/validation/ValidationUtil.java
@@ -121,7 +121,7 @@ public class ValidationUtil {
             handleNotObjectError(value, type);
             return false;
         }
-        GraphqlFieldVisibility fieldVisibility = schema.getFieldVisibility();
+        GraphqlFieldVisibility fieldVisibility = schema.getCodeRegistry().getFieldVisibility();
         ObjectValue objectValue = (ObjectValue) value;
         Map<String, ObjectField> objectFieldMap = fieldMap(objectValue);
 

--- a/src/main/java/graphql/validation/rules/OverlappingFieldsCanBeMerged.java
+++ b/src/main/java/graphql/validation/rules/OverlappingFieldsCanBeMerged.java
@@ -333,7 +333,7 @@ public class OverlappingFieldsCanBeMerged extends AbstractRule {
     }
 
     private GraphQLFieldDefinition getVisibleFieldDefinition(GraphQLFieldsContainer fieldsContainer, Field field) {
-        return getValidationContext().getSchema().getFieldVisibility().getFieldDefinition(fieldsContainer, field.getName());
+        return getValidationContext().getSchema().getCodeRegistry().getFieldVisibility().getFieldDefinition(fieldsContainer, field.getName());
     }
 
     private static class FieldPair {

--- a/src/test/groovy/graphql/schema/GraphQLCodeRegistryTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLCodeRegistryTest.groovy
@@ -79,17 +79,14 @@ class GraphQLCodeRegistryTest extends Specification {
 
         when:
         def codeRegistryBuilder = GraphQLCodeRegistry.newCodeRegistry()
-                .dataFetcher(objectType("parentType1"), field("A"), new NamedDF("A"))
-                .dataFetcher(objectType("parentType2"), field("B"), new NamedDF("B"))
-                .dataFetcher(interfaceType("interfaceType1"), field("C"), new NamedDF("C"))
-                .dataFetchers(objectType("parentType3"), [fieldD: new NamedDF("D"), fieldE: new NamedDF("E")])
+                .dataFetcher(FieldCoordinates.coordinates("parentType1", "A"), new NamedDF("A"))
+                .dataFetcher(FieldCoordinates.coordinates("parentType2", "B"), new NamedDF("B"))
+                .dataFetchers("parentType3", [fieldD: new NamedDF("D"), fieldE: new NamedDF("E")])
 
         // we can do a read on a half built code registry, namely for schema directive wiring use cases
         then:
         (codeRegistryBuilder.getDataFetcher(objectType("parentType1"), field("A")) as NamedDF).name == "A"
         (codeRegistryBuilder.getDataFetcher(objectType("parentType2"), field("B")) as NamedDF).name == "B"
-        (codeRegistryBuilder.getDataFetcher(interfaceType("interfaceType1"), field("C")) as NamedDF).name == "C"
-        (codeRegistryBuilder.getDataFetcher(interfaceType("interfaceType1"), field("C")) as NamedDF).name == "C"
         (codeRegistryBuilder.getDataFetcher(objectType("parentType3"), field("fieldD")) as NamedDF).name == "D"
         (codeRegistryBuilder.getDataFetcher(objectType("parentType3"), field("fieldE")) as NamedDF).name == "E"
 
@@ -100,7 +97,6 @@ class GraphQLCodeRegistryTest extends Specification {
         then:
         (codeRegistry.getDataFetcher(objectType("parentType1"), field("A")) as NamedDF).name == "A"
         (codeRegistry.getDataFetcher(objectType("parentType2"), field("B")) as NamedDF).name == "B"
-        (codeRegistry.getDataFetcher(interfaceType("interfaceType1"), field("C")) as NamedDF).name == "C"
         (codeRegistry.getDataFetcher(objectType("parentType3"), field("fieldD")) as NamedDF).name == "D"
         (codeRegistry.getDataFetcher(objectType("parentType3"), field("fieldE")) as NamedDF).name == "E"
 

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorDirectiveHelperTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorDirectiveHelperTest.groovy
@@ -7,6 +7,7 @@ import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
 import graphql.schema.DataFetcher
+import graphql.schema.FieldCoordinates
 import graphql.schema.GraphQLArgument
 import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLDirective
@@ -205,7 +206,7 @@ class SchemaGeneratorDirectiveHelperTest extends Specification {
         targetList.contains("ScalarType")
     }
 
-    def     "can modify the existing behaviour"() {
+    def "can modify the existing behaviour"() {
         def spec = '''
             type Query {
                 lowerCaseValue : String @uppercase
@@ -229,7 +230,7 @@ class SchemaGeneratorDirectiveHelperTest extends Specification {
             @Override
             GraphQLFieldDefinition onField(SchemaDirectiveWiringEnvironment<GraphQLFieldDefinition> directiveEnv) {
                 GraphQLFieldDefinition field = directiveEnv.getElement()
-                def fetcher = directiveEnv.getCodeRegistry().getDataFetcher(directiveEnv.fieldsContainer,field)
+                def fetcher = directiveEnv.getCodeRegistry().getDataFetcher(directiveEnv.fieldsContainer, field)
                 def newFetcher = wrapDataFetcher(fetcher, { dfEnv, value ->
                     def directiveName = directiveEnv.directive.name
                     if (directiveName == "uppercase") {
@@ -242,7 +243,8 @@ class SchemaGeneratorDirectiveHelperTest extends Specification {
                         return String.valueOf(value).reverse()
                     }
                 })
-                directiveEnv.getCodeRegistry().dataFetcher(directiveEnv.getFieldsContainer(), field, newFetcher)
+                def coordinates = FieldCoordinates.coordinates(directiveEnv.getFieldsContainer(), field)
+                directiveEnv.getCodeRegistry().dataFetcher(coordinates, newFetcher)
                 return field
             }
 
@@ -263,7 +265,8 @@ class SchemaGeneratorDirectiveHelperTest extends Specification {
                 DataFetcher echoDF = { dfEnv ->
                     return fieldName
                 }
-                env.codeRegistry.dataFetcher(env.fieldsContainer, field, echoDF)
+                def coordinates = FieldCoordinates.coordinates(env.fieldsContainer, field)
+                env.codeRegistry.dataFetcher(coordinates, echoDF)
                 return field
             }
         }
@@ -405,7 +408,8 @@ class SchemaGeneratorDirectiveHelperTest extends Specification {
                     }
                     return null
                 }
-                codeRegistry.dataFetcher(parentType, field, wrapper)
+                def coordinates = FieldCoordinates.coordinates(parentType, field)
+                codeRegistry.dataFetcher(coordinates, wrapper)
                 return field
             }
 

--- a/src/test/groovy/readme/DirectivesExamples.java
+++ b/src/test/groovy/readme/DirectivesExamples.java
@@ -7,6 +7,7 @@ import graphql.Scalars;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetcherFactories;
 import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.FieldCoordinates;
 import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLFieldsContainer;
@@ -63,7 +64,8 @@ public class DirectivesExamples {
             };
             //
             // now change the field definition to have the new authorising data fetcher
-            environment.getCodeRegistry().dataFetcher(parentType, field, authDataFetcher);
+            FieldCoordinates coordinates = FieldCoordinates.coordinates(parentType, field);
+            environment.getCodeRegistry().dataFetcher(coordinates, authDataFetcher);
             return field;
         }
     }
@@ -115,7 +117,8 @@ public class DirectivesExamples {
             // which allows clients to opt into that as well as wrapping the base data fetcher so it
             // performs the formatting over top of the base values.
             //
-            environment.getCodeRegistry().dataFetcher(parentType, field, dataFetcher);
+            FieldCoordinates coordinates = FieldCoordinates.coordinates(parentType, field);
+            environment.getCodeRegistry().dataFetcher(coordinates, dataFetcher);
 
             return field.transform(builder -> builder
                     .argument(GraphQLArgument


### PR DESCRIPTION
Added field coordinates representing the unique place for a field data fetcher

Later we want `Validation` rules per field location and hence the need for this simple key like class.