### PR TITLE
Non-null input object fields with default values should be valid

### DIFF
--- a/src/main/java/graphql/validation/ValidationUtil.java
+++ b/src/main/java/graphql/validation/ValidationUtil.java
@@ -150,8 +150,8 @@ public class ValidationUtil {
     private Set<String> getMissingFields(GraphQLInputObjectType type, Map<String, ObjectField> objectFieldMap, GraphqlFieldVisibility fieldVisibility) {
         return fieldVisibility.getFieldDefinitions(type).stream()
                 .filter(field -> isNonNull(field.getType()))
+                .filter(value -> (value.getDefaultValue() == null) && !objectFieldMap.containsKey(value.getName()))
                 .map(GraphQLInputObjectField::getName)
-                .filter(((Predicate<String>) objectFieldMap::containsKey).negate())
                 .collect(Collectors.toSet());
     }
 

--- a/src/test/groovy/graphql/IssueNonNullDefaultAttribute.groovy
+++ b/src/test/groovy/graphql/IssueNonNullDefaultAttribute.groovy
@@ -11,8 +11,16 @@ import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring
 // See https://github.com/facebook/graphql/pull/418
 class IssueNonNullDefaultAttribute extends Specification {
     def spec = '''
+            input Locale {
+                country: String! = "CA"
+                language: String! = "en"
+            }
+            
             type Query {
-                name(characterNumber: Int! = 2): String
+                name(
+                    characterNumber: Int! = 2
+                    locale: Locale! = {country: "US" language: "en"}
+                ): String
             }
             '''
 
@@ -20,7 +28,11 @@ class IssueNonNullDefaultAttribute extends Specification {
         @Override
         Object get(DataFetchingEnvironment env) {
             def number = env.getArgument("characterNumber")
-            return "Character No. " + number
+            def locale = env.getArgument("locale")
+
+            def country = locale["country"]
+            def language = locale["language"]
+            return sprintf("Character No. $number $country-$language", number, country, language)
         }
     }
 
@@ -38,7 +50,7 @@ class IssueNonNullDefaultAttribute extends Specification {
 
         then:
         result.errors.isEmpty()
-        result.data == [name: "Character No. 2"]
+        result.data == [name: "Character No. 2 US-en"]
     }
 
     // Already works, should continue to work
@@ -70,7 +82,33 @@ class IssueNonNullDefaultAttribute extends Specification {
 
         then:
         result.errors.isEmpty()
-        result.data == [name: "Character No. 3"]
+        result.data == [name: "Character No. 3 US-en"]
+    }
+
+    def "Can omit non-null attributes in input objects that have default values"() {
+        when:
+        def result = graphql.execute('''
+                {
+                    name(locale: {})
+                }
+            ''')
+
+        then:
+        result.errors.isEmpty()
+        result.data == [name: "Character No. 2 CA-en"]
+    }
+
+    def "Provided non-null attribute in input objects will override default value"() {
+        when:
+        def result = graphql.execute('''
+                {
+                    name(locale: {language: "fr"})
+                }
+            ''')
+
+        then:
+        result.errors.isEmpty()
+        result.data == [name: "Character No. 2 CA-fr"]
     }
 
 }

--- a/src/test/groovy/graphql/validation/ValidationUtilTest.groovy
+++ b/src/test/groovy/graphql/validation/ValidationUtilTest.groovy
@@ -182,4 +182,19 @@ class ValidationUtilTest extends Specification {
         expect:
         !validationUtil.isValidLiteralValue(objectValue, inputObjectType,schema)
     }
+
+    def "a valid ObjectValue with a nonNull field and default value"() {
+        given:
+        def inputObjectType = GraphQLInputObjectType.newInputObject()
+                .name("inputObjectType")
+                .field(GraphQLInputObjectField.newInputObjectField()
+                .name("hello")
+                .type(nonNull(GraphQLString))
+                .defaultValue("default"))
+                .build()
+        def objectValue = ObjectValue.newObjectValue()
+
+        expect:
+        validationUtil.isValidLiteralValue(objectValue.build(), inputObjectType, schema)
+    }
 }


### PR DESCRIPTION
Update query validation to take default value for input object fields into account.

This should not break existing functionality but instead allow additional requests to pass validation. It should improve compliance with https://github.com/facebook/graphql/pull/418

Addresses: https://github.com/graphql-java/graphql-java/issues/1588