### PR TITLE
Indent args and use multiline comments when printing schema

### DIFF
--- a/src/main/java/graphql/schema/idl/SchemaPrinter.java
+++ b/src/main/java/graphql/schema/idl/SchemaPrinter.java
@@ -405,7 +405,8 @@ public class SchemaPrinter {
 
     String argsString(List<GraphQLArgument> arguments) {
         boolean hasDescriptions = arguments.stream().anyMatch(arg -> !isNullOrEmpty(arg.getDescription()));
-        String prefix = hasDescriptions ? "  " : "";
+        String halfPrefix = hasDescriptions ? "  " : "";
+        String prefix = hasDescriptions ? "    " : "";
         int count = 0;
         StringBuilder sb = new StringBuilder();
         arguments = arguments
@@ -424,7 +425,7 @@ public class SchemaPrinter {
             String description = argument.getDescription();
             if (!isNullOrEmpty(description)) {
                 Stream<String> stream = Arrays.stream(description.split("\n"));
-                stream.map(s -> "  #" + s + "\n").forEach(sb::append);
+                stream.map(s -> prefix + "#" + s + "\n").forEach(sb::append);
             }
             sb.append(prefix).append(argument.getName()).append(": ").append(typeString(argument.getType()));
             Object defaultValue = argument.getDefaultValue();
@@ -438,7 +439,7 @@ public class SchemaPrinter {
             if (hasDescriptions) {
                 sb.append("\n");
             }
-            sb.append(prefix).append(")");
+            sb.append(halfPrefix).append(")");
         }
         return sb.toString();
     }

--- a/src/main/java/graphql/schema/idl/SchemaPrinter.java
+++ b/src/main/java/graphql/schema/idl/SchemaPrinter.java
@@ -424,8 +424,16 @@ public class SchemaPrinter {
             }
             String description = argument.getDescription();
             if (!isNullOrEmpty(description)) {
-                Stream<String> stream = Arrays.stream(description.split("\n"));
-                stream.map(s -> prefix + "#" + s + "\n").forEach(sb::append);
+                String[] descriptionSplitByNewlines = description.split("\n");
+                Stream<String> stream = Arrays.stream(descriptionSplitByNewlines);
+                if (descriptionSplitByNewlines.length > 1) {
+                    String multiLineComment = "\"\"\"";
+                    stream = Stream.concat(Stream.of(multiLineComment), stream);
+                    stream = Stream.concat(stream, Stream.of(multiLineComment));
+                    stream.map(s -> prefix + s + "\n").forEach(sb::append);
+                } else {
+                    stream.map(s -> prefix + "#" + s + "\n").forEach(sb::append);
+                }
             }
             sb.append(prefix).append(argument.getName()).append(": ").append(typeString(argument.getType()));
             Object defaultValue = argument.getDefaultValue();

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -539,8 +539,10 @@ scalar Scalar
     #about arg1
     arg1: String, 
     arg2: String, 
-    #about 3
-    #second line
+    \"\"\"
+    about 3
+    second line
+    \"\"\"
     arg3: String
   ): String
 }

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -8,7 +8,6 @@ import graphql.introspection.IntrospectionQuery
 import graphql.introspection.IntrospectionResultToSchema
 import graphql.schema.Coercing
 import graphql.schema.GraphQLArgument
-import graphql.schema.GraphQLDirective
 import graphql.schema.GraphQLEnumType
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLInputObjectType
@@ -23,11 +22,9 @@ import graphql.schema.GraphQLUnionType
 import graphql.schema.TypeResolver
 import spock.lang.Specification
 
-import java.util.Collections
 import java.util.function.UnaryOperator
 
 import static graphql.Scalars.GraphQLString
-import static graphql.TestUtil.mockDirective
 import static graphql.TestUtil.mockScalar
 import static graphql.TestUtil.mockTypeRuntimeWiring
 import static graphql.schema.GraphQLArgument.newArgument
@@ -539,12 +536,12 @@ scalar Scalar
         then:
         result == """type Query {
   field(
-  #about arg1
-  arg1: String, 
-  arg2: String, 
-  #about 3
-  #second line
-  arg3: String
+    #about arg1
+    arg1: String, 
+    arg2: String, 
+    #about 3
+    #second line
+    arg3: String
   ): String
 }
 """

--- a/src/test/groovy/graphql/schema/visibility/GraphqlFieldVisibilityTest.groovy
+++ b/src/test/groovy/graphql/schema/visibility/GraphqlFieldVisibilityTest.groovy
@@ -167,16 +167,16 @@ type Human implements Character {
 
 type QueryType {
   droid(
-  #id of the droid
-  id: String!
+    #id of the droid
+    id: String!
   ): Droid
   hero(
-  #If omitted, returns the hero of the whole saga. If provided, returns the hero of that particular episode.
-  episode: Episode
+    #If omitted, returns the hero of the whole saga. If provided, returns the hero of that particular episode.
+    episode: Episode
   ): Character
   human(
-  #id of the human
-  id: String!
+    #id of the human
+    id: String!
   ): Human
 }
 
@@ -244,12 +244,12 @@ type Human implements Character {
 
 type QueryType {
   droid(
-  #id of the droid
-  id: String!
+    #id of the droid
+    id: String!
   ): Droid
   human(
-  #id of the human
-  id: String!
+    #id of the human
+    id: String!
   ): Human
 }
 


### PR DESCRIPTION
While looking at some pretty printed schemas from graphql-js I noticed the graphql-java schemas were not as pretty.

Now they will look more like:

```
type Query {
  field(
    #about arg1
    arg1: String, 
    arg2: String, 
    """
    about 3
    second line
    """
    arg3: String
  ): String
}
```

Would like to even add newlines between args to pad them out but this is a good first step.