### PR TITLE
This will capture `extend type` AST and put them into the runtime types

### DIFF
--- a/src/main/java/graphql/schema/GraphQLEnumType.java
+++ b/src/main/java/graphql/schema/GraphQLEnumType.java
@@ -85,6 +85,7 @@ public class GraphQLEnumType implements GraphQLNamedInputType, GraphQLNamedOutpu
      * @param name        the name
      * @param description the description
      * @param values      the values
+     *
      * @deprecated use the {@link #newEnum()}  builder pattern instead, as this constructor will be made private in a future version.
      */
     @Internal
@@ -99,6 +100,7 @@ public class GraphQLEnumType implements GraphQLNamedInputType, GraphQLNamedOutpu
      * @param values      the values
      * @param directives  the directives on this type element
      * @param definition  the AST definition
+     *
      * @deprecated use the {@link #newEnum()}  builder pattern instead, as this constructor will be made private in a future version.
      */
     @Internal
@@ -114,7 +116,7 @@ public class GraphQLEnumType implements GraphQLNamedInputType, GraphQLNamedOutpu
         this.name = name;
         this.description = description;
         this.definition = definition;
-        this.extensionDefinitions = Collections.unmodifiableList(extensionDefinitions);
+        this.extensionDefinitions = Collections.unmodifiableList(new ArrayList<>(extensionDefinitions));
         this.directives = directives;
         buildMap(values);
     }
@@ -202,6 +204,7 @@ public class GraphQLEnumType implements GraphQLNamedInputType, GraphQLNamedOutpu
      * the current values and allows you to transform it how you want.
      *
      * @param builderConsumer the consumer code that will be given a builder to transform
+     *
      * @return a new field based on calling build on that builder
      */
     public GraphQLEnumType transform(Consumer<Builder> builderConsumer) {

--- a/src/main/java/graphql/schema/GraphQLInputObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectType.java
@@ -4,10 +4,12 @@ import graphql.AssertException;
 import graphql.Internal;
 import graphql.PublicApi;
 import graphql.language.InputObjectTypeDefinition;
+import graphql.language.InputObjectTypeExtensionDefinition;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,6 +34,7 @@ public class GraphQLInputObjectType implements GraphQLNamedInputType, GraphQLUnm
     private final String description;
     private final Map<String, GraphQLInputObjectField> fieldMap = new LinkedHashMap<>();
     private final InputObjectTypeDefinition definition;
+    private final List<InputObjectTypeExtensionDefinition> extensionDefinitions;
     private final List<GraphQLDirective> directives;
 
     public static final String CHILD_FIELD_DEFINITIONS = "fieldDefinitions";
@@ -62,6 +65,10 @@ public class GraphQLInputObjectType implements GraphQLNamedInputType, GraphQLUnm
     @Internal
     @Deprecated
     public GraphQLInputObjectType(String name, String description, List<GraphQLInputObjectField> fields, List<GraphQLDirective> directives, InputObjectTypeDefinition definition) {
+        this(name,description,fields,directives,definition,emptyList());
+    }
+
+    public GraphQLInputObjectType(String name, String description, List<GraphQLInputObjectField> fields, List<GraphQLDirective> directives, InputObjectTypeDefinition definition, List<InputObjectTypeExtensionDefinition> extensionDefinitions) {
         assertValidName(name);
         assertNotNull(fields, "fields can't be null");
         assertNotNull(directives, "directives cannot be null");
@@ -69,6 +76,7 @@ public class GraphQLInputObjectType implements GraphQLNamedInputType, GraphQLUnm
         this.name = name;
         this.description = description;
         this.definition = definition;
+        this.extensionDefinitions = Collections.unmodifiableList(extensionDefinitions);
         this.directives = directives;
         buildMap(fields);
     }
@@ -117,6 +125,10 @@ public class GraphQLInputObjectType implements GraphQLNamedInputType, GraphQLUnm
 
     public InputObjectTypeDefinition getDefinition() {
         return definition;
+    }
+
+    public List<InputObjectTypeExtensionDefinition> getExtensionDefinitions() {
+        return extensionDefinitions;
     }
 
     /**
@@ -183,6 +195,7 @@ public class GraphQLInputObjectType implements GraphQLNamedInputType, GraphQLUnm
     @PublicApi
     public static class Builder extends GraphqlTypeBuilder {
         private InputObjectTypeDefinition definition;
+        private List<InputObjectTypeExtensionDefinition> extensionDefinitions = emptyList();
         private final Map<String, GraphQLInputObjectField> fields = new LinkedHashMap<>();
         private final Map<String, GraphQLDirective> directives = new LinkedHashMap<>();
 
@@ -193,6 +206,7 @@ public class GraphQLInputObjectType implements GraphQLNamedInputType, GraphQLUnm
             this.name = existing.getName();
             this.description = existing.getDescription();
             this.definition = existing.getDefinition();
+            this.extensionDefinitions = existing.getExtensionDefinitions();
             this.fields.putAll(getByName(existing.getFields(), GraphQLInputObjectField::getName));
             this.directives.putAll(getByName(existing.getDirectives(), GraphQLDirective::getName));
         }
@@ -217,6 +231,11 @@ public class GraphQLInputObjectType implements GraphQLNamedInputType, GraphQLUnm
 
         public Builder definition(InputObjectTypeDefinition definition) {
             this.definition = definition;
+            return this;
+        }
+
+        public Builder extensionDefinitions(List<InputObjectTypeExtensionDefinition> extensionDefinitions) {
+            this.extensionDefinitions = extensionDefinitions;
             return this;
         }
 
@@ -326,7 +345,8 @@ public class GraphQLInputObjectType implements GraphQLNamedInputType, GraphQLUnm
                     description,
                     sort(fields, GraphQLInputObjectType.class, GraphQLInputObjectField.class),
                     sort(directives, GraphQLInputObjectType.class, GraphQLDirective.class),
-                    definition);
+                    definition,
+                    extensionDefinitions);
         }
     }
 }

--- a/src/main/java/graphql/schema/GraphQLInputObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectType.java
@@ -76,7 +76,7 @@ public class GraphQLInputObjectType implements GraphQLNamedInputType, GraphQLUnm
         this.name = name;
         this.description = description;
         this.definition = definition;
-        this.extensionDefinitions = Collections.unmodifiableList(extensionDefinitions);
+        this.extensionDefinitions = Collections.unmodifiableList(new ArrayList<>(extensionDefinitions));
         this.directives = directives;
         buildMap(fields);
     }

--- a/src/main/java/graphql/schema/GraphQLInterfaceType.java
+++ b/src/main/java/graphql/schema/GraphQLInterfaceType.java
@@ -52,6 +52,7 @@ public class GraphQLInterfaceType implements GraphQLNamedOutputType, GraphQLFiel
      * @param description      the description
      * @param fieldDefinitions the fields
      * @param typeResolver     the type resolver function
+     *
      * @deprecated use the {@link #newInterface()} builder pattern instead, as this constructor will be made private in a future version.
      */
     @Internal
@@ -67,6 +68,7 @@ public class GraphQLInterfaceType implements GraphQLNamedOutputType, GraphQLFiel
      * @param typeResolver     the type resolver function
      * @param directives       the directives on this type element
      * @param definition       the AST definition
+     *
      * @deprecated use the {@link #newInterface()} builder pattern instead, as this constructor will be made private in a future version.
      */
     @Internal
@@ -84,7 +86,7 @@ public class GraphQLInterfaceType implements GraphQLNamedOutputType, GraphQLFiel
         this.description = description;
         this.typeResolver = typeResolver;
         this.definition = definition;
-        this.extensionDefinitions = Collections.unmodifiableList(extensionDefinitions);
+        this.extensionDefinitions = Collections.unmodifiableList(new ArrayList<>(extensionDefinitions));
         this.directives = directives;
         buildDefinitionMap(fieldDefinitions);
     }
@@ -152,6 +154,7 @@ public class GraphQLInterfaceType implements GraphQLNamedOutputType, GraphQLFiel
      * the current values and allows you to transform it how you want.
      *
      * @param builderConsumer the consumer code that will be given a builder to transform
+     *
      * @return a new object based on calling build on that builder
      */
     public GraphQLInterfaceType transform(Consumer<Builder> builderConsumer) {
@@ -262,6 +265,7 @@ public class GraphQLInterfaceType implements GraphQLNamedOutputType, GraphQLFiel
          * </pre>
          *
          * @param builderFunction a supplier for the builder impl
+         *
          * @return this
          */
         public Builder field(UnaryOperator<GraphQLFieldDefinition.Builder> builderFunction) {
@@ -276,6 +280,7 @@ public class GraphQLInterfaceType implements GraphQLNamedOutputType, GraphQLFiel
          * from within
          *
          * @param builder an un-built/incomplete GraphQLFieldDefinition
+         *
          * @return this
          */
         public Builder field(GraphQLFieldDefinition.Builder builder) {

--- a/src/main/java/graphql/schema/GraphQLObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLObjectType.java
@@ -105,7 +105,7 @@ public class GraphQLObjectType implements GraphQLNamedOutputType, GraphQLFieldsC
         this.interfaceComparator = interfaceComparator;
         this.originalInterfaces = sortTypes(interfaceComparator, interfaces);
         this.definition = definition;
-        this.extensionDefinitions = Collections.unmodifiableList(extensionDefinitions);
+        this.extensionDefinitions = Collections.unmodifiableList(new ArrayList<>(extensionDefinitions));
         this.directives = assertNotNull(directives);
         buildDefinitionMap(fieldDefinitions);
     }

--- a/src/main/java/graphql/schema/GraphQLScalarType.java
+++ b/src/main/java/graphql/schema/GraphQLScalarType.java
@@ -4,10 +4,12 @@ package graphql.schema;
 import graphql.Internal;
 import graphql.PublicApi;
 import graphql.language.ScalarTypeDefinition;
+import graphql.language.ScalarTypeExtensionDefinition;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,6 +42,7 @@ public class GraphQLScalarType implements GraphQLNamedInputType, GraphQLNamedOut
     private final String description;
     private final Coercing coercing;
     private final ScalarTypeDefinition definition;
+    private final List<ScalarTypeExtensionDefinition> extensionDefinitions;
     private final List<GraphQLDirective> directives;
 
     public static final String CHILD_DIRECTIVES = "directives";
@@ -70,6 +73,10 @@ public class GraphQLScalarType implements GraphQLNamedInputType, GraphQLNamedOut
     @Internal
     @Deprecated
     public GraphQLScalarType(String name, String description, Coercing coercing, List<GraphQLDirective> directives, ScalarTypeDefinition definition) {
+        this(name,description,coercing,directives,definition,emptyList());
+    }
+
+    private GraphQLScalarType(String name, String description, Coercing coercing, List<GraphQLDirective> directives, ScalarTypeDefinition definition, List<ScalarTypeExtensionDefinition> extensionDefinitions) {
         assertValidName(name);
         assertNotNull(coercing, "coercing can't be null");
         assertNotNull(directives, "directives can't be null");
@@ -79,6 +86,7 @@ public class GraphQLScalarType implements GraphQLNamedInputType, GraphQLNamedOut
         this.coercing = coercing;
         this.definition = definition;
         this.directives = directives;
+        this.extensionDefinitions = Collections.unmodifiableList(extensionDefinitions);
     }
 
     @Override
@@ -98,6 +106,10 @@ public class GraphQLScalarType implements GraphQLNamedInputType, GraphQLNamedOut
 
     public ScalarTypeDefinition getDefinition() {
         return definition;
+    }
+
+    public List<ScalarTypeExtensionDefinition> getExtensionDefinitions() {
+        return extensionDefinitions;
     }
 
     @Override
@@ -165,6 +177,7 @@ public class GraphQLScalarType implements GraphQLNamedInputType, GraphQLNamedOut
     public static class Builder extends GraphqlTypeBuilder {
         private Coercing coercing;
         private ScalarTypeDefinition definition;
+        private List<ScalarTypeExtensionDefinition> extensionDefinitions = emptyList();
         private final Map<String, GraphQLDirective> directives = new LinkedHashMap<>();
 
         public Builder() {
@@ -175,6 +188,7 @@ public class GraphQLScalarType implements GraphQLNamedInputType, GraphQLNamedOut
             description = existing.getDescription();
             coercing = existing.getCoercing();
             definition = existing.getDefinition();
+            extensionDefinitions = existing.getExtensionDefinitions();
             directives.putAll(getByName(existing.getDirectives(), GraphQLDirective::getName));
         }
 
@@ -198,6 +212,11 @@ public class GraphQLScalarType implements GraphQLNamedInputType, GraphQLNamedOut
 
         public Builder definition(ScalarTypeDefinition definition) {
             this.definition = definition;
+            return this;
+        }
+
+        public Builder extensionDefinitions(List<ScalarTypeExtensionDefinition> extensionDefinitions) {
+            this.extensionDefinitions = extensionDefinitions;
             return this;
         }
 
@@ -247,7 +266,8 @@ public class GraphQLScalarType implements GraphQLNamedInputType, GraphQLNamedOut
                     description,
                     coercing,
                     sort(directives, GraphQLScalarType.class, GraphQLDirective.class),
-                    definition);
+                    definition,
+                    extensionDefinitions);
         }
     }
 }

--- a/src/main/java/graphql/schema/GraphQLScalarType.java
+++ b/src/main/java/graphql/schema/GraphQLScalarType.java
@@ -73,7 +73,7 @@ public class GraphQLScalarType implements GraphQLNamedInputType, GraphQLNamedOut
     @Internal
     @Deprecated
     public GraphQLScalarType(String name, String description, Coercing coercing, List<GraphQLDirective> directives, ScalarTypeDefinition definition) {
-        this(name,description,coercing,directives,definition,emptyList());
+        this(name, description, coercing, directives, definition, emptyList());
     }
 
     private GraphQLScalarType(String name, String description, Coercing coercing, List<GraphQLDirective> directives, ScalarTypeDefinition definition, List<ScalarTypeExtensionDefinition> extensionDefinitions) {
@@ -86,7 +86,7 @@ public class GraphQLScalarType implements GraphQLNamedInputType, GraphQLNamedOut
         this.coercing = coercing;
         this.definition = definition;
         this.directives = directives;
-        this.extensionDefinitions = Collections.unmodifiableList(extensionDefinitions);
+        this.extensionDefinitions = Collections.unmodifiableList(new ArrayList<>(extensionDefinitions));
     }
 
     @Override

--- a/src/main/java/graphql/schema/GraphQLUnionType.java
+++ b/src/main/java/graphql/schema/GraphQLUnionType.java
@@ -90,7 +90,7 @@ public class GraphQLUnionType implements GraphQLNamedType, GraphQLOutputType, Gr
         this.originalTypes = types;
         this.typeResolver = typeResolver;
         this.definition = definition;
-        this.extensionDefinitions = Collections.unmodifiableList(extensionDefinitions);
+        this.extensionDefinitions = Collections.unmodifiableList(new ArrayList<>(extensionDefinitions));
         this.directives = directives;
     }
 

--- a/src/main/java/graphql/schema/GraphQLUnionType.java
+++ b/src/main/java/graphql/schema/GraphQLUnionType.java
@@ -4,6 +4,7 @@ package graphql.schema;
 import graphql.Internal;
 import graphql.PublicApi;
 import graphql.language.UnionTypeDefinition;
+import graphql.language.UnionTypeExtensionDefinition;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
@@ -24,12 +25,12 @@ import static java.util.Collections.unmodifiableList;
 
 /**
  * A union type is a polymorphic type that dynamically represents one of more concrete object types.
- *
+ * <p>
  * At runtime a {@link graphql.schema.TypeResolver} is used to take an union object value and decide what {@link graphql.schema.GraphQLObjectType}
  * represents this union of types.
- *
+ * <p>
  * Note that members of a union type need to be concrete object types; you can't create a union type out of interfaces or other unions.
- *
+ * <p>
  * See http://graphql.org/learn/schema/#union-types for more details on the concept.
  */
 @PublicApi
@@ -40,6 +41,8 @@ public class GraphQLUnionType implements GraphQLNamedType, GraphQLOutputType, Gr
     private final List<GraphQLNamedOutputType> originalTypes;
     private final TypeResolver typeResolver;
     private final UnionTypeDefinition definition;
+    private final List<UnionTypeExtensionDefinition> extensionDefinitions;
+
     private final List<GraphQLDirective> directives;
 
     private List<GraphQLNamedOutputType> replacedTypes;
@@ -53,7 +56,6 @@ public class GraphQLUnionType implements GraphQLNamedType, GraphQLOutputType, Gr
      * @param description  the description
      * @param types        the possible types
      * @param typeResolver the type resolver function
-     *
      * @deprecated use the {@link #newUnionType()} builder pattern instead, as this constructor will be made private in a future version.
      */
     @Internal
@@ -69,12 +71,15 @@ public class GraphQLUnionType implements GraphQLNamedType, GraphQLOutputType, Gr
      * @param typeResolver the type resolver function
      * @param directives   the directives on this type element
      * @param definition   the AST definition
-     *
      * @deprecated use the {@link #newUnionType()} builder pattern instead, as this constructor will be made private in a future version.
      */
     @Internal
     @Deprecated
     public GraphQLUnionType(String name, String description, List<GraphQLNamedOutputType> types, TypeResolver typeResolver, List<GraphQLDirective> directives, UnionTypeDefinition definition) {
+        this(name, description, types, typeResolver, directives, definition, emptyList());
+    }
+
+    private GraphQLUnionType(String name, String description, List<GraphQLNamedOutputType> types, TypeResolver typeResolver, List<GraphQLDirective> directives, UnionTypeDefinition definition, List<UnionTypeExtensionDefinition> extensionDefinitions) {
         assertValidName(name);
         assertNotNull(types, "types can't be null");
         assertNotEmpty(types, "A Union type must define one or more member types.");
@@ -85,6 +90,7 @@ public class GraphQLUnionType implements GraphQLNamedType, GraphQLOutputType, Gr
         this.originalTypes = types;
         this.typeResolver = typeResolver;
         this.definition = definition;
+        this.extensionDefinitions = Collections.unmodifiableList(extensionDefinitions);
         this.directives = directives;
     }
 
@@ -122,6 +128,10 @@ public class GraphQLUnionType implements GraphQLNamedType, GraphQLOutputType, Gr
         return definition;
     }
 
+    public List<UnionTypeExtensionDefinition> getExtensionDefinitions() {
+        return extensionDefinitions;
+    }
+
     @Override
     public List<GraphQLDirective> getDirectives() {
         return new ArrayList<>(directives);
@@ -132,7 +142,6 @@ public class GraphQLUnionType implements GraphQLNamedType, GraphQLOutputType, Gr
      * the current values and allows you to transform it how you want.
      *
      * @param builderConsumer the consumer code that will be given a builder to transform
-     *
      * @return a new object based on calling build on that builder
      */
     public GraphQLUnionType transform(Consumer<Builder> builderConsumer) {
@@ -181,6 +190,8 @@ public class GraphQLUnionType implements GraphQLNamedType, GraphQLOutputType, Gr
     public static class Builder extends GraphqlTypeBuilder {
         private TypeResolver typeResolver;
         private UnionTypeDefinition definition;
+        private List<UnionTypeExtensionDefinition> extensionDefinitions = emptyList();
+
         private final Map<String, GraphQLNamedOutputType> types = new LinkedHashMap<>();
         private final Map<String, GraphQLDirective> directives = new LinkedHashMap<>();
 
@@ -192,6 +203,7 @@ public class GraphQLUnionType implements GraphQLNamedType, GraphQLOutputType, Gr
             this.description = existing.getDescription();
             this.typeResolver = existing.getTypeResolver();
             this.definition = existing.getDefinition();
+            this.extensionDefinitions = existing.getExtensionDefinitions();
             this.types.putAll(getByName(existing.originalTypes, GraphQLNamedType::getName));
             this.directives.putAll(getByName(existing.getDirectives(), GraphQLDirective::getName));
         }
@@ -219,6 +231,10 @@ public class GraphQLUnionType implements GraphQLNamedType, GraphQLOutputType, Gr
             return this;
         }
 
+        public Builder extensionDefinitions(List<UnionTypeExtensionDefinition> extensionDefinitions) {
+            this.extensionDefinitions = extensionDefinitions;
+            return this;
+        }
 
         @Deprecated
         public Builder typeResolver(TypeResolver typeResolver) {
@@ -318,7 +334,8 @@ public class GraphQLUnionType implements GraphQLNamedType, GraphQLOutputType, Gr
                     sort(types, GraphQLUnionType.class, GraphQLOutputType.class),
                     typeResolver,
                     sort(directives, GraphQLUnionType.class, GraphQLDirective.class),
-                    definition);
+                    definition,
+                    extensionDefinitions);
         }
     }
 }

--- a/src/main/java/graphql/schema/idl/SchemaGenerator.java
+++ b/src/main/java/graphql/schema/idl/SchemaGenerator.java
@@ -477,6 +477,7 @@ public class SchemaGenerator {
         builder.comparatorRegistry(buildCtx.getComparatorRegistry());
 
         List<ObjectTypeExtensionDefinition> extensions = objectTypeExtensions(typeDefinition, buildCtx);
+        builder.extensionDefinitions(extensions);
         builder.withDirectives(
                 buildDirectives(typeDefinition.getDirectives(),
                         directivesOf(extensions), OBJECT, buildCtx.getDirectiveDefinitions(), buildCtx.getComparatorRegistry())
@@ -535,6 +536,7 @@ public class SchemaGenerator {
 
 
         List<InterfaceTypeExtensionDefinition> extensions = interfaceTypeExtensions(typeDefinition, buildCtx);
+        builder.extensionDefinitions(extensions);
         builder.withDirectives(
                 buildDirectives(typeDefinition.getDirectives(),
                         directivesOf(extensions), OBJECT, buildCtx.getDirectiveDefinitions(), buildCtx.getComparatorRegistry())
@@ -570,6 +572,7 @@ public class SchemaGenerator {
         builder.comparatorRegistry(buildCtx.getComparatorRegistry());
 
         List<UnionTypeExtensionDefinition> extensions = unionTypeExtensions(typeDefinition, buildCtx);
+        builder.extensionDefinitions(extensions);
 
         typeDefinition.getMemberTypes().forEach(mt -> {
             GraphQLOutputType outputType = buildOutputType(buildCtx, mt);
@@ -614,6 +617,7 @@ public class SchemaGenerator {
         builder.comparatorRegistry(buildCtx.getComparatorRegistry());
 
         List<EnumTypeExtensionDefinition> extensions = enumTypeExtensions(typeDefinition, buildCtx);
+        builder.extensionDefinitions(extensions);
 
         EnumValuesProvider enumValuesProvider = buildCtx.getWiring().getEnumValuesProviders().get(typeDefinition.getName());
         typeDefinition.getEnumValueDefinitions().forEach(evd -> {
@@ -775,6 +779,7 @@ public class SchemaGenerator {
         builder.comparatorRegistry(buildCtx.getComparatorRegistry());
 
         List<InputObjectTypeExtensionDefinition> extensions = inputObjectTypeExtensions(typeDefinition, buildCtx);
+        builder.extensionDefinitions(extensions);
 
         builder.withDirectives(
                 buildDirectives(typeDefinition.getDirectives(),

--- a/src/main/java/graphql/schema/idl/SchemaPrinter.java
+++ b/src/main/java/graphql/schema/idl/SchemaPrinter.java
@@ -194,7 +194,7 @@ public class SchemaPrinter {
          * @return options
          */
         public Options setComparators(GraphqlTypeComparatorRegistry comparatorRegistry) {
-            return new Options(this.includeIntrospectionTypes, this.includeScalars, this.includeExtendedScalars, this.includeSchemaDefinition, this.useAstDefinitions, this.includeDirectives,
+            return new Options(this.includeIntrospectionTypes, this.includeScalars, this.includeExtendedScalars, this.includeSchemaDefinition, this.includeDirectives, this.useAstDefinitions,
                     comparatorRegistry);
         }
 

--- a/src/main/java/graphql/schema/idl/SchemaPrinter.java
+++ b/src/main/java/graphql/schema/idl/SchemaPrinter.java
@@ -64,6 +64,8 @@ public class SchemaPrinter {
 
         private final boolean includeScalars;
 
+        private final boolean useAstDefinitions;
+
         private final boolean includeExtendedScalars;
 
         private final boolean includeSchemaDefinition;
@@ -77,12 +79,14 @@ public class SchemaPrinter {
                         boolean includeExtendedScalars,
                         boolean includeSchemaDefinition,
                         boolean includeDirectives,
+                        boolean useAstDefinitions,
                         GraphqlTypeComparatorRegistry comparatorRegistry) {
             this.includeIntrospectionTypes = includeIntrospectionTypes;
             this.includeScalars = includeScalars;
             this.includeExtendedScalars = includeExtendedScalars;
             this.includeSchemaDefinition = includeSchemaDefinition;
             this.includeDirectives = includeDirectives;
+            this.useAstDefinitions = useAstDefinitions;
             this.comparatorRegistry = comparatorRegistry;
         }
 
@@ -106,9 +110,13 @@ public class SchemaPrinter {
             return includeDirectives;
         }
 
+        public boolean isUseAstDefinitions() {
+            return useAstDefinitions;
+        }
+
         public static Options defaultOptions() {
             return new Options(false, false, false, false, true,
-                    DefaultGraphqlTypeComparatorRegistry.defaultComparators());
+                    false, DefaultGraphqlTypeComparatorRegistry.defaultComparators());
         }
 
         /**
@@ -118,7 +126,7 @@ public class SchemaPrinter {
          * @return options
          */
         public Options includeIntrospectionTypes(boolean flag) {
-            return new Options(flag, this.includeScalars, this.includeExtendedScalars, this.includeSchemaDefinition, this.includeDirectives, this.comparatorRegistry);
+            return new Options(flag, this.includeScalars, this.includeExtendedScalars, this.includeSchemaDefinition, this.includeDirectives, this.useAstDefinitions, this.comparatorRegistry);
         }
 
         /**
@@ -128,7 +136,7 @@ public class SchemaPrinter {
          * @return options
          */
         public Options includeScalarTypes(boolean flag) {
-            return new Options(this.includeIntrospectionTypes, flag, this.includeExtendedScalars, this.includeSchemaDefinition, this.includeDirectives, this.comparatorRegistry);
+            return new Options(this.includeIntrospectionTypes, flag, this.includeExtendedScalars, this.includeSchemaDefinition, this.includeDirectives, this.useAstDefinitions, this.comparatorRegistry);
         }
 
         /**
@@ -139,7 +147,7 @@ public class SchemaPrinter {
          * @return options
          */
         public Options includeExtendedScalarTypes(boolean flag) {
-            return new Options(this.includeIntrospectionTypes, this.includeScalars, flag, this.includeSchemaDefinition, this.includeDirectives, this.comparatorRegistry);
+            return new Options(this.includeIntrospectionTypes, this.includeScalars, flag, this.includeSchemaDefinition, this.includeDirectives, this.useAstDefinitions, this.comparatorRegistry);
         }
 
         /**
@@ -152,7 +160,7 @@ public class SchemaPrinter {
          * @return options
          */
         public Options includeSchemaDefintion(boolean flag) {
-            return new Options(this.includeIntrospectionTypes, this.includeScalars, this.includeExtendedScalars, flag, this.includeDirectives, this.comparatorRegistry);
+            return new Options(this.includeIntrospectionTypes, this.includeScalars, this.includeExtendedScalars, flag, this.includeDirectives, this.useAstDefinitions, this.comparatorRegistry);
         }
 
         /**
@@ -163,7 +171,18 @@ public class SchemaPrinter {
          * @return new instance of options
          */
         public Options includeDirectives(boolean flag) {
-            return new Options(this.includeIntrospectionTypes, this.includeScalars, this.includeExtendedScalars, this.includeSchemaDefinition, flag, this.comparatorRegistry);
+            return new Options(this.includeIntrospectionTypes, this.includeScalars, this.includeExtendedScalars, this.includeSchemaDefinition, flag, this.useAstDefinitions, this.comparatorRegistry);
+        }
+
+        /**
+         * This flag controls whether schema printer will use the {@link graphql.schema.GraphQLType}'s original Ast {@link graphql.language.TypeDefinition}s when printing the type.  This
+         * allows access to any `extend type` declarations that might have been originally made.
+         *
+         * @param flag whether to print via AST type definitions
+         * @return new instance of options
+         */
+        public Options useAstDefinitions(boolean flag) {
+            return new Options(this.includeIntrospectionTypes, this.includeScalars, this.includeExtendedScalars, this.includeSchemaDefinition, this.includeDirectives, flag, this.comparatorRegistry);
         }
 
         /**
@@ -175,7 +194,7 @@ public class SchemaPrinter {
          * @return options
          */
         public Options setComparators(GraphqlTypeComparatorRegistry comparatorRegistry) {
-            return new Options(this.includeIntrospectionTypes, this.includeScalars, this.includeExtendedScalars, this.includeSchemaDefinition, this.includeDirectives,
+            return new Options(this.includeIntrospectionTypes, this.includeScalars, this.includeExtendedScalars, this.includeSchemaDefinition, this.useAstDefinitions, this.includeDirectives,
                     comparatorRegistry);
         }
 
@@ -473,7 +492,7 @@ public class SchemaPrinter {
      * @return true if we should print using AST nodes
      */
     private boolean shouldPrintAsAst(TypeDefinition definition) {
-        return definition != null && false; // TODO - get this from options
+        return options.isUseAstDefinitions() && definition != null;
     }
 
     /**

--- a/src/main/java/graphql/schema/idl/SchemaPrinter.java
+++ b/src/main/java/graphql/schema/idl/SchemaPrinter.java
@@ -8,6 +8,7 @@ import graphql.language.Comment;
 import graphql.language.Description;
 import graphql.language.Document;
 import graphql.language.Node;
+import graphql.language.TypeDefinition;
 import graphql.schema.DefaultGraphqlTypeComparatorRegistry;
 import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLDirective;
@@ -114,7 +115,6 @@ public class SchemaPrinter {
          * This will allow you to include introspection types that are contained in a schema
          *
          * @param flag whether to include them
-         *
          * @return options
          */
         public Options includeIntrospectionTypes(boolean flag) {
@@ -125,7 +125,6 @@ public class SchemaPrinter {
          * This will allow you to include scalar types that are contained in a schema
          *
          * @param flag whether to include them
-         *
          * @return options
          */
         public Options includeScalarTypes(boolean flag) {
@@ -137,7 +136,6 @@ public class SchemaPrinter {
          * GraphQLBigDecimal or GraphQLBigInteger
          *
          * @param flag whether to include them
-         *
          * @return options
          */
         public Options includeExtendedScalarTypes(boolean flag) {
@@ -151,7 +149,6 @@ public class SchemaPrinter {
          * types do not use the default names.
          *
          * @param flag whether to force include the schema definition
-         *
          * @return options
          */
         public Options includeSchemaDefintion(boolean flag) {
@@ -163,7 +160,6 @@ public class SchemaPrinter {
          * make the printout noisy and having this flag would allow cleaner printout. On by default.
          *
          * @param flag whether to print directives
-         *
          * @return new instance of options
          */
         public Options includeDirectives(boolean flag) {
@@ -176,7 +172,6 @@ public class SchemaPrinter {
          * The default is to sort elements by name but you can put in your own code to decide on the field order
          *
          * @param comparatorRegistry The registry containing the {@code Comparator} and environment scoping rules.
-         *
          * @return options
          */
         public Options setComparators(GraphqlTypeComparatorRegistry comparatorRegistry) {
@@ -215,7 +210,6 @@ public class SchemaPrinter {
      * first to get the {@link graphql.language.Document} and then print that.
      *
      * @param schemaIDL the parsed schema IDL
-     *
      * @return the logical schema definition
      */
     public String print(Document schemaIDL) {
@@ -227,7 +221,6 @@ public class SchemaPrinter {
      * This can print an in memory GraphQL schema back to a logical schema definition
      *
      * @param schema the schema in play
-     *
      * @return the logical schema definition
      */
     public String print(GraphQLSchema schema) {
@@ -283,11 +276,16 @@ public class SchemaPrinter {
                 printScalar = true;
             }
             if (printScalar) {
-                printComments(out, type, "");
-                out.format("scalar %s%s\n\n", type.getName(), directivesString(GraphQLScalarType.class, type.getDirectives()));
+                if (shouldPrintAsAst(type.getDefinition())) {
+                    printAsAst(out, type.getDefinition(), type.getExtensionDefinitions());
+                } else {
+                    printComments(out, type, "");
+                    out.format("scalar %s%s\n\n", type.getName(), directivesString(GraphQLScalarType.class, type.getDirectives()));
+                }
             }
         };
     }
+
 
     private TypePrinter<GraphQLEnumType> enumPrinter() {
         return (out, type, visibility) -> {
@@ -301,17 +299,21 @@ public class SchemaPrinter {
                     .build();
             Comparator<? super GraphQLSchemaElement> comparator = options.comparatorRegistry.getComparator(environment);
 
-            printComments(out, type, "");
-            out.format("enum %s%s {\n", type.getName(), directivesString(GraphQLEnumType.class, type.getDirectives()));
-            List<GraphQLEnumValueDefinition> values = type.getValues()
-                    .stream()
-                    .sorted(comparator)
-                    .collect(toList());
-            for (GraphQLEnumValueDefinition enumValueDefinition : values) {
-                printComments(out, enumValueDefinition, "  ");
-                out.format("  %s%s\n", enumValueDefinition.getName(), directivesString(GraphQLEnumValueDefinition.class, enumValueDefinition.getDirectives()));
+            if (shouldPrintAsAst(type.getDefinition())) {
+                printAsAst(out, type.getDefinition(), type.getExtensionDefinitions());
+            } else {
+                printComments(out, type, "");
+                out.format("enum %s%s {\n", type.getName(), directivesString(GraphQLEnumType.class, type.getDirectives()));
+                List<GraphQLEnumValueDefinition> values = type.getValues()
+                        .stream()
+                        .sorted(comparator)
+                        .collect(toList());
+                for (GraphQLEnumValueDefinition enumValueDefinition : values) {
+                    printComments(out, enumValueDefinition, "  ");
+                    out.format("  %s%s\n", enumValueDefinition.getName(), directivesString(GraphQLEnumValueDefinition.class, enumValueDefinition.getDirectives()));
+                }
+                out.format("}\n\n");
             }
-            out.format("}\n\n");
         };
     }
 
@@ -327,18 +329,22 @@ public class SchemaPrinter {
                     .build();
             Comparator<? super GraphQLSchemaElement> comparator = options.comparatorRegistry.getComparator(environment);
 
-            printComments(out, type, "");
-            out.format("interface %s%s {\n", type.getName(), directivesString(GraphQLInterfaceType.class, type.getDirectives()));
-            visibility.getFieldDefinitions(type)
-                    .stream()
-                    .sorted(comparator)
-                    .forEach(fd -> {
-                        printComments(out, fd, "  ");
-                        out.format("  %s%s: %s%s\n",
-                                fd.getName(), argsString(GraphQLFieldDefinition.class, fd.getArguments()), typeString(fd.getType()),
-                                directivesString(GraphQLFieldDefinition.class, fd.getDirectives()));
-                    });
-            out.format("}\n\n");
+            if (shouldPrintAsAst(type.getDefinition())) {
+                printAsAst(out, type.getDefinition(), type.getExtensionDefinitions());
+            } else {
+                printComments(out, type, "");
+                out.format("interface %s%s {\n", type.getName(), directivesString(GraphQLInterfaceType.class, type.getDirectives()));
+                visibility.getFieldDefinitions(type)
+                        .stream()
+                        .sorted(comparator)
+                        .forEach(fd -> {
+                            printComments(out, fd, "  ");
+                            out.format("  %s%s: %s%s\n",
+                                    fd.getName(), argsString(GraphQLFieldDefinition.class, fd.getArguments()), typeString(fd.getType()),
+                                    directivesString(GraphQLFieldDefinition.class, fd.getDirectives()));
+                        });
+                out.format("}\n\n");
+            }
         };
     }
 
@@ -354,20 +360,24 @@ public class SchemaPrinter {
                     .build();
             Comparator<? super GraphQLSchemaElement> comparator = options.comparatorRegistry.getComparator(environment);
 
-            printComments(out, type, "");
-            out.format("union %s%s = ", type.getName(), directivesString(GraphQLUnionType.class, type.getDirectives()));
-            List<GraphQLNamedOutputType> types = type.getTypes()
-                    .stream()
-                    .sorted(comparator)
-                    .collect(toList());
-            for (int i = 0; i < types.size(); i++) {
-                GraphQLNamedOutputType objectType = types.get(i);
-                if (i > 0) {
-                    out.format(" | ");
+            if (shouldPrintAsAst(type.getDefinition())) {
+                printAsAst(out, type.getDefinition(), type.getExtensionDefinitions());
+            } else {
+                printComments(out, type, "");
+                out.format("union %s%s = ", type.getName(), directivesString(GraphQLUnionType.class, type.getDirectives()));
+                List<GraphQLNamedOutputType> types = type.getTypes()
+                        .stream()
+                        .sorted(comparator)
+                        .collect(toList());
+                for (int i = 0; i < types.size(); i++) {
+                    GraphQLNamedOutputType objectType = types.get(i);
+                    if (i > 0) {
+                        out.format(" | ");
+                    }
+                    out.format("%s", objectType.getName());
                 }
-                out.format("%s", objectType.getName());
+                out.format("\n\n");
             }
-            out.format("\n\n");
         };
     }
 
@@ -376,43 +386,47 @@ public class SchemaPrinter {
             if (isIntrospectionType(type)) {
                 return;
             }
-            printComments(out, type, "");
-            if (type.getInterfaces().isEmpty()) {
-                out.format("type %s%s {\n", type.getName(), directivesString(GraphQLObjectType.class, type.getDirectives()));
+            if (shouldPrintAsAst(type.getDefinition())) {
+                printAsAst(out, type.getDefinition(), type.getExtensionDefinitions());
             } else {
+                printComments(out, type, "");
+                if (type.getInterfaces().isEmpty()) {
+                    out.format("type %s%s {\n", type.getName(), directivesString(GraphQLObjectType.class, type.getDirectives()));
+                } else {
+
+                    GraphqlTypeComparatorEnvironment environment = GraphqlTypeComparatorEnvironment.newEnvironment()
+                            .parentType(GraphQLObjectType.class)
+                            .elementType(GraphQLOutputType.class)
+                            .build();
+                    Comparator<? super GraphQLSchemaElement> implementsComparator = options.comparatorRegistry.getComparator(environment);
+
+                    Stream<String> interfaceNames = type.getInterfaces()
+                            .stream()
+                            .sorted(implementsComparator)
+                            .map(GraphQLNamedType::getName);
+                    out.format("type %s implements %s%s {\n",
+                            type.getName(),
+                            interfaceNames.collect(joining(" & ")),
+                            directivesString(GraphQLObjectType.class, type.getDirectives()));
+                }
 
                 GraphqlTypeComparatorEnvironment environment = GraphqlTypeComparatorEnvironment.newEnvironment()
                         .parentType(GraphQLObjectType.class)
-                        .elementType(GraphQLOutputType.class)
+                        .elementType(GraphQLFieldDefinition.class)
                         .build();
-                Comparator<? super GraphQLSchemaElement> implementsComparator = options.comparatorRegistry.getComparator(environment);
+                Comparator<? super GraphQLSchemaElement> comparator = options.comparatorRegistry.getComparator(environment);
 
-                Stream<String> interfaceNames = type.getInterfaces()
+                visibility.getFieldDefinitions(type)
                         .stream()
-                        .sorted(implementsComparator)
-                        .map(GraphQLNamedType::getName);
-                out.format("type %s implements %s%s {\n",
-                        type.getName(),
-                        interfaceNames.collect(joining(" & ")),
-                        directivesString(GraphQLObjectType.class, type.getDirectives()));
+                        .sorted(comparator)
+                        .forEach(fd -> {
+                            printComments(out, fd, "  ");
+                            out.format("  %s%s: %s%s\n",
+                                    fd.getName(), argsString(GraphQLFieldDefinition.class, fd.getArguments()), typeString(fd.getType()),
+                                    directivesString(GraphQLFieldDefinition.class, fd.getDirectives()));
+                        });
+                out.format("}\n\n");
             }
-
-            GraphqlTypeComparatorEnvironment environment = GraphqlTypeComparatorEnvironment.newEnvironment()
-                    .parentType(GraphQLObjectType.class)
-                    .elementType(GraphQLFieldDefinition.class)
-                    .build();
-            Comparator<? super GraphQLSchemaElement> comparator = options.comparatorRegistry.getComparator(environment);
-
-            visibility.getFieldDefinitions(type)
-                    .stream()
-                    .sorted(comparator)
-                    .forEach(fd -> {
-                        printComments(out, fd, "  ");
-                        out.format("  %s%s: %s%s\n",
-                                fd.getName(), argsString(GraphQLFieldDefinition.class, fd.getArguments()), typeString(fd.getType()),
-                                directivesString(GraphQLFieldDefinition.class, fd.getDirectives()));
-                    });
-            out.format("}\n\n");
         };
     }
 
@@ -421,32 +435,63 @@ public class SchemaPrinter {
             if (isIntrospectionType(type)) {
                 return;
             }
-            printComments(out, type, "");
+            if (shouldPrintAsAst(type.getDefinition())) {
+                printAsAst(out, type.getDefinition(), type.getExtensionDefinitions());
+            } else {
+                printComments(out, type, "");
+                GraphqlTypeComparatorEnvironment environment = GraphqlTypeComparatorEnvironment.newEnvironment()
+                        .parentType(GraphQLInputObjectType.class)
+                        .elementType(GraphQLInputObjectField.class)
+                        .build();
+                Comparator<? super GraphQLSchemaElement> comparator = options.comparatorRegistry.getComparator(environment);
 
-            GraphqlTypeComparatorEnvironment environment = GraphqlTypeComparatorEnvironment.newEnvironment()
-                    .parentType(GraphQLInputObjectType.class)
-                    .elementType(GraphQLInputObjectField.class)
-                    .build();
-            Comparator<? super GraphQLSchemaElement> comparator = options.comparatorRegistry.getComparator(environment);
-
-            out.format("input %s%s {\n", type.getName(), directivesString(GraphQLInputObjectType.class, type.getDirectives()));
-            visibility.getFieldDefinitions(type)
-                    .stream()
-                    .sorted(comparator)
-                    .forEach(fd -> {
-                        printComments(out, fd, "  ");
-                        out.format("  %s: %s",
-                                fd.getName(), typeString(fd.getType()));
-                        Object defaultValue = fd.getDefaultValue();
-                        if (defaultValue != null) {
-                            String astValue = printAst(defaultValue, fd.getType());
-                            out.format(" = %s", astValue);
-                        }
-                        out.format(directivesString(GraphQLInputObjectField.class, fd.getDirectives()));
-                        out.format("\n");
-                    });
-            out.format("}\n\n");
+                out.format("input %s%s {\n", type.getName(), directivesString(GraphQLInputObjectType.class, type.getDirectives()));
+                visibility.getFieldDefinitions(type)
+                        .stream()
+                        .sorted(comparator)
+                        .forEach(fd -> {
+                            printComments(out, fd, "  ");
+                            out.format("  %s: %s",
+                                    fd.getName(), typeString(fd.getType()));
+                            Object defaultValue = fd.getDefaultValue();
+                            if (defaultValue != null) {
+                                String astValue = printAst(defaultValue, fd.getType());
+                                out.format(" = %s", astValue);
+                            }
+                            out.format(directivesString(GraphQLInputObjectField.class, fd.getDirectives()));
+                            out.format("\n");
+                        });
+                out.format("}\n\n");
+            }
         };
+    }
+
+    /**
+     * This will return true if the options say to use the AST and we have an AST element
+     *
+     * @param definition the AST type definition
+     * @return true if we should print using AST nodes
+     */
+    private boolean shouldPrintAsAst(TypeDefinition definition) {
+        return definition != null && false; // TODO - get this from options
+    }
+
+    /**
+     * This will print out a runtime graphql schema element using its contained AST type definition.  This
+     * must be guarded by a called to `shouldPrintAsAst`
+     *
+     * @param out        the output writer
+     * @param definition the AST type definition
+     * @param extensions a list of type definition extensions
+     */
+    private void printAsAst(PrintWriter out, TypeDefinition definition, List<? extends TypeDefinition> extensions) {
+        out.printf("%s\n", AstPrinter.printAst(definition));
+        if (extensions != null) {
+            for (TypeDefinition extension : extensions) {
+                out.printf("\n%s\n", AstPrinter.printAst(extension));
+            }
+        }
+        out.println();
     }
 
     private static String printAst(Object value, GraphQLInputType type) {

--- a/src/main/java/graphql/schema/idl/SchemaPrinter.java
+++ b/src/main/java/graphql/schema/idl/SchemaPrinter.java
@@ -497,7 +497,7 @@ public class SchemaPrinter {
 
     /**
      * This will print out a runtime graphql schema element using its contained AST type definition.  This
-     * must be guarded by a called to `shouldPrintAsAst`
+     * must be guarded by a called to {@link #shouldPrintAsAst(TypeDefinition)}
      *
      * @param out        the output writer
      * @param definition the AST type definition

--- a/src/test/groovy/graphql/TestUtil.groovy
+++ b/src/test/groovy/graphql/TestUtil.groovy
@@ -162,7 +162,7 @@ class TestUtil {
         new GraphQLScalarType(name, name, mockCoercing())
     }
 
-    private static Coercing mockCoercing() {
+    static Coercing mockCoercing() {
         new Coercing() {
             @Override
             Object serialize(Object dataFetcherResult) {

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -14,6 +14,7 @@ import graphql.schema.GraphQLInterfaceType
 import graphql.schema.GraphQLList
 import graphql.schema.GraphQLNonNull
 import graphql.schema.GraphQLObjectType
+import graphql.schema.GraphQLScalarType
 import graphql.schema.GraphQLSchema
 import graphql.schema.GraphQLType
 import graphql.schema.GraphQLUnionType
@@ -1305,7 +1306,7 @@ class SchemaGeneratorTest extends Specification {
 
         expect:
 
-        schema.getFieldVisibility() == fieldVisibility
+        schema.getCodeRegistry().getFieldVisibility() == fieldVisibility
 
     }
 
@@ -1782,5 +1783,131 @@ class SchemaGeneratorTest extends Specification {
         def fieldWithString = queryType.getFieldDefinition("fieldWithString")
         def arg2 = fieldWithString.getArgument("arg")
         arg2.defaultValue == [value: "ONE"]
+    }
+
+    def "extensions are captured into runtime objects"() {
+        def sdl = '''
+            ######## Objects
+             
+            type Query {
+                foo : String
+            }
+            
+            extend type Query {
+                bar : String
+            }
+
+            extend type Query {
+                baz : String
+            }
+
+            ######## Enums 
+          
+            enum Enum {
+                A
+            }
+            
+            extend enum Enum {
+                B
+            }
+
+            ######## Interface 
+            
+            interface Interface {
+                foo : String
+            }
+
+            extend interface Interface {
+                bar : String
+            }
+
+            extend interface Interface {
+                baz : String
+            }
+            
+            ######## Unions 
+            
+            type Foo {
+                foo : String
+            }
+            
+            type Bar {
+                bar : Scalar
+            }
+
+            union Union = Foo
+            
+            extend union Union = Bar
+            
+            ######## Input Objects 
+
+            input Input {
+                foo: String
+            }
+            
+            extend input Input {
+                bar: String
+            }
+
+            extend input Input {
+                baz: String
+            }
+
+            extend input Input {
+                faz: String
+            }
+            
+            ######## Scalar 
+
+            scalar Scalar
+            
+            extend scalar Scalar @directive1
+        '''
+
+
+        when:
+        def wiringFactory = new MockedWiringFactory() {
+            @Override
+            boolean providesScalar(ScalarWiringEnvironment env) {
+                return env.getScalarTypeDefinition().getName() == "Scalar"
+            }
+
+            @Override
+            GraphQLScalarType getScalar(ScalarWiringEnvironment env) {
+                def definition = env.getScalarTypeDefinition()
+                return GraphQLScalarType.newScalar()
+                        .name(definition.getName())
+                        .definition(definition)
+                        .extensionDefinitions(env.getExtensions())
+                        .coercing(TestUtil.mockCoercing())
+                        .build()
+            }
+        }
+
+        def runtimeWiring = RuntimeWiring.newRuntimeWiring()
+                .wiringFactory(wiringFactory)
+                .build()
+
+        def options = SchemaGenerator.Options.defaultOptions().enforceSchemaDirectives(false)
+
+        def types = new SchemaParser().parse(sdl)
+        GraphQLSchema schema = new SchemaGenerator().makeExecutableSchema(options, types, runtimeWiring)
+
+        then:
+        schema != null
+
+        (schema.getType("Query") as GraphQLObjectType).getExtensionDefinitions().size() == 2
+
+        (schema.getType("Enum") as GraphQLEnumType).getExtensionDefinitions().size() == 1
+
+        (schema.getType("Interface") as GraphQLInterfaceType).getExtensionDefinitions().size() == 2
+
+        (schema.getType("Union") as GraphQLUnionType).getExtensionDefinitions().size() == 1
+
+        (schema.getType("Input") as GraphQLInputObjectType).getExtensionDefinitions().size() == 3
+
+        // scalars are special - they are created via a WiringFactory - but this tests they are given the extensions
+        (schema.getType("Scalar") as GraphQLScalarType).getExtensionDefinitions().size() == 1
+
     }
 }

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -20,7 +20,6 @@ import graphql.schema.GraphQLSchema
 import graphql.schema.GraphQLType
 import graphql.schema.GraphQLUnionType
 import graphql.schema.TypeResolver
-import spock.lang.Ignore
 import spock.lang.Specification
 
 import java.util.function.UnaryOperator
@@ -967,7 +966,6 @@ type Query {
 '''
     }
 
-    @Ignore("until we have the option in the SchemaPrinter")
     def "can print a schema as AST elements"() {
         def sdl = '''
             type Query {
@@ -1063,7 +1061,8 @@ type Query {
         def types = new SchemaParser().parse(sdl)
         GraphQLSchema schema = new SchemaGenerator().makeExecutableSchema(options, types, runtimeWiring)
 
-        def result = new SchemaPrinter(defaultOptions().includeScalarTypes(true)).print(schema)
+        def printOptions = defaultOptions().includeScalarTypes(true).useAstDefinitions(true)
+        def result = new SchemaPrinter(printOptions).print(schema)
 
         then:
         result == '''interface Interface {
@@ -1129,6 +1128,26 @@ extend input Input {
 extend input Input {
   faz: String
 }
+'''
+
+        when:
+        // we can print by direct type using AST
+        def queryType = schema.getType("Query")
+        result = new SchemaPrinter(printOptions).print(queryType)
+
+        then:
+        result == '''type Query {
+  foo: String
+}
+
+extend type Query {
+  bar: String
+}
+
+extend type Query {
+  baz: String
+}
+
 '''
     }
 }


### PR DESCRIPTION
This is a one step towards Apollo Federation support.

#1644

It now does two major things

* It captures the original AST type definitions including `extends` definitions
* SchemaPrinter now has a mode where you can print out the original AST definitions

Given the following SL

```
type Query {
  foo: String
}

extend type Query {
  bar: String
}

extend type Query {
  baz: String
}
```

The original (and default mode) SchemaPrinter will print the combined runtime view eg

```
type Query {
  foo: String
  bar: String
  baz: String
}
```

Now with the capture of the original AST type definitions we get it as it was in the SDL including `extends` declarations.

@pcarrier - does this make sense to help Apollo Federation?

