### PR TITLE
Disallow complex input values to be coerced to String (#1665)

### DIFF
--- a/src/main/java/graphql/Scalars.java
+++ b/src/main/java/graphql/Scalars.java
@@ -184,7 +184,13 @@ public class Scalars {
 
         @Override
         public String parseValue(Object input) {
-            return serialize(input);
+            if (input instanceof Boolean || isNumberIsh(input)) {
+                return input.toString();
+            }
+
+            throw new CoercingParseValueException(
+                    "Expected type 'String' but was '" + typeName(input) + "'."
+            );
         }
 
         @Override

--- a/src/test/groovy/graphql/ScalarsStringTest.groovy
+++ b/src/test/groovy/graphql/ScalarsStringTest.groovy
@@ -50,10 +50,35 @@ class ScalarsStringTest extends Specification {
 
         where:
         value        | result
+        true         | "true"
+        false        | "false"
         "123ab"      | "123ab"
         123          | "123"
+    }
+
+    @Unroll
+    def "String serialize complex #value into #result (#result.class)"() {
+        expect:
+        Scalars.GraphQLString.getCoercing().serialize(value) == result
+
+        where:
+        value        | result
         customObject | "foo"
     }
 
+    @Unroll
+    def "String parseValue throws exception for complex input #value"() {
+        when:
+        Scalars.GraphQLString.getCoercing().parseValue(value)
+        then:
+        thrown(CoercingParseValueException)
+
+        where:
+        value        | _
+        customObject | _
+        new Object() | _
+        [:]          | _
+        []           | _
+    }
 
 }


### PR DESCRIPTION
Number, String and Boolean are still allowed to be coerced to String
in input because those types have well-defined string representations.

However, passing values of complex types to String fields in input
values will result in CoercingParseValueException.

This behaviour is in line with current parsing logic for Boolean
and numeric types.

Note: serializing complex values (Map, Lists, custom classes) on
output is still allowed since the query implementation controls
the toString() representation in that case.