### PR TITLE
Changed the PreParsedDocumentProvider so it has the full input and not just query string

### DIFF
--- a/src/main/java/graphql/execution/preparsed/NoOpPreparsedDocumentProvider.java
+++ b/src/main/java/graphql/execution/preparsed/NoOpPreparsedDocumentProvider.java
@@ -1,13 +1,15 @@
 package graphql.execution.preparsed;
 
 
+import graphql.ExecutionInput;
+
 import java.util.function.Function;
 
 public class NoOpPreparsedDocumentProvider implements PreparsedDocumentProvider {
     public static final NoOpPreparsedDocumentProvider INSTANCE = new NoOpPreparsedDocumentProvider();
 
     @Override
-    public PreparsedDocumentEntry get(String query, Function<String, PreparsedDocumentEntry> compute) {
-        return compute.apply(query);
+    public PreparsedDocumentEntry getDocument(ExecutionInput executionInput, Function<ExecutionInput, PreparsedDocumentEntry> computeFunction) {
+        return computeFunction.apply(executionInput);
     }
 }

--- a/src/main/java/graphql/execution/preparsed/PreparsedDocumentEntry.java
+++ b/src/main/java/graphql/execution/preparsed/PreparsedDocumentEntry.java
@@ -1,6 +1,7 @@
 package graphql.execution.preparsed;
 
 import graphql.GraphQLError;
+import graphql.PublicApi;
 import graphql.language.Document;
 
 import java.io.Serializable;
@@ -18,6 +19,7 @@ import static java.util.Collections.singletonList;
  * with times frames that cross graphql-java versions.  While we don't change things unnecessarily,  we may inadvertently break
  * the serialised compatibility across versions.
  */
+@PublicApi
 public class PreparsedDocumentEntry implements Serializable {
     private final Document document;
     private final List<? extends GraphQLError> errors;

--- a/src/main/java/graphql/execution/preparsed/PreparsedDocumentProvider.java
+++ b/src/main/java/graphql/execution/preparsed/PreparsedDocumentProvider.java
@@ -1,23 +1,26 @@
 package graphql.execution.preparsed;
 
 
+import graphql.ExecutionInput;
+import graphql.PublicSpi;
+
 import java.util.function.Function;
 
 /**
  * Interface that allows clients to hook in Document caching and/or the whitelisting of queries
  */
-@FunctionalInterface
+@PublicSpi
 public interface PreparsedDocumentProvider {
     /**
      * This is called to get a "cached" pre-parsed query and if its not present, then the computeFunction
-     * can be called to parse the query
+     * can be called to parse and validate the query
      *
-     * @param query           The graphql query
+     * @param executionInput  The {@link graphql.ExecutionInput} containing the query
      * @param computeFunction If the query has not be pre-parsed, this function can be called to parse it
      *
      * @return an instance of {@link PreparsedDocumentEntry}
      */
-    PreparsedDocumentEntry get(String query, Function<String, PreparsedDocumentEntry> computeFunction);
+    PreparsedDocumentEntry getDocument(ExecutionInput executionInput, Function<ExecutionInput, PreparsedDocumentEntry> computeFunction);
 }
 
 

--- a/src/test/groovy/graphql/execution/preparsed/NoOpPreparsedDocumentProviderTest.groovy
+++ b/src/test/groovy/graphql/execution/preparsed/NoOpPreparsedDocumentProviderTest.groovy
@@ -1,8 +1,10 @@
 package graphql.execution.preparsed
 
+
 import graphql.language.Document
 import spock.lang.Specification
 
+import static graphql.ExecutionInput.newExecutionInput
 
 class NoOpPreparsedDocumentProviderTest extends Specification {
     def "NoOp always returns result of compute function"() {
@@ -11,7 +13,7 @@ class NoOpPreparsedDocumentProviderTest extends Specification {
         def documentEntry = new PreparsedDocumentEntry(Document.newDocument().build())
 
         when:
-        def actual = provider.get("{}", { return documentEntry })
+        def actual = provider.getDocument(newExecutionInput("{}").build(), { return documentEntry })
 
         then:
         actual == documentEntry

--- a/src/test/groovy/graphql/execution/preparsed/PreparsedDocumentProviderTest.groovy
+++ b/src/test/groovy/graphql/execution/preparsed/PreparsedDocumentProviderTest.groovy
@@ -186,13 +186,15 @@ class PreparsedDocumentProviderTest extends Specification {
               """
 
         def documentProvider = new PreparsedDocumentProvider() {
+
             @Override
-            PreparsedDocumentEntry get(String query, Function<String, PreparsedDocumentEntry> computeFunction) {
-                if (query == "#A") {
-                    return computeFunction.apply(queryA)
+            PreparsedDocumentEntry getDocument(ExecutionInput executionInput, Function<ExecutionInput, PreparsedDocumentEntry> computeFunction) {
+                if (executionInput.getQuery() == "#A") {
+                    executionInput = executionInput.transform({ it.query(queryA) })
                 } else {
-                    return computeFunction.apply(queryB)
+                    executionInput = executionInput.transform({ it.query(queryB) })
                 }
+                return computeFunction.apply(executionInput)
             }
         }
 

--- a/src/test/groovy/graphql/execution/preparsed/TestingPreparsedDocumentProvider.groovy
+++ b/src/test/groovy/graphql/execution/preparsed/TestingPreparsedDocumentProvider.groovy
@@ -1,5 +1,7 @@
 package graphql.execution.preparsed
 
+import graphql.ExecutionInput
+
 import java.util.function.Function
 
 
@@ -7,8 +9,9 @@ class TestingPreparsedDocumentProvider implements PreparsedDocumentProvider {
     private Map<String, PreparsedDocumentEntry> cache = new HashMap<>()
 
     @Override
-    PreparsedDocumentEntry get(String query, Function<String, PreparsedDocumentEntry> compute) {
-        return cache.computeIfAbsent(query, compute)
+    PreparsedDocumentEntry getDocument(ExecutionInput executionInput, Function<ExecutionInput, PreparsedDocumentEntry> computeFunction) {
+        Function<String, PreparsedDocumentEntry> mapCompute = { key -> computeFunction.apply(executionInput) }
+        return cache.computeIfAbsent(executionInput.query, mapCompute)
     }
 
 }


### PR DESCRIPTION
This will improve the ability for people to do better "query caching" because it now sends the operation name (and all ExecutionInput properties) in to the call back.

This is a breaking change to the SPI.

There is a way to do it where we delegate from the new to the old via a `default` interface method.  But I dont think enough people will be affected by this change to, nor the scope of change is big enough to warrant those gymnastics