### PR TITLE
SchemaDirectiveWiring is now done after the full set of graphql elements are built

### DIFF
--- a/src/main/java/graphql/language/NodeParentTree.java
+++ b/src/main/java/graphql/language/NodeParentTree.java
@@ -4,6 +4,7 @@ import graphql.Internal;
 import graphql.PublicApi;
 
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
 import java.util.Optional;
@@ -22,7 +23,7 @@ import static graphql.Assert.assertTrue;
 public class NodeParentTree<T extends Node> {
 
     private final T node;
-    private final Optional<NodeParentTree<T>> parent;
+    private final NodeParentTree<T> parent;
     private final List<String> path;
 
     @Internal
@@ -34,9 +35,9 @@ public class NodeParentTree<T extends Node> {
         path = mkPath(copy);
         node = copy.pop();
         if (!copy.isEmpty()) {
-            parent = Optional.of(new NodeParentTree<T>(copy));
+            parent = new NodeParentTree<T>(copy);
         } else {
-            parent = Optional.empty();
+            parent = null;
         }
     }
 
@@ -61,7 +62,7 @@ public class NodeParentTree<T extends Node> {
      * @return a node MAY have an optional parent
      */
     public Optional<NodeParentTree<T>> getParentInfo() {
-        return parent;
+        return Optional.ofNullable(parent);
     }
 
     /**
@@ -71,10 +72,24 @@ public class NodeParentTree<T extends Node> {
         return path;
     }
 
+    /**
+     * @return the tree as a list of T
+     */
+    public List<T> toList() {
+        List<T> nodes = new ArrayList<>();
+        nodes.add(node);
+        Optional<NodeParentTree<T>> parentInfo = this.getParentInfo();
+        while (parentInfo.isPresent()) {
+            nodes.add(parentInfo.get().getNode());
+            parentInfo = parentInfo.get().getParentInfo();
+        }
+        return nodes;
+    }
+
     @Override
     public String toString() {
         return String.valueOf(node) +
                 " - parent : " +
-                parent.isPresent();
+                parent;
     }
 }

--- a/src/main/java/graphql/schema/GraphQLCodeRegistry.java
+++ b/src/main/java/graphql/schema/GraphQLCodeRegistry.java
@@ -244,6 +244,19 @@ public class GraphQLCodeRegistry {
         }
 
         /**
+         * Sets the data fetcher for a specific field inside a container type
+         *
+         * @param parentType      the container type
+         * @param fieldDefinition the field definition
+         * @param dataFetcher     the data fetcher code for that field
+         *
+         * @return this builder
+         */
+        public Builder dataFetcher(GraphQLFieldsContainer parentType, GraphQLFieldDefinition fieldDefinition, DataFetcher<?> dataFetcher) {
+            return dataFetcher(FieldCoordinates.coordinates(parentType.getName(), fieldDefinition.getName()), dataFetcher);
+        }
+
+        /**
          * Called to place system data fetchers (eg Introspection fields) into the mix
          *
          * @param coordinates the field coordinates

--- a/src/main/java/graphql/schema/GraphQLEnumType.java
+++ b/src/main/java/graphql/schema/GraphQLEnumType.java
@@ -17,6 +17,7 @@ import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
+import static graphql.schema.GraphQLEnumValueDefinition.newEnumValueDefinition;
 import static graphql.schema.GraphqlTypeComparators.sortGraphQLTypes;
 import static graphql.util.FpKit.getByName;
 import static graphql.util.FpKit.valuesToList;
@@ -252,21 +253,31 @@ public class GraphQLEnumType implements GraphQLType, GraphQLInputType, GraphQLOu
 
 
         public Builder value(String name, Object value, String description, String deprecationReason) {
-            value(new GraphQLEnumValueDefinition(name, description, value, deprecationReason));
-            return this;
+            return value(newEnumValueDefinition().name(name)
+                    .description(description).value(value)
+                    .deprecationReason(deprecationReason).build());
         }
 
         public Builder value(String name, Object value, String description) {
-            return value(new GraphQLEnumValueDefinition(name, description, value));
+            return value(newEnumValueDefinition().name(name)
+                    .description(description).value(value).build());
         }
 
         public Builder value(String name, Object value) {
             assertNotNull(value, "value can't be null");
-            return value(new GraphQLEnumValueDefinition(name, null, value));
+            return value(newEnumValueDefinition().name(name)
+                    .value(value).build());
         }
 
+
         public Builder value(String name) {
-            return value(new GraphQLEnumValueDefinition(name, null, name));
+            return value(newEnumValueDefinition().name(name)
+                    .value(name).build());
+        }
+
+        public Builder values(List<GraphQLEnumValueDefinition> valueDefinitions) {
+            valueDefinitions.forEach(this::value);
+            return this;
         }
 
         public Builder value(GraphQLEnumValueDefinition enumValueDefinition) {

--- a/src/main/java/graphql/schema/GraphQLEnumValueDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLEnumValueDefinition.java
@@ -4,6 +4,7 @@ package graphql.schema;
 import graphql.DirectivesUtil;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.language.EnumValueDefinition;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
@@ -15,7 +16,6 @@ import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
-import static graphql.schema.GraphqlTypeComparators.sortGraphQLTypes;
 import static graphql.util.FpKit.getByName;
 import static graphql.util.FpKit.valuesToList;
 import static java.util.Collections.emptyList;
@@ -35,6 +35,7 @@ public class GraphQLEnumValueDefinition implements GraphQLDirectiveContainer {
     private final Object value;
     private final String deprecationReason;
     private final List<GraphQLDirective> directives;
+    private final EnumValueDefinition definition;
 
     /**
      * @param name        the name
@@ -75,6 +76,10 @@ public class GraphQLEnumValueDefinition implements GraphQLDirectiveContainer {
     @Internal
     @Deprecated
     public GraphQLEnumValueDefinition(String name, String description, Object value, String deprecationReason, List<GraphQLDirective> directives) {
+        this(name, description, value, deprecationReason, directives, null);
+    }
+
+    private GraphQLEnumValueDefinition(String name, String description, Object value, String deprecationReason, List<GraphQLDirective> directives, EnumValueDefinition definition) {
         assertValidName(name);
         assertNotNull(directives, "directives cannot be null");
 
@@ -83,6 +88,7 @@ public class GraphQLEnumValueDefinition implements GraphQLDirectiveContainer {
         this.value = value;
         this.deprecationReason = deprecationReason;
         this.directives = directives;
+        this.definition = definition;
     }
 
     @Override
@@ -119,6 +125,10 @@ public class GraphQLEnumValueDefinition implements GraphQLDirectiveContainer {
     @Override
     public GraphQLDirective getDirective(String directiveName) {
         return getDirectivesByName().get(directiveName);
+    }
+
+    public EnumValueDefinition getDefinition() {
+        return definition;
     }
 
     /**
@@ -159,6 +169,7 @@ public class GraphQLEnumValueDefinition implements GraphQLDirectiveContainer {
         private String description;
         private Object value;
         private String deprecationReason;
+        private EnumValueDefinition definition;
         private final Map<String, GraphQLDirective> directives = new LinkedHashMap<>();
 
         public Builder() {
@@ -192,6 +203,11 @@ public class GraphQLEnumValueDefinition implements GraphQLDirectiveContainer {
             return this;
         }
 
+        public Builder definition(EnumValueDefinition definition) {
+            this.definition = definition;
+            return this;
+        }
+
         public Builder withDirectives(GraphQLDirective... directives) {
             assertNotNull(directives, "directives can't be null");
             for (GraphQLDirective directive : directives) {
@@ -221,7 +237,7 @@ public class GraphQLEnumValueDefinition implements GraphQLDirectiveContainer {
         }
 
         public GraphQLEnumValueDefinition build() {
-            return new GraphQLEnumValueDefinition(name, description, value, deprecationReason, valuesToList(directives));
+            return new GraphQLEnumValueDefinition(name, description, value, deprecationReason, valuesToList(directives), definition);
         }
     }
 }

--- a/src/main/java/graphql/schema/GraphQLFieldDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLFieldDefinition.java
@@ -272,6 +272,7 @@ public class GraphQLFieldDefinition implements GraphQLDirectiveContainer {
          * Sets the {@link graphql.schema.DataFetcherFactory} to use with this field.
          *
          * @param dataFetcherFactory the data fetcher factory
+         *
          * @return this builder
          *
          * @deprecated use {@link graphql.schema.GraphQLCodeRegistry} instead
@@ -336,7 +337,28 @@ public class GraphQLFieldDefinition implements GraphQLDirectiveContainer {
             return this;
         }
 
+        /**
+         * This adds the list of arguments to the field.
+         *
+         * @param arguments the arguments to add
+         *
+         * @return this
+         *
+         * @deprecated This is a badly named method and is replaced by {@link #arguments(java.util.List)}
+         */
+        @Deprecated
         public Builder argument(List<GraphQLArgument> arguments) {
+            return arguments(arguments);
+        }
+
+        /**
+         * This adds the list of arguments to the field.
+         *
+         * @param arguments the arguments to add
+         *
+         * @return this
+         */
+        public Builder arguments(List<GraphQLArgument> arguments) {
             assertNotNull(arguments, "arguments can't be null");
             for (GraphQLArgument argument : arguments) {
                 argument(argument);

--- a/src/main/java/graphql/schema/GraphqlElementParentTree.java
+++ b/src/main/java/graphql/schema/GraphqlElementParentTree.java
@@ -1,0 +1,76 @@
+package graphql.schema;
+
+import graphql.Internal;
+import graphql.PublicApi;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Optional;
+
+import static graphql.Assert.assertNotNull;
+import static graphql.Assert.assertTrue;
+
+/**
+ * This represents a hierarchy an graphql runtime element upwards to its
+ * associated parent elements.  For example a GraphqlDirective can be on a GraphqlArgument
+ * which can be on a GraphqlFieldDefinition, which can be on a GraphqlObjectType.
+ */
+@PublicApi
+public class GraphqlElementParentTree {
+
+    private final GraphQLType element;
+    private final GraphqlElementParentTree parent;
+
+    @Internal
+    public GraphqlElementParentTree(Deque<GraphQLType> nodeStack) {
+        assertNotNull(nodeStack, "You MUST have a non null stack of elements");
+        assertTrue(!nodeStack.isEmpty(), "You MUST have a non empty stack of element");
+
+        Deque<GraphQLType> copy = new ArrayDeque<>(nodeStack);
+        element = copy.pop();
+        if (!copy.isEmpty()) {
+            parent = new GraphqlElementParentTree(copy);
+        } else {
+            parent = null;
+        }
+    }
+
+    /**
+     * Returns the element represented by this info
+     *
+     * @return the element in play
+     */
+    public GraphQLType getElement() {
+        return element;
+    }
+
+    /**
+     * @return an element MAY have an optional parent
+     */
+    public Optional<GraphqlElementParentTree> getParentInfo() {
+        return Optional.ofNullable(parent);
+    }
+
+    /**
+     * @return the tree as a list of types
+     */
+    public List<GraphQLType> toList() {
+        List<GraphQLType> types = new ArrayList<>();
+        types.add(element);
+        Optional<GraphqlElementParentTree> parentInfo = this.getParentInfo();
+        while (parentInfo.isPresent()) {
+            types.add(parentInfo.get().getElement());
+            parentInfo = parentInfo.get().getParentInfo();
+        }
+        return types;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(element) +
+                " - parent : " +
+                parent;
+    }
+}

--- a/src/main/java/graphql/schema/idl/SchemaDirectiveWiring.java
+++ b/src/main/java/graphql/schema/idl/SchemaDirectiveWiring.java
@@ -24,7 +24,10 @@ public interface SchemaDirectiveWiring {
 
     /**
      * This is called when an object is encountered, which gives the schema directive a chance to modify the shape and behaviour
-     * of that DSL  element
+     * of that DSL element
+     * <p>
+     * The {@link #onArgument(SchemaDirectiveWiringEnvironment)} and {@link #onField(SchemaDirectiveWiringEnvironment)} callbacks will have been
+     * invoked for this element beforehand
      *
      * @param environment the wiring element
      *
@@ -36,7 +39,10 @@ public interface SchemaDirectiveWiring {
 
     /**
      * This is called when a field is encountered, which gives the schema directive a chance to modify the shape and behaviour
-     * of that DSL  element
+     * of that DSL element
+     * <p>
+     * The {@link #onArgument(SchemaDirectiveWiringEnvironment)} callbacks will have been
+     * invoked for this element beforehand
      *
      * @param environment the wiring element
      *
@@ -48,7 +54,7 @@ public interface SchemaDirectiveWiring {
 
     /**
      * This is called when an argument is encountered, which gives the schema directive a chance to modify the shape and behaviour
-     * of that DSL  element
+     * of that DSL element
      *
      * @param environment the wiring element
      *
@@ -60,7 +66,10 @@ public interface SchemaDirectiveWiring {
 
     /**
      * This is called when an interface is encountered, which gives the schema directive a chance to modify the shape and behaviour
-     * of that DSL  element
+     * of that DSL element
+     * <p>
+     * The {@link #onArgument(SchemaDirectiveWiringEnvironment)} and {@link #onField(SchemaDirectiveWiringEnvironment)} callbacks will have been
+     * invoked for this element beforehand
      *
      * @param environment the wiring element
      *
@@ -72,7 +81,7 @@ public interface SchemaDirectiveWiring {
 
     /**
      * This is called when a union is encountered, which gives the schema directive a chance to modify the shape and behaviour
-     * of that DSL  element
+     * of that DSL element
      *
      * @param environment the wiring element
      *
@@ -84,7 +93,9 @@ public interface SchemaDirectiveWiring {
 
     /**
      * This is called when an enum is encountered, which gives the schema directive a chance to modify the shape and behaviour
-     * of that DSL  element
+     * of that DSL element
+     * <p>
+     * The {@link #onEnumValue(SchemaDirectiveWiringEnvironment)} callbacks will have been invoked for this element beforehand
      *
      * @param environment the wiring element
      *
@@ -96,7 +107,7 @@ public interface SchemaDirectiveWiring {
 
     /**
      * This is called when an enum value is encountered, which gives the schema directive a chance to modify the shape and behaviour
-     * of that DSL  element
+     * of that DSL element
      *
      * @param environment the wiring element
      *
@@ -121,6 +132,8 @@ public interface SchemaDirectiveWiring {
     /**
      * This is called when an input object is encountered, which gives the schema directive a chance to modify the shape and behaviour
      * of that DSL  element
+     * <p>
+     * The {@link #onInputObjectField(SchemaDirectiveWiringEnvironment)}callbacks will have been invoked for this element beforehand
      *
      * @param environment the wiring element
      *

--- a/src/main/java/graphql/schema/idl/SchemaDirectiveWiringEnvironment.java
+++ b/src/main/java/graphql/schema/idl/SchemaDirectiveWiringEnvironment.java
@@ -6,7 +6,9 @@ import graphql.language.NodeParentTree;
 import graphql.schema.GraphQLCodeRegistry;
 import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLDirectiveContainer;
+import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLFieldsContainer;
+import graphql.schema.GraphqlElementParentTree;
 
 import java.util.Map;
 
@@ -39,6 +41,15 @@ public interface SchemaDirectiveWiringEnvironment<T extends GraphQLDirectiveCont
     NodeParentTree<NamedNode> getNodeParentTree();
 
     /**
+     * The type hierarchy depends on the element in question.  For example {@link graphql.schema.GraphQLObjectType} elements
+     * have no parent, however a {@link graphql.schema.GraphQLArgument} might be on a {@link graphql.schema.GraphQLFieldDefinition}
+     * which in turn might be on a {@link graphql.schema.GraphQLObjectType} say
+     *
+     * @return hierarchical graphql type information
+     */
+    GraphqlElementParentTree getElementParentTree();
+
+    /**
      * @return the type registry
      */
     TypeDefinitionRegistry getRegistry();
@@ -54,8 +65,13 @@ public interface SchemaDirectiveWiringEnvironment<T extends GraphQLDirectiveCont
     GraphQLCodeRegistry.Builder getCodeRegistry();
 
     /**
-     * @return a {@link graphql.schema.GraphQLFieldsContainer} when the element is a {@link graphql.schema.GraphQLFieldDefinition}
+     * @return a {@link graphql.schema.GraphQLFieldsContainer} when the element is contained with a fields container
      */
     GraphQLFieldsContainer getFieldsContainer();
+
+    /**
+     * @return a {@link GraphQLFieldDefinition} when the element is one or is contained within one
+     */
+    GraphQLFieldDefinition getFieldDefinition();
 
 }

--- a/src/main/java/graphql/schema/idl/SchemaDirectiveWiringEnvironmentImpl.java
+++ b/src/main/java/graphql/schema/idl/SchemaDirectiveWiringEnvironmentImpl.java
@@ -6,7 +6,9 @@ import graphql.language.NodeParentTree;
 import graphql.schema.GraphQLCodeRegistry;
 import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLDirectiveContainer;
+import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLFieldsContainer;
+import graphql.schema.GraphqlElementParentTree;
 
 import java.util.Map;
 
@@ -19,16 +21,20 @@ public class SchemaDirectiveWiringEnvironmentImpl<T extends GraphQLDirectiveCont
     private final TypeDefinitionRegistry typeDefinitionRegistry;
     private final Map<String, Object> context;
     private final GraphQLCodeRegistry.Builder codeRegistry;
+    private final GraphqlElementParentTree elementParentTree;
     private final GraphQLFieldsContainer fieldsContainer;
+    private final GraphQLFieldDefinition fieldDefinition;
 
-    public SchemaDirectiveWiringEnvironmentImpl(T element, GraphQLDirective directive, NodeParentTree<NamedNode> nodeParentTree, TypeDefinitionRegistry typeDefinitionRegistry, Map<String, Object> context, GraphQLCodeRegistry.Builder codeRegistry, GraphQLFieldsContainer fieldsContainer) {
+    public SchemaDirectiveWiringEnvironmentImpl(T element, GraphQLDirective directive, SchemaGeneratorDirectiveHelper.Parameters parameters) {
         this.element = element;
-        this.nodeParentTree = nodeParentTree;
-        this.typeDefinitionRegistry = typeDefinitionRegistry;
+        this.typeDefinitionRegistry = parameters.getTypeRegistry();
         this.directive = directive;
-        this.context = context;
-        this.codeRegistry = codeRegistry;
-        this.fieldsContainer = fieldsContainer;
+        this.context = parameters.getContext();
+        this.codeRegistry = parameters.getCodeRegistry();
+        this.nodeParentTree = parameters.getNodeParentTree();
+        this.elementParentTree = parameters.getElementParentTree();
+        this.fieldsContainer = parameters.getFieldsContainer();
+        this.fieldDefinition = parameters.getFieldsDefinition();
     }
 
     @Override
@@ -64,5 +70,15 @@ public class SchemaDirectiveWiringEnvironmentImpl<T extends GraphQLDirectiveCont
     @Override
     public GraphQLFieldsContainer getFieldsContainer() {
         return fieldsContainer;
+    }
+
+    @Override
+    public GraphqlElementParentTree getElementParentTree() {
+        return elementParentTree;
+    }
+
+    @Override
+    public GraphQLFieldDefinition getFieldDefinition() {
+        return fieldDefinition;
     }
 }

--- a/src/main/java/graphql/schema/idl/SchemaGeneratorDirectiveHelper.java
+++ b/src/main/java/graphql/schema/idl/SchemaGeneratorDirectiveHelper.java
@@ -1,5 +1,6 @@
 package graphql.schema.idl;
 
+import graphql.Internal;
 import graphql.language.NamedNode;
 import graphql.language.NodeParentTree;
 import graphql.schema.GraphQLArgument;
@@ -15,40 +16,49 @@ import graphql.schema.GraphQLInputObjectType;
 import graphql.schema.GraphQLInterfaceType;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLScalarType;
+import graphql.schema.GraphQLType;
 import graphql.schema.GraphQLUnionType;
+import graphql.schema.GraphqlElementParentTree;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import static graphql.Assert.assertNotNull;
+import static java.util.stream.Collectors.toList;
 
+@Internal
+/**
+ * This contains the helper code that allows {@link graphql.schema.idl.SchemaDirectiveWiring} implementations
+ * to be invoked during schema generation.
+ */
 class SchemaGeneratorDirectiveHelper {
 
     static class Parameters {
         private final TypeDefinitionRegistry typeRegistry;
         private final RuntimeWiring runtimeWiring;
-        private final NodeParentTree nodeParentTree;
+        private final NodeParentTree<NamedNode> nodeParentTree;
         private final Map<String, Object> context;
-        private final GraphQLFieldsContainer fieldsContainer;
         private final GraphQLCodeRegistry.Builder codeRegistry;
+        private final GraphqlElementParentTree elementParentTree;
+        private final GraphQLFieldsContainer fieldsContainer;
+        private final GraphQLFieldDefinition fieldDefinition;
 
-        Parameters(TypeDefinitionRegistry typeRegistry, RuntimeWiring runtimeWiring, NodeParentTree<NamedNode> nodeParentTree, Map<String, Object> context, GraphQLCodeRegistry.Builder codeRegistry) {
+        Parameters(TypeDefinitionRegistry typeRegistry, RuntimeWiring runtimeWiring, Map<String, Object> context, GraphQLCodeRegistry.Builder codeRegistry) {
+            this(typeRegistry, runtimeWiring, context, codeRegistry, null, null, null, null);
+        }
+
+        Parameters(TypeDefinitionRegistry typeRegistry, RuntimeWiring runtimeWiring, Map<String, Object> context, GraphQLCodeRegistry.Builder codeRegistry, NodeParentTree<NamedNode> nodeParentTree, GraphqlElementParentTree elementParentTree, GraphQLFieldsContainer fieldsContainer, GraphQLFieldDefinition fieldDefinition) {
             this.typeRegistry = typeRegistry;
             this.runtimeWiring = runtimeWiring;
             this.nodeParentTree = nodeParentTree;
             this.context = context;
-            this.fieldsContainer = null;
             this.codeRegistry = codeRegistry;
-        }
-
-        Parameters(Parameters parameters, GraphQLFieldsContainer fieldsContainer) {
-            this.typeRegistry = parameters.typeRegistry;
-            this.runtimeWiring = parameters.runtimeWiring;
-            this.nodeParentTree = parameters.nodeParentTree;
-            this.context = parameters.context;
-            this.codeRegistry = parameters.codeRegistry;
+            this.elementParentTree = elementParentTree;
             this.fieldsContainer = fieldsContainer;
+            this.fieldDefinition = fieldDefinition;
         }
 
         public TypeDefinitionRegistry getTypeRegistry() {
@@ -63,6 +73,14 @@ class SchemaGeneratorDirectiveHelper {
             return nodeParentTree;
         }
 
+        public GraphqlElementParentTree getElementParentTree() {
+            return elementParentTree;
+        }
+
+        public GraphQLFieldsContainer getFieldsContainer() {
+            return fieldsContainer;
+        }
+
         public Map<String, Object> getContext() {
             return context;
         }
@@ -71,59 +89,176 @@ class SchemaGeneratorDirectiveHelper {
             return codeRegistry;
         }
 
-        public GraphQLFieldsContainer getFieldsContainer() {
-            return fieldsContainer;
+        public GraphQLFieldDefinition getFieldsDefinition() {
+            return fieldDefinition;
+        }
+
+        public Parameters newParams(GraphQLFieldsContainer fieldsContainer, NodeParentTree<NamedNode> nodeParentTree, GraphqlElementParentTree elementParentTree) {
+            return new Parameters(this.typeRegistry, this.runtimeWiring, this.context, this.codeRegistry, nodeParentTree, elementParentTree, fieldsContainer, fieldDefinition);
+        }
+
+        public Parameters newParams(GraphQLFieldDefinition fieldDefinition, GraphQLFieldsContainer fieldsContainer, NodeParentTree<NamedNode> nodeParentTree, GraphqlElementParentTree elementParentTree) {
+            return new Parameters(this.typeRegistry, this.runtimeWiring, this.context, this.codeRegistry, nodeParentTree, elementParentTree, fieldsContainer, fieldDefinition);
+        }
+
+        public Parameters newParams(NodeParentTree<NamedNode> nodeParentTree, GraphqlElementParentTree elementParentTree) {
+            return new Parameters(this.typeRegistry, this.runtimeWiring, this.context, this.codeRegistry, nodeParentTree, elementParentTree, this.fieldsContainer, fieldDefinition);
         }
     }
 
-    public GraphQLObjectType onObject(GraphQLObjectType element, Parameters params) {
-        return wireForEachDirective(params, element, element.getDirectives(),
-                (outputElement, directive) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directive, params.getNodeParentTree(), params.getTypeRegistry(), params.getContext(), params.getCodeRegistry(), params.getFieldsContainer()), SchemaDirectiveWiring::onObject);
+    private NodeParentTree<NamedNode> buildAstTree(NamedNode... nodes) {
+        Deque<NamedNode> nodeStack = new ArrayDeque<>();
+        for (NamedNode node : nodes) {
+            nodeStack.push(node);
+        }
+        return new NodeParentTree<>(nodeStack);
     }
 
-    public GraphQLFieldDefinition onField(GraphQLFieldDefinition element, Parameters params) {
-        return wireForEachDirective(params, element, element.getDirectives(),
-                (outputElement, directive) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directive, params.getNodeParentTree(), params.getTypeRegistry(), params.getContext(), params.getCodeRegistry(), params.getFieldsContainer()), SchemaDirectiveWiring::onField);
+    private GraphqlElementParentTree buildRuntimeTree(GraphQLType... elements) {
+        Deque<GraphQLType> nodeStack = new ArrayDeque<>();
+        for (GraphQLType element : elements) {
+            nodeStack.push(element);
+        }
+        return new GraphqlElementParentTree(nodeStack);
     }
 
-    public GraphQLInterfaceType onInterface(GraphQLInterfaceType element, Parameters params) {
-        return wireForEachDirective(params, element, element.getDirectives(),
-                (outputElement, directive) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directive, params.getNodeParentTree(), params.getTypeRegistry(), params.getContext(), params.getCodeRegistry(), params.getFieldsContainer()), SchemaDirectiveWiring::onInterface);
+    private List<GraphQLArgument> wireArguments(GraphQLFieldDefinition fieldDefinition, GraphQLFieldsContainer fieldsContainer, NamedNode fieldsContainerNode, Parameters params, GraphQLFieldDefinition field) {
+        return field.getArguments().stream().map(argument -> {
+
+            NodeParentTree<NamedNode> nodeParentTree = buildAstTree(fieldsContainerNode, field.getDefinition(), argument.getDefinition());
+            GraphqlElementParentTree elementParentTree = buildRuntimeTree(fieldsContainer, field, argument);
+
+            Parameters argParams = params.newParams(fieldDefinition, fieldsContainer, nodeParentTree, elementParentTree);
+
+            return onArgument(argument, argParams);
+        }).collect(toList());
     }
+
+    private List<GraphQLFieldDefinition> wireFields(GraphQLFieldsContainer fieldsContainer, NamedNode fieldsContainerNode, Parameters params) {
+        return fieldsContainer.getFieldDefinitions().stream().map(fieldDefinition -> {
+
+            // and for each argument in the fieldDefinition run the wiring for them - and note that they can change
+            List<GraphQLArgument> newArgs = wireArguments(fieldDefinition, fieldsContainer, fieldsContainerNode, params, fieldDefinition);
+
+            // they may have changed the arguments to the fieldDefinition so reflect that
+            fieldDefinition = fieldDefinition.transform(builder -> builder.clearArguments().arguments(newArgs));
+
+            NodeParentTree<NamedNode> nodeParentTree = buildAstTree(fieldsContainerNode, fieldDefinition.getDefinition());
+            GraphqlElementParentTree elementParentTree = buildRuntimeTree(fieldsContainer, fieldDefinition);
+            Parameters fieldParams = params.newParams(fieldDefinition, fieldsContainer, nodeParentTree, elementParentTree);
+
+            // now for each fieldDefinition run the new wiring and capture the results
+            return onField(fieldDefinition, fieldParams);
+        }).collect(toList());
+    }
+
+
+    public GraphQLObjectType onObject(final GraphQLObjectType objectType, Parameters params) {
+        List<GraphQLFieldDefinition> newFields = wireFields(objectType, objectType.getDefinition(), params);
+
+        GraphQLObjectType newObjectType = objectType.transform(builder -> builder.clearFields().fields(newFields));
+
+        NodeParentTree<NamedNode> nodeParentTree = buildAstTree(newObjectType.getDefinition());
+        GraphqlElementParentTree elementParentTree = buildRuntimeTree(newObjectType);
+        Parameters newParams = params.newParams(newObjectType, nodeParentTree, elementParentTree);
+
+        return wireForEachDirective(params, newObjectType, newObjectType.getDirectives(),
+                (outputElement, directive) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directive, newParams), SchemaDirectiveWiring::onObject);
+    }
+
+    public GraphQLInterfaceType onInterface(GraphQLInterfaceType interfaceType, Parameters params) {
+        List<GraphQLFieldDefinition> newFields = wireFields(interfaceType, interfaceType.getDefinition(), params);
+
+        GraphQLInterfaceType newInterfaceType = interfaceType.transform(builder -> builder.clearFields().fields(newFields));
+
+        NodeParentTree<NamedNode> nodeParentTree = buildAstTree(newInterfaceType.getDefinition());
+        GraphqlElementParentTree elementParentTree = buildRuntimeTree(newInterfaceType);
+        Parameters newParams = params.newParams(newInterfaceType, nodeParentTree, elementParentTree);
+
+        return wireForEachDirective(params, newInterfaceType, newInterfaceType.getDirectives(),
+                (outputElement, directive) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directive, newParams), SchemaDirectiveWiring::onInterface);
+    }
+
+    public GraphQLEnumType onEnum(GraphQLEnumType enumType, Parameters params) {
+
+        List<GraphQLEnumValueDefinition> newEnums = enumType.getValues().stream().map(enumValueDefinition -> {
+
+            NodeParentTree<NamedNode> nodeParentTree = buildAstTree(enumType.getDefinition(), enumValueDefinition.getDefinition());
+            GraphqlElementParentTree elementParentTree = buildRuntimeTree(enumType, enumValueDefinition);
+            Parameters fieldParams = params.newParams(nodeParentTree, elementParentTree);
+
+            // now for each field run the new wiring and capture the results
+            return onEnumValue(enumValueDefinition, fieldParams);
+        }).collect(toList());
+
+        GraphQLEnumType newEnumType = enumType.transform(builder -> builder.clearValues().values(newEnums));
+
+        NodeParentTree<NamedNode> nodeParentTree = buildAstTree(newEnumType.getDefinition());
+        GraphqlElementParentTree elementParentTree = buildRuntimeTree(newEnumType);
+        Parameters newParams = params.newParams(nodeParentTree, elementParentTree);
+
+        return wireForEachDirective(params, newEnumType, newEnumType.getDirectives(),
+                (outputElement, directive) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directive, newParams), SchemaDirectiveWiring::onEnum);
+    }
+
+    public GraphQLInputObjectType onInputObjectType(GraphQLInputObjectType inputObjectType, Parameters params) {
+        List<GraphQLInputObjectField> newFields = inputObjectType.getFieldDefinitions().stream().map(inputField -> {
+
+            NodeParentTree<NamedNode> nodeParentTree = buildAstTree(inputObjectType.getDefinition(), inputField.getDefinition());
+            GraphqlElementParentTree elementParentTree = buildRuntimeTree(inputObjectType, inputField);
+            Parameters fieldParams = params.newParams(nodeParentTree, elementParentTree);
+
+            // now for each field run the new wiring and capture the results
+            return onInputObjectField(inputField, fieldParams);
+        }).collect(toList());
+
+        GraphQLInputObjectType newInputObjectType = inputObjectType.transform(builder -> builder.clearFields().fields(newFields));
+
+        NodeParentTree<NamedNode> nodeParentTree = buildAstTree(newInputObjectType.getDefinition());
+        GraphqlElementParentTree elementParentTree = buildRuntimeTree(newInputObjectType);
+        Parameters newParams = params.newParams(nodeParentTree, elementParentTree);
+
+        return wireForEachDirective(params, newInputObjectType, newInputObjectType.getDirectives(),
+                (outputElement, directive) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directive, newParams), SchemaDirectiveWiring::onInputObjectType);
+    }
+
 
     public GraphQLUnionType onUnion(GraphQLUnionType element, Parameters params) {
+        NodeParentTree<NamedNode> nodeParentTree = buildAstTree(element.getDefinition());
+        GraphqlElementParentTree elementParentTree = buildRuntimeTree(element);
+        Parameters newParams = params.newParams(nodeParentTree, elementParentTree);
+
         return wireForEachDirective(params, element, element.getDirectives(),
-                (outputElement, directive) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directive, params.getNodeParentTree(), params.getTypeRegistry(), params.getContext(), params.getCodeRegistry(), params.getFieldsContainer()), SchemaDirectiveWiring::onUnion);
+                (outputElement, directive) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directive, newParams), SchemaDirectiveWiring::onUnion);
     }
 
     public GraphQLScalarType onScalar(GraphQLScalarType element, Parameters params) {
+        NodeParentTree<NamedNode> nodeParentTree = buildAstTree(element.getDefinition());
+        GraphqlElementParentTree elementParentTree = buildRuntimeTree(element);
+        Parameters newParams = params.newParams(nodeParentTree, elementParentTree);
+
         return wireForEachDirective(params, element, element.getDirectives(),
-                (outputElement, directive) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directive, params.getNodeParentTree(), params.getTypeRegistry(), params.getContext(), params.getCodeRegistry(), params.getFieldsContainer()), SchemaDirectiveWiring::onScalar);
+                (outputElement, directive) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directive, newParams), SchemaDirectiveWiring::onScalar);
     }
 
-    public GraphQLEnumType onEnum(GraphQLEnumType element, Parameters params) {
-        return wireForEachDirective(params, element, element.getDirectives(),
-                (outputElement, directive) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directive, params.getNodeParentTree(), params.getTypeRegistry(), params.getContext(), params.getCodeRegistry(), params.getFieldsContainer()), SchemaDirectiveWiring::onEnum);
+    private GraphQLFieldDefinition onField(GraphQLFieldDefinition fieldDefinition, Parameters params) {
+        return wireForEachDirective(params, fieldDefinition, fieldDefinition.getDirectives(),
+                (outputElement, directive) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directive, params), SchemaDirectiveWiring::onField);
     }
 
-    public GraphQLEnumValueDefinition onEnumValue(GraphQLEnumValueDefinition element, Parameters params) {
+    private GraphQLInputObjectField onInputObjectField(GraphQLInputObjectField element, Parameters params) {
         return wireForEachDirective(params, element, element.getDirectives(),
-                (outputElement, directive) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directive, params.getNodeParentTree(), params.getTypeRegistry(), params.getContext(), params.getCodeRegistry(), params.getFieldsContainer()), SchemaDirectiveWiring::onEnumValue);
+                (outputElement, directive) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directive, params), SchemaDirectiveWiring::onInputObjectField);
     }
 
-    public GraphQLArgument onArgument(GraphQLArgument element, Parameters params) {
-        return wireForEachDirective(params, element, element.getDirectives(),
-                (outputElement, directive) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directive, params.getNodeParentTree(), params.getTypeRegistry(), params.getContext(), params.getCodeRegistry(), params.getFieldsContainer()), SchemaDirectiveWiring::onArgument);
+    private GraphQLEnumValueDefinition onEnumValue(GraphQLEnumValueDefinition enumValueDefinition, Parameters params) {
+        return wireForEachDirective(params, enumValueDefinition, enumValueDefinition.getDirectives(),
+                (outputElement, directive) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directive, params), SchemaDirectiveWiring::onEnumValue);
     }
 
-    public GraphQLInputObjectType onInputObjectType(GraphQLInputObjectType element, Parameters params) {
-        return wireForEachDirective(params, element, element.getDirectives(),
-                (outputElement, directive) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directive, params.getNodeParentTree(), params.getTypeRegistry(), params.getContext(), params.getCodeRegistry(), params.getFieldsContainer()), SchemaDirectiveWiring::onInputObjectType);
-    }
-
-    public GraphQLInputObjectField onInputObjectField(GraphQLInputObjectField element, Parameters params) {
-        return wireForEachDirective(params, element, element.getDirectives(),
-                (outputElement, directive) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directive, params.getNodeParentTree(), params.getTypeRegistry(), params.getContext(), params.getCodeRegistry(), params.getFieldsContainer()), SchemaDirectiveWiring::onInputObjectField);
+    private GraphQLArgument onArgument(GraphQLArgument argument, Parameters params) {
+        return wireForEachDirective(params, argument, argument.getDirectives(),
+                (outputElement, directive) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directive, params), SchemaDirectiveWiring::onArgument);
     }
 
 

--- a/src/test/groovy/readme/DirectivesExamples.java
+++ b/src/test/groovy/readme/DirectivesExamples.java
@@ -64,8 +64,7 @@ public class DirectivesExamples {
             };
             //
             // now change the field definition to have the new authorising data fetcher
-            FieldCoordinates coordinates = FieldCoordinates.coordinates(parentType, field);
-            environment.getCodeRegistry().dataFetcher(coordinates, authDataFetcher);
+            environment.getCodeRegistry().dataFetcher(parentType, field, authDataFetcher);
             return field;
         }
     }


### PR DESCRIPTION
This makes the schema directive wiring occur after the type has been built and hence the callback gets full access to the type hierarchy