### PR TITLE
This fixes up the example code so it used CodeRegistry

### DIFF
--- a/src/main/java/graphql/schema/GraphQLCodeRegistry.java
+++ b/src/main/java/graphql/schema/GraphQLCodeRegistry.java
@@ -315,28 +315,28 @@ public class GraphQLCodeRegistry {
             return this;
         }
 
-        public Builder typeResolver(GraphQLInterfaceType parentType, TypeResolver typeResolver) {
-            typeResolverMap.put(parentType.getName(), typeResolver);
+        public Builder typeResolver(GraphQLInterfaceType interfaceType, TypeResolver typeResolver) {
+            typeResolverMap.put(interfaceType.getName(), typeResolver);
             return this;
         }
 
-        public Builder typeResolverIfAbsent(GraphQLInterfaceType parentType, TypeResolver typeResolver) {
-            typeResolverMap.putIfAbsent(parentType.getName(), typeResolver);
+        public Builder typeResolverIfAbsent(GraphQLInterfaceType interfaceType, TypeResolver typeResolver) {
+            typeResolverMap.putIfAbsent(interfaceType.getName(), typeResolver);
             return this;
         }
 
-        public Builder typeResolver(GraphQLUnionType parentType, TypeResolver typeResolver) {
-            typeResolverMap.put(parentType.getName(), typeResolver);
+        public Builder typeResolver(GraphQLUnionType unionType, TypeResolver typeResolver) {
+            typeResolverMap.put(unionType.getName(), typeResolver);
             return this;
         }
 
-        public Builder typeResolverIfAbsent(GraphQLUnionType parentType, TypeResolver typeResolver) {
-            typeResolverMap.putIfAbsent(parentType.getName(), typeResolver);
+        public Builder typeResolverIfAbsent(GraphQLUnionType unionType, TypeResolver typeResolver) {
+            typeResolverMap.putIfAbsent(unionType.getName(), typeResolver);
             return this;
         }
 
-        public Builder typeResolver(String parentTypeName, TypeResolver typeResolver) {
-            typeResolverMap.put(assertValidName(parentTypeName), typeResolver);
+        public Builder typeResolver(String typeName, TypeResolver typeResolver) {
+            typeResolverMap.put(assertValidName(typeName), typeResolver);
             return this;
         }
 

--- a/src/test/groovy/readme/MappingExamples.java
+++ b/src/test/groovy/readme/MappingExamples.java
@@ -3,6 +3,8 @@ package readme;
 import graphql.Scalars;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.FieldCoordinates;
+import graphql.schema.GraphQLCodeRegistry;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.PropertyDataFetcher;
 
@@ -10,6 +12,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static graphql.schema.FieldCoordinates.coordinates;
 
 @SuppressWarnings({"Convert2Lambda", "unused", "ClassCanBeStatic"})
 public class MappingExamples {
@@ -132,7 +136,12 @@ public class MappingExamples {
         GraphQLFieldDefinition descriptionField = GraphQLFieldDefinition.newFieldDefinition()
                 .name("description")
                 .type(Scalars.GraphQLString)
-                .dataFetcher(PropertyDataFetcher.fetching("desc"))
+                .build();
+
+        GraphQLCodeRegistry codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .dataFetcher(
+                        coordinates("ObjectType", "description"),
+                        PropertyDataFetcher.fetching("desc"))
                 .build();
 
     }


### PR DESCRIPTION
This fixes up the example code so it used CodeRegistry and also quick rename of parameter names there