### PR TITLE
Adds toSpecification support to ErrorClassification

### DIFF
--- a/src/main/java/graphql/ErrorClassification.java
+++ b/src/main/java/graphql/ErrorClassification.java
@@ -9,4 +9,18 @@ package graphql;
  */
 @PublicApi
 public interface ErrorClassification {
+
+    /**
+     * This is called to create a representation of the error classification
+     * that can be put into the `extensions` map of the graphql error under the key 'classification'
+     * when {@link GraphQLError#toSpecification()} is called
+     *
+     * @param error the error associated with this classification
+     *
+     * @return an object representation of this error classification
+     */
+    @SuppressWarnings("unused")
+    default Object toSpecification(GraphQLError error) {
+        return String.valueOf(this);
+    }
 }

--- a/src/main/java/graphql/GraphqlErrorHelper.java
+++ b/src/main/java/graphql/GraphqlErrorHelper.java
@@ -24,8 +24,23 @@ public class GraphqlErrorHelper {
         if (error.getPath() != null) {
             errorMap.put("path", error.getPath());
         }
-        if (error.getExtensions() != null) {
-            errorMap.put("extensions", error.getExtensions());
+
+        Map<String, Object> extensions = error.getExtensions();
+        ErrorClassification errorClassification = error.getErrorType();
+        //
+        // we move the ErrorClassification into extensions which allows
+        // downstream people to see them but still be spec compliant
+        if (errorClassification != null) {
+            if (extensions != null) {
+                extensions = new LinkedHashMap<>(extensions);
+            } else {
+                extensions = new LinkedHashMap<>();
+            }
+            extensions.put("classification", errorClassification.toSpecification(error));
+        }
+
+        if (extensions != null) {
+            errorMap.put("extensions", extensions);
         }
         return errorMap;
     }

--- a/src/test/groovy/graphql/ExecutionResultImplTest.groovy
+++ b/src/test/groovy/graphql/ExecutionResultImplTest.groovy
@@ -6,7 +6,7 @@ import spock.lang.Specification
 class ExecutionResultImplTest extends Specification {
 
     def KNOWN_ERRORS = [new InvalidSyntaxError(new SourceLocation(666, 664), "Yikes")]
-    def EXPECTED_SPEC_ERRORS = [['message': 'Yikes', 'locations': [[line: 666, column: 664]]]]
+    def EXPECTED_SPEC_ERRORS = [['message': 'Yikes', 'locations': [[line: 666, column: 664]], extensions:[classification:"InvalidSyntax"]]]
 
 
     def "data with no errors"() {
@@ -124,8 +124,8 @@ class ExecutionResultImplTest extends Specification {
 
         specMap.size() == 1
         specMap["errors"] == [
-                ['message': 'Yikes', 'locations': [[line: 666, column: 664]]],
-                ['message': 'Yowza', 'locations': [[line: 966, column: 964]]]
+                ['message': 'Yikes', 'locations': [[line: 666, column: 664]], extensions:[classification:"InvalidSyntax"]],
+                ['message': 'Yowza', 'locations': [[line: 966, column: 964]], extensions:[classification:"InvalidSyntax"]]
         ]
     }
 

--- a/src/test/groovy/graphql/GraphQLErrorTest.groovy
+++ b/src/test/groovy/graphql/GraphQLErrorTest.groovy
@@ -29,35 +29,41 @@ class GraphQLErrorTest extends Specification {
                 [
                         locations: [[line: 666, column: 999], [line: 333, column: 0]],
                         message  : "Validation error of type UnknownType: Test ValidationError",
+                        extensions:[classification:"ValidationError"],
                 ]
 
         new MissingRootTypeException("Mutations are not supported on this schema", null)               |
                 [
                         message: "Mutations are not supported on this schema",
+                        extensions:[classification:"OperationNotSupported"],
                 ]
 
         new InvalidSyntaxError(mkLocations(), "Not good syntax m'kay")                                 |
                 [
                         locations: [[line: 666, column: 999], [line: 333, column: 0]],
                         message  : "Not good syntax m'kay",
+                        extensions:[classification:"InvalidSyntax"],
                 ]
 
         new NonNullableFieldWasNullError(new NonNullableFieldWasNullException(mkTypeInfo(), mkPath())) |
                 [
                         message: 'Cannot return null for non-nullable type: \'__Schema\' (/heroes[0]/abilities/speed[4])',
                         path   : ["heroes", 0, "abilities", "speed", 4],
+                        extensions:[classification:"DataFetchingException"],
                 ]
 
         new SerializationError(mkPath(), new CoercingSerializeException("Bad coercing"))               |
                 [
                         message: "Can't serialize value (/heroes[0]/abilities/speed[4]) : Bad coercing",
                         path   : ["heroes", 0, "abilities", "speed", 4],
+                        extensions:[classification:"DataFetchingException"],
                 ]
 
         new ExceptionWhileDataFetching(mkPath(), new RuntimeException("Bang"), mkLocation(666, 999))   |
                 [locations: [[line: 666, column: 999]],
                  message  : "Exception while fetching data (/heroes[0]/abilities/speed[4]) : Bang",
                  path     : ["heroes", 0, "abilities", "speed", 4],
+                 extensions:[classification:"DataFetchingException"],
                 ]
 
     }

--- a/src/test/groovy/graphql/GraphqlErrorHelperTest.groovy
+++ b/src/test/groovy/graphql/GraphqlErrorHelperTest.groovy
@@ -1,0 +1,66 @@
+package graphql
+
+import graphql.language.SourceLocation
+import graphql.validation.ValidationError
+import graphql.validation.ValidationErrorType
+import spock.lang.Specification
+
+class GraphqlErrorHelperTest extends Specification {
+
+    class TestError implements GraphQLError {
+        @Override
+        String getMessage() {
+            return "test"
+        }
+
+        @Override
+        List<SourceLocation> getLocations() {
+            return [new SourceLocation(6, 9)]
+        }
+
+        @Override
+        ErrorClassification getErrorType() {
+            return new ErrorClassification() {
+                @Override
+                Object toSpecification(GraphQLError error) {
+                    return [statusCode: 200, reason: "Bad juj ju"]
+                }
+            }
+        }
+
+        @Override
+        Map<String, Object> getExtensions() {
+            return [extra: "extensionData"]
+        }
+    }
+
+    def "can turn error classifications into extensions"() {
+
+        def validationErr = new ValidationError(ValidationErrorType.InvalidFragmentType, new SourceLocation(6, 9), "Things are not valid")
+
+        when:
+        def specMap = GraphqlErrorHelper.toSpecification(validationErr)
+        then:
+        specMap == [
+                locations : [[line: 6, column: 9]],
+                message   : "Validation error of type InvalidFragmentType: Things are not valid",
+                extensions: [classification: "ValidationError"],
+
+        ]
+    }
+
+    def "can handle custom extensions and custom error classification"() {
+        when:
+        def specMap = GraphqlErrorHelper.toSpecification(new TestError())
+        then:
+        specMap == [extensions: [
+                extra         : "extensionData",
+                classification: [
+                        statusCode: 200,
+                        reason    : "Bad juj ju"
+                ]],
+                    locations : [[line: 6, column: 9]],
+                    message   : "test"
+        ]
+    }
+}


### PR DESCRIPTION
This now adds support in graphql-java for errors to put a `classification : objValue` into the `extensions` map of a graphql error.

This will be useful for downstream errors such that you can might have something like this as an error

```
{
   message : "Unable to make downstream call",
   extensions : {
      classification : {
           failureSystem : "http",
           statusCode : 403
   }
}
```
GraphqlErrors are still able to have their own "extensions".  This is just for the ErrorClassification aspect so that a standard error comes out with some sort of classification in the extensions
