### PR TITLE
rename QueryTraversal to QueryTraverser

### DIFF
--- a/src/main/java/graphql/analysis/MaxQueryComplexityInstrumentation.java
+++ b/src/main/java/graphql/analysis/MaxQueryComplexityInstrumentation.java
@@ -82,7 +82,7 @@ public class MaxQueryComplexityInstrumentation extends SimpleInstrumentation {
             if ((errors != null && errors.size() > 0) || throwable != null) {
                 return;
             }
-            QueryTraverser queryTraverser = newQueryTraversal(parameters);
+            QueryTraverser queryTraverser = newQueryTraverser(parameters);
 
             Map<QueryVisitorFieldEnvironment, Integer> valuesByParent = new LinkedHashMap<>();
             queryTraverser.visitPostOrder(new QueryVisitorStub() {
@@ -122,7 +122,7 @@ public class MaxQueryComplexityInstrumentation extends SimpleInstrumentation {
         return new AbortExecutionException("maximum query complexity exceeded " + totalComplexity + " > " + maxComplexity);
     }
 
-    QueryTraverser newQueryTraversal(InstrumentationValidationParameters parameters) {
+    QueryTraverser newQueryTraverser(InstrumentationValidationParameters parameters) {
         return QueryTraverser.newQueryTraverser()
                 .schema(parameters.getSchema())
                 .document(parameters.getDocument())

--- a/src/main/java/graphql/analysis/MaxQueryComplexityInstrumentation.java
+++ b/src/main/java/graphql/analysis/MaxQueryComplexityInstrumentation.java
@@ -82,10 +82,10 @@ public class MaxQueryComplexityInstrumentation extends SimpleInstrumentation {
             if ((errors != null && errors.size() > 0) || throwable != null) {
                 return;
             }
-            QueryTraversal queryTraversal = newQueryTraversal(parameters);
+            QueryTraverser queryTraverser = newQueryTraversal(parameters);
 
             Map<QueryVisitorFieldEnvironment, Integer> valuesByParent = new LinkedHashMap<>();
-            queryTraversal.visitPostOrder(new QueryVisitorStub() {
+            queryTraverser.visitPostOrder(new QueryVisitorStub() {
                 @Override
                 public void visitField(QueryVisitorFieldEnvironment env) {
                     int childsComplexity = valuesByParent.getOrDefault(env, 0);
@@ -122,8 +122,8 @@ public class MaxQueryComplexityInstrumentation extends SimpleInstrumentation {
         return new AbortExecutionException("maximum query complexity exceeded " + totalComplexity + " > " + maxComplexity);
     }
 
-    QueryTraversal newQueryTraversal(InstrumentationValidationParameters parameters) {
-        return QueryTraversal.newQueryTraversal()
+    QueryTraverser newQueryTraversal(InstrumentationValidationParameters parameters) {
+        return QueryTraverser.newQueryTraverser()
                 .schema(parameters.getSchema())
                 .document(parameters.getDocument())
                 .operationName(parameters.getOperation())

--- a/src/main/java/graphql/analysis/MaxQueryDepthInstrumentation.java
+++ b/src/main/java/graphql/analysis/MaxQueryDepthInstrumentation.java
@@ -54,8 +54,8 @@ public class MaxQueryDepthInstrumentation extends SimpleInstrumentation {
             if ((errors != null && errors.size() > 0) || throwable != null) {
                 return;
             }
-            QueryTraversal queryTraversal = newQueryTraversal(parameters);
-            int depth = queryTraversal.reducePreOrder((env, acc) -> Math.max(getPathLength(env.getParentEnvironment()), acc), 0);
+            QueryTraverser queryTraverser = newQueryTraversal(parameters);
+            int depth = queryTraverser.reducePreOrder((env, acc) -> Math.max(getPathLength(env.getParentEnvironment()), acc), 0);
             log.debug("Query depth info: {}", depth);
             if (depth > maxDepth) {
                 QueryDepthInfo queryDepthInfo = QueryDepthInfo.newQueryDepthInfo()
@@ -81,8 +81,8 @@ public class MaxQueryDepthInstrumentation extends SimpleInstrumentation {
         return new AbortExecutionException("maximum query depth exceeded " + depth + " > " + maxDepth);
     }
 
-    QueryTraversal newQueryTraversal(InstrumentationValidationParameters parameters) {
-        return QueryTraversal.newQueryTraversal()
+    QueryTraverser newQueryTraversal(InstrumentationValidationParameters parameters) {
+        return QueryTraverser.newQueryTraverser()
                 .schema(parameters.getSchema())
                 .document(parameters.getDocument())
                 .operationName(parameters.getOperation())

--- a/src/main/java/graphql/analysis/MaxQueryDepthInstrumentation.java
+++ b/src/main/java/graphql/analysis/MaxQueryDepthInstrumentation.java
@@ -54,7 +54,7 @@ public class MaxQueryDepthInstrumentation extends SimpleInstrumentation {
             if ((errors != null && errors.size() > 0) || throwable != null) {
                 return;
             }
-            QueryTraverser queryTraverser = newQueryTraversal(parameters);
+            QueryTraverser queryTraverser = newQueryTraverser(parameters);
             int depth = queryTraverser.reducePreOrder((env, acc) -> Math.max(getPathLength(env.getParentEnvironment()), acc), 0);
             log.debug("Query depth info: {}", depth);
             if (depth > maxDepth) {
@@ -81,7 +81,7 @@ public class MaxQueryDepthInstrumentation extends SimpleInstrumentation {
         return new AbortExecutionException("maximum query depth exceeded " + depth + " > " + maxDepth);
     }
 
-    QueryTraverser newQueryTraversal(InstrumentationValidationParameters parameters) {
+    QueryTraverser newQueryTraverser(InstrumentationValidationParameters parameters) {
         return QueryTraverser.newQueryTraverser()
                 .schema(parameters.getSchema())
                 .document(parameters.getDocument())

--- a/src/main/java/graphql/analysis/QueryReducer.java
+++ b/src/main/java/graphql/analysis/QueryReducer.java
@@ -3,11 +3,11 @@ package graphql.analysis;
 import graphql.PublicApi;
 
 /**
- * Used by {@link QueryTraversal} to reduce the fields of a Document (or part of it) to a single value.
+ * Used by {@link QueryTraverser} to reduce the fields of a Document (or part of it) to a single value.
  * <p>
- * How this happens in detail (pre vs post-order for example) is defined by {@link QueryTraversal}.
+ * How this happens in detail (pre vs post-order for example) is defined by {@link QueryTraverser}.
  * <p>
- * See {@link QueryTraversal#reducePostOrder(QueryReducer, Object)} and {@link QueryTraversal#reducePreOrder(QueryReducer, Object)}
+ * See {@link QueryTraverser#reducePostOrder(QueryReducer, Object)} and {@link QueryTraverser#reducePreOrder(QueryReducer, Object)}
  */
 @PublicApi
 @FunctionalInterface

--- a/src/main/java/graphql/analysis/QueryTraversalContext.java
+++ b/src/main/java/graphql/analysis/QueryTraversalContext.java
@@ -7,7 +7,7 @@ import graphql.schema.GraphQLOutputType;
 import graphql.schema.GraphQLTypeUtil;
 
 /**
- * QueryTraversal helper class that maintains traversal context as
+ * QueryTraverser helper class that maintains traversal context as
  * the query traversal algorithm traverses down the Selection AST
  */
 @Internal

--- a/src/main/java/graphql/analysis/QueryTraverser.java
+++ b/src/main/java/graphql/analysis/QueryTraverser.java
@@ -35,7 +35,7 @@ import static java.util.Collections.singletonList;
  * visitField calls.
  */
 @PublicApi
-public class QueryTraversal {
+public class QueryTraverser {
 
     private final Collection<? extends Node> roots;
     private final GraphQLSchema schema;
@@ -44,7 +44,7 @@ public class QueryTraversal {
 
     private final GraphQLCompositeType rootParentType;
 
-    private QueryTraversal(GraphQLSchema schema,
+    private QueryTraverser(GraphQLSchema schema,
                            Document document,
                            String operation,
                            Map<String, Object> variables) {
@@ -57,7 +57,7 @@ public class QueryTraversal {
         this.rootParentType = getRootTypeFromOperation(getOperationResult.operationDefinition);
     }
 
-    private QueryTraversal(GraphQLSchema schema,
+    private QueryTraverser(GraphQLSchema schema,
                            Node root,
                            GraphQLCompositeType rootParentType,
                            Map<String, FragmentDefinition> fragmentsByName,
@@ -178,7 +178,7 @@ public class QueryTraversal {
         return nodeTraverser.depthFirst(nodeVisitorWithTypeTracking, roots);
     }
 
-    public static Builder newQueryTraversal() {
+    public static Builder newQueryTraverser() {
         return new Builder();
     }
 
@@ -282,14 +282,14 @@ public class QueryTraversal {
         }
 
         /**
-         * @return a built {@link graphql.analysis.QueryTraversal} object
+         * @return a built {@link QueryTraverser} object
          */
-        public QueryTraversal build() {
+        public QueryTraverser build() {
             checkState();
             if (document != null) {
-                return new QueryTraversal(schema, document, operation, variables);
+                return new QueryTraverser(schema, document, operation, variables);
             } else {
-                return new QueryTraversal(schema, root, rootParentType, fragmentsByName, variables);
+                return new QueryTraverser(schema, root, rootParentType, fragmentsByName, variables);
             }
         }
 

--- a/src/main/java/graphql/analysis/QueryVisitor.java
+++ b/src/main/java/graphql/analysis/QueryVisitor.java
@@ -4,9 +4,9 @@ import graphql.PublicApi;
 import graphql.util.TraversalControl;
 
 /**
- * Used by {@link QueryTraversal} to visit the nodes of a Query.
+ * Used by {@link QueryTraverser} to visit the nodes of a Query.
  * <p>
- * How this happens in detail (pre vs post-order for example) is defined by {@link QueryTraversal}.
+ * How this happens in detail (pre vs post-order for example) is defined by {@link QueryTraverser}.
  */
 @PublicApi
 public interface QueryVisitor {

--- a/src/main/java/graphql/execution/instrumentation/fieldvalidation/FieldValidationSupport.java
+++ b/src/main/java/graphql/execution/instrumentation/fieldvalidation/FieldValidationSupport.java
@@ -3,7 +3,7 @@ package graphql.execution.instrumentation.fieldvalidation;
 import graphql.ErrorType;
 import graphql.GraphQLError;
 import graphql.Internal;
-import graphql.analysis.QueryTraversal;
+import graphql.analysis.QueryTraverser;
 import graphql.analysis.QueryVisitorFieldEnvironment;
 import graphql.analysis.QueryVisitorStub;
 import graphql.execution.ExecutionContext;
@@ -29,14 +29,14 @@ class FieldValidationSupport {
 
         Map<ExecutionPath, List<FieldAndArguments>> fieldArgumentsMap = new LinkedHashMap<>();
 
-        QueryTraversal queryTraversal = QueryTraversal.newQueryTraversal()
+        QueryTraverser queryTraverser = QueryTraverser.newQueryTraverser()
                 .schema(executionContext.getGraphQLSchema())
                 .document(executionContext.getDocument())
                 .operationName(executionContext.getOperationDefinition().getName())
                 .variables(executionContext.getVariables())
                 .build();
 
-        queryTraversal.visitPreOrder(new QueryVisitorStub() {
+        queryTraverser.visitPreOrder(new QueryVisitorStub() {
             @Override
             public void visitField(QueryVisitorFieldEnvironment env) {
                 Field field = env.getField();

--- a/src/test/groovy/graphql/analysis/MaxQueryComplexityInstrumentationTest.groovy
+++ b/src/test/groovy/graphql/analysis/MaxQueryComplexityInstrumentationTest.groovy
@@ -34,7 +34,7 @@ class MaxQueryComplexityInstrumentationTest extends Specification {
         MaxQueryComplexityInstrumentation maxQueryComplexityInstrumentation = new MaxQueryComplexityInstrumentation(6) {
 
             @Override
-            QueryTraverser newQueryTraversal(InstrumentationValidationParameters parameters) {
+            QueryTraverser newQueryTraverser(InstrumentationValidationParameters parameters) {
                 return queryTraversal
             }
         }
@@ -62,7 +62,7 @@ class MaxQueryComplexityInstrumentationTest extends Specification {
         MaxQueryComplexityInstrumentation maxQueryComplexityInstrumentation = new MaxQueryComplexityInstrumentation(6) {
 
             @Override
-            QueryTraverser newQueryTraversal(InstrumentationValidationParameters parameters) {
+            QueryTraverser newQueryTraverser(InstrumentationValidationParameters parameters) {
                 return queryTraversal
             }
         }

--- a/src/test/groovy/graphql/analysis/MaxQueryComplexityInstrumentationTest.groovy
+++ b/src/test/groovy/graphql/analysis/MaxQueryComplexityInstrumentationTest.groovy
@@ -30,11 +30,11 @@ class MaxQueryComplexityInstrumentationTest extends Specification {
         def query = createQuery("""
             { bar { thisIsWrong } }
             """)
-        def queryTraversal = Mock(QueryTraversal)
+        def queryTraversal = Mock(QueryTraverser)
         MaxQueryComplexityInstrumentation maxQueryComplexityInstrumentation = new MaxQueryComplexityInstrumentation(6) {
 
             @Override
-            QueryTraversal newQueryTraversal(InstrumentationValidationParameters parameters) {
+            QueryTraverser newQueryTraversal(InstrumentationValidationParameters parameters) {
                 return queryTraversal
             }
         }
@@ -58,11 +58,11 @@ class MaxQueryComplexityInstrumentationTest extends Specification {
         def query = createQuery("""
             { bar { thisIsWrong } }
             """)
-        def queryTraversal = Mock(QueryTraversal)
+        def queryTraversal = Mock(QueryTraverser)
         MaxQueryComplexityInstrumentation maxQueryComplexityInstrumentation = new MaxQueryComplexityInstrumentation(6) {
 
             @Override
-            QueryTraversal newQueryTraversal(InstrumentationValidationParameters parameters) {
+            QueryTraverser newQueryTraversal(InstrumentationValidationParameters parameters) {
                 return queryTraversal
             }
         }

--- a/src/test/groovy/graphql/analysis/MaxQueryDepthInstrumentationTest.groovy
+++ b/src/test/groovy/graphql/analysis/MaxQueryDepthInstrumentationTest.groovy
@@ -35,7 +35,7 @@ class MaxQueryDepthInstrumentationTest extends Specification {
         MaxQueryDepthInstrumentation maximumQueryDepthInstrumentation = new MaxQueryDepthInstrumentation(6) {
 
             @Override
-            QueryTraverser newQueryTraversal(InstrumentationValidationParameters parameters) {
+            QueryTraverser newQueryTraverser(InstrumentationValidationParameters parameters) {
                 return queryTraversal
             }
         }
@@ -63,7 +63,7 @@ class MaxQueryDepthInstrumentationTest extends Specification {
         MaxQueryDepthInstrumentation maximumQueryDepthInstrumentation = new MaxQueryDepthInstrumentation(6) {
 
             @Override
-            QueryTraverser newQueryTraversal(InstrumentationValidationParameters parameters) {
+            QueryTraverser newQueryTraverser(InstrumentationValidationParameters parameters) {
                 return queryTraversal
             }
         }

--- a/src/test/groovy/graphql/analysis/MaxQueryDepthInstrumentationTest.groovy
+++ b/src/test/groovy/graphql/analysis/MaxQueryDepthInstrumentationTest.groovy
@@ -31,11 +31,11 @@ class MaxQueryDepthInstrumentationTest extends Specification {
         def query = createQuery("""
             { bar { thisIsWrong } }
             """)
-        def queryTraversal = Mock(QueryTraversal)
+        def queryTraversal = Mock(QueryTraverser)
         MaxQueryDepthInstrumentation maximumQueryDepthInstrumentation = new MaxQueryDepthInstrumentation(6) {
 
             @Override
-            QueryTraversal newQueryTraversal(InstrumentationValidationParameters parameters) {
+            QueryTraverser newQueryTraversal(InstrumentationValidationParameters parameters) {
                 return queryTraversal
             }
         }
@@ -59,11 +59,11 @@ class MaxQueryDepthInstrumentationTest extends Specification {
         def query = createQuery("""
             { bar { thisIsWrong } }
             """)
-        def queryTraversal = Mock(QueryTraversal)
+        def queryTraversal = Mock(QueryTraverser)
         MaxQueryDepthInstrumentation maximumQueryDepthInstrumentation = new MaxQueryDepthInstrumentation(6) {
 
             @Override
-            QueryTraversal newQueryTraversal(InstrumentationValidationParameters parameters) {
+            QueryTraverser newQueryTraversal(InstrumentationValidationParameters parameters) {
                 return queryTraversal
             }
         }

--- a/src/test/groovy/graphql/analysis/QueryTraverserTest.groovy
+++ b/src/test/groovy/graphql/analysis/QueryTraverserTest.groovy
@@ -24,7 +24,7 @@ import static graphql.util.TraverserContext.Phase.ENTER
 import static graphql.util.TraverserContext.Phase.LEAVE
 import static java.util.Collections.emptyMap
 
-class QueryTraversalTest extends Specification {
+class QueryTraverserTest extends Specification {
 
 
     Document createQuery(String query) {
@@ -32,8 +32,8 @@ class QueryTraversalTest extends Specification {
         parser.parseDocument(query)
     }
 
-    QueryTraversal createQueryTraversal(Document document, GraphQLSchema schema, Map variables = [:]) {
-        QueryTraversal queryTraversal = QueryTraversal.newQueryTraversal()
+    QueryTraverser createQueryTraversal(Document document, GraphQLSchema schema, Map variables = [:]) {
+        QueryTraverser queryTraversal = QueryTraverser.newQueryTraverser()
                 .schema(schema)
                 .document(document)
                 .variables(variables)
@@ -66,7 +66,7 @@ class QueryTraversalTest extends Specification {
         def query = createQuery("""
             {foo { subFoo} bar }
             """)
-        QueryTraversal queryTraversal = createQueryTraversal(query, schema)
+        QueryTraverser queryTraversal = createQueryTraversal(query, schema)
         when:
         queryTraversal.visitPreOrder(visitor)
 
@@ -104,7 +104,7 @@ class QueryTraversalTest extends Specification {
         def query = createQuery("""
             {foo { subFoo} bar }
             """)
-        QueryTraversal queryTraversal = createQueryTraversal(query, schema)
+        QueryTraverser queryTraversal = createQueryTraversal(query, schema)
         when:
         queryTraversal.visitPostOrder(visitor)
 
@@ -152,7 +152,7 @@ class QueryTraversalTest extends Specification {
         assert inlineFragmentLeft instanceof InlineFragment
         def inlineFragmentRight = inlineFragmentRoot.selectionSet.children[1]
         assert inlineFragmentRight instanceof InlineFragment
-        QueryTraversal queryTraversal = createQueryTraversal(query, schema)
+        QueryTraverser queryTraversal = createQueryTraversal(query, schema)
         when:
         queryTraversal.visitPreOrder(visitor)
 
@@ -196,7 +196,7 @@ class QueryTraversalTest extends Specification {
         assert inlineFragmentLeft instanceof InlineFragment
         def inlineFragmentRight = inlineFragmentRoot.selectionSet.children[1]
         assert inlineFragmentRight instanceof InlineFragment
-        QueryTraversal queryTraversal = createQueryTraversal(query, schema)
+        QueryTraverser queryTraversal = createQueryTraversal(query, schema)
         when:
         queryTraversal.visitPostOrder(visitor)
 
@@ -250,7 +250,7 @@ class QueryTraversalTest extends Specification {
         assert fragmentSpreadLeft instanceof FragmentSpread
         def fragmentSpreadRight = fragmentF1.selectionSet.children[1]
         assert fragmentSpreadRight instanceof FragmentSpread
-        QueryTraversal queryTraversal = createQueryTraversal(query, schema)
+        QueryTraverser queryTraversal = createQueryTraversal(query, schema)
         when:
         queryTraversal.visitPreOrder(visitor)
 
@@ -304,7 +304,7 @@ class QueryTraversalTest extends Specification {
         assert fragmentSpreadLeft instanceof FragmentSpread
         def fragmentSpreadRight = fragmentF1.selectionSet.children[1]
         assert fragmentSpreadRight instanceof FragmentSpread
-        QueryTraversal queryTraversal = createQueryTraversal(query, schema)
+        QueryTraverser queryTraversal = createQueryTraversal(query, schema)
         when:
         queryTraversal.visitPostOrder(visitor)
 
@@ -344,7 +344,7 @@ class QueryTraversalTest extends Specification {
 
         def fragments = NodeUtil.getFragmentsByName(query)
 
-        QueryTraversal queryTraversal = QueryTraversal.newQueryTraversal()
+        QueryTraverser queryTraversal = QueryTraverser.newQueryTraverser()
                 .schema(schema)
                 .root(fragments["F1"])
                 .rootParentType(schema.getQueryType())
@@ -384,7 +384,7 @@ class QueryTraversalTest extends Specification {
         def query = createQuery("""
             mutation M{bar foo { subFoo} }
             """)
-        QueryTraversal queryTraversal = createQueryTraversal(query, schema)
+        QueryTraverser queryTraversal = createQueryTraversal(query, schema)
         when:
         queryTraversal."$visitFn"(visitor)
 
@@ -423,7 +423,7 @@ class QueryTraversalTest extends Specification {
         def query = createQuery("""
             subscription S{bar foo { subFoo} }
             """)
-        QueryTraversal queryTraversal = createQueryTraversal(query, schema)
+        QueryTraverser queryTraversal = createQueryTraversal(query, schema)
         when:
         queryTraversal."$visitFn"(visitor)
 
@@ -455,7 +455,7 @@ class QueryTraversalTest extends Specification {
         def query = createQuery("""
             query myQuery(\$myVar: String){foo(arg1: \$myVar, arg2: true)} 
             """)
-        QueryTraversal queryTraversal = createQueryTraversal(query, schema, ['myVar': 'hello'])
+        QueryTraverser queryTraversal = createQueryTraversal(query, schema, ['myVar': 'hello'])
         when:
         queryTraversal."$visitFn"(visitor)
 
@@ -487,7 +487,7 @@ class QueryTraversalTest extends Specification {
         def query = createQuery("""
             {bar foo { subFoo} }
             """)
-        QueryTraversal queryTraversal = createQueryTraversal(query, schema)
+        QueryTraverser queryTraversal = createQueryTraversal(query, schema)
         when:
         queryTraversal."$visitFn"(visitor)
 
@@ -524,7 +524,7 @@ class QueryTraversalTest extends Specification {
         def query = createQuery("""
             {bar foo { subFoo} foo2 { subFoo} foo3 { subFoo}}
             """)
-        QueryTraversal queryTraversal = createQueryTraversal(query, schema)
+        QueryTraverser queryTraversal = createQueryTraversal(query, schema)
         when:
         queryTraversal."$visitFn"(visitor)
 
@@ -568,7 +568,7 @@ class QueryTraversalTest extends Specification {
                 }
             }
             """)
-        QueryTraversal queryTraversal = createQueryTraversal(query, schema)
+        QueryTraverser queryTraversal = createQueryTraversal(query, schema)
         def inlineFragment = query.children[0].children[0].children[1]
         assert inlineFragment instanceof InlineFragment
         when:
@@ -613,7 +613,7 @@ class QueryTraversalTest extends Specification {
                 }
             }
             """)
-        QueryTraversal queryTraversal = createQueryTraversal(query, schema)
+        QueryTraverser queryTraversal = createQueryTraversal(query, schema)
         when:
         queryTraversal."$visitFn"(visitor)
 
@@ -658,7 +658,7 @@ class QueryTraversalTest extends Specification {
             }
             
             """)
-        QueryTraversal queryTraversal = createQueryTraversal(query, schema)
+        QueryTraverser queryTraversal = createQueryTraversal(query, schema)
         def fragmentDefinition = query.children[1]
         assert fragmentDefinition instanceof FragmentDefinition
         when:
@@ -705,7 +705,7 @@ class QueryTraversalTest extends Specification {
             }
             
             """)
-        QueryTraversal queryTraversal = createQueryTraversal(query, schema)
+        QueryTraverser queryTraversal = createQueryTraversal(query, schema)
         when:
         queryTraversal."$visitFn"(visitor)
 
@@ -744,7 +744,7 @@ class QueryTraversalTest extends Specification {
             }
             
             """)
-        QueryTraversal queryTraversal = createQueryTraversal(query, schema, [variableFoo: true])
+        QueryTraverser queryTraversal = createQueryTraversal(query, schema, [variableFoo: true])
         when:
         queryTraversal."$visitFn"(visitor)
 
@@ -797,7 +797,7 @@ class QueryTraversalTest extends Specification {
             }
             
             """)
-        QueryTraversal queryTraversal = createQueryTraversal(query, schema, [variableFoo: true])
+        QueryTraverser queryTraversal = createQueryTraversal(query, schema, [variableFoo: true])
         when:
         queryTraversal."$visitFn"(visitor)
 
@@ -846,7 +846,7 @@ class QueryTraversalTest extends Specification {
                 bar
             }
             """)
-        QueryTraversal queryTraversal = createQueryTraversal(query, schema, [variableFoo: false])
+        QueryTraverser queryTraversal = createQueryTraversal(query, schema, [variableFoo: false])
         when:
         queryTraversal."$visitFn"(visitor)
 
@@ -886,7 +886,7 @@ class QueryTraversalTest extends Specification {
                 }
             }
             """)
-        QueryTraversal queryTraversal = createQueryTraversal(query, schema, [variableFoo: false])
+        QueryTraverser queryTraversal = createQueryTraversal(query, schema, [variableFoo: false])
         when:
         queryTraversal."$visitFn"(visitor)
 
@@ -924,7 +924,7 @@ class QueryTraversalTest extends Specification {
                 foo @include(if: \$variableFoo)
             }
             """)
-        QueryTraversal queryTraversal = createQueryTraversal(query, schema, [variableFoo: false])
+        QueryTraverser queryTraversal = createQueryTraversal(query, schema, [variableFoo: false])
         when:
         queryTraversal."$visitFn"(visitor)
 
@@ -954,7 +954,7 @@ class QueryTraversalTest extends Specification {
         def query = createQuery("""
             {foo { subFoo} bar }
             """)
-        QueryTraversal queryTraversal = createQueryTraversal(query, schema)
+        QueryTraverser queryTraversal = createQueryTraversal(query, schema)
         QueryReducer reducer = Mock(QueryReducer)
         when:
         def result = queryTraversal.reducePreOrder(reducer, 1)
@@ -984,7 +984,7 @@ class QueryTraversalTest extends Specification {
         def query = createQuery("""
             {foo { subFoo} bar }
             """)
-        QueryTraversal queryTraversal = createQueryTraversal(query, schema)
+        QueryTraverser queryTraversal = createQueryTraversal(query, schema)
         QueryReducer reducer = Mock(QueryReducer)
         when:
         def result = queryTraversal.reducePostOrder(reducer, 1)
@@ -1021,7 +1021,7 @@ class QueryTraversalTest extends Specification {
         def query = createQuery("""
             {a {id... on Person {name}}}
         """)
-        QueryTraversal queryTraversal = createQueryTraversal(query, schema)
+        QueryTraverser queryTraversal = createQueryTraversal(query, schema)
         when:
         queryTraversal."$visitFn"(visitor)
 
@@ -1059,7 +1059,7 @@ class QueryTraversalTest extends Specification {
         def query = createQuery("""
             {foo {... on Cat {catName} ... on Dog {dogName}} }
         """)
-        QueryTraversal queryTraversal = createQueryTraversal(query, schema)
+        QueryTraverser queryTraversal = createQueryTraversal(query, schema)
         when:
         queryTraversal."$visitFn"(visitor)
 
@@ -1105,7 +1105,7 @@ class QueryTraversalTest extends Specification {
         def query = createQuery("""
             {foo {... on Cat {catName} ... on Dog {dogName}} bar {id}}
         """)
-        QueryTraversal queryTraversal = createQueryTraversal(query, schema)
+        QueryTraverser queryTraversal = createQueryTraversal(query, schema)
         when:
         queryTraversal."$visitFn"(visitor)
 
@@ -1139,7 +1139,7 @@ class QueryTraversalTest extends Specification {
             __type(name: "Foo") { name } 
             }
             """)
-        QueryTraversal queryTraversal = createQueryTraversal(query, schema)
+        QueryTraverser queryTraversal = createQueryTraversal(query, schema)
         when:
         queryTraversal."$visitFn"(visitor)
 
@@ -1193,7 +1193,7 @@ class QueryTraversalTest extends Specification {
             }
         }
             """)
-        QueryTraversal queryTraversal = createQueryTraversal(query, schema)
+        QueryTraverser queryTraversal = createQueryTraversal(query, schema)
         when:
         queryTraversal."$visitFn"(visitor)
 
@@ -1233,7 +1233,7 @@ class QueryTraversalTest extends Specification {
         assert subFooAsRoot instanceof Field
         ((Field) subFooAsRoot).name == "subFoo"
         def rootParentType = schema.getType("Foo")
-        QueryTraversal queryTraversal = QueryTraversal.newQueryTraversal()
+        QueryTraverser queryTraversal = QueryTraverser.newQueryTraverser()
                 .schema(schema)
                 .root(subFooAsRoot)
                 .rootParentType(rootParentType)
@@ -1256,7 +1256,7 @@ class QueryTraversalTest extends Specification {
     @Unroll
     def "builder doesn't allow ambiguous arguments"() {
         when:
-        QueryTraversal.newQueryTraversal()
+        QueryTraverser.newQueryTraverser()
                 .document(document)
                 .operationName(operationName)
                 .root(root)
@@ -1295,7 +1295,7 @@ class QueryTraversalTest extends Specification {
         def query = createQuery("""
             { __typename }
             """)
-        QueryTraversal queryTraversal = createQueryTraversal(query, schema)
+        QueryTraverser queryTraversal = createQueryTraversal(query, schema)
         QueryVisitorFieldEnvironment env
         1 * visitor.visitField({ QueryVisitorFieldEnvironmentImpl it ->
             env = it
@@ -1325,7 +1325,7 @@ class QueryTraversalTest extends Specification {
         def query = createQuery("""
             {foo { subFoo} bar }
             """)
-        QueryTraversal queryTraversal = createQueryTraversal(query, schema)
+        QueryTraverser queryTraversal = createQueryTraversal(query, schema)
         when:
         queryTraversal.visitPreOrder(visitor)
 
@@ -1357,7 +1357,7 @@ class QueryTraversalTest extends Specification {
         def query = createQuery("""
             { ...F } fragment F on Query @myDirective {bar}
             """)
-        QueryTraversal queryTraversal = createQueryTraversal(query, schema)
+        QueryTraverser queryTraversal = createQueryTraversal(query, schema)
         when:
         queryTraversal.visitPreOrder(visitor)
 
@@ -1386,7 +1386,7 @@ class QueryTraversalTest extends Specification {
         def query = createQuery("""
             {foo { subFoo} bar }
             """)
-        QueryTraversal queryTraversal = createQueryTraversal(query, schema)
+        QueryTraverser queryTraversal = createQueryTraversal(query, schema)
         when:
         queryTraversal.visitDepthFirst(visitor)
 
@@ -1429,7 +1429,7 @@ class QueryTraversalTest extends Specification {
         def query = createQuery("""
             {bar}
             """)
-        QueryTraversal queryTraversal = createQueryTraversal(query, schema)
+        QueryTraverser queryTraversal = createQueryTraversal(query, schema)
         def visitor = new QueryVisitorStub() {
             @Override
             void visitField(QueryVisitorFieldEnvironment queryVisitorFieldEnvironment) {
@@ -1463,7 +1463,7 @@ class QueryTraversalTest extends Specification {
         def hello = rootField.selectionSet.selections[0] as Field
         hello.name == "hello"
         def rootParentType = schema.getType("SomeInterface") as GraphQLInterfaceType
-        QueryTraversal queryTraversal = QueryTraversal.newQueryTraversal()
+        QueryTraverser queryTraversal = QueryTraverser.newQueryTraverser()
                 .schema(schema)
                 .root(hello)
                 .rootParentType(rootParentType)
@@ -1501,7 +1501,7 @@ class QueryTraversalTest extends Specification {
         def rootField = (query.children[0] as OperationDefinition).selectionSet.selections[0] as Field
         def typeNameField = rootField.selectionSet.selections[0] as Field
         def rootParentType = schema.getType("SomeUnion") as GraphQLUnionType
-        QueryTraversal queryTraversal = QueryTraversal.newQueryTraversal()
+        QueryTraverser queryTraversal = QueryTraverser.newQueryTraverser()
                 .schema(schema)
                 .root(typeNameField)
                 .rootParentType(rootParentType)
@@ -1532,7 +1532,7 @@ class QueryTraversalTest extends Specification {
         def query = createQuery("""
             {field { a } }
             """)
-        QueryTraversal queryTraversal = QueryTraversal.newQueryTraversal()
+        QueryTraverser queryTraversal = QueryTraverser.newQueryTraverser()
                 .schema(schema)
                 .document(query)
                 .variables(emptyMap())


### PR DESCRIPTION
This is a breaking change.

It is renamed to be consistent with other classes in GraphQL Java and also because `Traverser` is the better more accurate name.