### PR TITLE
Adds context onto ExecutionResultNode

### DIFF
--- a/src/main/java/graphql/execution/nextgen/result/ExecutionResultNode.java
+++ b/src/main/java/graphql/execution/nextgen/result/ExecutionResultNode.java
@@ -20,20 +20,34 @@ public abstract class ExecutionResultNode {
     private final NonNullableFieldWasNullException nonNullableFieldWasNullException;
     private final List<ExecutionResultNode> children;
     private final List<GraphQLError> errors;
+    private final Object context;
 
     protected ExecutionResultNode(FetchedValueAnalysis fetchedValueAnalysis,
                                   NonNullableFieldWasNullException nonNullableFieldWasNullException,
                                   List<ExecutionResultNode> children,
-                                  List<GraphQLError> errors) {
+                                  List<GraphQLError> errors,
+                                  Object context
+    ) {
         this.fetchedValueAnalysis = fetchedValueAnalysis;
         this.nonNullableFieldWasNullException = nonNullableFieldWasNullException;
         this.children = assertNotNull(children);
+        this.context = context;
         children.forEach(Assert::assertNotNull);
         this.errors = new ArrayList<>(errors);
     }
 
     public List<GraphQLError> getErrors() {
         return new ArrayList<>(errors);
+    }
+
+    /**
+     * Each node has a context object associated with it
+     *
+     * @return the context associated with this node
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T getContext() {
+        return (T) context;
     }
 
     /*
@@ -89,6 +103,15 @@ public abstract class ExecutionResultNode {
      */
     public abstract ExecutionResultNode withNewErrors(List<GraphQLError> errors);
 
+    /**
+     * Creates a new ExecutionResultNode of the same specific type with a new context associated with it
+     *
+     * @param context the new context for this result node
+     *
+     * @return a new ExecutionResultNode with the new context
+     */
+    public abstract ExecutionResultNode withNewContext(Object context);
+
 
     @Override
     public String toString() {
@@ -96,6 +119,7 @@ public abstract class ExecutionResultNode {
                 "fva=" + fetchedValueAnalysis +
                 ", children=" + children +
                 ", errors=" + errors +
+                ", ctx=" + context +
                 ", nonNullableEx=" + nonNullableFieldWasNullException +
                 '}';
     }

--- a/src/main/java/graphql/execution/nextgen/result/LeafExecutionResultNode.java
+++ b/src/main/java/graphql/execution/nextgen/result/LeafExecutionResultNode.java
@@ -21,7 +21,14 @@ public class LeafExecutionResultNode extends ExecutionResultNode {
     public LeafExecutionResultNode(FetchedValueAnalysis fetchedValueAnalysis,
                                    NonNullableFieldWasNullException nonNullableFieldWasNullException,
                                    List<GraphQLError> errors) {
-        super(fetchedValueAnalysis, nonNullableFieldWasNullException, Collections.emptyList(), errors);
+        this(fetchedValueAnalysis, nonNullableFieldWasNullException, errors, null);
+    }
+
+    private LeafExecutionResultNode(FetchedValueAnalysis fetchedValueAnalysis,
+                                    NonNullableFieldWasNullException nonNullableFieldWasNullException,
+                                    List<GraphQLError> errors,
+                                    Object context) {
+        super(fetchedValueAnalysis, nonNullableFieldWasNullException, Collections.emptyList(), errors, context);
     }
 
 
@@ -36,11 +43,16 @@ public class LeafExecutionResultNode extends ExecutionResultNode {
 
     @Override
     public ExecutionResultNode withNewFetchedValueAnalysis(FetchedValueAnalysis fetchedValueAnalysis) {
-        return new LeafExecutionResultNode(fetchedValueAnalysis, getNonNullableFieldWasNullException(), getErrors());
+        return new LeafExecutionResultNode(fetchedValueAnalysis, getNonNullableFieldWasNullException(), getErrors(), getContext());
     }
 
     @Override
     public ExecutionResultNode withNewErrors(List<GraphQLError> errors) {
-        return new LeafExecutionResultNode(getFetchedValueAnalysis(), getNonNullableFieldWasNullException(), new ArrayList<>(errors));
+        return new LeafExecutionResultNode(getFetchedValueAnalysis(), getNonNullableFieldWasNullException(), new ArrayList<>(errors), getContext());
+    }
+
+    @Override
+    public ExecutionResultNode withNewContext(Object context) {
+        return new LeafExecutionResultNode(getFetchedValueAnalysis(), getNonNullableFieldWasNullException(), getErrors(), context);
     }
 }

--- a/src/main/java/graphql/execution/nextgen/result/ListExecutionResultNode.java
+++ b/src/main/java/graphql/execution/nextgen/result/ListExecutionResultNode.java
@@ -20,21 +20,33 @@ public class ListExecutionResultNode extends ExecutionResultNode {
     public ListExecutionResultNode(FetchedValueAnalysis fetchedValueAnalysis,
                                    List<ExecutionResultNode> children,
                                    List<GraphQLError> errors) {
-        super(fetchedValueAnalysis, ResultNodesUtil.newNullableException(fetchedValueAnalysis, children), children, errors);
+        this(fetchedValueAnalysis, children, errors, null);
+    }
+
+    private ListExecutionResultNode(FetchedValueAnalysis fetchedValueAnalysis,
+                                    List<ExecutionResultNode> children,
+                                    List<GraphQLError> errors,
+                                    Object context) {
+        super(fetchedValueAnalysis, ResultNodesUtil.newNullableException(fetchedValueAnalysis, children), children, errors, context);
     }
 
     @Override
     public ExecutionResultNode withNewChildren(List<ExecutionResultNode> children) {
-        return new ListExecutionResultNode(getFetchedValueAnalysis(), children, getErrors());
+        return new ListExecutionResultNode(getFetchedValueAnalysis(), children, getErrors(), getContext());
     }
 
     @Override
     public ExecutionResultNode withNewFetchedValueAnalysis(FetchedValueAnalysis fetchedValueAnalysis) {
-        return new ListExecutionResultNode(fetchedValueAnalysis, getChildren(), getErrors());
+        return new ListExecutionResultNode(fetchedValueAnalysis, getChildren(), getErrors(), getContext());
     }
 
     @Override
     public ExecutionResultNode withNewErrors(List<GraphQLError> errors) {
-        return new ListExecutionResultNode(getFetchedValueAnalysis(), getChildren(), new ArrayList<>(errors));
+        return new ListExecutionResultNode(getFetchedValueAnalysis(), getChildren(), new ArrayList<>(errors), getContext());
+    }
+
+    @Override
+    public ExecutionResultNode withNewContext(Object context) {
+        return new ListExecutionResultNode(getFetchedValueAnalysis(), getChildren(), getErrors(), context);
     }
 }

--- a/src/main/java/graphql/execution/nextgen/result/ObjectExecutionResultNode.java
+++ b/src/main/java/graphql/execution/nextgen/result/ObjectExecutionResultNode.java
@@ -21,22 +21,34 @@ public class ObjectExecutionResultNode extends ExecutionResultNode {
     public ObjectExecutionResultNode(FetchedValueAnalysis fetchedValueAnalysis,
                                      List<ExecutionResultNode> children,
                                      List<GraphQLError> errors) {
-        super(fetchedValueAnalysis, ResultNodesUtil.newNullableException(fetchedValueAnalysis, children), children, errors);
+        this(fetchedValueAnalysis, children, errors, null);
+    }
+
+    protected ObjectExecutionResultNode(FetchedValueAnalysis fetchedValueAnalysis,
+                                        List<ExecutionResultNode> children,
+                                        List<GraphQLError> errors,
+                                        Object context) {
+        super(fetchedValueAnalysis, ResultNodesUtil.newNullableException(fetchedValueAnalysis, children), children, errors, context);
     }
 
 
     @Override
     public ObjectExecutionResultNode withNewChildren(List<ExecutionResultNode> children) {
-        return new ObjectExecutionResultNode(getFetchedValueAnalysis(), children, getErrors());
+        return new ObjectExecutionResultNode(getFetchedValueAnalysis(), children, getErrors(), getContext());
     }
 
     @Override
     public ExecutionResultNode withNewFetchedValueAnalysis(FetchedValueAnalysis fetchedValueAnalysis) {
-        return new ObjectExecutionResultNode(fetchedValueAnalysis, getChildren(), getErrors());
+        return new ObjectExecutionResultNode(fetchedValueAnalysis, getChildren(), getErrors(), getContext());
     }
 
     @Override
     public ExecutionResultNode withNewErrors(List<GraphQLError> errors) {
-        return new ObjectExecutionResultNode(getFetchedValueAnalysis(), getChildren(), new ArrayList<>(errors));
+        return new ObjectExecutionResultNode(getFetchedValueAnalysis(), getChildren(), new ArrayList<>(errors), getContext());
+    }
+
+    @Override
+    public ExecutionResultNode withNewContext(Object context) {
+        return new ObjectExecutionResultNode(getFetchedValueAnalysis(), getChildren(), getErrors(), context);
     }
 }

--- a/src/main/java/graphql/execution/nextgen/result/RootExecutionResultNode.java
+++ b/src/main/java/graphql/execution/nextgen/result/RootExecutionResultNode.java
@@ -11,13 +11,16 @@ import static graphql.Assert.assertShouldNeverHappen;
 
 public class RootExecutionResultNode extends ObjectExecutionResultNode {
 
-
-    public RootExecutionResultNode(List<ExecutionResultNode> children, List<GraphQLError> errors) {
-        super(null, children, errors);
+    public RootExecutionResultNode(List<ExecutionResultNode> children) {
+        this(children, Collections.emptyList());
     }
 
-    public RootExecutionResultNode(List<ExecutionResultNode> children) {
-        super(null, children, Collections.emptyList());
+    public RootExecutionResultNode(List<ExecutionResultNode> children, List<GraphQLError> errors) {
+        this(children, errors, null);
+    }
+
+    private RootExecutionResultNode(List<ExecutionResultNode> children, List<GraphQLError> errors, Object context) {
+        super(null, children, errors, context);
     }
 
 
@@ -28,7 +31,7 @@ public class RootExecutionResultNode extends ObjectExecutionResultNode {
 
     @Override
     public RootExecutionResultNode withNewChildren(List<ExecutionResultNode> children) {
-        return new RootExecutionResultNode(children, getErrors());
+        return new RootExecutionResultNode(children, getErrors(), getContext());
     }
 
     @Override
@@ -38,6 +41,11 @@ public class RootExecutionResultNode extends ObjectExecutionResultNode {
 
     @Override
     public ExecutionResultNode withNewErrors(List<GraphQLError> errors) {
-        return new RootExecutionResultNode(getChildren(), new ArrayList<>(errors));
+        return new RootExecutionResultNode(getChildren(), new ArrayList<>(errors), getContext());
+    }
+
+    @Override
+    public ExecutionResultNode withNewContext(Object context) {
+        return new RootExecutionResultNode(getChildren(), getErrors(), context);
     }
 }

--- a/src/test/groovy/graphql/execution/nextgen/result/ExecutionResultNodeTest.groovy
+++ b/src/test/groovy/graphql/execution/nextgen/result/ExecutionResultNodeTest.groovy
@@ -86,4 +86,25 @@ class ExecutionResultNodeTest extends Specification {
         new ObjectExecutionResultNode(startingFetchValueAnalysis, startingChildren, startingErrors) | _
         new ListExecutionResultNode(startingFetchValueAnalysis, startingChildren, startingErrors)   | _
     }
+
+
+    @Unroll
+    def "construction of objects with new context works"() {
+
+        expect:
+        ExecutionResultNode nodeUnderTest = node
+        def className = node.getClass().getSimpleName()
+        node.getContext() == null
+        def newNode = nodeUnderTest.withNewContext(className)
+        newNode != nodeUnderTest
+        newNode.getContext() == className
+
+        where:
+
+        node                                                                                        | expectedValue
+        new RootExecutionResultNode(startingChildren, startingErrors)                               | _
+        new ObjectExecutionResultNode(startingFetchValueAnalysis, startingChildren, startingErrors) | _
+        new ListExecutionResultNode(startingFetchValueAnalysis, startingChildren, startingErrors)   | _
+        new LeafExecutionResultNode(startingFetchValueAnalysis, null, [])                           | _
+    }
 }


### PR DESCRIPTION
This adds a context object on ExecutionResultNode.

This is not needed for graphql-java but in Nadel we need to know the original "field information" as we map though to new hydrated and renamed fields.

The ExecutionResultNode tree is our structure and we need to be able to associated with those nodes extra data for later processing