### PR TITLE
add phase to general traverser context

### DIFF
--- a/src/main/java/graphql/analysis/NodeVisitorWithTypeTracking.java
+++ b/src/main/java/graphql/analysis/NodeVisitorWithTypeTracking.java
@@ -9,7 +9,6 @@ import graphql.language.FragmentDefinition;
 import graphql.language.FragmentSpread;
 import graphql.language.InlineFragment;
 import graphql.language.Node;
-import graphql.language.NodeTraverser;
 import graphql.language.NodeVisitorStub;
 import graphql.language.TypeName;
 import graphql.schema.GraphQLCodeRegistry;
@@ -24,8 +23,8 @@ import graphql.util.TraverserContext;
 import java.util.Map;
 
 import static graphql.Assert.assertNotNull;
-import static graphql.language.NodeTraverser.LeaveOrEnter.LEAVE;
 import static graphql.schema.GraphQLTypeUtil.unwrapAll;
+import static graphql.util.TraverserContext.Phase.LEAVE;
 
 /**
  * Internally used node visitor which delegates to a {@link QueryVisitor} with type
@@ -61,7 +60,7 @@ public class NodeVisitorWithTypeTracking extends NodeVisitorStub {
 
         QueryVisitorInlineFragmentEnvironment inlineFragmentEnvironment = new QueryVisitorInlineFragmentEnvironmentImpl(inlineFragment, context);
 
-        if (context.getVar(NodeTraverser.LeaveOrEnter.class) == LEAVE) {
+        if (context.getPhase() == LEAVE) {
             postOrderCallback.visitInlineFragment(inlineFragmentEnvironment);
             return TraversalControl.CONTINUE;
         }
@@ -91,7 +90,7 @@ public class NodeVisitorWithTypeTracking extends NodeVisitorStub {
 
         QueryVisitorFragmentDefinitionEnvironment fragmentEnvironment = new QueryVisitorFragmentDefinitionEnvironmentImpl(node, context);
 
-        if (context.getVar(NodeTraverser.LeaveOrEnter.class) == LEAVE) {
+        if (context.getPhase() == LEAVE) {
             postOrderCallback.visitFragmentDefinition(fragmentEnvironment);
             return TraversalControl.CONTINUE;
         }
@@ -116,7 +115,7 @@ public class NodeVisitorWithTypeTracking extends NodeVisitorStub {
         }
 
         QueryVisitorFragmentSpreadEnvironment fragmentSpreadEnvironment = new QueryVisitorFragmentSpreadEnvironmentImpl(fragmentSpread, fragmentDefinition, context);
-        if (context.getVar(NodeTraverser.LeaveOrEnter.class) == LEAVE) {
+        if (context.getPhase() == LEAVE) {
             postOrderCallback.visitFragmentSpread(fragmentSpreadEnvironment);
             return TraversalControl.CONTINUE;
         }
@@ -152,8 +151,7 @@ public class NodeVisitorWithTypeTracking extends NodeVisitorStub {
                 parentEnv.getSelectionSetContainer(),
                 context);
 
-        NodeTraverser.LeaveOrEnter leaveOrEnter = context.getVar(NodeTraverser.LeaveOrEnter.class);
-        if (leaveOrEnter == LEAVE) {
+        if (context.getPhase() == LEAVE) {
             postOrderCallback.visitField(environment);
             return TraversalControl.CONTINUE;
         }

--- a/src/main/java/graphql/analysis/QueryTransformer.java
+++ b/src/main/java/graphql/analysis/QueryTransformer.java
@@ -3,7 +3,6 @@ package graphql.analysis;
 import graphql.PublicApi;
 import graphql.language.FragmentDefinition;
 import graphql.language.Node;
-import graphql.language.NodeTraverser.LeaveOrEnter;
 import graphql.schema.GraphQLCompositeType;
 import graphql.schema.GraphQLSchema;
 import graphql.util.TraversalControl;
@@ -74,7 +73,6 @@ public class QueryTransformer {
 
             @Override
             public TraversalControl enter(TraverserContext<Node> context) {
-                context.setVar(LeaveOrEnter.class, LeaveOrEnter.ENTER);
                 return context.thisNode().accept(context, nodeVisitor);
             }
 

--- a/src/main/java/graphql/language/NodeTraverser.java
+++ b/src/main/java/graphql/language/NodeTraverser.java
@@ -20,14 +20,6 @@ import java.util.function.Function;
 public class NodeTraverser {
 
 
-    /**
-     * Used to indicate via {@link TraverserContext#getVar(Class)} if the visit happens inside the ENTER or LEAVE phase.
-     */
-    public enum LeaveOrEnter {
-        LEAVE,
-        ENTER
-    }
-
     private final Map<Class<?>, Object> rootVars;
     private final Function<? super Node, ? extends List<Node>> getChildren;
 
@@ -66,13 +58,11 @@ public class NodeTraverser {
 
             @Override
             public TraversalControl enter(TraverserContext<Node> context) {
-                context.setVar(LeaveOrEnter.class, LeaveOrEnter.ENTER);
                 return context.thisNode().accept(context, nodeVisitor);
             }
 
             @Override
             public TraversalControl leave(TraverserContext<Node> context) {
-                context.setVar(LeaveOrEnter.class, LeaveOrEnter.LEAVE);
                 return context.thisNode().accept(context, nodeVisitor);
             }
         };
@@ -104,7 +94,6 @@ public class NodeTraverser {
 
             @Override
             public TraversalControl enter(TraverserContext<Node> context) {
-                context.setVar(LeaveOrEnter.class, LeaveOrEnter.ENTER);
                 return context.thisNode().accept(context, nodeVisitor);
             }
 
@@ -147,7 +136,6 @@ public class NodeTraverser {
 
             @Override
             public TraversalControl leave(TraverserContext<Node> context) {
-                context.setVar(LeaveOrEnter.class, LeaveOrEnter.LEAVE);
                 return context.thisNode().accept(context, nodeVisitor);
             }
 

--- a/src/main/java/graphql/util/DefaultTraverserContext.java
+++ b/src/main/java/graphql/util/DefaultTraverserContext.java
@@ -30,6 +30,7 @@ public class DefaultTraverserContext<T> implements TraverserContext<T> {
     private final NodeLocation location;
     private final boolean isRootContext;
     private Map<String, List<TraverserContext<T>>> children;
+    private Phase phase;
 
     public DefaultTraverserContext(T curNode,
                                    TraverserContext<T> parent,
@@ -218,9 +219,22 @@ public class DefaultTraverserContext<T> implements TraverserContext<T> {
         this.children = children;
     }
 
+
     @Override
     public Map<String, List<TraverserContext<T>>> getChildrenContexts() {
         assertNotNull(children, "children not available");
         return children;
+    }
+
+    /*
+     * PRIVATE: Used by {@link Traverser}
+     */
+    void setPhase(Phase phase) {
+        this.phase = phase;
+    }
+
+    @Override
+    public Phase getPhase() {
+        return phase;
     }
 }

--- a/src/main/java/graphql/util/Traverser.java
+++ b/src/main/java/graphql/util/Traverser.java
@@ -112,6 +112,7 @@ public class Traverser<T> {
                 currentContext = (DefaultTraverserContext) traverserState.pop();
                 currentContext.setCurAccValue(currentAccValue);
                 currentContext.setChildrenContexts(childrenContextMap);
+                currentContext.setPhase(TraverserContext.Phase.LEAVE);
                 TraversalControl traversalControl = visitor.leave(currentContext);
                 currentAccValue = currentContext.getNewAccumulate();
                 assertNotNull(traversalControl, "result of leave must not be null");
@@ -131,6 +132,7 @@ public class Traverser<T> {
 
             if (currentContext.isVisited()) {
                 currentContext.setCurAccValue(currentAccValue);
+                currentContext.setPhase(TraverserContext.Phase.BACKREF);
                 TraversalControl traversalControl = visitor.backRef(currentContext);
                 currentAccValue = currentContext.getNewAccumulate();
                 assertNotNull(traversalControl, "result of backRef must not be null");
@@ -141,6 +143,7 @@ public class Traverser<T> {
             } else {
                 currentContext.setCurAccValue(currentAccValue);
                 Object nodeBeforeEnter = currentContext.thisNode();
+                currentContext.setPhase(TraverserContext.Phase.ENTER);
                 TraversalControl traversalControl = visitor.enter(currentContext);
                 currentAccValue = currentContext.getNewAccumulate();
                 assertNotNull(traversalControl, "result of enter must not be null");

--- a/src/main/java/graphql/util/TraverserContext.java
+++ b/src/main/java/graphql/util/TraverserContext.java
@@ -18,6 +18,12 @@ import java.util.Set;
 @PublicApi
 public interface TraverserContext<T> {
 
+    enum Phase {
+        LEAVE,
+        ENTER,
+        BACKREF
+    }
+
     /**
      * Returns current node being visited.
      * Special cases:
@@ -201,5 +207,10 @@ public interface TraverserContext<T> {
      * @return the children contexts. If the childs are a simple list the key is null.
      */
     Map<String, List<TraverserContext<T>>> getChildrenContexts();
+
+    /**
+     * @return the phase in which the node visits currently happens (Enter,Leave or BackRef)
+     */
+    Phase getPhase();
 
 }

--- a/src/test/groovy/graphql/analysis/QueryTraversalTest.groovy
+++ b/src/test/groovy/graphql/analysis/QueryTraversalTest.groovy
@@ -6,7 +6,6 @@ import graphql.language.Field
 import graphql.language.FragmentDefinition
 import graphql.language.FragmentSpread
 import graphql.language.InlineFragment
-import graphql.language.NodeTraverser
 import graphql.language.NodeUtil
 import graphql.language.OperationDefinition
 import graphql.parser.Parser
@@ -19,10 +18,10 @@ import graphql.util.TraversalControl
 import spock.lang.Specification
 import spock.lang.Unroll
 
-import static graphql.language.NodeTraverser.LeaveOrEnter.ENTER
-import static graphql.language.NodeTraverser.LeaveOrEnter.LEAVE
 import static graphql.schema.GraphQLList.list
 import static graphql.schema.GraphQLNonNull.nonNull
+import static graphql.util.TraverserContext.Phase.ENTER
+import static graphql.util.TraverserContext.Phase.LEAVE
 import static java.util.Collections.emptyMap
 
 class QueryTraversalTest extends Specification {
@@ -1393,29 +1392,29 @@ class QueryTraversalTest extends Specification {
 
         then:
         1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it ->
-            it.field.name == "foo" && it.traverserContext.getVar(NodeTraverser.LeaveOrEnter.class) == ENTER
+            it.field.name == "foo" && it.traverserContext.phase == ENTER
         })
         then:
         1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it ->
-            it.field.name == "subFoo" && it.traverserContext.getVar(NodeTraverser.LeaveOrEnter.class) == ENTER
+            it.field.name == "subFoo" && it.traverserContext.phase == ENTER
 
         })
         then:
         1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it ->
-            it.field.name == "subFoo" && it.traverserContext.getVar(NodeTraverser.LeaveOrEnter.class) == LEAVE
+            it.field.name == "subFoo" && it.traverserContext.phase == LEAVE
 
         })
         then:
         1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it ->
-            it.field.name == "foo" && it.traverserContext.getVar(NodeTraverser.LeaveOrEnter.class) == LEAVE
+            it.field.name == "foo" && it.traverserContext.phase == LEAVE
         })
         then:
         1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it ->
-            it.field.name == "bar" && it.traverserContext.getVar(NodeTraverser.LeaveOrEnter.class) == ENTER
+            it.field.name == "bar" && it.traverserContext.phase == ENTER
         })
         then:
         1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it ->
-            it.field.name == "bar" && it.traverserContext.getVar(NodeTraverser.LeaveOrEnter.class) == LEAVE
+            it.field.name == "bar" && it.traverserContext.phase == LEAVE
         })
 
     }

--- a/src/test/groovy/graphql/language/NodeTraverserTest.groovy
+++ b/src/test/groovy/graphql/language/NodeTraverserTest.groovy
@@ -4,8 +4,9 @@ import graphql.util.TraversalControl
 import graphql.util.TraverserContext
 import spock.lang.Specification
 
-import static graphql.language.NodeTraverser.LeaveOrEnter.ENTER
-import static graphql.language.NodeTraverser.LeaveOrEnter.LEAVE
+import static graphql.util.TraverserContext.Phase.ENTER
+import static graphql.util.TraverserContext.Phase.LEAVE
+
 
 class NodeTraverserTest extends Specification {
 
@@ -148,10 +149,10 @@ class NodeTraverserTest extends Specification {
 
 
     boolean isEnter(TraverserContext context) {
-        return context.getVar(NodeTraverser.LeaveOrEnter.class) == ENTER
+        return context.phase == ENTER
     }
 
     boolean isLeave(TraverserContext context) {
-        return context.getVar(NodeTraverser.LeaveOrEnter.class) == LEAVE
+        return context.phase == LEAVE
     }
 }


### PR DESCRIPTION
This removes the Leave/Enter context variable from NodeTraverser and makes it a general property on `TraverserContext`.
