### PR TITLE
add modificationType for NodeZipper to handle delete and insert

### DIFF
--- a/src/main/java/graphql/util/DefaultTraverserContext.java
+++ b/src/main/java/graphql/util/DefaultTraverserContext.java
@@ -76,6 +76,7 @@ public class DefaultTraverserContext<T> implements TraverserContext<T> {
         this.newNode = newNode;
     }
 
+
     @Override
     public void deleteNode() {
         assertNull(this.newNode, "node is already changed");
@@ -87,6 +88,12 @@ public class DefaultTraverserContext<T> implements TraverserContext<T> {
     public boolean isDeleted() {
         return this.nodeDeleted;
     }
+
+    @Override
+    public boolean isChanged() {
+        return this.newNode != null;
+    }
+
 
     @Override
     public TraverserContext<T> getParentContext() {

--- a/src/main/java/graphql/util/FpKit.java
+++ b/src/main/java/graphql/util/FpKit.java
@@ -164,4 +164,14 @@ public class FpKit {
         return findOne(list, filter).orElse(null);
     }
 
+    public static <T> int findIndex(List<T> list, Predicate<T> filter) {
+        for (int i = 0; i < list.size(); i++) {
+            if (filter.test(list.get(i))) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+
 }

--- a/src/main/java/graphql/util/NodeMultiZipper.java
+++ b/src/main/java/graphql/util/NodeMultiZipper.java
@@ -83,6 +83,15 @@ public class NodeMultiZipper<T> {
         return new NodeMultiZipper<>(commonRoot, newZippers, this.nodeAdapter);
     }
 
+    public NodeMultiZipper<T> withReplacedZipperForNode(T currentNode, T newNode) {
+        int index = FpKit.findIndex(zippers, zipper -> zipper.getCurNode() == currentNode);
+        assertTrue(index >= 0, "No current zipper found for provided node");
+        NodeZipper<T> newZipper = zippers.get(index).withNewNode(newNode);
+        List<NodeZipper<T>> newZippers = new ArrayList<>(zippers);
+        newZippers.set(index, newZipper);
+        return new NodeMultiZipper<>(commonRoot, newZippers, this.nodeAdapter);
+    }
+
 
     private List<NodeZipper<T>> getDeepestZippers(List<NodeZipper<T>> zippers) {
         Map<Integer, List<NodeZipper<T>>> grouped = FpKit.groupingBy(zippers, astZipper -> astZipper.getBreadcrumbs().size());

--- a/src/main/java/graphql/util/NodeMultiZipper.java
+++ b/src/main/java/graphql/util/NodeMultiZipper.java
@@ -123,12 +123,12 @@ public class NodeMultiZipper<T> {
                     childrenMap.get(name).remove(ix);
                     indexCorrection.put(name, ixDiff - 1);
                     break;
-                case INSERT_AFTER:
-                    childrenMap.get(name).add(ix + 1, zipper.getCurNode());
-                    indexCorrection.put(name, ixDiff + 1);
-                    break;
                 case INSERT_BEFORE:
                     childrenMap.get(name).add(ix, zipper.getCurNode());
+                    indexCorrection.put(name, ixDiff + 1);
+                    break;
+                case INSERT_AFTER:
+                    childrenMap.get(name).add(ix + 1, zipper.getCurNode());
                     indexCorrection.put(name, ixDiff + 1);
                     break;
             }

--- a/src/main/java/graphql/util/NodeMultiZipper.java
+++ b/src/main/java/graphql/util/NodeMultiZipper.java
@@ -115,15 +115,15 @@ public class NodeMultiZipper<T> {
                     break;
                 case DELETE:
                     childrenMap.get(name).remove(ix);
-                    indexCorrection.put(name, ix - 1);
+                    indexCorrection.put(name, ixDiff - 1);
                     break;
                 case INSERT_AFTER:
                     childrenMap.get(name).add(ix + 1, zipper.getCurNode());
-                    indexCorrection.put(name, ix + 1);
+                    indexCorrection.put(name, ixDiff + 1);
                     break;
                 case INSERT_BEFORE:
                     childrenMap.get(name).add(ix, zipper.getCurNode());
-                    indexCorrection.put(name, ix + 1);
+                    indexCorrection.put(name, ixDiff + 1);
                     break;
             }
 

--- a/src/main/java/graphql/util/NodeMultiZipper.java
+++ b/src/main/java/graphql/util/NodeMultiZipper.java
@@ -5,7 +5,6 @@ import graphql.PublicApi;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -96,13 +95,20 @@ public class NodeMultiZipper<T> {
         assertNotEmpty(sameParent, "expected at least one zipper");
 
         Map<String, List<T>> childrenMap = nodeAdapter.getNamedChildren(parent);
-        //first replace nodes
-        // delete node makes the list shorter inserting it after problem
-        // add increases in it, inserting it makes it hard
-
         Map<String, Integer> indexCorrection = new LinkedHashMap<>();
 
-        sameParent.sort(Comparator.comparingInt(zipper -> zipper.getBreadcrumbs().get(0).getLocation().getIndex()));
+        sameParent.sort((zipper1, zipper2) -> {
+            int index1 = zipper1.getBreadcrumbs().get(0).getLocation().getIndex();
+            int index2 = zipper2.getBreadcrumbs().get(0).getLocation().getIndex();
+            if (index1 != index2) {
+                return Integer.compare(index1, index2);
+            }
+            if (zipper1.getModificationType() == NodeZipper.ModificationType.INSERT_BEFORE) {
+                return zipper2.getModificationType() == NodeZipper.ModificationType.INSERT_BEFORE ? 0 : -1;
+            }
+            return zipper2.getModificationType() == NodeZipper.ModificationType.INSERT_BEFORE ? 1 : 0;
+
+        });
 
         for (NodeZipper<T> zipper : sameParent) {
             NodeLocation location = zipper.getBreadcrumbs().get(0).getLocation();

--- a/src/main/java/graphql/util/NodeZipper.java
+++ b/src/main/java/graphql/util/NodeZipper.java
@@ -103,11 +103,11 @@ public class NodeZipper<T> {
             case DELETE:
                 childrenForParent.get(name).remove(ix);
                 break;
-            case INSERT_AFTER:
-                childrenForParent.get(name).add(ix + 1, curNode);
-                break;
             case INSERT_BEFORE:
                 childrenForParent.get(name).add(ix, curNode);
+                break;
+            case INSERT_AFTER:
+                childrenForParent.get(name).add(ix + 1, curNode);
                 break;
         }
         curNode = nodeAdapter.withNewChildren(firstBreadcrumb.getNode(), childrenForParent);

--- a/src/main/java/graphql/util/NodeZipper.java
+++ b/src/main/java/graphql/util/NodeZipper.java
@@ -12,16 +12,35 @@ import static graphql.Assert.assertNotNull;
 @PublicApi
 public class NodeZipper<T> {
 
+
+    public enum ModificationType {
+        REPLACE,
+        DELETE,
+        INSERT_AFTER,
+        INSERT_BEFORE
+    }
+
     private final T curNode;
     private final NodeAdapter<T> nodeAdapter;
     // reverse: the breadCrumbs start from curNode upwards
     private final List<Breadcrumb<T>> breadcrumbs;
 
+    private final ModificationType modificationType;
+
 
     public NodeZipper(T curNode, List<Breadcrumb<T>> breadcrumbs, NodeAdapter<T> nodeAdapter) {
+        this(curNode, breadcrumbs, nodeAdapter, ModificationType.REPLACE);
+    }
+
+    public NodeZipper(T curNode, List<Breadcrumb<T>> breadcrumbs, NodeAdapter<T> nodeAdapter, ModificationType modificationType) {
         this.curNode = assertNotNull(curNode);
         this.breadcrumbs = assertNotNull(breadcrumbs);
         this.nodeAdapter = nodeAdapter;
+        this.modificationType = modificationType;
+    }
+
+    public ModificationType getModificationType() {
+        return modificationType;
     }
 
     public T getCurNode() {
@@ -44,6 +63,18 @@ public class NodeZipper<T> {
         return new NodeZipper<T>(transform.apply(curNode), breadcrumbs, nodeAdapter);
     }
 
+    public NodeZipper<T> deleteNode() {
+        return new NodeZipper<T>(this.curNode, breadcrumbs, nodeAdapter, ModificationType.DELETE);
+    }
+
+    public NodeZipper<T> insertAfter(T toInsertAfter) {
+        return new NodeZipper<T>(toInsertAfter, breadcrumbs, nodeAdapter, ModificationType.INSERT_AFTER);
+    }
+
+    public NodeZipper<T> insertBefore(T toInsertBefore) {
+        return new NodeZipper<T>(toInsertBefore, breadcrumbs, nodeAdapter, ModificationType.INSERT_BEFORE);
+    }
+
     public NodeZipper<T> withNewNode(T newNode) {
         return new NodeZipper<T>(newNode, breadcrumbs, nodeAdapter);
     }
@@ -55,8 +86,35 @@ public class NodeZipper<T> {
     }
 
     public T toRoot() {
+        if (breadcrumbs.size() == 0) {
+            return this.curNode;
+        }
         T curNode = this.curNode;
-        for (Breadcrumb<T> breadcrumb : breadcrumbs) {
+
+        Breadcrumb<T> firstBreadcrumb = breadcrumbs.get(0);
+        Map<String, List<T>> childrenForParent = nodeAdapter.getNamedChildren(firstBreadcrumb.getNode());
+        NodeLocation locationInParent = firstBreadcrumb.getLocation();
+        int ix = locationInParent.getIndex();
+        String name = locationInParent.getName();
+        switch (modificationType) {
+            case REPLACE:
+                childrenForParent.get(name).set(ix, curNode);
+                break;
+            case DELETE:
+                childrenForParent.get(name).remove(ix);
+                break;
+            case INSERT_AFTER:
+                childrenForParent.get(name).add(ix + 1, curNode);
+                break;
+            case INSERT_BEFORE:
+                childrenForParent.get(name).add(ix, curNode);
+                break;
+        }
+        curNode = nodeAdapter.withNewChildren(firstBreadcrumb.getNode(), childrenForParent);
+        if (breadcrumbs.size() == 1) {
+            return curNode;
+        }
+        for (Breadcrumb<T> breadcrumb : breadcrumbs.subList(1, breadcrumbs.size())) {
             // just handle replace
             Map<String, List<T>> newChildren = nodeAdapter.getNamedChildren(breadcrumb.getNode());
             final T newChild = curNode;

--- a/src/main/java/graphql/util/NodeZipper.java
+++ b/src/main/java/graphql/util/NodeZipper.java
@@ -60,7 +60,7 @@ public class NodeZipper<T> {
     }
 
     public NodeZipper<T> modifyNode(Function<T, T> transform) {
-        return new NodeZipper<T>(transform.apply(curNode), breadcrumbs, nodeAdapter);
+        return new NodeZipper<T>(transform.apply(curNode), breadcrumbs, nodeAdapter, this.modificationType);
     }
 
     public NodeZipper<T> deleteNode() {
@@ -76,13 +76,13 @@ public class NodeZipper<T> {
     }
 
     public NodeZipper<T> withNewNode(T newNode) {
-        return new NodeZipper<T>(newNode, breadcrumbs, nodeAdapter);
+        return new NodeZipper<T>(newNode, breadcrumbs, nodeAdapter, this.modificationType);
     }
 
     public NodeZipper<T> moveUp() {
         T node = getParent();
         List<Breadcrumb<T>> newBreadcrumbs = breadcrumbs.subList(1, breadcrumbs.size());
-        return new NodeZipper<>(node, newBreadcrumbs, nodeAdapter);
+        return new NodeZipper<>(node, newBreadcrumbs, nodeAdapter, this.modificationType);
     }
 
     public T toRoot() {

--- a/src/main/java/graphql/util/TraverserContext.java
+++ b/src/main/java/graphql/util/TraverserContext.java
@@ -54,9 +54,14 @@ public interface TraverserContext<T> {
     void deleteNode();
 
     /**
-     * @return true if the current node is deleted
+     * @return true if the current node is deleted (by calling {@link #deleteNode()}
      */
     boolean isDeleted();
+
+    /**
+     * @return true if the current node is changed (by calling {@link #changeNode(Object)}
+     */
+    boolean isChanged();
 
     /**
      * Returns parent context.

--- a/src/main/java/graphql/util/TraverserContext.java
+++ b/src/main/java/graphql/util/TraverserContext.java
@@ -149,7 +149,7 @@ public interface TraverserContext<T> {
     /**
      * Sets the new accumulate value.
      *
-     * Can be retrieved by getA
+     * Can be retrieved by {@link #getNewAccumulate()}
      *
      * @param accumulate to set
      */

--- a/src/main/java/graphql/util/TreeTransformerUtil.java
+++ b/src/main/java/graphql/util/TreeTransformerUtil.java
@@ -2,58 +2,37 @@ package graphql.util;
 
 import graphql.PublicApi;
 
-import java.util.function.Function;
-
-import static graphql.Assert.assertTrue;
-
 @PublicApi
 public class TreeTransformerUtil {
 
     public static <T> TraversalControl changeNode(TraverserContext<T> context, T changedNode) {
         NodeZipper<T> zipperWithChangedNode = context.getVar(NodeZipper.class).withNewNode(changedNode);
-        NodeMultiZipper<T> multiZipper = context.getCurrentAccumulate();
+        NodeMultiZipper<T> multiZipper = context.getNewAccumulate();
         context.setAccumulate(multiZipper.withNewZipper(zipperWithChangedNode));
         context.changeNode(changedNode);
         return TraversalControl.CONTINUE;
     }
 
     public static <T> TraversalControl deleteNode(TraverserContext<T> context) {
-        NodeZipper<T> curZipper = context.getVar(NodeZipper.class);
-        NodeAdapter<T> nodeAdaper = context.getVar(NodeAdapter.class);
-        NodeLocation nodeLocation = curZipper.getBreadcrumbs().get(0).getLocation();
-
-        changeParentNode(context, parentNode -> nodeAdaper.removeChild(parentNode, nodeLocation));
-
+        NodeZipper<T> deleteNodeZipper = context.getVar(NodeZipper.class).deleteNode();
+        NodeMultiZipper<T> multiZipper = context.getNewAccumulate();
+        context.setAccumulate(multiZipper.withNewZipper(deleteNodeZipper));
         context.deleteNode();
         return TraversalControl.CONTINUE;
     }
 
-    public static <T> TraversalControl changeParentNode(TraverserContext<T> context, Function<T, T> changeNodeFunction) {
-        assertTrue(context.getParentNode() != null, "can't delete root node");
-        NodeMultiZipper<T> multiZipper = context.getCurrentAccumulate();
-        NodeZipper<T> curZipper = context.getVar(NodeZipper.class);
-        NodeZipper<T> zipperForParent = multiZipper.getZipperForNode(curZipper.getParent());
-
-        boolean zipperForParentAlreadyExisted = true;
-        if (zipperForParent == null) {
-            zipperForParent = curZipper.moveUp();
-            zipperForParentAlreadyExisted = false;
-        }
-        T parentNode = zipperForParent.getCurNode();
-
-        T newParent = changeNodeFunction.apply(parentNode);
-
-        NodeZipper newZipperForParent = zipperForParent.withNewNode(newParent);
-
-        NodeMultiZipper<T> newMultiZipper;
-        if (zipperForParentAlreadyExisted) {
-            newMultiZipper = multiZipper.withReplacedZipper(zipperForParent, newZipperForParent);
-        } else {
-            newMultiZipper = multiZipper.withNewZipper(newZipperForParent);
-        }
-        context.getParentContext().changeNode(newParent);
-        context.setAccumulate(newMultiZipper);
+    public static <T> TraversalControl insertAfter(TraverserContext<T> context, T toInsertAfter) {
+        NodeZipper<T> insertNodeZipper = context.getVar(NodeZipper.class).insertAfter(toInsertAfter);
+        NodeMultiZipper<T> multiZipper = context.getNewAccumulate();
+        context.setAccumulate(multiZipper.withNewZipper(insertNodeZipper));
         return TraversalControl.CONTINUE;
-
     }
+
+    public static <T> TraversalControl insertBefore(TraverserContext<T> context, T toInsertBefore) {
+        NodeZipper<T> insertNodeZipper = context.getVar(NodeZipper.class).insertBefore(toInsertBefore);
+        NodeMultiZipper<T> multiZipper = context.getNewAccumulate();
+        context.setAccumulate(multiZipper.withNewZipper(insertNodeZipper));
+        return TraversalControl.CONTINUE;
+    }
+
 }

--- a/src/main/java/graphql/util/TreeTransformerUtil.java
+++ b/src/main/java/graphql/util/TreeTransformerUtil.java
@@ -5,11 +5,25 @@ import graphql.PublicApi;
 @PublicApi
 public class TreeTransformerUtil {
 
+    /**
+     * Can be called multiple times to change the current node of the context. The latest call wins
+     *
+     * @param context
+     * @param changedNode
+     * @param <T>
+     *
+     * @return
+     */
     public static <T> TraversalControl changeNode(TraverserContext<T> context, T changedNode) {
         NodeZipper<T> zipperWithChangedNode = context.getVar(NodeZipper.class).withNewNode(changedNode);
         NodeMultiZipper<T> multiZipper = context.getNewAccumulate();
-        context.setAccumulate(multiZipper.withNewZipper(zipperWithChangedNode));
-        context.changeNode(changedNode);
+        if (context.isChanged()) {
+            context.setAccumulate(multiZipper.withReplacedZipperForNode(context.thisNode(), changedNode));
+            context.changeNode(changedNode);
+        } else {
+            context.setAccumulate(multiZipper.withNewZipper(zipperWithChangedNode));
+            context.changeNode(changedNode);
+        }
         return TraversalControl.CONTINUE;
     }
 

--- a/src/test/groovy/graphql/language/AstTransformerTest.groovy
+++ b/src/test/groovy/graphql/language/AstTransformerTest.groovy
@@ -474,5 +474,29 @@ class AstTransformerTest extends Specification {
 
     }
 
+    def "changeNode can be called multiple times"() {
+        def document = TestUtil.parseQuery("{ field }")
+
+        AstTransformer astTransformer = new AstTransformer()
+
+        def visitor = new NodeVisitorStub() {
+
+            @Override
+            TraversalControl visitField(Field node, TraverserContext<Node> context) {
+                changeNode(context, new Field("change1"))
+                changeNode(context, new Field("change2"))
+                changeNode(context, new Field("change3"))
+                TraversalControl.CONTINUE
+            }
+        }
+
+        when:
+        def newDocument = astTransformer.transform(document, visitor)
+
+        then:
+        printAstCompact(newDocument) == "query {change3}"
+
+    }
+
 
 }


### PR DESCRIPTION
Enhance zipper to specify a modification type to allow for delete and insert changes.

Breaking change because it removes the  `TreeTransformerUtil.changeParent` method which was the wrong approach. 