### PR TITLE
added ability to specify 'extensions' via DataFetcherResult

### DIFF
--- a/src/main/java/graphql/execution/AbstractAsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AbstractAsyncExecutionStrategy.java
@@ -32,7 +32,7 @@ public abstract class AbstractAsyncExecutionStrategy extends ExecutionStrategy {
                 String fieldName = fieldNames.get(ix++);
                 resolvedValuesByField.put(fieldName, executionResult.getData());
             }
-            overallResult.complete(new ExecutionResultImpl(resolvedValuesByField, executionContext.getErrors()));
+            overallResult.complete(new ExecutionResultImpl(resolvedValuesByField, executionContext.getErrors(), executionContext.getExtensions()));
         };
     }
 }

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -166,7 +166,7 @@ public class Execution {
             //
             // http://facebook.github.io/graphql/#sec-Errors-and-Non-Nullability
             //
-            result = completedFuture(new ExecutionResultImpl(null, executionContext.getErrors()));
+            result = completedFuture(new ExecutionResultImpl(null, executionContext.getErrors(), executionContext.getExtensions()));
         }
 
         // note this happens NOW - not when the result completes

--- a/src/main/java/graphql/execution/ExecutionContextBuilder.java
+++ b/src/main/java/graphql/execution/ExecutionContextBuilder.java
@@ -39,6 +39,7 @@ public class ExecutionContextBuilder {
     private DataLoaderRegistry dataLoaderRegistry;
     private CacheControl cacheControl;
     private List<GraphQLError> errors = new ArrayList<>();
+    private Map<Object, Object> extensions;
 
     /**
      * @return a new builder of {@link graphql.execution.ExecutionContext}s
@@ -80,6 +81,7 @@ public class ExecutionContextBuilder {
         dataLoaderRegistry = other.getDataLoaderRegistry();
         cacheControl = other.getCacheControl();
         errors = new ArrayList<>(other.getErrors());
+        extensions = (other.getExtensions() == null ? null : new LinkedHashMap<>(other.getExtensions()));
     }
 
     public ExecutionContextBuilder instrumentation(Instrumentation instrumentation) {
@@ -178,7 +180,8 @@ public class ExecutionContextBuilder {
                 root,
                 dataLoaderRegistry,
                 cacheControl,
-                errors
+                errors,
+                extensions
         );
     }
 }

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -294,6 +294,8 @@ public abstract class ExecutionStrategy {
                 dataFetcherResult.getErrors().forEach(executionContext::addError);
             }
 
+            executionContext.addExtensions(dataFetcherResult.getExtensions());
+
             Object localContext = dataFetcherResult.getLocalContext();
             if (localContext == null) {
                 // if the field returns nothing then they get the context of their parent field
@@ -303,6 +305,7 @@ public abstract class ExecutionStrategy {
                     .fetchedValue(UnboxPossibleOptional.unboxPossibleOptional(dataFetcherResult.getData()))
                     .rawFetchedValue(dataFetcherResult.getData())
                     .errors(dataFetcherResult.getErrors())
+                    .extensions(dataFetcherResult.getExtensions())
                     .localContext(localContext)
                     .build();
         } else {
@@ -752,7 +755,7 @@ public abstract class ExecutionStrategy {
         if (underlyingException instanceof NonNullableFieldWasNullException) {
             assertNonNullFieldPrecondition((NonNullableFieldWasNullException) underlyingException, result);
             if (!result.isDone()) {
-                executionResult = new ExecutionResultImpl(null, errors);
+                executionResult = new ExecutionResultImpl(null, errors, executionContext.getExtensions());
                 result.complete(executionResult);
             }
         } else if (underlyingException instanceof AbortExecutionException) {

--- a/src/main/java/graphql/execution/ExecutorServiceExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutorServiceExecutionStrategy.java
@@ -102,7 +102,7 @@ public class ExecutorServiceExecutionStrategy extends ExecutionStrategy {
                 results.put(fieldName, executionResult != null ? executionResult.getData() : null);
             }
 
-            ExecutionResultImpl executionResult = new ExecutionResultImpl(results, executionContext.getErrors());
+            ExecutionResultImpl executionResult = new ExecutionResultImpl(results, executionContext.getErrors(), executionContext.getExtensions());
             overallResult.complete(executionResult);
 
             overallResult = overallResult.whenComplete(executionStrategyCtx::onCompleted);

--- a/src/main/java/graphql/execution/FetchedValue.java
+++ b/src/main/java/graphql/execution/FetchedValue.java
@@ -4,7 +4,9 @@ import graphql.GraphQLError;
 import graphql.Internal;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 @Internal
@@ -13,11 +15,13 @@ public class FetchedValue {
     private final Object rawFetchedValue;
     private final Object localContext;
     private final List<GraphQLError> errors;
+    private final Map<Object, Object> extensions;
 
-    private FetchedValue(Object fetchedValue, Object rawFetchedValue, List<GraphQLError> errors, Object localContext) {
+    private FetchedValue(Object fetchedValue, Object rawFetchedValue, List<GraphQLError> errors, Map<Object, Object> extensions, Object localContext) {
         this.fetchedValue = fetchedValue;
         this.rawFetchedValue = rawFetchedValue;
         this.errors = errors;
+        this.extensions = extensions;
         this.localContext = localContext;
     }
 
@@ -34,6 +38,10 @@ public class FetchedValue {
 
     public List<GraphQLError> getErrors() {
         return new ArrayList<>(errors);
+    }
+
+    public Map<Object, Object> getExtensions() {
+      return (this.extensions == null ? null : new LinkedHashMap<>(this.extensions));
     }
 
     public Object getLocalContext() {
@@ -55,6 +63,7 @@ public class FetchedValue {
                 .fetchedValue(otherValue.getFetchedValue())
                 .rawFetchedValue(otherValue.getRawFetchedValue())
                 .errors(otherValue.getErrors())
+                .extensions(otherValue.extensions)
                 .localContext(otherValue.getLocalContext())
                 ;
     }
@@ -65,6 +74,7 @@ public class FetchedValue {
         private Object rawFetchedValue;
         private Object localContext;
         private List<GraphQLError> errors = new ArrayList<>();
+        private Map<Object, Object> extensions;
 
         public Builder fetchedValue(Object fetchedValue) {
             this.fetchedValue = fetchedValue;
@@ -86,8 +96,13 @@ public class FetchedValue {
             return this;
         }
 
+        public Builder extensions(Map<Object, Object> extensions) {
+          this.extensions = extensions;
+          return this;
+        }
+
         public FetchedValue build() {
-            return new FetchedValue(fetchedValue, rawFetchedValue, errors, localContext);
+            return new FetchedValue(fetchedValue, rawFetchedValue, errors, extensions, localContext);
         }
     }
 }

--- a/src/main/java/graphql/execution/SubscriptionExecutionStrategy.java
+++ b/src/main/java/graphql/execution/SubscriptionExecutionStrategy.java
@@ -40,13 +40,13 @@ public class SubscriptionExecutionStrategy extends ExecutionStrategy {
         // when the upstream source event stream completes, subscribe to it and wire in our adapter
         return sourceEventStream.thenApply((publisher) -> {
             if (publisher == null) {
-                return new ExecutionResultImpl(null, executionContext.getErrors());
+                return new ExecutionResultImpl(null, executionContext.getErrors(), executionContext.getExtensions());
             }
             CompletionStageMappingPublisher<ExecutionResult, Object> mapSourceToResponse = new CompletionStageMappingPublisher<>(
                     publisher,
                     eventPayload -> executeSubscriptionEvent(executionContext, parameters, eventPayload)
             );
-            return new ExecutionResultImpl(mapSourceToResponse, executionContext.getErrors());
+            return new ExecutionResultImpl(mapSourceToResponse, executionContext.getErrors(), executionContext.getExtensions());
         });
     }
 

--- a/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
+++ b/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
@@ -144,7 +144,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
                              CompletableFuture<ExecutionResult> overallResult) {
 
         if (!curFieldNames.hasNext() && queueOfNodes.isEmpty()) {
-            overallResult.complete(new ExecutionResultImpl(root.getParentResults().get(0).toObject(), executionContext.getErrors()));
+            overallResult.complete(new ExecutionResultImpl(root.getParentResults().get(0).toObject(), executionContext.getErrors(), executionContext.getExtensions()));
             return;
         }
 

--- a/src/main/java/graphql/execution/nextgen/FetchedValueAnalysis.java
+++ b/src/main/java/graphql/execution/nextgen/FetchedValueAnalysis.java
@@ -8,7 +8,9 @@ import graphql.execution.MergedField;
 import graphql.schema.GraphQLObjectType;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
@@ -26,6 +28,7 @@ public class FetchedValueAnalysis {
 
     private final FetchedValueType valueType;
     private final List<GraphQLError> errors;
+    private final Map<Object, Object> extensions;
     // not applicable for LIST
     private final Object completedValue;
     private final boolean nullValue;
@@ -40,6 +43,7 @@ public class FetchedValueAnalysis {
     private FetchedValueAnalysis(Builder builder) {
         this.errors = new ArrayList<>(builder.errors);
         this.errors.addAll(builder.fetchedValue.getErrors());
+        this.extensions = (builder.extensions == null ? null : new LinkedHashMap<>(builder.extensions));
         this.valueType = assertNotNull(builder.valueType);
         this.completedValue = builder.completedValue;
         this.nullValue = builder.nullValue;
@@ -55,6 +59,10 @@ public class FetchedValueAnalysis {
 
     public List<GraphQLError> getErrors() {
         return errors;
+    }
+
+    public Map<Object, Object> getExtensions() {
+        return extensions;
     }
 
     public Object getCompletedValue() {
@@ -110,6 +118,7 @@ public class FetchedValueAnalysis {
     public static final class Builder {
         private FetchedValueType valueType;
         private final List<GraphQLError> errors = new ArrayList<>();
+        private Map<Object, Object> extensions;
         private Object completedValue;
         private FetchedValue fetchedValue;
         private List<FetchedValueAnalysis> children;
@@ -123,6 +132,7 @@ public class FetchedValueAnalysis {
         private Builder(FetchedValueAnalysis existing) {
             valueType = existing.getValueType();
             errors.addAll(existing.getErrors());
+            extensions = existing.extensions;
             completedValue = existing.getCompletedValue();
             fetchedValue = existing.getFetchedValue();
             children = existing.getChildren();

--- a/src/main/java/graphql/execution/nextgen/ValueFetcher.java
+++ b/src/main/java/graphql/execution/nextgen/ValueFetcher.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -86,6 +87,7 @@ public class ValueFetcher {
                     .fetchedValue(list.get(i))
                     .rawFetchedValue(fetchedValueContainingList.getRawFetchedValue())
                     .errors(errors)
+                    .extensions(fetchedValueContainingList.getExtensions())
                     .localContext(fetchedValueContainingList.getLocalContext())
                     .build();
             result.add(fetchedValue);
@@ -203,6 +205,17 @@ public class ValueFetcher {
             newErrors = new ArrayList<>(result.getErrors());
             newErrors.addAll(addErrors);
 
+            Map<Object, Object> newExtensions = new LinkedHashMap<>();
+            if (result.getExtensions() != null) {
+                newExtensions.putAll(result.getExtensions());
+            }
+            if (dataFetcherResult.getExtensions() != null) {
+                newExtensions.putAll(dataFetcherResult.getExtensions());
+            }
+            if (newExtensions.isEmpty()) {
+                newExtensions = null;
+            }
+
             Object newLocalContext = dataFetcherResult.getLocalContext();
             if (newLocalContext == null) {
                 // if the field returns nothing then they get the context of their parent field
@@ -212,6 +225,7 @@ public class ValueFetcher {
                     .fetchedValue(dataFetcherResult.getData())
                     .rawFetchedValue(result.getRawFetchedValue())
                     .errors(newErrors)
+                    .extensions(newExtensions)
                     .localContext(newLocalContext)
                     .build();
         } else {

--- a/src/test/groovy/graphql/execution/BreadthFirstExecutionTestStrategy.java
+++ b/src/test/groovy/graphql/execution/BreadthFirstExecutionTestStrategy.java
@@ -48,7 +48,7 @@ public class BreadthFirstExecutionTestStrategy extends ExecutionStrategy {
                 break;
             }
         }
-        return CompletableFuture.completedFuture(new ExecutionResultImpl(results, executionContext.getErrors()));
+        return CompletableFuture.completedFuture(new ExecutionResultImpl(results, executionContext.getErrors(), executionContext.getExtensions()));
     }
 
     private FetchedValue fetchField(ExecutionContext executionContext, ExecutionStrategyParameters parameters, MergedSelectionSet fields, String fieldName) {

--- a/src/test/groovy/graphql/execution/BreadthFirstTestStrategy.java
+++ b/src/test/groovy/graphql/execution/BreadthFirstTestStrategy.java
@@ -71,7 +71,7 @@ public class BreadthFirstTestStrategy extends ExecutionStrategy {
                 break;
             }
         }
-        return CompletableFuture.completedFuture(new ExecutionResultImpl(results, executionContext.getErrors()));
+        return CompletableFuture.completedFuture(new ExecutionResultImpl(results, executionContext.getErrors(), executionContext.getExtensions()));
     }
 
     private ExecutionStrategyParameters newParameters(ExecutionStrategyParameters parameters, MergedSelectionSet fields, String fieldName) {

--- a/src/test/groovy/graphql/execution/DataFetcherResultTest.groovy
+++ b/src/test/groovy/graphql/execution/DataFetcherResultTest.groovy
@@ -10,14 +10,25 @@ class DataFetcherResultTest extends Specification {
     def error1 = new ValidationError(ValidationErrorType.DuplicateOperationName)
     def error2 = new InvalidSyntaxError([], "Boo")
 
+    def ext1Value = 42
+    def ext2Value = "Fish fingers and Custard"
+
     def "basic building"() {
         when:
-        def result = DataFetcherResult.newResult().data("hello")
-                .error(error1).errors([error2]).localContext("world").build()
+        def result = DataFetcherResult
+                .newResult()
+                .data("hello")
+                .error(error1)
+                .errors([error2])
+                .extension("ext1", ext1Value)
+                .extensions([11: ext2Value])
+                .localContext("world")
+                .build()
         then:
         result.getData() == "hello"
         result.getLocalContext() == "world"
         result.getErrors() == [error1, error2]
+        result.getExtensions() == [ext1: ext1Value, 11: ext2Value]
     }
 
     def "hasErrors can be called"() {
@@ -47,5 +58,19 @@ class DataFetcherResultTest extends Specification {
         result = DataFetcherResult.newResult().mapRelativeErrors(true).build()
         then:
         result.isMapRelativeErrors()
+    }
+
+    def "extensions is null by default"() {
+        when:
+        def result = DataFetcherResult.newResult().build()
+        then:
+        result.getExtensions() == null
+    }
+
+    def "empty extensions results is null value when calling getter"() {
+        when:
+        def result = DataFetcherResult.newResult().extensions([:]).build()
+        then:
+        result.getExtensions() == null
     }
 }

--- a/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
@@ -63,7 +63,7 @@ class ExecutionStrategyTest extends Specification {
         new ExecutionContext(SimpleInstrumentation.INSTANCE, executionId, schema ?: StarWarsSchema.starWarsSchema, null,
                 executionStrategy, executionStrategy, executionStrategy,
                 null, null, null,
-                variables, "context", "root", new DataLoaderRegistry(), null, Collections.emptyList())
+                variables, "context", "root", new DataLoaderRegistry(), null, Collections.emptyList(), null)
     }
 
     @SuppressWarnings("GroovyAssignabilityCheck")
@@ -699,6 +699,7 @@ class ExecutionStrategyTest extends Specification {
                 DataFetcherResult.newResult().data(executionData)
                         .mapRelativeErrors(true)
                         .error(new DataFetchingErrorGraphQLError("bad foo", ["child", "foo"]))
+                        .extensions([ext1: 42, ext2: "fish fingers and custard"])
                         .build()
         )
 
@@ -707,6 +708,9 @@ class ExecutionStrategyTest extends Specification {
         executionContext.getErrors()[0].locations == [new SourceLocation(7, 20)]
         executionContext.getErrors()[0].message == "bad foo"
         executionContext.getErrors()[0].path == ["parent", "child", "foo"]
+        executionContext.getExtensions() != null
+        executionContext.getExtensions().get("ext1") == 42
+        executionContext.getExtensions().get("ext2") == "fish fingers and custard"
     }
 
     def "#820 processes DataFetcherResult just message"() {
@@ -729,12 +733,16 @@ class ExecutionStrategyTest extends Specification {
         def fetchedValue = executionStrategy.unboxPossibleDataFetcherResult(executionContext, parameters,
                 DataFetcherResult.newResult().data(executionData)
                         .error(new DataFetchingErrorGraphQLError("bad foo"))
+                        .extensions([ext1: 42, ext2: "fish fingers and custard"])
                         .build())
         then:
         fetchedValue.getFetchedValue() == executionData
         executionContext.getErrors()[0].locations == null
         executionContext.getErrors()[0].message == "bad foo"
         executionContext.getErrors()[0].path == null
+        executionContext.getExtensions() != null
+        executionContext.getExtensions().get("ext1") == 42
+        executionContext.getExtensions().get("ext2") == "fish fingers and custard"
     }
 
     def "completes value for an iterable"() {


### PR DESCRIPTION
### Why?
This update allows a user to specify `extension` values that are to be added to the response returned by a GraphQL query.

The overall purpose of, and problem to be solved by, this update is to make the addition of extensions much easier when said additions are contingent upon the presence of specific data or the upon the properties/state of data. `DataFetcherResult` only allows for one to specify `data` and `errors`. While it initially makes sense to exclude `extensions` from `DataFetcherResult` due to the fact that a `DataFetcher` is used to obtain data for every single field queried (regardless of it's location in the graph) and not for the entire graph; it makes it quite difficult to add to the query `extensions`. Currently (from what I've been able to tell), extensions are most easily added by creating custom instrumentation or custom execution strategies. However, when extensions need to be added based upon specific data (as mentioned previously), this causes a need to do a lot of time consuming (and sometimes confusing) checks on returned data. This tends to force a user to iterate over values and basically parse the entire returned tree in search of, potentially, one small value.

### Solution (High Level)
This update added `extensions` to `DataFetcherResult` (and a couple of other objects so that those extensions can be passed eventually to the `ExecutionResult`). Adding values to `DataFetcherResult.extensions` will not connect those values to the field of the `DataFetcher` like `errors` are connected to a specific field. Instead, those values are added to the top level `extensions` field of a query result. If a user wants to connect the extensions to the field of a `DataFetcher` that adds the extensions, then that is something that the user needs to be concerned with figuring out.

### Tests
I've updated tests and added new tests to account for the changes, but it seems as though there may be other locations where we might want to update some tests so that we can ensure that the `extensions` specified in `DataFetcherResult` will be passed eventually up to the end `ExecutionResult`. I didn't add these tests initially because it seemed that there were no tests for the same thing in regards to `DataFetcherResult.errors` and because I didn't want to take the time to write modify all of the tests if this change isn't even considered to be accepted.