### PR TITLE
The line numbers of elements are no longer off by one

### DIFF
--- a/src/main/java/graphql/language/Document.java
+++ b/src/main/java/graphql/language/Document.java
@@ -9,6 +9,7 @@ import graphql.util.TraverserContext;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 
@@ -36,6 +37,21 @@ public class Document extends AbstractNode<Document> {
 
     public List<Definition> getDefinitions() {
         return new ArrayList<>(definitions);
+    }
+
+    /**
+     * Returns a list of definitions of the specific type.  It uses {@link java.lang.Class#isAssignableFrom(Class)} for the test
+     *
+     * @param definitionClass the definition class
+     * @param <T>             the type of definition
+     *
+     * @return a list of definitions of that class or empty list
+     */
+    public <T extends Definition> List<T> getDefinitionsOfType(Class<T> definitionClass) {
+        return definitions.stream()
+                .filter(d -> definitionClass.isAssignableFrom(d.getClass()))
+                .map(definitionClass::cast)
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/graphql/language/SelectionSet.java
+++ b/src/main/java/graphql/language/SelectionSet.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 
@@ -37,6 +38,21 @@ public class SelectionSet extends AbstractNode<SelectionSet> {
 
     public List<Selection> getSelections() {
         return new ArrayList<>(selections);
+    }
+
+    /**
+     * Returns a list of selections of the specific type.  It uses {@link java.lang.Class#isAssignableFrom(Class)} for the test
+     *
+     * @param selectionClass the selection class
+     * @param <T>            the type of selection
+     *
+     * @return a list of selections of that class or empty list
+     */
+    public <T extends Selection> List<T> getSelectionsOfType(Class<T> selectionClass) {
+        return selections.stream()
+                .filter(d -> selectionClass.isAssignableFrom(d.getClass()))
+                .map(selectionClass::cast)
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -810,11 +810,7 @@ public class GraphqlAntlrToLanguage {
     }
 
     protected SourceLocation getSourceLocation(Token token) {
-        MultiSourceReader.SourceAndLine sourceAndLine = multiSourceReader.getSourceAndLineFromOverallLine(token.getLine());
-        int column = token.getCharPositionInLine() + 1;
-        // graphql spec says line numbers start at 1
-        int line = sourceAndLine.getLine() + 1;
-        return new SourceLocation(line, column, sourceAndLine.getSourceName());
+        return SourceLocationHelper.mkSourceLocation(multiSourceReader, token);
     }
 
     protected SourceLocation getSourceLocation(ParserRuleContext parserRuleContext) {

--- a/src/main/java/graphql/parser/MultiSourceReader.java
+++ b/src/main/java/graphql/parser/MultiSourceReader.java
@@ -79,6 +79,14 @@ public class MultiSourceReader extends Reader {
         public int getLine() {
             return line;
         }
+
+        @Override
+        public String toString() {
+            return "SourceAndLine{" +
+                    "sourceName='" + sourceName + '\'' +
+                    ", line=" + line +
+                    '}';
+        }
     }
 
     /**
@@ -95,6 +103,11 @@ public class MultiSourceReader extends Reader {
         if (sourceParts.isEmpty()) {
             return sourceAndLine;
         }
+        if (overallLineNumber == 0) {
+            sourceAndLine.sourceName = sourceParts.get(0).sourceName;
+            sourceAndLine.line = 0;
+            return sourceAndLine;
+        }
         SourcePart currentPart;
         if (currentIndex >= sourceParts.size()) {
             currentPart = sourceParts.get(sourceParts.size() - 1);
@@ -107,9 +120,9 @@ public class MultiSourceReader extends Reader {
             sourceAndLine.sourceName = sourcePart.sourceName;
             if (sourcePart == currentPart) {
                 // we cant go any further
-                int offset = currentPart.lineReader.getLineNumber();
+                int partLineNumber = currentPart.lineReader.getLineNumber();
                 previousPage = page;
-                page += offset;
+                page += partLineNumber;
                 if (page > overallLineNumber) {
                     sourceAndLine.line = overallLineNumber - previousPage;
                 } else {
@@ -118,7 +131,8 @@ public class MultiSourceReader extends Reader {
                 return sourceAndLine;
             } else {
                 previousPage = page;
-                page += sourcePart.lineReader.getLineNumber();
+                int partLineNumber = sourcePart.lineReader.getLineNumber();
+                page += partLineNumber;
                 if (page > overallLineNumber) {
                     sourceAndLine.line = overallLineNumber - previousPage;
                     return sourceAndLine;

--- a/src/main/java/graphql/parser/SourceLocationHelper.java
+++ b/src/main/java/graphql/parser/SourceLocationHelper.java
@@ -1,0 +1,23 @@
+package graphql.parser;
+
+import graphql.language.SourceLocation;
+import org.antlr.v4.runtime.Token;
+
+class SourceLocationHelper {
+
+    static SourceLocation mkSourceLocation(MultiSourceReader multiSourceReader, Token token) {
+        //
+        // multi source reader lines are 0 based while Antler lines are 1's based
+        //
+        // Antler columns ironically are 0 based - go figure!
+        //
+        int tokenLine = token.getLine() - 1;
+        MultiSourceReader.SourceAndLine sourceAndLine = multiSourceReader.getSourceAndLineFromOverallLine(tokenLine);
+        //
+        // graphql spec says line numbers and columns start at 1
+        int line = sourceAndLine.getLine() + 1;
+        int column = token.getCharPositionInLine() + 1;
+        return new SourceLocation(line, column, sourceAndLine.getSourceName());
+    }
+
+}

--- a/src/test/groovy/graphql/DataFetcherWithErrorsAndDataTest.groovy
+++ b/src/test/groovy/graphql/DataFetcherWithErrorsAndDataTest.groovy
@@ -108,7 +108,7 @@ class DataFetcherWithErrorsAndDataTest extends Specification {
         result.errors.size() == 1
         result.errors[0].path == ["root", "parent", "child", "badField"]
         result.errors[0].message == "badField is bad"
-        result.errors[0].locations == [new SourceLocation(7, 27)]
+        result.errors[0].locations == [new SourceLocation(6, 27)]
 
         result.data["root"]["parent"]["child"]["goodField"] == "good"
         result.data["root"]["parent"]["child"]["badField"] == null
@@ -191,10 +191,10 @@ class DataFetcherWithErrorsAndDataTest extends Specification {
         result.errors.size() == 2
         result.errors[0].path == ["root", "parent", "child", "goodField"]
         result.errors[0].message == "goodField is bad"
-        result.errors[0].locations == [new SourceLocation(8, 31)]
+        result.errors[0].locations == [new SourceLocation(7, 31)]
         result.errors[1].path == ["root", "parent", "child", "badField"]
         result.errors[1].message == "badField is bad"
-        result.errors[1].locations == [new SourceLocation(8, 31)]
+        result.errors[1].locations == [new SourceLocation(7, 31)]
 
         result.data["root"]["parent"]["child"]["goodField"] == null
         result.data["root"]["parent"]["child"]["badField"] == null
@@ -268,11 +268,11 @@ class DataFetcherWithErrorsAndDataTest extends Specification {
         result.errors.size() == 2
         result.errors[0].path == ["parent", "child"]
         result.errors[0].message == "error 1"
-        result.errors[0].locations == [new SourceLocation(7, 27)]
+        result.errors[0].locations == [new SourceLocation(6, 27)]
 
         result.errors[1].path == ["parent", "child"]
         result.errors[1].message == "error 2"
-        result.errors[1].locations == [new SourceLocation(7, 27)]
+        result.errors[1].locations == [new SourceLocation(6, 27)]
 
         result.data["parent"]["child"] == null
 
@@ -344,7 +344,7 @@ class DataFetcherWithErrorsAndDataTest extends Specification {
         result.errors.size() == 1
         result.errors[0].path == ["parent", "child", "badField"]
         result.errors[0].message == "badField is bad"
-        result.errors[0].locations == [new SourceLocation(7, 27)]
+        result.errors[0].locations == [new SourceLocation(6, 27)]
 
         result.data["parent"]["child"]["goodField"] == "good"
         result.data["parent"]["child"]["badField"] == null

--- a/src/test/groovy/graphql/GraphQLTest.groovy
+++ b/src/test/groovy/graphql/GraphQLTest.groovy
@@ -139,7 +139,7 @@ class GraphQLTest extends Specification {
         then:
         errors.size() == 1
         errors[0].errorType == ErrorType.InvalidSyntax
-        errors[0].locations == [new SourceLocation(1, 8)]
+        errors[0].locations == [new SourceLocation(1, 9)]
     }
 
     def "query with invalid syntax 2"() {
@@ -156,7 +156,7 @@ class GraphQLTest extends Specification {
         then:
         errors.size() == 1
         errors[0].errorType == ErrorType.InvalidSyntax
-        errors[0].locations == [new SourceLocation(1, 7)]
+        errors[0].locations == [new SourceLocation(1, 8)]
     }
 
     def "non null argument is missing"() {

--- a/src/test/groovy/graphql/IssueNonNullDefaultAttribute.groovy
+++ b/src/test/groovy/graphql/IssueNonNullDefaultAttribute.groovy
@@ -54,7 +54,7 @@ class IssueNonNullDefaultAttribute extends Specification {
         result.errors.size() == 1
         result.errors[0].errorType == ErrorType.ValidationError
         result.errors[0].message == "Validation error of type WrongType: argument 'characterNumber' with value 'NullValue{}' must not be null @ 'name'"
-        result.errors[0].locations == [new SourceLocation(4, 26)]
+        result.errors[0].locations == [new SourceLocation(3, 26)]
         result.data == null
 
     }

--- a/src/test/groovy/graphql/parser/LineNumberingTest.groovy
+++ b/src/test/groovy/graphql/parser/LineNumberingTest.groovy
@@ -1,0 +1,136 @@
+package graphql.parser
+
+import graphql.language.Field
+import graphql.language.FragmentDefinition
+import graphql.language.OperationDefinition
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/*
+   See https://github.com/graphql-java/graphql-java/issues/1512
+ */
+
+class LineNumberingTest extends Specification {
+
+    def "basic line numbering works as expected with string input"() {
+        def query = '''query X {
+   field1
+   field2
+   field3
+   field4
+}
+
+fragment X on Book {
+   frag1
+}
+
+'''
+
+        when:
+        def document = new Parser().parseDocument(query)
+        def queryOp = document.getDefinitionsOfType(OperationDefinition.class)[0]
+        then:
+        queryOp.getSourceLocation().getLine() == 1
+
+        when:
+        def field1 = queryOp.getSelectionSet().getSelectionsOfType(Field.class)[0]
+        then:
+        field1.getSourceLocation().getLine() == 2
+
+        when:
+        def field2 = queryOp.getSelectionSet().getSelectionsOfType(Field.class)[1]
+        then:
+        field2.getSourceLocation().getLine() == 3
+
+    }
+
+    def "multi source line numbering works as expected"() {
+        def queryBit1 = '''query X {
+   field1
+    field2  # note the extra space here
+   field3
+   field4
+}'''
+        def queryBit2 = '''fragment X on Book {
+   frag1
+    frag2 # note the extra space here
+   frag2
+}'''
+
+        MultiSourceReader msr = MultiSourceReader.newMultiSourceReader()
+                .string(queryBit1, "bit1")
+                .string(queryBit2, "bit2")
+                .build()
+
+        when:
+        def document = new Parser().parseDocument(msr)
+        then:
+        document.getSourceLocation().getLine() == 1
+        document.getSourceLocation().getColumn() == 1
+        document.getSourceLocation().getSourceName() == "bit1"
+
+        when:
+        def queryOp = document.getDefinitionsOfType(OperationDefinition.class)[0]
+        then:
+        queryOp.getSourceLocation().getLine() == 1
+        queryOp.getSourceLocation().getColumn() == 1
+        queryOp.getSourceLocation().getSourceName() == "bit1"
+
+        when:
+        def field1 = queryOp.getSelectionSet().getSelectionsOfType(Field.class)[0]
+        then:
+        field1.getSourceLocation().getLine() == 2
+        field1.getSourceLocation().getColumn() == 4
+        field1.getSourceLocation().getSourceName() == "bit1"
+
+        when:
+        def field2 = queryOp.getSelectionSet().getSelectionsOfType(Field.class)[1]
+        then:
+        field2.getSourceLocation().getLine() == 3
+        field2.getSourceLocation().getColumn() == 5
+        field2.getSourceLocation().getSourceName() == "bit1"
+
+        when:
+        def fragment = document.getDefinitionsOfType(FragmentDefinition.class)[0]
+        then:
+        fragment.getSourceLocation().getLine() == 1
+        fragment.getSourceLocation().getColumn() == 2
+        fragment.getSourceLocation().getSourceName() == "bit2"
+
+        when:
+        def fragField1 = fragment.getSelectionSet().getSelectionsOfType(Field.class)[0]
+        then:
+        fragField1.getSourceLocation().getLine() == 2
+        fragField1.getSourceLocation().getColumn() == 4
+        fragField1.getSourceLocation().getSourceName() == "bit2"
+
+        when:
+        def fragField2 = fragment.getSelectionSet().getSelectionsOfType(Field.class)[1]
+        then:
+        fragField2.getSourceLocation().getLine() == 3
+        fragField2.getSourceLocation().getColumn() == 5
+        fragField2.getSourceLocation().getSourceName() == "bit2"
+    }
+
+    @SuppressWarnings("GroovyVariableNotAssigned")
+    @Unroll
+    def "error is on the right line with string input"() {
+        expect:
+        def e
+        try {
+            new Parser().parseDocument(badQuery)
+            assert false, "Should have barfed"
+        } catch (InvalidSyntaxException ise) {
+            e = ise
+        }
+        e.getLocation().getLine() == line
+        e.getLocation().getColumn() == column
+        e.getLocation().getSourceName() == null
+
+        where:
+        badQuery                                | line | column
+        '''query X { field() field2'''          | 1    | 17
+        '''query X { field()\nfield2'''         | 1    | 17
+        '''query X { field\nfield2()\nfield3''' | 2    | 8
+    }
+}

--- a/src/test/groovy/graphql/parser/ParserExceptionTest.groovy
+++ b/src/test/groovy/graphql/parser/ParserExceptionTest.groovy
@@ -34,15 +34,15 @@ fragment X on SomeType {
         then:
         def e = thrown(InvalidSyntaxException)
 
-        e.location.line == 14
-        e.location.column == 4
-        e.sourcePreview == '''    fragField1
+        e.location.line == 13
+        e.location.column == 5
+        e.sourcePreview == '''fragment X on SomeType {
+    fragField1
     fragField2(syntaxErrorHere
     fragField3
     fragField4
     fragField5
 }
-        
 '''
     }
 
@@ -57,16 +57,16 @@ fragment X on SomeType {
         then:
         def e = thrown(InvalidSyntaxException)
 
-        e.location.line == 7
-        e.location.column == 4
+        e.location.line == 6
+        e.location.column == 5
         e.location.sourceName == "part2"
-        e.sourcePreview == '''    fragField1
+        e.sourcePreview == '''fragment X on SomeType {
+    fragField1
     fragField2(syntaxErrorHere
     fragField3
     fragField4
     fragField5
 }
-        
 '''
     }
 
@@ -84,8 +84,8 @@ fragment X on SomeType {
         def e = thrown(InvalidSyntaxException)
         print e
 
-        e.location.line == 3
-        e.location.column == 12
+        e.location.line == 2
+        e.location.column == 13
         e.location.sourceName == "namedSource"
     }
 
@@ -97,7 +97,7 @@ fragment X on SomeType {
         def e = thrown(InvalidSyntaxException)
 
         e.location.line == 1
-        e.location.column == 39
+        e.location.column == 40
         e.location.sourceName == null
     }
 

--- a/src/test/groovy/graphql/parser/ParserTest.groovy
+++ b/src/test/groovy/graphql/parser/ParserTest.groovy
@@ -678,24 +678,25 @@ triple3 : """edge cases \\""" "" " \\"" \\" edge cases"""
 
     def "parse ignored chars"() {
         given:
-        def input = "{,\r me\n\t} ,"
+        def input = "{,\r me\n\t} ,\n"
 
         when:
         Document document = new Parser().parseDocument(input)
         def field = (document.definitions[0] as OperationDefinition).selectionSet.selections[0]
         then:
         field.getIgnoredChars().getLeft().size() == 3
-        field.getIgnoredChars().getLeft()[0] == new IgnoredChar(",", IgnoredChar.IgnoredCharKind.COMMA, new SourceLocation(2, 2))
-        field.getIgnoredChars().getLeft()[1] == new IgnoredChar("\r", IgnoredChar.IgnoredCharKind.CR, new SourceLocation(2, 3))
-        field.getIgnoredChars().getLeft()[2] == new IgnoredChar(" ", IgnoredChar.IgnoredCharKind.SPACE, new SourceLocation(2, 4))
+        field.getIgnoredChars().getLeft()[0] == new IgnoredChar(",", IgnoredChar.IgnoredCharKind.COMMA, new SourceLocation(1, 2))
+        field.getIgnoredChars().getLeft()[1] == new IgnoredChar("\r", IgnoredChar.IgnoredCharKind.CR, new SourceLocation(1, 3))
+        field.getIgnoredChars().getLeft()[2] == new IgnoredChar(" ", IgnoredChar.IgnoredCharKind.SPACE, new SourceLocation(1, 4))
 
         field.getIgnoredChars().getRight().size() == 2
-        field.getIgnoredChars().getRight()[0] == new IgnoredChar("\n", IgnoredChar.IgnoredCharKind.LF, new SourceLocation(2, 7))
-        field.getIgnoredChars().getRight()[1] == new IgnoredChar("\t", IgnoredChar.IgnoredCharKind.TAB, new SourceLocation(3, 1))
+        field.getIgnoredChars().getRight()[0] == new IgnoredChar("\n", IgnoredChar.IgnoredCharKind.LF, new SourceLocation(1, 7))
+        field.getIgnoredChars().getRight()[1] == new IgnoredChar("\t", IgnoredChar.IgnoredCharKind.TAB, new SourceLocation(2, 1))
 
-        document.getIgnoredChars().getRight().size() == 2
-        document.getIgnoredChars().getRight()[0] == new IgnoredChar(" ", IgnoredChar.IgnoredCharKind.SPACE, new SourceLocation(3, 3))
-        document.getIgnoredChars().getRight()[1] == new IgnoredChar(",", IgnoredChar.IgnoredCharKind.COMMA, new SourceLocation(3, 4))
+        document.getIgnoredChars().getRight().size() == 3
+        document.getIgnoredChars().getRight()[0] == new IgnoredChar(" ", IgnoredChar.IgnoredCharKind.SPACE, new SourceLocation(2, 3))
+        document.getIgnoredChars().getRight()[1] == new IgnoredChar(",", IgnoredChar.IgnoredCharKind.COMMA, new SourceLocation(2, 4))
+        document.getIgnoredChars().getRight()[2] == new IgnoredChar("\n", IgnoredChar.IgnoredCharKind.LF, new SourceLocation(2, 5))
     }
 
     def "parsed float with positive exponent"() {

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -641,7 +641,7 @@ class SchemaGeneratorTest extends Specification {
 
         then:
         def err = thrown(NotAnInputTypeError.class)
-        err.message == "The type 'CharacterInput' [@12:13] is not an input type, but was used as an input type [@8:42]"
+        err.message == "The type 'CharacterInput' [@11:13] is not an input type, but was used as an input type [@7:42]"
     }
 
     def "InputType used as type should throw appropriate error #425"() {
@@ -666,7 +666,7 @@ class SchemaGeneratorTest extends Specification {
 
         then:
         def err = thrown(NotAnOutputTypeError.class)
-        err.message == "The type 'CharacterInput' [@12:13] is not an output type, but was used to declare the output type of a field [@8:32]"
+        err.message == "The type 'CharacterInput' [@11:13] is not an output type, but was used to declare the output type of a field [@7:32]"
     }
 
     def "schema with subscription"() {

--- a/src/test/groovy/graphql/validation/rules/ExecutableDefinitionsTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/ExecutableDefinitionsTest.groovy
@@ -27,7 +27,7 @@ class ExecutableDefinitionsTest extends Specification {
     }
 
     def 'Executable Definitions with operation and fragment'() {
-        def query = """\
+        def query = """
               query Foo {
                 dog {
                   name
@@ -47,7 +47,7 @@ class ExecutableDefinitionsTest extends Specification {
     }
 
     def 'Executable Definitions with type definition'() {
-        def query = """\
+        def query = """
               query Foo {
                 dog {
                   name
@@ -74,7 +74,7 @@ class ExecutableDefinitionsTest extends Specification {
     }
 
     def 'Executable Definitions with schema definition'() {
-        def query = """\
+        def query = """
               schema {
                 query: QueryRoot
               }
@@ -94,7 +94,7 @@ class ExecutableDefinitionsTest extends Specification {
     }
 
     def 'Executable Definitions with input value type definition'() {
-        def query = """\
+        def query = """
             type QueryRoot {               
                 getDog(id: String!): String
             }

--- a/src/test/groovy/graphql/validation/rules/OverlappingFieldsCanBeMergedTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/OverlappingFieldsCanBeMergedTest.groovy
@@ -74,7 +74,7 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
         then:
         errorCollector.getErrors().size() == 1
         errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: myName: name and nickname are different fields @ 'f'"
-        errorCollector.getErrors()[0].locations == [new SourceLocation(4, 17), new SourceLocation(5, 17)]
+        errorCollector.getErrors()[0].locations == [new SourceLocation(3, 17), new SourceLocation(4, 17)]
     }
 
     GraphQLSchema unionSchema() {
@@ -314,7 +314,7 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
         then:
         errorCollector.getErrors().size() == 1
         errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: fido: name and nickname are different fields @ 'sameAliasesWithDifferentFieldTargets'"
-        errorCollector.getErrors()[0].locations == [new SourceLocation(4, 13), new SourceLocation(5, 13)]
+        errorCollector.getErrors()[0].locations == [new SourceLocation(3, 13), new SourceLocation(4, 13)]
     }
 
     def 'Alias masking direct field access'() {
@@ -331,7 +331,7 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
         then:
         errorCollector.getErrors().size() == 1
         errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: name: nickname and name are different fields @ 'aliasMaskingDirectFieldAccess'"
-        errorCollector.getErrors()[0].locations == [new SourceLocation(4, 13), new SourceLocation(5, 13)]
+        errorCollector.getErrors()[0].locations == [new SourceLocation(3, 13), new SourceLocation(4, 13)]
     }
 
     def 'conflicting args'() {
@@ -348,7 +348,7 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
         then:
         errorCollector.getErrors().size() == 1
         errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: doesKnowCommand: they have differing arguments @ 'conflictingArgs'"
-        errorCollector.getErrors()[0].locations == [new SourceLocation(4, 13), new SourceLocation(5, 13)]
+        errorCollector.getErrors()[0].locations == [new SourceLocation(3, 13), new SourceLocation(4, 13)]
     }
 
     //
@@ -391,7 +391,7 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
         then:
         errorCollector.getErrors().size() == 1
         errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: x: a and b are different fields"
-        errorCollector.getErrors()[0].locations == [new SourceLocation(8, 13), new SourceLocation(11, 13)]
+        errorCollector.getErrors()[0].locations == [new SourceLocation(7, 13), new SourceLocation(10, 13)]
     }
 
     def 'reports each conflict once'() {
@@ -425,13 +425,13 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
         errorCollector.getErrors().size() == 3
 
         errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: x: a and b are different fields @ 'f1'"
-        errorCollector.getErrors()[0].locations == [new SourceLocation(19, 13), new SourceLocation(22, 13)]
+        errorCollector.getErrors()[0].locations == [new SourceLocation(18, 13), new SourceLocation(21, 13)]
 
         errorCollector.getErrors()[1].message == "Validation error of type FieldsConflict: x: a and c are different fields @ 'f3'"
-        errorCollector.getErrors()[1].locations == [new SourceLocation(19, 13), new SourceLocation(15, 17)]
+        errorCollector.getErrors()[1].locations == [new SourceLocation(18, 13), new SourceLocation(14, 17)]
 
         errorCollector.getErrors()[2].message == "Validation error of type FieldsConflict: x: b and c are different fields @ 'f3'"
-        errorCollector.getErrors()[2].locations == [new SourceLocation(22, 13), new SourceLocation(15, 17)]
+        errorCollector.getErrors()[2].locations == [new SourceLocation(21, 13), new SourceLocation(14, 17)]
     }
 
 

--- a/src/test/groovy/graphql/validation/rules/UniqueDirectiveNamesPerLocationTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/UniqueDirectiveNamesPerLocationTest.groovy
@@ -32,7 +32,7 @@ class UniqueDirectiveNamesPerLocationTest extends Specification {
         then:
         !validationErrors.empty
         validationErrors.size() == 1
-        assertDuplicateDirectiveName("upper", "FragmentDefinition", 13, 39, validationErrors[0])
+        assertDuplicateDirectiveName("upper", "FragmentDefinition", 12, 39, validationErrors[0])
     }
 
     def '5.7.3 Directives Are Unique Per Location - OperationDefinition'() {
@@ -57,7 +57,7 @@ class UniqueDirectiveNamesPerLocationTest extends Specification {
         then:
         !validationErrors.empty
         validationErrors.size() == 1
-        assertDuplicateDirectiveName("upper", "OperationDefinition", 3, 29, validationErrors[0])
+        assertDuplicateDirectiveName("upper", "OperationDefinition", 2, 29, validationErrors[0])
     }
 
     def '5.7.3 Directives Are Unique Per Location - Field'() {
@@ -82,7 +82,7 @@ class UniqueDirectiveNamesPerLocationTest extends Specification {
         then:
         !validationErrors.empty
         validationErrors.size() == 1
-        assertDuplicateDirectiveName("upper", "Field", 5, 28, validationErrors[0])
+        assertDuplicateDirectiveName("upper", "Field", 4, 28, validationErrors[0])
     }
 
     def '5.7.3 Directives Are Unique Per Location - FragmentSpread'() {
@@ -107,7 +107,7 @@ class UniqueDirectiveNamesPerLocationTest extends Specification {
         then:
         !validationErrors.empty
         validationErrors.size() == 1
-        assertDuplicateDirectiveName("upper", "FragmentSpread", 6, 35, validationErrors[0])
+        assertDuplicateDirectiveName("upper", "FragmentSpread", 5, 35, validationErrors[0])
     }
 
     def '5.7.3 Directives Are Unique Per Location - InlineFragment'() {
@@ -132,7 +132,7 @@ class UniqueDirectiveNamesPerLocationTest extends Specification {
         then:
         !validationErrors.empty
         validationErrors.size() == 1
-        assertDuplicateDirectiveName("upper", "InlineFragment", 7, 27, validationErrors[0])
+        assertDuplicateDirectiveName("upper", "InlineFragment", 6, 27, validationErrors[0])
     }
 
 

--- a/src/test/groovy/graphql/validation/rules/UniqueOperationNamesTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/UniqueOperationNamesTest.groovy
@@ -13,7 +13,7 @@ import static graphql.validation.rules.UniqueOperationNames.duplicateOperationNa
 class UniqueOperationNamesTest extends Specification {
 
     def '5.1.1.1 Operation Name Uniqueness Not Valid'() {
-        def query = """\
+        def query = """
         query getName {
             dog {
                 name
@@ -38,7 +38,7 @@ class UniqueOperationNamesTest extends Specification {
     }
 
     def '5.1.1.1 Operation Name Uniqueness Not Valid Different Operations'() {
-        def query = """\
+        def query = """
         query dogOperation {
             dog {
                 name


### PR DESCRIPTION
see #1512 

The previous multi source line reader work was a bit hasty in how it calculated line numbers.

Antler is 1s based while the multi source reader is zeroes based - so we got out by one

And then the tests got updated to reflect it - even though it was wrong in practice

This corrects that