### PR TITLE
result node adaptor now can delete children

### DIFF
--- a/src/main/java/graphql/execution/FetchedValue.java
+++ b/src/main/java/graphql/execution/FetchedValue.java
@@ -46,6 +46,16 @@ public class FetchedValue {
         return builder.build();
     }
 
+    @Override
+    public String toString() {
+        return "FetchedValue{" +
+                "fetchedValue=" + fetchedValue +
+                ", rawFetchedValue=" + rawFetchedValue +
+                ", localContext=" + localContext +
+                ", errors=" + errors +
+                '}';
+    }
+
     public static Builder newFetchedValue() {
         return new Builder();
     }

--- a/src/main/java/graphql/execution/nextgen/FetchedValueAnalysis.java
+++ b/src/main/java/graphql/execution/nextgen/FetchedValueAnalysis.java
@@ -107,6 +107,20 @@ public class FetchedValueAnalysis {
         return executionStepInfo.getResultKey();
     }
 
+    @Override
+    public String toString() {
+        return "{" +
+                "valueType=" + valueType +
+                ", completedValue=" + completedValue +
+                ", errors=" + errors +
+                ", children=" + children +
+                ", stepInfo=" + executionStepInfo +
+                ", nullValue=" + nullValue +
+                ", resolvedType=" + resolvedType +
+                ", fetchedValue=" + fetchedValue +
+                '}';
+    }
+
     public static final class Builder {
         private FetchedValueType valueType;
         private final List<GraphQLError> errors = new ArrayList<>();

--- a/src/main/java/graphql/execution/nextgen/result/ExecutionResultNode.java
+++ b/src/main/java/graphql/execution/nextgen/result/ExecutionResultNode.java
@@ -88,4 +88,15 @@ public abstract class ExecutionResultNode {
      * @return a new ExecutionResultNode with the new errors
      */
     public abstract ExecutionResultNode withNewErrors(List<GraphQLError> errors);
+
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "{" +
+                "fva=" + fetchedValueAnalysis +
+                ", children=" + children +
+                ", errors=" + errors +
+                ", nonNullableEx=" + nonNullableFieldWasNullException +
+                '}';
+    }
 }

--- a/src/main/java/graphql/execution/nextgen/result/ResultNodeAdapter.java
+++ b/src/main/java/graphql/execution/nextgen/result/ResultNodeAdapter.java
@@ -1,6 +1,5 @@
 package graphql.execution.nextgen.result;
 
-import graphql.Assert;
 import graphql.PublicApi;
 import graphql.util.NodeAdapter;
 import graphql.util.NodeLocation;
@@ -8,6 +7,9 @@ import graphql.util.NodeLocation;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+
+import static graphql.Assert.assertNotNull;
+import static graphql.Assert.assertTrue;
 
 @PublicApi
 public class ResultNodeAdapter implements NodeAdapter<ExecutionResultNode> {
@@ -19,22 +21,26 @@ public class ResultNodeAdapter implements NodeAdapter<ExecutionResultNode> {
     }
 
     @Override
-    public Map<String, List<ExecutionResultNode>> getNamedChildren(ExecutionResultNode node) {
+    public Map<String, List<ExecutionResultNode>> getNamedChildren(ExecutionResultNode parentNode) {
         Map<String, List<ExecutionResultNode>> result = new LinkedHashMap<>();
-        result.put(null, node.getChildren());
+        result.put(null, parentNode.getChildren());
         return result;
     }
 
     @Override
-    public ExecutionResultNode withNewChildren(ExecutionResultNode node, Map<String, List<ExecutionResultNode>> newChildren) {
-        Assert.assertTrue(newChildren.size() == 1);
+    public ExecutionResultNode withNewChildren(ExecutionResultNode parentNode, Map<String, List<ExecutionResultNode>> newChildren) {
+        assertTrue(newChildren.size() == 1);
         List<ExecutionResultNode> childrenList = newChildren.get(null);
-        Assert.assertNotNull(childrenList);
-        return node.withNewChildren(childrenList);
+        assertNotNull(childrenList);
+        return parentNode.withNewChildren(childrenList);
     }
 
     @Override
-    public ExecutionResultNode removeChild(ExecutionResultNode node, NodeLocation location) {
-        throw new UnsupportedOperationException();
+    public ExecutionResultNode removeChild(ExecutionResultNode parentNode, NodeLocation location) {
+        int index = location.getIndex();
+        List<ExecutionResultNode> childrenList = parentNode.getChildren();
+        assertTrue(index >= 0 && index < childrenList.size(), "The remove index MUST be within the range of the children");
+        childrenList.remove(index);
+        return parentNode.withNewChildren(childrenList);
     }
 }

--- a/src/test/groovy/graphql/execution/nextgen/result/ExecutionResultNodeTest.groovy
+++ b/src/test/groovy/graphql/execution/nextgen/result/ExecutionResultNodeTest.groovy
@@ -1,16 +1,12 @@
 package graphql.execution.nextgen.result
 
-import graphql.Scalars
-import graphql.execution.nextgen.FetchedValueAnalysis
+
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
 
 import static graphql.GraphqlErrorBuilder.newError
-import static graphql.execution.ExecutionStepInfo.newExecutionStepInfo
-import static graphql.execution.FetchedValue.newFetchedValue
-import static graphql.execution.nextgen.FetchedValueAnalysis.FetchedValueType.SCALAR
-import static graphql.execution.nextgen.FetchedValueAnalysis.newFetchedValueAnalysis
+import static graphql.execution.nextgen.result.ExecutionResultNodeTestUtils.fvaForValue
 
 class ExecutionResultNodeTest extends Specification {
 
@@ -18,23 +14,10 @@ class ExecutionResultNodeTest extends Specification {
     def startingErrors = [newError().message("Starting").build()]
 
     @Shared
-    def startingFetchValueAnalysis = fetchedValueAnalysis("Starting")
+    def startingFetchValueAnalysis = fvaForValue("Starting")
 
     @Shared
     def startingChildren = [new LeafExecutionResultNode(startingFetchValueAnalysis, null)]
-
-    static FetchedValueAnalysis fetchedValueAnalysis(String value) {
-        def executionStepInfo = newExecutionStepInfo().type(Scalars.GraphQLString).build()
-        def fetchedValue = newFetchedValue()
-                .fetchedValue(value)
-                .rawFetchedValue(value).build()
-        newFetchedValueAnalysis()
-                .executionStepInfo(executionStepInfo)
-                .valueType(SCALAR)
-                .fetchedValue(fetchedValue)
-                .completedValue(value)
-                .build()
-    }
 
     @Unroll
     def "construction of objects with new errors works"() {
@@ -61,7 +44,7 @@ class ExecutionResultNodeTest extends Specification {
     def "construction of objects with new fetched value analysis  works"() {
 
         given:
-        def newFetchValueAnalysis = fetchedValueAnalysis("hi")
+        def newFetchValueAnalysis = fvaForValue("hi")
 
         expect:
         ExecutionResultNode nodeUnderTest = node

--- a/src/test/groovy/graphql/execution/nextgen/result/ExecutionResultNodeTestUtils.groovy
+++ b/src/test/groovy/graphql/execution/nextgen/result/ExecutionResultNodeTestUtils.groovy
@@ -1,0 +1,26 @@
+package graphql.execution.nextgen.result
+
+import graphql.Scalars
+import graphql.execution.nextgen.FetchedValueAnalysis
+
+import static graphql.execution.ExecutionStepInfo.newExecutionStepInfo
+import static graphql.execution.FetchedValue.newFetchedValue
+import static graphql.execution.nextgen.FetchedValueAnalysis.FetchedValueType.SCALAR
+import static graphql.execution.nextgen.FetchedValueAnalysis.newFetchedValueAnalysis
+
+class ExecutionResultNodeTestUtils {
+
+    static FetchedValueAnalysis fvaForValue(Object value) {
+        def executionStepInfo = newExecutionStepInfo().type(Scalars.GraphQLString).build()
+        def fetchedValue = newFetchedValue()
+                .fetchedValue(value)
+                .rawFetchedValue(value).build()
+        newFetchedValueAnalysis()
+                .executionStepInfo(executionStepInfo)
+                .valueType(SCALAR)
+                .fetchedValue(fetchedValue)
+                .completedValue(value)
+                .build()
+    }
+
+}

--- a/src/test/groovy/graphql/execution/nextgen/result/ResultNodeAdapterTest.groovy
+++ b/src/test/groovy/graphql/execution/nextgen/result/ResultNodeAdapterTest.groovy
@@ -1,0 +1,35 @@
+package graphql.execution.nextgen.result
+
+import graphql.AssertException
+import graphql.util.NodeLocation
+import spock.lang.Specification
+
+import static graphql.execution.nextgen.result.ExecutionResultNodeTestUtils.fvaForValue
+
+class ResultNodeAdapterTest extends Specification {
+
+    def parentNode = new ObjectExecutionResultNode(null, [
+            new LeafExecutionResultNode(fvaForValue("v1"), null),
+            new LeafExecutionResultNode(fvaForValue("v2"), null),
+            new LeafExecutionResultNode(fvaForValue("v3"), null),
+    ])
+
+    def "can remove a child from a node"() {
+        when:
+        ResultNodeAdapter.RESULT_NODE_ADAPTER.removeChild(parentNode, new NodeLocation(null, -1))
+        then:
+        thrown(AssertException)
+
+        when:
+        ResultNodeAdapter.RESULT_NODE_ADAPTER.removeChild(parentNode, new NodeLocation(null, -3))
+        then:
+        thrown(AssertException)
+
+        when:
+        def newNode = ResultNodeAdapter.RESULT_NODE_ADAPTER.removeChild(parentNode, new NodeLocation(null, 1))
+        then:
+        newNode.children.size() == 2
+        newNode.children[0].getFetchedValueAnalysis().getCompletedValue() == "v1"
+        newNode.children[1].getFetchedValueAnalysis().getCompletedValue() == "v3"
+    }
+}


### PR DESCRIPTION
I also added toStrings on ERN because those guys are complex and it makes it  asmidge easier in the debugger