### PR TITLE
Invented a new interface type - GraphqlInputValueDefinition

### DIFF
--- a/src/main/java/graphql/analysis/NodeVisitorWithTypeTracking.java
+++ b/src/main/java/graphql/analysis/NodeVisitorWithTypeTracking.java
@@ -197,8 +197,9 @@ public class NodeVisitorWithTypeTracking extends NodeVisitorStub {
                 fieldDefinition, argument, graphQLArgument, argumentValue, variables, fieldEnv, context, schema);
 
         QueryVisitorFieldArgumentInputValue inputValue = QueryVisitorFieldArgumentInputValueImpl
-                .incompleteArgumentInputValue(fieldDefinition, graphQLArgument);
+                .incompleteArgumentInputValue(graphQLArgument);
 
+        context.setVar(QueryVisitorFieldArgumentEnvironment.class, environment);
         context.setVar(QueryVisitorFieldArgumentInputValue.class, inputValue);
         if (context.getPhase() == LEAVE) {
             return postOrderCallback.visitArgument(environment);
@@ -221,13 +222,14 @@ public class NodeVisitorWithTypeTracking extends NodeVisitorStub {
 
     @Override
     protected TraversalControl visitValue(Value<?> value, TraverserContext<Node> context) {
+        QueryVisitorFieldArgumentEnvironment fieldArgEnv = context.getVarFromParents(QueryVisitorFieldArgumentEnvironment.class);
         QueryVisitorFieldArgumentInputValueImpl inputValue = context.getVarFromParents(QueryVisitorFieldArgumentInputValue.class);
         // previous visits have set up the previous information
         inputValue = inputValue.completeArgumentInputValue(value);
         context.setVar(QueryVisitorFieldArgumentInputValue.class, inputValue);
 
         QueryVisitorFieldArgumentValueEnvironment environment = new QueryVisitorFieldArgumentValueEnvironmentImpl(
-                schema, inputValue.getGraphQLFieldDefinition(), inputValue.getGraphQLArgument(), inputValue, context,
+                schema, fieldArgEnv.getFieldDefinition(), fieldArgEnv.getGraphQLArgument(), inputValue, context,
                 variables);
 
         if (context.getPhase() == LEAVE) {

--- a/src/main/java/graphql/analysis/QueryVisitorFieldArgumentInputValue.java
+++ b/src/main/java/graphql/analysis/QueryVisitorFieldArgumentInputValue.java
@@ -2,10 +2,8 @@ package graphql.analysis;
 
 import graphql.PublicApi;
 import graphql.language.Value;
-import graphql.schema.GraphQLArgument;
-import graphql.schema.GraphQLDirectiveContainer;
-import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLInputType;
+import graphql.schema.GraphQLInputValueDefinition;
 
 /**
  * This describes the tree structure that forms from a argument input type,
@@ -15,13 +13,9 @@ import graphql.schema.GraphQLInputType;
 @PublicApi
 public interface QueryVisitorFieldArgumentInputValue {
 
-    GraphQLFieldDefinition getGraphQLFieldDefinition();
-
-    GraphQLArgument getGraphQLArgument();
-
     QueryVisitorFieldArgumentInputValue getParent();
 
-    GraphQLDirectiveContainer getDirectiveContainer();
+    GraphQLInputValueDefinition getInputValueDefinition();
 
     String getName();
 

--- a/src/main/java/graphql/analysis/QueryVisitorFieldArgumentInputValueImpl.java
+++ b/src/main/java/graphql/analysis/QueryVisitorFieldArgumentInputValueImpl.java
@@ -3,78 +3,55 @@ package graphql.analysis;
 import graphql.Internal;
 import graphql.language.Value;
 import graphql.schema.GraphQLArgument;
-import graphql.schema.GraphQLDirectiveContainer;
-import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLInputObjectField;
 import graphql.schema.GraphQLInputType;
+import graphql.schema.GraphQLInputValueDefinition;
 
 @Internal
 public class QueryVisitorFieldArgumentInputValueImpl implements QueryVisitorFieldArgumentInputValue {
-    private final GraphQLFieldDefinition graphQLFieldDefinition;
-    private final GraphQLArgument graphQLArgument;
-    private final QueryVisitorFieldArgumentInputValue parent;
-    private final GraphQLDirectiveContainer directiveContainer;
-    private final String name;
-    private final GraphQLInputType inputType;
+    private final GraphQLInputValueDefinition inputValueDefinition;
     private final Value value;
+    private final QueryVisitorFieldArgumentInputValue parent;
 
-    private QueryVisitorFieldArgumentInputValueImpl(QueryVisitorFieldArgumentInputValue parent, GraphQLFieldDefinition graphQLFieldDefinition, GraphQLArgument graphQLArgument, GraphQLDirectiveContainer directiveContainer, String name, GraphQLInputType inputType, Value value) {
-        this.graphQLFieldDefinition = graphQLFieldDefinition;
-        this.graphQLArgument = graphQLArgument;
+    private QueryVisitorFieldArgumentInputValueImpl(QueryVisitorFieldArgumentInputValue parent, GraphQLInputValueDefinition inputValueDefinition, Value value) {
         this.parent = parent;
-        this.directiveContainer = directiveContainer;
-        this.name = name;
-        this.inputType = inputType;
+        this.inputValueDefinition = inputValueDefinition;
         this.value = value;
     }
 
-    @Internal
-    public static QueryVisitorFieldArgumentInputValue incompleteArgumentInputValue(GraphQLFieldDefinition graphQLFieldDefinition, GraphQLArgument graphQLArgument) {
-        return new QueryVisitorFieldArgumentInputValueImpl(null, graphQLFieldDefinition, graphQLArgument,
-                graphQLArgument, graphQLArgument.getName(), graphQLArgument.getType(), null);
-    }
-
-    @Internal
-    public QueryVisitorFieldArgumentInputValueImpl incompleteNewChild(GraphQLInputObjectField inputObjectField) {
+    static QueryVisitorFieldArgumentInputValue incompleteArgumentInputValue(GraphQLArgument graphQLArgument) {
         return new QueryVisitorFieldArgumentInputValueImpl(
-                this, this.graphQLFieldDefinition, this.graphQLArgument, inputObjectField, inputObjectField.getName(), inputObjectField.getType(), null);
+                null, graphQLArgument, null);
     }
 
-    @Internal
-    public QueryVisitorFieldArgumentInputValueImpl completeArgumentInputValue(Value<?> value) {
+    QueryVisitorFieldArgumentInputValueImpl incompleteNewChild(GraphQLInputObjectField inputObjectField) {
         return new QueryVisitorFieldArgumentInputValueImpl(
-                this.parent, this.graphQLFieldDefinition, this.graphQLArgument,
-                this.directiveContainer, this.name, this.inputType, value);
+                this, inputObjectField, null);
     }
 
-
-    @Override
-    public GraphQLFieldDefinition getGraphQLFieldDefinition() {
-        return graphQLFieldDefinition;
+    QueryVisitorFieldArgumentInputValueImpl completeArgumentInputValue(Value<?> value) {
+        return new QueryVisitorFieldArgumentInputValueImpl(
+                this.parent, this.inputValueDefinition, value);
     }
 
-    @Override
-    public GraphQLArgument getGraphQLArgument() {
-        return graphQLArgument;
-    }
 
     @Override
     public QueryVisitorFieldArgumentInputValue getParent() {
         return parent;
     }
 
-    public GraphQLDirectiveContainer getDirectiveContainer() {
-        return directiveContainer;
+    public GraphQLInputValueDefinition getInputValueDefinition() {
+        return inputValueDefinition;
     }
 
     @Override
     public String getName() {
-        return name;
+        return inputValueDefinition.getName();
     }
 
     @Override
     public GraphQLInputType getInputType() {
-        return inputType;
+        return inputValueDefinition.getType();
     }
 
     @Override
@@ -84,11 +61,10 @@ public class QueryVisitorFieldArgumentInputValueImpl implements QueryVisitorFiel
 
     @Override
     public String toString() {
-        return "{" +
-                "parent=" + parent +
-                ", name='" + name + '\'' +
-                ", inputType=" + inputType +
+        return "QueryVisitorFieldArgumentInputValueImpl{" +
+                "inputValue=" + inputValueDefinition +
                 ", value=" + value +
+                ", parent=" + parent +
                 '}';
     }
 }

--- a/src/main/java/graphql/schema/GraphQLArgument.java
+++ b/src/main/java/graphql/schema/GraphQLArgument.java
@@ -38,7 +38,7 @@ import static graphql.Assert.assertValidName;
  * specific value on that directive.
  */
 @PublicApi
-public class GraphQLArgument implements GraphQLInputValue {
+public class GraphQLArgument implements GraphQLInputValueDefinition {
 
     private final String name;
     private final String description;

--- a/src/main/java/graphql/schema/GraphQLArgument.java
+++ b/src/main/java/graphql/schema/GraphQLArgument.java
@@ -38,7 +38,7 @@ import static graphql.Assert.assertValidName;
  * specific value on that directive.
  */
 @PublicApi
-public class GraphQLArgument implements GraphQLDirectiveContainer {
+public class GraphQLArgument implements GraphQLInputValue {
 
     private final String name;
     private final String description;

--- a/src/main/java/graphql/schema/GraphQLInputObjectField.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectField.java
@@ -27,7 +27,7 @@ import static java.util.Collections.emptyList;
  * See http://graphql.org/learn/schema/#input-types for more details on the concept.
  */
 @PublicApi
-public class GraphQLInputObjectField implements GraphQLDirectiveContainer {
+public class GraphQLInputObjectField implements GraphQLInputValue {
 
     private final String name;
     private final String description;

--- a/src/main/java/graphql/schema/GraphQLInputObjectField.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectField.java
@@ -27,7 +27,7 @@ import static java.util.Collections.emptyList;
  * See http://graphql.org/learn/schema/#input-types for more details on the concept.
  */
 @PublicApi
-public class GraphQLInputObjectField implements GraphQLInputValue {
+public class GraphQLInputObjectField implements GraphQLInputValueDefinition {
 
     private final String name;
     private final String description;

--- a/src/main/java/graphql/schema/GraphQLInputValue.java
+++ b/src/main/java/graphql/schema/GraphQLInputValue.java
@@ -1,0 +1,17 @@
+package graphql.schema;
+
+import graphql.PublicApi;
+
+/**
+ * Named schema elements that contain input value type information and directivesvvcccckddfdngndbrvcfgtjrvkkdgbhjirnldfjhlvbu
+ * .
+ *
+ * @see graphql.schema.GraphQLInputType
+ * @see graphql.schema.GraphQLInputObjectField
+ * @see graphql.schema.GraphQLArgument
+ */
+@PublicApi
+public interface GraphQLInputValue extends GraphQLDirectiveContainer {
+
+    <T extends GraphQLInputType> T getType();
+}

--- a/src/main/java/graphql/schema/GraphQLInputValueDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLInputValueDefinition.java
@@ -3,7 +3,7 @@ package graphql.schema;
 import graphql.PublicApi;
 
 /**
- * Named schema elements that contain input value type information.
+ * Named schema elements that contain input type information.
  *
  *
  * @see graphql.schema.GraphQLInputType

--- a/src/main/java/graphql/schema/GraphQLInputValueDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLInputValueDefinition.java
@@ -3,15 +3,15 @@ package graphql.schema;
 import graphql.PublicApi;
 
 /**
- * Named schema elements that contain input value type information and directivesvvcccckddfdngndbrvcfgtjrvkkdgbhjirnldfjhlvbu
- * .
+ * Named schema elements that contain input value type information.
+ *
  *
  * @see graphql.schema.GraphQLInputType
  * @see graphql.schema.GraphQLInputObjectField
  * @see graphql.schema.GraphQLArgument
  */
 @PublicApi
-public interface GraphQLInputValue extends GraphQLDirectiveContainer {
+public interface GraphQLInputValueDefinition extends GraphQLDirectiveContainer {
 
     <T extends GraphQLInputType> T getType();
 }

--- a/src/test/groovy/graphql/analysis/QueryTraverserTest.groovy
+++ b/src/test/groovy/graphql/analysis/QueryTraverserTest.groovy
@@ -205,14 +205,14 @@ class QueryTraverserTest extends Specification {
                     env.argumentInputValue.parent.name == "moreComplex" &&
                     env.argumentInputValue.name == "height" &&
                     env.argumentInputValue.value instanceof IntValue &&
-                    env.argumentInputValue.directiveContainer instanceof GraphQLInputObjectField
+                    env.argumentInputValue.inputValueDefinition instanceof GraphQLInputObjectField
         }) >> TraversalControl.CONTINUE
 
         1 * visitor.visitArgumentValue({ QueryVisitorFieldArgumentValueEnvironment env ->
             env.graphQLArgument.name == "simpleArg" &&
                     env.argumentInputValue.name == "simpleArg" &&
                     env.argumentInputValue.value instanceof StringValue &&
-                    env.argumentInputValue.directiveContainer instanceof GraphQLArgument
+                    env.argumentInputValue.inputValueDefinition instanceof GraphQLArgument
         }) >> TraversalControl.CONTINUE
 
 


### PR DESCRIPTION
Naming comes from the counter part InputValueDefinition

Also named in line with GraphqlFieldDefinition (with counterpart FieldDefinition)

Consistency would called for GraphqlArgumentDefinition and GraphqlInputObjectFieldDefinition - but thats a bridge too far

