### PR TITLE
Fix #1440 ClassCastException - fragment with wrong input type condition

### DIFF
--- a/src/main/java/graphql/validation/rules/FragmentsOnCompositeType.java
+++ b/src/main/java/graphql/validation/rules/FragmentsOnCompositeType.java
@@ -36,7 +36,7 @@ public class FragmentsOnCompositeType extends AbstractRule {
         if (type == null) return;
         if (!(type instanceof GraphQLCompositeType)) {
             String message = "Fragment type condition is invalid, must be on Object/Interface/Union";
-            addError(ValidationErrorType.InlineFragmentTypeConditionInvalid, fragmentDefinition.getSourceLocation(), message);
+            addError(ValidationErrorType.FragmentTypeConditionInvalid, fragmentDefinition.getSourceLocation(), message);
         }
     }
 }

--- a/src/main/java/graphql/validation/rules/OverlappingFieldsCanBeMerged.java
+++ b/src/main/java/graphql/validation/rules/OverlappingFieldsCanBeMerged.java
@@ -305,14 +305,14 @@ public class OverlappingFieldsCanBeMerged extends AbstractRule {
             return;
         }
         visitedFragmentSpreads.add(fragment.getName());
-        GraphQLOutputType graphQLType = (GraphQLOutputType) TypeFromAST.getTypeFromAST(getValidationContext().getSchema(),
+        GraphQLType graphQLType = TypeFromAST.getTypeFromAST(getValidationContext().getSchema(),
                 fragment.getTypeCondition());
         collectFields(fieldMap, fragment.getSelectionSet(), graphQLType, visitedFragmentSpreads);
     }
 
     private void collectFieldsForInlineFragment(Map<String, List<FieldAndType>> fieldMap, Set<String> visitedFragmentSpreads, GraphQLType parentType, InlineFragment inlineFragment) {
         GraphQLType graphQLType = inlineFragment.getTypeCondition() != null
-                ? (GraphQLOutputType) TypeFromAST.getTypeFromAST(getValidationContext().getSchema(), inlineFragment.getTypeCondition())
+                ? TypeFromAST.getTypeFromAST(getValidationContext().getSchema(), inlineFragment.getTypeCondition())
                 : parentType;
         collectFields(fieldMap, inlineFragment.getSelectionSet(), graphQLType, visitedFragmentSpreads);
     }

--- a/src/test/groovy/graphql/Issue1440.groovy
+++ b/src/test/groovy/graphql/Issue1440.groovy
@@ -1,0 +1,90 @@
+package graphql
+
+import graphql.validation.ValidationError
+import graphql.validation.ValidationErrorType
+import spock.lang.Specification
+
+class Issue1440 extends Specification {
+
+    def schema = TestUtil.schema("""
+            type Query {
+                nothing: String
+            }
+            
+            type Mutation {
+                updateUDI(input: UDIInput!): UDIOutput
+            }
+            
+            type UDIOutput {
+                device: String
+                version: String
+            }
+            
+            input UDIInput {
+                device: String 
+                version: String
+            }
+        """)
+
+    def graphQL = GraphQL.newGraphQL(schema).build()
+
+
+    def "#1440 when fragment type condition is input type it should return validation error - not classCastException"() {
+        when:
+        def executionInput = ExecutionInput.newExecutionInput()
+                .query('''                    
+                    mutation UpdateUDI($input: UDIInput!) { 
+                        updateUDI(input: $input) { 
+                            ...fragOnInputType 
+                            __typename 
+                        } 
+                    }
+                    
+                    # fragment should only target composite types
+                    fragment fragOnInputType on UDIInput { 
+                        device
+                        version 
+                        __typename 
+                    } 
+                    
+                    ''')
+                .variables([input: [device: 'device', version: 'version'] ])
+                .build()
+
+        def executionResult = graphQL.execute(executionInput)
+
+        then:
+
+        executionResult.data == null
+        executionResult.errors.size() == 1
+        (executionResult.errors[0] as ValidationError).validationErrorType == ValidationErrorType.InlineFragmentTypeConditionInvalid
+    }
+
+    def "#1440 when inline fragment type condition is input type it should return validation error - not classCastException"() {
+        when:
+        def executionInput = ExecutionInput.newExecutionInput()
+                .query('''                    
+                    mutation UpdateUDI($input: UDIInput!) { 
+                        updateUDI(input: $input) { 
+                            # fragment should only target composite types
+                            ... on UDIInput { 
+                                device
+                                version 
+                                __typename 
+                            }  
+                            __typename 
+                        } 
+                    }
+                    ''')
+                .variables([input: [device: 'device', version: 'version'] ])
+                .build()
+
+        def executionResult = graphQL.execute(executionInput)
+
+        then:
+
+        executionResult.data == null
+        executionResult.errors.size() == 1
+        (executionResult.errors[0] as ValidationError).validationErrorType == ValidationErrorType.InlineFragmentTypeConditionInvalid
+    }
+}

--- a/src/test/groovy/graphql/Issue1440.groovy
+++ b/src/test/groovy/graphql/Issue1440.groovy
@@ -57,7 +57,7 @@ class Issue1440 extends Specification {
 
         executionResult.data == null
         executionResult.errors.size() == 1
-        (executionResult.errors[0] as ValidationError).validationErrorType == ValidationErrorType.InlineFragmentTypeConditionInvalid
+        (executionResult.errors[0] as ValidationError).validationErrorType == ValidationErrorType.FragmentTypeConditionInvalid
     }
 
     def "#1440 when inline fragment type condition is input type it should return validation error - not classCastException"() {

--- a/src/test/groovy/graphql/validation/rules/FragmentsOnCompositeTypeTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/FragmentsOnCompositeTypeTest.groovy
@@ -68,7 +68,7 @@ class FragmentsOnCompositeTypeTest extends Specification {
         fragmentsOnCompositeType.checkFragmentDefinition(fragmentDefinition)
 
         then:
-        errorCollector.containsValidationError(ValidationErrorType.InlineFragmentTypeConditionInvalid)
+        errorCollector.containsValidationError(ValidationErrorType.FragmentTypeConditionInvalid)
     }
 
 


### PR DESCRIPTION
## Description

In cases where a fragment type condition is invalid (say it was an input type instead of a composite type), the `FragmentsOnCompositeType` rule rightfully collects the validation error. However, the `OverlappingFieldsCanBeMerged` validation rule is wrongly assuming that the type condition is valid and attempts to cast it as a `GraphQLOutputType`, throwing a `ClassCastException` described in issue #1440.

I wrote a test to reproduce the issue:

```java
    def schema = TestUtil.schema("""
            type Query {
                nothing: String
            }
            
            type Mutation {
                updateUDI(input: UDIInput!): UDIOutput
            }
            
            type UDIOutput {
                device: String
                version: String
            }
            
            input UDIInput {
                device: String 
                version: String
            }
        """)

    def graphQL = GraphQL.newGraphQL(schema).build()


    def "#1440 when fragment type condition is input type it should return validation error - not classCastException"() {
        when:
        def executionInput = ExecutionInput.newExecutionInput()
                .query('''                    
                    mutation UpdateUDI($input: UDIInput!) { 
                        updateUDI(input: $input) { 
                            ...fragOnInputType 
                            __typename 
                        } 
                    }
                    
                    # fragment should only target composite types
                    fragment fragOnInputType on UDIInput { 
                        device
                        version 
                        __typename 
                    } 
                    
                    ''')
                .variables([input: [device: 'device', version: 'version'] ])
                .build()

        def executionResult = graphQL.execute(executionInput)

        then:

        executionResult.data == null
        executionResult.errors.size() == 1
        (executionResult.errors[0] as ValidationError).validationErrorType == ValidationErrorType.InlineFragmentTypeConditionInvalid
    }
```
and this throws 
```
graphql.Issue1440 > #1440 when fragment type condition is input type it should return validation error - not classCastException FAILED
    java.lang.ClassCastException: graphql.schema.GraphQLInputObjectType cannot be cast to graphql.schema.GraphQLOutputType
        at graphql.validation.rules.OverlappingFieldsCanBeMerged.collectFieldsForFragmentSpread(OverlappingFieldsCanBeMerged.java:308)
        at graphql.validation.rules.OverlappingFieldsCanBeMerged.collectFields(OverlappingFieldsCanBeMerged.java:294)
        at graphql.validation.rules.OverlappingFieldsCanBeMerged.leaveSelectionSet(OverlappingFieldsCanBeMerged.java:58)
```

## Fix
The fix consists of removing the un-necessary casts as they appear to not be needed. 

I also added an additional test to cover for inline fragments as well. 

I will do a second PR for the stable branch.