### PR TITLE
Fix schemadiff input recursion

### DIFF
--- a/src/main/java/graphql/schema/diff/SchemaDiff.java
+++ b/src/main/java/graphql/schema/diff/SchemaDiff.java
@@ -859,6 +859,6 @@ public class SchemaDiff {
     }
 
     private String mkDotName(String... objectNames) {
-        return Arrays.stream(objectNames).collect(Collectors.joining("."));
+        return String.join(".", objectNames);
     }
 }

--- a/src/main/java/graphql/schema/diff/SchemaDiff.java
+++ b/src/main/java/graphql/schema/diff/SchemaDiff.java
@@ -390,6 +390,11 @@ public class SchemaDiff {
                                     oldField.getName(), getAstDesc(oldField.getType()), getAstDesc(newField.get().getType()))
                             .build());
                 }
+
+                //
+                // recurse via input types
+                //
+                checkType( ctx, oldField.getType(), newField.get().getType() );
             }
         }
 

--- a/src/test/groovy/graphql/schema/diff/SchemaDiffTest.groovy
+++ b/src/test/groovy/graphql/schema/diff/SchemaDiffTest.groovy
@@ -317,6 +317,21 @@ class SchemaDiffTest extends Specification {
 
     }
 
+    def "changed nested input object field types"() {
+        DiffSet diffSet = diffSet("schema_changed_nested_input_object_fields.graphqls")
+
+        def diff = new SchemaDiff()
+        diff.diffSchema(diffSet, chainedReporter)
+
+        expect:
+        reporter.breakageCount == 1
+        reporter.breakages[0].category == DiffCategory.INVALID
+        reporter.breakages[0].typeName == 'NestedInput'
+        reporter.breakages[0].typeKind == TypeKind.InputObject
+        reporter.breakages[0].fieldName == 'nestedInput'
+
+    }
+
     def "changed input object field types"() {
         DiffSet diffSet = diffSet("schema_changed_input_object_fields.graphqls")
 

--- a/src/test/resources/diff/schema_ABaseLine.graphqls
+++ b/src/test/resources/diff/schema_ABaseLine.graphqls
@@ -24,6 +24,11 @@ type Mutation {
 input Questor {
     beingID : ID
     queryTarget : String
+    nestedInput : NestedInput
+}
+
+input NestedInput {
+    nestedInput: String
 }
 
 scalar CustomScalar

--- a/src/test/resources/diff/schema_changed_field_arguments.graphqls
+++ b/src/test/resources/diff/schema_changed_field_arguments.graphqls
@@ -25,6 +25,11 @@ type Mutation {
 input Questor {
     beingID : ID
     queryTarget : String
+    nestedInput : NestedInput
+}
+
+input NestedInput {
+    nestedInput: String
 }
 
 scalar CustomScalar

--- a/src/test/resources/diff/schema_changed_input_object_fields.graphqls
+++ b/src/test/resources/diff/schema_changed_input_object_fields.graphqls
@@ -24,7 +24,12 @@ type Mutation {
 input Questor {
     beingID : ID
     queryTarget : Int
+    nestedInput : NestedInput
     newMandatoryField : String!
+}
+
+input NestedInput {
+    nestedInput: String
 }
 
 scalar CustomScalar

--- a/src/test/resources/diff/schema_changed_nested_input_object_fields.graphqls
+++ b/src/test/resources/diff/schema_changed_nested_input_object_fields.graphqls
@@ -28,7 +28,7 @@ input Questor {
 }
 
 input NestedInput {
-    nestedInput: String
+    nestedInput: Int
 }
 
 scalar CustomScalar
@@ -45,7 +45,6 @@ interface Being {
 type Ainur implements Being {
     id : ID
     name : String
-    surname : String
     nameInQuenyan : String
     invitedBy(id : ID) : Being
     loves : String
@@ -59,7 +58,7 @@ type Istari implements Being {
     invitedBy(id : ID) : Being
     colour : String
     temperament : Temperament!
-
+    
 }
 
 type Deity implements Being {

--- a/src/test/resources/diff/schema_changed_object_fields.graphqls
+++ b/src/test/resources/diff/schema_changed_object_fields.graphqls
@@ -30,6 +30,11 @@ type Mutation {
 input Questor {
     beingID : ID
     queryTarget : String
+    nestedInput : NestedInput
+}
+
+input NestedInput {
+    nestedInput: String
 }
 
 scalar CustomScalar

--- a/src/test/resources/diff/schema_changed_type_kind.graphqls
+++ b/src/test/resources/diff/schema_changed_type_kind.graphqls
@@ -24,6 +24,11 @@ type Mutation {
 input Questor {
     beingID : ID
     queryTarget : String
+    nestedInput : NestedInput
+}
+
+input NestedInput {
+    nestedInput: String
 }
 
 scalar CustomScalar

--- a/src/test/resources/diff/schema_dangerous_changes.graphqls
+++ b/src/test/resources/diff/schema_dangerous_changes.graphqls
@@ -24,6 +24,11 @@ type Mutation {
 input Questor {
     beingID : ID
     queryTarget : String
+    nestedInput : NestedInput
+}
+
+input NestedInput {
+    nestedInput: String
 }
 
 scalar CustomScalar

--- a/src/test/resources/diff/schema_interface_fields_missing.graphqls
+++ b/src/test/resources/diff/schema_interface_fields_missing.graphqls
@@ -24,6 +24,11 @@ type Mutation {
 input Questor {
     beingID : ID
     queryTarget : String
+    nestedInput : NestedInput
+}
+
+input NestedInput {
+    nestedInput: String
 }
 
 scalar CustomScalar

--- a/src/test/resources/diff/schema_missing_enum_value.graphqls
+++ b/src/test/resources/diff/schema_missing_enum_value.graphqls
@@ -24,6 +24,11 @@ type Mutation {
 input Questor {
     beingID : ID
     queryTarget : String
+    nestedInput : NestedInput
+}
+
+input NestedInput {
+    nestedInput: String
 }
 
 scalar CustomScalar

--- a/src/test/resources/diff/schema_missing_field_arguments.graphqls
+++ b/src/test/resources/diff/schema_missing_field_arguments.graphqls
@@ -26,6 +26,11 @@ type Mutation {
 input Questor {
     beingID : ID
     queryTarget : String
+    nestedInput : NestedInput
+}
+
+input NestedInput {
+    nestedInput: String
 }
 
 scalar CustomScalar

--- a/src/test/resources/diff/schema_missing_input_object_fields.graphqls
+++ b/src/test/resources/diff/schema_missing_input_object_fields.graphqls
@@ -24,6 +24,11 @@ type Mutation {
 input Questor {
     beingID : ID
     #queryTarget : String
+    nestedInput : NestedInput
+}
+
+input NestedInput {
+    nestedInput: String
 }
 
 scalar CustomScalar

--- a/src/test/resources/diff/schema_missing_object_fields.graphqls
+++ b/src/test/resources/diff/schema_missing_object_fields.graphqls
@@ -24,6 +24,11 @@ type Mutation {
 input Questor {
     beingID : ID
     queryTarget : String
+    nestedInput : NestedInput
+}
+
+input NestedInput {
+    nestedInput: String
 }
 
 scalar CustomScalar

--- a/src/test/resources/diff/schema_missing_operation.graphqls
+++ b/src/test/resources/diff/schema_missing_operation.graphqls
@@ -18,6 +18,11 @@ type Query {
 input Questor {
     beingID : ID
     queryTarget : String
+    nestedInput : NestedInput
+}
+
+input NestedInput {
+    nestedInput: String
 }
 
 scalar CustomScalar

--- a/src/test/resources/diff/schema_missing_union_members.graphqls
+++ b/src/test/resources/diff/schema_missing_union_members.graphqls
@@ -24,6 +24,11 @@ type Mutation {
 input Questor {
     beingID : ID
     queryTarget : String
+    nestedInput : NestedInput
+}
+
+input NestedInput {
+    nestedInput: String
 }
 
 scalar CustomScalar


### PR DESCRIPTION
Fixes #1503 .

Looks like there was a missing call to recurse down to nested input types.

The changes are mostly test file changes -- the contents are copied and pasted for every file with only minor changes 😬 