### PR TITLE
simplifying ResultNodes 

### DIFF
--- a/src/main/java/graphql/execution/nextgen/BatchedExecutionStrategy.java
+++ b/src/main/java/graphql/execution/nextgen/BatchedExecutionStrategy.java
@@ -84,7 +84,7 @@ public class BatchedExecutionStrategy implements ExecutionStrategy {
         assertTrue(unresolvedNodes.size() > 0, "unresolvedNodes can't be empty");
 
         List<FieldSubSelection> fieldSubSelections = map(unresolvedNodes,
-                node -> util.createFieldSubSelection(executionContext, node.getCurNode().getFetchedValueAnalysis()));
+                node -> util.createFieldSubSelection(executionContext, node.getCurNode().getExecutionStepInfo(), node.getCurNode().getResolvedValue()));
 
         //constrain: all fieldSubSelections have the same mergedSelectionSet
         MergedSelectionSet mergedSelectionSet = fieldSubSelections.get(0).getMergedSelectionSet();

--- a/src/main/java/graphql/execution/nextgen/DefaultExecutionStrategy.java
+++ b/src/main/java/graphql/execution/nextgen/DefaultExecutionStrategy.java
@@ -2,8 +2,10 @@ package graphql.execution.nextgen;
 
 import graphql.Internal;
 import graphql.execution.ExecutionContext;
+import graphql.execution.ExecutionStepInfo;
 import graphql.execution.nextgen.result.ExecutionResultNode;
 import graphql.execution.nextgen.result.ObjectExecutionResultNode;
+import graphql.execution.nextgen.result.ResolvedValue;
 import graphql.execution.nextgen.result.ResultNodesUtil;
 import graphql.execution.nextgen.result.RootExecutionResultNode;
 import graphql.util.NodeMultiZipper;
@@ -47,10 +49,11 @@ public class DefaultExecutionStrategy implements ExecutionStrategy {
     }
 
     private CompletableFuture<NodeZipper<ExecutionResultNode>> resolveNode(ExecutionContext executionContext, NodeZipper<ExecutionResultNode> unresolvedNode) {
-        FetchedValueAnalysis fetchedValueAnalysis = unresolvedNode.getCurNode().getFetchedValueAnalysis();
-        FieldSubSelection fieldSubSelection = util.createFieldSubSelection(executionContext, fetchedValueAnalysis);
+        ExecutionStepInfo executionStepInfo = unresolvedNode.getCurNode().getExecutionStepInfo();
+        ResolvedValue resolvedValue = unresolvedNode.getCurNode().getResolvedValue();
+        FieldSubSelection fieldSubSelection = util.createFieldSubSelection(executionContext, executionStepInfo, resolvedValue);
         return resolveSubSelection(executionContext, fieldSubSelection)
-                .thenApply(resolvedChildMap -> unresolvedNode.withNewNode(new ObjectExecutionResultNode(fetchedValueAnalysis, resolvedChildMap)));
+                .thenApply(resolvedChildMap -> unresolvedNode.withNewNode(new ObjectExecutionResultNode(executionStepInfo, resolvedValue, resolvedChildMap)));
     }
 
     private CompletableFuture<ExecutionResultNode> resolvedNodesToResultNode(

--- a/src/main/java/graphql/execution/nextgen/ExecutionStrategyUtil.java
+++ b/src/main/java/graphql/execution/nextgen/ExecutionStrategyUtil.java
@@ -12,6 +12,7 @@ import graphql.execution.MergedField;
 import graphql.execution.MergedSelectionSet;
 import graphql.execution.ResolveType;
 import graphql.execution.nextgen.result.ExecutionResultNode;
+import graphql.execution.nextgen.result.ResolvedValue;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLOutputType;
 import graphql.util.FpKit;
@@ -66,11 +67,10 @@ public class ExecutionStrategyUtil {
         return fetchedValueAnalysis;
     }
 
-    public FieldSubSelection createFieldSubSelection(ExecutionContext executionContext, FetchedValueAnalysis analysis) {
-        ExecutionStepInfo executionInfo = analysis.getExecutionStepInfo();
-        MergedField field = analysis.getField();
-        Object source = analysis.getCompletedValue();
-        Object localContext = analysis.getFetchedValue().getLocalContext();
+    public FieldSubSelection createFieldSubSelection(ExecutionContext executionContext, ExecutionStepInfo executionInfo, ResolvedValue resolvedValue) {
+        MergedField field = executionInfo.getField();
+        Object source = resolvedValue.getCompletedValue();
+        Object localContext = resolvedValue.getLocalContext();
 
         GraphQLOutputType sourceType = executionInfo.getUnwrappedNonNullType();
         GraphQLObjectType resolvedObjectType = resolveType.resolveType(executionContext, field, source, executionInfo.getArguments(), sourceType);

--- a/src/main/java/graphql/execution/nextgen/result/ExecutionResultNode.java
+++ b/src/main/java/graphql/execution/nextgen/result/ExecutionResultNode.java
@@ -3,9 +3,9 @@ package graphql.execution.nextgen.result;
 import graphql.Assert;
 import graphql.GraphQLError;
 import graphql.Internal;
+import graphql.execution.ExecutionStepInfo;
 import graphql.execution.MergedField;
 import graphql.execution.NonNullableFieldWasNullException;
-import graphql.execution.nextgen.FetchedValueAnalysis;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,16 +16,19 @@ import static graphql.Assert.assertNotNull;
 @Internal
 public abstract class ExecutionResultNode {
 
-    private final FetchedValueAnalysis fetchedValueAnalysis;
+    private final ExecutionStepInfo executionStepInfo;
+    private final ResolvedValue resolvedValue;
     private final NonNullableFieldWasNullException nonNullableFieldWasNullException;
     private final List<ExecutionResultNode> children;
     private final List<GraphQLError> errors;
 
-    protected ExecutionResultNode(FetchedValueAnalysis fetchedValueAnalysis,
+    protected ExecutionResultNode(ExecutionStepInfo executionStepInfo,
+                                  ResolvedValue resolvedValue,
                                   NonNullableFieldWasNullException nonNullableFieldWasNullException,
                                   List<ExecutionResultNode> children,
                                   List<GraphQLError> errors) {
-        this.fetchedValueAnalysis = fetchedValueAnalysis;
+        this.resolvedValue = resolvedValue;
+        this.executionStepInfo = executionStepInfo;
         this.nonNullableFieldWasNullException = nonNullableFieldWasNullException;
         this.children = assertNotNull(children);
         children.forEach(Assert::assertNotNull);
@@ -39,12 +42,16 @@ public abstract class ExecutionResultNode {
     /*
      * can be null for the RootExecutionResultNode
      */
-    public FetchedValueAnalysis getFetchedValueAnalysis() {
-        return fetchedValueAnalysis;
+    public ResolvedValue getResolvedValue() {
+        return resolvedValue;
     }
 
     public MergedField getMergedField() {
-        return fetchedValueAnalysis.getExecutionStepInfo().getField();
+        return executionStepInfo.getField();
+    }
+
+    public ExecutionStepInfo getExecutionStepInfo() {
+        return executionStepInfo;
     }
 
     public NonNullableFieldWasNullException getNonNullableFieldWasNullException() {
@@ -71,14 +78,10 @@ public abstract class ExecutionResultNode {
      */
     public abstract ExecutionResultNode withNewChildren(List<ExecutionResultNode> children);
 
-    /**
-     * Creates a new ExecutionResultNode of the same specific type with the new {@link graphql.execution.nextgen.FetchedValueAnalysis}
-     *
-     * @param fetchedValueAnalysis the {@link graphql.execution.nextgen.FetchedValueAnalysis} for this result node
-     *
-     * @return a new ExecutionResultNode with the new {@link graphql.execution.nextgen.FetchedValueAnalysis}
-     */
-    public abstract ExecutionResultNode withNewFetchedValueAnalysis(FetchedValueAnalysis fetchedValueAnalysis);
+    public abstract ExecutionResultNode withNewResolvedValue(ResolvedValue resolvedValue);
+
+    public abstract ExecutionResultNode withNewExecutionStepInfo(ExecutionStepInfo executionStepInfo);
+
 
     /**
      * Creates a new ExecutionResultNode of the same specific type with the new error collection
@@ -92,11 +95,12 @@ public abstract class ExecutionResultNode {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "{" +
-                "fva=" + fetchedValueAnalysis +
+        return "ExecutionResultNode{" +
+                "executionStepInfo=" + executionStepInfo +
+                ", resolvedValue=" + resolvedValue +
+                ", nonNullableFieldWasNullException=" + nonNullableFieldWasNullException +
                 ", children=" + children +
                 ", errors=" + errors +
-                ", nonNullableEx=" + nonNullableFieldWasNullException +
                 '}';
     }
 }

--- a/src/main/java/graphql/execution/nextgen/result/LeafExecutionResultNode.java
+++ b/src/main/java/graphql/execution/nextgen/result/LeafExecutionResultNode.java
@@ -3,8 +3,8 @@ package graphql.execution.nextgen.result;
 import graphql.Assert;
 import graphql.GraphQLError;
 import graphql.Internal;
+import graphql.execution.ExecutionStepInfo;
 import graphql.execution.NonNullableFieldWasNullException;
-import graphql.execution.nextgen.FetchedValueAnalysis;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -13,20 +13,22 @@ import java.util.List;
 @Internal
 public class LeafExecutionResultNode extends ExecutionResultNode {
 
-    public LeafExecutionResultNode(FetchedValueAnalysis fetchedValueAnalysis,
+    public LeafExecutionResultNode(ExecutionStepInfo executionStepInfo,
+                                   ResolvedValue resolvedValue,
                                    NonNullableFieldWasNullException nonNullableFieldWasNullException) {
-        this(fetchedValueAnalysis, nonNullableFieldWasNullException, Collections.emptyList());
+        this(executionStepInfo, resolvedValue, nonNullableFieldWasNullException, Collections.emptyList());
     }
 
-    public LeafExecutionResultNode(FetchedValueAnalysis fetchedValueAnalysis,
+    public LeafExecutionResultNode(ExecutionStepInfo executionStepInfo,
+                                   ResolvedValue resolvedValue,
                                    NonNullableFieldWasNullException nonNullableFieldWasNullException,
                                    List<GraphQLError> errors) {
-        super(fetchedValueAnalysis, nonNullableFieldWasNullException, Collections.emptyList(), errors);
+        super(executionStepInfo, resolvedValue, nonNullableFieldWasNullException, Collections.emptyList(), errors);
     }
 
 
     public Object getValue() {
-        return getFetchedValueAnalysis().getCompletedValue();
+        return getResolvedValue().getCompletedValue();
     }
 
     @Override
@@ -35,12 +37,17 @@ public class LeafExecutionResultNode extends ExecutionResultNode {
     }
 
     @Override
-    public ExecutionResultNode withNewFetchedValueAnalysis(FetchedValueAnalysis fetchedValueAnalysis) {
-        return new LeafExecutionResultNode(fetchedValueAnalysis, getNonNullableFieldWasNullException(), getErrors());
+    public ExecutionResultNode withNewExecutionStepInfo(ExecutionStepInfo executionStepInfo) {
+        return new LeafExecutionResultNode(executionStepInfo, getResolvedValue(), getNonNullableFieldWasNullException(), getErrors());
+    }
+
+    @Override
+    public ExecutionResultNode withNewResolvedValue(ResolvedValue resolvedValue) {
+        return new LeafExecutionResultNode(getExecutionStepInfo(), resolvedValue, getNonNullableFieldWasNullException(), getErrors());
     }
 
     @Override
     public ExecutionResultNode withNewErrors(List<GraphQLError> errors) {
-        return new LeafExecutionResultNode(getFetchedValueAnalysis(), getNonNullableFieldWasNullException(), new ArrayList<>(errors));
+        return new LeafExecutionResultNode(getExecutionStepInfo(), getResolvedValue(), getNonNullableFieldWasNullException(), new ArrayList<>(errors));
     }
 }

--- a/src/main/java/graphql/execution/nextgen/result/ListExecutionResultNode.java
+++ b/src/main/java/graphql/execution/nextgen/result/ListExecutionResultNode.java
@@ -2,7 +2,7 @@ package graphql.execution.nextgen.result;
 
 import graphql.GraphQLError;
 import graphql.Internal;
-import graphql.execution.nextgen.FetchedValueAnalysis;
+import graphql.execution.ExecutionStepInfo;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -11,30 +11,37 @@ import java.util.List;
 @Internal
 public class ListExecutionResultNode extends ExecutionResultNode {
 
-    public ListExecutionResultNode(FetchedValueAnalysis fetchedValueAnalysis,
+    public ListExecutionResultNode(ExecutionStepInfo executionStepInfo,
+                                   ResolvedValue resolvedValue,
                                    List<ExecutionResultNode> children) {
-        this(fetchedValueAnalysis, children, Collections.emptyList());
+        this(executionStepInfo, resolvedValue, children, Collections.emptyList());
 
     }
 
-    public ListExecutionResultNode(FetchedValueAnalysis fetchedValueAnalysis,
+    public ListExecutionResultNode(ExecutionStepInfo executionStepInfo,
+                                   ResolvedValue resolvedValue,
                                    List<ExecutionResultNode> children,
                                    List<GraphQLError> errors) {
-        super(fetchedValueAnalysis, ResultNodesUtil.newNullableException(fetchedValueAnalysis, children), children, errors);
+        super(executionStepInfo, resolvedValue, ResultNodesUtil.newNullableException(executionStepInfo, children), children, errors);
     }
 
     @Override
     public ExecutionResultNode withNewChildren(List<ExecutionResultNode> children) {
-        return new ListExecutionResultNode(getFetchedValueAnalysis(), children, getErrors());
+        return new ListExecutionResultNode(getExecutionStepInfo(), getResolvedValue(), children, getErrors());
     }
 
     @Override
-    public ExecutionResultNode withNewFetchedValueAnalysis(FetchedValueAnalysis fetchedValueAnalysis) {
-        return new ListExecutionResultNode(fetchedValueAnalysis, getChildren(), getErrors());
+    public ExecutionResultNode withNewResolvedValue(ResolvedValue resolvedValue) {
+        return new ListExecutionResultNode(getExecutionStepInfo(), resolvedValue, getChildren(), getErrors());
+    }
+
+    @Override
+    public ExecutionResultNode withNewExecutionStepInfo(ExecutionStepInfo executionStepInfo) {
+        return new ListExecutionResultNode(executionStepInfo, getResolvedValue(), getChildren(), getErrors());
     }
 
     @Override
     public ExecutionResultNode withNewErrors(List<GraphQLError> errors) {
-        return new ListExecutionResultNode(getFetchedValueAnalysis(), getChildren(), new ArrayList<>(errors));
+        return new ListExecutionResultNode(getExecutionStepInfo(), getResolvedValue(), getChildren(), new ArrayList<>(errors));
     }
 }

--- a/src/main/java/graphql/execution/nextgen/result/ObjectExecutionResultNode.java
+++ b/src/main/java/graphql/execution/nextgen/result/ObjectExecutionResultNode.java
@@ -2,7 +2,7 @@ package graphql.execution.nextgen.result;
 
 import graphql.GraphQLError;
 import graphql.Internal;
-import graphql.execution.nextgen.FetchedValueAnalysis;
+import graphql.execution.ExecutionStepInfo;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -12,31 +12,38 @@ import java.util.List;
 public class ObjectExecutionResultNode extends ExecutionResultNode {
 
 
-    public ObjectExecutionResultNode(FetchedValueAnalysis fetchedValueAnalysis,
+    public ObjectExecutionResultNode(ExecutionStepInfo executionStepInfo,
+                                     ResolvedValue resolvedValue,
                                      List<ExecutionResultNode> children) {
-        this(fetchedValueAnalysis, children, Collections.emptyList());
+        this(executionStepInfo, resolvedValue, children, Collections.emptyList());
 
     }
 
-    public ObjectExecutionResultNode(FetchedValueAnalysis fetchedValueAnalysis,
+    public ObjectExecutionResultNode(ExecutionStepInfo executionStepInfo,
+                                     ResolvedValue resolvedValue,
                                      List<ExecutionResultNode> children,
                                      List<GraphQLError> errors) {
-        super(fetchedValueAnalysis, ResultNodesUtil.newNullableException(fetchedValueAnalysis, children), children, errors);
+        super(executionStepInfo, resolvedValue, ResultNodesUtil.newNullableException(executionStepInfo, children), children, errors);
     }
 
 
     @Override
     public ObjectExecutionResultNode withNewChildren(List<ExecutionResultNode> children) {
-        return new ObjectExecutionResultNode(getFetchedValueAnalysis(), children, getErrors());
+        return new ObjectExecutionResultNode(getExecutionStepInfo(), getResolvedValue(), children, getErrors());
     }
 
     @Override
-    public ExecutionResultNode withNewFetchedValueAnalysis(FetchedValueAnalysis fetchedValueAnalysis) {
-        return new ObjectExecutionResultNode(fetchedValueAnalysis, getChildren(), getErrors());
+    public ExecutionResultNode withNewResolvedValue(ResolvedValue resolvedValue) {
+        return new ObjectExecutionResultNode(getExecutionStepInfo(), resolvedValue, getChildren(), getErrors());
+    }
+
+    @Override
+    public ExecutionResultNode withNewExecutionStepInfo(ExecutionStepInfo executionStepInfo) {
+        return new ObjectExecutionResultNode(executionStepInfo, getResolvedValue(), getChildren(), getErrors());
     }
 
     @Override
     public ExecutionResultNode withNewErrors(List<GraphQLError> errors) {
-        return new ObjectExecutionResultNode(getFetchedValueAnalysis(), getChildren(), new ArrayList<>(errors));
+        return new ObjectExecutionResultNode(getExecutionStepInfo(), getResolvedValue(), getChildren(), new ArrayList<>(errors));
     }
 }

--- a/src/main/java/graphql/execution/nextgen/result/ResolvedValue.java
+++ b/src/main/java/graphql/execution/nextgen/result/ResolvedValue.java
@@ -1,0 +1,96 @@
+package graphql.execution.nextgen.result;
+
+import graphql.GraphQLError;
+import graphql.Internal;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+
+@Internal
+public class ResolvedValue {
+
+    private final Object completedValue;
+    private final Object localContext;
+    private final boolean nullValue;
+    private final List<GraphQLError> errors;
+
+    private ResolvedValue(Builder builder) {
+        this.completedValue = builder.completedValue;
+        this.localContext = builder.localContext;
+        this.nullValue = builder.nullValue;
+        this.errors = builder.errors;
+    }
+
+    public Object getCompletedValue() {
+        return completedValue;
+    }
+
+    public Object getLocalContext() {
+        return localContext;
+    }
+
+    public boolean isNullValue() {
+        return nullValue;
+    }
+
+    public List<GraphQLError> getErrors() {
+        return Collections.unmodifiableList(errors);
+    }
+
+    public static Builder newResolvedValue() {
+        return new Builder();
+    }
+
+
+    public ResolvedValue transform(Consumer<Builder> builderConsumer) {
+        Builder builder = new Builder(this);
+        builderConsumer.accept(builder);
+        return builder.build();
+    }
+
+
+    public static class Builder {
+        private Object completedValue;
+        private Object localContext;
+        private boolean nullValue;
+        private List<GraphQLError> errors = Collections.emptyList();
+
+        private Builder() {
+
+        }
+
+        private Builder(ResolvedValue existing) {
+            this.completedValue = existing.completedValue;
+            this.localContext = existing.localContext;
+            this.nullValue = existing.nullValue;
+            this.errors = existing.errors;
+        }
+
+        public Builder completedValue(Object completedValue) {
+            this.completedValue = completedValue;
+            return this;
+        }
+
+        public Builder localContext(Object localContext) {
+            this.localContext = localContext;
+            return this;
+        }
+
+        public Builder nullValue(boolean nullValue) {
+            this.nullValue = nullValue;
+            return this;
+        }
+
+        public Builder errors(List<GraphQLError> errors) {
+            this.errors = new ArrayList<>(errors);
+            return this;
+        }
+
+        public ResolvedValue build() {
+            return new ResolvedValue(this);
+        }
+    }
+
+}

--- a/src/main/java/graphql/execution/nextgen/result/RootExecutionResultNode.java
+++ b/src/main/java/graphql/execution/nextgen/result/RootExecutionResultNode.java
@@ -1,7 +1,7 @@
 package graphql.execution.nextgen.result;
 
 import graphql.GraphQLError;
-import graphql.execution.nextgen.FetchedValueAnalysis;
+import graphql.execution.ExecutionStepInfo;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -13,16 +13,20 @@ public class RootExecutionResultNode extends ObjectExecutionResultNode {
 
 
     public RootExecutionResultNode(List<ExecutionResultNode> children, List<GraphQLError> errors) {
-        super(null, children, errors);
+        super(null, null, children, errors);
     }
 
     public RootExecutionResultNode(List<ExecutionResultNode> children) {
-        super(null, children, Collections.emptyList());
+        super(null, null, children, Collections.emptyList());
     }
 
+    @Override
+    public ExecutionStepInfo getExecutionStepInfo() {
+        return assertShouldNeverHappen("not supported at root node");
+    }
 
     @Override
-    public FetchedValueAnalysis getFetchedValueAnalysis() {
+    public ResolvedValue getResolvedValue() {
         return assertShouldNeverHappen("not supported at root node");
     }
 
@@ -32,7 +36,12 @@ public class RootExecutionResultNode extends ObjectExecutionResultNode {
     }
 
     @Override
-    public RootExecutionResultNode withNewFetchedValueAnalysis(FetchedValueAnalysis fetchedValueAnalysis) {
+    public ExecutionResultNode withNewResolvedValue(ResolvedValue resolvedValue) {
+        return assertShouldNeverHappen("not supported at root node");
+    }
+
+    @Override
+    public ExecutionResultNode withNewExecutionStepInfo(ExecutionStepInfo executionStepInfo) {
         return assertShouldNeverHappen("not supported at root node");
     }
 

--- a/src/main/java/graphql/execution/nextgen/result/UnresolvedObjectResultNode.java
+++ b/src/main/java/graphql/execution/nextgen/result/UnresolvedObjectResultNode.java
@@ -1,19 +1,13 @@
 package graphql.execution.nextgen.result;
 
-import graphql.execution.nextgen.FetchedValueAnalysis;
+import graphql.execution.ExecutionStepInfo;
 
 import java.util.Collections;
 
 public class UnresolvedObjectResultNode extends ObjectExecutionResultNode {
 
-    public UnresolvedObjectResultNode(FetchedValueAnalysis fetchedValueAnalysis) {
-        super(fetchedValueAnalysis, Collections.emptyList(), Collections.emptyList());
+    public UnresolvedObjectResultNode(ExecutionStepInfo executionStepInfo, ResolvedValue resolvedValue) {
+        super(executionStepInfo, resolvedValue, Collections.emptyList(), Collections.emptyList());
     }
 
-    @Override
-    public String toString() {
-        return "UnresolvedObjectResultNode{" +
-                "fetchedValueAnalysis=" + getFetchedValueAnalysis() +
-                '}';
-    }
 }

--- a/src/main/java/graphql/language/AbstractNode.java
+++ b/src/main/java/graphql/language/AbstractNode.java
@@ -4,10 +4,15 @@ package graphql.language;
 import graphql.Assert;
 import graphql.PublicApi;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableMap;
 
 @PublicApi
 public abstract class AbstractNode<T extends Node> implements Node<T> {
@@ -27,8 +32,8 @@ public abstract class AbstractNode<T extends Node> implements Node<T> {
         Assert.assertNotNull(additionalData, "additionalData can't be null");
 
         this.sourceLocation = sourceLocation;
-        this.additionalData = Collections.unmodifiableMap(additionalData);
-        this.comments = Collections.unmodifiableList(comments);
+        this.additionalData = unmodifiableMap(new LinkedHashMap<>(additionalData));
+        this.comments = unmodifiableList(new ArrayList<>(comments));
         this.ignoredChars = ignoredChars;
     }
 

--- a/src/main/java/graphql/language/Field.java
+++ b/src/main/java/graphql/language/Field.java
@@ -231,7 +231,7 @@ public class Field extends AbstractNode<Field> implements Selection<Field>, Sele
             this.directives = existing.getDirectives();
             this.selectionSet = existing.getSelectionSet();
             this.ignoredChars = existing.getIgnoredChars();
-            this.additionalData = existing.getAdditionalData();
+            this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
         }
 
 

--- a/src/main/java/graphql/language/Node.java
+++ b/src/main/java/graphql/language/Node.java
@@ -68,7 +68,7 @@ public interface Node<T extends Node> extends Serializable {
      *
      * <p>
      * NOTE: The reason this is a map of strings is so the Node
-     * can stay an immutable object, which Map<String,Object> would not allow
+     * can stay an immutable object, which Map String,Object  would not allow
      * say.
      *
      * @return the map of additional data about this node

--- a/src/test/groovy/graphql/execution/nextgen/result/ExecutionResultNodeTest.groovy
+++ b/src/test/groovy/graphql/execution/nextgen/result/ExecutionResultNodeTest.groovy
@@ -1,12 +1,12 @@
 package graphql.execution.nextgen.result
 
-
+import graphql.Scalars
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
 
 import static graphql.GraphqlErrorBuilder.newError
-import static graphql.execution.nextgen.result.ExecutionResultNodeTestUtils.fvaForValue
+import static graphql.execution.ExecutionStepInfo.newExecutionStepInfo
 
 class ExecutionResultNodeTest extends Specification {
 
@@ -14,10 +14,12 @@ class ExecutionResultNodeTest extends Specification {
     def startingErrors = [newError().message("Starting").build()]
 
     @Shared
-    def startingFetchValueAnalysis = fvaForValue("Starting")
+    def startingExecutionStepInfo = newExecutionStepInfo().type(Scalars.GraphQLString).build()
+    @Shared
+    def startingResolveValue = ResolvedValue.newResolvedValue().completedValue("start").build();
 
     @Shared
-    def startingChildren = [new LeafExecutionResultNode(startingFetchValueAnalysis, null)]
+    def startingChildren = [new LeafExecutionResultNode(startingExecutionStepInfo, startingResolveValue, null)]
 
     @Unroll
     def "construction of objects with new errors works"() {
@@ -33,33 +35,32 @@ class ExecutionResultNodeTest extends Specification {
 
         where:
 
-        node                                                                                        | _
-        new RootExecutionResultNode([], startingErrors)                                             | _
-        new ObjectExecutionResultNode(startingFetchValueAnalysis, startingChildren, startingErrors) | _
-        new ListExecutionResultNode(startingFetchValueAnalysis, startingChildren, startingErrors)   | _
-        new LeafExecutionResultNode(startingFetchValueAnalysis, null, startingErrors)               | _
+        node                                                                                                             | _
+        new RootExecutionResultNode([], startingErrors)                                                                  | _
+        new ObjectExecutionResultNode(startingExecutionStepInfo, startingResolveValue, startingChildren, startingErrors) | _
+        new ListExecutionResultNode(startingExecutionStepInfo, startingResolveValue, startingChildren, startingErrors)   | _
+        new LeafExecutionResultNode(startingExecutionStepInfo, startingResolveValue, null, startingErrors)               | _
     }
 
     @Unroll
-    def "construction of objects with new fetched value analysis  works"() {
+    def "construction of objects with new esi works"() {
 
         given:
-        def newFetchValueAnalysis = fvaForValue("hi")
+        def newEsi = newExecutionStepInfo().type(Scalars.GraphQLString).build()
 
         expect:
         ExecutionResultNode nodeUnderTest = node
-        def newNode = nodeUnderTest.withNewFetchedValueAnalysis(newFetchValueAnalysis)
+        def newNode = nodeUnderTest.withNewExecutionStepInfo(newEsi)
         newNode != nodeUnderTest
-        newNode.getFetchedValueAnalysis() != startingFetchValueAnalysis
-        newNode.getFetchedValueAnalysis().getCompletedValue() == "hi"
+        newNode.getExecutionStepInfo() == newEsi
 
 
         where:
 
-        node                                                                                        | _
-        new ObjectExecutionResultNode(startingFetchValueAnalysis, startingChildren, startingErrors) | _
-        new ListExecutionResultNode(startingFetchValueAnalysis, startingChildren, startingErrors)   | _
-        new LeafExecutionResultNode(startingFetchValueAnalysis, null, startingErrors)               | _
+        node                                                                                                             | _
+        new ObjectExecutionResultNode(startingExecutionStepInfo, startingResolveValue, startingChildren, startingErrors) | _
+        new ListExecutionResultNode(startingExecutionStepInfo, startingResolveValue, startingChildren, startingErrors)   | _
+        new LeafExecutionResultNode(startingExecutionStepInfo, startingResolveValue, null, startingErrors)               | _
     }
 
     @Unroll
@@ -67,8 +68,8 @@ class ExecutionResultNodeTest extends Specification {
 
         given:
         def newChildren = [
-                new LeafExecutionResultNode(startingFetchValueAnalysis, null),
-                new LeafExecutionResultNode(startingFetchValueAnalysis, null),
+                new LeafExecutionResultNode(startingExecutionStepInfo, startingResolveValue, null),
+                new LeafExecutionResultNode(startingExecutionStepInfo, startingResolveValue, null),
         ]
 
         expect:
@@ -81,9 +82,9 @@ class ExecutionResultNodeTest extends Specification {
 
         where:
 
-        node                                                                                        | _
-        new RootExecutionResultNode(startingChildren, startingErrors)                               | _
-        new ObjectExecutionResultNode(startingFetchValueAnalysis, startingChildren, startingErrors) | _
-        new ListExecutionResultNode(startingFetchValueAnalysis, startingChildren, startingErrors)   | _
+        node                                                                                                             | _
+        new RootExecutionResultNode(startingChildren, startingErrors)                                                    | _
+        new ObjectExecutionResultNode(startingExecutionStepInfo, startingResolveValue, startingChildren, startingErrors) | _
+        new ListExecutionResultNode(startingExecutionStepInfo, startingResolveValue, startingChildren, startingErrors)   | _
     }
 }

--- a/src/test/groovy/graphql/execution/nextgen/result/ExecutionResultNodeTestUtils.groovy
+++ b/src/test/groovy/graphql/execution/nextgen/result/ExecutionResultNodeTestUtils.groovy
@@ -1,26 +1,19 @@
 package graphql.execution.nextgen.result
 
 import graphql.Scalars
-import graphql.execution.nextgen.FetchedValueAnalysis
+import graphql.execution.ExecutionStepInfo
 
 import static graphql.execution.ExecutionStepInfo.newExecutionStepInfo
-import static graphql.execution.FetchedValue.newFetchedValue
-import static graphql.execution.nextgen.FetchedValueAnalysis.FetchedValueType.SCALAR
-import static graphql.execution.nextgen.FetchedValueAnalysis.newFetchedValueAnalysis
 
 class ExecutionResultNodeTestUtils {
 
-    static FetchedValueAnalysis fvaForValue(Object value) {
-        def executionStepInfo = newExecutionStepInfo().type(Scalars.GraphQLString).build()
-        def fetchedValue = newFetchedValue()
-                .fetchedValue(value)
-                .rawFetchedValue(value).build()
-        newFetchedValueAnalysis()
-                .executionStepInfo(executionStepInfo)
-                .valueType(SCALAR)
-                .fetchedValue(fetchedValue)
-                .completedValue(value)
-                .build()
+
+    static ResolvedValue resolvedValue(Object value) {
+        return ResolvedValue.newResolvedValue().completedValue(value).build()
+    }
+
+    static ExecutionStepInfo esi() {
+        return newExecutionStepInfo().type(Scalars.GraphQLString).build()
     }
 
 }

--- a/src/test/groovy/graphql/execution/nextgen/result/ResultNodeAdapterTest.groovy
+++ b/src/test/groovy/graphql/execution/nextgen/result/ResultNodeAdapterTest.groovy
@@ -4,14 +4,15 @@ import graphql.AssertException
 import graphql.util.NodeLocation
 import spock.lang.Specification
 
-import static graphql.execution.nextgen.result.ExecutionResultNodeTestUtils.fvaForValue
+import static graphql.execution.nextgen.result.ExecutionResultNodeTestUtils.esi
+import static graphql.execution.nextgen.result.ExecutionResultNodeTestUtils.resolvedValue
 
 class ResultNodeAdapterTest extends Specification {
 
-    def parentNode = new ObjectExecutionResultNode(null, [
-            new LeafExecutionResultNode(fvaForValue("v1"), null),
-            new LeafExecutionResultNode(fvaForValue("v2"), null),
-            new LeafExecutionResultNode(fvaForValue("v3"), null),
+    def parentNode = new ObjectExecutionResultNode(null, null, [
+            new LeafExecutionResultNode(esi(), resolvedValue("v1"), null),
+            new LeafExecutionResultNode(esi(), resolvedValue("v2"), null),
+            new LeafExecutionResultNode(esi(), resolvedValue("v3"), null),
     ])
 
     def "can remove a child from a node"() {
@@ -29,7 +30,7 @@ class ResultNodeAdapterTest extends Specification {
         def newNode = ResultNodeAdapter.RESULT_NODE_ADAPTER.removeChild(parentNode, new NodeLocation(null, 1))
         then:
         newNode.children.size() == 2
-        newNode.children[0].getFetchedValueAnalysis().getCompletedValue() == "v1"
-        newNode.children[1].getFetchedValueAnalysis().getCompletedValue() == "v3"
+        newNode.children[0].getResolvedValue().getCompletedValue() == "v1"
+        newNode.children[1].getResolvedValue().getCompletedValue() == "v3"
     }
 }

--- a/src/test/groovy/graphql/execution/nextgen/result/ResultNodesUtilTest.groovy
+++ b/src/test/groovy/graphql/execution/nextgen/result/ResultNodesUtilTest.groovy
@@ -1,16 +1,11 @@
 package graphql.execution.nextgen.result
 
-
 import graphql.SerializationError
 import graphql.execution.ExecutionPath
 import graphql.execution.ExecutionStepInfo
-import graphql.execution.FetchedValue
 import graphql.execution.MergedField
-import graphql.execution.nextgen.FetchedValueAnalysis
 import graphql.schema.CoercingSerializeException
 import spock.lang.Specification
-
-import static graphql.execution.nextgen.FetchedValueAnalysis.FetchedValueType.SCALAR
 
 class ResultNodesUtilTest extends Specification {
 
@@ -21,14 +16,13 @@ class ResultNodesUtilTest extends Specification {
         MergedField mergedField = Mock(MergedField)
         mergedField.getResultKey() >> "foo"
         executionStepInfo.getField() >> mergedField
-        FetchedValue fetchedValue = FetchedValue.newFetchedValue().fetchedValue(null).build()
-        def leafValue = FetchedValueAnalysis.newFetchedValueAnalysis(SCALAR)
-                .executionStepInfo(executionStepInfo)
-                .nullValue()
+        ResolvedValue resolvedValue = ResolvedValue.newResolvedValue()
+                .completedValue(null)
+                .nullValue(true)
                 .errors([error])
-                .fetchedValue(fetchedValue)
                 .build()
-        LeafExecutionResultNode leafExecutionResultNode = new LeafExecutionResultNode(leafValue, null)
+
+        LeafExecutionResultNode leafExecutionResultNode = new LeafExecutionResultNode(executionStepInfo, resolvedValue, null)
         ExecutionResultNode executionResultNode = new RootExecutionResultNode([leafExecutionResultNode])
 
         when:


### PR DESCRIPTION
Main change: simplifying ResultNodes by putting ESI directly into the result node and introducing
a new ResolvedValue which contains only the needed information

also: making AbstractNode and Field more mutable by coping input
collections