### PR TITLE
Make the PageInfo type public static and use a type reference

### DIFF
--- a/src/main/java/graphql/relay/Relay.java
+++ b/src/main/java/graphql/relay/Relay.java
@@ -27,6 +27,7 @@ import static graphql.schema.GraphQLInterfaceType.newInterface;
 import static graphql.schema.GraphQLList.list;
 import static graphql.schema.GraphQLNonNull.nonNull;
 import static graphql.schema.GraphQLObjectType.newObject;
+import static graphql.schema.GraphQLTypeReference.typeRef;
 
 /**
  * This can be used to compose graphql runtime types that implement
@@ -39,7 +40,7 @@ public class Relay {
 
     public static final String NODE = "Node";
 
-    private final GraphQLObjectType pageInfoType = newObject()
+    public static final GraphQLObjectType pageInfoType = newObject()
             .name("PageInfo")
             .description("Information about pagination in a connection.")
             .field(newFieldDefinition()
@@ -167,7 +168,7 @@ public class Relay {
                 .field(newFieldDefinition()
                         .name("pageInfo")
                         .description("details about this specific page")
-                        .type(nonNull(pageInfoType)))
+                        .type(nonNull(typeRef("PageInfo"))))
                 .fields(connectionFields)
                 .build();
     }

--- a/src/test/groovy/graphql/RelaySchema.java
+++ b/src/test/groovy/graphql/RelaySchema.java
@@ -67,5 +67,6 @@ public class RelaySchema {
 
     public static GraphQLSchema Schema = GraphQLSchema.newSchema()
             .query(RelayQueryType)
+            .additionalType(Relay.pageInfoType)
             .build();
 }


### PR DESCRIPTION
Make the PageInfo type public static and use a type reference so that when the schema is traversed, it won't generate a new one.
This means that the PageInfo type should be added by the dev consumer to the schema manually.

This will solve #1441