### PR TITLE
[RFC] Support executing multiple operations in a single query

### DIFF
--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -56,9 +56,9 @@ public class Execution {
         this.instrumentation = instrumentation;
     }
 
-    public CompletableFuture<ExecutionResult> execute(Document document, GraphQLSchema graphQLSchema, ExecutionId executionId, ExecutionInput executionInput, InstrumentationState instrumentationState) {
+    public CompletableFuture<ExecutionResult> execute(Document document, GraphQLSchema graphQLSchema, ExecutionId executionId, ExecutionInput executionInput, String operationName, InstrumentationState instrumentationState) {
 
-        NodeUtil.GetOperationResult getOperationResult = NodeUtil.getOperation(document, executionInput.getOperationName());
+        NodeUtil.GetOperationResult getOperationResult = NodeUtil.getOperation(document, operationName);
         Map<String, FragmentDefinition> fragmentsByName = getOperationResult.fragmentsByName;
         OperationDefinition operationDefinition = getOperationResult.operationDefinition;
 
@@ -94,7 +94,7 @@ public class Execution {
 
 
         InstrumentationExecutionParameters parameters = new InstrumentationExecutionParameters(
-                executionInput, graphQLSchema, instrumentationState
+                executionInput, operationName, graphQLSchema, instrumentationState
         );
         executionContext = instrumentation.instrumentExecutionContext(executionContext, parameters);
         return executeOperation(executionContext, parameters, executionInput.getRoot(), executionContext.getOperationDefinition());

--- a/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationExecutionParameters.java
+++ b/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationExecutionParameters.java
@@ -22,10 +22,10 @@ public class InstrumentationExecutionParameters {
     private final InstrumentationState instrumentationState;
     private final GraphQLSchema schema;
 
-    public InstrumentationExecutionParameters(ExecutionInput executionInput, GraphQLSchema schema, InstrumentationState instrumentationState) {
+    public InstrumentationExecutionParameters(ExecutionInput executionInput, String operationName, GraphQLSchema schema, InstrumentationState instrumentationState) {
         this.executionInput = executionInput;
         this.query = executionInput.getQuery();
-        this.operation = executionInput.getOperationName();
+        this.operation = operationName;
         this.context = executionInput.getContext();
         this.variables = executionInput.getVariables() != null ? executionInput.getVariables() : Collections.emptyMap();
         this.instrumentationState = instrumentationState;
@@ -40,7 +40,7 @@ public class InstrumentationExecutionParameters {
      * @return a new parameters object with the new state
      */
     public InstrumentationExecutionParameters withNewState(InstrumentationState instrumentationState) {
-        return new InstrumentationExecutionParameters(this.getExecutionInput(), this.schema, instrumentationState);
+        return new InstrumentationExecutionParameters(this.getExecutionInput(), this.operation, this.schema, instrumentationState);
     }
 
     public ExecutionInput getExecutionInput() {

--- a/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationValidationParameters.java
+++ b/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationValidationParameters.java
@@ -12,8 +12,8 @@ import graphql.schema.GraphQLSchema;
 public class InstrumentationValidationParameters extends InstrumentationExecutionParameters {
     private final Document document;
 
-    public InstrumentationValidationParameters(ExecutionInput executionInput, Document document, GraphQLSchema schema, InstrumentationState instrumentationState) {
-        super(executionInput, schema, instrumentationState);
+    public InstrumentationValidationParameters(ExecutionInput executionInput, String operationName, Document document, GraphQLSchema schema, InstrumentationState instrumentationState) {
+        super(executionInput, operationName, schema, instrumentationState);
         this.document = document;
     }
 
@@ -27,7 +27,7 @@ public class InstrumentationValidationParameters extends InstrumentationExecutio
     @Override
     public InstrumentationValidationParameters withNewState(InstrumentationState instrumentationState) {
         return new InstrumentationValidationParameters(
-                this.getExecutionInput(), document, getSchema(), instrumentationState);
+                this.getExecutionInput(), getOperation(), document, getSchema(), instrumentationState);
     }
 
 

--- a/src/main/java/graphql/execution/nextgen/Execution.java
+++ b/src/main/java/graphql/execution/nextgen/Execution.java
@@ -35,11 +35,13 @@ public class Execution {
 
     private final FieldCollector fieldCollector = new FieldCollector();
 
-    public CompletableFuture<ExecutionResult> execute(Class<? extends ExecutionStrategy> executionStrategy, Document document,
+    public CompletableFuture<ExecutionResult> execute(Class<? extends ExecutionStrategy> executionStrategy,
+                                                      Document document,
                                                       GraphQLSchema graphQLSchema,
                                                       ExecutionId executionId,
-                                                      ExecutionInput executionInput) {
-        NodeUtil.GetOperationResult getOperationResult = NodeUtil.getOperation(document, executionInput.getOperationName());
+                                                      ExecutionInput executionInput,
+                                                      String operationName) {
+        NodeUtil.GetOperationResult getOperationResult = NodeUtil.getOperation(document, operationName);
         Map<String, FragmentDefinition> fragmentsByName = getOperationResult.fragmentsByName;
         OperationDefinition operationDefinition = getOperationResult.operationDefinition;
 

--- a/src/test/groovy/graphql/GraphQLTest.groovy
+++ b/src/test/groovy/graphql/GraphQLTest.groovy
@@ -232,6 +232,33 @@ class GraphQLTest extends Specification {
         result.errors.size() == 0
     }
 
+    def "document with two operations executes them both in sequence"() {
+        given:
+
+        GraphQLSchema schema = newSchema().query(
+                newObject()
+                        .name("RootQueryType")
+                        .field(newFieldDefinition().name("field1").type(GraphQLString).dataFetcher(new StaticDataFetcher("value1")))
+                        .field(newFieldDefinition().name("field2").type(GraphQLString).dataFetcher(new StaticDataFetcher("value2")))
+        )
+                .build()
+
+        def query = """
+        query Query1 { field1 }
+        query Query2 { field2 }
+        """
+
+        def expected = [field2: 'value2']
+
+        when:
+        def executionInput = newExecutionInput().query(query).operationNames('Query1', 'Query2').context(null).variables([:])
+        def result = GraphQL.newGraphQL(schema).build().execute(executionInput)
+
+        then:
+        result.data == expected
+        result.errors.size() == 0
+    }
+
     def "document with two operations but no specified operation throws"() {
         given:
 

--- a/src/test/groovy/graphql/analysis/MaxQueryComplexityInstrumentationTest.groovy
+++ b/src/test/groovy/graphql/analysis/MaxQueryComplexityInstrumentationTest.groovy
@@ -39,7 +39,7 @@ class MaxQueryComplexityInstrumentationTest extends Specification {
             }
         }
         ExecutionInput executionInput = Mock(ExecutionInput)
-        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, null)
+        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, null, query, schema, null)
         InstrumentationContext instrumentationContext = maxQueryComplexityInstrumentation.beginValidation(validationParameters)
         when:
         instrumentationContext.onCompleted([new ValidationError(ValidationErrorType.SubSelectionNotAllowed)], null)
@@ -67,7 +67,7 @@ class MaxQueryComplexityInstrumentationTest extends Specification {
             }
         }
         ExecutionInput executionInput = Mock(ExecutionInput)
-        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, null)
+        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, null, query, schema, null)
         InstrumentationContext instrumentationContext = maxQueryComplexityInstrumentation.beginValidation(validationParameters)
         when:
         instrumentationContext.onCompleted(null, new RuntimeException())
@@ -93,7 +93,7 @@ class MaxQueryComplexityInstrumentationTest extends Specification {
             """)
         MaxQueryComplexityInstrumentation queryComplexityInstrumentation = new MaxQueryComplexityInstrumentation(10)
         ExecutionInput executionInput = Mock(ExecutionInput)
-        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, null)
+        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, null, query, schema, null)
         InstrumentationContext instrumentationContext = queryComplexityInstrumentation.beginValidation(validationParameters)
         when:
         instrumentationContext.onCompleted(null, null)
@@ -115,7 +115,7 @@ class MaxQueryComplexityInstrumentationTest extends Specification {
             """)
         MaxQueryComplexityInstrumentation queryComplexityInstrumentation = new MaxQueryComplexityInstrumentation(1)
         ExecutionInput executionInput = Mock(ExecutionInput)
-        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, null)
+        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, null, query, schema, null)
         InstrumentationContext instrumentationContext = queryComplexityInstrumentation.beginValidation(validationParameters)
         when:
         instrumentationContext.onCompleted(null, null)
@@ -143,7 +143,7 @@ class MaxQueryComplexityInstrumentationTest extends Specification {
         def calculator = Mock(FieldComplexityCalculator)
         MaxQueryComplexityInstrumentation queryComplexityInstrumentation = new MaxQueryComplexityInstrumentation(5, calculator)
         ExecutionInput executionInput = Mock(ExecutionInput)
-        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, null)
+        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, null, query, schema, null)
         InstrumentationContext instrumentationContext = queryComplexityInstrumentation.beginValidation(validationParameters)
         when:
         instrumentationContext.onCompleted(null, null)
@@ -181,7 +181,7 @@ class MaxQueryComplexityInstrumentationTest extends Specification {
         }
         MaxQueryComplexityInstrumentation queryComplexityInstrumentation = new MaxQueryComplexityInstrumentation(10, maxQueryComplexityExceededFunction)
         ExecutionInput executionInput = Mock(ExecutionInput)
-        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, null)
+        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, null, query, schema, null)
         InstrumentationContext instrumentationContext = queryComplexityInstrumentation.beginValidation(validationParameters)
         when:
         instrumentationContext.onCompleted(null, null)

--- a/src/test/groovy/graphql/analysis/MaxQueryDepthInstrumentationTest.groovy
+++ b/src/test/groovy/graphql/analysis/MaxQueryDepthInstrumentationTest.groovy
@@ -40,7 +40,7 @@ class MaxQueryDepthInstrumentationTest extends Specification {
             }
         }
         ExecutionInput executionInput = Mock(ExecutionInput)
-        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, null)
+        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, null, query, schema, null)
         InstrumentationContext instrumentationContext = maximumQueryDepthInstrumentation.beginValidation(validationParameters)
         when:
         instrumentationContext.onCompleted([new ValidationError(ValidationErrorType.SubSelectionNotAllowed)], null)
@@ -68,7 +68,7 @@ class MaxQueryDepthInstrumentationTest extends Specification {
             }
         }
         ExecutionInput executionInput = Mock(ExecutionInput)
-        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, null)
+        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, null, query, schema, null)
         InstrumentationContext instrumentationContext = maximumQueryDepthInstrumentation.beginValidation(validationParameters)
         when:
         instrumentationContext.onCompleted(null, new RuntimeException())
@@ -94,7 +94,7 @@ class MaxQueryDepthInstrumentationTest extends Specification {
             """)
         MaxQueryDepthInstrumentation maximumQueryDepthInstrumentation = new MaxQueryDepthInstrumentation(6)
         ExecutionInput executionInput = Mock(ExecutionInput)
-        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, null)
+        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, null, query, schema, null)
         InstrumentationContext instrumentationContext = maximumQueryDepthInstrumentation.beginValidation(validationParameters)
         when:
         instrumentationContext.onCompleted(null, null)
@@ -120,7 +120,7 @@ class MaxQueryDepthInstrumentationTest extends Specification {
             """)
         MaxQueryDepthInstrumentation maximumQueryDepthInstrumentation = new MaxQueryDepthInstrumentation(7)
         ExecutionInput executionInput = Mock(ExecutionInput)
-        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, null)
+        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, null, query, schema, null)
         InstrumentationContext instrumentationContext = maximumQueryDepthInstrumentation.beginValidation(validationParameters)
         when:
         instrumentationContext.onCompleted(null, null)
@@ -153,7 +153,7 @@ class MaxQueryDepthInstrumentationTest extends Specification {
         }
         MaxQueryDepthInstrumentation maximumQueryDepthInstrumentation = new MaxQueryDepthInstrumentation(6, maxQueryDepthExceededFunction)
         ExecutionInput executionInput = Mock(ExecutionInput)
-        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, null)
+        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, null, query, schema, null)
         InstrumentationContext instrumentationContext = maximumQueryDepthInstrumentation.beginValidation(validationParameters)
         when:
         instrumentationContext.onCompleted(null, null)

--- a/src/test/groovy/graphql/execution/ExecutionTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionTest.groovy
@@ -55,7 +55,7 @@ class ExecutionTest extends Specification {
         def document = parser.parseDocument(query)
 
         when:
-        execution.execute(document, MutationSchema.schema, ExecutionId.generate(), emptyExecutionInput, instrumentationState)
+        execution.execute(document, MutationSchema.schema, ExecutionId.generate(), emptyExecutionInput, null, instrumentationState)
 
         then:
         queryStrategy.execute == 1
@@ -75,7 +75,7 @@ class ExecutionTest extends Specification {
         def document = parser.parseDocument(query)
 
         when:
-        execution.execute(document, MutationSchema.schema, ExecutionId.generate(), emptyExecutionInput, instrumentationState)
+        execution.execute(document, MutationSchema.schema, ExecutionId.generate(), emptyExecutionInput, null, instrumentationState)
 
         then:
         queryStrategy.execute == 0
@@ -95,7 +95,7 @@ class ExecutionTest extends Specification {
         def document = parser.parseDocument(query)
 
         when:
-        execution.execute(document, MutationSchema.schema, ExecutionId.generate(), emptyExecutionInput, instrumentationState)
+        execution.execute(document, MutationSchema.schema, ExecutionId.generate(), emptyExecutionInput, null, instrumentationState)
 
         then:
         queryStrategy.execute == 0

--- a/src/test/groovy/graphql/execution/instrumentation/fieldvalidation/FieldValidationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/fieldvalidation/FieldValidationTest.groovy
@@ -307,7 +307,7 @@ class FieldValidationTest extends Specification {
         def execution = new Execution(strategy, strategy, strategy, instrumentation)
 
         def executionInput = ExecutionInput.newExecutionInput().query(query).variables(variables).build()
-        execution.execute(document, schema, ExecutionId.generate(), executionInput, SimpleInstrumentation.INSTANCE.createState())
+        execution.execute(document, schema, ExecutionId.generate(), executionInput, null, SimpleInstrumentation.INSTANCE.createState())
     }
 
 }

--- a/src/test/groovy/graphql/execution/nextgen/BatchedExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/nextgen/BatchedExecutionStrategyTest.groovy
@@ -45,7 +45,7 @@ class BatchedExecutionStrategyTest extends Specification {
         Execution execution = new Execution()
 
         when:
-        def monoResult = execution.execute(BatchedExecutionStrategy, document, schema, ExecutionId.generate(), executionInput)
+        def monoResult = execution.execute(BatchedExecutionStrategy, document, schema, ExecutionId.generate(), executionInput, null)
         def result = monoResult.get()
 
 
@@ -93,7 +93,7 @@ class BatchedExecutionStrategyTest extends Specification {
         Execution execution = new Execution();
 
         when:
-        def monoResult = execution.execute(BatchedExecutionStrategy, document, schema, ExecutionId.generate(), executionInput)
+        def monoResult = execution.execute(BatchedExecutionStrategy, document, schema, ExecutionId.generate(), executionInput, null)
         def result = monoResult.get()
 
 
@@ -140,7 +140,7 @@ class BatchedExecutionStrategyTest extends Specification {
         Execution execution = new Execution()
 
         when:
-        def monoResult = execution.execute(BatchedExecutionStrategy, document, schema, ExecutionId.generate(), executionInput)
+        def monoResult = execution.execute(BatchedExecutionStrategy, document, schema, ExecutionId.generate(), executionInput, null)
         def result = monoResult.get()
 
 
@@ -187,7 +187,7 @@ class BatchedExecutionStrategyTest extends Specification {
         Execution execution = new Execution()
 
         when:
-        def monoResult = execution.execute(BatchedExecutionStrategy, document, schema, ExecutionId.generate(), executionInput)
+        def monoResult = execution.execute(BatchedExecutionStrategy, document, schema, ExecutionId.generate(), executionInput, null)
         def result = monoResult.get()
 
 
@@ -237,7 +237,7 @@ class BatchedExecutionStrategyTest extends Specification {
         Execution execution = new Execution()
 
         when:
-        def monoResult = execution.execute(BatchedExecutionStrategy, document, schema, ExecutionId.generate(), executionInput)
+        def monoResult = execution.execute(BatchedExecutionStrategy, document, schema, ExecutionId.generate(), executionInput, null)
         def result = monoResult.get()
 
 
@@ -287,7 +287,7 @@ class BatchedExecutionStrategyTest extends Specification {
         Execution execution = new Execution()
 
         when:
-        def monoResult = execution.execute(BatchedExecutionStrategy, document, schema, ExecutionId.generate(), executionInput)
+        def monoResult = execution.execute(BatchedExecutionStrategy, document, schema, ExecutionId.generate(), executionInput, null)
         def result = monoResult.get()
 
 
@@ -335,7 +335,7 @@ class BatchedExecutionStrategyTest extends Specification {
         Execution execution = new Execution()
 
         when:
-        def monoResult = execution.execute(BatchedExecutionStrategy, document, schema, ExecutionId.generate(), executionInput)
+        def monoResult = execution.execute(BatchedExecutionStrategy, document, schema, ExecutionId.generate(), executionInput, null)
         def result = monoResult.get()
 
 
@@ -372,7 +372,7 @@ class BatchedExecutionStrategyTest extends Specification {
         Execution execution = new Execution();
 
         when:
-        def monoResult = execution.execute(BatchedExecutionStrategy, document, schema, ExecutionId.generate(), executionInput)
+        def monoResult = execution.execute(BatchedExecutionStrategy, document, schema, ExecutionId.generate(), executionInput, null)
         def result = monoResult.get()
 
 
@@ -415,7 +415,7 @@ class BatchedExecutionStrategyTest extends Specification {
         Execution execution = new Execution();
 
         when:
-        def monoResult = execution.execute(BatchedExecutionStrategy, document, schema, ExecutionId.generate(), executionInput)
+        def monoResult = execution.execute(BatchedExecutionStrategy, document, schema, ExecutionId.generate(), executionInput, null)
         def result = monoResult.get()
 
 
@@ -453,7 +453,7 @@ class BatchedExecutionStrategyTest extends Specification {
         Execution execution = new Execution();
 
         when:
-        def monoResult = execution.execute(BatchedExecutionStrategy, document, schema, ExecutionId.generate(), executionInput)
+        def monoResult = execution.execute(BatchedExecutionStrategy, document, schema, ExecutionId.generate(), executionInput, null)
         def result = monoResult.get()
 
 

--- a/src/test/groovy/graphql/execution/nextgen/DefaultExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/nextgen/DefaultExecutionStrategyTest.groovy
@@ -45,7 +45,7 @@ class DefaultExecutionStrategyTest extends Specification {
         Execution execution = new Execution()
 
         when:
-        def monoResult = execution.execute(DefaultExecutionStrategy, document, schema, ExecutionId.generate(), executionInput)
+        def monoResult = execution.execute(DefaultExecutionStrategy, document, schema, ExecutionId.generate(), executionInput, null)
         def result = monoResult.get()
 
 
@@ -93,7 +93,7 @@ class DefaultExecutionStrategyTest extends Specification {
         Execution execution = new Execution();
 
         when:
-        def monoResult = execution.execute(DefaultExecutionStrategy, document, schema, ExecutionId.generate(), executionInput)
+        def monoResult = execution.execute(DefaultExecutionStrategy, document, schema, ExecutionId.generate(), executionInput, null)
         def result = monoResult.get()
 
 
@@ -140,7 +140,7 @@ class DefaultExecutionStrategyTest extends Specification {
         Execution execution = new Execution()
 
         when:
-        def monoResult = execution.execute(DefaultExecutionStrategy, document, schema, ExecutionId.generate(), executionInput)
+        def monoResult = execution.execute(DefaultExecutionStrategy, document, schema, ExecutionId.generate(), executionInput, null)
         def result = monoResult.get()
 
 
@@ -187,7 +187,7 @@ class DefaultExecutionStrategyTest extends Specification {
         Execution execution = new Execution()
 
         when:
-        def monoResult = execution.execute(DefaultExecutionStrategy, document, schema, ExecutionId.generate(), executionInput)
+        def monoResult = execution.execute(DefaultExecutionStrategy, document, schema, ExecutionId.generate(), executionInput, null)
         def result = monoResult.get()
 
 
@@ -237,7 +237,7 @@ class DefaultExecutionStrategyTest extends Specification {
         Execution execution = new Execution()
 
         when:
-        def monoResult = execution.execute(DefaultExecutionStrategy, document, schema, ExecutionId.generate(), executionInput)
+        def monoResult = execution.execute(DefaultExecutionStrategy, document, schema, ExecutionId.generate(), executionInput, null)
         def result = monoResult.get()
 
 
@@ -287,7 +287,7 @@ class DefaultExecutionStrategyTest extends Specification {
         Execution execution = new Execution()
 
         when:
-        def monoResult = execution.execute(DefaultExecutionStrategy, document, schema, ExecutionId.generate(), executionInput)
+        def monoResult = execution.execute(DefaultExecutionStrategy, document, schema, ExecutionId.generate(), executionInput, null)
         def result = monoResult.get()
 
 
@@ -335,7 +335,7 @@ class DefaultExecutionStrategyTest extends Specification {
         Execution execution = new Execution()
 
         when:
-        def monoResult = execution.execute(DefaultExecutionStrategy, document, schema, ExecutionId.generate(), executionInput)
+        def monoResult = execution.execute(DefaultExecutionStrategy, document, schema, ExecutionId.generate(), executionInput, null)
         def result = monoResult.get()
 
 
@@ -372,7 +372,7 @@ class DefaultExecutionStrategyTest extends Specification {
         Execution execution = new Execution();
 
         when:
-        def monoResult = execution.execute(DefaultExecutionStrategy, document, schema, ExecutionId.generate(), executionInput)
+        def monoResult = execution.execute(DefaultExecutionStrategy, document, schema, ExecutionId.generate(), executionInput, null)
         def result = monoResult.get()
 
 
@@ -415,7 +415,7 @@ class DefaultExecutionStrategyTest extends Specification {
         Execution execution = new Execution();
 
         when:
-        def monoResult = execution.execute(DefaultExecutionStrategy, document, schema, ExecutionId.generate(), executionInput)
+        def monoResult = execution.execute(DefaultExecutionStrategy, document, schema, ExecutionId.generate(), executionInput, null)
         def result = monoResult.get()
 
 
@@ -453,7 +453,7 @@ class DefaultExecutionStrategyTest extends Specification {
         Execution execution = new Execution();
 
         when:
-        def monoResult = execution.execute(DefaultExecutionStrategy, document, schema, ExecutionId.generate(), executionInput)
+        def monoResult = execution.execute(DefaultExecutionStrategy, document, schema, ExecutionId.generate(), executionInput, null)
         def result = monoResult.get()
 
 


### PR DESCRIPTION
This is an admittedly incomplete attempt to resolve https://github.com/graphql-java/graphql-java/issues/806. I mostly just want to get the conversation started on how this could work.

As it stands right now, this just promotes `ExecutionInput.operationName` to a list, and renames it to `operationNames`. It then uses a helper method `ExecutionInput.mapOperations` to run the full execution (instrumentations and all) for each operation in sequence.

This currently discards all intermediate execution results and only returns the last one. I think a requirement for this approach would be to instead introduce a configuration hook for combining the execution results. I imagine it looking something like this:

```java
executionInputBuilder
  .operationNames("Foo", "Bar")
  .operationResultMerger(new OperationResultMerger() {
    public ExecutionResult merge(ExecutionResult prevResult, ExecutionResult nextResult) {
      // Merge data/errors/extensions ...
    }
  });
```

... although I spiked this out and it likely will end up being a little more complicated. Maybe we can address those complications if we decide to move forward with this approach.

Some things I'm not sure about:

- Can this live side-by-side with execution strategies? It seems like those operate at a lower level, i.e. coordinating the resolution of fields _within_ an operation.
- Do the instrumentation hooks still make sense with this approach? I think they will basically fire off as if a separate request was made for each operation name, but I'm not sure.
- Is this to spec? It's kind of vague when it comes to executing multiple operations.

Thoughts?