### PR TITLE
introduce MergedFields class

### DIFF
--- a/src/main/java/graphql/Assert.java
+++ b/src/main/java/graphql/Assert.java
@@ -9,12 +9,16 @@ import static java.lang.String.format;
 public class Assert {
 
     public static <T> T assertNotNull(T object, String format, Object... args) {
-        if (object != null) return object;
+        if (object != null) {
+            return object;
+        }
         throw new AssertException(format(format, args));
     }
 
     public static <T> T assertNotNull(T object) {
-        if (object != null) return object;
+        if (object != null) {
+            return object;
+        }
         throw new AssertException("Object required to be not null");
     }
 
@@ -30,14 +34,24 @@ public class Assert {
         throw new AssertException("Internal error: should never happen");
     }
 
-    public static <T> Collection<T> assertNotEmpty(Collection<T> c, String format, Object... args) {
-        if (c == null || c.isEmpty())
+    public static <T> Collection<T> assertNotEmpty(Collection<T> collection) {
+        if (collection == null || collection.isEmpty()) {
+            throw new AssertException("collection must be not null and not empty");
+        }
+        return collection;
+    }
+
+    public static <T> Collection<T> assertNotEmpty(Collection<T> collection, String format, Object... args) {
+        if (collection == null || collection.isEmpty()) {
             throw new AssertException(format(format, args));
-        return c;
+        }
+        return collection;
     }
 
     public static void assertTrue(boolean condition, String format, Object... args) {
-        if (condition) return;
+        if (condition) {
+            return;
+        }
         throw new AssertException(format(format, args));
     }
 
@@ -55,7 +69,7 @@ public class Assert {
         if (name != null && !name.isEmpty() && name.matches("[_A-Za-z][_0-9A-Za-z]*")) {
             return name;
         }
-        throw new AssertException(String.format(invalidNameErrorMessage,name));
+        throw new AssertException(String.format(invalidNameErrorMessage, name));
     }
 
 }

--- a/src/main/java/graphql/TypeResolutionEnvironment.java
+++ b/src/main/java/graphql/TypeResolutionEnvironment.java
@@ -1,6 +1,6 @@
 package graphql;
 
-import graphql.language.Field;
+import graphql.execution.MergedFields;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
 
@@ -16,12 +16,12 @@ public class TypeResolutionEnvironment {
 
     private final Object object;
     private final Map<String, Object> arguments;
-    private final Field field;
+    private final MergedFields field;
     private final GraphQLType fieldType;
     private final GraphQLSchema schema;
     private final Object context;
 
-    public TypeResolutionEnvironment(Object object, Map<String, Object> arguments, Field field, GraphQLType fieldType, GraphQLSchema schema, final Object context) {
+    public TypeResolutionEnvironment(Object object, Map<String, Object> arguments, MergedFields field, GraphQLType fieldType, GraphQLSchema schema, final Object context) {
         this.object = object;
         this.arguments = arguments;
         this.field = field;
@@ -52,7 +52,7 @@ public class TypeResolutionEnvironment {
     /**
      * @return the graphql field in question
      */
-    public Field getField() {
+    public MergedFields getField() {
         return field;
     }
 

--- a/src/main/java/graphql/execution/AbsoluteGraphQLError.java
+++ b/src/main/java/graphql/execution/AbsoluteGraphQLError.java
@@ -3,7 +3,6 @@ package graphql.execution;
 import graphql.ErrorType;
 import graphql.GraphQLError;
 import graphql.Internal;
-import graphql.language.Field;
 import graphql.language.SourceLocation;
 import graphql.schema.DataFetcher;
 
@@ -44,7 +43,7 @@ public class AbsoluteGraphQLError implements GraphQLError {
         }
     }
 
-    public AbsoluteGraphQLError(List<Field> sameField, ExecutionPath executionPath, GraphQLError relativeError) {
+    public AbsoluteGraphQLError(MergedFields sameField, ExecutionPath executionPath, GraphQLError relativeError) {
         this.absolutePath = createAbsolutePath(executionPath, relativeError);
         this.locations = createAbsoluteLocations(relativeError, sameField);
         this.message = relativeError.getMessage();
@@ -116,13 +115,13 @@ public class AbsoluteGraphQLError implements GraphQLError {
      *
      * @return List of locations from the root.
      */
-    private List<SourceLocation> createAbsoluteLocations(GraphQLError relativeError, List<Field> fields) {
-        Optional<SourceLocation> baseLocation;
-        if (!fields.isEmpty()) {
-            baseLocation = Optional.ofNullable(fields.get(0).getSourceLocation());
-        } else {
-            baseLocation = Optional.empty();
-        }
+    private List<SourceLocation> createAbsoluteLocations(GraphQLError relativeError, MergedFields fields) {
+        Optional<SourceLocation> baseLocation = Optional.ofNullable(fields.getSingleField().getSourceLocation());
+//        if (!fields.isEmpty()) {
+//            baseLocation = Optional.ofNullable(fields.get(0).getSourceLocation());
+//        } else {
+//            baseLocation = Optional.empty();
+//        }
 
         // relative error empty path should yield an absolute error with the base path
         if (relativeError.getLocations() != null && relativeError.getLocations().isEmpty()) {

--- a/src/main/java/graphql/execution/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncExecutionStrategy.java
@@ -9,7 +9,6 @@ import graphql.execution.instrumentation.ExecutionStrategyInstrumentationContext
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.parameters.InstrumentationDeferredFieldParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionStrategyParameters;
-import graphql.language.Field;
 import graphql.schema.GraphQLFieldDefinition;
 
 import java.util.ArrayList;
@@ -51,12 +50,12 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
 
         ExecutionStrategyInstrumentationContext executionStrategyCtx = instrumentation.beginExecutionStrategy(instrumentationParameters);
 
-        Map<String, List<Field>> fields = parameters.getFields();
+        Map<String, MergedFields> fields = parameters.getFields();
         List<String> fieldNames = new ArrayList<>(fields.keySet());
         List<CompletableFuture<FieldValueInfo>> futures = new ArrayList<>();
         List<String> resolvedFields = new ArrayList<>();
         for (String fieldName : fieldNames) {
-            List<Field> currentField = fields.get(fieldName);
+            MergedFields currentField = fields.get(fieldName);
 
             ExecutionPath fieldPath = parameters.getPath().segment(mkNameForPath(currentField));
             ExecutionStrategyParameters newParameters = parameters
@@ -94,14 +93,14 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
         return overallResult;
     }
 
-    private boolean isDeferred(ExecutionContext executionContext, ExecutionStrategyParameters parameters, List<Field> currentField) {
+    private boolean isDeferred(ExecutionContext executionContext, ExecutionStrategyParameters parameters, MergedFields currentField) {
         DeferSupport deferSupport = executionContext.getDeferSupport();
         if (deferSupport.checkForDeferDirective(currentField)) {
             DeferredErrorSupport errorSupport = new DeferredErrorSupport();
 
             // with a deferred field we are really resetting where we execute from, that is from this current field onwards
-            Map<String, List<Field>> fields = new LinkedHashMap<>();
-            fields.put(currentField.get(0).getName(), currentField);
+            Map<String, MergedFields> fields = new LinkedHashMap<>();
+            fields.put(currentField.getName(), currentField);
 
             ExecutionStrategyParameters callParameters = parameters.transform(builder ->
                     builder.deferredErrorSupport(errorSupport)
@@ -122,7 +121,7 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
     @SuppressWarnings("FutureReturnValueIgnored")
     private Supplier<CompletableFuture<ExecutionResult>> deferredExecutionResult(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
         return () -> {
-            GraphQLFieldDefinition fieldDef = getFieldDef(executionContext, parameters, parameters.getField().get(0));
+            GraphQLFieldDefinition fieldDef = getFieldDef(executionContext, parameters, parameters.getField().getSingleField());
 
             Instrumentation instrumentation = executionContext.getInstrumentation();
             DeferredFieldInstrumentationContext fieldCtx = instrumentation.beginDeferredField(

--- a/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
@@ -4,7 +4,6 @@ import graphql.ExecutionResult;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionStrategyParameters;
-import graphql.language.Field;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,11 +31,11 @@ public class AsyncSerialExecutionStrategy extends AbstractAsyncExecutionStrategy
         Instrumentation instrumentation = executionContext.getInstrumentation();
         InstrumentationExecutionStrategyParameters instrumentationParameters = new InstrumentationExecutionStrategyParameters(executionContext, parameters);
         InstrumentationContext<ExecutionResult> executionStrategyCtx = instrumentation.beginExecutionStrategy(instrumentationParameters);
-        Map<String, List<Field>> fields = parameters.getFields();
+        Map<String, MergedFields> fields = parameters.getFields();
         List<String> fieldNames = new ArrayList<>(fields.keySet());
 
         CompletableFuture<List<ExecutionResult>> resultsFuture = Async.eachSequentially(fieldNames, (fieldName, index, prevResults) -> {
-            List<Field> currentField = fields.get(fieldName);
+            MergedFields currentField = fields.get(fieldName);
             ExecutionPath fieldPath = parameters.getPath().segment(mkNameForPath(currentField));
             ExecutionStrategyParameters newParameters = parameters
                     .transform(builder -> builder.field(currentField).path(fieldPath));

--- a/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
@@ -7,7 +7,6 @@ import graphql.execution.instrumentation.parameters.InstrumentationExecutionStra
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -31,11 +30,11 @@ public class AsyncSerialExecutionStrategy extends AbstractAsyncExecutionStrategy
         Instrumentation instrumentation = executionContext.getInstrumentation();
         InstrumentationExecutionStrategyParameters instrumentationParameters = new InstrumentationExecutionStrategyParameters(executionContext, parameters);
         InstrumentationContext<ExecutionResult> executionStrategyCtx = instrumentation.beginExecutionStrategy(instrumentationParameters);
-        Map<String, MergedFields> fields = parameters.getFields();
+        MergedSelectionSet fields = parameters.getFields();
         List<String> fieldNames = new ArrayList<>(fields.keySet());
 
         CompletableFuture<List<ExecutionResult>> resultsFuture = Async.eachSequentially(fieldNames, (fieldName, index, prevResults) -> {
-            MergedFields currentField = fields.get(fieldName);
+            MergedFields currentField = fields.getSubField(fieldName);
             ExecutionPath fieldPath = parameters.getPath().segment(mkNameForPath(currentField));
             ExecutionStrategyParameters newParameters = parameters
                     .transform(builder -> builder.field(currentField).path(fieldPath));

--- a/src/main/java/graphql/execution/DataFetcherExceptionHandlerParameters.java
+++ b/src/main/java/graphql/execution/DataFetcherExceptionHandlerParameters.java
@@ -1,6 +1,6 @@
 package graphql.execution;
 
-import graphql.language.Field;
+import graphql.PublicApi;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.GraphQLFieldDefinition;
 
@@ -9,17 +9,18 @@ import java.util.Map;
 /**
  * The parameters available to {@link DataFetcherExceptionHandler}s
  */
+@PublicApi
 public class DataFetcherExceptionHandlerParameters {
 
     private final ExecutionContext executionContext;
     private final DataFetchingEnvironment dataFetchingEnvironment;
-    private final Field field;
+    private final MergedFields field;
     private final GraphQLFieldDefinition fieldDefinition;
     private final Map<String, Object> argumentValues;
     private final ExecutionPath path;
     private final Throwable exception;
 
-    public DataFetcherExceptionHandlerParameters(ExecutionContext executionContext, DataFetchingEnvironment dataFetchingEnvironment, Field field, GraphQLFieldDefinition fieldDefinition, Map<String, Object> argumentValues, ExecutionPath path, Throwable exception) {
+    public DataFetcherExceptionHandlerParameters(ExecutionContext executionContext, DataFetchingEnvironment dataFetchingEnvironment, MergedFields field, GraphQLFieldDefinition fieldDefinition, Map<String, Object> argumentValues, ExecutionPath path, Throwable exception) {
         this.executionContext = executionContext;
         this.dataFetchingEnvironment = dataFetchingEnvironment;
         this.field = field;
@@ -41,7 +42,7 @@ public class DataFetcherExceptionHandlerParameters {
         return dataFetchingEnvironment;
     }
 
-    public Field getField() {
+    public MergedFields getField() {
         return field;
     }
 
@@ -64,7 +65,7 @@ public class DataFetcherExceptionHandlerParameters {
     public static class Builder {
         ExecutionContext executionContext;
         DataFetchingEnvironment dataFetchingEnvironment;
-        Field field;
+        MergedFields field;
         GraphQLFieldDefinition fieldDefinition;
         Map<String, Object> argumentValues;
         ExecutionPath path;
@@ -83,7 +84,7 @@ public class DataFetcherExceptionHandlerParameters {
             return this;
         }
 
-        public Builder field(Field field) {
+        public Builder field(MergedFields field) {
             this.field = field;
             return this;
         }

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -130,7 +130,7 @@ public class Execution {
                 .variables(executionContext.getVariables())
                 .build();
 
-        Map<String, MergedFields> fields = fieldCollector.collectFields(collectorParameters, operationDefinition.getSelectionSet());
+        MergedSelectionSet fields = fieldCollector.collectFields(collectorParameters, operationDefinition.getSelectionSet());
 
         ExecutionPath path = ExecutionPath.rootPath();
         ExecutionStepInfo executionStepInfo = newExecutionStepInfo().type(operationRootType).path(path).build();

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -14,7 +14,6 @@ import graphql.execution.instrumentation.InstrumentationState;
 import graphql.execution.instrumentation.parameters.InstrumentationExecuteOperationParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
 import graphql.language.Document;
-import graphql.language.Field;
 import graphql.language.FragmentDefinition;
 import graphql.language.NodeUtil;
 import graphql.language.OperationDefinition;
@@ -131,7 +130,7 @@ public class Execution {
                 .variables(executionContext.getVariables())
                 .build();
 
-        Map<String, List<Field>> fields = fieldCollector.collectFields(collectorParameters, operationDefinition.getSelectionSet());
+        Map<String, MergedFields> fields = fieldCollector.collectFields(collectorParameters, operationDefinition.getSelectionSet());
 
         ExecutionPath path = ExecutionPath.rootPath();
         ExecutionStepInfo executionStepInfo = newExecutionStepInfo().type(operationRootType).path(path).build();

--- a/src/main/java/graphql/execution/ExecutionStepInfo.java
+++ b/src/main/java/graphql/execution/ExecutionStepInfo.java
@@ -1,7 +1,6 @@
 package graphql.execution;
 
 import graphql.PublicApi;
-import graphql.language.Field;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLInterfaceType;
 import graphql.schema.GraphQLNonNull;
@@ -32,11 +31,11 @@ public class ExecutionStepInfo {
     private final ExecutionStepInfo parent;
 
     // field, fieldDefinition and arguments stay the same for steps inside a list field
-    private final Field field;
+    private final MergedFields field;
     private final GraphQLFieldDefinition fieldDefinition;
     private final Map<String, Object> arguments;
 
-    private ExecutionStepInfo(GraphQLOutputType type, GraphQLFieldDefinition fieldDefinition, Field field, ExecutionPath path, ExecutionStepInfo parent, Map<String, Object> arguments) {
+    private ExecutionStepInfo(GraphQLOutputType type, GraphQLFieldDefinition fieldDefinition, MergedFields field, ExecutionPath path, ExecutionStepInfo parent, Map<String, Object> arguments) {
         this.fieldDefinition = fieldDefinition;
         this.field = field;
         this.path = path;
@@ -75,11 +74,11 @@ public class ExecutionStepInfo {
     }
 
     /**
-     * This returns the AST field that matches the {@link #getFieldDefinition()} during execution
+     * This returns the AST fields that matches the {@link #getFieldDefinition()} during execution
      *
-     * @return the field
+     * @return the  merged fields
      */
-    public Field getField() {
+    public MergedFields getField() {
         return field;
     }
 
@@ -196,7 +195,7 @@ public class ExecutionStepInfo {
         GraphQLOutputType type;
         ExecutionStepInfo parentInfo;
         GraphQLFieldDefinition fieldDefinition;
-        Field field;
+        MergedFields field;
         ExecutionPath path;
         Map<String, Object> arguments = new LinkedHashMap<>();
 
@@ -230,7 +229,7 @@ public class ExecutionStepInfo {
             return this;
         }
 
-        public Builder field(Field field) {
+        public Builder field(MergedFields field) {
             this.field = field;
             return this;
         }

--- a/src/main/java/graphql/execution/ExecutionStepInfoFactory.java
+++ b/src/main/java/graphql/execution/ExecutionStepInfoFactory.java
@@ -9,7 +9,6 @@ import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLOutputType;
-import graphql.schema.visibility.GraphqlFieldVisibility;
 
 import java.util.List;
 import java.util.Map;
@@ -21,8 +20,8 @@ public class ExecutionStepInfoFactory {
     ValuesResolver valuesResolver = new ValuesResolver();
 
 
-    public ExecutionStepInfo newExecutionStepInfoForSubField(ExecutionContext executionContext, List<Field> sameFields, ExecutionStepInfo parentInfo) {
-        Field field = sameFields.get(0);
+    public ExecutionStepInfo newExecutionStepInfoForSubField(ExecutionContext executionContext, MergedFields sameFields, ExecutionStepInfo parentInfo) {
+        Field field = sameFields.getSingleField();
         GraphQLObjectType parentType = (GraphQLObjectType) parentInfo.getUnwrappedNonNullType();
         GraphQLFieldDefinition fieldDefinition = Introspection.getFieldDef(executionContext.getGraphQLSchema(), parentType, field.getName());
         GraphQLOutputType fieldType = fieldDefinition.getType();
@@ -51,8 +50,8 @@ public class ExecutionStepInfoFactory {
                 .path(indexedPath));
     }
 
-    private static String mkNameForPath(List<Field> currentField) {
-        Field field = currentField.get(0);
+    private static String mkNameForPath(MergedFields currentField) {
+        Field field = currentField.getSingleField();
         return field.getAlias() != null ? field.getAlias() : field.getName();
     }
 }

--- a/src/main/java/graphql/execution/ExecutionStepInfoFactory.java
+++ b/src/main/java/graphql/execution/ExecutionStepInfoFactory.java
@@ -20,22 +20,21 @@ public class ExecutionStepInfoFactory {
     ValuesResolver valuesResolver = new ValuesResolver();
 
 
-    public ExecutionStepInfo newExecutionStepInfoForSubField(ExecutionContext executionContext, MergedFields sameFields, ExecutionStepInfo parentInfo) {
-        Field field = sameFields.getSingleField();
+    public ExecutionStepInfo newExecutionStepInfoForSubField(ExecutionContext executionContext, MergedFields mergedFields, ExecutionStepInfo parentInfo) {
         GraphQLObjectType parentType = (GraphQLObjectType) parentInfo.getUnwrappedNonNullType();
-        GraphQLFieldDefinition fieldDefinition = Introspection.getFieldDef(executionContext.getGraphQLSchema(), parentType, field.getName());
+        GraphQLFieldDefinition fieldDefinition = Introspection.getFieldDef(executionContext.getGraphQLSchema(), parentType, mergedFields.getName());
         GraphQLOutputType fieldType = fieldDefinition.getType();
-        List<Argument> fieldArgs = field.getArguments();
+        List<Argument> fieldArgs = mergedFields.getArguments();
         GraphQLCodeRegistry codeRegistry = executionContext.getGraphQLSchema().getCodeRegistry();
         Map<String, Object> argumentValues = valuesResolver.getArgumentValues(codeRegistry, fieldDefinition.getArguments(), fieldArgs, executionContext.getVariables());
 
-        ExecutionPath newPath = parentInfo.getPath().segment(mkNameForPath(sameFields));
+        ExecutionPath newPath = parentInfo.getPath().segment(mkNameForPath(mergedFields));
 
         return parentInfo.transform(builder -> builder
                 .parentInfo(parentInfo)
                 .type(fieldType)
                 .fieldDefinition(fieldDefinition)
-                .field(field)
+                .field(mergedFields)
                 .path(newPath)
                 .arguments(argumentValues));
     }

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -607,7 +607,7 @@ public abstract class ExecutionStrategy {
                 .variables(executionContext.getVariables())
                 .build();
 
-        Map<String, MergedFields> subFields = fieldCollector.collectFields(collectorParameters, parameters.getField());
+        MergedSelectionSet subFields = fieldCollector.collectFields(collectorParameters, parameters.getField());
 
         ExecutionStepInfo newExecutionStepInfo = executionStepInfo.changeTypeWithPreservedNonNull(resolvedObjectType);
         NonNullableFieldValidator nonNullableFieldValidator = new NonNullableFieldValidator(executionContext, newExecutionStepInfo);

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -220,9 +220,9 @@ public abstract class ExecutionStrategy {
      * @throws NonNullableFieldWasNullException in the future if a non null field resolves to a null value
      */
     protected CompletableFuture<Object> fetchField(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
-        Field field = parameters.getField().getSingleField();
+        MergedFields field = parameters.getField();
         GraphQLObjectType parentType = (GraphQLObjectType) parameters.getExecutionStepInfo().getUnwrappedNonNullType();
-        GraphQLFieldDefinition fieldDef = getFieldDef(executionContext.getGraphQLSchema(), parentType, field);
+        GraphQLFieldDefinition fieldDef = getFieldDef(executionContext.getGraphQLSchema(), parentType, field.getSingleField());
 
         GraphQLCodeRegistry codeRegistry = executionContext.getGraphQLSchema().getCodeRegistry();
         Map<String, Object> argumentValues = valuesResolver.getArgumentValues(codeRegistry, fieldDef.getArguments(), field.getArguments(), executionContext.getVariables());
@@ -296,7 +296,7 @@ public abstract class ExecutionStrategy {
 
     private void handleFetchingException(ExecutionContext executionContext,
                                          ExecutionStrategyParameters parameters,
-                                         Field field,
+                                         MergedFields field,
                                          GraphQLFieldDefinition fieldDef,
                                          Map<String, Object> argumentValues,
                                          DataFetchingEnvironment environment,

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -763,15 +763,14 @@ public abstract class ExecutionStrategy {
      */
     protected ExecutionStepInfo createExecutionStepInfo(ExecutionContext executionContext, ExecutionStrategyParameters parameters, GraphQLFieldDefinition fieldDefinition) {
         GraphQLOutputType fieldType = fieldDefinition.getType();
-        Field field = parameters.getField().getSingleField();
-        List<Argument> fieldArgs = field.getArguments();
+        List<Argument> fieldArgs = parameters.getField().getArguments();
         GraphQLCodeRegistry codeRegistry = executionContext.getGraphQLSchema().getCodeRegistry();
         Map<String, Object> argumentValues = valuesResolver.getArgumentValues(codeRegistry, fieldDefinition.getArguments(), fieldArgs, executionContext.getVariables());
 
         return newExecutionStepInfo()
                 .type(fieldType)
                 .fieldDefinition(fieldDefinition)
-                .field(field)
+                .field(parameters.getField())
                 .path(parameters.getPath())
                 .parentInfo(parameters.getExecutionStepInfo())
                 .arguments(argumentValues)

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -651,7 +651,7 @@ public abstract class ExecutionStrategy {
     }
 
     protected GraphQLObjectType resolveType(ExecutionContext executionContext, ExecutionStrategyParameters parameters, GraphQLType fieldType) {
-        return resolvedType.resolveType(executionContext, parameters.getField().getSingleField(), parameters.getSource(), parameters.getArguments(), fieldType);
+        return resolvedType.resolveType(executionContext, parameters.getField(), parameters.getSource(), parameters.getArguments(), fieldType);
     }
 
 

--- a/src/main/java/graphql/execution/ExecutionStrategyParameters.java
+++ b/src/main/java/graphql/execution/ExecutionStrategyParameters.java
@@ -3,9 +3,7 @@ package graphql.execution;
 import graphql.Assert;
 import graphql.PublicApi;
 import graphql.execution.defer.DeferredErrorSupport;
-import graphql.language.Field;
 
-import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -19,10 +17,10 @@ public class ExecutionStrategyParameters {
     private final ExecutionStepInfo executionStepInfo;
     private final Object source;
     private final Map<String, Object> arguments;
-    private final Map<String, List<Field>> fields;
+    private final Map<String, MergedFields> fields;
     private final NonNullableFieldValidator nonNullableFieldValidator;
     private final ExecutionPath path;
-    private final List<Field> currentField;
+    private final MergedFields currentField;
     private final int listSize;
     private final int currentListIndex;
     private final ExecutionStrategyParameters parent;
@@ -30,11 +28,11 @@ public class ExecutionStrategyParameters {
 
     private ExecutionStrategyParameters(ExecutionStepInfo executionStepInfo,
                                         Object source,
-                                        Map<String, List<Field>> fields,
+                                        Map<String, MergedFields> fields,
                                         Map<String, Object> arguments,
                                         NonNullableFieldValidator nonNullableFieldValidator,
                                         ExecutionPath path,
-                                        List<Field> currentField,
+                                        MergedFields currentField,
                                         int listSize,
                                         int currentListIndex,
                                         ExecutionStrategyParameters parent,
@@ -61,7 +59,7 @@ public class ExecutionStrategyParameters {
         return source;
     }
 
-    public Map<String, List<Field>> getFields() {
+    public Map<String, MergedFields> getFields() {
         return fields;
     }
 
@@ -94,13 +92,10 @@ public class ExecutionStrategyParameters {
     }
 
     /**
-     * This returns the current field in its query representations.  Global fragments mean that
-     * a single named field can have multiple representations and different field subselections
-     * hence the use of a list of Field
-     *
-     * @return the current field in list form  or null if this has not be computed yet
+     * This returns the current field in its query representations.
+     * @return the current merged fields
      */
-    public List<Field> getField() {
+    public MergedFields getField() {
         return currentField;
     }
 
@@ -127,11 +122,11 @@ public class ExecutionStrategyParameters {
     public static class Builder {
         ExecutionStepInfo executionStepInfo;
         Object source;
-        Map<String, List<Field>> fields;
+        Map<String, MergedFields> fields;
         Map<String, Object> arguments;
         NonNullableFieldValidator nonNullableFieldValidator;
         ExecutionPath path = ExecutionPath.rootPath();
-        List<Field> currentField;
+        MergedFields currentField;
         int listSize;
         int currentListIndex;
         ExecutionStrategyParameters parent;
@@ -170,12 +165,12 @@ public class ExecutionStrategyParameters {
             return this;
         }
 
-        public Builder fields(Map<String, List<Field>> fields) {
+        public Builder fields(Map<String, MergedFields> fields) {
             this.fields = fields;
             return this;
         }
 
-        public Builder field(List<Field> currentField) {
+        public Builder field(MergedFields currentField) {
             this.currentField = currentField;
             return this;
         }

--- a/src/main/java/graphql/execution/ExecutionStrategyParameters.java
+++ b/src/main/java/graphql/execution/ExecutionStrategyParameters.java
@@ -17,7 +17,7 @@ public class ExecutionStrategyParameters {
     private final ExecutionStepInfo executionStepInfo;
     private final Object source;
     private final Map<String, Object> arguments;
-    private final Map<String, MergedFields> fields;
+    private final MergedSelectionSet fields;
     private final NonNullableFieldValidator nonNullableFieldValidator;
     private final ExecutionPath path;
     private final MergedFields currentField;
@@ -28,7 +28,7 @@ public class ExecutionStrategyParameters {
 
     private ExecutionStrategyParameters(ExecutionStepInfo executionStepInfo,
                                         Object source,
-                                        Map<String, MergedFields> fields,
+                                        MergedSelectionSet fields,
                                         Map<String, Object> arguments,
                                         NonNullableFieldValidator nonNullableFieldValidator,
                                         ExecutionPath path,
@@ -59,7 +59,7 @@ public class ExecutionStrategyParameters {
         return source;
     }
 
-    public Map<String, MergedFields> getFields() {
+    public MergedSelectionSet getFields() {
         return fields;
     }
 
@@ -122,7 +122,7 @@ public class ExecutionStrategyParameters {
     public static class Builder {
         ExecutionStepInfo executionStepInfo;
         Object source;
-        Map<String, MergedFields> fields;
+        MergedSelectionSet fields;
         Map<String, Object> arguments;
         NonNullableFieldValidator nonNullableFieldValidator;
         ExecutionPath path = ExecutionPath.rootPath();
@@ -165,7 +165,7 @@ public class ExecutionStrategyParameters {
             return this;
         }
 
-        public Builder fields(Map<String, MergedFields> fields) {
+        public Builder fields(MergedSelectionSet fields) {
             this.fields = fields;
             return this;
         }

--- a/src/main/java/graphql/execution/ExecutorServiceExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutorServiceExecutionStrategy.java
@@ -7,10 +7,8 @@ import graphql.PublicApi;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionStrategyParameters;
-import graphql.language.Field;
 
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
@@ -70,10 +68,10 @@ public class ExecutorServiceExecutionStrategy extends ExecutionStrategy {
         InstrumentationExecutionStrategyParameters instrumentationParameters = new InstrumentationExecutionStrategyParameters(executionContext, parameters);
         InstrumentationContext<ExecutionResult> executionStrategyCtx = instrumentation.beginExecutionStrategy(instrumentationParameters);
 
-        Map<String, List<Field>> fields = parameters.getFields();
+        Map<String, MergedFields> fields = parameters.getFields();
         Map<String, Future<CompletableFuture<ExecutionResult>>> futures = new LinkedHashMap<>();
         for (String fieldName : fields.keySet()) {
-            final List<Field> currentField = fields.get(fieldName);
+            final MergedFields currentField = fields.get(fieldName);
 
             ExecutionPath fieldPath = parameters.getPath().segment(mkNameForPath(currentField));
             ExecutionStrategyParameters newParameters = parameters

--- a/src/main/java/graphql/execution/ExecutorServiceExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutorServiceExecutionStrategy.java
@@ -68,10 +68,10 @@ public class ExecutorServiceExecutionStrategy extends ExecutionStrategy {
         InstrumentationExecutionStrategyParameters instrumentationParameters = new InstrumentationExecutionStrategyParameters(executionContext, parameters);
         InstrumentationContext<ExecutionResult> executionStrategyCtx = instrumentation.beginExecutionStrategy(instrumentationParameters);
 
-        Map<String, MergedFields> fields = parameters.getFields();
+        MergedSelectionSet fields = parameters.getFields();
         Map<String, Future<CompletableFuture<ExecutionResult>>> futures = new LinkedHashMap<>();
         for (String fieldName : fields.keySet()) {
-            final MergedFields currentField = fields.get(fieldName);
+            final MergedFields currentField = fields.getSubField(fieldName);
 
             ExecutionPath fieldPath = parameters.getPath().segment(mkNameForPath(currentField));
             ExecutionStrategyParameters newParameters = parameters

--- a/src/main/java/graphql/execution/FieldCollector.java
+++ b/src/main/java/graphql/execution/FieldCollector.java
@@ -18,6 +18,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import static graphql.execution.MergedSelectionSet.newMergedSelectionSet;
 import static graphql.execution.TypeFromAST.getTypeFromAST;
 
 /**
@@ -29,7 +30,7 @@ public class FieldCollector {
 
     private final ConditionalNodes conditionalNodes = new ConditionalNodes();
 
-    public Map<String, MergedFields> collectFields(FieldCollectorParameters parameters, MergedFields mergedFields) {
+    public MergedSelectionSet collectFields(FieldCollectorParameters parameters, MergedFields mergedFields) {
         Map<String, MergedFields> subFields = new LinkedHashMap<>();
         List<String> visitedFragments = new ArrayList<>();
         for (Field field : mergedFields.getFields()) {
@@ -38,7 +39,7 @@ public class FieldCollector {
             }
             this.collectFields(parameters, field.getSelectionSet(), visitedFragments, subFields);
         }
-        return subFields;
+        return newMergedSelectionSet().subFields(subFields).build();
     }
 
     /**
@@ -49,11 +50,11 @@ public class FieldCollector {
      *
      * @return a map of the sub field selections
      */
-    public Map<String, MergedFields> collectFields(FieldCollectorParameters parameters, SelectionSet selectionSet) {
+    public MergedSelectionSet collectFields(FieldCollectorParameters parameters, SelectionSet selectionSet) {
         Map<String, MergedFields> subFields = new LinkedHashMap<>();
         List<String> visitedFragments = new ArrayList<>();
         this.collectFields(parameters, selectionSet, visitedFragments, subFields);
-        return subFields;
+        return newMergedSelectionSet().subFields(subFields).build();
     }
 
 

--- a/src/main/java/graphql/execution/MergedFields.java
+++ b/src/main/java/graphql/execution/MergedFields.java
@@ -68,6 +68,8 @@ public class MergedFields {
     /**
      * All merged fields have the same name.
      *
+     * WARNING: This is not always the key in the execution result, because of possible aliases.
+     *
      * @return the name of of the merged fields.
      */
     public String getName() {

--- a/src/main/java/graphql/execution/MergedFields.java
+++ b/src/main/java/graphql/execution/MergedFields.java
@@ -1,0 +1,118 @@
+package graphql.execution;
+
+import graphql.PublicApi;
+import graphql.language.Field;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static graphql.Assert.assertNotEmpty;
+
+/**
+ * This represent all Fields in query which overlap and are merged into one.
+ * This means they all represent the same field actually when the query is executed.
+ *
+ * Example query with more than one Field merged together:
+ *
+ * <pre>
+ * {@code
+ *
+ *      query Foo {
+ *          bar
+ *          ...BarFragment
+ *      }
+ *
+ *      fragment BarFragment on Query {
+ *          bar
+ *      }
+ * }
+ * </pre>
+ */
+@PublicApi
+public class MergedFields {
+
+    private final List<Field> fields;
+
+    public MergedFields(List<Field> fields) {
+        assertNotEmpty(fields);
+        this.fields = new ArrayList<>(fields);
+    }
+
+    /**
+     * All merged fields have the same name.
+     *
+     * @return the name of of the merged fields.
+     */
+    public String getName() {
+        return fields.get(0).getName();
+    }
+
+    /**
+     * The first of the merged fields.
+     *
+     * Because all fields are almost identically
+     * often only one of the merged fields are used.
+     *
+     * @return the fist of the merged Fields
+     */
+    public Field getSingleField() {
+        return fields.get(0);
+    }
+
+    /**
+     * All merged fields
+     *
+     * @return all merged fields
+     */
+    public List<Field> getFields() {
+        return new ArrayList<>(fields);
+    }
+
+    public static Builder newMergedFields() {
+        return new Builder();
+    }
+
+    public static Builder newMergedFields(Field field) {
+        return new Builder().addField(field);
+    }
+
+    public static Builder newMergedFields(List<Field> fields) {
+        return new Builder().fields(fields);
+    }
+
+    public MergedFields transform(Consumer<Builder> builderConsumer) {
+        Builder builder = new Builder(this);
+        builderConsumer.accept(builder);
+        return builder.build();
+    }
+
+    public static class Builder {
+        private List<Field> fields = new ArrayList<>();
+
+        private Builder() {
+
+        }
+
+        private Builder(MergedFields existing) {
+            this.fields = existing.getFields();
+        }
+
+        public Builder fields(List<Field> fields) {
+            this.fields = fields;
+            return this;
+        }
+
+        public Builder addField(Field field) {
+            this.fields.add(field);
+            return this;
+        }
+
+        public MergedFields build() {
+            return new MergedFields(fields);
+        }
+
+
+    }
+
+}

--- a/src/main/java/graphql/execution/MergedFields.java
+++ b/src/main/java/graphql/execution/MergedFields.java
@@ -1,6 +1,7 @@
 package graphql.execution;
 
 import graphql.PublicApi;
+import graphql.language.Argument;
 import graphql.language.Field;
 
 import java.util.ArrayList;
@@ -84,6 +85,16 @@ public class MergedFields {
     public Field getSingleField() {
         return fields.get(0);
     }
+
+    /**
+     * All merged fields share the same arguments.
+     *
+     * @return
+     */
+    public List<Argument> getArguments() {
+        return getSingleField().getArguments();
+    }
+
 
     /**
      * All merged fields

--- a/src/main/java/graphql/execution/MergedFields.java
+++ b/src/main/java/graphql/execution/MergedFields.java
@@ -28,6 +28,31 @@ import static graphql.Assert.assertNotEmpty;
  *      }
  * }
  * </pre>
+ *
+ * Another example:
+ * <pre>
+ * {@code
+ *     {
+ *          me{fistName}
+ *          me{lastName}
+ *     }
+ * }
+ * </pre>
+ *
+ * Here the me field is merged together including the sub selections.
+ *
+ * A third example with different directives:
+ * <pre>
+ * {@code
+ *     {
+ *          foo @someDirective
+ *          foo @anotherDirective
+ *     }
+ * }
+ * </pre>
+ * These examples make clear that you need to consider all merged fields together to have the full picture.
+ *
+ * The actual logic when fields can successfully merged together is implemented in {#graphql.validation.rules.OverlappingFieldsCanBeMerged}
  */
 @PublicApi
 public class MergedFields {

--- a/src/main/java/graphql/execution/MergedSelectionSet.java
+++ b/src/main/java/graphql/execution/MergedSelectionSet.java
@@ -1,5 +1,6 @@
 package graphql.execution;
 
+import graphql.Assert;
 import graphql.PublicApi;
 
 import java.util.ArrayList;
@@ -15,7 +16,7 @@ public class MergedSelectionSet {
     private final Map<String, MergedFields> subFields;
 
     private MergedSelectionSet(Map<String, MergedFields> subFields) {
-        this.subFields = subFields;
+        this.subFields = Assert.assertNotNull(subFields);
     }
 
     public Map<String, MergedFields> getSubFields() {
@@ -36,6 +37,10 @@ public class MergedSelectionSet {
 
     public List<String> getKeys() {
         return new ArrayList<>(keySet());
+    }
+
+    public boolean isEmpty() {
+        return subFields.isEmpty();
     }
 
     public static Builder newMergedSelectionSet() {

--- a/src/main/java/graphql/execution/MergedSelectionSet.java
+++ b/src/main/java/graphql/execution/MergedSelectionSet.java
@@ -1,0 +1,63 @@
+package graphql.execution;
+
+import graphql.PublicApi;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+
+@PublicApi
+public class MergedSelectionSet {
+
+    private final Map<String, MergedFields> subFields;
+
+    private MergedSelectionSet(Map<String, MergedFields> subFields) {
+        this.subFields = subFields;
+    }
+
+    public Map<String, MergedFields> getSubFields() {
+        return subFields;
+    }
+
+    public int size() {
+        return subFields.size();
+    }
+
+    public Set<String> keySet() {
+        return subFields.keySet();
+    }
+
+    public MergedFields getSubField(String key) {
+        return subFields.get(key);
+    }
+
+    public List<String> getKeys() {
+        return new ArrayList<>(keySet());
+    }
+
+    public static Builder newMergedSelectionSet() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Map<String, MergedFields> subFields = new LinkedHashMap<>();
+
+        private Builder() {
+
+        }
+
+        public Builder subFields(Map<String, MergedFields> subFields) {
+            this.subFields = subFields;
+            return this;
+        }
+
+        public MergedSelectionSet build() {
+            return new MergedSelectionSet(subFields);
+        }
+
+    }
+
+}

--- a/src/main/java/graphql/execution/ResolveType.java
+++ b/src/main/java/graphql/execution/ResolveType.java
@@ -2,7 +2,6 @@ package graphql.execution;
 
 import graphql.Internal;
 import graphql.TypeResolutionEnvironment;
-import graphql.language.Field;
 import graphql.schema.GraphQLInterfaceType;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLType;
@@ -15,7 +14,7 @@ import java.util.Map;
 public class ResolveType {
 
 
-    public GraphQLObjectType resolveType(ExecutionContext executionContext, Field field, Object source, Map<String, Object> arguments, GraphQLType fieldType) {
+    public GraphQLObjectType resolveType(ExecutionContext executionContext, MergedFields field, Object source, Map<String, Object> arguments, GraphQLType fieldType) {
         GraphQLObjectType resolvedType;
         if (fieldType instanceof GraphQLInterfaceType) {
             TypeResolutionParameters resolutionParams = TypeResolutionParameters.newParameters()

--- a/src/main/java/graphql/execution/SimpleDataFetcherExceptionHandler.java
+++ b/src/main/java/graphql/execution/SimpleDataFetcherExceptionHandler.java
@@ -15,7 +15,7 @@ public class SimpleDataFetcherExceptionHandler implements DataFetcherExceptionHa
     @Override
     public void accept(DataFetcherExceptionHandlerParameters handlerParameters) {
         Throwable exception = handlerParameters.getException();
-        SourceLocation sourceLocation = handlerParameters.getField().getSourceLocation();
+        SourceLocation sourceLocation = handlerParameters.getField().getSingleField().getSourceLocation();
         ExecutionPath path = handlerParameters.getPath();
 
         ExceptionWhileDataFetching error = new ExceptionWhileDataFetching(path, exception, sourceLocation);

--- a/src/main/java/graphql/execution/SubscriptionExecutionStrategy.java
+++ b/src/main/java/graphql/execution/SubscriptionExecutionStrategy.java
@@ -111,17 +111,17 @@ public class SubscriptionExecutionStrategy extends ExecutionStrategy {
     }
 
     private String getRootFieldName(ExecutionStrategyParameters parameters) {
-        Field rootField = parameters.getField().get(0);
+        Field rootField = parameters.getField().getSingleField();
         return rootField.getAlias() != null ? rootField.getAlias() : rootField.getName();
     }
 
     private ExecutionStrategyParameters firstFieldOfSubscriptionSelection(ExecutionStrategyParameters parameters) {
-        Map<String, List<Field>> fields = parameters.getFields();
+        Map<String, MergedFields> fields = parameters.getFields();
         List<String> fieldNames = new ArrayList<>(fields.keySet());
 
-        List<Field> firstField = fields.get(fieldNames.get(0));
+        MergedFields firstField = fields.get(fieldNames.get(0));
 
-        ExecutionPath fieldPath = parameters.getPath().segment(mkNameForPath(firstField));
+        ExecutionPath fieldPath = parameters.getPath().segment(mkNameForPath(firstField.getSingleField()));
         return parameters.transform(builder -> builder.field(firstField).path(fieldPath));
     }
 

--- a/src/main/java/graphql/execution/SubscriptionExecutionStrategy.java
+++ b/src/main/java/graphql/execution/SubscriptionExecutionStrategy.java
@@ -6,9 +6,6 @@ import graphql.execution.reactive.CompletionStageMappingPublisher;
 import graphql.language.Field;
 import org.reactivestreams.Publisher;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import static graphql.Assert.assertTrue;
@@ -116,10 +113,8 @@ public class SubscriptionExecutionStrategy extends ExecutionStrategy {
     }
 
     private ExecutionStrategyParameters firstFieldOfSubscriptionSelection(ExecutionStrategyParameters parameters) {
-        Map<String, MergedFields> fields = parameters.getFields();
-        List<String> fieldNames = new ArrayList<>(fields.keySet());
-
-        MergedFields firstField = fields.get(fieldNames.get(0));
+        MergedSelectionSet fields = parameters.getFields();
+        MergedFields firstField = fields.getSubField(fields.getKeys().get(0));
 
         ExecutionPath fieldPath = parameters.getPath().segment(mkNameForPath(firstField.getSingleField()));
         return parameters.transform(builder -> builder.field(firstField).path(fieldPath));

--- a/src/main/java/graphql/execution/TypeResolutionParameters.java
+++ b/src/main/java/graphql/execution/TypeResolutionParameters.java
@@ -1,24 +1,25 @@
 package graphql.execution;
 
-import graphql.language.Field;
+import graphql.PublicApi;
 import graphql.schema.GraphQLInterfaceType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLUnionType;
 
 import java.util.Map;
 
+@PublicApi
 public class TypeResolutionParameters {
 
     private final GraphQLInterfaceType graphQLInterfaceType;
     private final GraphQLUnionType graphQLUnionType;
-    private final Field field;
+    private final MergedFields field;
     private final Object value;
     private final Map<String, Object> argumentValues;
     private final GraphQLSchema schema;
     private final Object context;
 
     private TypeResolutionParameters(GraphQLInterfaceType graphQLInterfaceType, GraphQLUnionType graphQLUnionType,
-                                     Field field, Object value, Map<String, Object> argumentValues, GraphQLSchema schema, final Object context) {
+                                     MergedFields field, Object value, Map<String, Object> argumentValues, GraphQLSchema schema, final Object context) {
         this.graphQLInterfaceType = graphQLInterfaceType;
         this.graphQLUnionType = graphQLUnionType;
         this.field = field;
@@ -36,7 +37,7 @@ public class TypeResolutionParameters {
         return graphQLUnionType;
     }
 
-    public Field getField() {
+    public MergedFields getField() {
         return field;
     }
 
@@ -62,7 +63,7 @@ public class TypeResolutionParameters {
 
     public static class Builder {
 
-        private Field field;
+        private MergedFields field;
         private GraphQLInterfaceType graphQLInterfaceType;
         private GraphQLUnionType graphQLUnionType;
         private Object value;
@@ -70,7 +71,7 @@ public class TypeResolutionParameters {
         private GraphQLSchema schema;
         private Object context;
 
-        public Builder field(Field field) {
+        public Builder field(MergedFields field) {
             this.field = field;
             return this;
         }

--- a/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
+++ b/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
@@ -23,7 +23,6 @@ import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionStrategyParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldParameters;
-import graphql.language.Field;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.DataFetchingFieldSelectionSet;
@@ -401,7 +400,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
             }
             MapOrList childResult = mapOrList.createAndPutMap(fieldName);
 
-            GraphQLObjectType resolvedType = getGraphQLObjectType(executionContext, fields.getSingleField(), executionStepInfo.getUnwrappedNonNullType(), value.getValue(), argumentValues);
+            GraphQLObjectType resolvedType = getGraphQLObjectType(executionContext, fields, executionStepInfo.getUnwrappedNonNullType(), value.getValue(), argumentValues);
             resultsByType.putIfAbsent(resolvedType, new ArrayList<>());
             resultsByType.get(resolvedType).add(childResult);
 
@@ -446,7 +445,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
         return fieldCollector.collectFields(collectorParameters, fields);
     }
 
-    private GraphQLObjectType getGraphQLObjectType(ExecutionContext executionContext, Field field, GraphQLType fieldType, Object value, Map<String, Object> argumentValues) {
+    private GraphQLObjectType getGraphQLObjectType(ExecutionContext executionContext, MergedFields field, GraphQLType fieldType, Object value, Map<String, Object> argumentValues) {
         return resolveType.resolveType(executionContext, field, value, argumentValues, fieldType);
     }
 

--- a/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
+++ b/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
@@ -295,7 +295,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
                         .executionContext(executionContext)
                         .dataFetchingEnvironment(environment)
                         .argumentValues(argumentValues)
-                        .field(fields.getSingleField())
+                        .field(fields)
                         .fieldDefinition(fieldDef)
                         .path(parameters.getPath())
                         .exception(exception)

--- a/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
+++ b/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
@@ -174,7 +174,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
         ExecutionStepInfo executionStepInfo = newExecutionStepInfo()
                 .type(fieldDefinition.getType())
                 .fieldDefinition(fieldDefinition)
-                .field(currentField.getSingleField())
+                .field(currentField)
                 .path(fieldPath)
                 .parentInfo(newParentExecutionStepInfo)
                 .build();

--- a/src/main/java/graphql/execution/batched/ExecutionNode.java
+++ b/src/main/java/graphql/execution/batched/ExecutionNode.java
@@ -1,7 +1,7 @@
 package graphql.execution.batched;
 
 import graphql.execution.ExecutionStepInfo;
-import graphql.language.Field;
+import graphql.execution.MergedFields;
 import graphql.schema.GraphQLObjectType;
 
 import java.util.List;
@@ -12,13 +12,13 @@ class ExecutionNode {
 
     private final GraphQLObjectType type;
     private final ExecutionStepInfo executionStepInfo;
-    private final Map<String, List<Field>> fields;
+    private final Map<String, MergedFields> fields;
     private final List<MapOrList> parentResults;
     private final List<Object> sources;
 
     public ExecutionNode(GraphQLObjectType type,
                          ExecutionStepInfo executionStepInfo,
-                         Map<String, List<Field>> fields,
+                         Map<String, MergedFields> fields,
                          List<MapOrList> parentResults,
                          List<Object> sources) {
         this.type = type;
@@ -36,7 +36,7 @@ class ExecutionNode {
         return executionStepInfo;
     }
 
-    public Map<String, List<Field>> getFields() {
+    public Map<String, MergedFields> getFields() {
         return fields;
     }
 

--- a/src/main/java/graphql/execution/defer/DeferSupport.java
+++ b/src/main/java/graphql/execution/defer/DeferSupport.java
@@ -3,12 +3,12 @@ package graphql.execution.defer;
 import graphql.Directives;
 import graphql.ExecutionResult;
 import graphql.Internal;
+import graphql.execution.MergedFields;
 import graphql.execution.reactive.SingleSubscriberPublisher;
 import graphql.language.Field;
 import org.reactivestreams.Publisher;
 
 import java.util.Deque;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -24,8 +24,8 @@ public class DeferSupport {
     private final Deque<DeferredCall> deferredCalls = new ConcurrentLinkedDeque<>();
     private final SingleSubscriberPublisher<ExecutionResult> publisher = new SingleSubscriberPublisher<>();
 
-    public boolean checkForDeferDirective(List<Field> currentField) {
-        for (Field field : currentField) {
+    public boolean checkForDeferDirective(MergedFields currentField) {
+        for (Field field : currentField.getFields()) {
             if (field.getDirective(Directives.DeferDirective.getName()) != null) {
                 return true;
             }

--- a/src/main/java/graphql/execution/defer/DeferredErrorSupport.java
+++ b/src/main/java/graphql/execution/defer/DeferredErrorSupport.java
@@ -17,7 +17,7 @@ public class DeferredErrorSupport {
     private final List<GraphQLError> errors = new CopyOnWriteArrayList<>();
 
     public void onFetchingException(ExecutionStrategyParameters parameters, Throwable e) {
-        ExceptionWhileDataFetching error = new ExceptionWhileDataFetching(parameters.getPath(), e, parameters.getField().get(0).getSourceLocation());
+        ExceptionWhileDataFetching error = new ExceptionWhileDataFetching(parameters.getPath(), e, parameters.getField().getSingleField().getSourceLocation());
         onError(error);
     }
 

--- a/src/main/java/graphql/execution/instrumentation/ChainedInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/ChainedInstrumentation.java
@@ -6,6 +6,7 @@ import graphql.PublicApi;
 import graphql.execution.Async;
 import graphql.execution.ExecutionContext;
 import graphql.execution.FieldValueInfo;
+import graphql.execution.MergedFields;
 import graphql.execution.instrumentation.parameters.InstrumentationCreateStateParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationDeferredFieldParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationExecuteOperationParameters;
@@ -16,7 +17,6 @@ import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchPar
 import graphql.execution.instrumentation.parameters.InstrumentationFieldParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationValidationParameters;
 import graphql.language.Document;
-import graphql.language.Field;
 import graphql.schema.DataFetcher;
 import graphql.schema.GraphQLSchema;
 import graphql.validation.ValidationError;
@@ -279,7 +279,7 @@ public class ChainedInstrumentation implements Instrumentation {
         }
 
         @Override
-        public void onDeferredField(List<Field> field) {
+        public void onDeferredField(MergedFields field) {
             contexts.forEach(context -> context.onDeferredField(field));
         }
     }

--- a/src/main/java/graphql/execution/instrumentation/ExecutionStrategyInstrumentationContext.java
+++ b/src/main/java/graphql/execution/instrumentation/ExecutionStrategyInstrumentationContext.java
@@ -2,7 +2,7 @@ package graphql.execution.instrumentation;
 
 import graphql.ExecutionResult;
 import graphql.execution.FieldValueInfo;
-import graphql.language.Field;
+import graphql.execution.MergedFields;
 
 import java.util.List;
 
@@ -12,7 +12,7 @@ public interface ExecutionStrategyInstrumentationContext extends Instrumentation
 
     }
 
-    default void onDeferredField(List<Field> field) {
+    default void onDeferredField(MergedFields field) {
 
     }
 }

--- a/src/main/java/graphql/execution/instrumentation/dataloader/FieldLevelTrackingApproach.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/FieldLevelTrackingApproach.java
@@ -5,6 +5,7 @@ import graphql.ExecutionResult;
 import graphql.Internal;
 import graphql.execution.ExecutionPath;
 import graphql.execution.FieldValueInfo;
+import graphql.execution.MergedFields;
 import graphql.execution.instrumentation.DeferredFieldInstrumentationContext;
 import graphql.execution.instrumentation.ExecutionStrategyInstrumentationContext;
 import graphql.execution.instrumentation.InstrumentationContext;
@@ -12,7 +13,6 @@ import graphql.execution.instrumentation.InstrumentationState;
 import graphql.execution.instrumentation.parameters.InstrumentationDeferredFieldParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionStrategyParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
-import graphql.language.Field;
 import org.dataloader.DataLoaderRegistry;
 import org.slf4j.Logger;
 
@@ -161,7 +161,7 @@ public class FieldLevelTrackingApproach {
             }
 
             @Override
-            public void onDeferredField(List<Field> field) {
+            public void onDeferredField(MergedFields field) {
                 boolean dispatchNeeded;
                 // fake fetch count for this field
                 synchronized (callStack) {

--- a/src/main/java/graphql/execution/nextgen/BatchedExecutionStrategy.java
+++ b/src/main/java/graphql/execution/nextgen/BatchedExecutionStrategy.java
@@ -89,7 +89,7 @@ public class BatchedExecutionStrategy implements ExecutionStrategy {
 
     private List<ExecutionResultMultiZipper> groupNodesIntoBatches(ExecutionResultMultiZipper unresolvedZipper) {
         Map<Map<String, MergedFields>, List<ExecutionResultZipper>> zipperBySubSelection = unresolvedZipper.getZippers().stream()
-                .collect(groupingBy(executionResultZipper -> executionResultZipper.getCurNode().getFetchedValueAnalysis().getFieldSubSelection().getFields()));
+                .collect(groupingBy(executionResultZipper -> executionResultZipper.getCurNode().getFetchedValueAnalysis().getFieldSubSelection().getSubFields()));
 
         return zipperBySubSelection
                 .entrySet()
@@ -110,7 +110,7 @@ public class BatchedExecutionStrategy implements ExecutionStrategy {
         // each field in the subSelection has n sources as input
         List<CompletableFuture<List<FetchedValueAnalysis>>> fetchedValues = fieldSubSelections
                 .get(0)
-                .getFields()
+                .getSubFields()
                 .entrySet()
                 .stream()
                 .map(entry -> {
@@ -161,7 +161,7 @@ public class BatchedExecutionStrategy implements ExecutionStrategy {
 
     // only used for the root sub selection atm
     private CompletableFuture<List<FetchedValueAnalysis>> fetchAndAnalyze(FieldSubSelection fieldSubSelection) {
-        List<CompletableFuture<FetchedValueAnalysis>> fetchedValues = fieldSubSelection.getFields().entrySet().stream()
+        List<CompletableFuture<FetchedValueAnalysis>> fetchedValues = fieldSubSelection.getSubFields().entrySet().stream()
                 .map(entry -> {
                     MergedFields sameFields = entry.getValue();
                     String name = entry.getKey();

--- a/src/main/java/graphql/execution/nextgen/BatchedExecutionStrategy.java
+++ b/src/main/java/graphql/execution/nextgen/BatchedExecutionStrategy.java
@@ -6,6 +6,7 @@ import graphql.execution.Async;
 import graphql.execution.ExecutionContext;
 import graphql.execution.ExecutionStepInfo;
 import graphql.execution.ExecutionStepInfoFactory;
+import graphql.execution.MergedFields;
 import graphql.execution.nextgen.result.ExecutionResultMultiZipper;
 import graphql.execution.nextgen.result.ExecutionResultNode;
 import graphql.execution.nextgen.result.ExecutionResultZipper;
@@ -13,7 +14,6 @@ import graphql.execution.nextgen.result.NamedResultNode;
 import graphql.execution.nextgen.result.ObjectExecutionResultNode;
 import graphql.execution.nextgen.result.ObjectExecutionResultNode.RootExecutionResultNode;
 import graphql.execution.nextgen.result.ResultNodesUtil;
-import graphql.language.Field;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -88,7 +88,7 @@ public class BatchedExecutionStrategy implements ExecutionStrategy {
     }
 
     private List<ExecutionResultMultiZipper> groupNodesIntoBatches(ExecutionResultMultiZipper unresolvedZipper) {
-        Map<Map<String, List<Field>>, List<ExecutionResultZipper>> zipperBySubSelection = unresolvedZipper.getZippers().stream()
+        Map<Map<String, MergedFields>, List<ExecutionResultZipper>> zipperBySubSelection = unresolvedZipper.getZippers().stream()
                 .collect(groupingBy(executionResultZipper -> executionResultZipper.getCurNode().getFetchedValueAnalysis().getFieldSubSelection().getFields()));
 
         return zipperBySubSelection
@@ -114,7 +114,7 @@ public class BatchedExecutionStrategy implements ExecutionStrategy {
                 .entrySet()
                 .stream()
                 .map(entry -> {
-                    List<Field> sameFields = entry.getValue();
+                    MergedFields sameFields = entry.getValue();
                     String name = entry.getKey();
 
                     List<ExecutionStepInfo> newExecutionStepInfos = fieldSubSelections.stream().map(executionResultNode -> {
@@ -163,7 +163,7 @@ public class BatchedExecutionStrategy implements ExecutionStrategy {
     private CompletableFuture<List<FetchedValueAnalysis>> fetchAndAnalyze(FieldSubSelection fieldSubSelection) {
         List<CompletableFuture<FetchedValueAnalysis>> fetchedValues = fieldSubSelection.getFields().entrySet().stream()
                 .map(entry -> {
-                    List<Field> sameFields = entry.getValue();
+                    MergedFields sameFields = entry.getValue();
                     String name = entry.getKey();
                     ExecutionStepInfo newExecutionStepInfo = executionInfoFactory.newExecutionStepInfoForSubField(executionContext, sameFields, fieldSubSelection.getExecutionStepInfo());
                     return valueFetcher
@@ -176,13 +176,13 @@ public class BatchedExecutionStrategy implements ExecutionStrategy {
     }
 
     // only used for the root sub selection atm
-    private FetchedValueAnalysis analyseValue(FetchedValue fetchedValue, String name, List<Field> field, ExecutionStepInfo executionInfo) {
+    private FetchedValueAnalysis analyseValue(FetchedValue fetchedValue, String name, MergedFields field, ExecutionStepInfo executionInfo) {
         FetchedValueAnalysis fetchedValueAnalysis = fetchedValueAnalyzer.analyzeFetchedValue(fetchedValue, name, field, executionInfo);
         return fetchedValueAnalysis;
     }
 
 
-    private List<FetchedValueAnalysis> analyseValues(List<FetchedValue> fetchedValues, String name, List<Field> field, List<ExecutionStepInfo> executionInfos) {
+    private List<FetchedValueAnalysis> analyseValues(List<FetchedValue> fetchedValues, String name, MergedFields field, List<ExecutionStepInfo> executionInfos) {
         List<FetchedValueAnalysis> result = new ArrayList<>();
         for (int i = 0; i < fetchedValues.size(); i++) {
             FetchedValue fetchedValue = fetchedValues.get(i);

--- a/src/main/java/graphql/execution/nextgen/DefaultExecutionStrategy.java
+++ b/src/main/java/graphql/execution/nextgen/DefaultExecutionStrategy.java
@@ -90,7 +90,7 @@ public class DefaultExecutionStrategy implements ExecutionStrategy {
     }
 
     private CompletableFuture<List<FetchedValueAnalysis>> fetchAndAnalyze(FieldSubSelection fieldSubSelection) {
-        List<CompletableFuture<FetchedValueAnalysis>> fetchedValues = fieldSubSelection.getFields().entrySet().stream()
+        List<CompletableFuture<FetchedValueAnalysis>> fetchedValues = fieldSubSelection.getSubFields().entrySet().stream()
                 .map(entry -> {
                     MergedFields sameFields = entry.getValue();
                     String name = entry.getKey();

--- a/src/main/java/graphql/execution/nextgen/DefaultExecutionStrategy.java
+++ b/src/main/java/graphql/execution/nextgen/DefaultExecutionStrategy.java
@@ -5,13 +5,13 @@ import graphql.execution.Async;
 import graphql.execution.ExecutionContext;
 import graphql.execution.ExecutionStepInfo;
 import graphql.execution.ExecutionStepInfoFactory;
+import graphql.execution.MergedFields;
 import graphql.execution.nextgen.result.ExecutionResultMultiZipper;
 import graphql.execution.nextgen.result.ExecutionResultNode;
 import graphql.execution.nextgen.result.ExecutionResultZipper;
 import graphql.execution.nextgen.result.NamedResultNode;
 import graphql.execution.nextgen.result.ObjectExecutionResultNode;
 import graphql.execution.nextgen.result.ResultNodesUtil;
-import graphql.language.Field;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -92,7 +92,7 @@ public class DefaultExecutionStrategy implements ExecutionStrategy {
     private CompletableFuture<List<FetchedValueAnalysis>> fetchAndAnalyze(FieldSubSelection fieldSubSelection) {
         List<CompletableFuture<FetchedValueAnalysis>> fetchedValues = fieldSubSelection.getFields().entrySet().stream()
                 .map(entry -> {
-                    List<Field> sameFields = entry.getValue();
+                    MergedFields sameFields = entry.getValue();
                     String name = entry.getKey();
                     ExecutionStepInfo newExecutionStepInfo = executionInfoFactory.newExecutionStepInfoForSubField(executionContext, sameFields, fieldSubSelection.getExecutionStepInfo());
                     return valueFetcher
@@ -103,7 +103,7 @@ public class DefaultExecutionStrategy implements ExecutionStrategy {
         return Async.each(fetchedValues);
     }
 
-    private FetchedValueAnalysis analyseValue(FetchedValue fetchedValue, String name, List<Field> field, ExecutionStepInfo executionInfo) {
+    private FetchedValueAnalysis analyseValue(FetchedValue fetchedValue, String name, MergedFields field, ExecutionStepInfo executionInfo) {
         FetchedValueAnalysis fetchedValueAnalysis = fetchedValueAnalyzer.analyzeFetchedValue(fetchedValue, name, field, executionInfo);
         return fetchedValueAnalysis;
     }

--- a/src/main/java/graphql/execution/nextgen/Execution.java
+++ b/src/main/java/graphql/execution/nextgen/Execution.java
@@ -12,7 +12,7 @@ import graphql.execution.ExecutionPath;
 import graphql.execution.ExecutionStepInfo;
 import graphql.execution.FieldCollector;
 import graphql.execution.FieldCollectorParameters;
-import graphql.execution.MergedFields;
+import graphql.execution.MergedSelectionSet;
 import graphql.execution.ValuesResolver;
 import graphql.execution.nextgen.result.ResultNodesUtil;
 import graphql.language.Document;
@@ -86,12 +86,12 @@ public class Execution {
                 .fragments(executionContext.getFragmentsByName())
                 .variables(executionContext.getVariables())
                 .build();
-        Map<String, MergedFields> fields = fieldCollector.collectFields(collectorParameters, operationDefinition.getSelectionSet());
+        MergedSelectionSet mergedSelectionSet = fieldCollector.collectFields(collectorParameters, operationDefinition.getSelectionSet());
         ExecutionStepInfo executionInfo = newExecutionStepInfo().type(operationRootType).path(ExecutionPath.rootPath()).build();
 
         FieldSubSelection fieldSubSelection = new FieldSubSelection();
         fieldSubSelection.setSource(root);
-        fieldSubSelection.setFields(fields);
+        fieldSubSelection.setMergedSelectionSet(mergedSelectionSet);
         fieldSubSelection.setExecutionStepInfo(executionInfo);
 
         try {

--- a/src/main/java/graphql/execution/nextgen/Execution.java
+++ b/src/main/java/graphql/execution/nextgen/Execution.java
@@ -12,10 +12,10 @@ import graphql.execution.ExecutionPath;
 import graphql.execution.ExecutionStepInfo;
 import graphql.execution.FieldCollector;
 import graphql.execution.FieldCollectorParameters;
+import graphql.execution.MergedFields;
 import graphql.execution.ValuesResolver;
 import graphql.execution.nextgen.result.ResultNodesUtil;
 import graphql.language.Document;
-import graphql.language.Field;
 import graphql.language.FragmentDefinition;
 import graphql.language.NodeUtil;
 import graphql.language.OperationDefinition;
@@ -86,7 +86,7 @@ public class Execution {
                 .fragments(executionContext.getFragmentsByName())
                 .variables(executionContext.getVariables())
                 .build();
-        Map<String, List<Field>> fields = fieldCollector.collectFields(collectorParameters, operationDefinition.getSelectionSet());
+        Map<String, MergedFields> fields = fieldCollector.collectFields(collectorParameters, operationDefinition.getSelectionSet());
         ExecutionStepInfo executionInfo = newExecutionStepInfo().type(operationRootType).path(ExecutionPath.rootPath()).build();
 
         FieldSubSelection fieldSubSelection = new FieldSubSelection();

--- a/src/main/java/graphql/execution/nextgen/FetchedValueAnalyzer.java
+++ b/src/main/java/graphql/execution/nextgen/FetchedValueAnalyzer.java
@@ -86,7 +86,7 @@ public class FetchedValueAnalyzer {
                         .nullValue()
                         .build();
             }
-            resolvedObjectType = resolveType.resolveType(executionContext, field.getSingleField(), toAnalyze, executionInfo.getArguments(), fieldType);
+            resolvedObjectType = resolveType.resolveType(executionContext, field, toAnalyze, executionInfo.getArguments(), fieldType);
             return analyzeObject(fetchedValue, toAnalyze, name, resolvedObjectType, executionInfo);
         } catch (UnresolvedTypeException ex) {
             return handleUnresolvedTypeProblem(fetchedValue, name, executionInfo, ex);

--- a/src/main/java/graphql/execution/nextgen/FetchedValueAnalyzer.java
+++ b/src/main/java/graphql/execution/nextgen/FetchedValueAnalyzer.java
@@ -10,6 +10,7 @@ import graphql.execution.ExecutionStepInfoFactory;
 import graphql.execution.FieldCollector;
 import graphql.execution.FieldCollectorParameters;
 import graphql.execution.MergedFields;
+import graphql.execution.MergedSelectionSet;
 import graphql.execution.NonNullableFieldWasNullException;
 import graphql.execution.ResolveType;
 import graphql.execution.UnresolvedTypeException;
@@ -25,7 +26,6 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
 import static graphql.execution.FieldCollectorParameters.newParameters;
 import static graphql.execution.nextgen.FetchedValueAnalysis.FetchedValueType.ENUM;
@@ -235,7 +235,7 @@ public class FetchedValueAnalyzer {
                 .fragments(executionContext.getFragmentsByName())
                 .variables(executionContext.getVariables())
                 .build();
-        Map<String, MergedFields> subFields = fieldCollector.collectFields(collectorParameters,
+        MergedSelectionSet subFields = fieldCollector.collectFields(collectorParameters,
                 executionInfo.getField());
 
         // it is not really a new step but rather a refinement
@@ -244,7 +244,7 @@ public class FetchedValueAnalyzer {
         FieldSubSelection fieldSubSelection = new FieldSubSelection();
         fieldSubSelection.setSource(toAnalyze);
         fieldSubSelection.setExecutionStepInfo(newExecutionStepInfoWithResolvedType);
-        fieldSubSelection.setFields(subFields);
+        fieldSubSelection.setMergedSelectionSet(subFields);
 
 
         FetchedValueAnalysis result = newFetchedValueAnalysis(OBJECT)

--- a/src/main/java/graphql/execution/nextgen/FetchedValueAnalyzer.java
+++ b/src/main/java/graphql/execution/nextgen/FetchedValueAnalyzer.java
@@ -34,7 +34,6 @@ import static graphql.execution.nextgen.FetchedValueAnalysis.FetchedValueType.OB
 import static graphql.execution.nextgen.FetchedValueAnalysis.FetchedValueType.SCALAR;
 import static graphql.execution.nextgen.FetchedValueAnalysis.newFetchedValueAnalysis;
 import static graphql.schema.GraphQLTypeUtil.isList;
-import static java.util.Collections.singletonList;
 
 @Internal
 public class FetchedValueAnalyzer {
@@ -140,8 +139,7 @@ public class FetchedValueAnalyzer {
         int index = 0;
         for (Object item : values) {
             ExecutionStepInfo executionInfoForListElement = executionInfoFactory.newExecutionStepInfoForListElement(executionInfo, index);
-            MergedFields mergedField = MergedFields.newMergedFields().fields(singletonList(executionInfo.getField())).build();
-            children.add(analyzeFetchedValueImpl(fetchedValue, item, name, mergedField, executionInfoForListElement));
+            children.add(analyzeFetchedValueImpl(fetchedValue, item, name, executionInfo.getField(), executionInfoForListElement));
             index++;
         }
         return newFetchedValueAnalysis(LIST)
@@ -238,7 +236,7 @@ public class FetchedValueAnalyzer {
                 .variables(executionContext.getVariables())
                 .build();
         Map<String, MergedFields> subFields = fieldCollector.collectFields(collectorParameters,
-                MergedFields.newMergedFields().fields(singletonList(executionInfo.getField())).build());
+                executionInfo.getField());
 
         // it is not really a new step but rather a refinement
         ExecutionStepInfo newExecutionStepInfoWithResolvedType = executionInfo.changeTypeWithPreservedNonNull(resolvedObjectType);

--- a/src/main/java/graphql/execution/nextgen/FieldSubSelection.java
+++ b/src/main/java/graphql/execution/nextgen/FieldSubSelection.java
@@ -3,8 +3,8 @@ package graphql.execution.nextgen;
 import graphql.Internal;
 import graphql.execution.ExecutionStepInfo;
 import graphql.execution.MergedFields;
+import graphql.execution.MergedSelectionSet;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 
@@ -18,7 +18,7 @@ public class FieldSubSelection {
     private Object source;
     // the type of this must be objectType
     private ExecutionStepInfo executionInfo;
-    private Map<String, MergedFields> fields = new LinkedHashMap<>();
+    private MergedSelectionSet mergedSelectionSet;
 
     public Object getSource() {
         return source;
@@ -28,12 +28,12 @@ public class FieldSubSelection {
         this.source = source;
     }
 
-    public Map<String, MergedFields> getFields() {
-        return fields;
+    public Map<String, MergedFields> getSubFields() {
+        return mergedSelectionSet.getSubFields();
     }
 
-    public void setFields(Map<String, MergedFields> fields) {
-        this.fields = fields;
+    public void setMergedSelectionSet(MergedSelectionSet mergedSelectionSet) {
+        this.mergedSelectionSet = mergedSelectionSet;
     }
 
     public ExecutionStepInfo getExecutionStepInfo() {
@@ -49,13 +49,13 @@ public class FieldSubSelection {
         return "FieldSubSelection{" +
                 "source=" + source +
                 ", executionInfo=" + executionInfo +
-                ", fields=" + fields +
+                ", mergedSelectionSet" + mergedSelectionSet +
                 '}';
     }
 
     public String toShortString() {
         return "FieldSubSelection{" +
-                "fields=" + fields.keySet() +
+                "fields=" + mergedSelectionSet.getSubFields().keySet() +
                 '}';
     }
 

--- a/src/main/java/graphql/execution/nextgen/FieldSubSelection.java
+++ b/src/main/java/graphql/execution/nextgen/FieldSubSelection.java
@@ -2,10 +2,9 @@ package graphql.execution.nextgen;
 
 import graphql.Internal;
 import graphql.execution.ExecutionStepInfo;
-import graphql.language.Field;
+import graphql.execution.MergedFields;
 
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 
@@ -19,7 +18,7 @@ public class FieldSubSelection {
     private Object source;
     // the type of this must be objectType
     private ExecutionStepInfo executionInfo;
-    private Map<String, List<Field>> fields = new LinkedHashMap<>();
+    private Map<String, MergedFields> fields = new LinkedHashMap<>();
 
     public Object getSource() {
         return source;
@@ -29,11 +28,11 @@ public class FieldSubSelection {
         this.source = source;
     }
 
-    public Map<String, List<Field>> getFields() {
+    public Map<String, MergedFields> getFields() {
         return fields;
     }
 
-    public void setFields(Map<String, List<Field>> fields) {
+    public void setFields(Map<String, MergedFields> fields) {
         this.fields = fields;
     }
 

--- a/src/main/java/graphql/execution/nextgen/ValueFetcher.java
+++ b/src/main/java/graphql/execution/nextgen/ValueFetcher.java
@@ -12,6 +12,7 @@ import graphql.execution.ExecutionContext;
 import graphql.execution.ExecutionId;
 import graphql.execution.ExecutionPath;
 import graphql.execution.ExecutionStepInfo;
+import graphql.execution.MergedFields;
 import graphql.execution.UnboxPossibleOptional;
 import graphql.execution.ValuesResolver;
 import graphql.language.Field;
@@ -53,7 +54,7 @@ public class ValueFetcher {
     }
 
 
-    public CompletableFuture<List<FetchedValue>> fetchBatchedValues(List<Object> sources, List<Field> sameFields, List<ExecutionStepInfo> executionInfos) {
+    public CompletableFuture<List<FetchedValue>> fetchBatchedValues(List<Object> sources, MergedFields sameFields, List<ExecutionStepInfo> executionInfos) {
         System.out.println("Fetch batch values size: " + sources.size());
         ExecutionStepInfo executionStepInfo = executionInfos.get(0);
         if (isDataFetcherBatched(executionStepInfo)) {
@@ -98,8 +99,8 @@ public class ValueFetcher {
         return dataFetcher instanceof BatchedDataFetcher;
     }
 
-    public CompletableFuture<FetchedValue> fetchValue(Object source, List<Field> sameFields, ExecutionStepInfo executionInfo) {
-        Field field = sameFields.get(0);
+    public CompletableFuture<FetchedValue> fetchValue(Object source, MergedFields sameFields, ExecutionStepInfo executionInfo) {
+        Field field = sameFields.getSingleField();
         GraphQLFieldDefinition fieldDef = executionInfo.getFieldDefinition();
 
         GraphQLCodeRegistry codeRegistry = executionContext.getGraphQLSchema().getCodeRegistry();
@@ -114,7 +115,7 @@ public class ValueFetcher {
                 .source(source)
                 .arguments(argumentValues)
                 .fieldDefinition(fieldDef)
-                .fields(sameFields)
+                .mergedFields(sameFields)
                 .fieldType(fieldType)
                 .executionStepInfo(executionInfo)
                 .parentType(parentType)
@@ -178,7 +179,7 @@ public class ValueFetcher {
 
     }
 
-    private FetchedValue unboxPossibleDataFetcherResult(List<Field> sameField, ExecutionPath executionPath, FetchedValue result) {
+    private FetchedValue unboxPossibleDataFetcherResult(MergedFields sameField, ExecutionPath executionPath, FetchedValue result) {
         if (result.getFetchedValue() instanceof DataFetcherResult) {
             DataFetcherResult<?> dataFetcherResult = (DataFetcherResult) result.getFetchedValue();
             List<AbsoluteGraphQLError> addErrors = dataFetcherResult.getErrors().stream()

--- a/src/main/java/graphql/schema/DataFetchingEnvironment.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironment.java
@@ -4,6 +4,7 @@ import graphql.PublicApi;
 import graphql.execution.ExecutionContext;
 import graphql.execution.ExecutionId;
 import graphql.execution.ExecutionStepInfo;
+import graphql.execution.MergedFields;
 import graphql.language.Field;
 import graphql.language.FragmentDefinition;
 import org.dataloader.DataLoader;
@@ -84,6 +85,12 @@ public interface DataFetchingEnvironment {
 
 
     /**
+     * Use {@link #getMergedFields()}.
+     */
+    @Deprecated
+    List<Field> getFields();
+
+    /**
      * It can happen that a query has overlapping fields which are
      * are querying the same data. If this is the case they get merged
      * together and fetched only once, but this method returns all of the Fields
@@ -109,10 +116,10 @@ public interface DataFetchingEnvironment {
      *
      * @return the list of fields currently queried
      */
-    List<Field> getFields();
+    MergedFields getMergedFields();
 
     /**
-     * @return returns the field which is currently queried. See also {@link #getFields()}
+     * @return returns the field which is currently queried. See also {@link #getMergedFields()}.
      */
     Field getField();
 

--- a/src/main/java/graphql/schema/DataFetchingEnvironmentBuilder.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironmentBuilder.java
@@ -4,11 +4,10 @@ import graphql.PublicApi;
 import graphql.execution.ExecutionContext;
 import graphql.execution.ExecutionId;
 import graphql.execution.ExecutionStepInfo;
-import graphql.language.Field;
+import graphql.execution.MergedFields;
 import graphql.language.FragmentDefinition;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -32,7 +31,7 @@ public class DataFetchingEnvironmentBuilder {
                 .context(environment.getContext())
                 .root(environment.getRoot())
                 .fieldDefinition(environment.getFieldDefinition())
-                .fields(environment.getFields())
+                .mergedFields(environment.getMergedFields())
                 .fieldType(environment.getFieldType())
                 .executionStepInfo(environment.getExecutionStepInfo())
                 .parentType(environment.getParentType())
@@ -61,7 +60,7 @@ public class DataFetchingEnvironmentBuilder {
     private Object context;
     private Object root;
     private GraphQLFieldDefinition fieldDefinition;
-    private List<Field> fields = Collections.emptyList();
+    private MergedFields mergedFields;
     private GraphQLOutputType fieldType;
     private GraphQLType parentType;
     private GraphQLSchema graphQLSchema;
@@ -96,8 +95,8 @@ public class DataFetchingEnvironmentBuilder {
         return this;
     }
 
-    public DataFetchingEnvironmentBuilder fields(List<Field> fields) {
-        this.fields = fields;
+    public DataFetchingEnvironmentBuilder mergedFields(MergedFields mergedFields) {
+        this.mergedFields = mergedFields;
         return this;
     }
 
@@ -143,7 +142,7 @@ public class DataFetchingEnvironmentBuilder {
 
     public DataFetchingEnvironment build() {
         return new DataFetchingEnvironmentImpl(source, arguments, context, root,
-                fieldDefinition, fields, fieldType, parentType, graphQLSchema, fragmentsByName, executionId, selectionSet,
+                fieldDefinition, mergedFields, fieldType, parentType, graphQLSchema, fragmentsByName, executionId, selectionSet,
                 executionStepInfo,
                 executionContext);
     }

--- a/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
@@ -5,6 +5,7 @@ import graphql.Internal;
 import graphql.execution.ExecutionContext;
 import graphql.execution.ExecutionId;
 import graphql.execution.ExecutionStepInfo;
+import graphql.execution.MergedFields;
 import graphql.language.Field;
 import graphql.language.FragmentDefinition;
 import org.dataloader.DataLoader;
@@ -24,7 +25,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
     private final Object context;
     private final Object root;
     private final GraphQLFieldDefinition fieldDefinition;
-    private final List<Field> fields;
+    private final MergedFields mergedFields;
     private final GraphQLOutputType fieldType;
     private final GraphQLType parentType;
     private final GraphQLSchema graphQLSchema;
@@ -39,7 +40,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
                                        Object context,
                                        Object root,
                                        GraphQLFieldDefinition fieldDefinition,
-                                       List<Field> fields,
+                                       MergedFields mergedFields,
                                        GraphQLOutputType fieldType,
                                        GraphQLType parentType,
                                        GraphQLSchema graphQLSchema,
@@ -54,7 +55,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
         this.context = context;
         this.root = root;
         this.fieldDefinition = fieldDefinition;
-        this.fields = fields;
+        this.mergedFields = mergedFields;
         this.fieldType = fieldType;
         this.parentType = parentType;
         this.graphQLSchema = graphQLSchema;
@@ -101,12 +102,17 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
 
     @Override
     public List<Field> getFields() {
-        return fields;
+        return mergedFields.getFields();
     }
 
     @Override
     public Field getField() {
-        return fields.get(0);
+        return mergedFields.getSingleField();
+    }
+
+    @Override
+    public MergedFields getMergedFields() {
+        return mergedFields;
     }
 
     @Override

--- a/src/main/java/graphql/schema/DataFetchingFieldSelectionSet.java
+++ b/src/main/java/graphql/schema/DataFetchingFieldSelectionSet.java
@@ -1,6 +1,6 @@
 package graphql.schema;
 
-import graphql.execution.MergedFields;
+import graphql.execution.MergedSelectionSet;
 
 import java.util.List;
 import java.util.Map;
@@ -34,13 +34,13 @@ import java.util.function.Supplier;
  * from the underlying data system.  Imagine a SQL system where this might represent the SQL 'projection'
  * of columns say.
  */
-public interface DataFetchingFieldSelectionSet extends Supplier<Map<String, MergedFields>> {
+public interface DataFetchingFieldSelectionSet extends Supplier<MergedSelectionSet> {
 
     /**
      * @return a map of the fields that represent the selection set
      */
     @Override
-    Map<String, MergedFields> get();
+    MergedSelectionSet get();
 
     /**
      * @return a map of the arguments for each field in the selection set

--- a/src/main/java/graphql/schema/DataFetchingFieldSelectionSet.java
+++ b/src/main/java/graphql/schema/DataFetchingFieldSelectionSet.java
@@ -1,6 +1,6 @@
 package graphql.schema;
 
-import graphql.language.Field;
+import graphql.execution.MergedFields;
 
 import java.util.List;
 import java.util.Map;
@@ -34,13 +34,13 @@ import java.util.function.Supplier;
  * from the underlying data system.  Imagine a SQL system where this might represent the SQL 'projection'
  * of columns say.
  */
-public interface DataFetchingFieldSelectionSet extends Supplier<Map<String, List<Field>>> {
+public interface DataFetchingFieldSelectionSet extends Supplier<Map<String, MergedFields>> {
 
     /**
      * @return a map of the fields that represent the selection set
      */
     @Override
-    Map<String, List<Field>> get();
+    Map<String, MergedFields> get();
 
     /**
      * @return a map of the arguments for each field in the selection set

--- a/src/main/java/graphql/schema/DataFetchingFieldSelectionSetImpl.java
+++ b/src/main/java/graphql/schema/DataFetchingFieldSelectionSetImpl.java
@@ -5,6 +5,7 @@ import graphql.execution.ExecutionContext;
 import graphql.execution.FieldCollector;
 import graphql.execution.FieldCollectorParameters;
 import graphql.execution.MergedFields;
+import graphql.execution.MergedSelectionSet;
 import graphql.execution.ValuesResolver;
 import graphql.introspection.Introspection;
 import graphql.language.Field;
@@ -30,8 +31,8 @@ public class DataFetchingFieldSelectionSetImpl implements DataFetchingFieldSelec
 
     private final static DataFetchingFieldSelectionSet NOOP = new DataFetchingFieldSelectionSet() {
         @Override
-        public Map<String, MergedFields> get() {
-            return emptyMap();
+        public MergedSelectionSet get() {
+            return MergedSelectionSet.newMergedSelectionSet().build();
         }
 
         @Override
@@ -106,10 +107,10 @@ public class DataFetchingFieldSelectionSetImpl implements DataFetchingFieldSelec
     }
 
     @Override
-    public Map<String, MergedFields> get() {
+    public MergedSelectionSet get() {
         // by having a .get() method we get lazy evaluation.
         computeValuesLazily();
-        return selectionSetFields;
+        return MergedSelectionSet.newMergedSelectionSet().subFields(selectionSetFields).build();
     }
 
     @Override
@@ -260,8 +261,8 @@ public class DataFetchingFieldSelectionSetImpl implements DataFetchingFieldSelec
                 .variables(variables)
                 .build();
 
-        Map<String, MergedFields> collectedFields = fieldCollector.collectFields(parameters, fieldList);
-        for (Map.Entry<String, MergedFields> entry : collectedFields.entrySet()) {
+        MergedSelectionSet collectedFields = fieldCollector.collectFields(parameters, fieldList);
+        for (Map.Entry<String, MergedFields> entry : collectedFields.getSubFields().entrySet()) {
             String fieldName = mkFieldName(fieldPrefix, entry.getKey());
             MergedFields collectedFieldList = entry.getValue();
             selectionSetFields.put(fieldName, collectedFieldList);

--- a/src/main/java/graphql/schema/DataFetchingFieldSelectionSetImpl.java
+++ b/src/main/java/graphql/schema/DataFetchingFieldSelectionSetImpl.java
@@ -4,6 +4,7 @@ import graphql.Internal;
 import graphql.execution.ExecutionContext;
 import graphql.execution.FieldCollector;
 import graphql.execution.FieldCollectorParameters;
+import graphql.execution.MergedFields;
 import graphql.execution.ValuesResolver;
 import graphql.introspection.Introspection;
 import graphql.language.Field;
@@ -29,7 +30,7 @@ public class DataFetchingFieldSelectionSetImpl implements DataFetchingFieldSelec
 
     private final static DataFetchingFieldSelectionSet NOOP = new DataFetchingFieldSelectionSet() {
         @Override
-        public Map<String, List<Field>> get() {
+        public Map<String, MergedFields> get() {
             return emptyMap();
         }
 
@@ -64,10 +65,10 @@ public class DataFetchingFieldSelectionSetImpl implements DataFetchingFieldSelec
         }
     };
 
-    public static DataFetchingFieldSelectionSet newCollector(ExecutionContext executionContext, GraphQLType fieldType, List<Field> fields) {
+    public static DataFetchingFieldSelectionSet newCollector(ExecutionContext executionContext, GraphQLType fieldType, MergedFields mergedFields) {
         GraphQLType unwrappedType = GraphQLTypeUtil.unwrapAll(fieldType);
         if (unwrappedType instanceof GraphQLFieldsContainer) {
-            return new DataFetchingFieldSelectionSetImpl(executionContext, (GraphQLFieldsContainer) unwrappedType, fields);
+            return new DataFetchingFieldSelectionSetImpl(executionContext, (GraphQLFieldsContainer) unwrappedType, mergedFields);
         } else {
             // we can only collect fields on object types and interfaces.  Scalars, Unions etc... cant be done.
             return NOOP;
@@ -81,22 +82,22 @@ public class DataFetchingFieldSelectionSetImpl implements DataFetchingFieldSelec
     private final FieldCollector fieldCollector = new FieldCollector();
     private final ValuesResolver valuesResolver = new ValuesResolver();
 
-    private final List<Field> parentFields;
+    private final MergedFields parentFields;
     private final GraphQLSchema graphQLSchema;
     private final GraphQLFieldsContainer parentFieldType;
     private final Map<String, Object> variables;
     private final Map<String, FragmentDefinition> fragmentsByName;
 
-    private Map<String, List<Field>> selectionSetFields;
+    private Map<String, MergedFields> selectionSetFields;
     private Map<String, GraphQLFieldDefinition> selectionSetFieldDefinitions;
     private Map<String, Map<String, Object>> selectionSetFieldArgs;
     private Set<String> flattenedFields;
 
-    private DataFetchingFieldSelectionSetImpl(ExecutionContext executionContext, GraphQLFieldsContainer parentFieldType, List<Field> parentFields) {
+    private DataFetchingFieldSelectionSetImpl(ExecutionContext executionContext, GraphQLFieldsContainer parentFieldType, MergedFields parentFields) {
         this(parentFields, parentFieldType, executionContext.getGraphQLSchema(), executionContext.getVariables(), executionContext.getFragmentsByName());
     }
 
-    public DataFetchingFieldSelectionSetImpl(List<Field> parentFields, GraphQLFieldsContainer parentFieldType, GraphQLSchema graphQLSchema, Map<String, Object> variables, Map<String, FragmentDefinition> fragmentsByName) {
+    public DataFetchingFieldSelectionSetImpl(MergedFields parentFields, GraphQLFieldsContainer parentFieldType, GraphQLSchema graphQLSchema, Map<String, Object> variables, Map<String, FragmentDefinition> fragmentsByName) {
         this.parentFields = parentFields;
         this.graphQLSchema = graphQLSchema;
         this.parentFieldType = parentFieldType;
@@ -105,7 +106,7 @@ public class DataFetchingFieldSelectionSetImpl implements DataFetchingFieldSelec
     }
 
     @Override
-    public Map<String, List<Field>> get() {
+    public Map<String, MergedFields> get() {
         // by having a .get() method we get lazy evaluation.
         computeValuesLazily();
         return selectionSetFields;
@@ -143,7 +144,7 @@ public class DataFetchingFieldSelectionSetImpl implements DataFetchingFieldSelec
     public SelectedField getField(String fqFieldName) {
         computeValuesLazily();
 
-        List<Field> fields = selectionSetFields.get(fqFieldName);
+        MergedFields fields = selectionSetFields.get(fqFieldName);
         if (fields == null) {
             return null;
         }
@@ -189,9 +190,9 @@ public class DataFetchingFieldSelectionSetImpl implements DataFetchingFieldSelec
         private final DataFetchingFieldSelectionSet selectionSet;
         private final Map<String, Object> arguments;
 
-        private SelectedFieldImpl(String qualifiedName, List<Field> parentFields, GraphQLFieldDefinition fieldDefinition, Map<String, Object> arguments) {
+        private SelectedFieldImpl(String qualifiedName, MergedFields parentFields, GraphQLFieldDefinition fieldDefinition, Map<String, Object> arguments) {
             this.qualifiedName = qualifiedName;
-            this.name = parentFields.get(0).getName();
+            this.name = parentFields.getName();
             this.fieldDefinition = fieldDefinition;
             this.arguments = arguments;
             GraphQLType unwrappedType = GraphQLTypeUtil.unwrapAll(fieldDefinition.getType());
@@ -250,7 +251,7 @@ public class DataFetchingFieldSelectionSetImpl implements DataFetchingFieldSelec
     private final static String SEP = "/";
 
 
-    private void traverseFields(List<Field> fieldList, GraphQLFieldsContainer parentFieldType, String fieldPrefix) {
+    private void traverseFields(MergedFields fieldList, GraphQLFieldsContainer parentFieldType, String fieldPrefix) {
 
         FieldCollectorParameters parameters = FieldCollectorParameters.newParameters()
                 .schema(graphQLSchema)
@@ -259,13 +260,13 @@ public class DataFetchingFieldSelectionSetImpl implements DataFetchingFieldSelec
                 .variables(variables)
                 .build();
 
-        Map<String, List<Field>> collectedFields = fieldCollector.collectFields(parameters, fieldList);
-        for (Map.Entry<String, List<Field>> entry : collectedFields.entrySet()) {
+        Map<String, MergedFields> collectedFields = fieldCollector.collectFields(parameters, fieldList);
+        for (Map.Entry<String, MergedFields> entry : collectedFields.entrySet()) {
             String fieldName = mkFieldName(fieldPrefix, entry.getKey());
-            List<Field> collectedFieldList = entry.getValue();
+            MergedFields collectedFieldList = entry.getValue();
             selectionSetFields.put(fieldName, collectedFieldList);
 
-            Field field = collectedFieldList.get(0);
+            Field field = collectedFieldList.getSingleField();
             GraphQLFieldDefinition fieldDef = Introspection.getFieldDef(graphQLSchema, parentFieldType, field.getName());
             GraphQLType unwrappedType = GraphQLTypeUtil.unwrapAll(fieldDef.getType());
             Map<String, Object> argumentValues = valuesResolver.getArgumentValues(fieldDef.getArguments(), field.getArguments(), variables);

--- a/src/test/groovy/graphql/TestUtil.groovy
+++ b/src/test/groovy/graphql/TestUtil.groovy
@@ -1,6 +1,7 @@
 package graphql
 
 import graphql.execution.MergedFields
+import graphql.execution.MergedSelectionSet
 import graphql.introspection.Introspection.DirectiveLocation
 import graphql.language.Document
 import graphql.language.Field
@@ -211,6 +212,10 @@ class TestUtil {
 
     static MergedFields mergedFields(Field field) {
         return MergedFields.newMergedFields(field).build()
+    }
+
+    static MergedSelectionSet mergedSelectionSet(Map<String, MergedFields> subFields) {
+        return MergedSelectionSet.newMergedSelectionSet().subFields(subFields).build()
     }
 
 }

--- a/src/test/groovy/graphql/TestUtil.groovy
+++ b/src/test/groovy/graphql/TestUtil.groovy
@@ -1,7 +1,9 @@
 package graphql
 
+import graphql.execution.MergedFields
 import graphql.introspection.Introspection.DirectiveLocation
 import graphql.language.Document
+import graphql.language.Field
 import graphql.language.ScalarTypeDefinition
 import graphql.parser.Parser
 import graphql.schema.Coercing
@@ -21,7 +23,6 @@ import graphql.schema.idl.SchemaParser
 import graphql.schema.idl.TypeRuntimeWiring
 import graphql.schema.idl.WiringFactory
 import graphql.schema.idl.errors.SchemaProblem
-import org.antlr.v4.runtime.misc.ParseCancellationException
 
 import java.util.function.Supplier
 import java.util.stream.Collectors
@@ -202,6 +203,14 @@ class TestUtil {
 
     static Document parseQuery(String query) {
         new Parser().parseDocument(query)
+    }
+
+    static MergedFields mergedFields(List<Field> fields) {
+        return MergedFields.newMergedFields(fields).build()
+    }
+
+    static MergedFields mergedFields(Field field) {
+        return MergedFields.newMergedFields(field).build()
     }
 
 }

--- a/src/test/groovy/graphql/TypeResolutionEnvironmentTest.groovy
+++ b/src/test/groovy/graphql/TypeResolutionEnvironmentTest.groovy
@@ -5,6 +5,8 @@ import graphql.schema.GraphQLObjectType
 import graphql.schema.TypeResolver
 import spock.lang.Specification
 
+import static graphql.TestUtil.mergedFields
+
 class TypeResolutionEnvironmentTest extends Specification {
 
     def idl = """
@@ -37,7 +39,7 @@ class TypeResolutionEnvironmentTest extends Specification {
     def "basic operations"() {
         given:
 
-        def environment = new TypeResolutionEnvironment("source", [:], new Field("field"), Scalars.GraphQLString, schema, "FooBar")
+        def environment = new TypeResolutionEnvironment("source", [:], mergedFields(new Field("field")), Scalars.GraphQLString, schema, "FooBar")
 
         when:
 
@@ -91,14 +93,14 @@ class TypeResolutionEnvironmentTest extends Specification {
         }
 
         when:
-        def environmentFooBar = new TypeResolutionEnvironment("source", [:], new Field("field"), Scalars.GraphQLString, schema, "FooBar")
+        def environmentFooBar = new TypeResolutionEnvironment("source", [:], mergedFields(new Field("field")), Scalars.GraphQLString, schema, "FooBar")
         def objTypeFooBar = resolverWithContext.getType(environmentFooBar)
 
         then:
         objTypeFooBar.name == "FooBar"
 
         when:
-        def environmentFooImpl = new TypeResolutionEnvironment("source", [:], new Field("field"), Scalars.GraphQLString, schema, "Foo")
+        def environmentFooImpl = new TypeResolutionEnvironment("source", [:], mergedFields(new Field("field")), Scalars.GraphQLString, schema, "Foo")
         def objTypeFooImpl = resolverWithContext.getType(environmentFooImpl)
 
         then:

--- a/src/test/groovy/graphql/execution/AbsoluteGraphQLErrorTest.groovy
+++ b/src/test/groovy/graphql/execution/AbsoluteGraphQLErrorTest.groovy
@@ -6,6 +6,7 @@ import graphql.language.SourceLocation
 import spock.lang.Specification
 
 import static graphql.Scalars.GraphQLString
+import static graphql.TestUtil.mergedFields
 import static graphql.execution.ExecutionStrategyParameters.newParameters
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
 import static graphql.schema.GraphQLObjectType.newObject
@@ -29,8 +30,8 @@ class AbsoluteGraphQLErrorTest extends Specification {
         def parameters = newParameters()
                 .executionStepInfo(ExecutionStepInfo.newExecutionStepInfo().type(objectType))
                 .source(new Object())
-                .fields(["fld": [Field.newField().build()]])
-                .field([field])
+                .fields(["fld": mergedFields([Field.newField().build()])])
+                .field(mergedFields(field))
                 .path(ExecutionPath.fromList(["foo", "bar"]))
                 .build()
 
@@ -64,8 +65,8 @@ class AbsoluteGraphQLErrorTest extends Specification {
         def parameters = newParameters()
                 .executionStepInfo(ExecutionStepInfo.newExecutionStepInfo().type(objectType))
                 .source(new Object())
-                .fields(["fld": [Field.newField().build()]])
-                .field([field])
+                .fields(["fld": mergedFields(Field.newField().build())])
+                .field(mergedFields(field))
                 .path(ExecutionPath.fromList(["foo", "bar"]))
                 .build()
 
@@ -88,8 +89,8 @@ class AbsoluteGraphQLErrorTest extends Specification {
         def parameters = newParameters()
                 .executionStepInfo(ExecutionStepInfo.newExecutionStepInfo().type(objectType))
                 .source(new Object())
-                .fields(["fld": [Field.newField().build()]])
-                .field([field])
+                .fields(["fld": mergedFields(Field.newField().build())])
+                .field(mergedFields(field))
                 .path(ExecutionPath.fromList(["foo", "bar"]))
                 .build()
 
@@ -113,8 +114,8 @@ class AbsoluteGraphQLErrorTest extends Specification {
         def parameters = newParameters()
                 .executionStepInfo(ExecutionStepInfo.newExecutionStepInfo().type(objectType))
                 .source(new Object())
-                .fields(["fld": [Field.newField().build()]])
-                .field([field])
+                .fields(["fld": mergedFields(Field.newField().build())])
+                .field(mergedFields(field))
                 .path(ExecutionPath.fromList(["foo", "bar"]))
                 .build()
 
@@ -138,8 +139,8 @@ class AbsoluteGraphQLErrorTest extends Specification {
         def parameters = newParameters()
                 .executionStepInfo(ExecutionStepInfo.newExecutionStepInfo().type(objectType))
                 .source(new Object())
-                .fields(["fld": [Field.newField().build()]])
-                .field([field])
+                .fields(["fld": mergedFields(Field.newField().build())])
+                .field(mergedFields(field))
                 .path(ExecutionPath.fromList(["foo", "bar"]))
                 .build()
 
@@ -162,8 +163,8 @@ class AbsoluteGraphQLErrorTest extends Specification {
         def parameters = newParameters()
                 .executionStepInfo(ExecutionStepInfo.newExecutionStepInfo().type(objectType))
                 .source(new Object())
-                .fields(["fld": [Field.newField().build()]])
-                .field([field])
+                .fields(["fld": mergedFields(Field.newField().build())])
+                .field(mergedFields(field))
                 .path(ExecutionPath.fromList(["foo", "bar"]))
                 .build()
 

--- a/src/test/groovy/graphql/execution/AbsoluteGraphQLErrorTest.groovy
+++ b/src/test/groovy/graphql/execution/AbsoluteGraphQLErrorTest.groovy
@@ -7,6 +7,7 @@ import spock.lang.Specification
 
 import static graphql.Scalars.GraphQLString
 import static graphql.TestUtil.mergedFields
+import static graphql.TestUtil.mergedSelectionSet
 import static graphql.execution.ExecutionStrategyParameters.newParameters
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
 import static graphql.schema.GraphQLObjectType.newObject
@@ -30,7 +31,7 @@ class AbsoluteGraphQLErrorTest extends Specification {
         def parameters = newParameters()
                 .executionStepInfo(ExecutionStepInfo.newExecutionStepInfo().type(objectType))
                 .source(new Object())
-                .fields(["fld": mergedFields([Field.newField().build()])])
+                .fields(mergedSelectionSet(["fld": mergedFields([Field.newField().build()])]))
                 .field(mergedFields(field))
                 .path(ExecutionPath.fromList(["foo", "bar"]))
                 .build()
@@ -65,7 +66,7 @@ class AbsoluteGraphQLErrorTest extends Specification {
         def parameters = newParameters()
                 .executionStepInfo(ExecutionStepInfo.newExecutionStepInfo().type(objectType))
                 .source(new Object())
-                .fields(["fld": mergedFields(Field.newField().build())])
+                .fields(mergedSelectionSet(["fld": mergedFields(Field.newField().build())]))
                 .field(mergedFields(field))
                 .path(ExecutionPath.fromList(["foo", "bar"]))
                 .build()
@@ -89,7 +90,7 @@ class AbsoluteGraphQLErrorTest extends Specification {
         def parameters = newParameters()
                 .executionStepInfo(ExecutionStepInfo.newExecutionStepInfo().type(objectType))
                 .source(new Object())
-                .fields(["fld": mergedFields(Field.newField().build())])
+                .fields(mergedSelectionSet(["fld": mergedFields(Field.newField().build())]))
                 .field(mergedFields(field))
                 .path(ExecutionPath.fromList(["foo", "bar"]))
                 .build()
@@ -114,7 +115,7 @@ class AbsoluteGraphQLErrorTest extends Specification {
         def parameters = newParameters()
                 .executionStepInfo(ExecutionStepInfo.newExecutionStepInfo().type(objectType))
                 .source(new Object())
-                .fields(["fld": mergedFields(Field.newField().build())])
+                .fields(mergedSelectionSet(["fld": mergedFields(Field.newField().build())]))
                 .field(mergedFields(field))
                 .path(ExecutionPath.fromList(["foo", "bar"]))
                 .build()
@@ -139,7 +140,7 @@ class AbsoluteGraphQLErrorTest extends Specification {
         def parameters = newParameters()
                 .executionStepInfo(ExecutionStepInfo.newExecutionStepInfo().type(objectType))
                 .source(new Object())
-                .fields(["fld": mergedFields(Field.newField().build())])
+                .fields(mergedSelectionSet(["fld": mergedFields(Field.newField().build())]))
                 .field(mergedFields(field))
                 .path(ExecutionPath.fromList(["foo", "bar"]))
                 .build()
@@ -163,7 +164,7 @@ class AbsoluteGraphQLErrorTest extends Specification {
         def parameters = newParameters()
                 .executionStepInfo(ExecutionStepInfo.newExecutionStepInfo().type(objectType))
                 .source(new Object())
-                .fields(["fld": mergedFields(Field.newField().build())])
+                .fields(mergedSelectionSet(["fld": mergedFields(Field.newField().build())]))
                 .field(mergedFields(field))
                 .path(ExecutionPath.fromList(["foo", "bar"]))
                 .build()

--- a/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy
@@ -20,6 +20,7 @@ import java.util.concurrent.locks.ReentrantLock
 
 import static graphql.Scalars.GraphQLString
 import static graphql.TestUtil.mergedFields
+import static graphql.TestUtil.mergedSelectionSet
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
 import static graphql.schema.GraphQLObjectType.newObject
 import static graphql.schema.GraphQLSchema.newSchema
@@ -84,7 +85,7 @@ class AsyncExecutionStrategyTest extends Specification {
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
                 .executionStepInfo(typeInfo)
-                .fields(['hello': mergedFields([Field.newField('hello').build()]), 'hello2': mergedFields([Field.newField('hello2').build()])])
+                .fields(mergedSelectionSet(['hello': mergedFields([Field.newField('hello').build()]), 'hello2': mergedFields([Field.newField('hello2').build()])]))
                 .build()
 
         AsyncExecutionStrategy asyncExecutionStrategy = new AsyncExecutionStrategy()
@@ -122,7 +123,7 @@ class AsyncExecutionStrategyTest extends Specification {
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
                 .executionStepInfo(typeInfo)
-                .fields(['hello': mergedFields([Field.newField('hello').build()]), 'hello2': mergedFields([Field.newField('hello2').build()])])
+                .fields(mergedSelectionSet(['hello': mergedFields([Field.newField('hello').build()]), 'hello2': mergedFields([Field.newField('hello2').build()])]))
                 .build()
 
         AsyncExecutionStrategy asyncExecutionStrategy = new AsyncExecutionStrategy()
@@ -162,7 +163,7 @@ class AsyncExecutionStrategyTest extends Specification {
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
                 .executionStepInfo(typeInfo)
-                .fields(['hello': mergedFields([Field.newField('hello').build()]), 'hello2': mergedFields([Field.newField('hello2').build()])])
+                .fields(mergedSelectionSet(['hello': mergedFields([Field.newField('hello').build()]), 'hello2': mergedFields([Field.newField('hello2').build()])]))
                 .build()
 
         AsyncExecutionStrategy asyncExecutionStrategy = new AsyncExecutionStrategy()
@@ -201,7 +202,7 @@ class AsyncExecutionStrategyTest extends Specification {
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
                 .executionStepInfo(typeInfo)
-                .fields(['hello': mergedFields([Field.newField('hello').build()]), 'hello2': mergedFields([Field.newField('hello2').build()])])
+                .fields(mergedSelectionSet(['hello': mergedFields([Field.newField('hello').build()]), 'hello2': mergedFields([Field.newField('hello2').build()])]))
                 .build()
 
         AsyncExecutionStrategy asyncExecutionStrategy = new AsyncExecutionStrategy()
@@ -260,7 +261,7 @@ class AsyncExecutionStrategyTest extends Specification {
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
                 .executionStepInfo(typeInfo)
-                .fields(['hello': mergedFields([new Field('hello')]), 'hello2': mergedFields([new Field('hello2')])])
+                .fields(mergedSelectionSet(['hello': mergedFields([new Field('hello')]), 'hello2': mergedFields([new Field('hello2')])]))
                 .build()
 
         AsyncExecutionStrategy asyncExecutionStrategy = new AsyncExecutionStrategy()

--- a/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy
@@ -19,6 +19,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.locks.ReentrantLock
 
 import static graphql.Scalars.GraphQLString
+import static graphql.TestUtil.mergedFields
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
 import static graphql.schema.GraphQLObjectType.newObject
 import static graphql.schema.GraphQLSchema.newSchema
@@ -83,7 +84,7 @@ class AsyncExecutionStrategyTest extends Specification {
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
                 .executionStepInfo(typeInfo)
-                .fields(['hello': [Field.newField('hello').build()], 'hello2': [Field.newField('hello2').build()]])
+                .fields(['hello': mergedFields([Field.newField('hello').build()]), 'hello2': mergedFields([Field.newField('hello2').build()])])
                 .build()
 
         AsyncExecutionStrategy asyncExecutionStrategy = new AsyncExecutionStrategy()
@@ -121,7 +122,7 @@ class AsyncExecutionStrategyTest extends Specification {
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
                 .executionStepInfo(typeInfo)
-                .fields(['hello': [Field.newField('hello').build()], 'hello2': [Field.newField('hello2').build()]])
+                .fields(['hello': mergedFields([Field.newField('hello').build()]), 'hello2': mergedFields([Field.newField('hello2').build()])])
                 .build()
 
         AsyncExecutionStrategy asyncExecutionStrategy = new AsyncExecutionStrategy()
@@ -161,7 +162,7 @@ class AsyncExecutionStrategyTest extends Specification {
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
                 .executionStepInfo(typeInfo)
-                .fields(['hello': [Field.newField('hello').build()], 'hello2': [Field.newField('hello2').build()]])
+                .fields(['hello': mergedFields([Field.newField('hello').build()]), 'hello2': mergedFields([Field.newField('hello2').build()])])
                 .build()
 
         AsyncExecutionStrategy asyncExecutionStrategy = new AsyncExecutionStrategy()
@@ -200,7 +201,7 @@ class AsyncExecutionStrategyTest extends Specification {
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
                 .executionStepInfo(typeInfo)
-                .fields(['hello': [Field.newField('hello').build()], 'hello2': [Field.newField('hello2').build()]])
+                .fields(['hello': mergedFields([Field.newField('hello').build()]), 'hello2': mergedFields([Field.newField('hello2').build()])])
                 .build()
 
         AsyncExecutionStrategy asyncExecutionStrategy = new AsyncExecutionStrategy()
@@ -259,7 +260,7 @@ class AsyncExecutionStrategyTest extends Specification {
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
                 .executionStepInfo(typeInfo)
-                .fields(['hello': [new Field('hello')], 'hello2': [new Field('hello2')]])
+                .fields(['hello': mergedFields([new Field('hello')]), 'hello2': mergedFields([new Field('hello2')])])
                 .build()
 
         AsyncExecutionStrategy asyncExecutionStrategy = new AsyncExecutionStrategy()

--- a/src/test/groovy/graphql/execution/AsyncSerialExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/AsyncSerialExecutionStrategyTest.groovy
@@ -1,5 +1,6 @@
 package graphql.execution
 
+
 import graphql.execution.instrumentation.SimpleInstrumentation
 import graphql.language.Field
 import graphql.language.OperationDefinition
@@ -14,6 +15,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.locks.ReentrantLock
 
 import static graphql.Scalars.GraphQLString
+import static graphql.TestUtil.mergedFields
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
 import static graphql.schema.GraphQLObjectType.newObject
 import static graphql.schema.GraphQLSchema.newSchema
@@ -86,7 +88,7 @@ class AsyncSerialExecutionStrategyTest extends Specification {
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
                 .executionStepInfo(typeInfo)
-                .fields(['hello': [new Field('hello')], 'hello2': [new Field('hello2')], 'hello3': [new Field('hello3')]])
+                .fields(['hello': mergedFields(new Field('hello')), 'hello2': mergedFields(new Field('hello2')), 'hello3': mergedFields(new Field('hello3'))])
                 .build()
 
         AsyncSerialExecutionStrategy strategy = new AsyncSerialExecutionStrategy()
@@ -129,7 +131,7 @@ class AsyncSerialExecutionStrategyTest extends Specification {
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
                 .executionStepInfo(typeInfo)
-                .fields(['hello': [new Field('hello')], 'hello2': [new Field('hello2')], 'hello3': [new Field('hello3')]])
+                .fields(['hello': mergedFields(new Field('hello')), 'hello2': mergedFields(new Field('hello2')), 'hello3': mergedFields(new Field('hello3'))])
                 .build()
 
         AsyncSerialExecutionStrategy strategy = new AsyncSerialExecutionStrategy()

--- a/src/test/groovy/graphql/execution/AsyncSerialExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/AsyncSerialExecutionStrategyTest.groovy
@@ -16,6 +16,7 @@ import java.util.concurrent.locks.ReentrantLock
 
 import static graphql.Scalars.GraphQLString
 import static graphql.TestUtil.mergedFields
+import static graphql.TestUtil.mergedSelectionSet
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
 import static graphql.schema.GraphQLObjectType.newObject
 import static graphql.schema.GraphQLSchema.newSchema
@@ -88,7 +89,7 @@ class AsyncSerialExecutionStrategyTest extends Specification {
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
                 .executionStepInfo(typeInfo)
-                .fields(['hello': mergedFields(new Field('hello')), 'hello2': mergedFields(new Field('hello2')), 'hello3': mergedFields(new Field('hello3'))])
+                .fields(mergedSelectionSet(['hello': mergedFields(new Field('hello')), 'hello2': mergedFields(new Field('hello2')), 'hello3': mergedFields(new Field('hello3'))]))
                 .build()
 
         AsyncSerialExecutionStrategy strategy = new AsyncSerialExecutionStrategy()
@@ -131,7 +132,7 @@ class AsyncSerialExecutionStrategyTest extends Specification {
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
                 .executionStepInfo(typeInfo)
-                .fields(['hello': mergedFields(new Field('hello')), 'hello2': mergedFields(new Field('hello2')), 'hello3': mergedFields(new Field('hello3'))])
+                .fields(mergedSelectionSet(['hello': mergedFields(new Field('hello')), 'hello2': mergedFields(new Field('hello2')), 'hello3': mergedFields(new Field('hello3'))]))
                 .build()
 
         AsyncSerialExecutionStrategy strategy = new AsyncSerialExecutionStrategy()

--- a/src/test/groovy/graphql/execution/BreadthFirstExecutionTestStrategy.java
+++ b/src/test/groovy/graphql/execution/BreadthFirstExecutionTestStrategy.java
@@ -20,7 +20,7 @@ public class BreadthFirstExecutionTestStrategy extends ExecutionStrategy {
 
     @Override
     public CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) throws NonNullableFieldWasNullException {
-        Map<String, MergedFields> fields = parameters.getFields();
+        MergedSelectionSet fields = parameters.getFields();
 
         Map<String, Object> fetchedValues = new LinkedHashMap<>();
 
@@ -33,7 +33,7 @@ public class BreadthFirstExecutionTestStrategy extends ExecutionStrategy {
         // then for every fetched value, complete it
         Map<String, Object> results = new LinkedHashMap<>();
         for (String fieldName : fetchedValues.keySet()) {
-            MergedFields currentField = fields.get(fieldName);
+            MergedFields currentField = fields.getSubField(fieldName);
             Object fetchedValue = fetchedValues.get(fieldName);
 
             ExecutionPath fieldPath = parameters.getPath().segment(fieldName);
@@ -51,8 +51,8 @@ public class BreadthFirstExecutionTestStrategy extends ExecutionStrategy {
         return CompletableFuture.completedFuture(new ExecutionResultImpl(results, executionContext.getErrors()));
     }
 
-    private Object fetchField(ExecutionContext executionContext, ExecutionStrategyParameters parameters, Map<String, MergedFields> fields, String fieldName) {
-        MergedFields currentField = fields.get(fieldName);
+    private Object fetchField(ExecutionContext executionContext, ExecutionStrategyParameters parameters, MergedSelectionSet fields, String fieldName) {
+        MergedFields currentField = fields.getSubField(fieldName);
 
         ExecutionPath fieldPath = parameters.getPath().segment(fieldName);
         ExecutionStrategyParameters newParameters = parameters

--- a/src/test/groovy/graphql/execution/BreadthFirstExecutionTestStrategy.java
+++ b/src/test/groovy/graphql/execution/BreadthFirstExecutionTestStrategy.java
@@ -3,10 +3,8 @@ package graphql.execution;
 import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.Internal;
-import graphql.language.Field;
 
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
@@ -22,7 +20,7 @@ public class BreadthFirstExecutionTestStrategy extends ExecutionStrategy {
 
     @Override
     public CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) throws NonNullableFieldWasNullException {
-        Map<String, List<Field>> fields = parameters.getFields();
+        Map<String, MergedFields> fields = parameters.getFields();
 
         Map<String, Object> fetchedValues = new LinkedHashMap<>();
 
@@ -35,7 +33,7 @@ public class BreadthFirstExecutionTestStrategy extends ExecutionStrategy {
         // then for every fetched value, complete it
         Map<String, Object> results = new LinkedHashMap<>();
         for (String fieldName : fetchedValues.keySet()) {
-            List<Field> currentField = fields.get(fieldName);
+            MergedFields currentField = fields.get(fieldName);
             Object fetchedValue = fetchedValues.get(fieldName);
 
             ExecutionPath fieldPath = parameters.getPath().segment(fieldName);
@@ -53,8 +51,8 @@ public class BreadthFirstExecutionTestStrategy extends ExecutionStrategy {
         return CompletableFuture.completedFuture(new ExecutionResultImpl(results, executionContext.getErrors()));
     }
 
-    private Object fetchField(ExecutionContext executionContext, ExecutionStrategyParameters parameters, Map<String, List<Field>> fields, String fieldName) {
-        List<Field> currentField = fields.get(fieldName);
+    private Object fetchField(ExecutionContext executionContext, ExecutionStrategyParameters parameters, Map<String, MergedFields> fields, String fieldName) {
+        MergedFields currentField = fields.get(fieldName);
 
         ExecutionPath fieldPath = parameters.getPath().segment(fieldName);
         ExecutionStrategyParameters newParameters = parameters

--- a/src/test/groovy/graphql/execution/BreadthFirstTestStrategy.java
+++ b/src/test/groovy/graphql/execution/BreadthFirstTestStrategy.java
@@ -3,7 +3,6 @@ package graphql.execution;
 import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.Internal;
-import graphql.language.Field;
 
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -34,7 +33,7 @@ public class BreadthFirstTestStrategy extends ExecutionStrategy {
     }
 
     private Map<String, Object> fetchFields(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
-        Map<String, List<Field>> fields = parameters.getFields();
+        Map<String, MergedFields> fields = parameters.getFields();
 
         Map<String, CompletableFuture<Object>> fetchFutures = new LinkedHashMap<>();
 
@@ -55,12 +54,12 @@ public class BreadthFirstTestStrategy extends ExecutionStrategy {
     }
 
     private CompletableFuture<ExecutionResult> completeFields(ExecutionContext executionContext, ExecutionStrategyParameters parameters, Map<String, Object> fetchedValues) {
-        Map<String, List<Field>> fields = parameters.getFields();
+        Map<String, MergedFields> fields = parameters.getFields();
 
         // then for every fetched value, complete it, breath first
         Map<String, Object> results = new LinkedHashMap<>();
         for (String fieldName : fetchedValues.keySet()) {
-            List<Field> fieldList = fields.get(fieldName);
+            MergedFields fieldList = fields.get(fieldName);
 
             ExecutionStrategyParameters newParameters = newParameters(parameters, fields, fieldName);
 
@@ -77,8 +76,8 @@ public class BreadthFirstTestStrategy extends ExecutionStrategy {
         return CompletableFuture.completedFuture(new ExecutionResultImpl(results, executionContext.getErrors()));
     }
 
-    private ExecutionStrategyParameters newParameters(ExecutionStrategyParameters parameters, Map<String, List<Field>> fields, String fieldName) {
-        List<Field> currentField = fields.get(fieldName);
+    private ExecutionStrategyParameters newParameters(ExecutionStrategyParameters parameters, Map<String, MergedFields> fields, String fieldName) {
+        MergedFields currentField = fields.get(fieldName);
         ExecutionPath fieldPath = parameters.getPath().segment(fieldName);
         return parameters
                 .transform(builder -> builder.field(currentField).path(fieldPath));

--- a/src/test/groovy/graphql/execution/BreadthFirstTestStrategy.java
+++ b/src/test/groovy/graphql/execution/BreadthFirstTestStrategy.java
@@ -33,7 +33,7 @@ public class BreadthFirstTestStrategy extends ExecutionStrategy {
     }
 
     private Map<String, Object> fetchFields(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
-        Map<String, MergedFields> fields = parameters.getFields();
+        MergedSelectionSet fields = parameters.getFields();
 
         Map<String, CompletableFuture<Object>> fetchFutures = new LinkedHashMap<>();
 
@@ -54,12 +54,12 @@ public class BreadthFirstTestStrategy extends ExecutionStrategy {
     }
 
     private CompletableFuture<ExecutionResult> completeFields(ExecutionContext executionContext, ExecutionStrategyParameters parameters, Map<String, Object> fetchedValues) {
-        Map<String, MergedFields> fields = parameters.getFields();
+        MergedSelectionSet fields = parameters.getFields();
 
         // then for every fetched value, complete it, breath first
         Map<String, Object> results = new LinkedHashMap<>();
         for (String fieldName : fetchedValues.keySet()) {
-            MergedFields fieldList = fields.get(fieldName);
+            MergedFields fieldList = fields.getSubField(fieldName);
 
             ExecutionStrategyParameters newParameters = newParameters(parameters, fields, fieldName);
 
@@ -76,8 +76,8 @@ public class BreadthFirstTestStrategy extends ExecutionStrategy {
         return CompletableFuture.completedFuture(new ExecutionResultImpl(results, executionContext.getErrors()));
     }
 
-    private ExecutionStrategyParameters newParameters(ExecutionStrategyParameters parameters, Map<String, MergedFields> fields, String fieldName) {
-        MergedFields currentField = fields.get(fieldName);
+    private ExecutionStrategyParameters newParameters(ExecutionStrategyParameters parameters, MergedSelectionSet fields, String fieldName) {
+        MergedFields currentField = fields.getSubField(fieldName);
         ExecutionPath fieldPath = parameters.getPath().segment(fieldName);
         return parameters
                 .transform(builder -> builder.field(currentField).path(fieldPath));

--- a/src/test/groovy/graphql/execution/ExecutionStepInfoTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStepInfoTest.groovy
@@ -17,6 +17,7 @@ import java.util.function.Function
 
 import static ExecutionStepInfo.newExecutionStepInfo
 import static graphql.Scalars.GraphQLString
+import static graphql.TestUtil.mergedFields
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
 import static graphql.schema.GraphQLList.list
 import static graphql.schema.GraphQLNonNull.nonNull
@@ -27,6 +28,7 @@ import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring
 class ExecutionStepInfoTest extends Specification {
 
     def field = new Field("someAstField")
+    def mergedFields = mergedFields(field)
 
     def field1Def = newFieldDefinition().name("field1").type(GraphQLString).build()
 
@@ -49,7 +51,7 @@ class ExecutionStepInfoTest extends Specification {
     def "basic hierarchy"() {
         given:
         def rootTypeInfo = newExecutionStepInfo().type(rootType).build()
-        def fieldTypeInfo = newExecutionStepInfo().type(fieldType).fieldDefinition(field1Def).field(field).parentInfo(rootTypeInfo).build()
+        def fieldTypeInfo = newExecutionStepInfo().type(fieldType).fieldDefinition(field1Def).field(mergedFields).parentInfo(rootTypeInfo).build()
         def nonNullFieldTypeInfo = newExecutionStepInfo().type(nonNull(fieldType)).parentInfo(rootTypeInfo).build()
         def listTypeInfo = newExecutionStepInfo().type(list(fieldType)).parentInfo(rootTypeInfo).build()
 
@@ -64,7 +66,7 @@ class ExecutionStepInfoTest extends Specification {
         fieldTypeInfo.parent.type == rootType
         !fieldTypeInfo.isNonNullType()
         fieldTypeInfo.getFieldDefinition() == field1Def
-        fieldTypeInfo.getField() == field
+        fieldTypeInfo.getField() == mergedFields
 
         nonNullFieldTypeInfo.getUnwrappedNonNullType() == fieldType
         nonNullFieldTypeInfo.hasParent()

--- a/src/test/groovy/graphql/execution/ExecutionStrategyParametersTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategyParametersTest.groovy
@@ -1,9 +1,11 @@
 package graphql.execution
 
+
 import spock.lang.Specification
 
 import static ExecutionStepInfo.newExecutionStepInfo
 import static graphql.Scalars.GraphQLString
+import static graphql.TestUtil.mergedSelectionSet
 import static graphql.execution.ExecutionStrategyParameters.newParameters
 
 class ExecutionStrategyParametersTest extends Specification {
@@ -13,7 +15,7 @@ class ExecutionStrategyParametersTest extends Specification {
         def parameters = newParameters()
                 .executionStepInfo(newExecutionStepInfo().type(GraphQLString))
                 .source(new Object())
-                .fields("a": [])
+                .fields(mergedSelectionSet("a": []))
                 .build()
 
         when:

--- a/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
@@ -30,6 +30,7 @@ import java.util.concurrent.CompletionException
 
 import static ExecutionStrategyParameters.newParameters
 import static graphql.Scalars.GraphQLString
+import static graphql.TestUtil.mergedFields
 import static graphql.schema.GraphQLArgument.newArgument
 import static graphql.schema.GraphQLEnumType.newEnum
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
@@ -97,7 +98,7 @@ class ExecutionStrategyTest extends Specification {
                 .executionStepInfo(ExecutionStepInfo.newExecutionStepInfo().type(objectType))
                 .source(result)
                 .fields(["fld": [Field.newField().build()]])
-                .field([Field.newField().build()])
+                .field(mergedFields(Field.newField().build()))
                 .build()
 
         when:
@@ -126,7 +127,7 @@ class ExecutionStrategyTest extends Specification {
                 .source(result)
                 .nonNullFieldValidator(nullableFieldValidator)
                 .fields(["fld": []])
-                .field([field])
+                .field(mergedFields(field))
                 .build()
 
         when:
@@ -341,7 +342,7 @@ class ExecutionStrategyTest extends Specification {
                 .source(result)
                 .nonNullFieldValidator(nullableFieldValidator)
                 .fields(["fld": []])
-                .field([new Field("someField")])
+                .field(mergedFields(new Field("someField")))
                 .build()
 
         when:
@@ -487,7 +488,7 @@ class ExecutionStrategyTest extends Specification {
                 .executionStepInfo(typeInfo)
                 .source("source")
                 .fields(["someField": [field]])
-                .field([field])
+                .field(mergedFields(field))
                 .nonNullFieldValidator(nullableFieldValidator)
                 .path(executionPath)
                 .build()
@@ -536,7 +537,7 @@ class ExecutionStrategyTest extends Specification {
                 .executionStepInfo(typeInfo)
                 .source("source")
                 .fields(["someField": [field]])
-                .field([field])
+                .field(mergedFields(field))
                 .path(expectedPath)
                 .nonNullFieldValidator(nullableFieldValidator)
                 .build()
@@ -639,8 +640,8 @@ class ExecutionStrategyTest extends Specification {
                 .executionStepInfo(typeInfo)
                 .source(null)
                 .nonNullFieldValidator(nullableFieldValidator)
-                .field([field])
-                .fields(["someField": [field]])
+                .field(mergedFields(field))
+                .fields(["someField": [mergedFields(field)]])
                 .path(ExecutionPath.rootPath().segment("abc"))
                 .build()
 
@@ -666,8 +667,8 @@ class ExecutionStrategyTest extends Specification {
                 .executionStepInfo(executionStepInfo)
                 .source(result)
                 .nonNullFieldValidator(nullableFieldValidator)
-                .fields(["fld": [Field.newField().build()]])
-                .field([Field.newField().build()])
+                .fields(["fld": [mergedFields(Field.newField().build())]])
+                .field(mergedFields(Field.newField().build()))
                 .build()
 
         when:
@@ -687,8 +688,8 @@ class ExecutionStrategyTest extends Specification {
         def field = Field.newField("parent").sourceLocation(new SourceLocation(5, 10)).build()
         def parameters = newParameters()
                 .path(ExecutionPath.fromList(["parent"]))
-                .field([field])
-                .fields(["parent": [field]])
+                .field(mergedFields(field))
+                .fields(["parent": [mergedFields(field)]])
                 .executionStepInfo(executionStepInfo)
                 .build()
 
@@ -714,8 +715,8 @@ class ExecutionStrategyTest extends Specification {
         def field = Field.newField("parent").sourceLocation(new SourceLocation(5, 10)).build()
         def parameters = newParameters()
                 .path(ExecutionPath.fromList(["parent"]))
-                .field([field])
-                .fields(["parent": [field]])
+                .field(mergedFields(field))
+                .fields(["parent": [mergedFields(field)]])
                 .executionStepInfo(executionStepInfo)
                 .build()
 
@@ -744,8 +745,8 @@ class ExecutionStrategyTest extends Specification {
                 .executionStepInfo(executionStepInfo)
                 .source(result)
                 .nonNullFieldValidator(nullableFieldValidator)
-                .fields(["fld": [Field.newField().build()]])
-                .field([Field.newField().build()])
+                .fields(["fld": [mergedFields(Field.newField().build())]])
+                .field(mergedFields(Field.newField().build()))
                 .build()
 
         when:
@@ -768,8 +769,8 @@ class ExecutionStrategyTest extends Specification {
                 .executionStepInfo(typeInfo)
                 .source(result)
                 .nonNullFieldValidator(nullableFieldValidator)
-                .fields(["fld": [Field.newField().build()]])
-                .field([Field.newField().build()])
+                .fields(["fld": [mergedFields(Field.newField().build())]])
+                .field(mergedFields(Field.newField().build()))
                 .build()
 
         when:

--- a/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
@@ -31,6 +31,7 @@ import java.util.concurrent.CompletionException
 import static ExecutionStrategyParameters.newParameters
 import static graphql.Scalars.GraphQLString
 import static graphql.TestUtil.mergedFields
+import static graphql.TestUtil.mergedSelectionSet
 import static graphql.schema.GraphQLArgument.newArgument
 import static graphql.schema.GraphQLEnumType.newEnum
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
@@ -97,7 +98,7 @@ class ExecutionStrategyTest extends Specification {
         def parameters = newParameters()
                 .executionStepInfo(ExecutionStepInfo.newExecutionStepInfo().type(objectType))
                 .source(result)
-                .fields(["fld": [Field.newField().build()]])
+                .fields(mergedSelectionSet(["fld": [Field.newField().build()]]))
                 .field(mergedFields(Field.newField().build()))
                 .build()
 
@@ -126,7 +127,7 @@ class ExecutionStrategyTest extends Specification {
                 .executionStepInfo(executionStepInfo)
                 .source(result)
                 .nonNullFieldValidator(nullableFieldValidator)
-                .fields(["fld": []])
+                .fields(mergedSelectionSet(["fld": []]))
                 .field(mergedFields(field))
                 .build()
 
@@ -148,7 +149,7 @@ class ExecutionStrategyTest extends Specification {
                 .executionStepInfo(executionStepInfo)
                 .nonNullFieldValidator(nullableFieldValidator)
                 .source(result)
-                .fields(["fld": []])
+                .fields(mergedSelectionSet(["fld": []]))
                 .build()
 
         when:
@@ -174,7 +175,7 @@ class ExecutionStrategyTest extends Specification {
                 .executionStepInfo(executionStepInfo)
                 .nonNullFieldValidator(nullableFieldValidator)
                 .source(Optional.ofNullable(null))
-                .fields(["fld": []])
+                .fields(mergedSelectionSet(["fld": []]))
                 .build()
 
         when:
@@ -196,7 +197,7 @@ class ExecutionStrategyTest extends Specification {
                 .executionStepInfo(executionStepInfo)
                 .nonNullFieldValidator(nullableFieldValidator)
                 .source(result)
-                .fields(["fld": []])
+                .fields(mergedSelectionSet(["fld": []]))
                 .build()
 
         when:
@@ -222,7 +223,7 @@ class ExecutionStrategyTest extends Specification {
                 .executionStepInfo(executionStepInfo)
                 .nonNullFieldValidator(nullableFieldValidator)
                 .source(OptionalInt.empty())
-                .fields(["fld": []])
+                .fields(mergedSelectionSet(["fld": []]))
                 .build()
 
         when:
@@ -244,7 +245,7 @@ class ExecutionStrategyTest extends Specification {
                 .executionStepInfo(executionStepInfo)
                 .nonNullFieldValidator(nullableFieldValidator)
                 .source(result)
-                .fields(["fld": []])
+                .fields(mergedSelectionSet(["fld": []]))
                 .build()
 
         when:
@@ -270,7 +271,7 @@ class ExecutionStrategyTest extends Specification {
                 .executionStepInfo(typeInfo)
                 .nonNullFieldValidator(nullableFieldValidator)
                 .source(OptionalDouble.empty())
-                .fields(["fld": []])
+                .fields(mergedSelectionSet(["fld": []]))
                 .build()
 
         when:
@@ -292,7 +293,7 @@ class ExecutionStrategyTest extends Specification {
                 .executionStepInfo(typeInfo)
                 .nonNullFieldValidator(nullableFieldValidator)
                 .source(result)
-                .fields(["fld": []])
+                .fields(mergedSelectionSet(["fld": []]))
                 .build()
 
         when:
@@ -318,7 +319,7 @@ class ExecutionStrategyTest extends Specification {
                 .executionStepInfo(typeInfo)
                 .nonNullFieldValidator(nullableFieldValidator)
                 .source(OptionalLong.empty())
-                .fields(["fld": []])
+                .fields(mergedSelectionSet(["fld": []]))
                 .build()
 
         when:
@@ -341,7 +342,7 @@ class ExecutionStrategyTest extends Specification {
                 .executionStepInfo(executionStepInfo)
                 .source(result)
                 .nonNullFieldValidator(nullableFieldValidator)
-                .fields(["fld": []])
+                .fields(mergedSelectionSet(["fld": []]))
                 .field(mergedFields(new Field("someField")))
                 .build()
 
@@ -364,7 +365,7 @@ class ExecutionStrategyTest extends Specification {
                 .executionStepInfo(typeInfo)
                 .source(result)
                 .nonNullFieldValidator(nullableFieldValidator)
-                .fields(["dummy": []])
+                .fields(mergedSelectionSet(["dummy": []]))
                 .build()
 
         when:
@@ -389,7 +390,7 @@ class ExecutionStrategyTest extends Specification {
                 .executionStepInfo(typeInfo)
                 .source(result)
                 .nonNullFieldValidator(nullableFieldValidator)
-                .fields(["dummy": []])
+                .fields(mergedSelectionSet(["dummy": []]))
                 .build()
 
         when:
@@ -434,7 +435,7 @@ class ExecutionStrategyTest extends Specification {
         def parameters = newParameters()
                 .executionStepInfo(ExecutionStepInfo.newExecutionStepInfo().type(fieldType))
                 .source(result)
-                .fields(["dummy": []])
+                .fields(mergedSelectionSet(["dummy": []]))
                 .nonNullFieldValidator(nullableFieldValidator)
                 .build()
 
@@ -487,7 +488,7 @@ class ExecutionStrategyTest extends Specification {
         def parameters = newParameters()
                 .executionStepInfo(typeInfo)
                 .source("source")
-                .fields(["someField": [field]])
+                .fields(mergedSelectionSet(["someField": [field]]))
                 .field(mergedFields(field))
                 .nonNullFieldValidator(nullableFieldValidator)
                 .path(executionPath)
@@ -536,7 +537,7 @@ class ExecutionStrategyTest extends Specification {
         def parameters = newParameters()
                 .executionStepInfo(typeInfo)
                 .source("source")
-                .fields(["someField": [field]])
+                .fields(mergedSelectionSet(["someField": [field]]))
                 .field(mergedFields(field))
                 .path(expectedPath)
                 .nonNullFieldValidator(nullableFieldValidator)
@@ -641,7 +642,7 @@ class ExecutionStrategyTest extends Specification {
                 .source(null)
                 .nonNullFieldValidator(nullableFieldValidator)
                 .field(mergedFields(field))
-                .fields(["someField": [mergedFields(field)]])
+                .fields(mergedSelectionSet(["someField": [mergedFields(field)]]))
                 .path(ExecutionPath.rootPath().segment("abc"))
                 .build()
 
@@ -667,7 +668,7 @@ class ExecutionStrategyTest extends Specification {
                 .executionStepInfo(executionStepInfo)
                 .source(result)
                 .nonNullFieldValidator(nullableFieldValidator)
-                .fields(["fld": [mergedFields(Field.newField().build())]])
+                .fields(mergedSelectionSet(["fld": [mergedFields(Field.newField().build())]]))
                 .field(mergedFields(Field.newField().build()))
                 .build()
 
@@ -689,7 +690,7 @@ class ExecutionStrategyTest extends Specification {
         def parameters = newParameters()
                 .path(ExecutionPath.fromList(["parent"]))
                 .field(mergedFields(field))
-                .fields(["parent": [mergedFields(field)]])
+                .fields(mergedSelectionSet(["parent": [mergedFields(field)]]))
                 .executionStepInfo(executionStepInfo)
                 .build()
 
@@ -716,7 +717,7 @@ class ExecutionStrategyTest extends Specification {
         def parameters = newParameters()
                 .path(ExecutionPath.fromList(["parent"]))
                 .field(mergedFields(field))
-                .fields(["parent": [mergedFields(field)]])
+                .fields(mergedSelectionSet(["parent": [mergedFields(field)]]))
                 .executionStepInfo(executionStepInfo)
                 .build()
 
@@ -745,7 +746,7 @@ class ExecutionStrategyTest extends Specification {
                 .executionStepInfo(executionStepInfo)
                 .source(result)
                 .nonNullFieldValidator(nullableFieldValidator)
-                .fields(["fld": [mergedFields(Field.newField().build())]])
+                .fields(mergedSelectionSet(["fld": [mergedFields(Field.newField().build())]]))
                 .field(mergedFields(Field.newField().build()))
                 .build()
 
@@ -769,7 +770,7 @@ class ExecutionStrategyTest extends Specification {
                 .executionStepInfo(typeInfo)
                 .source(result)
                 .nonNullFieldValidator(nullableFieldValidator)
-                .fields(["fld": [mergedFields(Field.newField().build())]])
+                .fields(mergedSelectionSet(["fld": [mergedFields(Field.newField().build())]]))
                 .field(mergedFields(Field.newField().build()))
                 .build()
 

--- a/src/test/groovy/graphql/execution/FieldCollectorTest.groovy
+++ b/src/test/groovy/graphql/execution/FieldCollectorTest.groovy
@@ -39,8 +39,8 @@ class FieldCollectorTest extends Specification {
         def result = fieldCollector.collectFields(fieldCollectorParameters, mergedFields(field))
 
         then:
-        result['bar1'].getFields() == [bar1]
-        result['bar2'].getFields() == [bar2]
+        result.getSubField('bar1').getFields() == [bar1]
+        result.getSubField('bar2').getFields() == [bar2]
     }
 
     def "collect fields on inline fragments"() {
@@ -72,7 +72,7 @@ class FieldCollectorTest extends Specification {
         def result = fieldCollector.collectFields(fieldCollectorParameters, mergedFields(bar1Field))
 
         then:
-        result['fieldOnInterface'].getFields() == [interfaceField]
+        result.getSubField('fieldOnInterface').getFields() == [interfaceField]
 
     }
 }

--- a/src/test/groovy/graphql/execution/FieldCollectorTest.groovy
+++ b/src/test/groovy/graphql/execution/FieldCollectorTest.groovy
@@ -9,6 +9,7 @@ import graphql.parser.Parser
 import graphql.schema.GraphQLObjectType
 import spock.lang.Specification
 
+import static graphql.TestUtil.mergedFields
 import static graphql.execution.FieldCollectorParameters.newParameters
 
 class FieldCollectorTest extends Specification {
@@ -35,11 +36,11 @@ class FieldCollectorTest extends Specification {
         def bar2 = field.selectionSet.selections[1]
 
         when:
-        def result = fieldCollector.collectFields(fieldCollectorParameters, [field])
+        def result = fieldCollector.collectFields(fieldCollectorParameters, mergedFields(field))
 
         then:
-        result['bar1'] == [bar1]
-        result['bar2'] == [bar2]
+        result['bar1'].getFields() == [bar1]
+        result['bar2'].getFields() == [bar2]
     }
 
     def "collect fields on inline fragments"() {
@@ -68,10 +69,10 @@ class FieldCollectorTest extends Specification {
         def interfaceField = inlineFragment.selectionSet.selections[0]
 
         when:
-        def result = fieldCollector.collectFields(fieldCollectorParameters, [bar1Field])
+        def result = fieldCollector.collectFields(fieldCollectorParameters, mergedFields(bar1Field))
 
         then:
-        result['fieldOnInterface'] == [interfaceField]
+        result['fieldOnInterface'].getFields() == [interfaceField]
 
     }
 }

--- a/src/test/groovy/graphql/execution/defer/DeferSupportTest.groovy
+++ b/src/test/groovy/graphql/execution/defer/DeferSupportTest.groovy
@@ -9,6 +9,8 @@ import spock.lang.Specification
 
 import java.util.concurrent.CompletableFuture
 
+import static graphql.TestUtil.mergedFields
+
 class DeferSupportTest extends Specification {
 
 
@@ -175,19 +177,19 @@ class DeferSupportTest extends Specification {
         def deferSupport = new DeferSupport()
 
         when:
-        def noDirectivePresent = deferSupport.checkForDeferDirective([
+        def noDirectivePresent = deferSupport.checkForDeferDirective(mergedFields([
                 new Field("a"),
-                new Field("b")
-        ])
+                new Field("a")
+        ]))
 
         then:
         !noDirectivePresent
 
         when:
-        def directivePresent = deferSupport.checkForDeferDirective([
+        def directivePresent = deferSupport.checkForDeferDirective(mergedFields([
                 Field.newField("a").directives([new Directive("defer")]).build(),
-                new Field("b")
-        ])
+                new Field("a")
+        ]))
 
         then:
         directivePresent

--- a/src/test/groovy/graphql/schema/DataFetcherSelectionTest.groovy
+++ b/src/test/groovy/graphql/schema/DataFetcherSelectionTest.groovy
@@ -49,7 +49,7 @@ class DataFetcherSelectionTest extends Specification {
 
             if (!selectionSet.isEmpty()) {
                 for (String fieldName : selectionSet.keySet()) {
-                    String ast = captureFields(selectionSet.get(fieldName))
+                    String ast = captureFields(selectionSet.get(fieldName).getFields())
                     captureMap.put(fieldName, ast)
                 }
             }

--- a/src/test/groovy/graphql/schema/DataFetcherSelectionTest.groovy
+++ b/src/test/groovy/graphql/schema/DataFetcherSelectionTest.groovy
@@ -49,7 +49,7 @@ class DataFetcherSelectionTest extends Specification {
 
             if (!selectionSet.isEmpty()) {
                 for (String fieldName : selectionSet.keySet()) {
-                    String ast = captureFields(selectionSet.get(fieldName).getFields())
+                    String ast = captureFields(selectionSet.getSubField(fieldName).getFields())
                     captureMap.put(fieldName, ast)
                 }
             }

--- a/src/test/groovy/graphql/schema/DataFetchingFieldSelectionSetImplTest.groovy
+++ b/src/test/groovy/graphql/schema/DataFetchingFieldSelectionSetImplTest.groovy
@@ -11,6 +11,8 @@ import graphql.language.NodeUtil
 import graphql.language.OperationDefinition
 import spock.lang.Specification
 
+import static graphql.TestUtil.mergedFields
+
 class DataFetchingFieldSelectionSetImplTest extends Specification {
 
     def starWarsSchema = TestUtil.schemaFile("starWarsSchemaWithArguments.graphqls")
@@ -64,7 +66,7 @@ class DataFetchingFieldSelectionSetImplTest extends Specification {
                 .fragmentsByName(getFragments(document))
                 .graphQLSchema(starWarsSchema).build()
 
-        def selectionSet = DataFetchingFieldSelectionSetImpl.newCollector(executionContext, starWarsSchema.getType('Human'), fields)
+        def selectionSet = DataFetchingFieldSelectionSetImpl.newCollector(executionContext, starWarsSchema.getType('Human'), mergedFields(fields))
 
         expect:
         !selectionSet.contains(null)
@@ -120,7 +122,7 @@ class DataFetchingFieldSelectionSetImplTest extends Specification {
                 .fragmentsByName(getFragments(document))
                 .graphQLSchema(starWarsSchema).build()
 
-        def selectionSet = DataFetchingFieldSelectionSetImpl.newCollector(executionContext, starWarsSchema.getType('Human'), fields)
+        def selectionSet = DataFetchingFieldSelectionSetImpl.newCollector(executionContext, starWarsSchema.getType('Human'), mergedFields(fields))
 
         def fieldMap = selectionSet.get()
         expect:
@@ -149,7 +151,7 @@ class DataFetchingFieldSelectionSetImplTest extends Specification {
                 .fragmentsByName(getFragments(document))
                 .graphQLSchema(starWarsSchema).build()
 
-        def selectionSet = DataFetchingFieldSelectionSetImpl.newCollector(executionContext, starWarsSchema.getType('Human'), fields)
+        def selectionSet = DataFetchingFieldSelectionSetImpl.newCollector(executionContext, starWarsSchema.getType('Human'), mergedFields(fields))
 
         expect:
 
@@ -170,7 +172,7 @@ class DataFetchingFieldSelectionSetImplTest extends Specification {
                 .fragmentsByName(getFragments(document))
                 .graphQLSchema(starWarsSchema).build()
 
-        def selectionSet = DataFetchingFieldSelectionSetImpl.newCollector(executionContext, starWarsSchema.getType('Human'), fields)
+        def selectionSet = DataFetchingFieldSelectionSetImpl.newCollector(executionContext, starWarsSchema.getType('Human'), mergedFields(fields))
 
         expect:
 
@@ -239,7 +241,7 @@ class DataFetchingFieldSelectionSetImplTest extends Specification {
         def startingType = replaySchema.getType('ThingConnection')
 
         when:
-        def selectionSet = DataFetchingFieldSelectionSetImpl.newCollector(replayExecutionContext, startingType, startField)
+        def selectionSet = DataFetchingFieldSelectionSetImpl.newCollector(replayExecutionContext, startingType, mergedFields(startField))
 
         def selectedNodesField = selectionSet.getField("nodes")
 
@@ -288,7 +290,7 @@ class DataFetchingFieldSelectionSetImplTest extends Specification {
         def startingType = replaySchema.getType('ThingConnection')
 
         when:
-        def selectionSet = DataFetchingFieldSelectionSetImpl.newCollector(replayExecutionContext, startingType, startField)
+        def selectionSet = DataFetchingFieldSelectionSetImpl.newCollector(replayExecutionContext, startingType, mergedFields(startField))
         List<SelectedField> selectedUnderNodesAster = selectionSet.getFields("nodes/*")
 
         then:
@@ -319,7 +321,7 @@ class DataFetchingFieldSelectionSetImplTest extends Specification {
         def startingType = replaySchema.getType('ThingConnection')
 
         when:
-        def selectionSet = DataFetchingFieldSelectionSetImpl.newCollector(replayExecutionContext, startingType, startField)
+        def selectionSet = DataFetchingFieldSelectionSetImpl.newCollector(replayExecutionContext, startingType, mergedFields(startField))
         List<SelectedField> allFieldsViaAsterAster = selectionSet.getFields("**")
         List<SelectedField> allFields = selectionSet.getFields()
 


### PR DESCRIPTION
This introduces the class `MergedFields` which encapsulates merged Fields in an explicit type instead of just using `List<Field>`.

It also adds the related `MergedSelectionSet` which builds on top of `MergedFields` and is how 
the merged field results are represented in the execution results.

It changes a couple of places to use the new classes:

`DataFetchingEnvironment.getFields()` is now deprecated in favour of `getMergedFields()`. 

Breaking changes:
- `DataFetcherExceptionHandlerParameters.getField()` is now a MergedFields instead of just Field
- `TypeResolutionParameters.getField()` is now a MergedFields instead of just Field
- `ExecutionStepInfo.getField()` is now a MergedFields instead of just Field
- `ExecutionStrategyParameters.getField()` returns now MergedField instead of List<Field> and getFields() returns MergedSelectionSet
- `DataFetchingFieldSelectionSet: get()` returns  instead of Map<String,List<Field>


