### PR TITLE
Fix NPE in AstPrinter for inline fragments without type condition

### DIFF
--- a/src/main/java/graphql/language/AstPrinter.java
+++ b/src/main/java/graphql/language/AstPrinter.java
@@ -1,8 +1,6 @@
 package graphql.language;
 
-import static graphql.Assert.assertTrue;
-import static java.lang.String.valueOf;
-import static java.util.stream.Collectors.joining;
+import graphql.AssertException;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -13,7 +11,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import graphql.AssertException;
+import static graphql.Assert.assertTrue;
+import static java.lang.String.valueOf;
+import static java.util.stream.Collectors.joining;
 
 /**
  * This can take graphql language AST and print it out as a string
@@ -195,7 +195,9 @@ public class AstPrinter {
 
     private static NodePrinter<InlineFragment> inlineFragment() {
         return (out, node) -> {
-            String typeCondition = wrap("on ", type(node.getTypeCondition()), "");
+            TypeName typeName = node.getTypeCondition();
+            //Inline fragments may not have a type condition
+            String typeCondition = typeName == null ? "" : wrap("on ", type(typeName), "");
             String directives = directives(node.getDirectives());
             String selectionSet = node(node.getSelectionSet());
 

--- a/src/test/groovy/graphql/language/AstPrinterTest.groovy
+++ b/src/test/groovy/graphql/language/AstPrinterTest.groovy
@@ -524,4 +524,30 @@ extend input Input @directive {
         output == "query { foo { hello } world }"
     }
 
+    def "print ast with inline fragment without type condition"() {
+        def query = '''
+    { 
+        foo {
+            ... {
+                hello
+            }
+        }
+    }
+'''
+        def document = parse(query)
+        String outputCompact = AstPrinter.printAstCompact(document)
+        String outputFull = AstPrinter.printAst(document)
+
+        expect:
+        outputCompact == '''query {foo {... {hello}}}'''
+        outputFull == '''query {
+  foo {
+    ... {
+      hello
+    }
+  }
+}
+'''
+    }
+
 }

--- a/src/test/groovy/graphql/language/AstPrinterTest.groovy
+++ b/src/test/groovy/graphql/language/AstPrinterTest.groovy
@@ -539,7 +539,7 @@ extend input Input @directive {
         String outputFull = AstPrinter.printAst(document)
 
         expect:
-        outputCompact == '''query {foo {... {hello}}}'''
+        outputCompact == '''query { foo { ... { hello } } }'''
         outputFull == '''query {
   foo {
     ... {


### PR DESCRIPTION
(cherry picked from commit 84f4bc73805b94912a7cb046556817102945561f)