### PR TITLE
allow full range of unicode characters

### DIFF
--- a/src/main/antlr/GraphqlCommon.g4
+++ b/src/main/antlr/GraphqlCommon.g4
@@ -119,11 +119,18 @@ TripleQuotedStringValue
 
 
 // Fragments never become a token of their own: they are only used inside other lexer rules
-fragment TripleQuotedStringPart : ( EscapedTripleQuote | SourceCharacter )+?;
+fragment TripleQuotedStringPart : ( EscapedTripleQuote | ExtendedSourceCharacter )+?;
 fragment EscapedTripleQuote : '\\"""';
-fragment SourceCharacter :[\u0009\u000A\u000D\u0020-\u{10FFFF}];
 
-Comment: '#' ~[\n\r\u2028\u2029]* -> channel(2);
+// this is currently not covered by the spec because we allow all unicode chars
+fragment ExtendedSourceCharacter :[\u0009\u000A\u000D\u0020-\u{10FFFF}];
+fragment ExtendedSourceCharacterWitoutLineFeed :[\u0009\u000D\u0020-\u{10FFFF}];
+
+// this is the spec definition
+// fragment SourceCharacter :[\u0009\u000A\u000D\u0020-\uFFFF];
+
+
+Comment: '#' ExtendedSourceCharacterWitoutLineFeed* -> channel(2);
 
 fragment EscapedChar :   '\\' (["\\/bfnrt] | Unicode) ;
 fragment Unicode : 'u' Hex Hex Hex Hex ;

--- a/src/main/antlr/GraphqlCommon.g4
+++ b/src/main/antlr/GraphqlCommon.g4
@@ -121,7 +121,7 @@ TripleQuotedStringValue
 // Fragments never become a token of their own: they are only used inside other lexer rules
 fragment TripleQuotedStringPart : ( EscapedTripleQuote | SourceCharacter )+?;
 fragment EscapedTripleQuote : '\\"""';
-fragment SourceCharacter :[\u0009\u000A\u000D\u0020-\uFFFF];
+fragment SourceCharacter :[\u0009\u000A\u000D\u0020-\u{10FFFF}];
 
 Comment: '#' ~[\n\r\u2028\u2029]* -> channel(2);
 

--- a/src/test/groovy/graphql/parser/IDLParserTest.groovy
+++ b/src/test/groovy/graphql/parser/IDLParserTest.groovy
@@ -833,5 +833,25 @@ input Gun {
         name == "Query"
     }
 
+
+    def "parse description with emoji characters"() {
+        def input = '''
+        enum ReactionContent {
+              """
+              Represents the 😕 emoji.
+              """
+              someValue
+        }
+    '''
+        when:
+        Document document = Parser.parse(input)
+        EnumTypeDefinition enumType = (document.definitions[0] as EnumTypeDefinition)
+        String description = enumType.enumValueDefinitions[0].description.content
+
+        then:
+        description == "Represents the 😕 emoji."
+    }
+
+
 }
 

--- a/src/test/groovy/graphql/parser/ParserTest.groovy
+++ b/src/test/groovy/graphql/parser/ParserTest.groovy
@@ -748,4 +748,22 @@ triple3 : """edge cases \\""" "" " \\"" \\" edge cases"""
         def e = thrown(InvalidSyntaxException)
         e.message.contains("Invalid syntax")
     }
+
+    def "allow emoji in comments"() {
+        def input = '''
+              # Represents the 😕 emoji.
+              {
+              foo
+               }
+    '''
+        when:
+        Document document = Parser.parse(input)
+        OperationDefinition operationDefinition = (document.definitions[0] as OperationDefinition)
+
+
+        then:
+        operationDefinition.getComments()[0].content == " Represents the 😕 emoji."
+    }
+
+
 }


### PR DESCRIPTION
This allows all unicode characters and also fixes the comment rule: comments should also be `SourceCharacter` according to spec