### PR TITLE
the type of an OperationTypeDefinition is actually a typeName

### DIFF
--- a/src/main/java/graphql/introspection/IntrospectionResultToSchema.java
+++ b/src/main/java/graphql/introspection/IntrospectionResultToSchema.java
@@ -75,14 +75,14 @@ public class IntrospectionResultToSchema {
         boolean nonDefaultQueryName = !"Query".equals(query.getName());
 
         SchemaDefinition.Builder schemaDefinition = SchemaDefinition.newSchemaDefinition();
-        schemaDefinition.operationTypeDefinition(OperationTypeDefinition.newOperationTypeDefinition().name("query").type(query).build());
+        schemaDefinition.operationTypeDefinition(OperationTypeDefinition.newOperationTypeDefinition().name("query").typeName(query).build());
 
         Map<String, Object> mutationType = (Map<String, Object>) schema.get("mutationType");
         boolean nonDefaultMutationName = false;
         if (mutationType != null) {
             TypeName mutation = TypeName.newTypeName().name((String) mutationType.get("name")).build();
             nonDefaultMutationName = !"Mutation".equals(mutation.getName());
-            schemaDefinition.operationTypeDefinition(OperationTypeDefinition.newOperationTypeDefinition().name("mutation").type(mutation).build());
+            schemaDefinition.operationTypeDefinition(OperationTypeDefinition.newOperationTypeDefinition().name("mutation").typeName(mutation).build());
         }
 
         Map<String, Object> subscriptionType = (Map<String, Object>) schema.get("subscriptionType");
@@ -90,7 +90,7 @@ public class IntrospectionResultToSchema {
         if (subscriptionType != null) {
             TypeName subscription = TypeName.newTypeName().name(((String) subscriptionType.get("name"))).build();
             nonDefaultSubscriptionName = !"Subscription".equals(subscription.getName());
-            schemaDefinition.operationTypeDefinition(OperationTypeDefinition.newOperationTypeDefinition().name("subscription").type(subscription).build());
+            schemaDefinition.operationTypeDefinition(OperationTypeDefinition.newOperationTypeDefinition().name("subscription").typeName(subscription).build());
         }
 
         Document.Builder document = Document.newDocument();

--- a/src/main/java/graphql/language/AstPrinter.java
+++ b/src/main/java/graphql/language/AstPrinter.java
@@ -293,7 +293,7 @@ public class AstPrinter {
 
     private NodePrinter<OperationTypeDefinition> operationTypeDefinition() {
         String nameTypeSep = compactMode ? ":" : ": ";
-        return (out, node) -> out.printf("%s%s%s", node.getName(), nameTypeSep, type(node.getType()));
+        return (out, node) -> out.printf("%s%s%s", node.getName(), nameTypeSep, type(node.getTypeName()));
     }
 
     private NodePrinter<ObjectTypeDefinition> objectTypeDefinition() {

--- a/src/main/java/graphql/language/OperationTypeDefinition.java
+++ b/src/main/java/graphql/language/OperationTypeDefinition.java
@@ -16,29 +16,29 @@ import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 public class OperationTypeDefinition extends AbstractNode<OperationTypeDefinition> implements NamedNode<OperationTypeDefinition> {
 
     private final String name;
-    private final Type type;
+    private final TypeName typeName;
 
-    public static final String CHILD_TYPE = "type";
+    public static final String CHILD_TYPE_NAME = "typeName";
 
     @Internal
-    protected OperationTypeDefinition(String name, Type type, SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars) {
+    protected OperationTypeDefinition(String name, TypeName typeName, SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars) {
         super(sourceLocation, comments, ignoredChars);
         this.name = name;
-        this.type = type;
+        this.typeName = typeName;
     }
 
     /**
      * alternative to using a Builder for convenience
      *
      * @param name of the operation
-     * @param type the type in play
+     * @param typeName the type in play
      */
-    public OperationTypeDefinition(String name, Type type) {
-        this(name, type, null, new ArrayList<>(), IgnoredChars.EMPTY);
+    public OperationTypeDefinition(String name, TypeName typeName) {
+        this(name, typeName, null, new ArrayList<>(), IgnoredChars.EMPTY);
     }
 
-    public Type getType() {
-        return type;
+    public TypeName getTypeName() {
+        return typeName;
     }
 
     @Override
@@ -49,21 +49,21 @@ public class OperationTypeDefinition extends AbstractNode<OperationTypeDefinitio
     @Override
     public List<Node> getChildren() {
         List<Node> result = new ArrayList<>();
-        result.add(type);
+        result.add(typeName);
         return result;
     }
 
     @Override
     public NodeChildrenContainer getNamedChildren() {
         return newNodeChildrenContainer()
-                .child(CHILD_TYPE, type)
+                .child(CHILD_TYPE_NAME, typeName)
                 .build();
     }
 
     @Override
     public OperationTypeDefinition withNewChildren(NodeChildrenContainer newChildren) {
         return transform(builder -> builder
-                .type(newChildren.getChildOrNull(CHILD_TYPE))
+                .typeName(newChildren.getChildOrNull(CHILD_TYPE_NAME))
         );
     }
 
@@ -83,14 +83,14 @@ public class OperationTypeDefinition extends AbstractNode<OperationTypeDefinitio
 
     @Override
     public OperationTypeDefinition deepCopy() {
-        return new OperationTypeDefinition(name, deepCopy(type), getSourceLocation(), getComments(), getIgnoredChars());
+        return new OperationTypeDefinition(name, deepCopy(typeName), getSourceLocation(), getComments(), getIgnoredChars());
     }
 
     @Override
     public String toString() {
         return "OperationTypeDefinition{" +
                 "name='" + name + "'" +
-                ", type=" + type +
+                ", typeName=" + typeName +
                 "}";
     }
 
@@ -113,7 +113,7 @@ public class OperationTypeDefinition extends AbstractNode<OperationTypeDefinitio
         private SourceLocation sourceLocation;
         private List<Comment> comments = new ArrayList<>();
         private String name;
-        private Type type;
+        private TypeName typeName;
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
@@ -124,7 +124,7 @@ public class OperationTypeDefinition extends AbstractNode<OperationTypeDefinitio
             this.sourceLocation = existing.getSourceLocation();
             this.comments = existing.getComments();
             this.name = existing.getName();
-            this.type = existing.getType();
+            this.typeName = existing.getTypeName();
             this.ignoredChars = existing.getIgnoredChars();
         }
 
@@ -144,8 +144,8 @@ public class OperationTypeDefinition extends AbstractNode<OperationTypeDefinitio
             return this;
         }
 
-        public Builder type(Type type) {
-            this.type = type;
+        public Builder typeName(TypeName type) {
+            this.typeName = type;
             return this;
         }
 
@@ -155,7 +155,7 @@ public class OperationTypeDefinition extends AbstractNode<OperationTypeDefinitio
         }
 
         public OperationTypeDefinition build() {
-            OperationTypeDefinition operationTypeDefinition = new OperationTypeDefinition(name, type, sourceLocation, comments, ignoredChars);
+            OperationTypeDefinition operationTypeDefinition = new OperationTypeDefinition(name, typeName, sourceLocation, comments, ignoredChars);
             return operationTypeDefinition;
         }
     }

--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -374,7 +374,7 @@ public class GraphqlAntlrToLanguage {
     protected OperationTypeDefinition createOperationTypeDefinition(GraphqlParser.OperationTypeDefinitionContext ctx) {
         OperationTypeDefinition.Builder def = OperationTypeDefinition.newOperationTypeDefinition();
         def.name(ctx.operationType().getText());
-        def.type(createTypeName(ctx.typeName()));
+        def.typeName(createTypeName(ctx.typeName()));
         addCommonData(def, ctx);
         return def.build();
     }

--- a/src/main/java/graphql/schema/diff/SchemaDiff.java
+++ b/src/main/java/graphql/schema/diff/SchemaDiff.java
@@ -184,14 +184,14 @@ public class SchemaDiff {
         OperationTypeDefinition oldOpTypeDefinition = oldOpTypeDef.get();
         OperationTypeDefinition newOpTypeDefinition = newOpTypeDef.get();
 
-        Type oldType = oldOpTypeDefinition.getType();
+        Type oldType = oldOpTypeDefinition.getTypeName();
         //
         // if we have no old op, then it must have been added (which is ok)
         Optional<TypeDefinition> oldTD = ctx.getOldTypeDef(oldType, TypeDefinition.class);
         if (!oldTD.isPresent()) {
             return;
         }
-        checkType(ctx, oldType, newOpTypeDefinition.getType());
+        checkType(ctx, oldType, newOpTypeDefinition.getTypeName());
     }
 
     private void checkType(DiffCtx ctx, Type oldType, Type newType) {
@@ -835,7 +835,7 @@ public class SchemaDiff {
     private Optional<OperationTypeDefinition> synthOperationTypeDefinition(Function<Type, Optional<ObjectTypeDefinition>> typeReteriver, String opName) {
         TypeName type = TypeName.newTypeName().name(capitalize(opName)).build();
         Optional<ObjectTypeDefinition> typeDef = typeReteriver.apply(type);
-        return typeDef.map(objectTypeDefinition -> OperationTypeDefinition.newOperationTypeDefinition().name(opName).type(type).build());
+        return typeDef.map(objectTypeDefinition -> OperationTypeDefinition.newOperationTypeDefinition().name(opName).typeName(type).build());
     }
 
     private <T> Map<String, T> sortedMap(List<T> listOfNamedThings, Function<T, String> nameFunc) {

--- a/src/main/java/graphql/schema/idl/SchemaGenerator.java
+++ b/src/main/java/graphql/schema/idl/SchemaGenerator.java
@@ -356,7 +356,7 @@ public class SchemaGenerator {
     }
 
     private GraphQLObjectType buildOperation(BuildContext buildCtx, OperationTypeDefinition operation) {
-        Type type = operation.getType();
+        Type type = operation.getTypeName();
 
         return buildOutputType(buildCtx, type);
     }

--- a/src/main/java/graphql/schema/idl/SchemaTypeChecker.java
+++ b/src/main/java/graphql/schema/idl/SchemaTypeChecker.java
@@ -528,7 +528,7 @@ public class SchemaTypeChecker {
 
     private Consumer<OperationTypeDefinition> checkOperationTypesExist(TypeDefinitionRegistry typeRegistry, List<GraphQLError> errors) {
         return op -> {
-            TypeName unwrapped = TypeInfo.typeInfo(op.getType()).getTypeName();
+            TypeName unwrapped = TypeInfo.typeInfo(op.getTypeName()).getTypeName();
             if (!typeRegistry.hasType(unwrapped)) {
                 errors.add(new MissingTypeError("operation", op, op.getName(), unwrapped));
             }
@@ -538,7 +538,7 @@ public class SchemaTypeChecker {
     private Consumer<OperationTypeDefinition> checkOperationTypesAreObjects(TypeDefinitionRegistry typeRegistry, List<GraphQLError> errors) {
         return op -> {
             // make sure it is defined as a ObjectTypeDef
-            Type queryType = op.getType();
+            Type queryType = op.getTypeName();
             Optional<TypeDefinition> type = typeRegistry.getType(queryType);
             type.ifPresent(typeDef -> {
                 if (!(typeDef instanceof ObjectTypeDefinition)) {


### PR DESCRIPTION
This is a breaking change:

`OperationTypeDefinition.type` is changed to `OperationTypeDefinition.typeName`.
The type is changed from `Type` to `TypeName.`

I don't know why it was ever the way it was, but a `OperationTypeDefinition` doesn't have a type reference, but clearly just has a type name. (the grammar has it correct)