### PR TITLE
Support custom Optional unboxers

### DIFF
--- a/src/main/java/graphql/execution/UnboxPossibleOptional.java
+++ b/src/main/java/graphql/execution/UnboxPossibleOptional.java
@@ -1,46 +1,102 @@
 package graphql.execution;
 
-import graphql.Internal;
-
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import java.util.ServiceLoader;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import graphql.Internal;
+import graphql.VisibleForTesting;
 
 @Internal
 public class UnboxPossibleOptional {
 
+    @VisibleForTesting
+    static final List<PossibleOptionalUnboxer> UNBOXERS;
+
+    static {
+        final ServiceLoader<PossibleOptionalUnboxer> unboxers = ServiceLoader.load(PossibleOptionalUnboxer.class,
+                UnboxPossibleOptional.class.getClassLoader() );
+        final List<PossibleOptionalUnboxer> listOfUnboxers = new CopyOnWriteArrayList<>();
+        unboxers.iterator().forEachRemaining(listOfUnboxers::add);
+        UNBOXERS = Collections.unmodifiableList(listOfUnboxers);
+    }
+
     public static Object unboxPossibleOptional(Object result) {
-        if (result instanceof Optional) {
-            Optional optional = (Optional) result;
-            if (optional.isPresent()) {
-                return optional.get();
-            } else {
-                return null;
-            }
-        } else if (result instanceof OptionalInt) {
-            OptionalInt optional = (OptionalInt) result;
-            if (optional.isPresent()) {
-                return optional.getAsInt();
-            } else {
-                return null;
-            }
-        } else if (result instanceof OptionalDouble) {
-            OptionalDouble optional = (OptionalDouble) result;
-            if (optional.isPresent()) {
-                return optional.getAsDouble();
-            } else {
-                return null;
-            }
-        } else if (result instanceof OptionalLong) {
-            OptionalLong optional = (OptionalLong) result;
-            if (optional.isPresent()) {
-                return optional.getAsLong();
-            } else {
-                return null;
-            }
+        return UNBOXERS.stream()
+                .filter(unboxer -> unboxer.canUnbox(result))
+                .findFirst()
+                .map(unboxer -> unboxer.unbox(result))
+                .orElse(result);
+    }
+
+
+    /**
+     * Java SPI interface for unboxing possible optional types
+     */
+    public interface PossibleOptionalUnboxer {
+
+        /**
+         * Can this unboxer unbox the arg?
+         * @param object to try and unbox
+         * @return true if it can be unboxed
+         */
+        boolean canUnbox(final Object object);
+
+        /**
+         * Unboxes 'object' if it is boxed in an {@link Optional } like
+         * type that this unboxer can handle. Otherwise returns its input
+         * unmodified
+         *
+         * @param object to unbox
+         * @return unboxed object, or original if cannot unbox
+         */
+        Object unbox(final Object object);
+    }
+
+    public static final class JavaOptionalUnboxer implements PossibleOptionalUnboxer {
+
+        @Override
+        public boolean canUnbox(final Object object) {
+            return object instanceof Optional;
         }
 
-        return result;
+        @Override
+        public Object unbox(final Object object) {
+            if (object instanceof Optional) {
+                Optional optional = (Optional) object;
+                if (optional.isPresent()) {
+                    return optional.get();
+                } else {
+                    return null;
+                }
+            } else if (object instanceof OptionalInt) {
+                OptionalInt optional = (OptionalInt) object;
+                if (optional.isPresent()) {
+                    return optional.getAsInt();
+                } else {
+                    return null;
+                }
+            } else if (object instanceof OptionalDouble) {
+                OptionalDouble optional = (OptionalDouble) object;
+                if (optional.isPresent()) {
+                    return optional.getAsDouble();
+                } else {
+                    return null;
+                }
+            } else if (object instanceof OptionalLong) {
+                OptionalLong optional = (OptionalLong) object;
+                if (optional.isPresent()) {
+                    return optional.getAsLong();
+                } else {
+                    return null;
+                }
+            }
+            return object;
+        }
     }
 }

--- a/src/main/resources/META-INF/services/graphql.execution.UnboxPossibleOptional$PossibleOptionalUnboxer
+++ b/src/main/resources/META-INF/services/graphql.execution.UnboxPossibleOptional$PossibleOptionalUnboxer
@@ -1,0 +1,1 @@
+graphql.execution.UnboxPossibleOptional$JavaOptionalUnboxer

--- a/src/test/groovy/graphql/execution/UnboxPossibleOptionalTest.groovy
+++ b/src/test/groovy/graphql/execution/UnboxPossibleOptionalTest.groovy
@@ -1,0 +1,44 @@
+package graphql.execution
+
+import spock.lang.Specification
+
+/**
+ *
+ * @author Sean Brandt [ sean@bwcgroup.com ]
+ */
+class UnboxPossibleOptionalTest extends Specification {
+
+  def "should find default unboxers"() {
+    when:
+    UnboxPossibleOptional.UNBOXERS  // Force class load, and thus service provider load
+
+    then:
+    UnboxPossibleOptional.UNBOXERS.size() == 2
+    UnboxPossibleOptional.UNBOXERS.find( { u -> u.class == UnboxPossibleOptional.JavaOptionalUnboxer.class} ) != null
+    UnboxPossibleOptional.UNBOXERS.find( { u -> u.class == TestOptionalUnboxer.class} ) != null
+
+  }
+
+  def "will unbox an Optional"() {
+    given:
+    def data = "test"
+    def optional = Optional.of(data)
+
+    when:
+    def result = UnboxPossibleOptional.unboxPossibleOptional(optional)
+
+    then:
+    result == data
+  }
+
+  def "will pass input back as output for non optional"() {
+    given:
+    def data = "test"
+
+    when:
+    def result = UnboxPossibleOptional.unboxPossibleOptional(data)
+
+    then:
+    result == data
+  }
+}

--- a/src/test/java/graphql/execution/TestOptionalUnboxer.java
+++ b/src/test/java/graphql/execution/TestOptionalUnboxer.java
@@ -1,0 +1,16 @@
+package graphql.execution;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class TestOptionalUnboxer implements UnboxPossibleOptional.PossibleOptionalUnboxer {
+	@Override
+	public boolean canUnbox(final Object object) {
+		return object instanceof Optional;
+	}
+
+	@Override
+	public Object unbox(final Object object) {
+		return ((Optional)object).orElse(object);
+	}
+}

--- a/src/test/java/graphql/execution/TestOptionalUnboxer.java
+++ b/src/test/java/graphql/execution/TestOptionalUnboxer.java
@@ -1,16 +1,5 @@
 package graphql.execution;
 
-import java.util.Map;
-import java.util.Optional;
+public class TestOptionalUnboxer extends UnboxPossibleOptional.JavaOptionalUnboxer {
 
-public class TestOptionalUnboxer implements UnboxPossibleOptional.PossibleOptionalUnboxer {
-	@Override
-	public boolean canUnbox(final Object object) {
-		return object instanceof Optional;
-	}
-
-	@Override
-	public Object unbox(final Object object) {
-		return ((Optional)object).orElse(object);
-	}
 }

--- a/src/test/resources/META-INF/services/graphql.execution.UnboxPossibleOptional$PossibleOptionalUnboxer
+++ b/src/test/resources/META-INF/services/graphql.execution.UnboxPossibleOptional$PossibleOptionalUnboxer
@@ -1,0 +1,1 @@
+graphql.execution.TestOptionalUnboxer


### PR DESCRIPTION
Add support via the java ServiceLoader mechansim for providing custom
implementations and allowing for support of Guava, Vavr, etc.

No support for extension of the current mechanism, or overriding it

Addresses: #1581 