### PR TITLE
1389 empty input type defs

### DIFF
--- a/src/main/antlr/GraphqlSDL.g4
+++ b/src/main/antlr/GraphqlSDL.g4
@@ -72,7 +72,7 @@ unionMembers:
 unionMembers '|' typeName
 ;
 
-enumTypeDefinition : description? ENUM name directives? enumValueDefinitions;
+enumTypeDefinition : description? ENUM name directives? enumValueDefinitions?;
 
 enumTypeExtensionDefinition : EXTEND ENUM name directives? enumValueDefinitions?;
 
@@ -81,11 +81,11 @@ enumValueDefinitions : '{' enumValueDefinition+ '}';
 enumValueDefinition : description? enumValue directives?;
 
 
-inputObjectTypeDefinition : description? INPUT name directives? inputObjectValueDefinitions;
+inputObjectTypeDefinition : description? INPUT name directives? inputObjectValueDefinitions?;
 
 inputObjectTypeExtensionDefinition : EXTEND INPUT name directives? inputObjectValueDefinitions?;
 
-inputObjectValueDefinitions : '{' inputValueDefinition+ '}';
+inputObjectValueDefinitions : '{' inputValueDefinition* '}';
 
 
 directiveDefinition : description? DIRECTIVE '@' name argumentsDefinition? 'on' directiveLocations;

--- a/src/main/antlr/GraphqlSDL.g4
+++ b/src/main/antlr/GraphqlSDL.g4
@@ -38,17 +38,23 @@ typeExtension :
 
 scalarTypeDefinition : description? SCALAR name directives?;
 
-scalarTypeExtensionDefinition : EXTEND SCALAR name directives?;
+scalarTypeExtensionDefinition : EXTEND SCALAR name directives;
 
 objectTypeDefinition : description? TYPE name implementsInterfaces? directives? fieldsDefinition?;
 
-objectTypeExtensionDefinition : EXTEND TYPE name implementsInterfaces? directives? fieldsDefinition?;
+objectTypeExtensionDefinition :
+    EXTEND TYPE name implementsInterfaces? directives? extensionFieldsDefinition |
+    EXTEND TYPE name implementsInterfaces? directives |
+    EXTEND TYPE name implementsInterfaces
+;
 
 implementsInterfaces :
     IMPLEMENTS '&'? typeName+ |
     implementsInterfaces '&' typeName ;
 
 fieldsDefinition : '{' fieldDefinition* '}';
+
+extensionFieldsDefinition : '{' fieldDefinition+ '}';
 
 fieldDefinition : description? name argumentsDefinition? ':' type directives?;
 
@@ -58,12 +64,18 @@ inputValueDefinition : description? name ':' type defaultValue? directives?;
 
 interfaceTypeDefinition : description? INTERFACE name directives? fieldsDefinition?;
 
-interfaceTypeExtensionDefinition : EXTEND INTERFACE name directives? fieldsDefinition?;
+interfaceTypeExtensionDefinition :
+    EXTEND INTERFACE name directives? extensionFieldsDefinition |
+    EXTEND INTERFACE name directives
+;
 
 
-unionTypeDefinition : description? UNION name directives? unionMembership;
+unionTypeDefinition : description? UNION name directives? unionMembership?;
 
-unionTypeExtensionDefinition : EXTEND UNION name directives? unionMembership?;
+unionTypeExtensionDefinition :
+    EXTEND UNION name directives? unionMembership |
+    EXTEND UNION name directives
+;
 
 unionMembership : '=' unionMembers;
 
@@ -74,18 +86,28 @@ unionMembers '|' typeName
 
 enumTypeDefinition : description? ENUM name directives? enumValueDefinitions?;
 
-enumTypeExtensionDefinition : EXTEND ENUM name directives? enumValueDefinitions?;
+enumTypeExtensionDefinition :
+    EXTEND ENUM name directives? extensionEnumValueDefinitions |
+    EXTEND ENUM name directives
+;
 
-enumValueDefinitions : '{' enumValueDefinition+ '}';
+enumValueDefinitions : '{' enumValueDefinition* '}';
+
+extensionEnumValueDefinitions : '{' enumValueDefinition+ '}';
 
 enumValueDefinition : description? enumValue directives?;
 
 
 inputObjectTypeDefinition : description? INPUT name directives? inputObjectValueDefinitions?;
 
-inputObjectTypeExtensionDefinition : EXTEND INPUT name directives? inputObjectValueDefinitions?;
+inputObjectTypeExtensionDefinition :
+    EXTEND INPUT name directives? extensionInputObjectValueDefinitions |
+    EXTEND INPUT name directives
+;
 
 inputObjectValueDefinitions : '{' inputValueDefinition* '}';
+
+extensionInputObjectValueDefinitions : '{' inputValueDefinition+ '}';
 
 
 directiveDefinition : description? DIRECTIVE '@' name argumentsDefinition? 'on' directiveLocations;

--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -93,7 +93,7 @@ public class GraphqlAntlrToLanguage {
     public Document createDocument(GraphqlParser.DocumentContext ctx) {
         Document.Builder document = Document.newDocument();
         addCommonData(document, ctx);
-        document.definitions(ctx.definition().stream().map(definition -> createDefinition(definition))
+        document.definitions(ctx.definition().stream().map(this::createDefinition)
                 .collect(toList()));
         return document.build();
     }
@@ -129,14 +129,15 @@ public class GraphqlAntlrToLanguage {
     }
 
     protected OperationDefinition.Operation parseOperation(GraphqlParser.OperationTypeContext operationTypeContext) {
-        if (operationTypeContext.getText().equals("query")) {
-            return OperationDefinition.Operation.QUERY;
-        } else if (operationTypeContext.getText().equals("mutation")) {
-            return OperationDefinition.Operation.MUTATION;
-        } else if (operationTypeContext.getText().equals("subscription")) {
-            return OperationDefinition.Operation.SUBSCRIPTION;
-        } else {
-            return assertShouldNeverHappen("InternalError: unknown operationTypeContext=%s", operationTypeContext.getText());
+        switch (operationTypeContext.getText()) {
+            case "query":
+                return OperationDefinition.Operation.QUERY;
+            case "mutation":
+                return OperationDefinition.Operation.MUTATION;
+            case "subscription":
+                return OperationDefinition.Operation.SUBSCRIPTION;
+            default:
+                return assertShouldNeverHappen("InternalError: unknown operationTypeContext=%s", operationTypeContext.getText());
         }
     }
 
@@ -429,8 +430,8 @@ public class GraphqlAntlrToLanguage {
             implementsInterfacesContext = implementsInterfacesContext.implementsInterfaces();
         }
         def.implementz(implementz);
-        if (ctx.fieldsDefinition() != null) {
-            def.fieldDefinitions(createFieldDefinitions(ctx.fieldsDefinition()));
+        if (ctx.extensionFieldsDefinition() != null) {
+            def.fieldDefinitions(createFieldDefinitions(ctx.extensionFieldsDefinition()));
         }
         return def.build();
     }
@@ -441,6 +442,14 @@ public class GraphqlAntlrToLanguage {
         }
         return ctx.fieldDefinition().stream().map(this::createFieldDefinition).collect(toList());
     }
+
+    protected List<FieldDefinition> createFieldDefinitions(GraphqlParser.ExtensionFieldsDefinitionContext ctx) {
+        if (ctx == null) {
+            return new ArrayList<>();
+        }
+        return ctx.fieldDefinition().stream().map(this::createFieldDefinition).collect(toList());
+    }
+
 
     protected FieldDefinition createFieldDefinition(GraphqlParser.FieldDefinitionContext ctx) {
         FieldDefinition.Builder def = FieldDefinition.newFieldDefinition();
@@ -488,7 +497,7 @@ public class GraphqlAntlrToLanguage {
         def.name(ctx.name().getText());
         addCommonData(def, ctx);
         def.directives(createDirectives(ctx.directives()));
-        def.definitions(createFieldDefinitions(ctx.fieldsDefinition()));
+        def.definitions(createFieldDefinitions(ctx.extensionFieldsDefinition()));
         return def.build();
     }
 
@@ -543,9 +552,9 @@ public class GraphqlAntlrToLanguage {
         def.name(ctx.name().getText());
         addCommonData(def, ctx);
         def.directives(createDirectives(ctx.directives()));
-        if (ctx.enumValueDefinitions() != null) {
+        if (ctx.extensionEnumValueDefinitions() != null) {
             def.enumValueDefinitions(
-                    ctx.enumValueDefinitions().enumValueDefinition().stream().map(this::createEnumValueDefinition).collect(toList()));
+                    ctx.extensionEnumValueDefinitions().enumValueDefinition().stream().map(this::createEnumValueDefinition).collect(toList()));
         }
         return def.build();
     }
@@ -576,8 +585,8 @@ public class GraphqlAntlrToLanguage {
         def.name(ctx.name().getText());
         addCommonData(def, ctx);
         def.directives(createDirectives(ctx.directives()));
-        if (ctx.inputObjectValueDefinitions() != null) {
-            def.inputValueDefinitions(createInputValueDefinitions(ctx.inputObjectValueDefinitions().inputValueDefinition()));
+        if (ctx.extensionInputObjectValueDefinitions() != null) {
+            def.inputValueDefinitions(createInputValueDefinitions(ctx.extensionInputObjectValueDefinitions().inputValueDefinition()));
         }
         return def.build();
     }

--- a/src/test/groovy/graphql/schema/idl/SchemaParserTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaParserTest.groovy
@@ -169,4 +169,41 @@ class SchemaParserTest extends Specification {
         typeRegistry.types().size() == 4
     }
 
+    def "empty types and extensions are allowed"() {
+        def schema = '''
+            type Foo {
+            }
+
+            extend type Foo {
+            }
+            
+            interface InterfaceFoo {
+            }
+
+            extend interface InterfaceFoo {
+            }
+            
+            input InputFoo {
+            }
+
+            extend input InputFoo {
+            }
+            
+            enum EnumFoo {
+            }
+
+            extend enum EnumFoo {
+            }
+            
+        '''
+
+        when:
+        TypeDefinitionRegistry typeRegistry = new SchemaParser().parse(schema)
+        then:
+        typeRegistry.types().size() == 3
+        typeRegistry.interfaceTypeExtensions().size() == 1
+        typeRegistry.objectTypeExtensions().size() == 1
+        typeRegistry.inputObjectTypeExtensions().size() == 1
+
+    }
 }


### PR DESCRIPTION
see #1389 

This allows empty type defs but it does not allow empty extensions.

Its following the spec on type extensions and you MUST provide some form of extension

`extend type Foo {}` is not allowed nor is `extend type Foo `

 but it's relaxing the spec on type definitions a smidge by allowing

`type Foo { } ` to be equals to `type Foo`

The reasons to relax the  spec is that for "object type defs" we already broke spec and also just to be a smidge easier to use