### PR TITLE
#1585 logging now has not privacy safe suffix

### DIFF
--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -21,9 +21,9 @@ import graphql.language.OperationDefinition;
 import graphql.language.VariableDefinition;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
+import graphql.util.LogKit;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.List;
@@ -41,7 +41,7 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 
 @Internal
 public class Execution {
-    private static final Logger log = LoggerFactory.getLogger(Execution.class);
+    private static final Logger logNotSafe = LogKit.getNotPrivacySafeLogger(Execution.class);
 
     private final FieldCollector fieldCollector = new FieldCollector();
     private final ValuesResolver valuesResolver = new ValuesResolver();
@@ -157,7 +157,7 @@ public class Execution {
             } else {
                 executionStrategy = queryStrategy;
             }
-            log.debug("Executing '{}' query operation: '{}' using '{}' execution strategy", executionContext.getExecutionId(), operation, executionStrategy.getClass().getName());
+            logNotSafe.debug("Executing '{}' query operation: '{}' using '{}' execution strategy", executionContext.getExecutionId(), operation, executionStrategy.getClass().getName());
             result = executionStrategy.execute(executionContext, parameters);
         } catch (NonNullableFieldWasNullException e) {
             // this means it was non null types all the way from an offending non null type

--- a/src/main/java/graphql/execution/SimpleDataFetcherExceptionHandler.java
+++ b/src/main/java/graphql/execution/SimpleDataFetcherExceptionHandler.java
@@ -1,6 +1,7 @@
 package graphql.execution;
 
 import graphql.ExceptionWhileDataFetching;
+import graphql.PublicApi;
 import graphql.language.SourceLocation;
 import graphql.util.LogKit;
 import org.slf4j.Logger;
@@ -10,6 +11,7 @@ import org.slf4j.LoggerFactory;
  * The standard handling of data fetcher error involves placing a {@link ExceptionWhileDataFetching} error
  * into the error collection
  */
+@PublicApi
 public class SimpleDataFetcherExceptionHandler implements DataFetcherExceptionHandler {
 
     private static final Logger logNotSafe = LogKit.getNotPrivacySafeLogger(SimpleDataFetcherExceptionHandler.class);

--- a/src/main/java/graphql/execution/SimpleDataFetcherExceptionHandler.java
+++ b/src/main/java/graphql/execution/SimpleDataFetcherExceptionHandler.java
@@ -2,6 +2,7 @@ package graphql.execution;
 
 import graphql.ExceptionWhileDataFetching;
 import graphql.language.SourceLocation;
+import graphql.util.LogKit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -11,7 +12,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SimpleDataFetcherExceptionHandler implements DataFetcherExceptionHandler {
 
-    private static final Logger log = LoggerFactory.getLogger(SimpleDataFetcherExceptionHandler.class);
+    private static final Logger logNotSafe = LogKit.getNotPrivacySafeLogger(SimpleDataFetcherExceptionHandler.class);
 
     @Override
     public DataFetcherExceptionHandlerResult onException(DataFetcherExceptionHandlerParameters handlerParameters) {
@@ -20,7 +21,7 @@ public class SimpleDataFetcherExceptionHandler implements DataFetcherExceptionHa
         ExecutionPath path = handlerParameters.getPath();
 
         ExceptionWhileDataFetching error = new ExceptionWhileDataFetching(path, exception, sourceLocation);
-        log.warn(error.getMessage(), exception);
+        logNotSafe.warn(error.getMessage(), exception);
 
         return DataFetcherExceptionHandlerResult.newResult().error(error).build();
     }

--- a/src/main/java/graphql/execution/nextgen/ValueFetcher.java
+++ b/src/main/java/graphql/execution/nextgen/ValueFetcher.java
@@ -27,6 +27,7 @@ import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLFieldsContainer;
 import graphql.schema.GraphQLOutputType;
 import graphql.schema.GraphQLTypeUtil;
+import graphql.util.LogKit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,6 +49,7 @@ public class ValueFetcher {
     ValuesResolver valuesResolver = new ValuesResolver();
 
     private static final Logger log = LoggerFactory.getLogger(ValueFetcher.class);
+    private static final Logger logNotSafe = LogKit.getNotPrivacySafeLogger(ExecutionStrategy.class);
 
     public static final Object NULL_VALUE = new Object();
 
@@ -162,10 +164,10 @@ public class ValueFetcher {
             DataFetcher dataFetcher = codeRegistry.getDataFetcher(parentType, fieldDef);
             log.debug("'{}' fetching field '{}' using data fetcher '{}'...", executionId, path, dataFetcher.getClass().getName());
             Object fetchedValueRaw = dataFetcher.get(environment);
-            log.debug("'{}' field '{}' fetch returned '{}'", executionId, path, fetchedValueRaw == null ? "null" : fetchedValueRaw.getClass().getName());
+            logNotSafe.debug("'{}' field '{}' fetch returned '{}'", executionId, path, fetchedValueRaw == null ? "null" : fetchedValueRaw.getClass().getName());
             handleFetchedValue(fetchedValueRaw, result);
         } catch (Exception e) {
-            log.debug(String.format("'%s', field '%s' fetch threw exception", executionId, path), e);
+            logNotSafe.debug(String.format("'%s', field '%s' fetch threw exception", executionId, path), e);
             result.completeExceptionally(e);
         }
         return result;

--- a/src/main/java/graphql/schema/idl/ArgValueOfAllowedTypeChecker.java
+++ b/src/main/java/graphql/schema/idl/ArgValueOfAllowedTypeChecker.java
@@ -25,6 +25,7 @@ import graphql.language.Value;
 import graphql.schema.CoercingParseLiteralException;
 import graphql.schema.GraphQLScalarType;
 import graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError;
+import graphql.util.LogKit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,7 +54,7 @@ import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.UNKNOW
 @Internal
 class ArgValueOfAllowedTypeChecker {
 
-    private static final Logger log = LoggerFactory.getLogger(ArgValueOfAllowedTypeChecker.class);
+    private static final Logger logNotSafe = LogKit.getNotPrivacySafeLogger(ArgValueOfAllowedTypeChecker.class);
 
     private final Directive directive;
     private final Node element;
@@ -263,7 +264,7 @@ class ArgValueOfAllowedTypeChecker {
             scalarType.getCoercing().parseLiteral(instanceValue);
             return true;
         } catch (CoercingParseLiteralException ex) {
-            log.debug("Attempted parsing literal into '{}' but got the following error: ", scalarType.getName(), ex);
+            logNotSafe.debug("Attempted parsing literal into '{}' but got the following error: ", scalarType.getName(), ex);
             return false;
         }
     }

--- a/src/main/java/graphql/util/LogKit.java
+++ b/src/main/java/graphql/util/LogKit.java
@@ -1,0 +1,20 @@
+package graphql.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LogKit {
+
+    /**
+     * Creates a logger with a name indicating that the content might not be privacy safe
+     * eg it could contain user generated content or privacy information.
+     *
+     * @param clazz the class to make a logger for
+     *
+     * @return a new Logger
+     */
+    public static Logger getNotPrivacySafeLogger(Class clazz) {
+        return LoggerFactory.getLogger(String.format("%s_NotPrivacySafe", clazz.getName()));
+    }
+
+}

--- a/src/main/java/graphql/util/LogKit.java
+++ b/src/main/java/graphql/util/LogKit.java
@@ -1,8 +1,10 @@
 package graphql.util;
 
+import graphql.Internal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Internal
 public class LogKit {
 
     /**
@@ -14,7 +16,7 @@ public class LogKit {
      * @return a new Logger
      */
     public static Logger getNotPrivacySafeLogger(Class clazz) {
-        return LoggerFactory.getLogger(String.format("%s_NotPrivacySafe", clazz.getName()));
+        return LoggerFactory.getLogger(String.format("notprivacysafe.%s", clazz.getName()));
     }
 
 }

--- a/src/test/groovy/graphql/util/LogKitTest.groovy
+++ b/src/test/groovy/graphql/util/LogKitTest.groovy
@@ -1,0 +1,14 @@
+package graphql.util
+
+
+import spock.lang.Specification
+
+class LogKitTest extends Specification {
+
+    def "logger has a prefixed name"() {
+        when:
+        def logger = LogKit.getNotPrivacySafeLogger(LogKitTest.class)
+        then:
+        logger.getName() == "notprivacysafe.graphql.util.LogKitTest"
+    }
+}


### PR DESCRIPTION
See #1585 

Now will log query data and things that might not be privacy safe as

```
[main] WARN graphql.GraphQL_NotPrivacySafe - Query failed to validate : '
             fragment StoryDetail on Story {
                id
                text @defer
              }
```