### PR TITLE
Allow type inference for the context

### DIFF
--- a/src/main/java/graphql/execution/ExecutionContext.java
+++ b/src/main/java/graphql/execution/ExecutionContext.java
@@ -98,8 +98,9 @@ public class ExecutionContext {
         return variables;
     }
 
-    public Object getContext() {
-        return context;
+    @SuppressWarnings("unchecked")
+    public <T> T getContext() {
+        return (T) context;
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Allow type inference for the context, similar `DataFetchingEnvironment#getContext`