### PR TITLE
Fix a few performance regressions between 9.2 and 12.0

### DIFF
--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -169,23 +169,8 @@ public class GraphQL {
         this.mutationStrategy = mutationStrategy != null ? mutationStrategy : new AsyncSerialExecutionStrategy();
         this.subscriptionStrategy = subscriptionStrategy != null ? subscriptionStrategy : new SubscriptionExecutionStrategy();
         this.idProvider = assertNotNull(idProvider, "idProvider must be non null");
-        this.instrumentation = checkInstrumentation(assertNotNull(instrumentation));
+        this.instrumentation = assertNotNull(instrumentation);
         this.preparsedDocumentProvider = assertNotNull(preparsedDocumentProvider, "preparsedDocumentProvider must be non null");
-    }
-
-    private Instrumentation checkInstrumentation(Instrumentation instrumentation) {
-        List<Instrumentation> instrumentationList = new ArrayList<>();
-        if (instrumentation instanceof ChainedInstrumentation) {
-            instrumentationList.addAll(((ChainedInstrumentation) instrumentation).getInstrumentations());
-        } else {
-            instrumentationList.add(instrumentation);
-        }
-        boolean containsDLInstrumentation = instrumentationList.stream().anyMatch(instr -> instr instanceof DataLoaderDispatcherInstrumentation);
-        // if we don't have a DataLoaderDispatcherInstrumentation in play, we add one.  We want DataLoader to be 1st class in graphql
-        if (!containsDLInstrumentation) {
-            instrumentationList.add(new DataLoaderDispatcherInstrumentation());
-        }
-        return new ChainedInstrumentation(instrumentationList);
     }
 
     /**
@@ -235,6 +220,7 @@ public class GraphQL {
         private ExecutionIdProvider idProvider = DEFAULT_EXECUTION_ID_PROVIDER;
         private Instrumentation instrumentation = SimpleInstrumentation.INSTANCE;
         private PreparsedDocumentProvider preparsedDocumentProvider = NoOpPreparsedDocumentProvider.INSTANCE;
+        private boolean dataLoaderInstrumentationEnabled = true;
 
 
         public Builder(GraphQLSchema graphQLSchema) {
@@ -276,11 +262,17 @@ public class GraphQL {
             return this;
         }
 
+        public Builder dataLoaderInstrumentationEnabled(boolean dataLoaderInstrumentationEnabled) {
+            this.dataLoaderInstrumentationEnabled = dataLoaderInstrumentationEnabled;
+            return this;
+        }
+
         public GraphQL build() {
             assertNotNull(graphQLSchema, "graphQLSchema must be non null");
             assertNotNull(queryExecutionStrategy, "queryStrategy must be non null");
             assertNotNull(idProvider, "idProvider must be non null");
-            return new GraphQL(graphQLSchema, queryExecutionStrategy, mutationExecutionStrategy, subscriptionExecutionStrategy, idProvider, instrumentation, preparsedDocumentProvider);
+            final Instrumentation augmentedInstrumentation = dataLoaderInstrumentationEnabled ? checkInstrumentation(instrumentation) : instrumentation;
+            return new GraphQL(graphQLSchema, queryExecutionStrategy, mutationExecutionStrategy, subscriptionExecutionStrategy, idProvider, augmentedInstrumentation, preparsedDocumentProvider);
         }
     }
 
@@ -605,4 +597,18 @@ public class GraphQL {
         return future;
     }
 
+    private static Instrumentation checkInstrumentation(Instrumentation instrumentation) {
+        List<Instrumentation> instrumentationList = new ArrayList<>();
+        if (instrumentation instanceof ChainedInstrumentation) {
+            instrumentationList.addAll(((ChainedInstrumentation) instrumentation).getInstrumentations());
+        } else {
+            instrumentationList.add(instrumentation);
+        }
+        boolean containsDLInstrumentation = instrumentationList.stream().anyMatch(instr -> instr instanceof DataLoaderDispatcherInstrumentation);
+        // if we don't have a DataLoaderDispatcherInstrumentation in play, we add one.  We want DataLoader to be 1st class in graphql
+        if (!containsDLInstrumentation) {
+            instrumentationList.add(new DataLoaderDispatcherInstrumentation());
+        }
+        return new ChainedInstrumentation(instrumentationList);
+    }
 }

--- a/src/main/java/graphql/execution/ExecutionStepInfo.java
+++ b/src/main/java/graphql/execution/ExecutionStepInfo.java
@@ -126,7 +126,7 @@ public class ExecutionStepInfo {
      * @return the resolved arguments that have been passed to this field
      */
     public Map<String, Object> getArguments() {
-        return new LinkedHashMap<>(arguments);
+        return Collections.unmodifiableMap(arguments);
     }
 
     /**
@@ -221,12 +221,13 @@ public class ExecutionStepInfo {
         GraphQLObjectType fieldContainer;
         MergedField field;
         ExecutionPath path;
-        Map<String, Object> arguments = new LinkedHashMap<>();
+        Map<String, Object> arguments;
 
         /**
          * @see ExecutionStepInfo#newExecutionStepInfo()
          */
         private Builder() {
+            arguments = Collections.emptyMap();
         }
 
         private Builder(ExecutionStepInfo existing) {
@@ -265,7 +266,7 @@ public class ExecutionStepInfo {
         }
 
         public Builder arguments(Map<String, Object> arguments) {
-            this.arguments = new LinkedHashMap<>(arguments == null ? Collections.emptyMap() : arguments);
+            this.arguments = arguments == null ? Collections.emptyMap() : arguments;
             return this;
         }
 

--- a/src/main/java/graphql/execution/MergedField.java
+++ b/src/main/java/graphql/execution/MergedField.java
@@ -5,6 +5,7 @@ import graphql.language.Argument;
 import graphql.language.Field;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -119,7 +120,7 @@ public class MergedField {
      * @return all merged fields
      */
     public List<Field> getFields() {
-        return new ArrayList<>(fields);
+        return Collections.unmodifiableList(fields);
     }
 
     public static Builder newMergedField() {
@@ -141,14 +142,14 @@ public class MergedField {
     }
 
     public static class Builder {
-        private List<Field> fields = new ArrayList<>();
+        private List<Field> fields;
 
         private Builder() {
-
+            this.fields = new ArrayList<>();
         }
 
         private Builder(MergedField existing) {
-            this.fields = existing.getFields();
+            this.fields = new ArrayList<>(existing.getFields());
         }
 
         public Builder fields(List<Field> fields) {

--- a/src/main/java/graphql/language/Field.java
+++ b/src/main/java/graphql/language/Field.java
@@ -7,6 +7,7 @@ import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -133,12 +134,12 @@ public class Field extends AbstractNode<Field> implements Selection<Field>, Sele
     }
 
     public List<Argument> getArguments() {
-        return new ArrayList<>(arguments);
+        return Collections.unmodifiableList(arguments);
     }
 
     @Override
     public List<Directive> getDirectives() {
-        return new ArrayList<>(directives);
+        return Collections.unmodifiableList(directives);
     }
 
     @Override
@@ -147,7 +148,7 @@ public class Field extends AbstractNode<Field> implements Selection<Field>, Sele
     }
 
     public Map<String, String> getAdditionalData() {
-        return new LinkedHashMap<>(additionalData);
+        return Collections.unmodifiableMap(additionalData);
     }
 
     @Override

--- a/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
@@ -23,7 +23,7 @@ import java.util.Map;
 @Internal
 public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
     private final Object source;
-    private final Map<String, Object> arguments = new LinkedHashMap<>();
+    private final Map<String, Object> arguments;
     private final Object context;
     private final Object localContext;
     private final Object root;
@@ -32,7 +32,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
     private final GraphQLOutputType fieldType;
     private final GraphQLType parentType;
     private final GraphQLSchema graphQLSchema;
-    private final Map<String, FragmentDefinition> fragmentsByName = new LinkedHashMap<>();
+    private final Map<String, FragmentDefinition> fragmentsByName;
     private final ExecutionId executionId;
     private final DataFetchingFieldSelectionSet selectionSet;
     private final ExecutionStepInfo executionStepInfo;
@@ -44,7 +44,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
 
     private DataFetchingEnvironmentImpl(Builder builder) {
         this.source = builder.source;
-        this.arguments.putAll(builder.arguments);
+        this.arguments = builder.arguments == null ? Collections.emptyMap() : builder.arguments;
         this.context = builder.context;
         this.localContext = builder.localContext;
         this.root = builder.root;
@@ -53,7 +53,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
         this.fieldType = builder.fieldType;
         this.parentType = builder.parentType;
         this.graphQLSchema = builder.graphQLSchema;
-        this.fragmentsByName.putAll(builder.fragmentsByName);
+        this.fragmentsByName = builder.fragmentsByName == null ? Collections.emptyMap() : builder.fragmentsByName;
         this.executionId = builder.executionId;
         this.selectionSet = builder.selectionSet;
         this.executionStepInfo = builder.executionStepInfo;
@@ -61,7 +61,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
         this.cacheControl = builder.cacheControl;
         this.operationDefinition = builder.operationDefinition;
         this.document = builder.document;
-        this.variables = builder.variables;
+        this.variables = builder.variables == null ? Collections.emptyMap() : builder.variables;
     }
 
     @Override
@@ -71,7 +71,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
 
     @Override
     public Map<String, Object> getArguments() {
-        return new LinkedHashMap<>(arguments);
+        return Collections.unmodifiableMap(arguments);
     }
 
     @Override
@@ -136,7 +136,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
 
     @Override
     public Map<String, FragmentDefinition> getFragmentsByName() {
-        return new LinkedHashMap<>(fragmentsByName);
+        return Collections.unmodifiableMap(fragmentsByName);
     }
 
     @Override
@@ -176,7 +176,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
 
     @Override
     public Map<String, Object> getVariables() {
-        return new LinkedHashMap<>(variables);
+        return Collections.unmodifiableMap(variables);
     }
 
     @Override
@@ -229,13 +229,13 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
         private CacheControl cacheControl;
         private OperationDefinition operationDefinition;
         private Document document;
-        private final Map<String, Object> arguments = new LinkedHashMap<>();
-        private final Map<String, FragmentDefinition> fragmentsByName = new LinkedHashMap<>();
-        private final Map<String, Object> variables = new LinkedHashMap<>();
+        private Map<String, Object> arguments;
+        private Map<String, FragmentDefinition> fragmentsByName;
+        private Map<String, Object> variables;
 
         public Builder(DataFetchingEnvironmentImpl env) {
             this.source = env.source;
-            this.arguments.putAll(env.arguments);
+            this.arguments = env.arguments;
             this.context = env.context;
             this.localContext = env.localContext;
             this.root = env.root;
@@ -244,7 +244,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
             this.fieldType = env.fieldType;
             this.parentType = env.parentType;
             this.graphQLSchema = env.graphQLSchema;
-            this.fragmentsByName.putAll(env.fragmentsByName);
+            this.fragmentsByName = env.fragmentsByName;
             this.executionId = env.executionId;
             this.selectionSet = env.selectionSet;
             this.executionStepInfo = env.executionStepInfo;
@@ -252,7 +252,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
             this.cacheControl = env.cacheControl;
             this.operationDefinition = env.operationDefinition;
             this.document = env.document;
-            this.variables.putAll(env.variables);
+            this.variables = env.variables;
         }
 
         public Builder() {
@@ -264,7 +264,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
         }
 
         public Builder arguments(Map<String, Object> arguments) {
-            this.arguments.putAll(arguments == null ? Collections.emptyMap() : arguments);
+            this.arguments = arguments;
             return this;
         }
 
@@ -309,7 +309,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
         }
 
         public Builder fragmentsByName(Map<String, FragmentDefinition> fragmentsByName) {
-            this.fragmentsByName.putAll(fragmentsByName == null ? Collections.emptyMap() : fragmentsByName);
+            this.fragmentsByName = fragmentsByName;
             return this;
         }
 
@@ -349,7 +349,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
         }
 
         public Builder variables(Map<String, Object> variables) {
-            this.variables.putAll(variables == null ? Collections.emptyMap() : variables);
+            this.variables = variables;
             return this;
         }
 

--- a/src/test/groovy/graphql/GraphQLTest.groovy
+++ b/src/test/groovy/graphql/GraphQLTest.groovy
@@ -898,6 +898,24 @@ class GraphQLTest extends Specification {
         ! (queryStrategy.instrumentation as ChainedInstrumentation).getInstrumentations().contains(instrumentation)
     }
 
+    def "disabling data loader instrumentation leaves instrumentation as is"() {
+        given:
+        def queryStrategy = new CaptureStrategy()
+        def instrumentation = new SimpleInstrumentation()
+        def builder = GraphQL.newGraphQL(simpleSchema())
+            .queryExecutionStrategy(queryStrategy)
+            .instrumentation(instrumentation)
+
+        when:
+        def graphql = builder
+                .dataLoaderInstrumentationEnabled(false)
+                .build()
+        graphql.execute('{ hello }')
+
+        then:
+        queryStrategy.instrumentation == instrumentation
+    }
+
     def "query with triple quoted multi line strings"() {
         given:
         GraphQLFieldDefinition.Builder fieldDefinition = newFieldDefinition()

--- a/src/test/groovy/graphql/schema/DataFetchingEnvironmentImplTest.groovy
+++ b/src/test/groovy/graphql/schema/DataFetchingEnvironmentImplTest.groovy
@@ -56,9 +56,8 @@ class DataFetchingEnvironmentImplTest extends Specification {
         value == "argVal"
         when:
         dataFetchingEnvironment.getArguments().put("arg", "some other value")
-        value = dataFetchingEnvironment.getArguments().get("arg")
         then:
-        value == "argVal"
+        thrown(UnsupportedOperationException)
     }
 
     def "copying works as expected from execution context"() {
@@ -87,7 +86,7 @@ class DataFetchingEnvironmentImplTest extends Specification {
                 .executionStepInfo(Mock(ExecutionStepInfo))
                 .parentType(Mock(GraphQLType))
                 .graphQLSchema(Mock(GraphQLSchema))
-                .fragmentsByName(Mock(Map))
+                .fragmentsByName(fragmentByName)
                 .executionId(Mock(ExecutionId))
                 .selectionSet(Mock(DataFetchingFieldSelectionSet))
                 .operationDefinition(operationDefinition)


### PR DESCRIPTION
Hi. We recently upgraded from graphql-java 9.2 to 12.0 and noticed a few performance regressions. 

In a load test before rolling out this change, we saw our GraphQL service's CPU usage more than double along with significant increases in GC time and bytes allocated (graph included below). I attached a profiler and found two root causes:
1. The execution code has gotten more defensive by copying several lists repeatedly and excessively (in our case, tens of thousands of times per query). 
1. ChainedInstrumentation and DataLoaderDispatcherInstrumentation are expensive due to excessive object allocation and streaming. On 9.2, the ChainedInstrumentation / DataLoaderDispatcherInstrumentation was not included by default (and we do not use it) whereas it is now automatically injected when building the GraphQL instance.

This PR switches some hot spots to using `Collections.unmodifiableMap`/`unmodifiableList`. It also adds an option to disable the automatic installation of the ChainedInstrumentation / DataLoaderDispatcherInstrumentation.

There are several ways to address the excessive copying, so if you'd prefer another approach let me know and I'd be happy to revise the PR. This also doesn't address the root cause of the instrumentation cost, it just lets those who don't need it avoid the cost.

----

Here's a graph showing average time per request during our load test. The green line was our 9.2 instance. The yellow line is also running 9.2 except for ~13:45-14:10 when it runs 12.0 with the unmodifiable collection changes below, and ~15:05-15:30 when it runs the published version of 12.0. Not shown in the graph is 12.0 with both the unmodifiable collection changes and instrumentation disabled -- with both those changes, 12.0 was about equal to 9.2.

Note this is measuring wall clock time, but given that our downstream services take a bulk of the first 60ms, the divergence between the two versions represents a significant growth in CPU cost.

![Screen Shot 2019-05-30 at 3 39 15 PM](https://user-images.githubusercontent.com/1139644/58896362-d615ac00-86c3-11e9-8abf-97b0e53a3560.png)

