### PR TITLE
If a message has a String.format() specifier in it and no formats are provided - BOOM

### DIFF
--- a/src/main/java/graphql/GraphqlErrorBuilder.java
+++ b/src/main/java/graphql/GraphqlErrorBuilder.java
@@ -50,7 +50,11 @@ public class GraphqlErrorBuilder {
     }
 
     public GraphqlErrorBuilder message(String message, Object... formatArgs) {
-        this.message = String.format(assertNotNull(message), formatArgs);
+        if (formatArgs == null || formatArgs.length == 0) {
+            this.message = assertNotNull(message);
+        } else {
+            this.message = String.format(assertNotNull(message), formatArgs);
+        }
         return this;
     }
 

--- a/src/test/groovy/graphql/GraphqlErrorBuilderTest.groovy
+++ b/src/test/groovy/graphql/GraphqlErrorBuilderTest.groovy
@@ -76,4 +76,38 @@ class GraphqlErrorBuilderTest extends Specification {
         graphQLError.getPath() == ["field"]
         graphQLError.getLocations() == [new SourceLocation(1, 3)]
     }
+
+    def "java string format is safe"() {
+        when:
+        def gqlErr = GraphqlErrorBuilder.newError().message("This has %s in it").build()
+        then:
+        gqlErr.getMessage() == "This has %s in it"
+
+        when:
+        gqlErr = GraphqlErrorBuilder.newError().message("This has %s in it", null).build()
+        then:
+        gqlErr.getMessage() == "This has %s in it"
+
+        when:
+        gqlErr = GraphqlErrorBuilder.newError().message("This has %s in it", new Object[0]).build()
+        then:
+        gqlErr.getMessage() == "This has %s in it"
+
+        when:
+        gqlErr = GraphqlErrorBuilder.newError().message("This has %s in it", "data").build()
+        then:
+        gqlErr.getMessage() == "This has data in it"
+    }
+
+    def "null message is not acceptable"() {
+        when:
+        GraphqlErrorBuilder.newError().message(null, "a", "b").build()
+        then:
+        thrown(AssertException)
+
+        when:
+        GraphqlErrorBuilder.newError().message(null).build()
+        then:
+        thrown(AssertException)
+    }
 }


### PR DESCRIPTION
We found a bug where GraphErrorBuilder.newError().message("A %s style string").build() would blow up wanting format args