### PR TITLE
rename MergedFields to MergedField (singular)

### DIFF
--- a/src/main/java/graphql/TypeResolutionEnvironment.java
+++ b/src/main/java/graphql/TypeResolutionEnvironment.java
@@ -1,6 +1,6 @@
 package graphql;
 
-import graphql.execution.MergedFields;
+import graphql.execution.MergedField;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
 
@@ -16,12 +16,12 @@ public class TypeResolutionEnvironment {
 
     private final Object object;
     private final Map<String, Object> arguments;
-    private final MergedFields field;
+    private final MergedField field;
     private final GraphQLType fieldType;
     private final GraphQLSchema schema;
     private final Object context;
 
-    public TypeResolutionEnvironment(Object object, Map<String, Object> arguments, MergedFields field, GraphQLType fieldType, GraphQLSchema schema, final Object context) {
+    public TypeResolutionEnvironment(Object object, Map<String, Object> arguments, MergedField field, GraphQLType fieldType, GraphQLSchema schema, final Object context) {
         this.object = object;
         this.arguments = arguments;
         this.field = field;
@@ -52,7 +52,7 @@ public class TypeResolutionEnvironment {
     /**
      * @return the graphql field in question
      */
-    public MergedFields getField() {
+    public MergedField getField() {
         return field;
     }
 

--- a/src/main/java/graphql/execution/AbsoluteGraphQLError.java
+++ b/src/main/java/graphql/execution/AbsoluteGraphQLError.java
@@ -43,7 +43,7 @@ public class AbsoluteGraphQLError implements GraphQLError {
         }
     }
 
-    public AbsoluteGraphQLError(MergedFields sameField, ExecutionPath executionPath, GraphQLError relativeError) {
+    public AbsoluteGraphQLError(MergedField sameField, ExecutionPath executionPath, GraphQLError relativeError) {
         this.absolutePath = createAbsolutePath(executionPath, relativeError);
         this.locations = createAbsoluteLocations(relativeError, sameField);
         this.message = relativeError.getMessage();
@@ -115,7 +115,7 @@ public class AbsoluteGraphQLError implements GraphQLError {
      *
      * @return List of locations from the root.
      */
-    private List<SourceLocation> createAbsoluteLocations(GraphQLError relativeError, MergedFields fields) {
+    private List<SourceLocation> createAbsoluteLocations(GraphQLError relativeError, MergedField fields) {
         Optional<SourceLocation> baseLocation = Optional.ofNullable(fields.getSingleField().getSourceLocation());
 //        if (!fields.isEmpty()) {
 //            baseLocation = Optional.ofNullable(fields.get(0).getSourceLocation());

--- a/src/main/java/graphql/execution/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncExecutionStrategy.java
@@ -57,7 +57,7 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
         List<CompletableFuture<FieldValueInfo>> futures = new ArrayList<>();
         List<String> resolvedFields = new ArrayList<>();
         for (String fieldName : fieldNames) {
-            MergedFields currentField = fields.getSubField(fieldName);
+            MergedField currentField = fields.getSubField(fieldName);
 
             ExecutionPath fieldPath = parameters.getPath().segment(mkNameForPath(currentField));
             ExecutionStrategyParameters newParameters = parameters
@@ -95,13 +95,13 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
         return overallResult;
     }
 
-    private boolean isDeferred(ExecutionContext executionContext, ExecutionStrategyParameters parameters, MergedFields currentField) {
+    private boolean isDeferred(ExecutionContext executionContext, ExecutionStrategyParameters parameters, MergedField currentField) {
         DeferSupport deferSupport = executionContext.getDeferSupport();
         if (deferSupport.checkForDeferDirective(currentField)) {
             DeferredErrorSupport errorSupport = new DeferredErrorSupport();
 
             // with a deferred field we are really resetting where we execute from, that is from this current field onwards
-            Map<String, MergedFields> fields = new LinkedHashMap<>();
+            Map<String, MergedField> fields = new LinkedHashMap<>();
             fields.put(currentField.getName(), currentField);
 
             ExecutionStrategyParameters callParameters = parameters.transform(builder ->

--- a/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
@@ -34,7 +34,7 @@ public class AsyncSerialExecutionStrategy extends AbstractAsyncExecutionStrategy
         List<String> fieldNames = new ArrayList<>(fields.keySet());
 
         CompletableFuture<List<ExecutionResult>> resultsFuture = Async.eachSequentially(fieldNames, (fieldName, index, prevResults) -> {
-            MergedFields currentField = fields.getSubField(fieldName);
+            MergedField currentField = fields.getSubField(fieldName);
             ExecutionPath fieldPath = parameters.getPath().segment(mkNameForPath(currentField));
             ExecutionStrategyParameters newParameters = parameters
                     .transform(builder -> builder.field(currentField).path(fieldPath));

--- a/src/main/java/graphql/execution/DataFetcherExceptionHandlerParameters.java
+++ b/src/main/java/graphql/execution/DataFetcherExceptionHandlerParameters.java
@@ -14,13 +14,13 @@ public class DataFetcherExceptionHandlerParameters {
 
     private final ExecutionContext executionContext;
     private final DataFetchingEnvironment dataFetchingEnvironment;
-    private final MergedFields field;
+    private final MergedField field;
     private final GraphQLFieldDefinition fieldDefinition;
     private final Map<String, Object> argumentValues;
     private final ExecutionPath path;
     private final Throwable exception;
 
-    public DataFetcherExceptionHandlerParameters(ExecutionContext executionContext, DataFetchingEnvironment dataFetchingEnvironment, MergedFields field, GraphQLFieldDefinition fieldDefinition, Map<String, Object> argumentValues, ExecutionPath path, Throwable exception) {
+    public DataFetcherExceptionHandlerParameters(ExecutionContext executionContext, DataFetchingEnvironment dataFetchingEnvironment, MergedField field, GraphQLFieldDefinition fieldDefinition, Map<String, Object> argumentValues, ExecutionPath path, Throwable exception) {
         this.executionContext = executionContext;
         this.dataFetchingEnvironment = dataFetchingEnvironment;
         this.field = field;
@@ -42,7 +42,7 @@ public class DataFetcherExceptionHandlerParameters {
         return dataFetchingEnvironment;
     }
 
-    public MergedFields getField() {
+    public MergedField getField() {
         return field;
     }
 
@@ -65,7 +65,7 @@ public class DataFetcherExceptionHandlerParameters {
     public static class Builder {
         ExecutionContext executionContext;
         DataFetchingEnvironment dataFetchingEnvironment;
-        MergedFields field;
+        MergedField field;
         GraphQLFieldDefinition fieldDefinition;
         Map<String, Object> argumentValues;
         ExecutionPath path;
@@ -84,7 +84,7 @@ public class DataFetcherExceptionHandlerParameters {
             return this;
         }
 
-        public Builder field(MergedFields field) {
+        public Builder field(MergedField field) {
             this.field = field;
             return this;
         }

--- a/src/main/java/graphql/execution/ExecutionStepInfo.java
+++ b/src/main/java/graphql/execution/ExecutionStepInfo.java
@@ -31,11 +31,11 @@ public class ExecutionStepInfo {
     private final ExecutionStepInfo parent;
 
     // field, fieldDefinition and arguments stay the same for steps inside a list field
-    private final MergedFields field;
+    private final MergedField field;
     private final GraphQLFieldDefinition fieldDefinition;
     private final Map<String, Object> arguments;
 
-    private ExecutionStepInfo(GraphQLOutputType type, GraphQLFieldDefinition fieldDefinition, MergedFields field, ExecutionPath path, ExecutionStepInfo parent, Map<String, Object> arguments) {
+    private ExecutionStepInfo(GraphQLOutputType type, GraphQLFieldDefinition fieldDefinition, MergedField field, ExecutionPath path, ExecutionStepInfo parent, Map<String, Object> arguments) {
         this.fieldDefinition = fieldDefinition;
         this.field = field;
         this.path = path;
@@ -78,7 +78,7 @@ public class ExecutionStepInfo {
      *
      * @return the  merged fields
      */
-    public MergedFields getField() {
+    public MergedField getField() {
         return field;
     }
 
@@ -195,7 +195,7 @@ public class ExecutionStepInfo {
         GraphQLOutputType type;
         ExecutionStepInfo parentInfo;
         GraphQLFieldDefinition fieldDefinition;
-        MergedFields field;
+        MergedField field;
         ExecutionPath path;
         Map<String, Object> arguments = new LinkedHashMap<>();
 
@@ -229,7 +229,7 @@ public class ExecutionStepInfo {
             return this;
         }
 
-        public Builder field(MergedFields field) {
+        public Builder field(MergedField field) {
             this.field = field;
             return this;
         }

--- a/src/main/java/graphql/execution/ExecutionStepInfoFactory.java
+++ b/src/main/java/graphql/execution/ExecutionStepInfoFactory.java
@@ -20,21 +20,21 @@ public class ExecutionStepInfoFactory {
     ValuesResolver valuesResolver = new ValuesResolver();
 
 
-    public ExecutionStepInfo newExecutionStepInfoForSubField(ExecutionContext executionContext, MergedFields mergedFields, ExecutionStepInfo parentInfo) {
+    public ExecutionStepInfo newExecutionStepInfoForSubField(ExecutionContext executionContext, MergedField mergedField, ExecutionStepInfo parentInfo) {
         GraphQLObjectType parentType = (GraphQLObjectType) parentInfo.getUnwrappedNonNullType();
-        GraphQLFieldDefinition fieldDefinition = Introspection.getFieldDef(executionContext.getGraphQLSchema(), parentType, mergedFields.getName());
+        GraphQLFieldDefinition fieldDefinition = Introspection.getFieldDef(executionContext.getGraphQLSchema(), parentType, mergedField.getName());
         GraphQLOutputType fieldType = fieldDefinition.getType();
-        List<Argument> fieldArgs = mergedFields.getArguments();
+        List<Argument> fieldArgs = mergedField.getArguments();
         GraphQLCodeRegistry codeRegistry = executionContext.getGraphQLSchema().getCodeRegistry();
         Map<String, Object> argumentValues = valuesResolver.getArgumentValues(codeRegistry, fieldDefinition.getArguments(), fieldArgs, executionContext.getVariables());
 
-        ExecutionPath newPath = parentInfo.getPath().segment(mkNameForPath(mergedFields));
+        ExecutionPath newPath = parentInfo.getPath().segment(mkNameForPath(mergedField));
 
         return parentInfo.transform(builder -> builder
                 .parentInfo(parentInfo)
                 .type(fieldType)
                 .fieldDefinition(fieldDefinition)
-                .field(mergedFields)
+                .field(mergedField)
                 .path(newPath)
                 .arguments(argumentValues));
     }
@@ -49,7 +49,7 @@ public class ExecutionStepInfoFactory {
                 .path(indexedPath));
     }
 
-    private static String mkNameForPath(MergedFields currentField) {
+    private static String mkNameForPath(MergedField currentField) {
         Field field = currentField.getSingleField();
         return field.getAlias() != null ? field.getAlias() : field.getName();
     }

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -220,7 +220,7 @@ public abstract class ExecutionStrategy {
      * @throws NonNullableFieldWasNullException in the future if a non null field resolves to a null value
      */
     protected CompletableFuture<Object> fetchField(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
-        MergedFields field = parameters.getField();
+        MergedField field = parameters.getField();
         GraphQLObjectType parentType = (GraphQLObjectType) parameters.getExecutionStepInfo().getUnwrappedNonNullType();
         GraphQLFieldDefinition fieldDef = getFieldDef(executionContext.getGraphQLSchema(), parentType, field.getSingleField());
 
@@ -235,7 +235,7 @@ public abstract class ExecutionStrategy {
                 .source(parameters.getSource())
                 .arguments(argumentValues)
                 .fieldDefinition(fieldDef)
-                .mergedFields(parameters.getField())
+                .mergedField(parameters.getField())
                 .fieldType(fieldType)
                 .executionStepInfo(executionStepInfo)
                 .parentType(parentType)
@@ -296,7 +296,7 @@ public abstract class ExecutionStrategy {
 
     private void handleFetchingException(ExecutionContext executionContext,
                                          ExecutionStrategyParameters parameters,
-                                         MergedFields field,
+                                         MergedField field,
                                          GraphQLFieldDefinition fieldDef,
                                          Map<String, Object> argumentValues,
                                          DataFetchingEnvironment environment,
@@ -785,8 +785,8 @@ public abstract class ExecutionStrategy {
     }
 
     @Internal
-    public static String mkNameForPath(MergedFields mergedFields) {
-        return mkNameForPath(mergedFields.getFields());
+    public static String mkNameForPath(MergedField mergedField) {
+        return mkNameForPath(mergedField.getFields());
     }
 
 

--- a/src/main/java/graphql/execution/ExecutionStrategyParameters.java
+++ b/src/main/java/graphql/execution/ExecutionStrategyParameters.java
@@ -20,7 +20,7 @@ public class ExecutionStrategyParameters {
     private final MergedSelectionSet fields;
     private final NonNullableFieldValidator nonNullableFieldValidator;
     private final ExecutionPath path;
-    private final MergedFields currentField;
+    private final MergedField currentField;
     private final int listSize;
     private final int currentListIndex;
     private final ExecutionStrategyParameters parent;
@@ -32,7 +32,7 @@ public class ExecutionStrategyParameters {
                                         Map<String, Object> arguments,
                                         NonNullableFieldValidator nonNullableFieldValidator,
                                         ExecutionPath path,
-                                        MergedFields currentField,
+                                        MergedField currentField,
                                         int listSize,
                                         int currentListIndex,
                                         ExecutionStrategyParameters parent,
@@ -95,7 +95,7 @@ public class ExecutionStrategyParameters {
      * This returns the current field in its query representations.
      * @return the current merged fields
      */
-    public MergedFields getField() {
+    public MergedField getField() {
         return currentField;
     }
 
@@ -126,7 +126,7 @@ public class ExecutionStrategyParameters {
         Map<String, Object> arguments;
         NonNullableFieldValidator nonNullableFieldValidator;
         ExecutionPath path = ExecutionPath.rootPath();
-        MergedFields currentField;
+        MergedField currentField;
         int listSize;
         int currentListIndex;
         ExecutionStrategyParameters parent;
@@ -170,7 +170,7 @@ public class ExecutionStrategyParameters {
             return this;
         }
 
-        public Builder field(MergedFields currentField) {
+        public Builder field(MergedField currentField) {
             this.currentField = currentField;
             return this;
         }

--- a/src/main/java/graphql/execution/ExecutorServiceExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutorServiceExecutionStrategy.java
@@ -71,7 +71,7 @@ public class ExecutorServiceExecutionStrategy extends ExecutionStrategy {
         MergedSelectionSet fields = parameters.getFields();
         Map<String, Future<CompletableFuture<ExecutionResult>>> futures = new LinkedHashMap<>();
         for (String fieldName : fields.keySet()) {
-            final MergedFields currentField = fields.getSubField(fieldName);
+            final MergedField currentField = fields.getSubField(fieldName);
 
             ExecutionPath fieldPath = parameters.getPath().segment(mkNameForPath(currentField));
             ExecutionStrategyParameters newParameters = parameters

--- a/src/main/java/graphql/execution/FieldCollector.java
+++ b/src/main/java/graphql/execution/FieldCollector.java
@@ -30,10 +30,10 @@ public class FieldCollector {
 
     private final ConditionalNodes conditionalNodes = new ConditionalNodes();
 
-    public MergedSelectionSet collectFields(FieldCollectorParameters parameters, MergedFields mergedFields) {
-        Map<String, MergedFields> subFields = new LinkedHashMap<>();
+    public MergedSelectionSet collectFields(FieldCollectorParameters parameters, MergedField mergedField) {
+        Map<String, MergedField> subFields = new LinkedHashMap<>();
         List<String> visitedFragments = new ArrayList<>();
-        for (Field field : mergedFields.getFields()) {
+        for (Field field : mergedField.getFields()) {
             if (field.getSelectionSet() == null) {
                 continue;
             }
@@ -51,14 +51,14 @@ public class FieldCollector {
      * @return a map of the sub field selections
      */
     public MergedSelectionSet collectFields(FieldCollectorParameters parameters, SelectionSet selectionSet) {
-        Map<String, MergedFields> subFields = new LinkedHashMap<>();
+        Map<String, MergedField> subFields = new LinkedHashMap<>();
         List<String> visitedFragments = new ArrayList<>();
         this.collectFields(parameters, selectionSet, visitedFragments, subFields);
         return newMergedSelectionSet().subFields(subFields).build();
     }
 
 
-    private void collectFields(FieldCollectorParameters parameters, SelectionSet selectionSet, List<String> visitedFragments, Map<String, MergedFields> fields) {
+    private void collectFields(FieldCollectorParameters parameters, SelectionSet selectionSet, List<String> visitedFragments, Map<String, MergedField> fields) {
 
         for (Selection selection : selectionSet.getSelections()) {
             if (selection instanceof Field) {
@@ -71,7 +71,7 @@ public class FieldCollector {
         }
     }
 
-    private void collectFragmentSpread(FieldCollectorParameters parameters, List<String> visitedFragments, Map<String, MergedFields> fields, FragmentSpread fragmentSpread) {
+    private void collectFragmentSpread(FieldCollectorParameters parameters, List<String> visitedFragments, Map<String, MergedField> fields, FragmentSpread fragmentSpread) {
         if (visitedFragments.contains(fragmentSpread.getName())) {
             return;
         }
@@ -90,7 +90,7 @@ public class FieldCollector {
         collectFields(parameters, fragmentDefinition.getSelectionSet(), visitedFragments, fields);
     }
 
-    private void collectInlineFragment(FieldCollectorParameters parameters, List<String> visitedFragments, Map<String, MergedFields> fields, InlineFragment inlineFragment) {
+    private void collectInlineFragment(FieldCollectorParameters parameters, List<String> visitedFragments, Map<String, MergedField> fields, InlineFragment inlineFragment) {
         if (!conditionalNodes.shouldInclude(parameters.getVariables(), inlineFragment.getDirectives()) ||
                 !doesFragmentConditionMatch(parameters, inlineFragment)) {
             return;
@@ -98,16 +98,16 @@ public class FieldCollector {
         collectFields(parameters, inlineFragment.getSelectionSet(), visitedFragments, fields);
     }
 
-    private void collectField(FieldCollectorParameters parameters, Map<String, MergedFields> fields, Field field) {
+    private void collectField(FieldCollectorParameters parameters, Map<String, MergedField> fields, Field field) {
         if (!conditionalNodes.shouldInclude(parameters.getVariables(), field.getDirectives())) {
             return;
         }
         String name = getFieldEntryKey(field);
         if (fields.containsKey(name)) {
-            MergedFields curFields = fields.get(name);
+            MergedField curFields = fields.get(name);
             fields.put(name, curFields.transform(builder -> builder.addField(field)));
         } else {
-            fields.put(name, MergedFields.newMergedFields(field).build());
+            fields.put(name, MergedField.newMergedField(field).build());
         }
     }
 

--- a/src/main/java/graphql/execution/MergedField.java
+++ b/src/main/java/graphql/execution/MergedField.java
@@ -11,7 +11,7 @@ import java.util.function.Consumer;
 import static graphql.Assert.assertNotEmpty;
 
 /**
- * This represent all Fields in query which overlap and are merged into one.
+ * This represent all Fields in a query which overlap and are merged into one.
  * This means they all represent the same field actually when the query is executed.
  *
  * Example query with more than one Field merged together:
@@ -56,11 +56,11 @@ import static graphql.Assert.assertNotEmpty;
  * The actual logic when fields can successfully merged together is implemented in {#graphql.validation.rules.OverlappingFieldsCanBeMerged}
  */
 @PublicApi
-public class MergedFields {
+public class MergedField {
 
     private final List<Field> fields;
 
-    public MergedFields(List<Field> fields) {
+    public MergedField(List<Field> fields) {
         assertNotEmpty(fields);
         this.fields = new ArrayList<>(fields);
     }
@@ -107,19 +107,19 @@ public class MergedFields {
         return new ArrayList<>(fields);
     }
 
-    public static Builder newMergedFields() {
+    public static Builder newMergedField() {
         return new Builder();
     }
 
-    public static Builder newMergedFields(Field field) {
+    public static Builder newMergedField(Field field) {
         return new Builder().addField(field);
     }
 
-    public static Builder newMergedFields(List<Field> fields) {
+    public static Builder newMergedField(List<Field> fields) {
         return new Builder().fields(fields);
     }
 
-    public MergedFields transform(Consumer<Builder> builderConsumer) {
+    public MergedField transform(Consumer<Builder> builderConsumer) {
         Builder builder = new Builder(this);
         builderConsumer.accept(builder);
         return builder.build();
@@ -132,7 +132,7 @@ public class MergedFields {
 
         }
 
-        private Builder(MergedFields existing) {
+        private Builder(MergedField existing) {
             this.fields = existing.getFields();
         }
 
@@ -146,8 +146,8 @@ public class MergedFields {
             return this;
         }
 
-        public MergedFields build() {
-            return new MergedFields(fields);
+        public MergedField build() {
+            return new MergedField(fields);
         }
 
 

--- a/src/main/java/graphql/execution/MergedSelectionSet.java
+++ b/src/main/java/graphql/execution/MergedSelectionSet.java
@@ -13,13 +13,13 @@ import java.util.Set;
 @PublicApi
 public class MergedSelectionSet {
 
-    private final Map<String, MergedFields> subFields;
+    private final Map<String, MergedField> subFields;
 
-    private MergedSelectionSet(Map<String, MergedFields> subFields) {
+    private MergedSelectionSet(Map<String, MergedField> subFields) {
         this.subFields = Assert.assertNotNull(subFields);
     }
 
-    public Map<String, MergedFields> getSubFields() {
+    public Map<String, MergedField> getSubFields() {
         return subFields;
     }
 
@@ -31,7 +31,7 @@ public class MergedSelectionSet {
         return subFields.keySet();
     }
 
-    public MergedFields getSubField(String key) {
+    public MergedField getSubField(String key) {
         return subFields.get(key);
     }
 
@@ -48,13 +48,13 @@ public class MergedSelectionSet {
     }
 
     public static class Builder {
-        private Map<String, MergedFields> subFields = new LinkedHashMap<>();
+        private Map<String, MergedField> subFields = new LinkedHashMap<>();
 
         private Builder() {
 
         }
 
-        public Builder subFields(Map<String, MergedFields> subFields) {
+        public Builder subFields(Map<String, MergedField> subFields) {
             this.subFields = subFields;
             return this;
         }

--- a/src/main/java/graphql/execution/ResolveType.java
+++ b/src/main/java/graphql/execution/ResolveType.java
@@ -14,7 +14,7 @@ import java.util.Map;
 public class ResolveType {
 
 
-    public GraphQLObjectType resolveType(ExecutionContext executionContext, MergedFields field, Object source, Map<String, Object> arguments, GraphQLType fieldType) {
+    public GraphQLObjectType resolveType(ExecutionContext executionContext, MergedField field, Object source, Map<String, Object> arguments, GraphQLType fieldType) {
         GraphQLObjectType resolvedType;
         if (fieldType instanceof GraphQLInterfaceType) {
             TypeResolutionParameters resolutionParams = TypeResolutionParameters.newParameters()

--- a/src/main/java/graphql/execution/SubscriptionExecutionStrategy.java
+++ b/src/main/java/graphql/execution/SubscriptionExecutionStrategy.java
@@ -114,7 +114,7 @@ public class SubscriptionExecutionStrategy extends ExecutionStrategy {
 
     private ExecutionStrategyParameters firstFieldOfSubscriptionSelection(ExecutionStrategyParameters parameters) {
         MergedSelectionSet fields = parameters.getFields();
-        MergedFields firstField = fields.getSubField(fields.getKeys().get(0));
+        MergedField firstField = fields.getSubField(fields.getKeys().get(0));
 
         ExecutionPath fieldPath = parameters.getPath().segment(mkNameForPath(firstField.getSingleField()));
         return parameters.transform(builder -> builder.field(firstField).path(fieldPath));

--- a/src/main/java/graphql/execution/TypeResolutionParameters.java
+++ b/src/main/java/graphql/execution/TypeResolutionParameters.java
@@ -12,14 +12,14 @@ public class TypeResolutionParameters {
 
     private final GraphQLInterfaceType graphQLInterfaceType;
     private final GraphQLUnionType graphQLUnionType;
-    private final MergedFields field;
+    private final MergedField field;
     private final Object value;
     private final Map<String, Object> argumentValues;
     private final GraphQLSchema schema;
     private final Object context;
 
     private TypeResolutionParameters(GraphQLInterfaceType graphQLInterfaceType, GraphQLUnionType graphQLUnionType,
-                                     MergedFields field, Object value, Map<String, Object> argumentValues, GraphQLSchema schema, final Object context) {
+                                     MergedField field, Object value, Map<String, Object> argumentValues, GraphQLSchema schema, final Object context) {
         this.graphQLInterfaceType = graphQLInterfaceType;
         this.graphQLUnionType = graphQLUnionType;
         this.field = field;
@@ -37,7 +37,7 @@ public class TypeResolutionParameters {
         return graphQLUnionType;
     }
 
-    public MergedFields getField() {
+    public MergedField getField() {
         return field;
     }
 
@@ -63,7 +63,7 @@ public class TypeResolutionParameters {
 
     public static class Builder {
 
-        private MergedFields field;
+        private MergedField field;
         private GraphQLInterfaceType graphQLInterfaceType;
         private GraphQLUnionType graphQLUnionType;
         private Object value;
@@ -71,7 +71,7 @@ public class TypeResolutionParameters {
         private GraphQLSchema schema;
         private Object context;
 
-        public Builder field(MergedFields field) {
+        public Builder field(MergedField field) {
             this.field = field;
             return this;
         }

--- a/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
+++ b/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
@@ -14,7 +14,7 @@ import graphql.execution.ExecutionStepInfo;
 import graphql.execution.ExecutionStrategy;
 import graphql.execution.ExecutionStrategyParameters;
 import graphql.execution.FieldCollectorParameters;
-import graphql.execution.MergedFields;
+import graphql.execution.MergedField;
 import graphql.execution.MergedSelectionSet;
 import graphql.execution.NonNullableFieldValidator;
 import graphql.execution.ResolveType;
@@ -152,7 +152,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
         }
 
         String fieldName = curFieldNames.next();
-        MergedFields currentField = curNode.getFields().get(fieldName);
+        MergedField currentField = curNode.getFields().get(fieldName);
 
 
         //
@@ -206,7 +206,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
                                                                 String fieldName,
                                                                 ExecutionNode node) {
         GraphQLObjectType parentType = node.getType();
-        MergedFields fields = node.getFields().get(fieldName);
+        MergedField fields = node.getFields().get(fieldName);
 
         GraphQLFieldDefinition fieldDef = getFieldDef(executionContext.getGraphQLSchema(), parentType, fields.getSingleField());
 
@@ -239,7 +239,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
                                                        ExecutionNode node,
                                                        GraphQLFieldDefinition fieldDef) {
         GraphQLObjectType parentType = node.getType();
-        MergedFields fields = node.getFields().get(fieldName);
+        MergedField fields = node.getFields().get(fieldName);
         List<MapOrList> parentResults = node.getParentResults();
 
         GraphQLCodeRegistry codeRegistry = executionContext.getGraphQLSchema().getCodeRegistry();
@@ -254,7 +254,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
                 .source(node.getSources())
                 .arguments(argumentValues)
                 .fieldDefinition(fieldDef)
-                .mergedFields(fields)
+                .mergedField(fields)
                 .fieldType(fieldDef.getType())
                 .executionStepInfo(parameters.getExecutionStepInfo())
                 .parentType(parentType)
@@ -286,7 +286,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
                 .handle(handleResult(executionContext, parameters, parentResults, fields, fieldDef, argumentValues, environment));
     }
 
-    private BiFunction<List<Object>, Throwable, FetchedValues> handleResult(ExecutionContext executionContext, ExecutionStrategyParameters parameters, List<MapOrList> parentResults, MergedFields fields, GraphQLFieldDefinition fieldDef, Map<String, Object> argumentValues, DataFetchingEnvironment environment) {
+    private BiFunction<List<Object>, Throwable, FetchedValues> handleResult(ExecutionContext executionContext, ExecutionStrategyParameters parameters, List<MapOrList> parentResults, MergedField fields, GraphQLFieldDefinition fieldDef, Map<String, Object> argumentValues, DataFetchingEnvironment environment) {
         return (result, exception) -> {
             if (exception != null) {
                 if (exception instanceof CompletionException) {
@@ -336,7 +336,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
 
     private List<ExecutionNode> completeValues(ExecutionContext executionContext,
                                                FetchedValues fetchedValues, ExecutionStepInfo executionStepInfo,
-                                               String fieldName, MergedFields fields,
+                                               String fieldName, MergedField fields,
                                                Map<String, Object> argumentValues) {
 
         handleNonNullType(executionContext, fetchedValues);
@@ -357,7 +357,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
 
     @SuppressWarnings("unchecked")
     private List<ExecutionNode> handleList(ExecutionContext executionContext, Map<String, Object> argumentValues,
-                                           FetchedValues fetchedValues, String fieldName, MergedFields fields,
+                                           FetchedValues fetchedValues, String fieldName, MergedField fields,
                                            ExecutionStepInfo executionStepInfo) {
 
         GraphQLList listType = (GraphQLList) executionStepInfo.getUnwrappedNonNullType();
@@ -386,7 +386,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
 
     @SuppressWarnings("UnnecessaryLocalVariable")
     private List<ExecutionNode> handleObject(ExecutionContext executionContext, Map<String, Object> argumentValues,
-                                             FetchedValues fetchedValues, String fieldName, MergedFields fields,
+                                             FetchedValues fetchedValues, String fieldName, MergedField fields,
                                              ExecutionStepInfo executionStepInfo) {
 
         // collect list of values by actual type (needed because of interfaces and unions)
@@ -434,7 +434,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
     }
 
     private MergedSelectionSet getChildFields(ExecutionContext executionContext, GraphQLObjectType resolvedType,
-                                              MergedFields fields) {
+                                              MergedField fields) {
 
         FieldCollectorParameters collectorParameters = newParameters()
                 .schema(executionContext.getGraphQLSchema())
@@ -446,7 +446,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
         return fieldCollector.collectFields(collectorParameters, fields);
     }
 
-    private GraphQLObjectType getGraphQLObjectType(ExecutionContext executionContext, MergedFields field, GraphQLType fieldType, Object value, Map<String, Object> argumentValues) {
+    private GraphQLObjectType getGraphQLObjectType(ExecutionContext executionContext, MergedField field, GraphQLType fieldType, Object value, Map<String, Object> argumentValues) {
         return resolveType.resolveType(executionContext, field, value, argumentValues, fieldType);
     }
 

--- a/src/main/java/graphql/execution/batched/ExecutionNode.java
+++ b/src/main/java/graphql/execution/batched/ExecutionNode.java
@@ -1,7 +1,7 @@
 package graphql.execution.batched;
 
 import graphql.execution.ExecutionStepInfo;
-import graphql.execution.MergedFields;
+import graphql.execution.MergedField;
 import graphql.schema.GraphQLObjectType;
 
 import java.util.List;
@@ -12,13 +12,13 @@ class ExecutionNode {
 
     private final GraphQLObjectType type;
     private final ExecutionStepInfo executionStepInfo;
-    private final Map<String, MergedFields> fields;
+    private final Map<String, MergedField> fields;
     private final List<MapOrList> parentResults;
     private final List<Object> sources;
 
     public ExecutionNode(GraphQLObjectType type,
                          ExecutionStepInfo executionStepInfo,
-                         Map<String, MergedFields> fields,
+                         Map<String, MergedField> fields,
                          List<MapOrList> parentResults,
                          List<Object> sources) {
         this.type = type;
@@ -36,7 +36,7 @@ class ExecutionNode {
         return executionStepInfo;
     }
 
-    public Map<String, MergedFields> getFields() {
+    public Map<String, MergedField> getFields() {
         return fields;
     }
 

--- a/src/main/java/graphql/execution/defer/DeferSupport.java
+++ b/src/main/java/graphql/execution/defer/DeferSupport.java
@@ -3,7 +3,7 @@ package graphql.execution.defer;
 import graphql.Directives;
 import graphql.ExecutionResult;
 import graphql.Internal;
-import graphql.execution.MergedFields;
+import graphql.execution.MergedField;
 import graphql.execution.reactive.SingleSubscriberPublisher;
 import graphql.language.Field;
 import org.reactivestreams.Publisher;
@@ -24,7 +24,7 @@ public class DeferSupport {
     private final Deque<DeferredCall> deferredCalls = new ConcurrentLinkedDeque<>();
     private final SingleSubscriberPublisher<ExecutionResult> publisher = new SingleSubscriberPublisher<>();
 
-    public boolean checkForDeferDirective(MergedFields currentField) {
+    public boolean checkForDeferDirective(MergedField currentField) {
         for (Field field : currentField.getFields()) {
             if (field.getDirective(Directives.DeferDirective.getName()) != null) {
                 return true;

--- a/src/main/java/graphql/execution/instrumentation/ChainedInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/ChainedInstrumentation.java
@@ -6,7 +6,7 @@ import graphql.PublicApi;
 import graphql.execution.Async;
 import graphql.execution.ExecutionContext;
 import graphql.execution.FieldValueInfo;
-import graphql.execution.MergedFields;
+import graphql.execution.MergedField;
 import graphql.execution.instrumentation.parameters.InstrumentationCreateStateParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationDeferredFieldParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationExecuteOperationParameters;
@@ -279,7 +279,7 @@ public class ChainedInstrumentation implements Instrumentation {
         }
 
         @Override
-        public void onDeferredField(MergedFields field) {
+        public void onDeferredField(MergedField field) {
             contexts.forEach(context -> context.onDeferredField(field));
         }
     }

--- a/src/main/java/graphql/execution/instrumentation/ExecutionStrategyInstrumentationContext.java
+++ b/src/main/java/graphql/execution/instrumentation/ExecutionStrategyInstrumentationContext.java
@@ -2,7 +2,7 @@ package graphql.execution.instrumentation;
 
 import graphql.ExecutionResult;
 import graphql.execution.FieldValueInfo;
-import graphql.execution.MergedFields;
+import graphql.execution.MergedField;
 
 import java.util.List;
 
@@ -12,7 +12,7 @@ public interface ExecutionStrategyInstrumentationContext extends Instrumentation
 
     }
 
-    default void onDeferredField(MergedFields field) {
+    default void onDeferredField(MergedField field) {
 
     }
 }

--- a/src/main/java/graphql/execution/instrumentation/dataloader/FieldLevelTrackingApproach.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/FieldLevelTrackingApproach.java
@@ -5,7 +5,7 @@ import graphql.ExecutionResult;
 import graphql.Internal;
 import graphql.execution.ExecutionPath;
 import graphql.execution.FieldValueInfo;
-import graphql.execution.MergedFields;
+import graphql.execution.MergedField;
 import graphql.execution.instrumentation.DeferredFieldInstrumentationContext;
 import graphql.execution.instrumentation.ExecutionStrategyInstrumentationContext;
 import graphql.execution.instrumentation.InstrumentationContext;
@@ -161,7 +161,7 @@ public class FieldLevelTrackingApproach {
             }
 
             @Override
-            public void onDeferredField(MergedFields field) {
+            public void onDeferredField(MergedField field) {
                 boolean dispatchNeeded;
                 // fake fetch count for this field
                 synchronized (callStack) {

--- a/src/main/java/graphql/execution/nextgen/BatchedExecutionStrategy.java
+++ b/src/main/java/graphql/execution/nextgen/BatchedExecutionStrategy.java
@@ -6,7 +6,7 @@ import graphql.execution.Async;
 import graphql.execution.ExecutionContext;
 import graphql.execution.ExecutionStepInfo;
 import graphql.execution.ExecutionStepInfoFactory;
-import graphql.execution.MergedFields;
+import graphql.execution.MergedField;
 import graphql.execution.nextgen.result.ExecutionResultMultiZipper;
 import graphql.execution.nextgen.result.ExecutionResultNode;
 import graphql.execution.nextgen.result.ExecutionResultZipper;
@@ -88,7 +88,7 @@ public class BatchedExecutionStrategy implements ExecutionStrategy {
     }
 
     private List<ExecutionResultMultiZipper> groupNodesIntoBatches(ExecutionResultMultiZipper unresolvedZipper) {
-        Map<Map<String, MergedFields>, List<ExecutionResultZipper>> zipperBySubSelection = unresolvedZipper.getZippers().stream()
+        Map<Map<String, MergedField>, List<ExecutionResultZipper>> zipperBySubSelection = unresolvedZipper.getZippers().stream()
                 .collect(groupingBy(executionResultZipper -> executionResultZipper.getCurNode().getFetchedValueAnalysis().getFieldSubSelection().getSubFields()));
 
         return zipperBySubSelection
@@ -114,7 +114,7 @@ public class BatchedExecutionStrategy implements ExecutionStrategy {
                 .entrySet()
                 .stream()
                 .map(entry -> {
-                    MergedFields sameFields = entry.getValue();
+                    MergedField sameFields = entry.getValue();
                     String name = entry.getKey();
 
                     List<ExecutionStepInfo> newExecutionStepInfos = fieldSubSelections.stream().map(executionResultNode -> {
@@ -163,7 +163,7 @@ public class BatchedExecutionStrategy implements ExecutionStrategy {
     private CompletableFuture<List<FetchedValueAnalysis>> fetchAndAnalyze(FieldSubSelection fieldSubSelection) {
         List<CompletableFuture<FetchedValueAnalysis>> fetchedValues = fieldSubSelection.getSubFields().entrySet().stream()
                 .map(entry -> {
-                    MergedFields sameFields = entry.getValue();
+                    MergedField sameFields = entry.getValue();
                     String name = entry.getKey();
                     ExecutionStepInfo newExecutionStepInfo = executionInfoFactory.newExecutionStepInfoForSubField(executionContext, sameFields, fieldSubSelection.getExecutionStepInfo());
                     return valueFetcher
@@ -176,13 +176,13 @@ public class BatchedExecutionStrategy implements ExecutionStrategy {
     }
 
     // only used for the root sub selection atm
-    private FetchedValueAnalysis analyseValue(FetchedValue fetchedValue, String name, MergedFields field, ExecutionStepInfo executionInfo) {
+    private FetchedValueAnalysis analyseValue(FetchedValue fetchedValue, String name, MergedField field, ExecutionStepInfo executionInfo) {
         FetchedValueAnalysis fetchedValueAnalysis = fetchedValueAnalyzer.analyzeFetchedValue(fetchedValue, name, field, executionInfo);
         return fetchedValueAnalysis;
     }
 
 
-    private List<FetchedValueAnalysis> analyseValues(List<FetchedValue> fetchedValues, String name, MergedFields field, List<ExecutionStepInfo> executionInfos) {
+    private List<FetchedValueAnalysis> analyseValues(List<FetchedValue> fetchedValues, String name, MergedField field, List<ExecutionStepInfo> executionInfos) {
         List<FetchedValueAnalysis> result = new ArrayList<>();
         for (int i = 0; i < fetchedValues.size(); i++) {
             FetchedValue fetchedValue = fetchedValues.get(i);

--- a/src/main/java/graphql/execution/nextgen/DefaultExecutionStrategy.java
+++ b/src/main/java/graphql/execution/nextgen/DefaultExecutionStrategy.java
@@ -5,7 +5,7 @@ import graphql.execution.Async;
 import graphql.execution.ExecutionContext;
 import graphql.execution.ExecutionStepInfo;
 import graphql.execution.ExecutionStepInfoFactory;
-import graphql.execution.MergedFields;
+import graphql.execution.MergedField;
 import graphql.execution.nextgen.result.ExecutionResultMultiZipper;
 import graphql.execution.nextgen.result.ExecutionResultNode;
 import graphql.execution.nextgen.result.ExecutionResultZipper;
@@ -65,19 +65,19 @@ public class DefaultExecutionStrategy implements ExecutionStrategy {
 
     private List<CompletableFuture<FetchedValueAnalysis>> fetchAndAnalyze(FieldSubSelection fieldSubSelection) {
         List<CompletableFuture<FetchedValueAnalysis>> fetchedValues = fieldSubSelection.getSubFields().entrySet().stream()
-                .map(entry -> mapMergedFields(fieldSubSelection.getSource(), entry.getKey(), entry.getValue(), fieldSubSelection.getExecutionStepInfo()))
+                .map(entry -> mapmergedField(fieldSubSelection.getSource(), entry.getKey(), entry.getValue(), fieldSubSelection.getExecutionStepInfo()))
                 .collect(toList());
         return fetchedValues;
     }
 
-    private CompletableFuture<FetchedValueAnalysis> mapMergedFields(Object source, String key, MergedFields mergedFields, ExecutionStepInfo executionStepInfo) {
-        ExecutionStepInfo newExecutionStepInfo = executionInfoFactory.newExecutionStepInfoForSubField(executionContext, mergedFields, executionStepInfo);
+    private CompletableFuture<FetchedValueAnalysis> mapmergedField(Object source, String key, MergedField mergedField, ExecutionStepInfo executionStepInfo) {
+        ExecutionStepInfo newExecutionStepInfo = executionInfoFactory.newExecutionStepInfoForSubField(executionContext, mergedField, executionStepInfo);
         return valueFetcher
-                .fetchValue(source, mergedFields, newExecutionStepInfo)
-                .thenApply(fetchValue -> analyseValue(fetchValue, key, mergedFields, newExecutionStepInfo));
+                .fetchValue(source, mergedField, newExecutionStepInfo)
+                .thenApply(fetchValue -> analyseValue(fetchValue, key, mergedField, newExecutionStepInfo));
     }
 
-    private FetchedValueAnalysis analyseValue(FetchedValue fetchedValue, String name, MergedFields field, ExecutionStepInfo executionInfo) {
+    private FetchedValueAnalysis analyseValue(FetchedValue fetchedValue, String name, MergedField field, ExecutionStepInfo executionInfo) {
         FetchedValueAnalysis fetchedValueAnalysis = fetchedValueAnalyzer.analyzeFetchedValue(fetchedValue, name, field, executionInfo);
         return fetchedValueAnalysis;
     }

--- a/src/main/java/graphql/execution/nextgen/FetchedValueAnalyzer.java
+++ b/src/main/java/graphql/execution/nextgen/FetchedValueAnalyzer.java
@@ -9,7 +9,7 @@ import graphql.execution.ExecutionStepInfo;
 import graphql.execution.ExecutionStepInfoFactory;
 import graphql.execution.FieldCollector;
 import graphql.execution.FieldCollectorParameters;
-import graphql.execution.MergedFields;
+import graphql.execution.MergedField;
 import graphql.execution.MergedSelectionSet;
 import graphql.execution.NonNullableFieldWasNullException;
 import graphql.execution.ResolveType;
@@ -58,11 +58,11 @@ public class FetchedValueAnalyzer {
      * enum: same as scalar
      * list: list of X: X can be list again, list of scalars or enum or objects
      */
-    public FetchedValueAnalysis analyzeFetchedValue(FetchedValue fetchedValue, String name, MergedFields field, ExecutionStepInfo executionInfo) throws NonNullableFieldWasNullException {
+    public FetchedValueAnalysis analyzeFetchedValue(FetchedValue fetchedValue, String name, MergedField field, ExecutionStepInfo executionInfo) throws NonNullableFieldWasNullException {
         return analyzeFetchedValueImpl(fetchedValue, fetchedValue.getFetchedValue(), name, field, executionInfo);
     }
 
-    private FetchedValueAnalysis analyzeFetchedValueImpl(FetchedValue fetchedValue, Object toAnalyze, String name, MergedFields field, ExecutionStepInfo executionInfo) throws NonNullableFieldWasNullException {
+    private FetchedValueAnalysis analyzeFetchedValueImpl(FetchedValue fetchedValue, Object toAnalyze, String name, MergedField field, ExecutionStepInfo executionInfo) throws NonNullableFieldWasNullException {
         GraphQLType fieldType = executionInfo.getUnwrappedNonNullType();
 
         if (isList(fieldType)) {

--- a/src/main/java/graphql/execution/nextgen/FieldSubSelection.java
+++ b/src/main/java/graphql/execution/nextgen/FieldSubSelection.java
@@ -2,7 +2,7 @@ package graphql.execution.nextgen;
 
 import graphql.Internal;
 import graphql.execution.ExecutionStepInfo;
-import graphql.execution.MergedFields;
+import graphql.execution.MergedField;
 import graphql.execution.MergedSelectionSet;
 
 import java.util.Map;
@@ -28,7 +28,7 @@ public class FieldSubSelection {
         this.source = source;
     }
 
-    public Map<String, MergedFields> getSubFields() {
+    public Map<String, MergedField> getSubFields() {
         return mergedSelectionSet.getSubFields();
     }
 

--- a/src/main/java/graphql/execution/nextgen/ValueFetcher.java
+++ b/src/main/java/graphql/execution/nextgen/ValueFetcher.java
@@ -12,7 +12,7 @@ import graphql.execution.ExecutionContext;
 import graphql.execution.ExecutionId;
 import graphql.execution.ExecutionPath;
 import graphql.execution.ExecutionStepInfo;
-import graphql.execution.MergedFields;
+import graphql.execution.MergedField;
 import graphql.execution.UnboxPossibleOptional;
 import graphql.execution.ValuesResolver;
 import graphql.language.Field;
@@ -54,7 +54,7 @@ public class ValueFetcher {
     }
 
 
-    public CompletableFuture<List<FetchedValue>> fetchBatchedValues(List<Object> sources, MergedFields sameFields, List<ExecutionStepInfo> executionInfos) {
+    public CompletableFuture<List<FetchedValue>> fetchBatchedValues(List<Object> sources, MergedField sameFields, List<ExecutionStepInfo> executionInfos) {
         System.out.println("Fetch batch values size: " + sources.size());
         ExecutionStepInfo executionStepInfo = executionInfos.get(0);
         if (isDataFetcherBatched(executionStepInfo)) {
@@ -99,7 +99,7 @@ public class ValueFetcher {
         return dataFetcher instanceof BatchedDataFetcher;
     }
 
-    public CompletableFuture<FetchedValue> fetchValue(Object source, MergedFields sameFields, ExecutionStepInfo executionInfo) {
+    public CompletableFuture<FetchedValue> fetchValue(Object source, MergedField sameFields, ExecutionStepInfo executionInfo) {
         Field field = sameFields.getSingleField();
         GraphQLFieldDefinition fieldDef = executionInfo.getFieldDefinition();
 
@@ -115,7 +115,7 @@ public class ValueFetcher {
                 .source(source)
                 .arguments(argumentValues)
                 .fieldDefinition(fieldDef)
-                .mergedFields(sameFields)
+                .mergedField(sameFields)
                 .fieldType(fieldType)
                 .executionStepInfo(executionInfo)
                 .parentType(parentType)
@@ -179,7 +179,7 @@ public class ValueFetcher {
 
     }
 
-    private FetchedValue unboxPossibleDataFetcherResult(MergedFields sameField, ExecutionPath executionPath, FetchedValue result) {
+    private FetchedValue unboxPossibleDataFetcherResult(MergedField sameField, ExecutionPath executionPath, FetchedValue result) {
         if (result.getFetchedValue() instanceof DataFetcherResult) {
             DataFetcherResult<?> dataFetcherResult = (DataFetcherResult) result.getFetchedValue();
             List<AbsoluteGraphQLError> addErrors = dataFetcherResult.getErrors().stream()

--- a/src/main/java/graphql/schema/DataFetchingEnvironment.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironment.java
@@ -4,7 +4,7 @@ import graphql.PublicApi;
 import graphql.execution.ExecutionContext;
 import graphql.execution.ExecutionId;
 import graphql.execution.ExecutionStepInfo;
-import graphql.execution.MergedFields;
+import graphql.execution.MergedField;
 import graphql.language.Field;
 import graphql.language.FragmentDefinition;
 import org.dataloader.DataLoader;
@@ -85,7 +85,7 @@ public interface DataFetchingEnvironment {
 
 
     /**
-     * Use {@link #getMergedFields()}.
+     * Use {@link #getMergedField()}.
      */
     @Deprecated
     List<Field> getFields();
@@ -116,10 +116,10 @@ public interface DataFetchingEnvironment {
      *
      * @return the list of fields currently queried
      */
-    MergedFields getMergedFields();
+    MergedField getMergedField();
 
     /**
-     * @return returns the field which is currently queried. See also {@link #getMergedFields()}.
+     * @return returns the field which is currently queried. See also {@link #getMergedField()}.
      */
     Field getField();
 

--- a/src/main/java/graphql/schema/DataFetchingEnvironmentBuilder.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironmentBuilder.java
@@ -4,7 +4,7 @@ import graphql.PublicApi;
 import graphql.execution.ExecutionContext;
 import graphql.execution.ExecutionId;
 import graphql.execution.ExecutionStepInfo;
-import graphql.execution.MergedFields;
+import graphql.execution.MergedField;
 import graphql.language.FragmentDefinition;
 
 import java.util.Collections;
@@ -31,7 +31,7 @@ public class DataFetchingEnvironmentBuilder {
                 .context(environment.getContext())
                 .root(environment.getRoot())
                 .fieldDefinition(environment.getFieldDefinition())
-                .mergedFields(environment.getMergedFields())
+                .mergedField(environment.getMergedField())
                 .fieldType(environment.getFieldType())
                 .executionStepInfo(environment.getExecutionStepInfo())
                 .parentType(environment.getParentType())
@@ -60,7 +60,7 @@ public class DataFetchingEnvironmentBuilder {
     private Object context;
     private Object root;
     private GraphQLFieldDefinition fieldDefinition;
-    private MergedFields mergedFields;
+    private MergedField mergedField;
     private GraphQLOutputType fieldType;
     private GraphQLType parentType;
     private GraphQLSchema graphQLSchema;
@@ -95,8 +95,8 @@ public class DataFetchingEnvironmentBuilder {
         return this;
     }
 
-    public DataFetchingEnvironmentBuilder mergedFields(MergedFields mergedFields) {
-        this.mergedFields = mergedFields;
+    public DataFetchingEnvironmentBuilder mergedField(MergedField mergedField) {
+        this.mergedField = mergedField;
         return this;
     }
 
@@ -142,7 +142,7 @@ public class DataFetchingEnvironmentBuilder {
 
     public DataFetchingEnvironment build() {
         return new DataFetchingEnvironmentImpl(source, arguments, context, root,
-                fieldDefinition, mergedFields, fieldType, parentType, graphQLSchema, fragmentsByName, executionId, selectionSet,
+                fieldDefinition, mergedField, fieldType, parentType, graphQLSchema, fragmentsByName, executionId, selectionSet,
                 executionStepInfo,
                 executionContext);
     }

--- a/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
@@ -5,7 +5,7 @@ import graphql.Internal;
 import graphql.execution.ExecutionContext;
 import graphql.execution.ExecutionId;
 import graphql.execution.ExecutionStepInfo;
-import graphql.execution.MergedFields;
+import graphql.execution.MergedField;
 import graphql.language.Field;
 import graphql.language.FragmentDefinition;
 import org.dataloader.DataLoader;
@@ -25,7 +25,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
     private final Object context;
     private final Object root;
     private final GraphQLFieldDefinition fieldDefinition;
-    private final MergedFields mergedFields;
+    private final MergedField mergedField;
     private final GraphQLOutputType fieldType;
     private final GraphQLType parentType;
     private final GraphQLSchema graphQLSchema;
@@ -40,7 +40,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
                                        Object context,
                                        Object root,
                                        GraphQLFieldDefinition fieldDefinition,
-                                       MergedFields mergedFields,
+                                       MergedField mergedField,
                                        GraphQLOutputType fieldType,
                                        GraphQLType parentType,
                                        GraphQLSchema graphQLSchema,
@@ -55,7 +55,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
         this.context = context;
         this.root = root;
         this.fieldDefinition = fieldDefinition;
-        this.mergedFields = mergedFields;
+        this.mergedField = mergedField;
         this.fieldType = fieldType;
         this.parentType = parentType;
         this.graphQLSchema = graphQLSchema;
@@ -102,17 +102,17 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
 
     @Override
     public List<Field> getFields() {
-        return mergedFields.getFields();
+        return mergedField.getFields();
     }
 
     @Override
     public Field getField() {
-        return mergedFields.getSingleField();
+        return mergedField.getSingleField();
     }
 
     @Override
-    public MergedFields getMergedFields() {
-        return mergedFields;
+    public MergedField getMergedField() {
+        return mergedField;
     }
 
     @Override

--- a/src/test/groovy/graphql/TestUtil.groovy
+++ b/src/test/groovy/graphql/TestUtil.groovy
@@ -1,6 +1,6 @@
 package graphql
 
-import graphql.execution.MergedFields
+import graphql.execution.MergedField
 import graphql.execution.MergedSelectionSet
 import graphql.introspection.Introspection.DirectiveLocation
 import graphql.language.Document
@@ -206,15 +206,15 @@ class TestUtil {
         new Parser().parseDocument(query)
     }
 
-    static MergedFields mergedFields(List<Field> fields) {
-        return MergedFields.newMergedFields(fields).build()
+    static MergedField mergedField(List<Field> fields) {
+        return MergedField.newMergedField(fields).build()
     }
 
-    static MergedFields mergedFields(Field field) {
-        return MergedFields.newMergedFields(field).build()
+    static MergedField mergedField(Field field) {
+        return MergedField.newMergedField(field).build()
     }
 
-    static MergedSelectionSet mergedSelectionSet(Map<String, MergedFields> subFields) {
+    static MergedSelectionSet mergedSelectionSet(Map<String, MergedField> subFields) {
         return MergedSelectionSet.newMergedSelectionSet().subFields(subFields).build()
     }
 

--- a/src/test/groovy/graphql/TypeResolutionEnvironmentTest.groovy
+++ b/src/test/groovy/graphql/TypeResolutionEnvironmentTest.groovy
@@ -5,7 +5,7 @@ import graphql.schema.GraphQLObjectType
 import graphql.schema.TypeResolver
 import spock.lang.Specification
 
-import static graphql.TestUtil.mergedFields
+import static graphql.TestUtil.mergedField
 
 class TypeResolutionEnvironmentTest extends Specification {
 
@@ -39,7 +39,7 @@ class TypeResolutionEnvironmentTest extends Specification {
     def "basic operations"() {
         given:
 
-        def environment = new TypeResolutionEnvironment("source", [:], mergedFields(new Field("field")), Scalars.GraphQLString, schema, "FooBar")
+        def environment = new TypeResolutionEnvironment("source", [:], mergedField(new Field("field")), Scalars.GraphQLString, schema, "FooBar")
 
         when:
 
@@ -93,14 +93,14 @@ class TypeResolutionEnvironmentTest extends Specification {
         }
 
         when:
-        def environmentFooBar = new TypeResolutionEnvironment("source", [:], mergedFields(new Field("field")), Scalars.GraphQLString, schema, "FooBar")
+        def environmentFooBar = new TypeResolutionEnvironment("source", [:], mergedField(new Field("field")), Scalars.GraphQLString, schema, "FooBar")
         def objTypeFooBar = resolverWithContext.getType(environmentFooBar)
 
         then:
         objTypeFooBar.name == "FooBar"
 
         when:
-        def environmentFooImpl = new TypeResolutionEnvironment("source", [:], mergedFields(new Field("field")), Scalars.GraphQLString, schema, "Foo")
+        def environmentFooImpl = new TypeResolutionEnvironment("source", [:], mergedField(new Field("field")), Scalars.GraphQLString, schema, "Foo")
         def objTypeFooImpl = resolverWithContext.getType(environmentFooImpl)
 
         then:

--- a/src/test/groovy/graphql/execution/AbsoluteGraphQLErrorTest.groovy
+++ b/src/test/groovy/graphql/execution/AbsoluteGraphQLErrorTest.groovy
@@ -6,7 +6,7 @@ import graphql.language.SourceLocation
 import spock.lang.Specification
 
 import static graphql.Scalars.GraphQLString
-import static graphql.TestUtil.mergedFields
+import static graphql.TestUtil.mergedField
 import static graphql.TestUtil.mergedSelectionSet
 import static graphql.execution.ExecutionStrategyParameters.newParameters
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
@@ -31,8 +31,8 @@ class AbsoluteGraphQLErrorTest extends Specification {
         def parameters = newParameters()
                 .executionStepInfo(ExecutionStepInfo.newExecutionStepInfo().type(objectType))
                 .source(new Object())
-                .fields(mergedSelectionSet(["fld": mergedFields([Field.newField().build()])]))
-                .field(mergedFields(field))
+                .fields(mergedSelectionSet(["fld": mergedField([Field.newField().build()])]))
+                .field(mergedField(field))
                 .path(ExecutionPath.fromList(["foo", "bar"]))
                 .build()
 
@@ -66,8 +66,8 @@ class AbsoluteGraphQLErrorTest extends Specification {
         def parameters = newParameters()
                 .executionStepInfo(ExecutionStepInfo.newExecutionStepInfo().type(objectType))
                 .source(new Object())
-                .fields(mergedSelectionSet(["fld": mergedFields(Field.newField().build())]))
-                .field(mergedFields(field))
+                .fields(mergedSelectionSet(["fld": mergedField(Field.newField().build())]))
+                .field(mergedField(field))
                 .path(ExecutionPath.fromList(["foo", "bar"]))
                 .build()
 
@@ -90,8 +90,8 @@ class AbsoluteGraphQLErrorTest extends Specification {
         def parameters = newParameters()
                 .executionStepInfo(ExecutionStepInfo.newExecutionStepInfo().type(objectType))
                 .source(new Object())
-                .fields(mergedSelectionSet(["fld": mergedFields(Field.newField().build())]))
-                .field(mergedFields(field))
+                .fields(mergedSelectionSet(["fld": mergedField(Field.newField().build())]))
+                .field(mergedField(field))
                 .path(ExecutionPath.fromList(["foo", "bar"]))
                 .build()
 
@@ -115,8 +115,8 @@ class AbsoluteGraphQLErrorTest extends Specification {
         def parameters = newParameters()
                 .executionStepInfo(ExecutionStepInfo.newExecutionStepInfo().type(objectType))
                 .source(new Object())
-                .fields(mergedSelectionSet(["fld": mergedFields(Field.newField().build())]))
-                .field(mergedFields(field))
+                .fields(mergedSelectionSet(["fld": mergedField(Field.newField().build())]))
+                .field(mergedField(field))
                 .path(ExecutionPath.fromList(["foo", "bar"]))
                 .build()
 
@@ -140,8 +140,8 @@ class AbsoluteGraphQLErrorTest extends Specification {
         def parameters = newParameters()
                 .executionStepInfo(ExecutionStepInfo.newExecutionStepInfo().type(objectType))
                 .source(new Object())
-                .fields(mergedSelectionSet(["fld": mergedFields(Field.newField().build())]))
-                .field(mergedFields(field))
+                .fields(mergedSelectionSet(["fld": mergedField(Field.newField().build())]))
+                .field(mergedField(field))
                 .path(ExecutionPath.fromList(["foo", "bar"]))
                 .build()
 
@@ -164,8 +164,8 @@ class AbsoluteGraphQLErrorTest extends Specification {
         def parameters = newParameters()
                 .executionStepInfo(ExecutionStepInfo.newExecutionStepInfo().type(objectType))
                 .source(new Object())
-                .fields(mergedSelectionSet(["fld": mergedFields(Field.newField().build())]))
-                .field(mergedFields(field))
+                .fields(mergedSelectionSet(["fld": mergedField(Field.newField().build())]))
+                .field(mergedField(field))
                 .path(ExecutionPath.fromList(["foo", "bar"]))
                 .build()
 

--- a/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy
@@ -19,7 +19,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.locks.ReentrantLock
 
 import static graphql.Scalars.GraphQLString
-import static graphql.TestUtil.mergedFields
+import static graphql.TestUtil.mergedField
 import static graphql.TestUtil.mergedSelectionSet
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
 import static graphql.schema.GraphQLObjectType.newObject
@@ -85,7 +85,7 @@ class AsyncExecutionStrategyTest extends Specification {
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
                 .executionStepInfo(typeInfo)
-                .fields(mergedSelectionSet(['hello': mergedFields([Field.newField('hello').build()]), 'hello2': mergedFields([Field.newField('hello2').build()])]))
+                .fields(mergedSelectionSet(['hello': mergedField([Field.newField('hello').build()]), 'hello2': mergedField([Field.newField('hello2').build()])]))
                 .build()
 
         AsyncExecutionStrategy asyncExecutionStrategy = new AsyncExecutionStrategy()
@@ -123,7 +123,7 @@ class AsyncExecutionStrategyTest extends Specification {
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
                 .executionStepInfo(typeInfo)
-                .fields(mergedSelectionSet(['hello': mergedFields([Field.newField('hello').build()]), 'hello2': mergedFields([Field.newField('hello2').build()])]))
+                .fields(mergedSelectionSet(['hello': mergedField([Field.newField('hello').build()]), 'hello2': mergedField([Field.newField('hello2').build()])]))
                 .build()
 
         AsyncExecutionStrategy asyncExecutionStrategy = new AsyncExecutionStrategy()
@@ -163,7 +163,7 @@ class AsyncExecutionStrategyTest extends Specification {
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
                 .executionStepInfo(typeInfo)
-                .fields(mergedSelectionSet(['hello': mergedFields([Field.newField('hello').build()]), 'hello2': mergedFields([Field.newField('hello2').build()])]))
+                .fields(mergedSelectionSet(['hello': mergedField([Field.newField('hello').build()]), 'hello2': mergedField([Field.newField('hello2').build()])]))
                 .build()
 
         AsyncExecutionStrategy asyncExecutionStrategy = new AsyncExecutionStrategy()
@@ -202,7 +202,7 @@ class AsyncExecutionStrategyTest extends Specification {
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
                 .executionStepInfo(typeInfo)
-                .fields(mergedSelectionSet(['hello': mergedFields([Field.newField('hello').build()]), 'hello2': mergedFields([Field.newField('hello2').build()])]))
+                .fields(mergedSelectionSet(['hello': mergedField([Field.newField('hello').build()]), 'hello2': mergedField([Field.newField('hello2').build()])]))
                 .build()
 
         AsyncExecutionStrategy asyncExecutionStrategy = new AsyncExecutionStrategy()
@@ -261,7 +261,7 @@ class AsyncExecutionStrategyTest extends Specification {
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
                 .executionStepInfo(typeInfo)
-                .fields(mergedSelectionSet(['hello': mergedFields([new Field('hello')]), 'hello2': mergedFields([new Field('hello2')])]))
+                .fields(mergedSelectionSet(['hello': mergedField([new Field('hello')]), 'hello2': mergedField([new Field('hello2')])]))
                 .build()
 
         AsyncExecutionStrategy asyncExecutionStrategy = new AsyncExecutionStrategy()

--- a/src/test/groovy/graphql/execution/AsyncSerialExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/AsyncSerialExecutionStrategyTest.groovy
@@ -15,7 +15,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.locks.ReentrantLock
 
 import static graphql.Scalars.GraphQLString
-import static graphql.TestUtil.mergedFields
+import static graphql.TestUtil.mergedField
 import static graphql.TestUtil.mergedSelectionSet
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
 import static graphql.schema.GraphQLObjectType.newObject
@@ -89,7 +89,7 @@ class AsyncSerialExecutionStrategyTest extends Specification {
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
                 .executionStepInfo(typeInfo)
-                .fields(mergedSelectionSet(['hello': mergedFields(new Field('hello')), 'hello2': mergedFields(new Field('hello2')), 'hello3': mergedFields(new Field('hello3'))]))
+                .fields(mergedSelectionSet(['hello': mergedField(new Field('hello')), 'hello2': mergedField(new Field('hello2')), 'hello3': mergedField(new Field('hello3'))]))
                 .build()
 
         AsyncSerialExecutionStrategy strategy = new AsyncSerialExecutionStrategy()
@@ -132,7 +132,7 @@ class AsyncSerialExecutionStrategyTest extends Specification {
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
                 .executionStepInfo(typeInfo)
-                .fields(mergedSelectionSet(['hello': mergedFields(new Field('hello')), 'hello2': mergedFields(new Field('hello2')), 'hello3': mergedFields(new Field('hello3'))]))
+                .fields(mergedSelectionSet(['hello': mergedField(new Field('hello')), 'hello2': mergedField(new Field('hello2')), 'hello3': mergedField(new Field('hello3'))]))
                 .build()
 
         AsyncSerialExecutionStrategy strategy = new AsyncSerialExecutionStrategy()

--- a/src/test/groovy/graphql/execution/BreadthFirstExecutionTestStrategy.java
+++ b/src/test/groovy/graphql/execution/BreadthFirstExecutionTestStrategy.java
@@ -33,7 +33,7 @@ public class BreadthFirstExecutionTestStrategy extends ExecutionStrategy {
         // then for every fetched value, complete it
         Map<String, Object> results = new LinkedHashMap<>();
         for (String fieldName : fetchedValues.keySet()) {
-            MergedFields currentField = fields.getSubField(fieldName);
+            MergedField currentField = fields.getSubField(fieldName);
             Object fetchedValue = fetchedValues.get(fieldName);
 
             ExecutionPath fieldPath = parameters.getPath().segment(fieldName);
@@ -52,7 +52,7 @@ public class BreadthFirstExecutionTestStrategy extends ExecutionStrategy {
     }
 
     private Object fetchField(ExecutionContext executionContext, ExecutionStrategyParameters parameters, MergedSelectionSet fields, String fieldName) {
-        MergedFields currentField = fields.getSubField(fieldName);
+        MergedField currentField = fields.getSubField(fieldName);
 
         ExecutionPath fieldPath = parameters.getPath().segment(fieldName);
         ExecutionStrategyParameters newParameters = parameters

--- a/src/test/groovy/graphql/execution/BreadthFirstTestStrategy.java
+++ b/src/test/groovy/graphql/execution/BreadthFirstTestStrategy.java
@@ -59,7 +59,7 @@ public class BreadthFirstTestStrategy extends ExecutionStrategy {
         // then for every fetched value, complete it, breath first
         Map<String, Object> results = new LinkedHashMap<>();
         for (String fieldName : fetchedValues.keySet()) {
-            MergedFields fieldList = fields.getSubField(fieldName);
+            MergedField fieldList = fields.getSubField(fieldName);
 
             ExecutionStrategyParameters newParameters = newParameters(parameters, fields, fieldName);
 
@@ -77,7 +77,7 @@ public class BreadthFirstTestStrategy extends ExecutionStrategy {
     }
 
     private ExecutionStrategyParameters newParameters(ExecutionStrategyParameters parameters, MergedSelectionSet fields, String fieldName) {
-        MergedFields currentField = fields.getSubField(fieldName);
+        MergedField currentField = fields.getSubField(fieldName);
         ExecutionPath fieldPath = parameters.getPath().segment(fieldName);
         return parameters
                 .transform(builder -> builder.field(currentField).path(fieldPath));

--- a/src/test/groovy/graphql/execution/ExecutionStepInfoTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStepInfoTest.groovy
@@ -17,7 +17,7 @@ import java.util.function.Function
 
 import static ExecutionStepInfo.newExecutionStepInfo
 import static graphql.Scalars.GraphQLString
-import static graphql.TestUtil.mergedFields
+import static graphql.TestUtil.mergedField
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
 import static graphql.schema.GraphQLList.list
 import static graphql.schema.GraphQLNonNull.nonNull
@@ -28,7 +28,7 @@ import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring
 class ExecutionStepInfoTest extends Specification {
 
     def field = new Field("someAstField")
-    def mergedFields = mergedFields(field)
+    def mergedField = mergedField(field)
 
     def field1Def = newFieldDefinition().name("field1").type(GraphQLString).build()
 
@@ -51,7 +51,7 @@ class ExecutionStepInfoTest extends Specification {
     def "basic hierarchy"() {
         given:
         def rootTypeInfo = newExecutionStepInfo().type(rootType).build()
-        def fieldTypeInfo = newExecutionStepInfo().type(fieldType).fieldDefinition(field1Def).field(mergedFields).parentInfo(rootTypeInfo).build()
+        def fieldTypeInfo = newExecutionStepInfo().type(fieldType).fieldDefinition(field1Def).field(mergedField).parentInfo(rootTypeInfo).build()
         def nonNullFieldTypeInfo = newExecutionStepInfo().type(nonNull(fieldType)).parentInfo(rootTypeInfo).build()
         def listTypeInfo = newExecutionStepInfo().type(list(fieldType)).parentInfo(rootTypeInfo).build()
 
@@ -66,7 +66,7 @@ class ExecutionStepInfoTest extends Specification {
         fieldTypeInfo.parent.type == rootType
         !fieldTypeInfo.isNonNullType()
         fieldTypeInfo.getFieldDefinition() == field1Def
-        fieldTypeInfo.getField() == mergedFields
+        fieldTypeInfo.getField() == mergedField
 
         nonNullFieldTypeInfo.getUnwrappedNonNullType() == fieldType
         nonNullFieldTypeInfo.hasParent()

--- a/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
@@ -30,7 +30,7 @@ import java.util.concurrent.CompletionException
 
 import static ExecutionStrategyParameters.newParameters
 import static graphql.Scalars.GraphQLString
-import static graphql.TestUtil.mergedFields
+import static graphql.TestUtil.mergedField
 import static graphql.TestUtil.mergedSelectionSet
 import static graphql.schema.GraphQLArgument.newArgument
 import static graphql.schema.GraphQLEnumType.newEnum
@@ -99,7 +99,7 @@ class ExecutionStrategyTest extends Specification {
                 .executionStepInfo(ExecutionStepInfo.newExecutionStepInfo().type(objectType))
                 .source(result)
                 .fields(mergedSelectionSet(["fld": [Field.newField().build()]]))
-                .field(mergedFields(Field.newField().build()))
+                .field(mergedField(Field.newField().build()))
                 .build()
 
         when:
@@ -128,7 +128,7 @@ class ExecutionStrategyTest extends Specification {
                 .source(result)
                 .nonNullFieldValidator(nullableFieldValidator)
                 .fields(mergedSelectionSet(["fld": []]))
-                .field(mergedFields(field))
+                .field(mergedField(field))
                 .build()
 
         when:
@@ -343,7 +343,7 @@ class ExecutionStrategyTest extends Specification {
                 .source(result)
                 .nonNullFieldValidator(nullableFieldValidator)
                 .fields(mergedSelectionSet(["fld": []]))
-                .field(mergedFields(new Field("someField")))
+                .field(mergedField(new Field("someField")))
                 .build()
 
         when:
@@ -489,7 +489,7 @@ class ExecutionStrategyTest extends Specification {
                 .executionStepInfo(typeInfo)
                 .source("source")
                 .fields(mergedSelectionSet(["someField": [field]]))
-                .field(mergedFields(field))
+                .field(mergedField(field))
                 .nonNullFieldValidator(nullableFieldValidator)
                 .path(executionPath)
                 .build()
@@ -538,7 +538,7 @@ class ExecutionStrategyTest extends Specification {
                 .executionStepInfo(typeInfo)
                 .source("source")
                 .fields(mergedSelectionSet(["someField": [field]]))
-                .field(mergedFields(field))
+                .field(mergedField(field))
                 .path(expectedPath)
                 .nonNullFieldValidator(nullableFieldValidator)
                 .build()
@@ -641,8 +641,8 @@ class ExecutionStrategyTest extends Specification {
                 .executionStepInfo(typeInfo)
                 .source(null)
                 .nonNullFieldValidator(nullableFieldValidator)
-                .field(mergedFields(field))
-                .fields(mergedSelectionSet(["someField": [mergedFields(field)]]))
+                .field(mergedField(field))
+                .fields(mergedSelectionSet(["someField": [mergedField(field)]]))
                 .path(ExecutionPath.rootPath().segment("abc"))
                 .build()
 
@@ -668,8 +668,8 @@ class ExecutionStrategyTest extends Specification {
                 .executionStepInfo(executionStepInfo)
                 .source(result)
                 .nonNullFieldValidator(nullableFieldValidator)
-                .fields(mergedSelectionSet(["fld": [mergedFields(Field.newField().build())]]))
-                .field(mergedFields(Field.newField().build()))
+                .fields(mergedSelectionSet(["fld": [mergedField(Field.newField().build())]]))
+                .field(mergedField(Field.newField().build()))
                 .build()
 
         when:
@@ -689,8 +689,8 @@ class ExecutionStrategyTest extends Specification {
         def field = Field.newField("parent").sourceLocation(new SourceLocation(5, 10)).build()
         def parameters = newParameters()
                 .path(ExecutionPath.fromList(["parent"]))
-                .field(mergedFields(field))
-                .fields(mergedSelectionSet(["parent": [mergedFields(field)]]))
+                .field(mergedField(field))
+                .fields(mergedSelectionSet(["parent": [mergedField(field)]]))
                 .executionStepInfo(executionStepInfo)
                 .build()
 
@@ -716,8 +716,8 @@ class ExecutionStrategyTest extends Specification {
         def field = Field.newField("parent").sourceLocation(new SourceLocation(5, 10)).build()
         def parameters = newParameters()
                 .path(ExecutionPath.fromList(["parent"]))
-                .field(mergedFields(field))
-                .fields(mergedSelectionSet(["parent": [mergedFields(field)]]))
+                .field(mergedField(field))
+                .fields(mergedSelectionSet(["parent": [mergedField(field)]]))
                 .executionStepInfo(executionStepInfo)
                 .build()
 
@@ -746,8 +746,8 @@ class ExecutionStrategyTest extends Specification {
                 .executionStepInfo(executionStepInfo)
                 .source(result)
                 .nonNullFieldValidator(nullableFieldValidator)
-                .fields(mergedSelectionSet(["fld": [mergedFields(Field.newField().build())]]))
-                .field(mergedFields(Field.newField().build()))
+                .fields(mergedSelectionSet(["fld": [mergedField(Field.newField().build())]]))
+                .field(mergedField(Field.newField().build()))
                 .build()
 
         when:
@@ -770,8 +770,8 @@ class ExecutionStrategyTest extends Specification {
                 .executionStepInfo(typeInfo)
                 .source(result)
                 .nonNullFieldValidator(nullableFieldValidator)
-                .fields(mergedSelectionSet(["fld": [mergedFields(Field.newField().build())]]))
-                .field(mergedFields(Field.newField().build()))
+                .fields(mergedSelectionSet(["fld": [mergedField(Field.newField().build())]]))
+                .field(mergedField(Field.newField().build()))
                 .build()
 
         when:

--- a/src/test/groovy/graphql/execution/FieldCollectorTest.groovy
+++ b/src/test/groovy/graphql/execution/FieldCollectorTest.groovy
@@ -9,7 +9,7 @@ import graphql.parser.Parser
 import graphql.schema.GraphQLObjectType
 import spock.lang.Specification
 
-import static graphql.TestUtil.mergedFields
+import static graphql.TestUtil.mergedField
 import static graphql.execution.FieldCollectorParameters.newParameters
 
 class FieldCollectorTest extends Specification {
@@ -36,7 +36,7 @@ class FieldCollectorTest extends Specification {
         def bar2 = field.selectionSet.selections[1]
 
         when:
-        def result = fieldCollector.collectFields(fieldCollectorParameters, mergedFields(field))
+        def result = fieldCollector.collectFields(fieldCollectorParameters, mergedField(field))
 
         then:
         result.getSubField('bar1').getFields() == [bar1]
@@ -69,7 +69,7 @@ class FieldCollectorTest extends Specification {
         def interfaceField = inlineFragment.selectionSet.selections[0]
 
         when:
-        def result = fieldCollector.collectFields(fieldCollectorParameters, mergedFields(bar1Field))
+        def result = fieldCollector.collectFields(fieldCollectorParameters, mergedField(bar1Field))
 
         then:
         result.getSubField('fieldOnInterface').getFields() == [interfaceField]

--- a/src/test/groovy/graphql/execution/defer/DeferSupportTest.groovy
+++ b/src/test/groovy/graphql/execution/defer/DeferSupportTest.groovy
@@ -9,7 +9,7 @@ import spock.lang.Specification
 
 import java.util.concurrent.CompletableFuture
 
-import static graphql.TestUtil.mergedFields
+import static graphql.TestUtil.mergedField
 
 class DeferSupportTest extends Specification {
 
@@ -177,7 +177,7 @@ class DeferSupportTest extends Specification {
         def deferSupport = new DeferSupport()
 
         when:
-        def noDirectivePresent = deferSupport.checkForDeferDirective(mergedFields([
+        def noDirectivePresent = deferSupport.checkForDeferDirective(mergedField([
                 new Field("a"),
                 new Field("a")
         ]))
@@ -186,7 +186,7 @@ class DeferSupportTest extends Specification {
         !noDirectivePresent
 
         when:
-        def directivePresent = deferSupport.checkForDeferDirective(mergedFields([
+        def directivePresent = deferSupport.checkForDeferDirective(mergedField([
                 Field.newField("a").directives([new Directive("defer")]).build(),
                 new Field("a")
         ]))

--- a/src/test/groovy/graphql/schema/DataFetchingFieldSelectionSetImplTest.groovy
+++ b/src/test/groovy/graphql/schema/DataFetchingFieldSelectionSetImplTest.groovy
@@ -11,7 +11,7 @@ import graphql.language.NodeUtil
 import graphql.language.OperationDefinition
 import spock.lang.Specification
 
-import static graphql.TestUtil.mergedFields
+import static graphql.TestUtil.mergedField
 
 class DataFetchingFieldSelectionSetImplTest extends Specification {
 
@@ -66,7 +66,7 @@ class DataFetchingFieldSelectionSetImplTest extends Specification {
                 .fragmentsByName(getFragments(document))
                 .graphQLSchema(starWarsSchema).build()
 
-        def selectionSet = DataFetchingFieldSelectionSetImpl.newCollector(executionContext, starWarsSchema.getType('Human'), mergedFields(fields))
+        def selectionSet = DataFetchingFieldSelectionSetImpl.newCollector(executionContext, starWarsSchema.getType('Human'), mergedField(fields))
 
         expect:
         !selectionSet.contains(null)
@@ -122,7 +122,7 @@ class DataFetchingFieldSelectionSetImplTest extends Specification {
                 .fragmentsByName(getFragments(document))
                 .graphQLSchema(starWarsSchema).build()
 
-        def selectionSet = DataFetchingFieldSelectionSetImpl.newCollector(executionContext, starWarsSchema.getType('Human'), mergedFields(fields))
+        def selectionSet = DataFetchingFieldSelectionSetImpl.newCollector(executionContext, starWarsSchema.getType('Human'), mergedField(fields))
 
         def fieldMap = selectionSet.get()
         expect:
@@ -151,7 +151,7 @@ class DataFetchingFieldSelectionSetImplTest extends Specification {
                 .fragmentsByName(getFragments(document))
                 .graphQLSchema(starWarsSchema).build()
 
-        def selectionSet = DataFetchingFieldSelectionSetImpl.newCollector(executionContext, starWarsSchema.getType('Human'), mergedFields(fields))
+        def selectionSet = DataFetchingFieldSelectionSetImpl.newCollector(executionContext, starWarsSchema.getType('Human'), mergedField(fields))
 
         expect:
 
@@ -172,7 +172,7 @@ class DataFetchingFieldSelectionSetImplTest extends Specification {
                 .fragmentsByName(getFragments(document))
                 .graphQLSchema(starWarsSchema).build()
 
-        def selectionSet = DataFetchingFieldSelectionSetImpl.newCollector(executionContext, starWarsSchema.getType('Human'), mergedFields(fields))
+        def selectionSet = DataFetchingFieldSelectionSetImpl.newCollector(executionContext, starWarsSchema.getType('Human'), mergedField(fields))
 
         expect:
 
@@ -241,7 +241,7 @@ class DataFetchingFieldSelectionSetImplTest extends Specification {
         def startingType = replaySchema.getType('ThingConnection')
 
         when:
-        def selectionSet = DataFetchingFieldSelectionSetImpl.newCollector(replayExecutionContext, startingType, mergedFields(startField))
+        def selectionSet = DataFetchingFieldSelectionSetImpl.newCollector(replayExecutionContext, startingType, mergedField(startField))
 
         def selectedNodesField = selectionSet.getField("nodes")
 
@@ -290,7 +290,7 @@ class DataFetchingFieldSelectionSetImplTest extends Specification {
         def startingType = replaySchema.getType('ThingConnection')
 
         when:
-        def selectionSet = DataFetchingFieldSelectionSetImpl.newCollector(replayExecutionContext, startingType, mergedFields(startField))
+        def selectionSet = DataFetchingFieldSelectionSetImpl.newCollector(replayExecutionContext, startingType, mergedField(startField))
         List<SelectedField> selectedUnderNodesAster = selectionSet.getFields("nodes/*")
 
         then:
@@ -321,7 +321,7 @@ class DataFetchingFieldSelectionSetImplTest extends Specification {
         def startingType = replaySchema.getType('ThingConnection')
 
         when:
-        def selectionSet = DataFetchingFieldSelectionSetImpl.newCollector(replayExecutionContext, startingType, mergedFields(startField))
+        def selectionSet = DataFetchingFieldSelectionSetImpl.newCollector(replayExecutionContext, startingType, mergedField(startField))
         List<SelectedField> allFieldsViaAsterAster = selectionSet.getFields("**")
         List<SelectedField> allFields = selectionSet.getFields()
 


### PR DESCRIPTION
Even if a merged Field consists of multiple Fields it is treated as one (multiple fields merged into one), therefore using the singular makes more sense. 