### PR TITLE
Improve/fix schema transformation

### DIFF
--- a/src/main/java/graphql/schema/SchemaTransformer.java
+++ b/src/main/java/graphql/schema/SchemaTransformer.java
@@ -2,18 +2,31 @@ package graphql.schema;
 
 import graphql.PublicApi;
 import graphql.introspection.Introspection;
+import graphql.util.Breadcrumb;
+import graphql.util.FpKit;
+import graphql.util.NodeAdapter;
+import graphql.util.NodeLocation;
+import graphql.util.NodeZipper;
 import graphql.util.TraversalControl;
+import graphql.util.Traverser;
 import graphql.util.TraverserContext;
 import graphql.util.TraverserVisitor;
-import graphql.util.TreeTransformer;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
+import static graphql.Assert.assertNotEmpty;
 import static graphql.Assert.assertShouldNeverHappen;
 import static graphql.schema.GraphQLSchemaElementAdapter.SCHEMA_ELEMENT_ADAPTER;
 import static graphql.schema.SchemaElementChildrenContainer.newSchemaElementChildrenContainer;
+import static graphql.util.NodeZipper.ModificationType.REPLACE;
 
 /**
  * Transforms a {@link GraphQLSchema} object.
@@ -85,6 +98,7 @@ public class SchemaTransformer {
         }
     }
 
+
     /**
      * Transforms a GrapQLSchema and returns a new GraphQLSchema object.
      *
@@ -98,17 +112,38 @@ public class SchemaTransformer {
         return schemaTransformer.transform(schema, visitor);
     }
 
+
     public GraphQLSchema transform(final GraphQLSchema schema, GraphQLTypeVisitor visitor) {
 
 
         DummyRoot dummyRoot = new DummyRoot(schema);
-        TraverserVisitor<GraphQLSchemaElement> traverserVisitor = new TraverserVisitor<GraphQLSchemaElement>() {
+
+        List<NodeZipper<GraphQLSchemaElement>> zippers = new LinkedList<>();
+        Map<GraphQLSchemaElement, NodeZipper<GraphQLSchemaElement>> zipperByOriginalNode = new LinkedHashMap<>();
+
+        Map<NodeZipper<GraphQLSchemaElement>, List<List<Breadcrumb<GraphQLSchemaElement>>>> breadcrumbsByZipper = new LinkedHashMap<>();
+
+        TraverserVisitor<GraphQLSchemaElement> nodeTraverserVisitor = new TraverserVisitor<GraphQLSchemaElement>() {
             @Override
             public TraversalControl enter(TraverserContext<GraphQLSchemaElement> context) {
                 if (context.thisNode() == dummyRoot) {
                     return TraversalControl.CONTINUE;
                 }
-                return context.thisNode().accept(context, visitor);
+                NodeZipper<GraphQLSchemaElement> nodeZipper = new NodeZipper<>(context.thisNode(), context.getBreadcrumbs(), SCHEMA_ELEMENT_ADAPTER);
+                context.setVar(NodeZipper.class, nodeZipper);
+                context.setVar(NodeAdapter.class, SCHEMA_ELEMENT_ADAPTER);
+                zipperByOriginalNode.put(context.thisNode(), nodeZipper);
+
+                int zippersBefore = zippers.size();
+                TraversalControl result = context.thisNode().accept(context, visitor);
+                // detection if the node was changed: TODO make it better: doesn't work for parallel
+                if (zippersBefore + 1 == zippers.size()) {
+                    nodeZipper = zippers.get(zippers.size() - 1);
+                }
+                breadcrumbsByZipper.put(nodeZipper, new ArrayList<>());
+                breadcrumbsByZipper.get(nodeZipper).add(context.getBreadcrumbs());
+                return result;
+
             }
 
             @Override
@@ -118,14 +153,17 @@ public class SchemaTransformer {
 
             @Override
             public TraversalControl backRef(TraverserContext<GraphQLSchemaElement> context) {
+                NodeZipper<GraphQLSchemaElement> zipper = zipperByOriginalNode.get(context.thisNode());
+                breadcrumbsByZipper.get(zipper).add(context.getBreadcrumbs());
                 return TraversalControl.CONTINUE;
             }
-
         };
 
-        TreeTransformer<GraphQLSchemaElement> treeTransformer = new TreeTransformer<>(SCHEMA_ELEMENT_ADAPTER);
+        Traverser<GraphQLSchemaElement> traverser = Traverser.depthFirstWithNamedChildren(SCHEMA_ELEMENT_ADAPTER::getNamedChildren, zippers, null);
+        traverser.traverse(dummyRoot, nodeTraverserVisitor);
 
-        treeTransformer.transform(dummyRoot, traverserVisitor);
+        toRootNode(zippers, breadcrumbsByZipper, zipperByOriginalNode);
+
         GraphQLSchema newSchema = GraphQLSchema.newSchema()
                 .query(dummyRoot.query)
                 .mutation(dummyRoot.mutation)
@@ -134,6 +172,192 @@ public class SchemaTransformer {
                 .additionalDirectives(dummyRoot.directives)
                 .buildImpl(true);
         return newSchema;
+    }
+
+    private void toRootNode(List<NodeZipper<GraphQLSchemaElement>> zippers,
+                            Map<NodeZipper<GraphQLSchemaElement>, List<List<Breadcrumb<GraphQLSchemaElement>>>> breadcrumbsByZipper,
+                            Map<GraphQLSchemaElement, NodeZipper<GraphQLSchemaElement>> zipperByOriginalNode) {
+        if (zippers.size() == 0) {
+            return;
+        }
+
+
+        // we want to preserve the order here
+        Set<NodeZipper<GraphQLSchemaElement>> curZippers = new LinkedHashSet<>(zippers);
+        Map<NodeZipper<GraphQLSchemaElement>, List<List<Breadcrumb<GraphQLSchemaElement>>>> curBreadcrumbsByZipper = new LinkedHashMap<>(breadcrumbsByZipper);
+
+        while (curZippers.size() > 1 || !(curZippers.iterator().next().getCurNode() instanceof DummyRoot)) {
+            List<NodeZipper<GraphQLSchemaElement>> deepestZippers = new ArrayList<>();
+            int depth = getDeepestZippers(curZippers, curBreadcrumbsByZipper, deepestZippers);
+            Map<NodeZipper<GraphQLSchemaElement>, List<List<Breadcrumb<GraphQLSchemaElement>>>> breadcrumbsUsed = getBreadcrumbsUsed(curZippers, curBreadcrumbsByZipper, depth);
+
+            Map<GraphQLSchemaElement, List<NodeZipper<GraphQLSchemaElement>>> sameParentByParent = zipperWithSameParent(deepestZippers, breadcrumbsUsed);
+
+            List<NodeZipper<GraphQLSchemaElement>> newZippers = new ArrayList<>();
+            Map<GraphQLSchemaElement, NodeZipper<GraphQLSchemaElement>> zipperByNode = FpKit.groupingByUniqueKey(curZippers, NodeZipper::getCurNode);
+
+            for (Map.Entry<GraphQLSchemaElement, List<NodeZipper<GraphQLSchemaElement>>> entry : sameParentByParent.entrySet()) {
+                GraphQLSchemaElement parentNode = entry.getKey();
+                NodeZipper<GraphQLSchemaElement> newZipper = moveUp(parentNode, entry.getValue(), breadcrumbsUsed);
+                NodeZipper<GraphQLSchemaElement> originalZipperForParent = zipperByOriginalNode.get(parentNode);
+                List<List<Breadcrumb<GraphQLSchemaElement>>> breadcrumbsForOriginalParent = curBreadcrumbsByZipper.get(originalZipperForParent);
+                curBreadcrumbsByZipper.remove(originalZipperForParent);
+                curBreadcrumbsByZipper.put(newZipper, breadcrumbsForOriginalParent);
+
+//                //special case where we have an additional zipper on the parent
+//                Optional<NodeZipper<GraphQLSchemaElement>> zipperToBeReplaced = Optional.ofNullable(zipperByNode.get(parentNode));
+//                zipperToBeReplaced.ifPresent(curZippers::remove);
+                newZippers.add(newZipper);
+            }
+            for (Map.Entry<NodeZipper<GraphQLSchemaElement>, List<List<Breadcrumb<GraphQLSchemaElement>>>> entry : breadcrumbsUsed.entrySet()) {
+                List<List<Breadcrumb<GraphQLSchemaElement>>> all = curBreadcrumbsByZipper.get(entry.getKey());
+                all.removeAll(entry.getValue());
+                // if we used all breadcrumbs we are done with this zipper
+                if (all.size() == 0) {
+                    curZippers.remove(entry.getKey());
+                }
+            }
+            curZippers.addAll(newZippers);
+        }
+    }
+
+    private Map<NodeZipper<GraphQLSchemaElement>, List<List<Breadcrumb<GraphQLSchemaElement>>>> getBreadcrumbsUsed(
+            Set<NodeZipper<GraphQLSchemaElement>> zippers,
+            Map<NodeZipper<GraphQLSchemaElement>, List<List<Breadcrumb<GraphQLSchemaElement>>>> breadcrumbsByZipper,
+            int depth) {
+        Map<NodeZipper<GraphQLSchemaElement>, List<List<Breadcrumb<GraphQLSchemaElement>>>> result = new LinkedHashMap<>();
+        for (NodeZipper<GraphQLSchemaElement> zipper : zippers) {
+            List<List<Breadcrumb<GraphQLSchemaElement>>> breadcrumbsList = breadcrumbsByZipper.get(zipper);
+            for (List<Breadcrumb<GraphQLSchemaElement>> breadcrumbs : breadcrumbsList) {
+                if (breadcrumbs.size() == depth) {
+                    result.computeIfAbsent(zipper, ignored -> new ArrayList<>());
+                    result.get(zipper).add(breadcrumbs);
+                }
+            }
+        }
+        return result;
+    }
+
+    private int getDeepestZippers(
+            Set<NodeZipper<GraphQLSchemaElement>> zippers,
+            Map<NodeZipper<GraphQLSchemaElement>, List<List<Breadcrumb<GraphQLSchemaElement>>>> breadcrumbsByZipper,
+            List<NodeZipper<GraphQLSchemaElement>> result
+    ) {
+        Map<Integer, List<NodeZipper<GraphQLSchemaElement>>> grouped = FpKit.groupingBy(zippers, astZipper -> {
+            List<List<Breadcrumb<GraphQLSchemaElement>>> breadcrumbsList = breadcrumbsByZipper.get(astZipper);
+            List<Integer> sizes = FpKit.map(breadcrumbsList, List::size);
+            return Collections.max(sizes);
+        });
+
+        Integer maxLevel = Collections.max(grouped.keySet());
+        result.addAll(grouped.get(maxLevel));
+        return maxLevel;
+    }
+
+    private static class ZipperWithOneParent {
+        public ZipperWithOneParent(NodeZipper<GraphQLSchemaElement> zipper, Breadcrumb<GraphQLSchemaElement> parent) {
+            this.zipper = zipper;
+            this.parent = parent;
+        }
+
+        public NodeZipper<GraphQLSchemaElement> zipper;
+        public Breadcrumb<GraphQLSchemaElement> parent;
+    }
+
+    private NodeZipper<GraphQLSchemaElement> moveUp(
+            GraphQLSchemaElement parent,
+            List<NodeZipper<GraphQLSchemaElement>> sameParent,
+            Map<NodeZipper<GraphQLSchemaElement>, List<List<Breadcrumb<GraphQLSchemaElement>>>> breadcrumbsUsed) {
+        assertNotEmpty(sameParent, "expected at least one zipper");
+
+        Map<String, List<GraphQLSchemaElement>> childrenMap = new HashMap<>(SCHEMA_ELEMENT_ADAPTER.getNamedChildren(parent));
+        Map<String, Integer> indexCorrection = new HashMap<>();
+
+        List<ZipperWithOneParent> zipperWithOneParents = new ArrayList<>();
+        for (NodeZipper<GraphQLSchemaElement> zipper : sameParent) {
+            for (List<Breadcrumb<GraphQLSchemaElement>> breadcrumbs : breadcrumbsUsed.get(zipper)) {
+                // only consider breadcrumbs pointing the right parent
+                if (breadcrumbs.get(0).getNode() != parent) {
+                    continue;
+                }
+                zipperWithOneParents.add(new ZipperWithOneParent(zipper, breadcrumbs.get(0)));
+            }
+        }
+
+        zipperWithOneParents.sort((zipperWithOneParent1, zipperWithOneParent2) -> {
+            NodeZipper<GraphQLSchemaElement> zipper1 = zipperWithOneParent1.zipper;
+            NodeZipper<GraphQLSchemaElement> zipper2 = zipperWithOneParent2.zipper;
+            Breadcrumb<GraphQLSchemaElement> breadcrumb1 = zipperWithOneParent1.parent;
+            Breadcrumb<GraphQLSchemaElement> breadcrumb2 = zipperWithOneParent2.parent;
+            int index1 = breadcrumb1.getLocation().getIndex();
+            int index2 = breadcrumb2.getLocation().getIndex();
+            if (index1 != index2) {
+                return Integer.compare(index1, index2);
+            }
+            NodeZipper.ModificationType modificationType1 = zipper1.getModificationType();
+            NodeZipper.ModificationType modificationType2 = zipper2.getModificationType();
+
+            // same index can never be deleted and changed at the same time
+
+            if (modificationType1 == modificationType2) {
+                return 0;
+            }
+
+            // always first replacing the node
+            if (modificationType1 == REPLACE) {
+                return -1;
+            }
+            // and then INSERT_BEFORE before INSERT_AFTER
+            return modificationType1 == NodeZipper.ModificationType.INSERT_BEFORE ? -1 : 1;
+
+        });
+
+        for (ZipperWithOneParent zipperWithOneParent : zipperWithOneParents) {
+            NodeZipper<GraphQLSchemaElement> zipper = zipperWithOneParent.zipper;
+            Breadcrumb<GraphQLSchemaElement> breadcrumb = zipperWithOneParent.parent;
+            NodeLocation location = breadcrumb.getLocation();
+            Integer ixDiff = indexCorrection.getOrDefault(location.getName(), 0);
+            int ix = location.getIndex() + ixDiff;
+            String name = location.getName();
+            List<GraphQLSchemaElement> childList = new ArrayList<>(childrenMap.get(name));
+            switch (zipper.getModificationType()) {
+                case REPLACE:
+                    childList.set(ix, zipper.getCurNode());
+                    break;
+                case DELETE:
+                    childList.remove(ix);
+                    indexCorrection.put(name, ixDiff - 1);
+                    break;
+                case INSERT_BEFORE:
+                    childList.add(ix, zipper.getCurNode());
+                    indexCorrection.put(name, ixDiff + 1);
+                    break;
+                case INSERT_AFTER:
+                    childList.add(ix + 1, zipper.getCurNode());
+                    indexCorrection.put(name, ixDiff + 1);
+                    break;
+            }
+            childrenMap.put(name, childList);
+        }
+
+        GraphQLSchemaElement newNode = SCHEMA_ELEMENT_ADAPTER.withNewChildren(parent, childrenMap);
+        List<Breadcrumb<GraphQLSchemaElement>> newBreadcrumbs = sameParent.get(0).getBreadcrumbs().subList(1, sameParent.get(0).getBreadcrumbs().size());
+        return new NodeZipper<>(newNode, newBreadcrumbs, SCHEMA_ELEMENT_ADAPTER);
+    }
+
+    private Map<GraphQLSchemaElement, List<NodeZipper<GraphQLSchemaElement>>> zipperWithSameParent
+            (List<NodeZipper<GraphQLSchemaElement>> zippers,
+             Map<NodeZipper<GraphQLSchemaElement>, List<List<Breadcrumb<GraphQLSchemaElement>>>> breadcrumbsByZipper) {
+        Map<GraphQLSchemaElement, List<NodeZipper<GraphQLSchemaElement>>> result = new LinkedHashMap<>();
+
+        for (NodeZipper<GraphQLSchemaElement> zipper : zippers) {
+            for (List<Breadcrumb<GraphQLSchemaElement>> breadcrumbs : breadcrumbsByZipper.get(zipper)) {
+                GraphQLSchemaElement parent = breadcrumbs.get(0).getNode();
+                result.computeIfAbsent(parent, ignored -> new ArrayList<>());
+                result.get(parent).add(zipper);
+            }
+        }
+        return result;
     }
 
 

--- a/src/main/java/graphql/schema/SchemaTransformer.java
+++ b/src/main/java/graphql/schema/SchemaTransformer.java
@@ -115,6 +115,12 @@ public class SchemaTransformer {
             public TraversalControl leave(TraverserContext<GraphQLSchemaElement> context) {
                 return TraversalControl.CONTINUE;
             }
+
+            @Override
+            public TraversalControl backRef(TraverserContext<GraphQLSchemaElement> context) {
+                return TraversalControl.CONTINUE;
+            }
+
         };
 
         TreeTransformer<GraphQLSchemaElement> treeTransformer = new TreeTransformer<>(SCHEMA_ELEMENT_ADAPTER);

--- a/src/main/java/graphql/schema/SchemaTransformer.java
+++ b/src/main/java/graphql/schema/SchemaTransformer.java
@@ -197,11 +197,11 @@ public class SchemaTransformer {
             int depth = getDeepestZippers(curZippers, curBreadcrumbsByZipper, deepestZippers);
             Map<NodeZipper<GraphQLSchemaElement>, List<List<Breadcrumb<GraphQLSchemaElement>>>> breadcrumbsUsed = getBreadcrumbsUsed(curZippers, curBreadcrumbsByZipper, depth);
 
-            Map<GraphQLSchemaElement, List<NodeZipper<GraphQLSchemaElement>>> sameParentByParent = zipperWithSameParent(deepestZippers, breadcrumbsUsed);
+            Map<GraphQLSchemaElement, List<NodeZipper<GraphQLSchemaElement>>> zippersByParent = groupBySameParent(deepestZippers, breadcrumbsUsed);
 
             List<NodeZipper<GraphQLSchemaElement>> newZippers = new ArrayList<>();
 
-            for (Map.Entry<GraphQLSchemaElement, List<NodeZipper<GraphQLSchemaElement>>> entry : sameParentByParent.entrySet()) {
+            for (Map.Entry<GraphQLSchemaElement, List<NodeZipper<GraphQLSchemaElement>>> entry : zippersByParent.entrySet()) {
                 // this is the parenNode we want to replace
                 GraphQLSchemaElement parentNode = entry.getKey();
                 NodeZipper<GraphQLSchemaElement> newZipper = moveUp(parentNode, entry.getValue(), breadcrumbsUsed);
@@ -354,7 +354,7 @@ public class SchemaTransformer {
         return new NodeZipper<>(newNode, newBreadcrumbs, SCHEMA_ELEMENT_ADAPTER);
     }
 
-    private Map<GraphQLSchemaElement, List<NodeZipper<GraphQLSchemaElement>>> zipperWithSameParent
+    private Map<GraphQLSchemaElement, List<NodeZipper<GraphQLSchemaElement>>> groupBySameParent
             (List<NodeZipper<GraphQLSchemaElement>> zippers,
              Map<NodeZipper<GraphQLSchemaElement>, List<List<Breadcrumb<GraphQLSchemaElement>>>> breadcrumbsByZipper) {
         Map<GraphQLSchemaElement, List<NodeZipper<GraphQLSchemaElement>>> result = new LinkedHashMap<>();

--- a/src/main/java/graphql/util/TraverserVisitor.java
+++ b/src/main/java/graphql/util/TraverserVisitor.java
@@ -20,6 +20,12 @@ public interface TraverserVisitor<T> {
     TraversalControl leave(TraverserContext<T> context);
 
     /**
+     * This method is called when a node was already visited before.
+     *
+     * This can happen for two reasons:
+     * 1. There is a cycle.
+     * 2. A node has more than one parent. This means the structure is not a tree but a graph.
+     *
      * @param context the context in place
      *
      * @return Only Continue or Quit allowed

--- a/src/main/java/graphql/util/TreeTransformer.java
+++ b/src/main/java/graphql/util/TreeTransformer.java
@@ -46,6 +46,11 @@ public class TreeTransformer<T> {
             public TraversalControl leave(TraverserContext<T> context) {
                 return traverserVisitor.leave(context);
             }
+
+            @Override
+            public TraversalControl backRef(TraverserContext<T> context) {
+                return traverserVisitor.backRef(context);
+            }
         };
 
         List<NodeZipper<T>> zippers = new LinkedList<>();

--- a/src/test/groovy/graphql/schema/SchemaTransformerTest.groovy
+++ b/src/test/groovy/graphql/schema/SchemaTransformerTest.groovy
@@ -89,16 +89,18 @@ class SchemaTransformerTest extends Specification {
         given:
         GraphQLSchema schema = TestUtil.schema("""
         type Query {
-            parent: Parent 
+            parent: Parent
         }
         type Parent {
            child1: Child
            child2: Child
-       } 
+           otherParent: Parent
+       }
         type Child {
             hello: String
         }
         """)
+
         schema.getQueryType();
         SchemaTransformer schemaTransformer = new SchemaTransformer()
         when:
@@ -115,11 +117,13 @@ class SchemaTransformerTest extends Specification {
 
             @Override
             TraversalControl visitGraphQLObjectType(GraphQLObjectType node, TraverserContext<GraphQLSchemaElement> context) {
-                if (node.name == "Child") {
-                    println "CHILD VISIT: " + context
-                }
+//                if (node.name == "Parent") {
+//                    def changedNode = node.transform({ builder -> builder.name("ParentChanged") })
+//                    return changeNode(context, changedNode)
+//                }
                 return super.visitGraphQLObjectType(node, context)
             }
+
         })
 
         then:

--- a/src/test/groovy/graphql/schema/SchemaTransformerTest.groovy
+++ b/src/test/groovy/graphql/schema/SchemaTransformerTest.groovy
@@ -106,8 +106,6 @@ class SchemaTransformerTest extends Specification {
             hello: String
         }
         """)
-
-        schema.getQueryType();
         SchemaTransformer schemaTransformer = new SchemaTransformer()
         when:
         GraphQLSchema newSchema = schemaTransformer.transform(schema, new GraphQLTypeVisitorStub() {


### PR DESCRIPTION
A GraphQLSchema can be a DAG, but not a tree, which means one node can have multiple parents.

This PR aims to improve the SchemaTransformation  