### PR TITLE
Allow and process DataFetcherResult as an item for GraphQL List fields.

### DIFF
--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -507,13 +507,16 @@ public abstract class ExecutionStrategy {
             NonNullableFieldValidator nonNullableFieldValidator = new NonNullableFieldValidator(executionContext, stepInfoForListElement);
 
             int finalIndex = index;
+            FetchedValue value = unboxPossibleDataFetcherResult(executionContext, parameters, item);
+
             ExecutionStrategyParameters newParameters = parameters.transform(builder ->
                     builder.executionStepInfo(stepInfoForListElement)
                             .nonNullFieldValidator(nonNullableFieldValidator)
                             .listSize(values.size())
+                            .localContext(value.getLocalContext())
                             .currentListIndex(finalIndex)
                             .path(indexedPath)
-                            .source(item)
+                            .source(value.getFetchedValue())
             );
             fieldValueInfos.add(completeValue(executionContext, newParameters));
             index++;

--- a/src/test/groovy/graphql/Issue1559.groovy
+++ b/src/test/groovy/graphql/Issue1559.groovy
@@ -1,0 +1,90 @@
+package graphql
+
+import graphql.execution.DataFetcherResult
+import graphql.schema.DataFetcher
+import graphql.schema.DataFetchingEnvironment
+import graphql.schema.idl.RuntimeWiring
+import graphql.schema.idl.TypeRuntimeWiring
+import graphql.validation.ValidationError
+import graphql.validation.ValidationErrorType
+import spock.lang.Specification
+
+class Issue1559 extends Specification {
+
+    def graphql = TestUtil.graphQL("""
+                type Query {
+                    contextAwareList: [ContextAwareEntity!]!
+                }
+                
+                type ContextAwareEntity {
+                    name: String
+                    contextInfo: String
+                }
+                
+            """,
+            RuntimeWiring.newRuntimeWiring()
+                .type("ContextAwareEntity", {
+                    it.dataFetcher("contextInfo", { it.getLocalContext() })
+                })
+                .build())
+        .build()
+
+    def "#1559 test if a list of DataFetcherResults is processed properly"() {
+
+        when:
+        def input = ExecutionInput.newExecutionInput()
+                .root([contextAwareList: [
+                        DataFetcherResult.newResult().localContext("the context 1").data([name: "the name 1"]).build(),
+                        DataFetcherResult.newResult().localContext("the context 2").data([name: "the name 2"]).build(),
+                        DataFetcherResult.newResult().localContext("the context 3").data([name: "the name 3"]).build(),
+                        DataFetcherResult.newResult().localContext("the context 4").data([name: "the name 4"]).build(),
+                ]])
+                .query('''
+                        query getTheList {
+                            contextAwareList {
+                                name
+                                contextInfo
+                            }
+                        }
+                        ''')
+                .build()
+        def executionResult = graphql.execute(input)
+
+        then:
+        executionResult.errors.isEmpty()
+        executionResult.data == [ contextAwareList: [
+                [name: "the name 1", contextInfo: "the context 1"],
+                [name: "the name 2", contextInfo: "the context 2"],
+                [name: "the name 3", contextInfo: "the context 3"],
+                [name: "the name 4", contextInfo: "the context 4"],
+        ]]
+
+    }
+    def "#1559 test if null validations are processed properly on DataFetcherResult List"() {
+
+        when:
+        def input = ExecutionInput.newExecutionInput()
+                .root([contextAwareList: [
+                        DataFetcherResult.newResult().localContext("the context 1").data([name: "the name 1"]).build(),
+                        DataFetcherResult.newResult().localContext("the context 2").data(null).build(),
+                        null,
+                        DataFetcherResult.newResult().localContext("the context 4").data([name: "the name 4"]).build(),
+                ]])
+                .query('''
+                        query getTheList {
+                            contextAwareList {
+                                name
+                                contextInfo
+                            }
+                        }
+                        ''')
+                .build()
+        def executionResult = graphql.execute(input)
+
+        then:
+        executionResult.errors.size() == 2
+        executionResult.errors[0].path == ['contextAwareList', 1]
+        executionResult.errors[1].path == ['contextAwareList', 2]
+    }
+
+}


### PR DESCRIPTION
Issue [#1559 ](https://github.com/graphql-java/graphql-java/issues/1559) outlines a lack of control over list items in fetcher result for a list field, in particular, the inability to set a localContext for each item of a list. This pull request modifies list result handling in `ExecutionStrategy` class allowing an instance of `DataFetcherResult` as an item of a list. After the improvement, individual list items `DataFetcherResult` are handled the same way as a regular field's value of `DataFetcherResult` type: errors are added to query result, localContext for child nodes of the item is set.