### PR TITLE
Add 'Byte' to standard scalar definitions

### DIFF
--- a/src/main/java/graphql/schema/idl/ScalarInfo.java
+++ b/src/main/java/graphql/schema/idl/ScalarInfo.java
@@ -61,6 +61,7 @@ public class ScalarInfo {
         STANDARD_SCALAR_DEFINITIONS.put("Long", ScalarTypeDefinition.newScalarTypeDefinition().name("Long").build());
         STANDARD_SCALAR_DEFINITIONS.put("BigInteger", ScalarTypeDefinition.newScalarTypeDefinition().name("BigInteger").build());
         STANDARD_SCALAR_DEFINITIONS.put("BigDecimal", ScalarTypeDefinition.newScalarTypeDefinition().name("BigDecimal").build());
+        STANDARD_SCALAR_DEFINITIONS.put("Byte", ScalarTypeDefinition.newScalarTypeDefinition().name("Byte").build());
         STANDARD_SCALAR_DEFINITIONS.put("Short", ScalarTypeDefinition.newScalarTypeDefinition().name("Short").build());
         STANDARD_SCALAR_DEFINITIONS.put("Char", ScalarTypeDefinition.newScalarTypeDefinition().name("Char").build());
 

--- a/src/test/groovy/graphql/schema/idl/SchemaParserTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaParserTest.groovy
@@ -114,7 +114,7 @@ class SchemaParserTest extends Specification {
         typeExtensions.size() == 1
         typeExtensions.get("Query") != null
 
-        scalarTypes.size() == 11 // includes standard scalars
+        scalarTypes.size() == 12 // includes standard scalars
         scalarTypes.get("Url") instanceof ScalarTypeDefinition
 
 


### PR DESCRIPTION
Discussed in [spectrum chat](https://spectrum.chat/graphql-java/general/why-is-byte-not-included-in-the-standard-scalar-definitions~415c8b35-9ed4-4bb5-828c-b3c9eeca505a)

Adding `Byte` since it was missing from [ScalarInfo#STANDARD_SCALAR_DEFINITIONS](https://github.com/graphql-java/graphql-java/blob/master/src/main/java/graphql/schema/idl/ScalarInfo.java#L54-L65)