### PR TITLE
Allow instrumentation of the execution input once the parsed query is available

### DIFF
--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -503,7 +503,6 @@ public class GraphQL {
         }
     }
 
-
     private CompletableFuture<ExecutionResult> parseValidateAndExecute(ExecutionInput executionInput, GraphQLSchema graphQLSchema, InstrumentationState instrumentationState) {
         AtomicReference<ExecutionInput> executionInputRef = new AtomicReference<>(executionInput);
         PreparsedDocumentEntry preparsedDoc = preparsedDocumentProvider.get(executionInput.getQuery(),
@@ -516,7 +515,10 @@ public class GraphQL {
             return CompletableFuture.completedFuture(new ExecutionResultImpl(preparsedDoc.getErrors()));
         }
 
-        return execute(executionInputRef.get(), preparsedDoc.getDocument(), graphQLSchema, instrumentationState);
+        Document document = preparsedDoc.getDocument();
+        InstrumentationExecutionParameters parameters = new InstrumentationExecutionParameters(executionInputRef.get(), graphQLSchema, instrumentationState);
+        ExecutionInput finalExecutionInput = instrumentation.instrumentExecutionInputAfterParse(executionInputRef.get(), document, parameters);
+        return execute(finalExecutionInput, document, graphQLSchema, instrumentationState);
     }
 
     private PreparsedDocumentEntry parseAndValidate(ExecutionInput executionInput, GraphQLSchema graphQLSchema, InstrumentationState instrumentationState) {

--- a/src/main/java/graphql/execution/instrumentation/ChainedInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/ChainedInstrumentation.java
@@ -176,6 +176,15 @@ public class ChainedInstrumentation implements Instrumentation {
     }
 
     @Override
+    public ExecutionInput instrumentExecutionInputAfterParse(ExecutionInput executionInput, Document document, InstrumentationExecutionParameters parameters) {
+        for (Instrumentation instrumentation : instrumentations) {
+            InstrumentationState state = getState(instrumentation, parameters.getInstrumentationState());
+            executionInput = instrumentation.instrumentExecutionInputAfterParse(executionInput, document, parameters.withNewState(state));
+        }
+        return executionInput;
+    }
+
+    @Override
     public Document instrumentDocument(Document document, InstrumentationExecutionParameters parameters) {
         for (Instrumentation instrumentation : instrumentations) {
             InstrumentationState state = getState(instrumentation, parameters.getInstrumentationState());

--- a/src/main/java/graphql/execution/instrumentation/Instrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/Instrumentation.java
@@ -167,6 +167,20 @@ public interface Instrumentation {
     }
 
     /**
+     * This is called to instrument a {@link graphql.ExecutionInput} once the parsed query is available,
+     * allowing you to adjust what query input parameters are used
+     *
+     * @param executionInput the execution input to be used
+     * @param document   the document to be used
+     * @param parameters     the parameters describing the field to be fetched
+     *
+     * @return a non null instrumented ExecutionInput, the default is to return to the same object
+     */
+    default ExecutionInput instrumentExecutionInputAfterParse(ExecutionInput executionInput, Document document, InstrumentationExecutionParameters parameters) {
+        return executionInput;
+    }
+
+    /**
      * This is called to instrument a {@link graphql.language.Document} before it is used allowing you to adjust the query AST if you so desire
      *
      * @param document   the document to be used

--- a/src/test/groovy/graphql/execution/instrumentation/TestingInstrumentation.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/TestingInstrumentation.groovy
@@ -106,6 +106,18 @@ class TestingInstrumentation implements Instrumentation {
     }
 
     @Override
+    ExecutionInput instrumentExecutionInputAfterParse(ExecutionInput executionInput, Document document, InstrumentationExecutionParameters parameters) {
+        assert parameters.getInstrumentationState() == instrumentationState
+        return executionInput
+    }
+
+    @Override
+    Document instrumentDocument(Document document, InstrumentationExecutionParameters parameters) {
+        assert parameters.getInstrumentationState() == instrumentationState
+        return document
+    }
+
+    @Override
     ExecutionContext instrumentExecutionContext(ExecutionContext executionContext, InstrumentationExecutionParameters parameters) {
         assert parameters.getInstrumentationState() == instrumentationState
         return executionContext


### PR DESCRIPTION
PR for #1353

The test shows how you could also use this to make queries more cacheable