### PR TITLE
Get more information about @deprecated fields from SchemaDiff

### DIFF
--- a/src/main/java/graphql/schema/diff/DiffCategory.java
+++ b/src/main/java/graphql/schema/diff/DiffCategory.java
@@ -26,5 +26,9 @@ public enum DiffCategory {
     /**
      * The new API has changed something compared to the old API
      */
-    DIFFERENT
+    DIFFERENT,
+    /**
+     * The new API has deprecated something or removed something deprecated from the old API
+     */
+    DEPRECATED
 }

--- a/src/main/java/graphql/schema/diff/SchemaDiff.java
+++ b/src/main/java/graphql/schema/diff/SchemaDiff.java
@@ -3,6 +3,7 @@ package graphql.schema.diff;
 import graphql.introspection.IntrospectionResultToSchema;
 import graphql.language.Argument;
 import graphql.language.Directive;
+import graphql.language.DirectivesContainer;
 import graphql.language.Document;
 import graphql.language.EnumTypeDefinition;
 import graphql.language.EnumValueDefinition;
@@ -269,6 +270,10 @@ public class SchemaDiff {
         ctx.exitType();
     }
 
+    private boolean isDeprecated(DirectivesContainer node) {
+        return node.getDirective("deprecated") != null;
+    }
+
     private boolean isReservedType(String typeName) {
         return typeName.startsWith("__");
     }
@@ -370,13 +375,23 @@ public class SchemaDiff {
 
 
             if (!newField.isPresent()) {
-                ctx.report(DiffEvent.apiBreakage()
-                        .category(DiffCategory.MISSING)
-                        .typeName(old.getName())
-                        .typeKind(getTypeKind(old))
-                        .fieldName(oldField.getName())
-                        .reasonMsg("The new API is missing an input field '%s'", mkDotName(old.getName(), oldField.getName()))
-                        .build());
+                if (isDeprecated(oldField)) {
+                    ctx.report(DiffEvent.apiBreakage()
+                            .category(DiffCategory.DEPRECATED)
+                            .typeName(old.getName())
+                            .typeKind(getTypeKind(old))
+                            .fieldName(oldField.getName())
+                            .reasonMsg("The new API has removed a deprecated field '%s'",  mkDotName(old.getName(), oldField.getName()))
+                            .build());
+                } else {
+                    ctx.report(DiffEvent.apiBreakage()
+                            .category(DiffCategory.MISSING)
+                            .typeName(old.getName())
+                            .typeKind(getTypeKind(old))
+                            .fieldName(oldField.getName())
+                            .reasonMsg("The new API is missing an input field '%s'", mkDotName(old.getName(), oldField.getName()))
+                            .build());
+                }
             } else {
                 DiffCategory category = checkTypeWithNonNullAndList(oldField.getType(), newField.get().getType());
                 if (category != null) {
@@ -394,7 +409,7 @@ public class SchemaDiff {
                 //
                 // recurse via input types
                 //
-                checkType( ctx, oldField.getType(), newField.get().getType() );
+                checkType(ctx, oldField.getType(), newField.get().getType());
             }
         }
 
@@ -427,13 +442,23 @@ public class SchemaDiff {
             Optional<EnumValueDefinition> newEnum = Optional.ofNullable(newDefinitionMap.get(enumName));
 
             if (!newEnum.isPresent()) {
-                ctx.report(DiffEvent.apiBreakage()
-                        .category(DiffCategory.MISSING)
-                        .typeName(oldDef.getName())
-                        .typeKind(getTypeKind(oldDef))
-                        .components(oldEnum.getName())
-                        .reasonMsg("The new API is missing an enum value '%s'", oldEnum.getName())
-                        .build());
+                if (isDeprecated(oldEnum)) {
+                    ctx.report(DiffEvent.apiBreakage()
+                            .category(DiffCategory.DEPRECATED)
+                            .typeName(oldDef.getName())
+                            .typeKind(getTypeKind(oldDef))
+                            .components(oldEnum.getName())
+                            .reasonMsg("The new API has removed a deprecated enum value '%s'", mkDotName( oldDef.getName(), oldEnum.getName()))
+                            .build());
+                } else {
+                    ctx.report(DiffEvent.apiBreakage()
+                            .category(DiffCategory.MISSING)
+                            .typeName(oldDef.getName())
+                            .typeKind(getTypeKind(oldDef))
+                            .components(oldEnum.getName())
+                            .reasonMsg("The new API is missing an enum value '%s'", oldEnum.getName())
+                            .build());
+                }
             } else {
                 checkDirectives(ctx, oldDef, oldEnum.getDirectives(), newEnum.get().getDirectives());
             }
@@ -449,6 +474,14 @@ public class SchemaDiff {
                         .components(enumName)
                         .reasonMsg("The new API has added a new enum value '%s'", enumName)
                         .build());
+            } else if (isDeprecated(newDefinitionMap.get(enumName))) {
+                ctx.report(DiffEvent.apiDanger()
+                        .category(DiffCategory.DEPRECATED)
+                        .typeName(oldDef.getName())
+                        .typeKind(getTypeKind(oldDef))
+                        .components(oldEnum.getName())
+                        .reasonMsg("The new API has deprecated an enum value '%s'", oldEnum.getName())
+                        .build());
             }
         }
         checkDirectives(ctx, oldDef, newDef);
@@ -463,18 +496,21 @@ public class SchemaDiff {
         Map<String, Type> newImplementsMap = sortedMap(newImplements, t -> ((TypeName) t).getName());
 
         for (Map.Entry<String, Type> entry : oldImplementsMap.entrySet()) {
-            InterfaceTypeDefinition oldInterface = ctx.getOldTypeDef(entry.getValue(), InterfaceTypeDefinition.class).get();
+            Optional<InterfaceTypeDefinition> oldInterface = ctx.getOldTypeDef(entry.getValue(), InterfaceTypeDefinition.class);
+            if (!oldInterface.isPresent()) {
+                continue;
+            }
             Optional<InterfaceTypeDefinition> newInterface = ctx.getNewTypeDef(newImplementsMap.get(entry.getKey()), InterfaceTypeDefinition.class);
             if (!newInterface.isPresent()) {
                 ctx.report(DiffEvent.apiBreakage()
                         .category(DiffCategory.MISSING)
                         .typeName(old.getName())
                         .typeKind(getTypeKind(old))
-                        .components(oldInterface.getName())
-                        .reasonMsg("The new API is missing the interface named '%s'", oldInterface.getName())
+                        .components(oldInterface.get().getName())
+                        .reasonMsg("The new API is missing the interface named '%s'", oldInterface.get().getName())
                         .build());
             } else {
-                checkInterfaceType(ctx, oldInterface, newInterface.get());
+                checkInterfaceType(ctx, oldInterface.get(), newInterface.get());
             }
         }
     }
@@ -509,13 +545,23 @@ public class SchemaDiff {
 
             FieldDefinition newField = newFields.get(fieldName);
             if (newField == null) {
-                ctx.report(DiffEvent.apiBreakage()
-                        .category(DiffCategory.MISSING)
-                        .typeName(oldDef.getName())
-                        .typeKind(getTypeKind(oldDef))
-                        .fieldName(fieldName)
-                        .reasonMsg("The new API is missing the field '%s'", mkDotName(oldDef.getName(), fieldName))
-                        .build());
+                if (isDeprecated(entry.getValue())) {
+                    ctx.report(DiffEvent.apiBreakage()
+                            .category(DiffCategory.DEPRECATED)
+                            .typeName(oldDef.getName())
+                            .typeKind(getTypeKind(oldDef))
+                            .fieldName(fieldName)
+                            .reasonMsg("The new API has removed a deprecated field '%s'", mkDotName(oldDef.getName(), fieldName))
+                            .build());
+                } else {
+                    ctx.report(DiffEvent.apiBreakage()
+                            .category(DiffCategory.MISSING)
+                            .typeName(oldDef.getName())
+                            .typeKind(getTypeKind(oldDef))
+                            .fieldName(fieldName)
+                            .reasonMsg("The new API is missing the field '%s'", mkDotName(oldDef.getName(), fieldName))
+                            .build());
+                }
             } else {
                 checkField(ctx, oldDef, entry.getValue(), newField);
             }
@@ -546,6 +592,14 @@ public class SchemaDiff {
                         .typeKind(getTypeKind(newDef))
                         .fieldName(fieldName)
                         .reasonMsg("The new API adds the field '%s'", mkDotName(newDef.getName(), fieldName))
+                        .build());
+            } else if (!isDeprecated(oldField) && isDeprecated(entry.getValue())) {
+                ctx.report(DiffEvent.apiDanger()
+                        .category(DiffCategory.DEPRECATED)
+                        .typeName(newDef.getName())
+                        .typeKind(getTypeKind(newDef))
+                        .fieldName(fieldName)
+                        .reasonMsg("The new API deprecated a field '%s'", mkDotName(newDef.getName(), fieldName))
                         .build());
             }
         }

--- a/src/main/java/graphql/schema/diff/SchemaDiff.java
+++ b/src/main/java/graphql/schema/diff/SchemaDiff.java
@@ -375,7 +375,6 @@ public class SchemaDiff {
 
 
             if (!newField.isPresent()) {
-
                 DiffCategory category;
                 String message;
                 if (isDeprecated(oldField)) {

--- a/src/main/java/graphql/schema/diff/SchemaDiff.java
+++ b/src/main/java/graphql/schema/diff/SchemaDiff.java
@@ -375,23 +375,23 @@ public class SchemaDiff {
 
 
             if (!newField.isPresent()) {
+
+                DiffCategory category;
+                String message;
                 if (isDeprecated(oldField)) {
-                    ctx.report(DiffEvent.apiBreakage()
-                            .category(DiffCategory.DEPRECATED)
-                            .typeName(old.getName())
-                            .typeKind(getTypeKind(old))
-                            .fieldName(oldField.getName())
-                            .reasonMsg("The new API has removed a deprecated field '%s'",  mkDotName(old.getName(), oldField.getName()))
-                            .build());
+                    category = DiffCategory.DEPRECATED;
+                    message = "The new API has removed a deprecated field '%s'";
                 } else {
-                    ctx.report(DiffEvent.apiBreakage()
-                            .category(DiffCategory.MISSING)
-                            .typeName(old.getName())
-                            .typeKind(getTypeKind(old))
-                            .fieldName(oldField.getName())
-                            .reasonMsg("The new API is missing an input field '%s'", mkDotName(old.getName(), oldField.getName()))
-                            .build());
+                    category = DiffCategory.MISSING;
+                    message = "The new API is missing an input field '%s'";
                 }
+                ctx.report(DiffEvent.apiBreakage()
+                        .category(category)
+                        .typeName(old.getName())
+                        .typeKind(getTypeKind(old))
+                        .fieldName(oldField.getName())
+                        .reasonMsg(message, mkDotName(old.getName(), oldField.getName()))
+                        .build());
             } else {
                 DiffCategory category = checkTypeWithNonNullAndList(oldField.getType(), newField.get().getType());
                 if (category != null) {
@@ -442,23 +442,22 @@ public class SchemaDiff {
             Optional<EnumValueDefinition> newEnum = Optional.ofNullable(newDefinitionMap.get(enumName));
 
             if (!newEnum.isPresent()) {
+                DiffCategory category;
+                String message;
                 if (isDeprecated(oldEnum)) {
-                    ctx.report(DiffEvent.apiBreakage()
-                            .category(DiffCategory.DEPRECATED)
-                            .typeName(oldDef.getName())
-                            .typeKind(getTypeKind(oldDef))
-                            .components(oldEnum.getName())
-                            .reasonMsg("The new API has removed a deprecated enum value '%s'", mkDotName( oldDef.getName(), oldEnum.getName()))
-                            .build());
+                    category = DiffCategory.DEPRECATED;
+                    message = "The new API has removed a deprecated enum value '%s'";
                 } else {
-                    ctx.report(DiffEvent.apiBreakage()
-                            .category(DiffCategory.MISSING)
-                            .typeName(oldDef.getName())
-                            .typeKind(getTypeKind(oldDef))
-                            .components(oldEnum.getName())
-                            .reasonMsg("The new API is missing an enum value '%s'", oldEnum.getName())
-                            .build());
+                    category = DiffCategory.MISSING;
+                    message = "The new API is missing an enum value '%s'";
                 }
+                ctx.report(DiffEvent.apiBreakage()
+                        .category(category)
+                        .typeName(oldDef.getName())
+                        .typeKind(getTypeKind(oldDef))
+                        .components(oldEnum.getName())
+                        .reasonMsg(message, oldEnum.getName())
+                        .build());
             } else {
                 checkDirectives(ctx, oldDef, oldEnum.getDirectives(), newEnum.get().getDirectives());
             }
@@ -479,8 +478,8 @@ public class SchemaDiff {
                         .category(DiffCategory.DEPRECATED)
                         .typeName(oldDef.getName())
                         .typeKind(getTypeKind(oldDef))
-                        .components(oldEnum.getName())
-                        .reasonMsg("The new API has deprecated an enum value '%s'", oldEnum.getName())
+                        .components(enumName)
+                        .reasonMsg("The new API has deprecated an enum value '%s'", enumName)
                         .build());
             }
         }
@@ -545,23 +544,22 @@ public class SchemaDiff {
 
             FieldDefinition newField = newFields.get(fieldName);
             if (newField == null) {
+                DiffCategory category;
+                String message;
                 if (isDeprecated(entry.getValue())) {
-                    ctx.report(DiffEvent.apiBreakage()
-                            .category(DiffCategory.DEPRECATED)
-                            .typeName(oldDef.getName())
-                            .typeKind(getTypeKind(oldDef))
-                            .fieldName(fieldName)
-                            .reasonMsg("The new API has removed a deprecated field '%s'", mkDotName(oldDef.getName(), fieldName))
-                            .build());
+                    category = DiffCategory.DEPRECATED;
+                    message = "The new API has removed a deprecated field '%s'";
                 } else {
-                    ctx.report(DiffEvent.apiBreakage()
-                            .category(DiffCategory.MISSING)
-                            .typeName(oldDef.getName())
-                            .typeKind(getTypeKind(oldDef))
-                            .fieldName(fieldName)
-                            .reasonMsg("The new API is missing the field '%s'", mkDotName(oldDef.getName(), fieldName))
-                            .build());
+                    category = DiffCategory.MISSING;
+                    message = "The new API is missing the field '%s'";
                 }
+                ctx.report(DiffEvent.apiBreakage()
+                        .category(category)
+                        .typeName(oldDef.getName())
+                        .typeKind(getTypeKind(oldDef))
+                        .fieldName(fieldName)
+                        .reasonMsg(message, mkDotName(oldDef.getName(), fieldName))
+                        .build());
             } else {
                 checkField(ctx, oldDef, entry.getValue(), newField);
             }

--- a/src/test/groovy/graphql/schema/diff/SchemaDiffTest.groovy
+++ b/src/test/groovy/graphql/schema/diff/SchemaDiffTest.groovy
@@ -451,7 +451,7 @@ class SchemaDiffTest extends Specification {
 
     }
 
-    def "dangerous changes "() {
+    def "dangerous changes"() {
         DiffSet diffSet = diffSet("schema_dangerous_changes.graphqls")
 
         def diff = new SchemaDiff()
@@ -477,6 +477,38 @@ class SchemaDiffTest extends Specification {
         reporter.dangers[2].typeKind == TypeKind.Enum
         reporter.dangers[2].components.contains("Nonplussed")
 
+    }
+
+    def "field was deprecated"() {
+        DiffSet diffSet = diffSet("schema_deprecated_fields_new.graphqls")
+
+        def diff = new SchemaDiff()
+        diff.diffSchema(diffSet, chainedReporter)
+
+        expect:
+        reporter.dangerCount == 1
+        reporter.breakageCount == 0
+        reporter.dangers.every {
+            it.getCategory() == DiffCategory.DEPRECATED
+        }
+
+    }
+
+    def "deprecated field was removed"() {
+        def schemaOld = TestUtil.schemaFile("diff/" + "schema_deprecated_fields_new.graphqls", wireWithNoFetching())
+        def schemaNew = TestUtil.schemaFile("diff/" + "schema_deprecated_fields_removed.graphqls", wireWithNoFetching())
+
+        DiffSet diffSet = DiffSet.diffSet(schemaOld, schemaNew)
+
+        def diff = new SchemaDiff()
+        diff.diffSchema(diffSet, chainedReporter)
+
+        expect:
+        reporter.dangerCount == 0
+        reporter.breakageCount == 11
+        reporter.breakages.every {
+            it.getCategory() == DiffCategory.DEPRECATED
+        }
     }
 
 }

--- a/src/test/groovy/graphql/schema/diff/SchemaDiffTest.groovy
+++ b/src/test/groovy/graphql/schema/diff/SchemaDiffTest.groovy
@@ -486,7 +486,7 @@ class SchemaDiffTest extends Specification {
         diff.diffSchema(diffSet, chainedReporter)
 
         expect:
-        reporter.dangerCount == 1
+        reporter.dangerCount == 13
         reporter.breakageCount == 0
         reporter.dangers.every {
             it.getCategory() == DiffCategory.DEPRECATED

--- a/src/test/resources/diff/schema_deprecated_fields_new.graphqls
+++ b/src/test/resources/diff/schema_deprecated_fields_new.graphqls
@@ -1,0 +1,81 @@
+schema {
+    query : Query
+    mutation : Mutation
+}
+
+type Query {
+    being(id : ID, type : String = "wizard") : Being
+    beings(type : String) : [Being] @deprecated
+
+    wizards : [Istari]
+    gods : [Ainur]
+    deities : [Deity] @deprecated
+
+    allCharacters : [Character!] @deprecated(reason: "no longer supported")
+
+    customScalar : CustomScalar @deprecated(reason: "because")
+}
+
+type Mutation {
+    being(questor : Questor) : Query
+    sword(bearer : Questor, name : String, alloy : String, temperament : Temperament) : String
+}
+
+input Questor {
+    beingID : ID
+    queryTarget : String
+    nestedInput : NestedInput
+}
+
+input NestedInput {
+    nestedInput: String
+}
+
+scalar CustomScalar
+
+
+interface Being {
+    id : ID
+    name : String
+    nameInQuenyan : String @deprecated
+    invitedBy(id : ID) : Being
+}
+
+
+type Ainur implements Being {
+    id : ID
+    name : String
+    nameInQuenyan : String @deprecated
+    invitedBy(id : ID) : Being
+    loves : String
+}
+
+
+type Istari implements Being {
+    id : ID
+    name : String
+    nameInQuenyan : String @deprecated
+    invitedBy(id : ID) : Being
+    colour : String @deprecated
+    temperament : Temperament!
+
+}
+
+type Deity implements Being {
+    id : ID
+    name : String
+    nameInQuenyan : String @deprecated
+    invitedBy(id : ID) : Being
+    outlook : String @deprecated
+}
+
+union Character = Ainur | Istari | Deity
+
+enum Temperament {
+    Hero
+    Duplicitous @deprecated
+    Evil
+}
+
+
+

--- a/src/test/resources/diff/schema_deprecated_fields_removed.graphqls
+++ b/src/test/resources/diff/schema_deprecated_fields_removed.graphqls
@@ -1,0 +1,68 @@
+schema {
+    query : Query
+    mutation : Mutation
+}
+
+type Query {
+    being(id : ID, type : String = "wizard") : Being
+
+    wizards : [Istari]
+    gods : [Ainur]
+}
+
+type Mutation {
+    being(questor : Questor) : Query
+    sword(bearer : Questor, name : String, alloy : String, temperament : Temperament) : String
+}
+
+input Questor {
+    beingID : ID
+    queryTarget : String
+    nestedInput : NestedInput
+}
+
+input NestedInput {
+    nestedInput: String
+}
+
+scalar CustomScalar
+
+
+interface Being {
+    id : ID
+    name : String
+    invitedBy(id : ID) : Being
+}
+
+
+type Ainur implements Being {
+    id : ID
+    name : String
+    invitedBy(id : ID) : Being
+    loves : String
+}
+
+
+type Istari implements Being {
+    id : ID
+    name : String
+    invitedBy(id : ID) : Being
+    temperament : Temperament!
+
+}
+
+type Deity implements Being {
+    id : ID
+    name : String
+    invitedBy(id : ID) : Being
+}
+
+union Character = Ainur | Istari | Deity
+
+enum Temperament {
+    Hero
+    Evil
+}
+
+
+


### PR DESCRIPTION
Addresses #1504

Let me know your thoughts on this. My strategy was to just add another category, which can provide the extra information and keep the `Danger` and `Breaking` levels untouched.

The two new combinations of level and category are:
1. level: `DANGER`, category: `DEPRECATED` for fields that become deprecated
1. level: `BREAKING`, category: `DEPRECATED` for fields that were deprecated and now missing

Todo:
- [x] Detect fields that are `@deprecated` in the new schema
- [x] Detect removals that were `@deprecated` in the old schema
- [x] ???

Remarks:
It's actually interesting to note that `@deprecated` on anything but `FIELD_DEFINITION | ENUM_VALUE` is not currently a valid spec-compliant use of the directive.
See: https://graphql.github.io/graphql-spec/June2018/#sec--deprecated
and the corresponding implementation proposed on graphql-js: https://github.com/graphql/graphql-js/pull/1560/files