### PR TITLE
General Purpose Error Builder

### DIFF
--- a/src/main/java/graphql/GraphqlErrorBuilder.java
+++ b/src/main/java/graphql/GraphqlErrorBuilder.java
@@ -1,0 +1,131 @@
+package graphql;
+
+import graphql.execution.DataFetcherResult;
+import graphql.execution.ExecutionPath;
+import graphql.language.SourceLocation;
+import graphql.schema.DataFetchingEnvironment;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static graphql.Assert.assertNotNull;
+
+/**
+ * This helps you build {@link graphql.GraphQLError}s and also has a quick way to make a  {@link graphql.execution.DataFetcherResult}s
+ * from that error.
+ */
+@PublicApi
+public class GraphqlErrorBuilder {
+
+    private String message;
+    private List<Object> path;
+    private List<SourceLocation> locations = new ArrayList<>();
+    private ErrorType errorType = ErrorType.DataFetchingException;
+    private Map<String, Object> extensions = null;
+
+
+    /**
+     * @return a builder of {@link graphql.GraphQLError}s
+     */
+    public static GraphqlErrorBuilder newError() {
+        return new GraphqlErrorBuilder();
+    }
+
+    /**
+     * This will set up the {@link GraphQLError#getLocations()} and {@link graphql.GraphQLError#getPath()} for you from the
+     * fetching environment.
+     *
+     * @param dataFetchingEnvironment the data fetching environment
+     *
+     * @return a builder of {@link graphql.GraphQLError}s
+     */
+    public static GraphqlErrorBuilder newError(DataFetchingEnvironment dataFetchingEnvironment) {
+        return new GraphqlErrorBuilder()
+                .location(dataFetchingEnvironment.getField().getSourceLocation())
+                .path(dataFetchingEnvironment.getExecutionStepInfo().getPath());
+    }
+
+    private GraphqlErrorBuilder() {
+    }
+
+    public GraphqlErrorBuilder message(String message, Object... formatArgs) {
+        this.message = String.format(assertNotNull(message), formatArgs);
+        return this;
+    }
+
+    public GraphqlErrorBuilder locations(List<SourceLocation> locations) {
+        this.locations.addAll(assertNotNull(locations));
+        return this;
+    }
+
+    public GraphqlErrorBuilder location(SourceLocation location) {
+        this.locations.add(assertNotNull(location));
+        return this;
+    }
+
+    public GraphqlErrorBuilder path(ExecutionPath path) {
+        this.path = assertNotNull(path).toList();
+        return this;
+    }
+
+    public GraphqlErrorBuilder path(List<Object> path) {
+        this.path = assertNotNull(path);
+        return this;
+    }
+
+    public GraphqlErrorBuilder errorType(ErrorType errorType) {
+        this.errorType = assertNotNull(errorType);
+        return this;
+    }
+
+    public GraphqlErrorBuilder extensions(Map<String, Object> extensions) {
+        this.extensions = assertNotNull(extensions);
+        return this;
+    }
+
+    /**
+     * @return a newly built GraphqlError
+     */
+    public GraphQLError build() {
+        assertNotNull(message, "You must provide error message");
+        return new GraphQLError() {
+            @Override
+            public String getMessage() {
+                return message;
+            }
+
+            @Override
+            public List<SourceLocation> getLocations() {
+                return locations;
+            }
+
+            @Override
+            public ErrorType getErrorType() {
+                return errorType;
+            }
+
+            @Override
+            public List<Object> getPath() {
+                return path;
+            }
+
+            @Override
+            public Map<String, Object> getExtensions() {
+                return extensions;
+            }
+        };
+    }
+
+    /**
+     * A helper method that allows you to return this error as a {@link graphql.execution.DataFetcherResult}
+     *
+     * @return a new data fetcher result that contains the built error
+     */
+    public DataFetcherResult toResult() {
+        return DataFetcherResult.newResult()
+                .error(build())
+                .build();
+    }
+
+}

--- a/src/main/java/graphql/execution/DataFetcherResult.java
+++ b/src/main/java/graphql/execution/DataFetcherResult.java
@@ -29,6 +29,7 @@ public class DataFetcherResult<T> {
     private final T data;
     private final List<GraphQLError> errors;
     private final Object localContext;
+    private final boolean mapRelativeErrors;
 
     /**
      * Creates a data fetcher result
@@ -41,13 +42,14 @@ public class DataFetcherResult<T> {
     @Internal
     @Deprecated
     public DataFetcherResult(T data, List<GraphQLError> errors) {
-        this(data, errors, null);
+        this(data, errors, null, false);
     }
 
-    private DataFetcherResult(T data, List<GraphQLError> errors, Object localContext) {
+    private DataFetcherResult(T data, List<GraphQLError> errors, Object localContext, boolean mapRelativeErrors) {
         this.data = data;
         this.errors = unmodifiableList(assertNotNull(errors));
         this.localContext = localContext;
+        this.mapRelativeErrors = mapRelativeErrors;
     }
 
     /**
@@ -65,12 +67,33 @@ public class DataFetcherResult<T> {
     }
 
     /**
+     * @return true if there are any errors present
+     */
+    public boolean hasErrors() {
+        return !errors.isEmpty();
+    }
+
+    /**
      * A data fetcher result can supply a context object for that field that is passed down to child fields
      *
      * @return a local context object
      */
     public Object getLocalContext() {
         return localContext;
+    }
+
+    /**
+     * When this returns true, the data fetching code will map this error as being a relative error from the existing field.
+     * <p>
+     * This is useful when you are calling a down stream graphql system and you want to make the errors appear to be from a point
+     * relative to the currently executing field.
+     * <p>
+     * By default this behavior is off
+     *
+     * @return true if relative error mapping should occur.
+     */
+    public boolean isMapRelativeErrors() {
+        return mapRelativeErrors;
     }
 
     /**
@@ -88,6 +111,7 @@ public class DataFetcherResult<T> {
         private T data;
         private Object localContext;
         private final List<GraphQLError> errors = new ArrayList<>();
+        private boolean mapRelativeErrors = false;
 
         public Builder(T data) {
             this.data = data;
@@ -111,13 +135,25 @@ public class DataFetcherResult<T> {
             return this;
         }
 
+        public Builder<T> mapRelativeErrors(boolean mapRelativeErrors) {
+            this.mapRelativeErrors = mapRelativeErrors;
+            return this;
+        }
+
+        /**
+         * @return true if there are any errors present
+         */
+        public boolean hasErrors() {
+            return !errors.isEmpty();
+        }
+
         public Builder<T> localContext(Object localContext) {
             this.localContext = localContext;
             return this;
         }
 
         public DataFetcherResult<T> build() {
-            return new DataFetcherResult<>(data, errors, localContext);
+            return new DataFetcherResult<>(data, errors, localContext, mapRelativeErrors);
         }
     }
 }

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -286,9 +286,13 @@ public abstract class ExecutionStrategy {
         if (result instanceof DataFetcherResult) {
             //noinspection unchecked
             DataFetcherResult<?> dataFetcherResult = (DataFetcherResult) result;
-            dataFetcherResult.getErrors().stream()
-                    .map(relError -> new AbsoluteGraphQLError(parameters, relError))
-                    .forEach(executionContext::addError);
+            if (dataFetcherResult.isMapRelativeErrors()) {
+                dataFetcherResult.getErrors().stream()
+                        .map(relError -> new AbsoluteGraphQLError(parameters, relError))
+                        .forEach(executionContext::addError);
+            } else {
+                dataFetcherResult.getErrors().forEach(executionContext::addError);
+            }
 
             Object localContext = dataFetcherResult.getLocalContext();
             if (localContext == null) {

--- a/src/test/groovy/graphql/DataFetcherWithErrorsAndDataTest.groovy
+++ b/src/test/groovy/graphql/DataFetcherWithErrorsAndDataTest.groovy
@@ -66,6 +66,7 @@ class DataFetcherWithErrorsAndDataTest extends Specification {
                 .dataFetcher({ env ->
             newResult()
                     .data(new ParentObject())
+                    .mapRelativeErrors(true)
                     .errors([new DataFetchingErrorGraphQLError("badField is bad", ["child", "badField"])])
                     .build()
 
@@ -142,6 +143,7 @@ class DataFetcherWithErrorsAndDataTest extends Specification {
                 .dataFetcher({ env ->
             newResult()
                     .data(["goodField": null, "badField": null])
+                    .mapRelativeErrors(true)
                     .errors([
                     new DataFetchingErrorGraphQLError("goodField is bad", ["goodField"]),
                     new DataFetchingErrorGraphQLError("badField is bad", ["badField"])
@@ -225,7 +227,9 @@ class DataFetcherWithErrorsAndDataTest extends Specification {
                 .field(newFieldDefinition().name("child")
                 .type(childType)
                 .dataFetcher({ env ->
-            newResult().data(null).errors([
+            newResult().data(null)
+                    .mapRelativeErrors(true)
+                    .errors([
                     new DataFetchingErrorGraphQLError("error 1", []),
                     new DataFetchingErrorGraphQLError("error 2", [])
             ]).build()
@@ -300,7 +304,9 @@ class DataFetcherWithErrorsAndDataTest extends Specification {
                 .type(childType)
                 .dataFetcher({ env ->
             CompletableFuture.completedFuture(newResult()
-                    .data(new ChildObject()).error(
+                    .data(new ChildObject())
+                    .mapRelativeErrors(true)
+                    .error(
                     new DataFetchingErrorGraphQLError("badField is bad", ["badField"])
             ).build())
         }))

--- a/src/test/groovy/graphql/GraphqlErrorBuilderTest.groovy
+++ b/src/test/groovy/graphql/GraphqlErrorBuilderTest.groovy
@@ -1,0 +1,79 @@
+package graphql
+
+import graphql.execution.ExecutionPath
+import graphql.language.SourceLocation
+import graphql.schema.DataFetcher
+import graphql.schema.DataFetchingEnvironment
+import graphql.schema.DataFetchingEnvironmentImpl
+import spock.lang.Specification
+
+import static graphql.Scalars.GraphQLString
+import static graphql.execution.ExecutionStepInfo.newExecutionStepInfo
+import static graphql.execution.MergedField.newMergedField
+import static graphql.language.Field.newField
+
+class GraphqlErrorBuilderTest extends Specification {
+    def location = new SourceLocation(6, 9)
+    def field = newMergedField(newField("f").sourceLocation(location).build()).build()
+    def stepInfo = newExecutionStepInfo().path(ExecutionPath.fromList(["a", "b"])).type(GraphQLString).build()
+
+    def "dfe is passed on"() {
+        DataFetchingEnvironment dfe = DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
+                .mergedField(field)
+                .executionStepInfo(stepInfo)
+                .build()
+        when:
+        def graphQLError = GraphqlErrorBuilder.newError(dfe).message("Gunfight at the %s corral", "NotOK").build()
+        then:
+        graphQLError.getMessage() == "Gunfight at the NotOK corral"
+        graphQLError.getLocations() == [location]
+        graphQLError.getPath() == ["a", "b"]
+        graphQLError.getExtensions() == null
+    }
+
+    def "basic building"() {
+        when:
+        def graphQLError = GraphqlErrorBuilder.newError().message("Gunfight at the %s corral", "NotOK").build()
+        then:
+        graphQLError.getMessage() == "Gunfight at the NotOK corral"
+        graphQLError.getErrorType() == ErrorType.DataFetchingException
+    }
+
+    def "data fetcher result building works"() {
+        when:
+        def result = GraphqlErrorBuilder.newError().message("Gunfight at the %s corral", "NotOK").toResult()
+        then:
+        result.getErrors().size() == 1
+        result.getData() == null
+
+        def graphQLError = result.getErrors()[0]
+
+        graphQLError.getMessage() == "Gunfight at the NotOK corral"
+        graphQLError.getErrorType() == ErrorType.DataFetchingException
+    }
+
+    def "integration test of this"() {
+        def sdl = '''
+            type Query {
+                field(arg : String) : String
+            }    
+        '''
+        DataFetcher df = { env ->
+            GraphqlErrorBuilder.newError(env).message("Things are having %s", env.getArgument("arg")).toResult()
+        }
+        def graphQL = TestUtil.graphQL(sdl, [Query: [field: df]]).build()
+
+        when:
+        def er = graphQL.execute({ input -> input.query('{ field(arg : "problems") }') })
+        then:
+        er.getData() == [field: null]
+        er.getErrors().size() == 1
+        def graphQLError = er.getErrors()[0]
+
+        graphQLError.getMessage() == "Things are having problems"
+        graphQLError.getExtensions() == null
+        graphQLError.getErrorType() == ErrorType.DataFetchingException
+        graphQLError.getPath() == ["field"]
+        graphQLError.getLocations() == [new SourceLocation(1, 3)]
+    }
+}

--- a/src/test/groovy/graphql/execution/DataFetcherResultTest.groovy
+++ b/src/test/groovy/graphql/execution/DataFetcherResultTest.groovy
@@ -7,9 +7,10 @@ import spock.lang.Specification
 
 class DataFetcherResultTest extends Specification {
 
+    def error1 = new ValidationError(ValidationErrorType.DuplicateOperationName)
+    def error2 = new InvalidSyntaxError([], "Boo")
+
     def "basic building"() {
-        def error1 = new ValidationError(ValidationErrorType.DuplicateOperationName)
-        def error2 = new InvalidSyntaxError([], "Boo")
         when:
         def result = DataFetcherResult.newResult().data("hello")
                 .error(error1).errors([error2]).localContext("world").build()
@@ -17,5 +18,34 @@ class DataFetcherResultTest extends Specification {
         result.getData() == "hello"
         result.getLocalContext() == "world"
         result.getErrors() == [error1, error2]
+    }
+
+    def "hasErrors can be called"() {
+        when:
+        def builder = DataFetcherResult.newResult()
+        then:
+        !builder.hasErrors()
+
+        when:
+        builder.error(error1)
+        then:
+        builder.hasErrors()
+
+        when:
+        def result = builder.build()
+        then:
+        result.hasErrors()
+    }
+
+    def "map relative is off by default"() {
+        when:
+        def result = DataFetcherResult.newResult().build()
+        then:
+        !result.isMapRelativeErrors()
+
+        when:
+        result = DataFetcherResult.newResult().mapRelativeErrors(true).build()
+        then:
+        result.isMapRelativeErrors()
     }
 }

--- a/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
@@ -697,6 +697,7 @@ class ExecutionStrategyTest extends Specification {
         when:
         def fetchedValue = executionStrategy.unboxPossibleDataFetcherResult(executionContext, parameters,
                 DataFetcherResult.newResult().data(executionData)
+                        .mapRelativeErrors(true)
                         .error(new DataFetchingErrorGraphQLError("bad foo", ["child", "foo"]))
                         .build()
         )


### PR DESCRIPTION
General Purpose Error Builder and opt in to the AbsoluteGraphqlError handling

You use this in a data fetcher via 

    GraphqlErrorBuilder.newError(dfe).message("Bad %s", "JuJu").build()