### PR TITLE
#1650 - upgrades the dataloader version AND fixes lazy data loader support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ jar {
 dependencies {
     compile 'org.antlr:antlr4-runtime:4.7.2'
     compile 'org.slf4j:slf4j-api:' + slf4jVersion
-    compile 'com.graphql-java:java-dataloader:2.1.1'
+    compile 'com.graphql-java:java-dataloader:2.2.3'
     compile 'org.reactivestreams:reactive-streams:' + reactiveStreamsVersion
     antlr "org.antlr:antlr4:4.7.2"
     testCompile group: 'junit', name: 'junit', version: '4.12'

--- a/src/main/java/graphql/ExecutionInput.java
+++ b/src/main/java/graphql/ExecutionInput.java
@@ -2,6 +2,7 @@ package graphql;
 
 import graphql.cachecontrol.CacheControl;
 import graphql.execution.ExecutionId;
+import graphql.execution.instrumentation.dataloader.DataLoaderDispatcherInstrumentationState;
 import org.dataloader.DataLoaderRegistry;
 
 import java.util.Collections;
@@ -99,7 +100,6 @@ public class ExecutionInput {
      * the current values and allows you to transform it how you want.
      *
      * @param builderConsumer the consumer code that will be given a builder to transform
-     *
      * @return a new ExecutionInput object based on calling build on that builder
      */
     public ExecutionInput transform(Consumer<Builder> builderConsumer) {
@@ -143,7 +143,6 @@ public class ExecutionInput {
      * Creates a new builder of ExecutionInput objects with the given query
      *
      * @param query the query to execute
-     *
      * @return a new builder of ExecutionInput objects
      */
     public static Builder newExecutionInput(String query) {
@@ -157,7 +156,11 @@ public class ExecutionInput {
         private Object context = GraphQLContext.newContext().build();
         private Object root;
         private Map<String, Object> variables = Collections.emptyMap();
-        private DataLoaderRegistry dataLoaderRegistry = new DataLoaderRegistry();
+        //
+        // this is important - it allows code to later known if we never really set a dataloader and hence it can optimize
+        // dataloader field tracking away.
+        //
+        private DataLoaderRegistry dataLoaderRegistry = DataLoaderDispatcherInstrumentationState.EMPTY_DATALOADER_REGISTRY;
         private CacheControl cacheControl = CacheControl.newCacheControl();
         private ExecutionId executionId = null;
 
@@ -175,7 +178,6 @@ public class ExecutionInput {
          * A default one will be assigned, but you can set your own.
          *
          * @param executionId an execution id object
-         *
          * @return this builder
          */
         public Builder executionId(ExecutionId executionId) {
@@ -187,7 +189,6 @@ public class ExecutionInput {
          * By default you will get a {@link GraphQLContext} object but you can set your own.
          *
          * @param context the context object to use
-         *
          * @return this builder
          */
         public Builder context(Object context) {
@@ -222,7 +223,6 @@ public class ExecutionInput {
          * instances as this will create unexpected results.
          *
          * @param dataLoaderRegistry a registry of {@link org.dataloader.DataLoader}s
-         *
          * @return this builder
          */
         public Builder dataLoaderRegistry(DataLoaderRegistry dataLoaderRegistry) {

--- a/src/main/java/graphql/Internal.java
+++ b/src/main/java/graphql/Internal.java
@@ -5,6 +5,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 
@@ -15,6 +16,6 @@ import static java.lang.annotation.ElementType.TYPE;
  * In general unnecessary changes will be avoided but you should not depend on internal classes being stable
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(value = {CONSTRUCTOR, METHOD, TYPE})
+@Target(value = {CONSTRUCTOR, METHOD, TYPE, FIELD})
 public @interface Internal {
 }

--- a/src/main/java/graphql/PublicApi.java
+++ b/src/main/java/graphql/PublicApi.java
@@ -6,6 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 
@@ -17,7 +18,7 @@ import static java.lang.annotation.ElementType.TYPE;
  * maybe be added which would break derivations but not callers.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(value = {CONSTRUCTOR, METHOD, TYPE})
+@Target(value = {CONSTRUCTOR, METHOD, TYPE, FIELD})
 @Documented
 public @interface PublicApi {
 }

--- a/src/main/java/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentationState.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentationState.java
@@ -1,5 +1,6 @@
 package graphql.execution.instrumentation.dataloader;
 
+import graphql.Internal;
 import graphql.execution.instrumentation.InstrumentationState;
 import org.dataloader.DataLoaderRegistry;
 import org.slf4j.Logger;
@@ -8,6 +9,9 @@ import org.slf4j.Logger;
  * A base class that keeps track of whether aggressive batching can be used
  */
 public class DataLoaderDispatcherInstrumentationState implements InstrumentationState {
+
+    @Internal
+    public static final DataLoaderRegistry EMPTY_DATALOADER_REGISTRY = new DataLoaderRegistry();
 
     private final FieldLevelTrackingApproach approach;
     private final DataLoaderRegistry dataLoaderRegistry;
@@ -20,8 +24,11 @@ public class DataLoaderDispatcherInstrumentationState implements Instrumentation
         this.dataLoaderRegistry = dataLoaderRegistry;
         this.approach = new FieldLevelTrackingApproach(log, dataLoaderRegistry);
         this.state = approach.createState();
-        hasNoDataLoaders = dataLoaderRegistry.getKeys().isEmpty();
-
+        //
+        // if they have never set a dataloader into the execution input then we can optimize
+        // away the tracking code
+        //
+        hasNoDataLoaders = dataLoaderRegistry == EMPTY_DATALOADER_REGISTRY;
     }
 
     boolean isAggressivelyBatching() {
@@ -47,6 +54,4 @@ public class DataLoaderDispatcherInstrumentationState implements Instrumentation
     InstrumentationState getState() {
         return state;
     }
-
-
 }

--- a/src/main/java/graphql/schema/DataFetchingEnvironment.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironment.java
@@ -11,6 +11,7 @@ import graphql.language.Field;
 import graphql.language.FragmentDefinition;
 import graphql.language.OperationDefinition;
 import org.dataloader.DataLoader;
+import org.dataloader.DataLoaderRegistry;
 
 import java.util.List;
 import java.util.Map;
@@ -31,7 +32,6 @@ public interface DataFetchingEnvironment {
      * For the root query, it is equal to {{@link DataFetchingEnvironment#getRoot}
      *
      * @param <T> you decide what type it is
-     *
      * @return can be null for the root query, otherwise it is never null
      */
     <T> T getSource();
@@ -45,7 +45,6 @@ public interface DataFetchingEnvironment {
      * Returns true of the named argument is present
      *
      * @param name the name of the argument
-     *
      * @return true of the named argument is present
      */
     boolean containsArgument(String name);
@@ -55,19 +54,17 @@ public interface DataFetchingEnvironment {
      *
      * @param name the name of the argument
      * @param <T>  you decide what type it is
-     *
      * @return the named argument or null if its not [present
      */
     <T> T getArgument(String name);
 
     /**
-     * Returns a context argument that is set up when the {@link graphql.GraphQL#execute} method
+     * Returns a context argument that is set up when the {@link graphql.GraphQL#execute(graphql.ExecutionInput)} )} method
      * is invoked.
      * <p>
      * This is a info object which is provided to all DataFetchers, but never used by graphql-java itself.
      *
      * @param <T> you decide what type it is
-     *
      * @return can be null
      */
     <T> T getContext();
@@ -83,7 +80,6 @@ public interface DataFetchingEnvironment {
      * If the field is a top level field then 'localContext' equals the global 'context'
      *
      * @param <T> you decide what type it is
-     *
      * @return can be null if no field context objects are passed back by previous parent fields
      */
     <T> T getLocalContext();
@@ -92,7 +88,6 @@ public interface DataFetchingEnvironment {
      * This is the source object for the root query.
      *
      * @param <T> you decide what type it is
-     *
      * @return can be null
      */
     <T> T getRoot();
@@ -105,7 +100,6 @@ public interface DataFetchingEnvironment {
 
     /**
      * @return the list of fields
-     *
      * @deprecated Use {@link #getMergedField()}.
      */
     @Deprecated
@@ -116,9 +110,9 @@ public interface DataFetchingEnvironment {
      * are querying the same data. If this is the case they get merged
      * together and fetched only once, but this method returns all of the Fields
      * from the query.
-     *
+     * <p>
      * Most of the time you probably want to use {@link #getField()}.
-     *
+     * <p>
      * Example query with more than one Field returned:
      *
      * <pre>
@@ -184,7 +178,6 @@ public interface DataFetchingEnvironment {
      * This gives you access to the directives related to this field
      *
      * @return the {@link graphql.execution.directives.QueryDirectives} for the currently executing field
-     *
      * @see graphql.execution.directives.QueryDirectives for more information
      */
     QueryDirectives getQueryDirectives();
@@ -195,13 +188,15 @@ public interface DataFetchingEnvironment {
      * @param dataLoaderName the name of the data loader to fetch
      * @param <K>            the key type
      * @param <V>            the value type
-     *
      * @return the named data loader or null
-     *
-     * @see graphql.execution.ExecutionContext#getDataLoaderRegistry()
      * @see org.dataloader.DataLoaderRegistry#getDataLoader(String)
      */
     <K, V> DataLoader<K, V> getDataLoader(String dataLoaderName);
+
+    /**
+     * @return the {@link org.dataloader.DataLoaderRegistry} in play
+     */
+    DataLoaderRegistry getDataLoaderRegistry();
 
     /**
      * @return the current {@link CacheControl} instance used to add cache hints to the response

--- a/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
@@ -167,6 +167,11 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
     }
 
     @Override
+    public DataLoaderRegistry getDataLoaderRegistry() {
+        return dataLoaderRegistry;
+    }
+
+    @Override
     public CacheControl getCacheControl() {
         return cacheControl;
     }


### PR DESCRIPTION
This upgrades to the latest version of java-dataloader which has lazy data loader support.

#1650 shows a problem when the data loaders in action are not present at the time the instrumentation gets started.

We now use a magic variable to know if NO data loader registry has been set by the consumer.

This allows us to retain the optimisation whereby we do no work when no data loaders are in effect