### PR TITLE
add equals/hashcode to merged field

### DIFF
--- a/src/main/java/graphql/execution/MergedField.java
+++ b/src/main/java/graphql/execution/MergedField.java
@@ -6,6 +6,7 @@ import graphql.language.Field;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotEmpty;
@@ -165,6 +166,23 @@ public class MergedField {
         }
 
 
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MergedField that = (MergedField) o;
+        return fields.equals(that.fields);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fields);
     }
 
     @Override


### PR DESCRIPTION
A MergedField is just a collection of Field without a real identity behind the list of field it contains. So two MergedField should be considered equal when the lists a equal.