### PR TITLE
handle deleting root node

### DIFF
--- a/src/main/java/graphql/util/NodeMultiZipper.java
+++ b/src/main/java/graphql/util/NodeMultiZipper.java
@@ -1,6 +1,5 @@
 package graphql.util;
 
-import graphql.Assert;
 import graphql.PublicApi;
 
 import java.util.ArrayList;
@@ -27,6 +26,9 @@ public class NodeMultiZipper<T> {
         this.nodeAdapter = nodeAdapter;
     }
 
+    /**
+     * @return can be null if the root node is marked as deleted
+     */
     public T toRootNode() {
         if (zippers.size() == 0) {
             return commonRoot;
@@ -49,7 +51,7 @@ public class NodeMultiZipper<T> {
             curZippers.addAll(newZippers);
         }
         assertTrue(curZippers.size() == 1, "unexpected state: all zippers must share the same root node");
-        return Assert.assertNotNull(curZippers.get(0).toRoot());
+        return curZippers.get(0).toRoot();
     }
 
     public T getCommonRoot() {

--- a/src/main/java/graphql/util/NodeZipper.java
+++ b/src/main/java/graphql/util/NodeZipper.java
@@ -85,9 +85,16 @@ public class NodeZipper<T> {
         return new NodeZipper<>(node, newBreadcrumbs, nodeAdapter, this.modificationType);
     }
 
+
+    /**
+     * @return null if it is the root node and marked as deleted, otherwise never null
+     */
     public T toRoot() {
-        if (breadcrumbs.size() == 0) {
+        if (breadcrumbs.size() == 0 && modificationType != ModificationType.DELETE) {
             return this.curNode;
+        }
+        if (breadcrumbs.size() == 0 && modificationType == ModificationType.DELETE) {
+            return null;
         }
         T curNode = this.curNode;
 

--- a/src/test/groovy/graphql/language/AstTransformerTest.groovy
+++ b/src/test/groovy/graphql/language/AstTransformerTest.groovy
@@ -499,4 +499,27 @@ class AstTransformerTest extends Specification {
     }
 
 
+    def "delete root node"() {
+        def document = TestUtil.parseQuery("{ field }")
+
+        AstTransformer astTransformer = new AstTransformer()
+
+        def visitor = new NodeVisitorStub() {
+
+            @Override
+            TraversalControl visitDocument(Document node, TraverserContext<Node> context) {
+                deleteNode(context)
+                TraversalControl.CONTINUE
+            }
+        }
+
+        when:
+        def newDocument = astTransformer.transform(document, visitor)
+
+        then:
+        newDocument == null
+
+    }
+
+
 }


### PR DESCRIPTION
This handle the case of deleting the root node of a tree, which results in `null`.