### PR TITLE
get or default support in DFE

### DIFF
--- a/src/main/java/graphql/schema/DataFetchingEnvironment.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironment.java
@@ -56,9 +56,20 @@ public interface DataFetchingEnvironment {
      * @param name the name of the argument
      * @param <T>  you decide what type it is
      *
-     * @return the named argument or null if its not [present
+     * @return the named argument or null if its not present
      */
     <T> T getArgument(String name);
+
+    /**
+     * Returns the named argument or the default value
+     *
+     * @param name the name of the argument
+     * @param defaultValue  the default value if the argument is not present
+     * @param <T>  you decide what type it is
+     *
+     * @return the named argument or the default if its not present
+     */
+    <T> T getArgumentOrDefault(String name, T defaultValue);
 
     /**
      * Returns a context argument that is set up when the {@link graphql.GraphQL#execute} method

--- a/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
@@ -87,6 +87,11 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
     }
 
     @Override
+    public <T> T getArgumentOrDefault(String name, T defaultValue) {
+        return (T) arguments.getOrDefault(name, defaultValue);
+    }
+
+    @Override
     public <T> T getContext() {
         return (T) context;
     }

--- a/src/test/groovy/graphql/schema/DataFetchingEnvironmentImplTest.groovy
+++ b/src/test/groovy/graphql/schema/DataFetchingEnvironmentImplTest.groovy
@@ -118,4 +118,15 @@ class DataFetchingEnvironmentImplTest extends Specification {
         dfe.getCacheControl() == cacheControl
     }
 
+    def "get or default support"() {
+        when:
+        def dfe = newDataFetchingEnvironment(executionContext)
+                .arguments([x: "y"])
+                .build()
+        then:
+        dfe.getArgument("z") == null
+        dfe.getArgumentOrDefault("z", "default") == "default"
+        dfe.getArgument("x") == "y"
+        dfe.getArgumentOrDefault("x", "default") == "y"
+    }
 }


### PR DESCRIPTION
One of the most annoying things about DataFetchers is defaulting arguments

This adds this

```
  String argVal =  dfEnv.getOrDefault("someArg", "someDefault");
```