### PR TITLE
Fixes so that non SDL definitions are rejected by the SchemaParser

### DIFF
--- a/src/main/java/graphql/schema/idl/SchemaParser.java
+++ b/src/main/java/graphql/schema/idl/SchemaParser.java
@@ -8,13 +8,13 @@ import graphql.language.Document;
 import graphql.language.SDLDefinition;
 import graphql.parser.InvalidSyntaxException;
 import graphql.parser.Parser;
+import graphql.schema.idl.errors.NonSDLDefinitionError;
 import graphql.schema.idl.errors.SchemaProblem;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
-import java.io.StringWriter;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -108,6 +108,8 @@ public class SchemaParser {
         for (Definition definition : definitions) {
             if (definition instanceof SDLDefinition) {
                 typeRegistry.add((SDLDefinition) definition).ifPresent(errors::add);
+            } else {
+                errors.add(new NonSDLDefinitionError(definition));
             }
         }
         if (errors.size() > 0) {
@@ -115,15 +117,5 @@ public class SchemaParser {
         } else {
             return typeRegistry;
         }
-    }
-
-    private String read(Reader reader) throws IOException {
-        char[] buffer = new char[1024 * 4];
-        StringWriter sw = new StringWriter();
-        int n;
-        while (-1 != (n = reader.read(buffer))) {
-            sw.write(buffer, 0, n);
-        }
-        return sw.toString();
     }
 }

--- a/src/main/java/graphql/schema/idl/errors/NonSDLDefinitionError.java
+++ b/src/main/java/graphql/schema/idl/errors/NonSDLDefinitionError.java
@@ -1,0 +1,13 @@
+package graphql.schema.idl.errors;
+
+import graphql.language.Definition;
+
+import static java.lang.String.format;
+
+public class NonSDLDefinitionError extends BaseError {
+
+    public NonSDLDefinitionError(Definition definition) {
+        super(definition, format("The schema definition text contains a non schema definition language (SDL) element '%s'",
+                definition.getClass().getSimpleName(), lineCol(definition), lineCol(definition)));
+    }
+}


### PR DESCRIPTION
See  #1447

The justification is that a SchemaParser should parse for schemas.  Not other things.  The general parser can of course parse for all.