### PR TITLE
Ability to provide CacheControl instance via ExecutionInput

### DIFF
--- a/src/main/java/graphql/ExecutionInput.java
+++ b/src/main/java/graphql/ExecutionInput.java
@@ -1,5 +1,6 @@
 package graphql;
 
+import graphql.cachecontrol.CacheControl;
 import org.dataloader.DataLoaderRegistry;
 
 import java.util.Collections;
@@ -20,20 +21,22 @@ public class ExecutionInput {
     private final Object root;
     private final Map<String, Object> variables;
     private final DataLoaderRegistry dataLoaderRegistry;
+    private final CacheControl cacheControl;
 
 
     public ExecutionInput(String query, String operationName, Object context, Object root, Map<String, Object> variables) {
-        this(query, operationName, context, root, variables, new DataLoaderRegistry());
+        this(query, operationName, context, root, variables, new DataLoaderRegistry(), null);
     }
 
     @Internal
-    private ExecutionInput(String query, String operationName, Object context, Object root, Map<String, Object> variables, DataLoaderRegistry dataLoaderRegistry) {
+    private ExecutionInput(String query, String operationName, Object context, Object root, Map<String, Object> variables, DataLoaderRegistry dataLoaderRegistry, CacheControl cacheControl) {
         this.query = query;
         this.operationName = operationName;
         this.context = context;
         this.root = root;
         this.variables = variables;
         this.dataLoaderRegistry = dataLoaderRegistry;
+        this.cacheControl = cacheControl;
     }
 
     /**
@@ -79,6 +82,13 @@ public class ExecutionInput {
     }
 
     /**
+     * @return the cache control helper associated with this execution
+     */
+    public CacheControl getCacheControl() {
+        return cacheControl;
+    }
+
+    /**
      * This helps you transform the current ExecutionInput object into another one by starting a builder with all
      * the current values and allows you to transform it how you want.
      *
@@ -93,6 +103,7 @@ public class ExecutionInput {
                 .context(this.context)
                 .root(this.root)
                 .dataLoaderRegistry(this.dataLoaderRegistry)
+                .cacheControl(this.cacheControl)
                 .variables(this.variables);
 
         builderConsumer.accept(builder);
@@ -139,6 +150,7 @@ public class ExecutionInput {
         private Object root;
         private Map<String, Object> variables = Collections.emptyMap();
         private DataLoaderRegistry dataLoaderRegistry = new DataLoaderRegistry();
+        private CacheControl cacheControl;
 
         public Builder query(String query) {
             this.query = query;
@@ -196,8 +208,13 @@ public class ExecutionInput {
             return this;
         }
 
+        public Builder cacheControl(CacheControl cacheControl) {
+            this.cacheControl = cacheControl;
+            return this;
+        }
+
         public ExecutionInput build() {
-            return new ExecutionInput(query, operationName, context, root, variables, dataLoaderRegistry);
+            return new ExecutionInput(query, operationName, context, root, variables, dataLoaderRegistry, cacheControl);
         }
     }
 }

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -90,6 +90,7 @@ public class Execution {
                 .document(document)
                 .operationDefinition(operationDefinition)
                 .dataLoaderRegistry(executionInput.getDataLoaderRegistry())
+                .cacheControl(executionInput.getCacheControl())
                 .build();
 
 

--- a/src/main/java/graphql/execution/ExecutionContext.java
+++ b/src/main/java/graphql/execution/ExecutionContext.java
@@ -4,6 +4,7 @@ package graphql.execution;
 import graphql.GraphQLError;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.cachecontrol.CacheControl;
 import graphql.execution.defer.DeferSupport;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationState;
@@ -38,10 +39,11 @@ public class ExecutionContext {
     private final Instrumentation instrumentation;
     private final List<GraphQLError> errors = new CopyOnWriteArrayList<>();
     private final DataLoaderRegistry dataLoaderRegistry;
+    private final CacheControl cacheControl;
     private final DeferSupport deferSupport = new DeferSupport();
 
     @Internal
-    ExecutionContext(Instrumentation instrumentation, ExecutionId executionId, GraphQLSchema graphQLSchema, InstrumentationState instrumentationState, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy, ExecutionStrategy subscriptionStrategy, Map<String, FragmentDefinition> fragmentsByName, Document document, OperationDefinition operationDefinition, Map<String, Object> variables, Object context, Object root, DataLoaderRegistry dataLoaderRegistry, List<GraphQLError> startingErrors) {
+    ExecutionContext(Instrumentation instrumentation, ExecutionId executionId, GraphQLSchema graphQLSchema, InstrumentationState instrumentationState, ExecutionStrategy queryStrategy, ExecutionStrategy mutationStrategy, ExecutionStrategy subscriptionStrategy, Map<String, FragmentDefinition> fragmentsByName, Document document, OperationDefinition operationDefinition, Map<String, Object> variables, Object context, Object root, DataLoaderRegistry dataLoaderRegistry, CacheControl cacheControl, List<GraphQLError> startingErrors) {
         this.graphQLSchema = graphQLSchema;
         this.executionId = executionId;
         this.instrumentationState = instrumentationState;
@@ -56,6 +58,7 @@ public class ExecutionContext {
         this.root = root;
         this.instrumentation = instrumentation;
         this.dataLoaderRegistry = dataLoaderRegistry;
+        this.cacheControl = cacheControl;
         this.errors.addAll(startingErrors);
     }
 
@@ -107,6 +110,10 @@ public class ExecutionContext {
 
     public DataLoaderRegistry getDataLoaderRegistry() {
         return dataLoaderRegistry;
+    }
+
+    public CacheControl getCacheControl() {
+        return cacheControl;
     }
 
     /**

--- a/src/main/java/graphql/execution/ExecutionContextBuilder.java
+++ b/src/main/java/graphql/execution/ExecutionContextBuilder.java
@@ -3,6 +3,7 @@ package graphql.execution;
 import graphql.GraphQLError;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.cachecontrol.CacheControl;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationState;
 import graphql.language.Document;
@@ -36,6 +37,7 @@ public class ExecutionContextBuilder {
     private Map<String, Object> variables = new LinkedHashMap<>();
     private Map<String, FragmentDefinition> fragmentsByName = new LinkedHashMap<>();
     private DataLoaderRegistry dataLoaderRegistry;
+    private CacheControl cacheControl;
     private List<GraphQLError> errors = new ArrayList<>();
 
     /**
@@ -76,6 +78,7 @@ public class ExecutionContextBuilder {
         variables = new HashMap<>(other.getVariables());
         fragmentsByName = new HashMap<>(other.getFragmentsByName());
         dataLoaderRegistry = other.getDataLoaderRegistry();
+        cacheControl = other.getCacheControl();
         errors = new ArrayList<>(other.getErrors());
     }
 
@@ -150,6 +153,11 @@ public class ExecutionContextBuilder {
         return this;
     }
 
+    public ExecutionContextBuilder cacheControl(CacheControl cacheControl) {
+        this.cacheControl = cacheControl;
+        return this;
+    }
+
     public ExecutionContext build() {
         // preconditions
         assertNotNull(executionId, "You must provide a query identifier");
@@ -168,7 +176,9 @@ public class ExecutionContextBuilder {
                 variables,
                 context,
                 root,
-                dataLoaderRegistry, errors
+                dataLoaderRegistry,
+                cacheControl,
+                errors
         );
     }
 }

--- a/src/main/java/graphql/schema/DataFetchingEnvironment.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironment.java
@@ -1,6 +1,7 @@
 package graphql.schema;
 
 import graphql.PublicApi;
+import graphql.cachecontrol.CacheControl;
 import graphql.execution.ExecutionId;
 import graphql.execution.ExecutionStepInfo;
 import graphql.execution.MergedField;
@@ -191,6 +192,11 @@ public interface DataFetchingEnvironment {
      * @see org.dataloader.DataLoaderRegistry#getDataLoader(String)
      */
     <K, V> DataLoader<K, V> getDataLoader(String dataLoaderName);
+
+    /**
+     * @return the current {@link CacheControl} instance used to add cache hints to the response
+     */
+    CacheControl getCacheControl();
 
     /**
      * @return the current operation that is being executed

--- a/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
@@ -2,6 +2,7 @@ package graphql.schema;
 
 
 import graphql.Internal;
+import graphql.cachecontrol.CacheControl;
 import graphql.execution.ExecutionContext;
 import graphql.execution.ExecutionId;
 import graphql.execution.ExecutionStepInfo;
@@ -36,6 +37,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
     private final DataFetchingFieldSelectionSet selectionSet;
     private final ExecutionStepInfo executionStepInfo;
     private final DataLoaderRegistry dataLoaderRegistry;
+    private final CacheControl cacheControl;
     private final OperationDefinition operationDefinition;
     private final Document document;
     private final Map<String, Object> variables;
@@ -56,6 +58,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
         this.selectionSet = builder.selectionSet;
         this.executionStepInfo = builder.executionStepInfo;
         this.dataLoaderRegistry = builder.dataLoaderRegistry;
+        this.cacheControl = builder.cacheControl;
         this.operationDefinition = builder.operationDefinition;
         this.document = builder.document;
         this.variables = builder.variables;
@@ -157,6 +160,11 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
     }
 
     @Override
+    public CacheControl getCacheControl() {
+        return cacheControl;
+    }
+
+    @Override
     public OperationDefinition getOperationDefinition() {
         return operationDefinition;
     }
@@ -196,6 +204,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
                 .graphQLSchema(executionContext.getGraphQLSchema())
                 .fragmentsByName(executionContext.getFragmentsByName())
                 .dataLoaderRegistry(executionContext.getDataLoaderRegistry())
+                .cacheControl(executionContext.getCacheControl())
                 .document(executionContext.getDocument())
                 .operationDefinition(executionContext.getOperationDefinition())
                 .variables(executionContext.getVariables())
@@ -217,6 +226,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
         private DataFetchingFieldSelectionSet selectionSet;
         private ExecutionStepInfo executionStepInfo;
         private DataLoaderRegistry dataLoaderRegistry;
+        private CacheControl cacheControl;
         private OperationDefinition operationDefinition;
         private Document document;
         private final Map<String, Object> arguments = new LinkedHashMap<>();
@@ -239,6 +249,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
             this.selectionSet = env.selectionSet;
             this.executionStepInfo = env.executionStepInfo;
             this.dataLoaderRegistry = env.dataLoaderRegistry;
+            this.cacheControl = env.cacheControl;
             this.operationDefinition = env.operationDefinition;
             this.document = env.document;
             this.variables.putAll(env.variables);
@@ -319,6 +330,11 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
 
         public Builder dataLoaderRegistry(DataLoaderRegistry dataLoaderRegistry) {
             this.dataLoaderRegistry = dataLoaderRegistry;
+            return this;
+        }
+
+        public Builder cacheControl(CacheControl cacheControl) {
+            this.cacheControl = cacheControl;
             return this;
         }
 

--- a/src/test/groovy/graphql/ExecutionInputTest.groovy
+++ b/src/test/groovy/graphql/ExecutionInputTest.groovy
@@ -1,5 +1,6 @@
 package graphql
 
+import graphql.cachecontrol.CacheControl
 import org.dataloader.DataLoaderRegistry
 import spock.lang.Specification
 
@@ -9,6 +10,7 @@ class ExecutionInputTest extends Specification {
 
     def query = "query { hello }"
     def registry = new DataLoaderRegistry()
+    def cacheControl = CacheControl.newCacheControl()
     def root = "root"
     def context = "context"
     def variables = [key: "value"]
@@ -17,6 +19,7 @@ class ExecutionInputTest extends Specification {
         when:
         def executionInput = ExecutionInput.newExecutionInput().query(query)
                 .dataLoaderRegistry(registry)
+                .cacheControl(cacheControl)
                 .variables(variables)
                 .root(root)
                 .context(context)
@@ -26,6 +29,7 @@ class ExecutionInputTest extends Specification {
         executionInput.root == root
         executionInput.variables == variables
         executionInput.dataLoaderRegistry == registry
+        executionInput.cacheControl == cacheControl
         executionInput.query == query
     }
 
@@ -49,6 +53,7 @@ class ExecutionInputTest extends Specification {
         when:
         def executionInputOld = ExecutionInput.newExecutionInput().query(query)
                 .dataLoaderRegistry(registry)
+                .cacheControl(cacheControl)
                 .variables(variables)
                 .root(root)
                 .context(context)
@@ -60,6 +65,7 @@ class ExecutionInputTest extends Specification {
         executionInput.root == root
         executionInput.variables == variables
         executionInput.dataLoaderRegistry == registry
+        executionInput.cacheControl == cacheControl
         executionInput.query == "new query"
     }
 

--- a/src/test/groovy/graphql/execution/ExecutionContextBuilderTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionContextBuilderTest.groovy
@@ -1,5 +1,6 @@
 package graphql.execution
 
+import graphql.cachecontrol.CacheControl
 import graphql.execution.instrumentation.Instrumentation
 import graphql.language.Document
 import graphql.language.FragmentDefinition
@@ -53,7 +54,10 @@ class ExecutionContextBuilderTest extends Specification {
         executionContextBuilder.variables([var: 'value'])
 
         def dataLoaderRegistry = new DataLoaderRegistry()
-        executionContextBuilder.dataLoaderRegistry(dataLoaderRegistry);
+        executionContextBuilder.dataLoaderRegistry(dataLoaderRegistry)
+
+        def cacheControl = CacheControl.newCacheControl()
+        executionContextBuilder.cacheControl(cacheControl)
 
         when:
         def executionContext = executionContextBuilder.build()
@@ -71,5 +75,6 @@ class ExecutionContextBuilderTest extends Specification {
         executionContext.getFragmentsByName() == [MyFragment: fragment]
         executionContext.operationDefinition == operation
         executionContext.dataLoaderRegistry == dataLoaderRegistry
+        executionContext.cacheControl == cacheControl
     }
 }

--- a/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
@@ -63,7 +63,7 @@ class ExecutionStrategyTest extends Specification {
         new ExecutionContext(SimpleInstrumentation.INSTANCE, executionId, schema ?: StarWarsSchema.starWarsSchema, null,
                 executionStrategy, executionStrategy, executionStrategy,
                 null, null, null,
-                variables, "context", "root", new DataLoaderRegistry(), Collections.emptyList())
+                variables, "context", "root", new DataLoaderRegistry(), null, Collections.emptyList())
     }
 
     @SuppressWarnings("GroovyAssignabilityCheck")

--- a/src/test/groovy/graphql/schema/DataFetchingEnvironmentImplTest.groovy
+++ b/src/test/groovy/graphql/schema/DataFetchingEnvironmentImplTest.groovy
@@ -1,6 +1,6 @@
 package graphql.schema
 
-
+import graphql.cachecontrol.CacheControl
 import graphql.execution.ExecutionId
 import graphql.execution.ExecutionStepInfo
 import graphql.language.FragmentDefinition
@@ -30,6 +30,7 @@ class DataFetchingEnvironmentImplTest extends Specification {
     def fragmentByName = [frag: frag]
     def variables = [var: "able"]
     def dataLoaderRegistry = new DataLoaderRegistry().register("dataLoader", dataLoader)
+    def cacheControl = CacheControl.newCacheControl()
 
     def executionContext = newExecutionContextBuilder()
             .root("root")
@@ -41,6 +42,7 @@ class DataFetchingEnvironmentImplTest extends Specification {
             .graphQLSchema(starWarsSchema)
             .fragmentsByName(fragmentByName)
             .dataLoaderRegistry(dataLoaderRegistry)
+            .cacheControl(cacheControl)
             .build()
 
 
@@ -92,6 +94,7 @@ class DataFetchingEnvironmentImplTest extends Specification {
                 .document(document)
                 .variables(variables)
                 .dataLoaderRegistry(dataLoaderRegistry)
+                .cacheControl(cacheControl)
                 .build()
 
         when:
@@ -114,6 +117,7 @@ class DataFetchingEnvironmentImplTest extends Specification {
         dfe.getOperationDefinition() == dfeCopy.getOperationDefinition()
         dfe.getVariables() == dfeCopy.getVariables()
         dfe.getDataLoader("dataLoader") == dataLoader
+        dfe.getCacheControl() == cacheControl
     }
 
 }


### PR DESCRIPTION
Make CacheControl explicitly accessible from DataFetchingEnvironment, similar to how DataLoaderRegistry currently works