### PR TITLE
This changes directive wiring so that all directives are available 

### DIFF
--- a/src/main/java/graphql/schema/idl/RuntimeWiring.java
+++ b/src/main/java/graphql/schema/idl/RuntimeWiring.java
@@ -12,6 +12,7 @@ import graphql.schema.visibility.GraphqlFieldVisibility;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.UnaryOperator;
 
@@ -29,18 +30,20 @@ public class RuntimeWiring {
     private final Map<String, DataFetcher> defaultDataFetchers;
     private final Map<String, GraphQLScalarType> scalars;
     private final Map<String, TypeResolver> typeResolvers;
-    private final Map<String, SchemaDirectiveWiring> directiveWiring;
+    private final Map<String, SchemaDirectiveWiring> registeredDirectiveWiring;
+    private final List<SchemaDirectiveWiring> directiveWiring;
     private final WiringFactory wiringFactory;
     private final Map<String, EnumValuesProvider> enumValuesProviders;
     private final Collection<SchemaTransformer> schemaTransformers;
     private final GraphqlFieldVisibility fieldVisibility;
     private final GraphQLCodeRegistry codeRegistry;
 
-    private RuntimeWiring(Map<String, Map<String, DataFetcher>> dataFetchers, Map<String, DataFetcher> defaultDataFetchers, Map<String, GraphQLScalarType> scalars, Map<String, TypeResolver> typeResolvers, Map<String, SchemaDirectiveWiring> directiveWiring, Map<String, EnumValuesProvider> enumValuesProviders, WiringFactory wiringFactory, Collection<SchemaTransformer> schemaTransformers, GraphqlFieldVisibility fieldVisibility, GraphQLCodeRegistry codeRegistry) {
+    private RuntimeWiring(Map<String, Map<String, DataFetcher>> dataFetchers, Map<String, DataFetcher> defaultDataFetchers, Map<String, GraphQLScalarType> scalars, Map<String, TypeResolver> typeResolvers, Map<String, SchemaDirectiveWiring> registeredDirectiveWiring, List<SchemaDirectiveWiring> directiveWiring, Map<String, EnumValuesProvider> enumValuesProviders, WiringFactory wiringFactory, Collection<SchemaTransformer> schemaTransformers, GraphqlFieldVisibility fieldVisibility, GraphQLCodeRegistry codeRegistry) {
         this.dataFetchers = dataFetchers;
         this.defaultDataFetchers = defaultDataFetchers;
         this.scalars = scalars;
         this.typeResolvers = typeResolvers;
+        this.registeredDirectiveWiring = registeredDirectiveWiring;
         this.directiveWiring = directiveWiring;
         this.wiringFactory = wiringFactory;
         this.enumValuesProviders = enumValuesProviders;
@@ -92,7 +95,11 @@ public class RuntimeWiring {
         return fieldVisibility;
     }
 
-    public Map<String, SchemaDirectiveWiring> getDirectiveWiring() {
+    public Map<String, SchemaDirectiveWiring> getRegisteredDirectiveWiring() {
+        return registeredDirectiveWiring;
+    }
+
+    public List<SchemaDirectiveWiring> getDirectiveWiring() {
         return directiveWiring;
     }
 
@@ -107,7 +114,8 @@ public class RuntimeWiring {
         private final Map<String, GraphQLScalarType> scalars = new LinkedHashMap<>();
         private final Map<String, TypeResolver> typeResolvers = new LinkedHashMap<>();
         private final Map<String, EnumValuesProvider> enumValuesProviders = new LinkedHashMap<>();
-        private final Map<String, SchemaDirectiveWiring> directiveWiring = new LinkedHashMap<>();
+        private final Map<String, SchemaDirectiveWiring> registeredDirectiveWiring = new LinkedHashMap<>();
+        private final List<SchemaDirectiveWiring> directiveWiring = new ArrayList<>();
         private final Collection<SchemaTransformer> schemaTransformers = new ArrayList<>();
         private WiringFactory wiringFactory = new NoopWiringFactory();
         private GraphqlFieldVisibility fieldVisibility = DEFAULT_FIELD_VISIBILITY;
@@ -116,7 +124,7 @@ public class RuntimeWiring {
         private Builder() {
             ScalarInfo.STANDARD_SCALARS.forEach(this::scalar);
             // we give this out by default
-            directiveWiring.put(FetchSchemaDirectiveWiring.FETCH, new FetchSchemaDirectiveWiring());
+            registeredDirectiveWiring.put(FetchSchemaDirectiveWiring.FETCH, new FetchSchemaDirectiveWiring());
         }
 
         /**
@@ -232,16 +240,45 @@ public class RuntimeWiring {
 
         /**
          * This provides the wiring code for a named directive.
+         * <p>
+         * Note: The provided directive wiring will ONLY be called back if an element has a directive
+         * with the specified name.
+         * <p>
+         * To be called back for every directive the use {@link #directiveWiring(SchemaDirectiveWiring)} or
+         * use {@link graphql.schema.idl.WiringFactory#providesSchemaDirectiveWiring(SchemaDirectiveWiringEnvironment)}
+         * instead.
          *
          * @param directiveName         the name of the directive to wire
          * @param schemaDirectiveWiring the runtime behaviour of this wiring
          *
          * @return the runtime wiring builder
          *
+         * @see #directiveWiring(SchemaDirectiveWiring)
          * @see graphql.schema.idl.SchemaDirectiveWiring
+         * @see graphql.schema.idl.WiringFactory#providesSchemaDirectiveWiring(SchemaDirectiveWiringEnvironment)
          */
         public Builder directive(String directiveName, SchemaDirectiveWiring schemaDirectiveWiring) {
-            directiveWiring.put(directiveName, schemaDirectiveWiring);
+            registeredDirectiveWiring.put(directiveName, schemaDirectiveWiring);
+            return this;
+        }
+
+        /**
+         * This adds a directive wiring that will be called for all directives.
+         * <p>
+         * Note : Unlike {@link #directive(String, SchemaDirectiveWiring)} which is only called back if a  named
+         * directives is present, this directive wiring will be called back for every element
+         * in the schema even if it has zero directives.
+         *
+         * @param schemaDirectiveWiring the runtime behaviour of this wiring
+         *
+         * @return the runtime wiring builder
+         *
+         * @see #directive(String, SchemaDirectiveWiring)
+         * @see graphql.schema.idl.SchemaDirectiveWiring
+         * @see graphql.schema.idl.WiringFactory#providesSchemaDirectiveWiring(SchemaDirectiveWiringEnvironment)
+         */
+        public Builder directiveWiring(SchemaDirectiveWiring schemaDirectiveWiring) {
+            directiveWiring.add(schemaDirectiveWiring);
             return this;
         }
 
@@ -261,7 +298,7 @@ public class RuntimeWiring {
          * @return the built runtime wiring
          */
         public RuntimeWiring build() {
-            return new RuntimeWiring(dataFetchers, defaultDataFetchers, scalars, typeResolvers, directiveWiring, enumValuesProviders, wiringFactory, schemaTransformers, fieldVisibility, codeRegistry);
+            return new RuntimeWiring(dataFetchers, defaultDataFetchers, scalars, typeResolvers, registeredDirectiveWiring, directiveWiring, enumValuesProviders, wiringFactory, schemaTransformers, fieldVisibility, codeRegistry);
         }
 
     }

--- a/src/main/java/graphql/schema/idl/SchemaDirectiveWiring.java
+++ b/src/main/java/graphql/schema/idl/SchemaDirectiveWiring.java
@@ -15,9 +15,17 @@ import graphql.schema.GraphQLUnionType;
 /**
  * A SchemaDirectiveWiring is responsible for enhancing a runtime element based on directives placed on that
  * element in the Schema Definition Language (SDL).
- *
+ * <p>
  * It can enhance the graphql runtime element and add new behaviour for example by changing
  * the fields {@link graphql.schema.DataFetcher}
+ * <p>
+ * The SchemaDirectiveWiring objects are called in a specific order based on registration:
+ * <ol>
+ * <li>{@link graphql.schema.idl.RuntimeWiring.Builder#directive(String, SchemaDirectiveWiring)} which work against a specific named directive are called first</li>
+ * <li>{@link graphql.schema.idl.RuntimeWiring.Builder#directiveWiring(SchemaDirectiveWiring)} which work against all directives are called next</li>
+ * <li>{@link graphql.schema.idl.WiringFactory#providesSchemaDirectiveWiring(SchemaDirectiveWiringEnvironment)} which work against all directives are called last</li>
+ * </ol>
+ * <p>
  */
 @PublicApi
 public interface SchemaDirectiveWiring {

--- a/src/main/java/graphql/schema/idl/SchemaDirectiveWiringEnvironment.java
+++ b/src/main/java/graphql/schema/idl/SchemaDirectiveWiringEnvironment.java
@@ -3,6 +3,7 @@ package graphql.schema.idl;
 import graphql.PublicApi;
 import graphql.language.NamedNode;
 import graphql.language.NodeParentTree;
+import graphql.schema.DataFetcher;
 import graphql.schema.GraphQLCodeRegistry;
 import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLDirectiveContainer;
@@ -27,9 +28,41 @@ public interface SchemaDirectiveWiringEnvironment<T extends GraphQLDirectiveCont
     T getElement();
 
     /**
-     * @return the directive that is being examined
+     * This returns the directive that the {@link graphql.schema.idl.SchemaDirectiveWiring} was registered
+     * against during calls to {@link graphql.schema.idl.RuntimeWiring.Builder#directive(String, SchemaDirectiveWiring)}
+     * <p>
+     * If this method of registration is not used (say because
+     * {@link graphql.schema.idl.WiringFactory#providesSchemaDirectiveWiring(SchemaDirectiveWiringEnvironment)} or
+     * {@link graphql.schema.idl.RuntimeWiring.Builder#directiveWiring(SchemaDirectiveWiring)} was used)
+     * then this will return null.
+     *
+     * @return the directive that was registered under specific directive name or null if it was not
+     * registered this way
      */
     GraphQLDirective getDirective();
+
+    /**
+     * @return all of the directives that are on the runtime element
+     */
+    Map<String, GraphQLDirective> getDirectives();
+
+    /**
+     * Returns a named directive or null
+     *
+     * @param directiveName the name of the directive
+     *
+     * @return a named directive or null
+     */
+    GraphQLDirective getDirective(String directiveName);
+
+    /**
+     * Returns true if the named directive is present
+     *
+     * @param directiveName the name of the directive
+     *
+     * @return true if the named directive is present
+     */
+    boolean containsDirective(String directiveName);
 
     /**
      * The node hierarchy depends on the element in question.  For example {@link graphql.language.ObjectTypeDefinition} nodes
@@ -70,8 +103,32 @@ public interface SchemaDirectiveWiringEnvironment<T extends GraphQLDirectiveCont
     GraphQLFieldsContainer getFieldsContainer();
 
     /**
-     * @return a {@link GraphQLFieldDefinition} when the element is one or is contained within one
+     * @return a {@link GraphQLFieldDefinition} when the element is as field or is contained within one
      */
     GraphQLFieldDefinition getFieldDefinition();
+
+    /**
+     * This is useful as a shortcut to get the current fields existing data fetcher
+     *
+     * @return a {@link graphql.schema.DataFetcher} when the element is as field or is contained within one
+     *
+     * @throws graphql.AssertException if there is not field in context at the time of the directive wiring callback
+     */
+    DataFetcher getFieldDataFetcher();
+
+    /**
+     * This is a shortcut method to set a new data fetcher in the underlying {@link graphql.schema.GraphQLCodeRegistry}
+     * against the current field.
+     * <p>
+     * Often schema directive wiring modify behaviour by wrapping or replacing data fetchers on
+     * fields.  This method is a helper to make this easier in code.
+     *
+     * @param newDataFetcher the new data fetcher to use for this field
+     *
+     * @return the environments {@link #getFieldDefinition()} to allow for a more fluent code style
+     *
+     * @throws graphql.AssertException if there is not field in context at the time of the directive wiring callback
+     */
+    GraphQLFieldDefinition setFieldDataFetcher(DataFetcher newDataFetcher);
 
 }

--- a/src/main/java/graphql/schema/idl/SchemaDirectiveWiringEnvironmentImpl.java
+++ b/src/main/java/graphql/schema/idl/SchemaDirectiveWiringEnvironmentImpl.java
@@ -3,20 +3,27 @@ package graphql.schema.idl;
 import graphql.Internal;
 import graphql.language.NamedNode;
 import graphql.language.NodeParentTree;
+import graphql.schema.DataFetcher;
+import graphql.schema.FieldCoordinates;
 import graphql.schema.GraphQLCodeRegistry;
 import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLDirectiveContainer;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLFieldsContainer;
 import graphql.schema.GraphqlElementParentTree;
+import graphql.util.FpKit;
 
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+
+import static graphql.Assert.assertNotNull;
 
 @Internal
 public class SchemaDirectiveWiringEnvironmentImpl<T extends GraphQLDirectiveContainer> implements SchemaDirectiveWiringEnvironment<T> {
 
     private final T element;
-    private final GraphQLDirective directive;
+    private final Map<String, GraphQLDirective> directives;
     private final NodeParentTree<NamedNode> nodeParentTree;
     private final TypeDefinitionRegistry typeDefinitionRegistry;
     private final Map<String, Object> context;
@@ -24,11 +31,13 @@ public class SchemaDirectiveWiringEnvironmentImpl<T extends GraphQLDirectiveCont
     private final GraphqlElementParentTree elementParentTree;
     private final GraphQLFieldsContainer fieldsContainer;
     private final GraphQLFieldDefinition fieldDefinition;
+    private final GraphQLDirective registeredDirective;
 
-    public SchemaDirectiveWiringEnvironmentImpl(T element, GraphQLDirective directive, SchemaGeneratorDirectiveHelper.Parameters parameters) {
+    public SchemaDirectiveWiringEnvironmentImpl(T element, List<GraphQLDirective> directives, GraphQLDirective registeredDirective, SchemaGeneratorDirectiveHelper.Parameters parameters) {
         this.element = element;
+        this.registeredDirective = registeredDirective;
         this.typeDefinitionRegistry = parameters.getTypeRegistry();
-        this.directive = directive;
+        this.directives = FpKit.getByName(directives, GraphQLDirective::getName);
         this.context = parameters.getContext();
         this.codeRegistry = parameters.getCodeRegistry();
         this.nodeParentTree = parameters.getNodeParentTree();
@@ -44,7 +53,22 @@ public class SchemaDirectiveWiringEnvironmentImpl<T extends GraphQLDirectiveCont
 
     @Override
     public GraphQLDirective getDirective() {
-        return directive;
+        return registeredDirective;
+    }
+
+    @Override
+    public Map<String, GraphQLDirective> getDirectives() {
+        return new LinkedHashMap<>(directives);
+    }
+
+    @Override
+    public GraphQLDirective getDirective(String directiveName) {
+        return directives.get(directiveName);
+    }
+
+    @Override
+    public boolean containsDirective(String directiveName) {
+        return directives.containsKey(directiveName);
     }
 
     @Override
@@ -79,6 +103,23 @@ public class SchemaDirectiveWiringEnvironmentImpl<T extends GraphQLDirectiveCont
 
     @Override
     public GraphQLFieldDefinition getFieldDefinition() {
+        return fieldDefinition;
+    }
+
+    @Override
+    public DataFetcher getFieldDataFetcher() {
+        assertNotNull(fieldDefinition, "An output field must be in context to call this method");
+        assertNotNull(fieldsContainer, "An output field container must be in context to call this method");
+        return codeRegistry.getDataFetcher(fieldsContainer, fieldDefinition);
+    }
+
+    @Override
+    public GraphQLFieldDefinition setFieldDataFetcher(DataFetcher newDataFetcher) {
+        assertNotNull(fieldDefinition, "An output field must be in context to call this method");
+        assertNotNull(fieldsContainer, "An output field container must be in context to call this method");
+
+        FieldCoordinates coordinates = FieldCoordinates.coordinates(fieldsContainer, fieldDefinition);
+        codeRegistry.dataFetcher(coordinates, newDataFetcher);
         return fieldDefinition;
     }
 }

--- a/src/main/java/graphql/schema/idl/SchemaGeneratorDirectiveHelper.java
+++ b/src/main/java/graphql/schema/idl/SchemaGeneratorDirectiveHelper.java
@@ -24,16 +24,15 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static graphql.Assert.assertNotNull;
 import static java.util.stream.Collectors.toList;
 
-@Internal
 /**
  * This contains the helper code that allows {@link graphql.schema.idl.SchemaDirectiveWiring} implementations
  * to be invoked during schema generation.
  */
+@Internal
 class SchemaGeneratorDirectiveHelper {
 
     static class Parameters {
@@ -162,8 +161,8 @@ class SchemaGeneratorDirectiveHelper {
         GraphqlElementParentTree elementParentTree = buildRuntimeTree(newObjectType);
         Parameters newParams = params.newParams(newObjectType, nodeParentTree, elementParentTree);
 
-        return wireForEachDirective(params, newObjectType, newObjectType.getDirectives(),
-                (outputElement, directive) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directive, newParams), SchemaDirectiveWiring::onObject);
+        return wireDirectives(params, newObjectType, newObjectType.getDirectives(),
+                (outputElement, directives, registeredDirective) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directives, registeredDirective, newParams), SchemaDirectiveWiring::onObject);
     }
 
     public GraphQLInterfaceType onInterface(GraphQLInterfaceType interfaceType, Parameters params) {
@@ -175,8 +174,8 @@ class SchemaGeneratorDirectiveHelper {
         GraphqlElementParentTree elementParentTree = buildRuntimeTree(newInterfaceType);
         Parameters newParams = params.newParams(newInterfaceType, nodeParentTree, elementParentTree);
 
-        return wireForEachDirective(params, newInterfaceType, newInterfaceType.getDirectives(),
-                (outputElement, directive) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directive, newParams), SchemaDirectiveWiring::onInterface);
+        return wireDirectives(params, newInterfaceType, newInterfaceType.getDirectives(),
+                (outputElement, directives, registeredDirective) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directives, registeredDirective, newParams), SchemaDirectiveWiring::onInterface);
     }
 
     public GraphQLEnumType onEnum(GraphQLEnumType enumType, Parameters params) {
@@ -197,8 +196,8 @@ class SchemaGeneratorDirectiveHelper {
         GraphqlElementParentTree elementParentTree = buildRuntimeTree(newEnumType);
         Parameters newParams = params.newParams(nodeParentTree, elementParentTree);
 
-        return wireForEachDirective(params, newEnumType, newEnumType.getDirectives(),
-                (outputElement, directive) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directive, newParams), SchemaDirectiveWiring::onEnum);
+        return wireDirectives(params, newEnumType, newEnumType.getDirectives(),
+                (outputElement, directives, registeredDirective) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directives, registeredDirective, newParams), SchemaDirectiveWiring::onEnum);
     }
 
     public GraphQLInputObjectType onInputObjectType(GraphQLInputObjectType inputObjectType, Parameters params) {
@@ -218,8 +217,8 @@ class SchemaGeneratorDirectiveHelper {
         GraphqlElementParentTree elementParentTree = buildRuntimeTree(newInputObjectType);
         Parameters newParams = params.newParams(nodeParentTree, elementParentTree);
 
-        return wireForEachDirective(params, newInputObjectType, newInputObjectType.getDirectives(),
-                (outputElement, directive) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directive, newParams), SchemaDirectiveWiring::onInputObjectType);
+        return wireDirectives(params, newInputObjectType, newInputObjectType.getDirectives(),
+                (outputElement, directives, registeredDirective) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directives, registeredDirective, newParams), SchemaDirectiveWiring::onInputObjectType);
     }
 
 
@@ -228,8 +227,8 @@ class SchemaGeneratorDirectiveHelper {
         GraphqlElementParentTree elementParentTree = buildRuntimeTree(element);
         Parameters newParams = params.newParams(nodeParentTree, elementParentTree);
 
-        return wireForEachDirective(params, element, element.getDirectives(),
-                (outputElement, directive) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directive, newParams), SchemaDirectiveWiring::onUnion);
+        return wireDirectives(params, element, element.getDirectives(),
+                (outputElement, directives, registeredDirective) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directives, registeredDirective, newParams), SchemaDirectiveWiring::onUnion);
     }
 
     public GraphQLScalarType onScalar(GraphQLScalarType element, Parameters params) {
@@ -237,28 +236,28 @@ class SchemaGeneratorDirectiveHelper {
         GraphqlElementParentTree elementParentTree = buildRuntimeTree(element);
         Parameters newParams = params.newParams(nodeParentTree, elementParentTree);
 
-        return wireForEachDirective(params, element, element.getDirectives(),
-                (outputElement, directive) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directive, newParams), SchemaDirectiveWiring::onScalar);
+        return wireDirectives(params, element, element.getDirectives(),
+                (outputElement, directives, registeredDirective) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directives, registeredDirective, newParams), SchemaDirectiveWiring::onScalar);
     }
 
     private GraphQLFieldDefinition onField(GraphQLFieldDefinition fieldDefinition, Parameters params) {
-        return wireForEachDirective(params, fieldDefinition, fieldDefinition.getDirectives(),
-                (outputElement, directive) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directive, params), SchemaDirectiveWiring::onField);
+        return wireDirectives(params, fieldDefinition, fieldDefinition.getDirectives(),
+                (outputElement, directives, registeredDirective) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directives, registeredDirective, params), SchemaDirectiveWiring::onField);
     }
 
     private GraphQLInputObjectField onInputObjectField(GraphQLInputObjectField element, Parameters params) {
-        return wireForEachDirective(params, element, element.getDirectives(),
-                (outputElement, directive) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directive, params), SchemaDirectiveWiring::onInputObjectField);
+        return wireDirectives(params, element, element.getDirectives(),
+                (outputElement, directives, registeredDirective) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directives, registeredDirective, params), SchemaDirectiveWiring::onInputObjectField);
     }
 
     private GraphQLEnumValueDefinition onEnumValue(GraphQLEnumValueDefinition enumValueDefinition, Parameters params) {
-        return wireForEachDirective(params, enumValueDefinition, enumValueDefinition.getDirectives(),
-                (outputElement, directive) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directive, params), SchemaDirectiveWiring::onEnumValue);
+        return wireDirectives(params, enumValueDefinition, enumValueDefinition.getDirectives(),
+                (outputElement, directives, registeredDirective) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directives, registeredDirective, params), SchemaDirectiveWiring::onEnumValue);
     }
 
     private GraphQLArgument onArgument(GraphQLArgument argument, Parameters params) {
-        return wireForEachDirective(params, argument, argument.getDirectives(),
-                (outputElement, directive) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directive, params), SchemaDirectiveWiring::onArgument);
+        return wireDirectives(params, argument, argument.getDirectives(),
+                (outputElement, directives, registeredDirective) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement, directives, registeredDirective, params), SchemaDirectiveWiring::onArgument);
     }
 
 
@@ -266,7 +265,7 @@ class SchemaGeneratorDirectiveHelper {
     // builds a type safe SchemaDirectiveWiringEnvironment
     //
     interface EnvBuilder<T extends GraphQLDirectiveContainer> {
-        SchemaDirectiveWiringEnvironment<T> apply(T outputElement, GraphQLDirective directive);
+        SchemaDirectiveWiringEnvironment<T> apply(T outputElement, List<GraphQLDirective> allDirectives, GraphQLDirective registeredDirective);
     }
 
     //
@@ -276,32 +275,48 @@ class SchemaGeneratorDirectiveHelper {
         T apply(SchemaDirectiveWiring schemaDirectiveWiring, SchemaDirectiveWiringEnvironment<T> env);
     }
 
-    private <T extends GraphQLDirectiveContainer> T wireForEachDirective(
-            Parameters parameters, T element, List<GraphQLDirective> directives,
-            EnvBuilder<T> envBuilder, EnvInvoker<T> invoker) {
+    private <T extends GraphQLDirectiveContainer> T wireDirectives(
+            Parameters parameters, T element,
+            List<GraphQLDirective> allDirectives,
+            EnvBuilder<T> envBuilder,
+            EnvInvoker<T> invoker) {
+
+        RuntimeWiring runtimeWiring = parameters.getRuntimeWiring();
+        WiringFactory wiringFactory = runtimeWiring.getWiringFactory();
+        SchemaDirectiveWiring schemaDirectiveWiring;
+
+        SchemaDirectiveWiringEnvironment<T> env;
         T outputObject = element;
-        for (GraphQLDirective directive : directives) {
-            SchemaDirectiveWiringEnvironment<T> env = envBuilder.apply(outputObject, directive);
-            Optional<SchemaDirectiveWiring> directiveWiring = discoverWiringProvider(parameters, directive.getName(), env);
-            if (directiveWiring.isPresent()) {
-                SchemaDirectiveWiring schemaDirectiveWiring = directiveWiring.get();
-                T newElement = invoker.apply(schemaDirectiveWiring, env);
-                assertNotNull(newElement, "The SchemaDirectiveWiring MUST return a non null return value for element '" + element.getName() + "'");
-                outputObject = newElement;
+        //
+        // first the specific named directives
+        Map<String, SchemaDirectiveWiring> mapOfWiring = runtimeWiring.getRegisteredDirectiveWiring();
+        for (GraphQLDirective directive : allDirectives) {
+            schemaDirectiveWiring = mapOfWiring.get(directive.getName());
+            if (schemaDirectiveWiring != null) {
+                env = envBuilder.apply(outputObject, allDirectives, directive);
+                outputObject = invokeWiring(outputObject, invoker, schemaDirectiveWiring, env);
             }
         }
+        //
+        // now call any statically added to the the runtime
+        for (SchemaDirectiveWiring directiveWiring : runtimeWiring.getDirectiveWiring()) {
+            env = envBuilder.apply(outputObject, allDirectives, null);
+            outputObject = invokeWiring(outputObject, invoker, directiveWiring, env);
+        }
+        //
+        // wiring factory is last (if present)
+        env = envBuilder.apply(outputObject, allDirectives, null);
+        if (wiringFactory.providesSchemaDirectiveWiring(env)) {
+            schemaDirectiveWiring = assertNotNull(wiringFactory.getSchemaDirectiveWiring(env), "Your WiringFactory MUST provide a non null SchemaDirectiveWiring");
+            outputObject = invokeWiring(outputObject, invoker, schemaDirectiveWiring, env);
+        }
+
         return outputObject;
     }
 
-    private <T extends GraphQLDirectiveContainer> Optional<SchemaDirectiveWiring> discoverWiringProvider(Parameters parameters, String directiveName, SchemaDirectiveWiringEnvironment<T> env) {
-        SchemaDirectiveWiring directiveWiring;
-        RuntimeWiring runtimeWiring = parameters.getRuntimeWiring();
-        WiringFactory wiringFactory = runtimeWiring.getWiringFactory();
-        if (wiringFactory.providesSchemaDirectiveWiring(env)) {
-            directiveWiring = assertNotNull(wiringFactory.getSchemaDirectiveWiring(env), "You MUST provide a non null SchemaDirectiveWiring");
-        } else {
-            directiveWiring = runtimeWiring.getDirectiveWiring().get(directiveName);
-        }
-        return Optional.ofNullable(directiveWiring);
+    private <T extends GraphQLDirectiveContainer> T invokeWiring(T element, EnvInvoker<T> invoker, SchemaDirectiveWiring schemaDirectiveWiring, SchemaDirectiveWiringEnvironment<T> env) {
+        T newElement = invoker.apply(schemaDirectiveWiring, env);
+        assertNotNull(newElement, "The SchemaDirectiveWiring MUST return a non null return value for element '" + element.getName() + "'");
+        return newElement;
     }
 }

--- a/src/main/java/graphql/schema/idl/WiringFactory.java
+++ b/src/main/java/graphql/schema/idl/WiringFactory.java
@@ -4,7 +4,6 @@ import graphql.PublicSpi;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetcherFactory;
 import graphql.schema.GraphQLScalarType;
-import graphql.schema.PropertyDataFetcher;
 import graphql.schema.TypeResolver;
 
 import static graphql.Assert.assertShouldNeverHappen;
@@ -106,10 +105,27 @@ public interface WiringFactory {
         return assertShouldNeverHappen();
     }
 
+    /**
+     * This is called to ask if this factory can provide a schema directive wiring.
+     * <p>
+     * {@link SchemaDirectiveWiringEnvironment#getDirectives()} contains all the directives
+     * available which may in fact be an empty list.
+     *
+     * @param environment the calling environment
+     *
+     * @return true if the factory can give out a schema directive wiring.
+     */
     default boolean providesSchemaDirectiveWiring(SchemaDirectiveWiringEnvironment environment) {
         return false;
     }
 
+    /**
+     * Returns a {@link graphql.schema.idl.SchemaDirectiveWiring} given the environment
+     *
+     * @param environment the calling environment
+     *
+     * @return a {@link graphql.schema.idl.SchemaDirectiveWiring}
+     */
     default SchemaDirectiveWiring getSchemaDirectiveWiring(SchemaDirectiveWiringEnvironment environment) {
         return assertShouldNeverHappen();
     }


### PR DESCRIPTION
This changes directive wiring so that all directives are available  during callbacks.

Its also changes the behavior of registration so that "named directive" wirings are called as before but the WiringFactory directive wiring is ALSO called last.  Before it was either one or the other but not both.

This is a behaviour breaking change (not a compilation one)

I also added some helper methods since "data fetcher" tweaking is the most common actions and hence you can now write code like

```
  public GraphQLFieldDefinition onField(SchemaDirectiveWiringEnvironment<GraphQLFieldDefinition> environment) {
            String targetAuthRole = (String) environment.getDirective().getArgument("role").getValue();

            //
            // build a data fetcher that first checks authorisation roles before then calling the original data fetcher
            //
            DataFetcher originalDataFetcher = environment.getFieldDataFetcher();
            DataFetcher authDataFetcher = new DataFetcher() {
                @Override
                public Object get(DataFetchingEnvironment dataFetchingEnvironment) throws Exception {
                    Map<String, Object> contextMap = dataFetchingEnvironment.getContext();
                    AuthorisationCtx authContext = (AuthorisationCtx) contextMap.get("authContext");

                    if (authContext.hasRole(targetAuthRole)) {
                        return originalDataFetcher.get(dataFetchingEnvironment);
                    } else {
                        return null;
                    }
                }
            };
            //
            // now change the field definition to have the new authorising data fetcher
            return environment.setFieldDataFetcher(authDataFetcher);
        }
```