### PR TITLE
NOT READY - Ability to get parsed directive argument values inside a DataFetcher

### DIFF
--- a/src/main/java/graphql/execution/DirectivesResolver.java
+++ b/src/main/java/graphql/execution/DirectivesResolver.java
@@ -1,0 +1,57 @@
+package graphql.execution;
+
+import graphql.Internal;
+import graphql.introspection.Introspection;
+import graphql.language.Directive;
+import graphql.language.DirectivesContainer;
+import graphql.schema.GraphQLArgument;
+import graphql.schema.GraphQLDirective;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.visibility.GraphqlFieldVisibility;
+
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Internal
+public class DirectivesResolver {
+
+    private final ValuesResolver valuesResolver;
+
+    public DirectivesResolver(ValuesResolver valuesResolver) {
+        this.valuesResolver = valuesResolver;
+    }
+
+    public Map<String, GraphQLDirective> resolveDirectives(List<Directive> directives, GraphQLSchema schema, Map<String, Object> variables) {
+        GraphqlFieldVisibility fieldVisibility = schema.getCodeRegistry().getFieldVisibility();
+        Map<String, GraphQLDirective> directiveMap = new LinkedHashMap<>();
+        directives.forEach(directive -> {
+            GraphQLDirective protoType = schema.getDirective(directive.getName());
+            if (protoType != null) {
+                EnumSet<Introspection.DirectiveLocation> validLocations = protoType.validLocations();
+                //
+                // we only allow values for directives that exist and are on the right location.  Validation before hand
+                // will have caught most of these but we are being defensive here
+                //
+                if (validLocations.contains(Introspection.DirectiveLocation.FIELD)) {
+                    GraphQLDirective newDirective = protoType.transform(builder -> buildArguments(builder, fieldVisibility, protoType, directive, variables));
+                    directiveMap.put(newDirective.getName(), newDirective);
+                }
+            }
+        });
+        return directiveMap;
+    }
+
+    private void buildArguments(GraphQLDirective.Builder directiveBuilder, GraphqlFieldVisibility fieldVisibility, GraphQLDirective protoType, Directive fieldDirective, Map<String, Object> variables) {
+        Map<String, Object> argumentValues = valuesResolver.getArgumentValues(fieldVisibility, protoType.getArguments(), fieldDirective.getArguments(), variables);
+        directiveBuilder.clearArguments();
+        protoType.getArguments().forEach(protoArg -> {
+            if (argumentValues.containsKey(protoArg.getName())) {
+                Object argValue = argumentValues.get(protoArg.getName());
+                GraphQLArgument newArgument = protoArg.transform(argBuilder -> argBuilder.value(argValue));
+                directiveBuilder.argument(newArgument);
+            }
+        });
+    }
+}

--- a/src/main/java/graphql/execution/EncounterDirectives.java
+++ b/src/main/java/graphql/execution/EncounterDirectives.java
@@ -1,0 +1,89 @@
+package graphql.execution;
+
+import graphql.Internal;
+import graphql.schema.GraphQLDirective;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+public class EncounterDirectives {
+
+    private Map<String, List<GraphQLDirective>> fieldDirectives;
+    private Map<String, List<GraphQLDirective>> fragmentSpreadDirectives;
+    private Map<String, List<GraphQLDirective>> fragmentDefinitionDirectives;
+    private Map<String, List<GraphQLDirective>> inlineFragmentDirectives;
+    private Map<String, GraphQLDirective> operationDirectives;
+
+    @Internal
+    public EncounterDirectives(Map<String, List<GraphQLDirective>> fieldDirectives,
+                               Map<String, List<GraphQLDirective>> fragmentSpreadDirectives,
+                               Map<String, List<GraphQLDirective>> fragmentDefinitionDirectives,
+                               Map<String, List<GraphQLDirective>> inlineFragmentDirectives,
+                               Map<String, GraphQLDirective> operationDirectives) {
+        this.fieldDirectives = fieldDirectives;
+        this.fragmentSpreadDirectives = fragmentSpreadDirectives;
+        this.fragmentDefinitionDirectives = fragmentDefinitionDirectives;
+        this.inlineFragmentDirectives = inlineFragmentDirectives;
+        this.operationDirectives = operationDirectives;
+    }
+
+    public Map<String, List<GraphQLDirective>> getFieldDirectives() {
+        return fieldDirectives;
+    }
+
+    public Map<String, List<GraphQLDirective>> getFragmentSpreadDirectives() {
+        return fragmentSpreadDirectives;
+    }
+
+    public Map<String, List<GraphQLDirective>> getFragmentDefinitionDirectives() {
+        return fragmentDefinitionDirectives;
+    }
+
+    public Map<String, List<GraphQLDirective>> getInlineFragmentDirectives() {
+        return inlineFragmentDirectives;
+    }
+
+    public Map<String, GraphQLDirective> getOperationDirectives() {
+        return operationDirectives;
+    }
+
+    public GraphQLDirective getFieldDirective(String directiveName) {
+        return getDirective(fieldDirectives, directiveName);
+    }
+
+    public GraphQLDirective getFragmentSpreadDirective(String directiveName) {
+        return getDirective(fragmentSpreadDirectives, directiveName);
+    }
+
+    public GraphQLDirective getFragmentDefinitionDirective(String directiveName) {
+        return getDirective(fragmentDefinitionDirectives, directiveName);
+    }
+
+    public GraphQLDirective getInlineFragmentDirective(String directiveName) {
+        return getDirective(inlineFragmentDirectives, directiveName);
+    }
+
+    public GraphQLDirective getOperationDirective(String directiveName) {
+        return operationDirectives.get(directiveName);
+    }
+
+    public GraphQLDirective getFirstApplicableDirective(String directiveName) {
+        return Stream.of(
+                getFieldDirective(directiveName),
+                getInlineFragmentDirective(directiveName),
+                getFragmentSpreadDirective(directiveName),
+                getFragmentDefinitionDirective(directiveName))
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
+    }
+
+    private GraphQLDirective getDirective(Map<String, List<GraphQLDirective>> directiveMap, String directiveName) {
+        List<GraphQLDirective> directives = directiveMap.get(directiveName);
+        if (directives == null || directiveName.isEmpty()) {
+            return null;
+        }
+        return directives.get(0);
+    }
+}

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -91,6 +91,7 @@ public class Execution {
                 .document(document)
                 .operationDefinition(operationDefinition)
                 .dataLoaderRegistry(executionInput.getDataLoaderRegistry())
+                .fieldDirectives(new FieldDirectives(document, graphQLSchema, fragmentsByName, coercedVariables, operationDefinition, new DirectivesResolver(valuesResolver)))
                 .build();
 
 

--- a/src/main/java/graphql/execution/ExecutionContext.java
+++ b/src/main/java/graphql/execution/ExecutionContext.java
@@ -39,9 +39,10 @@ public class ExecutionContext {
     private final List<GraphQLError> errors = new CopyOnWriteArrayList<>();
     private final DataLoaderRegistry dataLoaderRegistry;
     private final DeferSupport deferSupport = new DeferSupport();
+    private final FieldDirectives fieldDirectives;
 
     @Internal
-    ExecutionContext(Instrumentation instrumentation, ExecutionId executionId, GraphQLSchema graphQLSchema, InstrumentationState instrumentationState, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy, ExecutionStrategy subscriptionStrategy, Map<String, FragmentDefinition> fragmentsByName, Document document, OperationDefinition operationDefinition, Map<String, Object> variables, Object context, Object root, DataLoaderRegistry dataLoaderRegistry, List<GraphQLError> startingErrors) {
+    ExecutionContext(Instrumentation instrumentation, ExecutionId executionId, GraphQLSchema graphQLSchema, InstrumentationState instrumentationState, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy, ExecutionStrategy subscriptionStrategy, Map<String, FragmentDefinition> fragmentsByName, Document document, OperationDefinition operationDefinition, Map<String, Object> variables, Object context, Object root, DataLoaderRegistry dataLoaderRegistry, List<GraphQLError> startingErrors, FieldDirectives fieldDirectives) {
         this.graphQLSchema = graphQLSchema;
         this.executionId = executionId;
         this.instrumentationState = instrumentationState;
@@ -56,6 +57,7 @@ public class ExecutionContext {
         this.root = root;
         this.instrumentation = instrumentation;
         this.dataLoaderRegistry = dataLoaderRegistry;
+        this.fieldDirectives = fieldDirectives;
         this.errors.addAll(startingErrors);
     }
 
@@ -166,6 +168,10 @@ public class ExecutionContext {
 
     public DeferSupport getDeferSupport() {
         return deferSupport;
+    }
+
+    public FieldDirectives getFieldDirectives() {
+        return fieldDirectives;
     }
 
     /**

--- a/src/main/java/graphql/execution/ExecutionContextBuilder.java
+++ b/src/main/java/graphql/execution/ExecutionContextBuilder.java
@@ -37,6 +37,7 @@ public class ExecutionContextBuilder {
     private Map<String, FragmentDefinition> fragmentsByName = new LinkedHashMap<>();
     private DataLoaderRegistry dataLoaderRegistry;
     private List<GraphQLError> errors = new ArrayList<>();
+    private FieldDirectives fieldDirectives;
 
     /**
      * @return a new builder of {@link graphql.execution.ExecutionContext}s
@@ -77,6 +78,8 @@ public class ExecutionContextBuilder {
         fragmentsByName = new HashMap<>(other.getFragmentsByName());
         dataLoaderRegistry = other.getDataLoaderRegistry();
         errors = new ArrayList<>(other.getErrors());
+        fieldDirectives = other.getFieldDirectives();
+
     }
 
     public ExecutionContextBuilder instrumentation(Instrumentation instrumentation) {
@@ -150,6 +153,11 @@ public class ExecutionContextBuilder {
         return this;
     }
 
+    public ExecutionContextBuilder fieldDirectives(FieldDirectives fieldDirectives) {
+        this.fieldDirectives = fieldDirectives;
+        return this;
+    }
+
     public ExecutionContext build() {
         // preconditions
         assertNotNull(executionId, "You must provide a query identifier");
@@ -168,7 +176,8 @@ public class ExecutionContextBuilder {
                 variables,
                 context,
                 root,
-                dataLoaderRegistry, errors
-        );
+                dataLoaderRegistry,
+                errors,
+                fieldDirectives);
     }
 }

--- a/src/main/java/graphql/execution/FieldDirectives.java
+++ b/src/main/java/graphql/execution/FieldDirectives.java
@@ -1,0 +1,180 @@
+package graphql.execution;
+
+import graphql.Internal;
+import graphql.analysis.QueryTraversal;
+import graphql.analysis.QueryVisitorFieldEnvironment;
+import graphql.analysis.QueryVisitorFragmentSpreadEnvironment;
+import graphql.analysis.QueryVisitorInlineFragmentEnvironment;
+import graphql.analysis.QueryVisitorStub;
+import graphql.language.Directive;
+import graphql.language.Document;
+import graphql.language.Field;
+import graphql.language.FragmentDefinition;
+import graphql.language.FragmentSpread;
+import graphql.language.InlineFragment;
+import graphql.language.Node;
+import graphql.language.OperationDefinition;
+import graphql.schema.GraphQLDirective;
+import graphql.schema.GraphQLSchema;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class FieldDirectives {
+
+    private final Map<Field, Map<String, GraphQLDirective>> fieldDirectives;
+    private final Map<Field, Map<String, GraphQLDirective>> inlineFragmentDirectives;
+    private final Map<Field, Map<String, GraphQLDirective>> fragmentDirectives;
+    private final Map<Field, Map<String, GraphQLDirective>> fragmentDefDirectives;
+    private final Map<String, GraphQLDirective> operationDirectives;
+
+    @Internal
+    public FieldDirectives(Document document, GraphQLSchema schema, Map<String, FragmentDefinition> fragmentsByName, Map<String, Object> variables, OperationDefinition operationDefinition, DirectivesResolver directivesResolver) {
+        DirectiveCollector collector = DirectiveCollector.collect(document, schema, fragmentsByName, variables, operationDefinition.getName(), directivesResolver);
+        this.fieldDirectives = collector.getFieldDirectives();
+        this.inlineFragmentDirectives = collector.getInlineFragmentDirectives();
+        this.fragmentDirectives = collector.getFragmentDirectives();
+        this.fragmentDefDirectives = collector.getFragmentDefDirectives();
+        this.operationDirectives = directivesResolver.resolveDirectives(operationDefinition.getDirectives(), schema, variables);
+    }
+
+    public Map<String, GraphQLDirective> getFieldDirectives(Field field) {
+        return fieldDirectives.get(field);
+    }
+
+    public Map<String, List<GraphQLDirective>> getFieldDirectives(List<Field> fields) {
+        return getFieldDirectives(fieldDirectives, fields);
+    }
+
+    public Map<String, List<GraphQLDirective>> getInlineFragmentDirectives(List<Field> fields) {
+        return getFieldDirectives(inlineFragmentDirectives, fields);
+    }
+
+    public Map<String, List<GraphQLDirective>> getFragmentDirectives(List<Field> fields) {
+        return getFieldDirectives(fragmentDirectives, fields);
+    }
+
+    public Map<String, List<GraphQLDirective>> getFragmentDefDirectives(List<Field> fields) {
+        return getFieldDirectives(fragmentDefDirectives, fields);
+    }
+
+    public Map<String, GraphQLDirective> getOperationDirectives() {
+        return operationDirectives;
+    }
+
+    private Map<String, List<GraphQLDirective>> getFieldDirectives(Map<Field, Map<String, GraphQLDirective>> directivesMap, List<Field> fields) {
+        return fields.stream()
+                .flatMap(field -> directivesMap.get(field).values().stream())
+                .collect(Collectors.groupingBy(GraphQLDirective::getName));
+    }
+
+    private static class DirectiveCollector extends QueryVisitorStub {
+
+        private final GraphQLSchema schema;
+        private final Map<String, Object> variables;
+        private final DirectivesResolver directivesResolver;
+        private final Map<Field, Map<String, GraphQLDirective>> fieldDirectives;
+        private final Map<Field, Map<String, GraphQLDirective>> inlineFragmentDirectives;
+        private final Map<Field, Map<String, GraphQLDirective>> fragmentDirectives;
+        private final Map<Field, Map<String, GraphQLDirective>> fragmentDefDirectives;
+        private final Map<Field, Set<Node>> fragmentsPerField;
+
+        private DirectiveCollector(Document document, GraphQLSchema schema, Map<String, FragmentDefinition> fragmentsByName, Map<String, Object> variables, String operationName, DirectivesResolver directivesResolver) {
+            this.schema = schema;
+            this.variables = variables;
+            this.directivesResolver = directivesResolver;
+            this.fieldDirectives = new HashMap<>();
+            this.inlineFragmentDirectives = new HashMap<>();
+            this.fragmentDirectives = new HashMap<>();
+            this.fragmentDefDirectives = new HashMap<>();
+            this.fragmentsPerField = new HashMap<>();
+        }
+
+        static DirectiveCollector collect(Document document, GraphQLSchema schema, Map<String, FragmentDefinition> fragmentsByName, Map<String, Object> variables, String operationName, DirectivesResolver directivesResolver) {
+            DirectiveCollector fragmentDirectiveCollector = new DirectiveCollector(document, schema, fragmentsByName, variables, operationName, directivesResolver);
+            QueryTraversal traversal = QueryTraversal.newQueryTraversal()
+                    .fragmentsByName(fragmentsByName)
+                    .schema(schema)
+                    .variables(variables)
+                    .document(document)
+                    .operationName(operationName)
+                    .build();
+            traversal.visitPostOrder(fragmentDirectiveCollector);
+            return fragmentDirectiveCollector;
+        }
+
+        @Override
+        public void visitInlineFragment(QueryVisitorInlineFragmentEnvironment env) {
+            env.getInlineFragment().getSelectionSet().getSelections().forEach(selection -> {
+                if (selection instanceof Field) {
+                    addFragmentDirectivesForField((Field) selection, env.getInlineFragment());
+                } else {
+                    fragmentsPerField.entrySet().stream()
+                            .filter(entry -> entry.getValue().contains(selection))
+                            .forEach(entry -> addFragmentDirectivesForField(entry.getKey(), env.getInlineFragment()));
+                }
+            });
+        }
+
+        @Override
+        public void visitFragmentSpread(QueryVisitorFragmentSpreadEnvironment env) {
+            env.getFragmentDefinition().getSelectionSet().getSelections().forEach(selection -> {
+                if (selection instanceof Field) {
+                    addFragmentDirectivesForField((Field) selection, env.getFragmentSpread(), env.getFragmentDefinition());
+                } else {
+                    fragmentsPerField.entrySet().stream()
+                            .filter(entry -> entry.getValue().contains(selection))
+                            .forEach(entry -> addFragmentDirectivesForField(entry.getKey(), env.getFragmentSpread(), env.getFragmentDefinition()));
+                }
+            });
+        }
+
+        @Override
+        public void visitField(QueryVisitorFieldEnvironment env) {
+            fieldDirectives.put(env.getField(), getDirectives(env.getField().getDirectives()));
+        }
+
+        private Map<String, GraphQLDirective> getDirectives(List<Directive> directives) {
+            return directivesResolver.resolveDirectives(directives, schema, variables);
+        }
+
+        @SuppressWarnings("Duplicates")
+        private void addFragmentDirectivesForField(Field field, FragmentSpread frag, FragmentDefinition fragDef) {
+            fragmentsPerField.computeIfAbsent(field, f -> new HashSet<>());
+            fragmentsPerField.get(field).add(frag);
+            fragmentDirectives.computeIfAbsent(field, f -> new HashMap<>());
+            fragmentDirectives.get(field).putAll(getDirectives(frag.getDirectives()));
+            fragmentDefDirectives.computeIfAbsent(field, f -> new HashMap<>());
+            fragmentDefDirectives.get(field).putAll(getDirectives(fragDef.getDirectives()));
+        }
+
+        @SuppressWarnings("Duplicates")
+        private void addFragmentDirectivesForField(Field field, InlineFragment frag) {
+            fragmentsPerField.computeIfAbsent(field, f -> new HashSet<>());
+            fragmentsPerField.get(field).add(frag);
+            inlineFragmentDirectives.computeIfAbsent(field, f -> new HashMap<>());
+            inlineFragmentDirectives.get(field).putAll(getDirectives(frag.getDirectives()));
+        }
+
+        public Map<Field, Map<String, GraphQLDirective>> getFieldDirectives() {
+            return fieldDirectives;
+        }
+
+        public Map<Field, Map<String, GraphQLDirective>> getInlineFragmentDirectives() {
+            return inlineFragmentDirectives;
+        }
+
+        public Map<Field, Map<String, GraphQLDirective>> getFragmentDirectives() {
+            return fragmentDirectives;
+        }
+
+        public Map<Field, Map<String, GraphQLDirective>> getFragmentDefDirectives() {
+            return fragmentDefDirectives;
+        }
+    }
+}

--- a/src/main/java/graphql/execution/FieldDirectives.java
+++ b/src/main/java/graphql/execution/FieldDirectives.java
@@ -17,7 +17,7 @@ import graphql.language.OperationDefinition;
 import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLSchema;
 
-import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -69,7 +69,7 @@ public class FieldDirectives {
 
     private Map<String, List<GraphQLDirective>> getFieldDirectives(Map<Field, Map<String, GraphQLDirective>> directivesMap, List<Field> fields) {
         return fields.stream()
-                .flatMap(field -> directivesMap.get(field).values().stream())
+                .flatMap(field -> directivesMap.getOrDefault(field, Collections.emptyMap()).values().stream())
                 .collect(Collectors.groupingBy(GraphQLDirective::getName));
     }
 
@@ -98,7 +98,6 @@ public class FieldDirectives {
         static DirectiveCollector collect(Document document, GraphQLSchema schema, Map<String, FragmentDefinition> fragmentsByName, Map<String, Object> variables, String operationName, DirectivesResolver directivesResolver) {
             DirectiveCollector fragmentDirectiveCollector = new DirectiveCollector(document, schema, fragmentsByName, variables, operationName, directivesResolver);
             QueryTraversal traversal = QueryTraversal.newQueryTraversal()
-                    .fragmentsByName(fragmentsByName)
                     .schema(schema)
                     .variables(variables)
                     .document(document)

--- a/src/main/java/graphql/execution2/Execution.java
+++ b/src/main/java/graphql/execution2/Execution.java
@@ -6,12 +6,14 @@ import graphql.ExecutionResultImpl;
 import graphql.GraphQLError;
 import graphql.Internal;
 import graphql.execution.Async;
+import graphql.execution.DirectivesResolver;
 import graphql.execution.ExecutionContext;
 import graphql.execution.ExecutionId;
 import graphql.execution.ExecutionPath;
 import graphql.execution.ExecutionStepInfo;
 import graphql.execution.FieldCollector;
 import graphql.execution.FieldCollectorParameters;
+import graphql.execution.FieldDirectives;
 import graphql.execution.ValuesResolver;
 import graphql.execution2.result.ResultNodesUtil;
 import graphql.language.Document;
@@ -68,6 +70,7 @@ public class Execution {
                 .document(document)
                 .operationDefinition(operationDefinition)
                 .dataLoaderRegistry(executionInput.getDataLoaderRegistry())
+                .fieldDirectives(new FieldDirectives(document, graphQLSchema, fragmentsByName, coercedVariables, operationDefinition, new DirectivesResolver(valuesResolver)))
                 .build();
 
         return executeOperation(executionStrategy, executionContext, executionInput.getRoot(), executionContext.getOperationDefinition());

--- a/src/main/java/graphql/schema/DataFetchingEnvironment.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironment.java
@@ -1,6 +1,7 @@
 package graphql.schema;
 
 import graphql.PublicApi;
+import graphql.execution.EncounterDirectives;
 import graphql.execution.ExecutionContext;
 import graphql.execution.ExecutionId;
 import graphql.execution.ExecutionStepInfo;
@@ -170,4 +171,6 @@ public interface DataFetchingEnvironment {
      * @see org.dataloader.DataLoaderRegistry#getDataLoader(String)
      */
     <K, V> DataLoader<K, V> getDataLoader(String dataLoaderName);
+
+    EncounterDirectives getEncounterDirectives();
 }

--- a/src/main/java/graphql/schema/DataFetchingEnvironmentBuilder.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironmentBuilder.java
@@ -1,13 +1,16 @@
 package graphql.schema;
 
 import graphql.PublicApi;
+import graphql.execution.EncounterDirectives;
 import graphql.execution.ExecutionContext;
 import graphql.execution.ExecutionId;
 import graphql.execution.ExecutionStepInfo;
+import graphql.execution.FieldDirectives;
 import graphql.language.Field;
 import graphql.language.FragmentDefinition;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -142,9 +145,17 @@ public class DataFetchingEnvironmentBuilder {
     }
 
     public DataFetchingEnvironment build() {
+        FieldDirectives dirs = executionContext.getFieldDirectives();
+        EncounterDirectives encounterDirectives = new EncounterDirectives(
+                dirs.getFieldDirectives(fields),
+                dirs.getFragmentDirectives(fields),
+                dirs.getFragmentDefDirectives(fields),
+                dirs.getInlineFragmentDirectives(fields),
+                dirs.getOperationDirectives()
+        );
+
         return new DataFetchingEnvironmentImpl(source, arguments, context, root,
                 fieldDefinition, fields, fieldType, parentType, graphQLSchema, fragmentsByName, executionId, selectionSet,
-                executionStepInfo,
-                executionContext);
+                executionStepInfo, executionContext, encounterDirectives);
     }
 }

--- a/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
@@ -2,6 +2,7 @@ package graphql.schema;
 
 
 import graphql.Internal;
+import graphql.execution.EncounterDirectives;
 import graphql.execution.ExecutionContext;
 import graphql.execution.ExecutionId;
 import graphql.execution.ExecutionStepInfo;
@@ -33,6 +34,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
     private final DataFetchingFieldSelectionSet selectionSet;
     private final ExecutionStepInfo executionStepInfo;
     private final ExecutionContext executionContext;
+    private final EncounterDirectives encounterDirectives;
 
     public DataFetchingEnvironmentImpl(Object source,
                                        Map<String, Object> arguments,
@@ -47,7 +49,8 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
                                        ExecutionId executionId,
                                        DataFetchingFieldSelectionSet selectionSet,
                                        ExecutionStepInfo executionStepInfo,
-                                       ExecutionContext executionContext) {
+                                       ExecutionContext executionContext,
+                                       EncounterDirectives encounterDirectives) {
         this.source = source;
         this.arguments = arguments == null ? Collections.emptyMap() : arguments;
         this.fragmentsByName = fragmentsByName == null ? Collections.emptyMap() : fragmentsByName;
@@ -62,6 +65,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
         this.selectionSet = selectionSet;
         this.executionStepInfo = executionStepInfo;
         this.executionContext = assertNotNull(executionContext);
+        this.encounterDirectives = encounterDirectives;
     }
 
     @Override
@@ -152,6 +156,11 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
     @Override
     public <K, V> DataLoader<K, V> getDataLoader(String dataLoaderName) {
         return executionContext.getDataLoaderRegistry().getDataLoader(dataLoaderName);
+    }
+
+    @Override
+    public EncounterDirectives getEncounterDirectives() {
+        return encounterDirectives;
     }
 
     @Override


### PR DESCRIPTION
This is again regarding #1228 .

This is for discussion purposes only: **does this approach make sense?**
There's quite a few things missing in the PR before it's ready

The crux of it is to allow the user to get a _deserialized_ directive on each field _or_ on any of container elements (fragments, operation etc) that enclose the field.

E.g. for a query such as:

```graphql
fragment Details on Book @timeout(afterMillis: 25) {
    title
    review @timeout(afterMillis: 5)" +
}

query Books @timeout(afterMillis: 30) {
    books(searchString: "monkey") {
        id
        ...Details @timeout(afterMillis: 20)
        ...on Book @timeout(afterMillis: 15) {
            review @timeout(afterMillis: 10)
        }
    }
}
```

this enables the user to do the following (for the `review` field):

```java
EncounterDirectives encounterDirectives = dataFetchingEnvironment.getEncounterDirectives();
encounterDirectives.getFieldDirectives().get("timeout"); //returns 5 and 10
encounterDirectives.getFieldDirective("timeout"); //returns 5
encounterDirectives.getInlineFragmentDirective("timeout"); //returns 15
encounterDirectives.getFragmentSpreadDirective("timeout"); //returns 20
encounterDirectives.getFragmentDefinitionDirective("timeout"); //returns 25
encounterDirectives.getOperationDirective("timeout"); //30

// and, most interestingly
encounterDirectives.getFirstApplicableDirective("timeout"); //returns 5 but would return 30 for other fields
```

As noted, this is very much not complete... E.g. `getFirstApplicableDirective` will return a directive from an inline fragment before a directive from a fragment spread even if the spread is closer to the field, thus not really _the first applicable directive_. For that, depth would need to be tracked, which I didn't want to get into if the whole approach is deemed an overkill. Also, I didn't add or even modify any tests, for the same reason.