### PR TITLE
Feature/optional query validation

### DIFF
--- a/src/main/java/graphql/ExecutionInput.java
+++ b/src/main/java/graphql/ExecutionInput.java
@@ -25,7 +25,7 @@ public class ExecutionInput {
     private final boolean validate;
 
     public ExecutionInput(String query, String operationName, Object context, Object root, Map<String, Object> variables) {
-        this(query, operationName, context, root, variables, new DataLoaderRegistry(),true);
+        this(query, operationName, context, root, variables, true);
     }
 
     public ExecutionInput(String query, String operationName, Object context, Object root, Map<String, Object> variables,boolean validate) {
@@ -235,7 +235,7 @@ public class ExecutionInput {
         }
 
         public ExecutionInput build() {
-            return new ExecutionInput(query, operationName, context, root, variables, dataLoaderRegistry, cacheControl);
+            return new ExecutionInput(query, operationName, context, root, variables, dataLoaderRegistry, cacheControl,validate);
         }
     }
 }

--- a/src/main/java/graphql/ExecutionInput.java
+++ b/src/main/java/graphql/ExecutionInput.java
@@ -22,14 +22,18 @@ public class ExecutionInput {
     private final Map<String, Object> variables;
     private final DataLoaderRegistry dataLoaderRegistry;
     private final CacheControl cacheControl;
-
+    private final boolean validate;
 
     public ExecutionInput(String query, String operationName, Object context, Object root, Map<String, Object> variables) {
-        this(query, operationName, context, root, variables, new DataLoaderRegistry(), null);
+        this(query, operationName, context, root, variables, new DataLoaderRegistry(),true);
+    }
+
+    public ExecutionInput(String query, String operationName, Object context, Object root, Map<String, Object> variables,boolean validate) {
+        this(query, operationName, context, root, variables, new DataLoaderRegistry(), null,validate);
     }
 
     @Internal
-    private ExecutionInput(String query, String operationName, Object context, Object root, Map<String, Object> variables, DataLoaderRegistry dataLoaderRegistry, CacheControl cacheControl) {
+    private ExecutionInput(String query, String operationName, Object context, Object root, Map<String, Object> variables, DataLoaderRegistry dataLoaderRegistry, CacheControl cacheControl,boolean validate) {
         this.query = query;
         this.operationName = operationName;
         this.context = context;
@@ -37,6 +41,7 @@ public class ExecutionInput {
         this.variables = variables;
         this.dataLoaderRegistry = dataLoaderRegistry;
         this.cacheControl = cacheControl;
+        this.validate=validate;
     }
 
     /**
@@ -88,6 +93,14 @@ public class ExecutionInput {
         return cacheControl;
     }
 
+
+    /**
+     * @return If the query validation should be performed. Default value is true
+     */
+    public boolean isValidate() {
+        return validate;
+    }
+
     /**
      * This helps you transform the current ExecutionInput object into another one by starting a builder with all
      * the current values and allows you to transform it how you want.
@@ -104,7 +117,8 @@ public class ExecutionInput {
                 .root(this.root)
                 .dataLoaderRegistry(this.dataLoaderRegistry)
                 .cacheControl(this.cacheControl)
-                .variables(this.variables);
+                .variables(this.variables)
+                .validate(this.validate);
 
         builderConsumer.accept(builder);
 
@@ -151,6 +165,7 @@ public class ExecutionInput {
         private Map<String, Object> variables = Collections.emptyMap();
         private DataLoaderRegistry dataLoaderRegistry = new DataLoaderRegistry();
         private CacheControl cacheControl;
+        private boolean validate = true;
 
         public Builder query(String query) {
             this.query = query;
@@ -192,6 +207,12 @@ public class ExecutionInput {
 
         public Builder variables(Map<String, Object> variables) {
             this.variables = variables;
+            return this;
+        }
+
+
+        public Builder validate(boolean validate) {
+            this.validate = validate;
             return this;
         }
 

--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -531,7 +531,7 @@ public class GraphQL {
         if (parseResult.isFailure()) {
             log.warn("Query failed to parse : '{}'", executionInput.getQuery());
             return new PreparsedDocumentEntry(parseResult.getException().toInvalidSyntaxError());
-        } else {
+        } else if(executionInput.isValidate()){
             final Document document = parseResult.getDocument();
             // they may have changed the document and the variables via instrumentation so update the reference to it
             executionInput = executionInput.transform(builder -> builder.variables(parseResult.getVariables()));

--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -546,6 +546,7 @@ public class GraphQL {
 
             return new PreparsedDocumentEntry(document);
         }
+        return new PreparsedDocumentEntry(parseResult.getDocument());
     }
 
     private ParseResult parse(ExecutionInput executionInput, GraphQLSchema graphQLSchema, InstrumentationState instrumentationState) {


### PR DESCRIPTION
Optional Query Validation issue #1479

> We have a very high latency system with a large schema and queries. I'm building a query registration system ,so in short on production only pre registered query will run . Thus guaranteeing all the queries are validated earlier.
> So I would like to skip the query validation on production to save some Milli sec. On some other framework(Sangria- scala lib) I found it very easy to skip it but in java it seems it's mandatory.

This pull request address this issue by distinguishing if the validation should be done on the query. On pre registered queries one can turn of the validation.

