### PR TITLE
Made the ErrorType implement a base interface

### DIFF
--- a/src/main/java/graphql/ErrorClassification.java
+++ b/src/main/java/graphql/ErrorClassification.java
@@ -8,5 +8,5 @@ package graphql;
  * graphql-java ships with a standard set of error classifications via {@link graphql.ErrorType}
  */
 @PublicApi
-public interface ErrorTypeClassification {
+public interface ErrorClassification {
 }

--- a/src/main/java/graphql/ErrorType.java
+++ b/src/main/java/graphql/ErrorType.java
@@ -5,7 +5,7 @@ package graphql;
  * All the errors in graphql belong to one of these categories
  */
 @PublicApi
-public enum ErrorType {
+public enum ErrorType implements ErrorTypeClassification {
     InvalidSyntax,
     ValidationError,
     DataFetchingException,

--- a/src/main/java/graphql/ErrorType.java
+++ b/src/main/java/graphql/ErrorType.java
@@ -5,7 +5,7 @@ package graphql;
  * All the errors in graphql belong to one of these categories
  */
 @PublicApi
-public enum ErrorType implements ErrorTypeClassification {
+public enum ErrorType implements ErrorClassification {
     InvalidSyntax,
     ValidationError,
     DataFetchingException,

--- a/src/main/java/graphql/ErrorTypeClassification.java
+++ b/src/main/java/graphql/ErrorTypeClassification.java
@@ -1,0 +1,12 @@
+package graphql;
+
+/**
+ * Errors in graphql-java can have a classification to help with the processing
+ * of errors.  Custom {@link graphql.GraphQLError} implementations could use
+ * custom classifications.
+ * <p>
+ * graphql-java ships with a standard set of error classifications via {@link graphql.ErrorType}
+ */
+@PublicApi
+public interface ErrorTypeClassification {
+}

--- a/src/main/java/graphql/GraphQLError.java
+++ b/src/main/java/graphql/GraphQLError.java
@@ -32,9 +32,9 @@ public interface GraphQLError extends Serializable {
     List<SourceLocation> getLocations();
 
     /**
-     * @return an enum classifying this error
+     * @return an object classifying this error
      */
-    ErrorType getErrorType();
+    ErrorTypeClassification getErrorType();
 
     /**
      * The graphql spec says that the (optional) path field of any error should be a list

--- a/src/main/java/graphql/GraphQLError.java
+++ b/src/main/java/graphql/GraphQLError.java
@@ -34,7 +34,7 @@ public interface GraphQLError extends Serializable {
     /**
      * @return an object classifying this error
      */
-    ErrorTypeClassification getErrorType();
+    ErrorClassification getErrorType();
 
     /**
      * The graphql spec says that the (optional) path field of any error should be a list

--- a/src/main/java/graphql/GraphqlErrorBuilder.java
+++ b/src/main/java/graphql/GraphqlErrorBuilder.java
@@ -21,7 +21,7 @@ public class GraphqlErrorBuilder {
     private String message;
     private List<Object> path;
     private List<SourceLocation> locations = new ArrayList<>();
-    private ErrorTypeClassification errorType = ErrorType.DataFetchingException;
+    private ErrorClassification errorType = ErrorType.DataFetchingException;
     private Map<String, Object> extensions = null;
 
 
@@ -74,7 +74,7 @@ public class GraphqlErrorBuilder {
         return this;
     }
 
-    public GraphqlErrorBuilder errorType(ErrorTypeClassification errorType) {
+    public GraphqlErrorBuilder errorType(ErrorClassification errorType) {
         this.errorType = assertNotNull(errorType);
         return this;
     }
@@ -95,11 +95,11 @@ public class GraphqlErrorBuilder {
     private static class GraphqlErrorImpl implements GraphQLError {
         private final String message;
         private final List<SourceLocation> locations;
-        private final ErrorTypeClassification errorType;
+        private final ErrorClassification errorType;
         private final List<Object> path;
         private final Map<String, Object> extensions;
 
-        public GraphqlErrorImpl(String message, List<SourceLocation> locations, ErrorTypeClassification errorType, List<Object> path, Map<String, Object> extensions) {
+        public GraphqlErrorImpl(String message, List<SourceLocation> locations, ErrorClassification errorType, List<Object> path, Map<String, Object> extensions) {
             this.message = message;
             this.locations = locations;
             this.errorType = errorType;
@@ -118,7 +118,7 @@ public class GraphqlErrorBuilder {
         }
 
         @Override
-        public ErrorTypeClassification getErrorType() {
+        public ErrorClassification getErrorType() {
             return errorType;
         }
 

--- a/src/main/java/graphql/GraphqlErrorBuilder.java
+++ b/src/main/java/graphql/GraphqlErrorBuilder.java
@@ -21,7 +21,7 @@ public class GraphqlErrorBuilder {
     private String message;
     private List<Object> path;
     private List<SourceLocation> locations = new ArrayList<>();
-    private ErrorType errorType = ErrorType.DataFetchingException;
+    private ErrorTypeClassification errorType = ErrorType.DataFetchingException;
     private Map<String, Object> extensions = null;
 
 
@@ -74,7 +74,7 @@ public class GraphqlErrorBuilder {
         return this;
     }
 
-    public GraphqlErrorBuilder errorType(ErrorType errorType) {
+    public GraphqlErrorBuilder errorType(ErrorTypeClassification errorType) {
         this.errorType = assertNotNull(errorType);
         return this;
     }
@@ -89,32 +89,48 @@ public class GraphqlErrorBuilder {
      */
     public GraphQLError build() {
         assertNotNull(message, "You must provide error message");
-        return new GraphQLError() {
-            @Override
-            public String getMessage() {
-                return message;
-            }
+        return new GraphqlErrorImpl(message, locations, errorType, path, extensions);
+    }
 
-            @Override
-            public List<SourceLocation> getLocations() {
-                return locations;
-            }
+    private static class GraphqlErrorImpl implements GraphQLError {
+        private final String message;
+        private final List<SourceLocation> locations;
+        private final ErrorTypeClassification errorType;
+        private final List<Object> path;
+        private final Map<String, Object> extensions;
 
-            @Override
-            public ErrorType getErrorType() {
-                return errorType;
-            }
+        public GraphqlErrorImpl(String message, List<SourceLocation> locations, ErrorTypeClassification errorType, List<Object> path, Map<String, Object> extensions) {
+            this.message = message;
+            this.locations = locations;
+            this.errorType = errorType;
+            this.path = path;
+            this.extensions = extensions;
+        }
 
-            @Override
-            public List<Object> getPath() {
-                return path;
-            }
+        @Override
+        public String getMessage() {
+            return message;
+        }
 
-            @Override
-            public Map<String, Object> getExtensions() {
-                return extensions;
-            }
-        };
+        @Override
+        public List<SourceLocation> getLocations() {
+            return locations;
+        }
+
+        @Override
+        public ErrorTypeClassification getErrorType() {
+            return errorType;
+        }
+
+        @Override
+        public List<Object> getPath() {
+            return path;
+        }
+
+        @Override
+        public Map<String, Object> getExtensions() {
+            return extensions;
+        }
     }
 
     /**

--- a/src/main/java/graphql/execution/AbsoluteGraphQLError.java
+++ b/src/main/java/graphql/execution/AbsoluteGraphQLError.java
@@ -1,7 +1,6 @@
 package graphql.execution;
 
-import graphql.ErrorType;
-import graphql.ErrorTypeClassification;
+import graphql.ErrorClassification;
 import graphql.GraphQLError;
 import graphql.Internal;
 import graphql.language.SourceLocation;
@@ -26,7 +25,7 @@ public class AbsoluteGraphQLError implements GraphQLError {
     private final List<SourceLocation> locations;
     private final List<Object> absolutePath;
     private final String message;
-    private final ErrorTypeClassification errorType;
+    private final ErrorClassification errorType;
     private final Map<String, Object> extensions;
 
     public AbsoluteGraphQLError(ExecutionStrategyParameters executionStrategyParameters, GraphQLError relativeError) {
@@ -69,7 +68,7 @@ public class AbsoluteGraphQLError implements GraphQLError {
     }
 
     @Override
-    public ErrorTypeClassification getErrorType() {
+    public ErrorClassification getErrorType() {
         return errorType;
     }
 

--- a/src/main/java/graphql/execution/AbsoluteGraphQLError.java
+++ b/src/main/java/graphql/execution/AbsoluteGraphQLError.java
@@ -1,6 +1,7 @@
 package graphql.execution;
 
 import graphql.ErrorType;
+import graphql.ErrorTypeClassification;
 import graphql.GraphQLError;
 import graphql.Internal;
 import graphql.language.SourceLocation;
@@ -25,7 +26,7 @@ public class AbsoluteGraphQLError implements GraphQLError {
     private final List<SourceLocation> locations;
     private final List<Object> absolutePath;
     private final String message;
-    private final ErrorType errorType;
+    private final ErrorTypeClassification errorType;
     private final Map<String, Object> extensions;
 
     public AbsoluteGraphQLError(ExecutionStrategyParameters executionStrategyParameters, GraphQLError relativeError) {
@@ -68,7 +69,7 @@ public class AbsoluteGraphQLError implements GraphQLError {
     }
 
     @Override
-    public ErrorType getErrorType() {
+    public ErrorTypeClassification getErrorType() {
         return errorType;
     }
 


### PR DESCRIPTION
This changes the closed enum that is ErrorType and creates  a new ErrorTypeClassification

(possible rename is ErrorTypeClassification -> ErrorClassification)

This means that any one can create a GraphqlError class and use their own "classification" object.

For example if one wanted to have "statusCode" as an attribute, then you could create

     class StatCodeClassification implements ErrorTypeClassification {
         
           int getStatusCode() 
   }

which in json terms will be

       {
           "msg" : "some text",
           "path" : [ "foo", "bar" ],
           "errorType" : {
                   "statusCode" : 403
            }
      }

