### PR TITLE
Unique query directives

### DIFF
--- a/src/main/java/graphql/validation/ValidationErrorType.java
+++ b/src/main/java/graphql/validation/ValidationErrorType.java
@@ -29,6 +29,6 @@ public enum ValidationErrorType {
     InvalidFragmentType,
     LoneAnonymousOperationViolation,
     NonExecutableDefinition,
-    DuplicateOperationName
-
+    DuplicateOperationName,
+    DuplicateDirectiveName
 }

--- a/src/main/java/graphql/validation/Validator.java
+++ b/src/main/java/graphql/validation/Validator.java
@@ -21,6 +21,7 @@ import graphql.validation.rules.OverlappingFieldsCanBeMerged;
 import graphql.validation.rules.PossibleFragmentSpreads;
 import graphql.validation.rules.ProvidedNonNullArguments;
 import graphql.validation.rules.ScalarLeafs;
+import graphql.validation.rules.UniqueDirectiveNamesPerLocation;
 import graphql.validation.rules.UniqueOperationNames;
 import graphql.validation.rules.VariableDefaultValuesOfCorrectType;
 import graphql.validation.rules.VariableTypesMatchRule;
@@ -99,6 +100,9 @@ public class Validator {
 
         UniqueOperationNames uniqueOperationNames = new UniqueOperationNames(validationContext, validationErrorCollector);
         rules.add(uniqueOperationNames);
+
+        UniqueDirectiveNamesPerLocation uniqueDirectiveNamesPerLocation = new UniqueDirectiveNamesPerLocation(validationContext, validationErrorCollector);
+        rules.add(uniqueDirectiveNamesPerLocation);
 
         return rules;
     }

--- a/src/main/java/graphql/validation/rules/UniqueDirectiveNamesPerLocation.java
+++ b/src/main/java/graphql/validation/rules/UniqueDirectiveNamesPerLocation.java
@@ -1,0 +1,77 @@
+package graphql.validation.rules;
+
+import graphql.language.Directive;
+import graphql.language.Document;
+import graphql.language.Field;
+import graphql.language.FragmentDefinition;
+import graphql.language.FragmentSpread;
+import graphql.language.InlineFragment;
+import graphql.language.Node;
+import graphql.language.OperationDefinition;
+import graphql.validation.AbstractRule;
+import graphql.validation.ValidationContext;
+import graphql.validation.ValidationErrorCollector;
+import graphql.validation.ValidationErrorType;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * https://facebook.github.io/graphql/June2018/#sec-Directives-Are-Unique-Per-Location
+ */
+public class UniqueDirectiveNamesPerLocation extends AbstractRule {
+
+    public UniqueDirectiveNamesPerLocation(ValidationContext validationContext, ValidationErrorCollector validationErrorCollector) {
+        super(validationContext, validationErrorCollector);
+    }
+
+    @Override
+    public void checkDocument(Document document) {
+        super.checkDocument(document);
+    }
+
+    @Override
+    public void checkInlineFragment(InlineFragment inlineFragment) {
+        checkDirectivesUniqueness(inlineFragment, inlineFragment.getDirectives());
+    }
+
+    @Override
+    public void checkFragmentDefinition(FragmentDefinition fragmentDefinition) {
+        checkDirectivesUniqueness(fragmentDefinition, fragmentDefinition.getDirectives());
+    }
+
+    @Override
+    public void checkFragmentSpread(FragmentSpread fragmentSpread) {
+        checkDirectivesUniqueness(fragmentSpread, fragmentSpread.getDirectives());
+    }
+
+    @Override
+    public void checkField(Field field) {
+        checkDirectivesUniqueness(field, field.getDirectives());
+    }
+
+    @Override
+    public void checkOperationDefinition(OperationDefinition operationDefinition) {
+        checkDirectivesUniqueness(operationDefinition, operationDefinition.getDirectives());
+    }
+
+    private void checkDirectivesUniqueness(Node<?> directivesContainer, List<Directive> directives) {
+        Set<String> names = new LinkedHashSet<>();
+        directives.forEach(directive -> {
+            String name = directive.getName();
+            if (names.contains(name)) {
+                addError(ValidationErrorType.DuplicateDirectiveName,
+                        directive.getSourceLocation(),
+                        duplicateDirectiveNameMessage(name, directivesContainer.getClass().getSimpleName()));
+            } else {
+                names.add(name);
+            }
+        });
+    }
+
+
+    static String duplicateDirectiveNameMessage(String directiveName, String location) {
+        return String.format("Directives must be uniquely named within a location. The directive '%s' used on a '%s' is not unique.", directiveName, location);
+    }
+}

--- a/src/main/java/graphql/validation/rules/UniqueDirectiveNamesPerLocation.java
+++ b/src/main/java/graphql/validation/rules/UniqueDirectiveNamesPerLocation.java
@@ -70,8 +70,7 @@ public class UniqueDirectiveNamesPerLocation extends AbstractRule {
         });
     }
 
-
-    static String duplicateDirectiveNameMessage(String directiveName, String location) {
+    private String duplicateDirectiveNameMessage(String directiveName, String location) {
         return String.format("Directives must be uniquely named within a location. The directive '%s' used on a '%s' is not unique.", directiveName, location);
     }
 }

--- a/src/test/groovy/graphql/validation/SpecValidationSchema.java
+++ b/src/test/groovy/graphql/validation/SpecValidationSchema.java
@@ -3,6 +3,7 @@ package graphql.validation;
 import graphql.Scalars;
 import graphql.TypeResolutionEnvironment;
 import graphql.schema.GraphQLArgument;
+import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLInterfaceType;
 import graphql.schema.GraphQLObjectType;
@@ -18,6 +19,11 @@ import graphql.validation.SpecValidationSchemaPojos.Human;
 import java.util.HashSet;
 import java.util.Set;
 
+import static graphql.introspection.Introspection.DirectiveLocation.FIELD;
+import static graphql.introspection.Introspection.DirectiveLocation.FRAGMENT_DEFINITION;
+import static graphql.introspection.Introspection.DirectiveLocation.FRAGMENT_SPREAD;
+import static graphql.introspection.Introspection.DirectiveLocation.INLINE_FRAGMENT;
+import static graphql.introspection.Introspection.DirectiveLocation.QUERY;
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 import static graphql.schema.GraphQLNonNull.nonNull;
 import static java.util.Collections.singletonList;
@@ -169,8 +175,21 @@ public class SpecValidationSchema {
         add(dogOrHuman);
         add(humanOrAlien);
     }};
+
+    public static final GraphQLDirective upperDirective = GraphQLDirective.newDirective()
+            .name("upper")
+            .validLocations(FIELD, FRAGMENT_SPREAD, FRAGMENT_DEFINITION, INLINE_FRAGMENT, QUERY)
+            .build();
+
+    public static final GraphQLDirective lowerDirective = GraphQLDirective.newDirective()
+            .name("lower")
+            .validLocations(FIELD, FRAGMENT_SPREAD, FRAGMENT_DEFINITION, INLINE_FRAGMENT, QUERY)
+            .build();
+
     public static final GraphQLSchema specValidationSchema = GraphQLSchema.newSchema()
             .query(queryRoot)
+            .additionalDirective(upperDirective)
+            .additionalDirective(lowerDirective)
             .build(specValidationDictionary);
 
 

--- a/src/test/groovy/graphql/validation/rules/UniqueDirectiveNamesPerLocationTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/UniqueDirectiveNamesPerLocationTest.groovy
@@ -1,0 +1,153 @@
+package graphql.validation.rules
+
+
+import graphql.parser.Parser
+import graphql.validation.SpecValidationSchema
+import graphql.validation.ValidationError
+import graphql.validation.ValidationErrorType
+import graphql.validation.Validator
+import spock.lang.Specification
+
+class UniqueDirectiveNamesPerLocationTest extends Specification {
+
+    def '5.7.3 Directives Are Unique Per Location - FragmentDefinition'() {
+        def query = '''
+        query getName {
+            dog {
+                name
+                ... FragDef
+                ... {
+                  name
+                }
+            }
+        }
+
+        fragment FragDef on Dog @upper @lower @upper {
+            name
+        }
+        '''.stripIndent()
+        when:
+        def validationErrors = validate(query)
+
+        then:
+        !validationErrors.empty
+        validationErrors.size() == 1
+        assertDuplicateDirectiveName("upper", "FragmentDefinition", 12, 39, validationErrors[0])
+    }
+
+    def '5.7.3 Directives Are Unique Per Location - OperationDefinition'() {
+        def query = '''
+        query getName @upper @lower @upper {
+            dog {
+                name
+                ... FragDef
+                ... {
+                  name
+                }
+            }
+        }
+
+        fragment FragDef on Dog {
+            name
+        }
+        '''.stripIndent()
+        when:
+        def validationErrors = validate(query)
+
+        then:
+        !validationErrors.empty
+        validationErrors.size() == 1
+        assertDuplicateDirectiveName("upper", "OperationDefinition", 2, 29, validationErrors[0])
+    }
+
+    def '5.7.3 Directives Are Unique Per Location - Field'() {
+        def query = '''
+        query getName {
+            dog {
+                name @upper @lower @upper
+                ... FragDef
+                ... {
+                  name
+                }
+            }
+        }
+
+        fragment FragDef on Dog {
+            name
+        }
+        '''.stripIndent()
+        when:
+        def validationErrors = validate(query)
+
+        then:
+        !validationErrors.empty
+        validationErrors.size() == 1
+        assertDuplicateDirectiveName("upper", "Field", 4, 28, validationErrors[0])
+    }
+
+    def '5.7.3 Directives Are Unique Per Location - FragmentSpread'() {
+        def query = '''
+        query getName {
+            dog {
+                name 
+                ... FragDef @upper @lower @upper
+                ... {
+                  name
+                }
+            }
+        }
+
+        fragment FragDef on Dog {
+            name
+        }
+        '''.stripIndent()
+        when:
+        def validationErrors = validate(query)
+
+        then:
+        !validationErrors.empty
+        validationErrors.size() == 1
+        assertDuplicateDirectiveName("upper", "FragmentSpread", 5, 35, validationErrors[0])
+    }
+
+    def '5.7.3 Directives Are Unique Per Location - InlineFragment'() {
+        def query = '''
+        query getName {
+            dog {
+                name 
+                ... FragDef 
+                ... @upper @lower @upper { 
+                  name
+                }
+            }
+        }
+
+        fragment FragDef on Dog {
+            name
+        }
+        '''.stripIndent()
+        when:
+        def validationErrors = validate(query)
+
+        then:
+        !validationErrors.empty
+        validationErrors.size() == 1
+        assertDuplicateDirectiveName("upper", "InlineFragment", 6, 27, validationErrors[0])
+    }
+
+
+
+    def assertDuplicateDirectiveName(String name, String type, int line, int column, ValidationError error) {
+        assert error.locations[0].line == line
+        assert error.locations[0].column == column
+        assert error.validationErrorType == ValidationErrorType.DuplicateDirectiveName
+        def expectedMsg = "Directives must be uniquely named within a location. The directive '${name}' used on a '${type}' is not unique."
+        assert error.message.contains(expectedMsg)
+        true
+    }
+
+    List<ValidationError> validate(String query) {
+        def document = new Parser().parseDocument(query)
+        return new Validator().validateDocument(SpecValidationSchema.specValidationSchema, document)
+    }
+}


### PR DESCRIPTION
Directive uniqueness is not enforced today.  This fixes that according to the graphql spec

SDL code already has directive uniqueness - just not query code