### PR TITLE
simplify ExecutionResultNodes

### DIFF
--- a/src/main/java/graphql/Assert.java
+++ b/src/main/java/graphql/Assert.java
@@ -69,6 +69,13 @@ public class Assert {
         throw new AssertException(format(format, args));
     }
 
+    public static void assertTrue(boolean condition) {
+        if (condition) {
+            return;
+        }
+        throw new AssertException("condition expected to be true");
+    }
+
     public static void assertFalse(boolean condition, String format, Object... args) {
         if (!condition) {
             return;

--- a/src/main/java/graphql/execution/ExecutionStepInfo.java
+++ b/src/main/java/graphql/execution/ExecutionStepInfo.java
@@ -199,6 +199,10 @@ public class ExecutionStepInfo {
         return builder.build();
     }
 
+    public String getResultKey() {
+        return field.getResultKey();
+    }
+
     /**
      * @return a builder of type info
      */

--- a/src/main/java/graphql/execution/nextgen/BatchedExecutionStrategy.java
+++ b/src/main/java/graphql/execution/nextgen/BatchedExecutionStrategy.java
@@ -9,7 +9,6 @@ import graphql.execution.FetchedValue;
 import graphql.execution.MergedField;
 import graphql.execution.MergedSelectionSet;
 import graphql.execution.nextgen.result.ExecutionResultNode;
-import graphql.execution.nextgen.result.NamedResultNode;
 import graphql.execution.nextgen.result.ObjectExecutionResultNode;
 import graphql.execution.nextgen.result.ResultNodesUtil;
 import graphql.execution.nextgen.result.RootExecutionResultNode;
@@ -129,8 +128,8 @@ public class BatchedExecutionStrategy implements ExecutionStrategy {
 
     private NodeZipper<ExecutionResultNode> resolveZipper(NodeZipper<ExecutionResultNode> unresolvedNodeZipper, List<FetchedValueAnalysis> fetchedValuesForNode) {
         UnresolvedObjectResultNode unresolvedNode = (UnresolvedObjectResultNode) unresolvedNodeZipper.getCurNode();
-        List<NamedResultNode> newChildren = util.fetchedValueAnalysisToNodes(fetchedValuesForNode);
-        ObjectExecutionResultNode newNode = unresolvedNode.withChildren(newChildren);
+        List<ExecutionResultNode> newChildren = util.fetchedValueAnalysisToNodes(fetchedValuesForNode);
+        ObjectExecutionResultNode newNode = unresolvedNode.withNewChildren(newChildren);
         return unresolvedNodeZipper.withNewNode(newNode);
     }
 

--- a/src/main/java/graphql/execution/nextgen/ExecutionStrategyUtil.java
+++ b/src/main/java/graphql/execution/nextgen/ExecutionStrategyUtil.java
@@ -12,7 +12,6 @@ import graphql.execution.MergedField;
 import graphql.execution.MergedSelectionSet;
 import graphql.execution.ResolveType;
 import graphql.execution.nextgen.result.ExecutionResultNode;
-import graphql.execution.nextgen.result.NamedResultNode;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLOutputType;
 import graphql.util.FpKit;
@@ -32,7 +31,7 @@ public class ExecutionStrategyUtil {
     ResolveType resolveType = new ResolveType();
     FieldCollector fieldCollector = new FieldCollector();
 
-    public List<CompletableFuture<NamedResultNode>> fetchSubSelection(ExecutionContext executionContext, FieldSubSelection fieldSubSelection) {
+    public List<CompletableFuture<ExecutionResultNode>> fetchSubSelection(ExecutionContext executionContext, FieldSubSelection fieldSubSelection) {
         List<CompletableFuture<FetchedValueAnalysis>> fetchedValueAnalysisList = fetchAndAnalyze(executionContext, fieldSubSelection);
         return fetchedValueAnalysisToNodesAsync(fetchedValueAnalysisList);
     }
@@ -53,18 +52,12 @@ public class ExecutionStrategyUtil {
                 .thenApply(fetchValue -> analyseValue(context, fetchValue, newExecutionStepInfo));
     }
 
-    private List<CompletableFuture<NamedResultNode>> fetchedValueAnalysisToNodesAsync(List<CompletableFuture<FetchedValueAnalysis>> list) {
-        return Async.map(list, fetchedValueAnalysis -> {
-            ExecutionResultNode resultNode = resultNodesCreator.createResultNode(fetchedValueAnalysis);
-            return new NamedResultNode(fetchedValueAnalysis.getField().getResultKey(), resultNode);
-        });
+    private List<CompletableFuture<ExecutionResultNode>> fetchedValueAnalysisToNodesAsync(List<CompletableFuture<FetchedValueAnalysis>> list) {
+        return Async.map(list, fetchedValueAnalysis -> resultNodesCreator.createResultNode(fetchedValueAnalysis));
     }
 
-    public List<NamedResultNode> fetchedValueAnalysisToNodes(List<FetchedValueAnalysis> fetchedValueAnalysisList) {
-        return FpKit.map(fetchedValueAnalysisList, fetchedValueAnalysis -> {
-            ExecutionResultNode resultNode = resultNodesCreator.createResultNode(fetchedValueAnalysis);
-            return new NamedResultNode(fetchedValueAnalysis.getField().getResultKey(), resultNode);
-        });
+    public List<ExecutionResultNode> fetchedValueAnalysisToNodes(List<FetchedValueAnalysis> fetchedValueAnalysisList) {
+        return FpKit.map(fetchedValueAnalysisList, fetchedValueAnalysis -> resultNodesCreator.createResultNode(fetchedValueAnalysis));
     }
 
 

--- a/src/main/java/graphql/execution/nextgen/FetchedValueAnalysis.java
+++ b/src/main/java/graphql/execution/nextgen/FetchedValueAnalysis.java
@@ -103,6 +103,10 @@ public class FetchedValueAnalysis {
         return executionStepInfo.getField();
     }
 
+    public String getResultKey() {
+        return executionStepInfo.getResultKey();
+    }
+
     public static final class Builder {
         private FetchedValueType valueType;
         private final List<GraphQLError> errors = new ArrayList<>();

--- a/src/main/java/graphql/execution/nextgen/result/LeafExecutionResultNode.java
+++ b/src/main/java/graphql/execution/nextgen/result/LeafExecutionResultNode.java
@@ -4,41 +4,25 @@ import graphql.Assert;
 import graphql.Internal;
 import graphql.execution.NonNullableFieldWasNullException;
 import graphql.execution.nextgen.FetchedValueAnalysis;
-import graphql.util.NodeLocation;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 @Internal
 public class LeafExecutionResultNode extends ExecutionResultNode {
 
     public LeafExecutionResultNode(FetchedValueAnalysis fetchedValueAnalysis,
                                    NonNullableFieldWasNullException nonNullableFieldWasNullException) {
-        super(fetchedValueAnalysis, nonNullableFieldWasNullException);
+        super(fetchedValueAnalysis, nonNullableFieldWasNullException, Collections.emptyList());
     }
 
-    @Override
-    public List<ExecutionResultNode> getChildren() {
-        return Collections.emptyList();
-    }
-
-    @Override
-    public Map<String, List<ExecutionResultNode>> getNamedChildren() {
-        return Collections.emptyMap();
-    }
-
-    @Override
-    public ExecutionResultNode withChild(ExecutionResultNode child, NodeLocation position) {
-        return Assert.assertShouldNeverHappen("Not available for leafs");
-    }
-
-    @Override
-    public ExecutionResultNode withNewChildren(Map<NodeLocation, ExecutionResultNode> children) {
-        return Assert.assertShouldNeverHappen();
-    }
 
     public Object getValue() {
         return getFetchedValueAnalysis().getCompletedValue();
+    }
+
+    @Override
+    public ExecutionResultNode withNewChildren(List<ExecutionResultNode> children) {
+        return Assert.assertShouldNeverHappen();
     }
 }

--- a/src/main/java/graphql/execution/nextgen/result/ListExecutionResultNode.java
+++ b/src/main/java/graphql/execution/nextgen/result/ListExecutionResultNode.java
@@ -1,60 +1,21 @@
 package graphql.execution.nextgen.result;
 
-import graphql.Assert;
 import graphql.Internal;
-import graphql.execution.NonNullableFieldWasNullException;
 import graphql.execution.nextgen.FetchedValueAnalysis;
-import graphql.util.NodeLocation;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 @Internal
 public class ListExecutionResultNode extends ExecutionResultNode {
 
-    private final List<ExecutionResultNode> children;
 
     public ListExecutionResultNode(FetchedValueAnalysis fetchedValueAnalysis,
                                    List<ExecutionResultNode> children) {
-        super(fetchedValueAnalysis, ResultNodesUtil.newNullableException(fetchedValueAnalysis, children));
-        this.children = Assert.assertNotNull(children);
-        children.forEach(Assert::assertNotNull);
-    }
-
-    public Optional<NonNullableFieldWasNullException> getChildNonNullableException() {
-        return children.stream()
-                .filter(executionResultNode -> executionResultNode.getNonNullableFieldWasNullException() != null)
-                .map(ExecutionResultNode::getNonNullableFieldWasNullException)
-                .findFirst();
+        super(fetchedValueAnalysis, ResultNodesUtil.newNullableException(fetchedValueAnalysis, children), children);
     }
 
     @Override
-    public List<ExecutionResultNode> getChildren() {
-        return children;
-    }
-
-    @Override
-    public Map<String, List<ExecutionResultNode>> getNamedChildren() {
-        Map<String, List<ExecutionResultNode>> result = new LinkedHashMap<>();
-        result.put(null, children);
-        return result;
-    }
-
-    @Override
-    public ExecutionResultNode withChild(ExecutionResultNode child, NodeLocation position) {
-        List<ExecutionResultNode> newChildren = new ArrayList<>(this.children);
-        newChildren.set(position.getIndex(), child);
-        return new ListExecutionResultNode(getFetchedValueAnalysis(), newChildren);
-    }
-
-    @Override
-    public ExecutionResultNode withNewChildren(Map<NodeLocation, ExecutionResultNode> newChildren) {
-        List<ExecutionResultNode> mergedChildren = new ArrayList<>(this.children);
-        newChildren.entrySet().forEach(entry -> mergedChildren.set(entry.getKey().getIndex(), entry.getValue()));
-
-        return new ListExecutionResultNode(getFetchedValueAnalysis(), mergedChildren);
+    public ExecutionResultNode withNewChildren(List<ExecutionResultNode> children) {
+        return new ListExecutionResultNode(getFetchedValueAnalysis(), children);
     }
 }

--- a/src/main/java/graphql/execution/nextgen/result/ObjectExecutionResultNode.java
+++ b/src/main/java/graphql/execution/nextgen/result/ObjectExecutionResultNode.java
@@ -1,74 +1,23 @@
 package graphql.execution.nextgen.result;
 
 import graphql.Internal;
-import graphql.execution.NonNullableFieldWasNullException;
 import graphql.execution.nextgen.FetchedValueAnalysis;
-import graphql.util.NodeLocation;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 @Internal
 public class ObjectExecutionResultNode extends ExecutionResultNode {
 
-    private Map<String, ExecutionResultNode> children;
 
     public ObjectExecutionResultNode(FetchedValueAnalysis fetchedValueAnalysis,
-                                     Map<String, ExecutionResultNode> children) {
-        super(fetchedValueAnalysis, ResultNodesUtil.newNullableException(fetchedValueAnalysis, children.values()));
-        this.children = children;
+                                     List<ExecutionResultNode> children) {
+        super(fetchedValueAnalysis, ResultNodesUtil.newNullableException(fetchedValueAnalysis, children), children);
     }
 
-    public ObjectExecutionResultNode(FetchedValueAnalysis fetchedValueAnalysis,
-                                     List<NamedResultNode> children) {
-        super(fetchedValueAnalysis, ResultNodesUtil.newNullableException(fetchedValueAnalysis, children));
-        this.children = ResultNodesUtil.namedNodesToMap(children);
-    }
 
     @Override
-    public List<ExecutionResultNode> getChildren() {
-        return new ArrayList<>(children.values());
-    }
-
-    @Override
-    public Map<String, List<ExecutionResultNode>> getNamedChildren() {
-        Map<String, List<ExecutionResultNode>> result = new LinkedHashMap<>();
-        children.forEach((key, node) -> result.put(key, Arrays.asList(node)));
-        return result;
-    }
-
-    @Override
-    public ExecutionResultNode withChild(ExecutionResultNode child, NodeLocation position) {
-        LinkedHashMap<String, ExecutionResultNode> newChildren = new LinkedHashMap<>(this.children);
-        newChildren.put(position.getName(), child);
-        return new ObjectExecutionResultNode(getFetchedValueAnalysis(), newChildren);
-    }
-
-    @Override
-    public ExecutionResultNode withNewChildren(Map<NodeLocation, ExecutionResultNode> children) {
-        LinkedHashMap<String, ExecutionResultNode> mergedChildren = new LinkedHashMap<>(this.children);
-        children.entrySet().stream().forEach(entry -> mergedChildren.put(entry.getKey().getName(), entry.getValue()));
-        return new ObjectExecutionResultNode(getFetchedValueAnalysis(), mergedChildren);
-    }
-
-    public Map<String, ExecutionResultNode> getChildrenMap() {
-        return new LinkedHashMap<>(children);
-    }
-
-    public Optional<NonNullableFieldWasNullException> getChildrenNonNullableException() {
-        return children.values().stream()
-                .filter(executionResultNode -> executionResultNode.getNonNullableFieldWasNullException() != null)
-                .map(ExecutionResultNode::getNonNullableFieldWasNullException)
-                .findFirst();
-    }
-
-    public ObjectExecutionResultNode withChildren(List<NamedResultNode> children) {
+    public ObjectExecutionResultNode withNewChildren(List<ExecutionResultNode> children) {
         return new ObjectExecutionResultNode(getFetchedValueAnalysis(), children);
     }
-
 
 }

--- a/src/main/java/graphql/execution/nextgen/result/ResultNodeAdapter.java
+++ b/src/main/java/graphql/execution/nextgen/result/ResultNodeAdapter.java
@@ -1,5 +1,6 @@
 package graphql.execution.nextgen.result;
 
+import graphql.Assert;
 import graphql.PublicApi;
 import graphql.util.NodeAdapter;
 import graphql.util.NodeLocation;
@@ -7,9 +8,6 @@ import graphql.util.NodeLocation;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-
-import static graphql.execution.nextgen.result.ResultNodesUtil.index;
-import static graphql.execution.nextgen.result.ResultNodesUtil.key;
 
 @PublicApi
 public class ResultNodeAdapter implements NodeAdapter<ExecutionResultNode> {
@@ -22,30 +20,17 @@ public class ResultNodeAdapter implements NodeAdapter<ExecutionResultNode> {
 
     @Override
     public Map<String, List<ExecutionResultNode>> getNamedChildren(ExecutionResultNode node) {
-        return node.getNamedChildren();
+        Map<String, List<ExecutionResultNode>> result = new LinkedHashMap<>();
+        result.put(null, node.getChildren());
+        return result;
     }
 
     @Override
     public ExecutionResultNode withNewChildren(ExecutionResultNode node, Map<String, List<ExecutionResultNode>> newChildren) {
-        Map<NodeLocation, ExecutionResultNode> adaptedChildren = new LinkedHashMap<>();
-        if (newChildren.size() == 1) {
-            String key = newChildren.keySet().iterator().next();
-            if (key == null) {
-                List<ExecutionResultNode> list = newChildren.get(null);
-                for (int i = 0; i < list.size(); i++) {
-                    adaptedChildren.put(index(i), list.get(i));
-                }
-            } else {
-                newChildren.forEach((name, list) -> {
-                    adaptedChildren.put(key(name), list.get(0));
-                });
-            }
-        } else {
-            newChildren.forEach((name, list) -> {
-                adaptedChildren.put(key(name), list.get(0));
-            });
-        }
-        return node.withNewChildren(adaptedChildren);
+        Assert.assertTrue(newChildren.size() == 1);
+        List<ExecutionResultNode> childrenList = newChildren.get(null);
+        Assert.assertNotNull(childrenList);
+        return node.withNewChildren(childrenList);
     }
 
     @Override

--- a/src/main/java/graphql/execution/nextgen/result/ResultNodeTraverser.java
+++ b/src/main/java/graphql/execution/nextgen/result/ResultNodeTraverser.java
@@ -16,7 +16,7 @@ public class ResultNodeTraverser {
     }
 
     public static ResultNodeTraverser depthFirst() {
-        return new ResultNodeTraverser(Traverser.depthFirstWithNamedChildren(ExecutionResultNode::getNamedChildren, null, null));
+        return new ResultNodeTraverser(Traverser.depthFirst(ExecutionResultNode::getChildren, null, null));
     }
 
     public void traverse(TraverserVisitor<ExecutionResultNode> visitor, ExecutionResultNode root) {

--- a/src/main/java/graphql/execution/nextgen/result/ResultNodesUtil.java
+++ b/src/main/java/graphql/execution/nextgen/result/ResultNodesUtil.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static graphql.execution.nextgen.result.ResultNodeAdapter.RESULT_NODE_ADAPTER;
+import static graphql.util.FpKit.map;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singleton;
 
@@ -76,11 +77,8 @@ public class ResultNodesUtil {
             if (childNonNullableException.isPresent()) {
                 return data(null, childNonNullableException.get());
             }
-            List<ExecutionResultData> list = root.getChildren().stream().map(ResultNodesUtil::toDataImpl).collect(Collectors.toList());
-            List<Object> data = list
-                    .stream()
-                    .map(erd -> erd.data)
-                    .collect(Collectors.toList());
+            List<ExecutionResultData> list = map(root.getChildren(), ResultNodesUtil::toDataImpl);
+            List<Object> data = map(list, erd -> erd.data);
             List<GraphQLError> errors = new ArrayList<>();
             list.forEach(erd -> errors.addAll(erd.errors));
             return data(data, errors);
@@ -91,15 +89,15 @@ public class ResultNodesUtil {
             return data("Not resolved : " + fetchedValueAnalysis.getExecutionStepInfo().getPath() + " with field " + fetchedValueAnalysis.getField(), emptyList());
         }
         if (root instanceof ObjectExecutionResultNode) {
-            Optional<NonNullableFieldWasNullException> childrenNonNullableException = ((ObjectExecutionResultNode) root).getChildrenNonNullableException();
+            Optional<NonNullableFieldWasNullException> childrenNonNullableException = ((ObjectExecutionResultNode) root).getChildNonNullableException();
             if (childrenNonNullableException.isPresent()) {
                 return data(null, childrenNonNullableException.get());
             }
             Map<String, Object> resultMap = new LinkedHashMap<>();
             List<GraphQLError> errors = new ArrayList<>();
-            ((ObjectExecutionResultNode) root).getChildrenMap().forEach((key, value) -> {
-                ExecutionResultData executionResultData = toDataImpl(value);
-                resultMap.put(key, executionResultData.data);
+            root.getChildren().forEach(child -> {
+                ExecutionResultData executionResultData = toDataImpl(child);
+                resultMap.put(child.getMergedField().getResultKey(), executionResultData.data);
                 errors.addAll(executionResultData.errors);
             });
             return data(resultMap, errors);

--- a/src/main/java/graphql/execution/nextgen/result/RootExecutionResultNode.java
+++ b/src/main/java/graphql/execution/nextgen/result/RootExecutionResultNode.java
@@ -1,19 +1,12 @@
 package graphql.execution.nextgen.result;
 
 import graphql.execution.nextgen.FetchedValueAnalysis;
-import graphql.util.NodeLocation;
 
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 public class RootExecutionResultNode extends ObjectExecutionResultNode {
 
-    public RootExecutionResultNode(Map<String, ExecutionResultNode> children) {
-        super(null, children);
-    }
-
-    public RootExecutionResultNode(List<NamedResultNode> children) {
+    public RootExecutionResultNode(List<ExecutionResultNode> children) {
         super(null, children);
     }
 
@@ -23,16 +16,7 @@ public class RootExecutionResultNode extends ObjectExecutionResultNode {
     }
 
     @Override
-    public ExecutionResultNode withNewChildren(Map<NodeLocation, ExecutionResultNode> children) {
-        LinkedHashMap<String, ExecutionResultNode> mergedChildren = new LinkedHashMap<>(getChildrenMap());
-        children.entrySet().stream().forEach(entry -> mergedChildren.put(entry.getKey().getName(), entry.getValue()));
-        return new RootExecutionResultNode(mergedChildren);
-    }
-
-    @Override
-    public ExecutionResultNode withChild(ExecutionResultNode child, NodeLocation position) {
-        LinkedHashMap<String, ExecutionResultNode> newChildren = new LinkedHashMap<>(getChildrenMap());
-        newChildren.put(position.getName(), child);
-        return new RootExecutionResultNode(newChildren);
+    public ObjectExecutionResultNode withNewChildren(List<ExecutionResultNode> children) {
+        return new RootExecutionResultNode(children);
     }
 }

--- a/src/main/java/graphql/execution/nextgen/result/UnresolvedObjectResultNode.java
+++ b/src/main/java/graphql/execution/nextgen/result/UnresolvedObjectResultNode.java
@@ -7,7 +7,7 @@ import java.util.Collections;
 public class UnresolvedObjectResultNode extends ObjectExecutionResultNode {
 
     public UnresolvedObjectResultNode(FetchedValueAnalysis fetchedValueAnalysis) {
-        super(fetchedValueAnalysis, Collections.emptyMap());
+        super(fetchedValueAnalysis, Collections.emptyList());
     }
 
     @Override

--- a/src/test/groovy/graphql/execution/nextgen/result/ResultNodesUtilTest.groovy
+++ b/src/test/groovy/graphql/execution/nextgen/result/ResultNodesUtilTest.groovy
@@ -5,6 +5,7 @@ import graphql.SerializationError
 import graphql.execution.ExecutionPath
 import graphql.execution.ExecutionStepInfo
 import graphql.execution.FetchedValue
+import graphql.execution.MergedField
 import graphql.execution.nextgen.FetchedValueAnalysis
 import graphql.schema.CoercingSerializeException
 import spock.lang.Specification
@@ -17,6 +18,9 @@ class ResultNodesUtilTest extends Specification {
         given:
         def error = new SerializationError(ExecutionPath.rootPath(), new CoercingSerializeException())
         ExecutionStepInfo executionStepInfo = Mock(ExecutionStepInfo)
+        MergedField mergedField = Mock(MergedField)
+        mergedField.getResultKey() >> "foo"
+        executionStepInfo.getField() >> mergedField
         FetchedValue fetchedValue = FetchedValue.newFetchedValue().fetchedValue(null).build()
         def leafValue = FetchedValueAnalysis.newFetchedValueAnalysis(SCALAR)
                 .executionStepInfo(executionStepInfo)
@@ -25,7 +29,7 @@ class ResultNodesUtilTest extends Specification {
                 .fetchedValue(fetchedValue)
                 .build()
         LeafExecutionResultNode leafExecutionResultNode = new LeafExecutionResultNode(leafValue, null)
-        ExecutionResultNode executionResultNode = new RootExecutionResultNode([foo: leafExecutionResultNode])
+        ExecutionResultNode executionResultNode = new RootExecutionResultNode([leafExecutionResultNode])
 
         when:
         def executionResult = ResultNodesUtil.toExecutionResult(executionResultNode)


### PR DESCRIPTION
 by using the resultKey from mergedField as key, therefore we just have a list of children for a ERN and
not list AND maps