### PR TITLE
Update jackson-databind version (security risk!), junit version (and fix typos)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ therefore we avoid adding any new dependency.
 access etc is out of scope.
 
 
-If you have any question please conside asking in our spectrum chat https://spectrum.chat/graphql-java. For bug reports or specific code related topics create a new issue.
+If you have any question please consider asking in our spectrum chat https://spectrum.chat/graphql-java. For bug reports or specific code related topics create a new issue.
 
 Thanks! 
   

--- a/build.gradle
+++ b/build.gradle
@@ -54,14 +54,14 @@ dependencies {
     compile 'com.graphql-java:java-dataloader:2.1.1'
     compile 'org.reactivestreams:reactive-streams:' + reactiveStreamsVersion
     antlr "org.antlr:antlr4:4.7.1"
-    testCompile group: 'junit', name: 'junit', version: '4.11'
+    testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile 'org.spockframework:spock-core:1.1-groovy-2.4'
     testCompile 'org.codehaus.groovy:groovy-all:2.4.13'
     testCompile 'cglib:cglib-nodep:3.1'
     testCompile 'org.objenesis:objenesis:2.1'
     testCompile 'com.google.code.gson:gson:2.8.0'
     testCompile 'org.eclipse.jetty:jetty-server:9.4.5.v20170502'
-    testCompile 'com.fasterxml.jackson.core:jackson-databind:2.8.8.1'
+    testCompile 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
     testCompile 'org.slf4j:slf4j-simple:' + slf4jVersion
     testCompile 'org.awaitility:awaitility-groovy:3.0.0'
     testCompile 'com.github.javafaker:javafaker:0.13'
@@ -129,7 +129,7 @@ publishing {
                 classifier "javadoc"
             }
             pom.withXml {
-                // The ANTLR-related code below--introdcued in `1ac98bf`--addresses an issue with
+                // The ANTLR-related code below--introduced in `1ac98bf`--addresses an issue with
                 // the Gradle ANTLR plugin. `1ac98bf` can be reverted and this comment removed once
                 // that issue is fixed and Gradle upgraded. See https://goo.gl/L92KiF and https://goo.gl/FY0PVR.
                 Node pomNode = asNode()


### PR DESCRIPTION
There were some security issues in jackson(-databind) recently, including:
* https://www.cvedetails.com/cve/CVE-2017-7525/
* https://www.cvedetails.com/cve/CVE-2018-1000873/
Therefore I wanted to update this dependency.

While I was here, also updated the Junit version and fixed some typos.

Afaik all tests still pass (although I'm not too familiar with Gradle...)

Please let me know if you have any feedback.