### PR TITLE
Enhanced execution input (and hence data loader registry) is now captured before use

### DIFF
--- a/src/main/java/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentation.java
@@ -95,8 +95,14 @@ public class DataLoaderDispatcherInstrumentation extends SimpleInstrumentation {
 
     @Override
     public InstrumentationContext<ExecutionResult> beginExecuteOperation(InstrumentationExecuteOperationParameters parameters) {
+        DataLoaderDispatcherInstrumentationState state = parameters.getInstrumentationState();
+        //
+        // during #instrumentExecutionInput they could have enhanced the data loader registry
+        // so we grab it now just before the query operation gets started
+        //
+        DataLoaderRegistry finalRegistry = parameters.getExecutionContext().getDataLoaderRegistry();
+        state.setDataLoaderRegistry(finalRegistry);
         if (!isDataLoaderCompatibleExecution(parameters.getExecutionContext())) {
-            DataLoaderDispatcherInstrumentationState state = parameters.getInstrumentationState();
             state.setAggressivelyBatching(false);
         }
         return new SimpleInstrumentationContext<>();

--- a/src/main/java/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentationState.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentationState.java
@@ -25,12 +25,22 @@ public class DataLoaderDispatcherInstrumentationState implements Instrumentation
     private final FieldLevelTrackingApproach approach;
     private final AtomicReference<DataLoaderRegistry> dataLoaderRegistry;
     private final InstrumentationState state;
-    private boolean aggressivelyBatching = true;
+    private volatile boolean aggressivelyBatching = true;
+    private volatile boolean hasNoDataLoaders;
 
     public DataLoaderDispatcherInstrumentationState(Logger log, DataLoaderRegistry dataLoaderRegistry) {
         this.dataLoaderRegistry = new AtomicReference<>(dataLoaderRegistry);
         this.approach = new FieldLevelTrackingApproach(log, this::getDataLoaderRegistry);
         this.state = approach.createState();
+        hasNoDataLoaders = checkForNoDataLoader(dataLoaderRegistry);
+    }
+
+    private boolean checkForNoDataLoader(DataLoaderRegistry dataLoaderRegistry) {
+        //
+        // if they have never set a dataloader into the execution input then we can optimize
+        // away the tracking code
+        //
+        return dataLoaderRegistry == EMPTY_DATALOADER_REGISTRY;
     }
 
     boolean isAggressivelyBatching() {
@@ -51,10 +61,11 @@ public class DataLoaderDispatcherInstrumentationState implements Instrumentation
 
     void setDataLoaderRegistry(DataLoaderRegistry newRegistry) {
         dataLoaderRegistry.set(newRegistry);
+        hasNoDataLoaders = checkForNoDataLoader(dataLoaderRegistry.get());
     }
 
     boolean hasNoDataLoaders() {
-        return getDataLoaderRegistry().getKeys().isEmpty();
+        return hasNoDataLoaders;
     }
 
     InstrumentationState getState() {

--- a/src/main/java/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentationState.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentationState.java
@@ -61,7 +61,7 @@ public class DataLoaderDispatcherInstrumentationState implements Instrumentation
 
     void setDataLoaderRegistry(DataLoaderRegistry newRegistry) {
         dataLoaderRegistry.set(newRegistry);
-        hasNoDataLoaders = checkForNoDataLoader(dataLoaderRegistry.get());
+        hasNoDataLoaders = checkForNoDataLoader(newRegistry);
     }
 
     boolean hasNoDataLoaders() {

--- a/src/main/java/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentationState.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentationState.java
@@ -4,24 +4,23 @@ import graphql.execution.instrumentation.InstrumentationState;
 import org.dataloader.DataLoaderRegistry;
 import org.slf4j.Logger;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 /**
  * A base class that keeps track of whether aggressive batching can be used
  */
 public class DataLoaderDispatcherInstrumentationState implements InstrumentationState {
 
     private final FieldLevelTrackingApproach approach;
-    private final DataLoaderRegistry dataLoaderRegistry;
+    private final AtomicReference<DataLoaderRegistry> dataLoaderRegistry;
     private final InstrumentationState state;
-    private final boolean hasNoDataLoaders;
     private boolean aggressivelyBatching = true;
 
     public DataLoaderDispatcherInstrumentationState(Logger log, DataLoaderRegistry dataLoaderRegistry) {
 
-        this.dataLoaderRegistry = dataLoaderRegistry;
-        this.approach = new FieldLevelTrackingApproach(log, dataLoaderRegistry);
+        this.dataLoaderRegistry = new AtomicReference<>(dataLoaderRegistry);
+        this.approach = new FieldLevelTrackingApproach(log, this::getDataLoaderRegistry);
         this.state = approach.createState();
-        hasNoDataLoaders = dataLoaderRegistry.getKeys().isEmpty();
-
     }
 
     boolean isAggressivelyBatching() {
@@ -37,11 +36,15 @@ public class DataLoaderDispatcherInstrumentationState implements Instrumentation
     }
 
     DataLoaderRegistry getDataLoaderRegistry() {
-        return dataLoaderRegistry;
+        return dataLoaderRegistry.get();
+    }
+
+    void setDataLoaderRegistry(DataLoaderRegistry newRegistry) {
+        dataLoaderRegistry.set(newRegistry);
     }
 
     boolean hasNoDataLoaders() {
-        return hasNoDataLoaders;
+        return getDataLoaderRegistry().getKeys().isEmpty();
     }
 
     InstrumentationState getState() {

--- a/src/main/java/graphql/execution/instrumentation/dataloader/FieldLevelTrackingApproach.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/FieldLevelTrackingApproach.java
@@ -24,13 +24,14 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 
 /**
  * This approach uses field level tracking to achieve its aims of making the data loader more efficient
  */
 @Internal
 public class FieldLevelTrackingApproach {
-    private final DataLoaderRegistry dataLoaderRegistry;
+    private final Supplier<DataLoaderRegistry> dataLoaderRegistrySupplier;
     private final Logger log;
 
     private static class CallStack implements InstrumentationState {
@@ -118,8 +119,8 @@ public class FieldLevelTrackingApproach {
         }
     }
 
-    public FieldLevelTrackingApproach(Logger log, DataLoaderRegistry dataLoaderRegistry) {
-        this.dataLoaderRegistry = dataLoaderRegistry;
+    public FieldLevelTrackingApproach(Logger log, Supplier<DataLoaderRegistry> dataLoaderRegistrySupplier) {
+        this.dataLoaderRegistrySupplier = dataLoaderRegistrySupplier;
         this.log = log;
     }
 
@@ -286,7 +287,12 @@ public class FieldLevelTrackingApproach {
     }
 
     void dispatch() {
+        DataLoaderRegistry dataLoaderRegistry = getDataLoaderRegistry();
         log.debug("Dispatching data loaders ({})", dataLoaderRegistry.getKeys());
         dataLoaderRegistry.dispatchAll();
+    }
+
+    private DataLoaderRegistry getDataLoaderRegistry() {
+        return dataLoaderRegistrySupplier.get();
     }
 }

--- a/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentationTest.groovy
@@ -1,5 +1,6 @@
 package graphql.execution.instrumentation.dataloader
 
+import graphql.ExecutionInput
 import graphql.ExecutionResult
 import graphql.GraphQL
 import graphql.execution.AsyncExecutionStrategy
@@ -11,6 +12,7 @@ import graphql.execution.batched.BatchedExecutionStrategy
 import graphql.execution.instrumentation.ChainedInstrumentation
 import graphql.execution.instrumentation.Instrumentation
 import graphql.execution.instrumentation.SimpleInstrumentation
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters
 import org.dataloader.BatchLoader
 import org.dataloader.DataLoader
 import org.dataloader.DataLoaderRegistry
@@ -35,6 +37,30 @@ class DataLoaderDispatcherInstrumentationTest extends Specification {
             return super.execute(executionContext, parameters)
         }
     }
+
+
+    def query = """
+        query {
+            hero {
+                name 
+                friends {
+                    name
+                    friends {
+                       name
+                    } 
+                }
+            }
+        }
+        """
+
+    def expectedQueryData = [hero: [name: 'R2-D2', friends: [
+            [name: 'Luke Skywalker', friends: [
+                    [name: 'Han Solo'], [name: 'Leia Organa'], [name: 'C-3PO'], [name: 'R2-D2']]],
+            [name: 'Han Solo', friends: [
+                    [name: 'Luke Skywalker'], [name: 'Leia Organa'], [name: 'R2-D2']]],
+            [name: 'Leia Organa', friends: [
+                    [name: 'Luke Skywalker'], [name: 'Han Solo'], [name: 'C-3PO'], [name: 'R2-D2']]]]]
+    ]
 
 
     def "dataloader instrumentation is always added and an empty data loader registry is in place"() {
@@ -95,19 +121,38 @@ class DataLoaderDispatcherInstrumentationTest extends Specification {
         dispatchedCalled
     }
 
-    def query = """
-        query {
-            hero {
-                name 
-                friends {
-                    name
-                    friends {
-                       name
-                    } 
-                }
+    def "enhanced execution input is respected"() {
+
+        def starWarsWiring = new StarWarsDataLoaderWiring()
+
+
+        DataLoaderRegistry startingDataLoaderRegistry = new DataLoaderRegistry();
+        def enhancedDataLoaderRegistry = starWarsWiring.newDataLoaderRegistry()
+
+        def dlInstrumentation = new DataLoaderDispatcherInstrumentation()
+        def enhancingInstrumentation = new SimpleInstrumentation() {
+            @Override
+            ExecutionInput instrumentExecutionInput(ExecutionInput executionInput, InstrumentationExecutionParameters parameters) {
+                assert executionInput.getDataLoaderRegistry() == startingDataLoaderRegistry
+                return executionInput.transform({ builder -> builder.dataLoaderRegistry(enhancedDataLoaderRegistry) })
             }
         }
-        """
+
+        def chainedInstrumentation = new ChainedInstrumentation([dlInstrumentation, enhancingInstrumentation])
+
+        def graphql = GraphQL.newGraphQL(starWarsWiring.schema)
+                .instrumentation(chainedInstrumentation).build()
+
+        def executionInput = newExecutionInput()
+                .dataLoaderRegistry(startingDataLoaderRegistry)
+                .query(query).build()
+
+        when:
+        def er = graphql.executeAsync(executionInput).join()
+        then:
+        er.data == expectedQueryData
+    }
+
 
     @Unroll
     def "ensure DataLoaderDispatcherInstrumentation works for #executionStrategyName"() {
@@ -129,14 +174,7 @@ class DataLoaderDispatcherInstrumentationTest extends Specification {
         def er = asyncResult.join()
 
         then:
-        er.data == [hero: [name: 'R2-D2', friends: [
-                [name: 'Luke Skywalker', friends: [
-                        [name: 'Han Solo'], [name: 'Leia Organa'], [name: 'C-3PO'], [name: 'R2-D2']]],
-                [name: 'Han Solo', friends: [
-                        [name: 'Luke Skywalker'], [name: 'Leia Organa'], [name: 'R2-D2']]],
-                [name: 'Leia Organa', friends: [
-                        [name: 'Luke Skywalker'], [name: 'Han Solo'], [name: 'C-3PO'], [name: 'R2-D2']]]]]
-        ]
+        er.data == expectedQueryData
 
         where:
         executionStrategyName              | executionStrategy                                               || _


### PR DESCRIPTION
See #1667 

If a Instrumentation enhances the `ExecutionInput` and hence the `DataLoaderRegistry` instance, we can now use the right instance during dispatching