### PR TITLE
Retrieve DataFetcher from CodeRegistry using FieldCoordinates

### DIFF
--- a/src/main/java/graphql/schema/GraphQLCodeRegistry.java
+++ b/src/main/java/graphql/schema/GraphQLCodeRegistry.java
@@ -55,16 +55,28 @@ public class GraphQLCodeRegistry {
      * @return the DataFetcher associated with this field.  All fields have data fetchers
      */
     public DataFetcher getDataFetcher(GraphQLFieldsContainer parentType, GraphQLFieldDefinition fieldDefinition) {
-        return getDataFetcherImpl(parentType, fieldDefinition, dataFetcherMap, systemDataFetcherMap);
+        return getDataFetcherImpl(FieldCoordinates.coordinates(parentType, fieldDefinition), fieldDefinition, dataFetcherMap, systemDataFetcherMap);
     }
 
-    private static DataFetcher getDataFetcherImpl(GraphQLFieldsContainer parentType, GraphQLFieldDefinition fieldDefinition, Map<FieldCoordinates, DataFetcherFactory> dataFetcherMap, Map<String, DataFetcherFactory> systemDataFetcherMap) {
-        assertNotNull(parentType);
+    /**
+     * Returns a data fetcher associated with a field located at specified coordinates.
+     *
+     * @param coordinates     the field coordinates
+     * @param fieldDefinition the field definition
+     *
+     * @return the DataFetcher associated with this field.  All fields have data fetchers
+     */
+    public DataFetcher getDataFetcher(FieldCoordinates coordinates, GraphQLFieldDefinition fieldDefinition) {
+        return getDataFetcherImpl(coordinates, fieldDefinition, dataFetcherMap, systemDataFetcherMap);
+    }
+
+    private static DataFetcher getDataFetcherImpl(FieldCoordinates coordinates, GraphQLFieldDefinition fieldDefinition, Map<FieldCoordinates, DataFetcherFactory> dataFetcherMap, Map<String, DataFetcherFactory> systemDataFetcherMap) {
+        assertNotNull(coordinates);
         assertNotNull(fieldDefinition);
 
         DataFetcherFactory dataFetcherFactory = systemDataFetcherMap.get(fieldDefinition.getName());
         if (dataFetcherFactory == null) {
-            dataFetcherFactory = dataFetcherMap.get(FieldCoordinates.coordinates(parentType, fieldDefinition));
+            dataFetcherFactory = dataFetcherMap.get(coordinates);
             if (dataFetcherFactory == null) {
                 dataFetcherFactory = DataFetcherFactories.useDataFetcher(new PropertyDataFetcher<>(fieldDefinition.getName()));
             }
@@ -183,7 +195,19 @@ public class GraphQLCodeRegistry {
          * @return the DataFetcher associated with this field.  All fields have data fetchers
          */
         public DataFetcher getDataFetcher(GraphQLFieldsContainer parentType, GraphQLFieldDefinition fieldDefinition) {
-            return getDataFetcherImpl(parentType, fieldDefinition, dataFetcherMap, systemDataFetcherMap);
+            return getDataFetcherImpl(FieldCoordinates.coordinates(parentType, fieldDefinition), fieldDefinition, dataFetcherMap, systemDataFetcherMap);
+        }
+
+        /**
+         * Returns a data fetcher associated with a field located at specified coordinates.
+         *
+         * @param coordinates     the field coordinates
+         * @param fieldDefinition the field definition
+         *
+         * @return the DataFetcher associated with this field.  All fields have data fetchers
+         */
+        public DataFetcher getDataFetcher(FieldCoordinates coordinates, GraphQLFieldDefinition fieldDefinition) {
+            return getDataFetcherImpl(coordinates, fieldDefinition, dataFetcherMap, systemDataFetcherMap);
         }
 
         /**

--- a/src/test/groovy/graphql/schema/GraphQLCodeRegistryTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLCodeRegistryTest.groovy
@@ -101,7 +101,33 @@ class GraphQLCodeRegistryTest extends Specification {
         (codeRegistry.getDataFetcher(objectType("parentType3"), field("fieldE")) as NamedDF).name == "E"
 
         codeRegistry.getDataFetcher(objectType("parentType2"), field("A")) instanceof PropertyDataFetcher // a default one
+    }
 
+    def "data fetchers can be retrieved using field coordinates"() {
+        when:
+        def codeRegistryBuilder = GraphQLCodeRegistry.newCodeRegistry()
+                .dataFetcher(FieldCoordinates.coordinates("parentType1", "A"), new NamedDF("A"))
+                .dataFetcher(FieldCoordinates.coordinates("parentType2", "B"), new NamedDF("B"))
+                .dataFetchers("parentType3", [fieldD: new NamedDF("D"), fieldE: new NamedDF("E")])
+
+        // we can do a read on a half built code registry, namely for schema directive wiring use cases
+        then:
+        (codeRegistryBuilder.getDataFetcher(FieldCoordinates.coordinates("parentType1", "A"), field("A")) as NamedDF).name == "A"
+        (codeRegistryBuilder.getDataFetcher(FieldCoordinates.coordinates("parentType2", "B"), field("B")) as NamedDF).name == "B"
+        (codeRegistryBuilder.getDataFetcher(FieldCoordinates.coordinates("parentType3", "fieldD"), field("fieldD")) as NamedDF).name == "D"
+        (codeRegistryBuilder.getDataFetcher(FieldCoordinates.coordinates("parentType3", "fieldE"), field("fieldE")) as NamedDF).name == "E"
+
+        codeRegistryBuilder.getDataFetcher(FieldCoordinates.coordinates("parentType2", "A"), field("A")) instanceof PropertyDataFetcher // a default one
+
+        when:
+        def codeRegistry = codeRegistryBuilder.build()
+        then:
+        (codeRegistry.getDataFetcher(FieldCoordinates.coordinates("parentType1", "A"), field("A")) as NamedDF).name == "A"
+        (codeRegistry.getDataFetcher(FieldCoordinates.coordinates("parentType2", "B"), field("B")) as NamedDF).name == "B"
+        (codeRegistry.getDataFetcher(FieldCoordinates.coordinates("parentType3", "fieldD"), field("fieldD")) as NamedDF).name == "D"
+        (codeRegistry.getDataFetcher(FieldCoordinates.coordinates("parentType3", "fieldE"), field("fieldE")) as NamedDF).name == "E"
+
+        codeRegistry.getDataFetcher(FieldCoordinates.coordinates("parentType2", "A"), field("A")) instanceof PropertyDataFetcher // a default one
     }
 
     def "records type resolvers against unions and interfaces"() {


### PR DESCRIPTION
Currently GraphQLCodeRegistry allows registering DataFetchers using either FieldCoordinates or by explicitly providing parent and target field (which is then used to construct field coordinates) but it only allows retrieving DataFetcher for a given field based on the parent container field. This is problematic when attempting to configure directives while recursively generating the schemas (i.e. how it is done in graphql-kotlin) as the parent object is not yet available.

It appears that parent GraphQLFieldsContainer is only used to construct target field coordinates for retrieving the data fetcher. It would be great if we could retrieve the data fetchers by the coordinates as well as it is blocking us (graphql-kotlin) from upgrading to latest version of graphql-java.