### PR TITLE
Update antlr4 from 4.7.1 to 4.7.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,11 +49,11 @@ jar {
 }
 
 dependencies {
-    compile 'org.antlr:antlr4-runtime:4.7.1'
+    compile 'org.antlr:antlr4-runtime:4.7.2'
     compile 'org.slf4j:slf4j-api:' + slf4jVersion
     compile 'com.graphql-java:java-dataloader:2.1.1'
     compile 'org.reactivestreams:reactive-streams:' + reactiveStreamsVersion
-    antlr "org.antlr:antlr4:4.7.1"
+    antlr "org.antlr:antlr4:4.7.2"
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile 'org.spockframework:spock-core:1.1-groovy-2.4'
     testCompile 'org.codehaus.groovy:groovy-all:2.4.13'


### PR DESCRIPTION
## Description
[This bug ](https://github.com/antlr/antlr4/pull/2309) appears in our service and has since been fixed in ANTRL 4.7.2. This PR is to update `graphql-java` use of ANTLR to from 4.7.1 to 4.7.2. 

As it is a patch version of ANTLR, no breaking changes have been identified from `graphql-java`.

I will create another pull request for the stable branch.