### PR TITLE
Schema extension support

### DIFF
--- a/src/main/antlr/Graphql.g4
+++ b/src/main/antlr/Graphql.g4
@@ -11,7 +11,8 @@ document : definition+;
 definition:
 operationDefinition |
 fragmentDefinition |
-typeSystemDefinition
+typeSystemDefinition |
+typeSystemExtension
 ;
 
 

--- a/src/main/antlr/GraphqlSDL.g4
+++ b/src/main/antlr/GraphqlSDL.g4
@@ -4,11 +4,20 @@ import GraphqlCommon;
 typeSystemDefinition: description?
 schemaDefinition |
 typeDefinition |
-typeExtension |
 directiveDefinition
 ;
 
+typeSystemExtension :
+schemaExtension |
+typeExtension
+;
+
 schemaDefinition : description? SCHEMA directives? '{' operationTypeDefinition+ '}';
+
+schemaExtension :
+    EXTEND SCHEMA directives? '{' operationTypeDefinition+ '}' |
+    EXTEND SCHEMA directives+
+;
 
 operationTypeDefinition : description? operationType ':' typeName;
 

--- a/src/main/java/graphql/language/SchemaExtensionDefinition.java
+++ b/src/main/java/graphql/language/SchemaExtensionDefinition.java
@@ -1,10 +1,6 @@
 package graphql.language;
 
-
-import graphql.Internal;
 import graphql.PublicApi;
-import graphql.util.TraversalControl;
-import graphql.util.TraverserContext;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -13,108 +9,43 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
-import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
-import static graphql.language.NodeUtil.directivesByName;
 
 @PublicApi
-public class SchemaDefinition extends AbstractNode<SchemaDefinition> implements SDLDefinition<SchemaDefinition> {
+public class SchemaExtensionDefinition extends SchemaDefinition {
 
-    private final List<Directive> directives;
-    private final List<OperationTypeDefinition> operationTypeDefinitions;
-
-    public static final String CHILD_DIRECTIVES = "directives";
-    public static final String CHILD_OPERATION_TYPE_DEFINITIONS = "operationTypeDefinitions";
-
-    @Internal
-    protected SchemaDefinition(List<Directive> directives,
-                               List<OperationTypeDefinition> operationTypeDefinitions,
-                               SourceLocation sourceLocation,
-                               List<Comment> comments,
-                               IgnoredChars ignoredChars,
-                               Map<String, String> additionalData) {
-        super(sourceLocation, comments, ignoredChars, additionalData);
-        this.directives = directives;
-        this.operationTypeDefinitions = operationTypeDefinitions;
-    }
-
-    public List<Directive> getDirectives() {
-        return new ArrayList<>(directives);
-    }
-
-    public Map<String, Directive> getDirectivesByName() {
-        return directivesByName(directives);
-    }
-
-    public Directive getDirective(String directiveName) {
-        return getDirectivesByName().get(directiveName);
-    }
-
-
-    public List<OperationTypeDefinition> getOperationTypeDefinitions() {
-        return new ArrayList<>(operationTypeDefinitions);
+    protected SchemaExtensionDefinition(List<Directive> directives, List<OperationTypeDefinition> operationTypeDefinitions, SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars, Map<String, String> additionalData) {
+        super(directives, operationTypeDefinitions, sourceLocation, comments, ignoredChars, additionalData);
     }
 
     @Override
-    public List<Node> getChildren() {
-        List<Node> result = new ArrayList<>();
-        result.addAll(directives);
-        result.addAll(operationTypeDefinitions);
-        return result;
-    }
-
-    @Override
-    public NodeChildrenContainer getNamedChildren() {
-        return newNodeChildrenContainer()
-                .children(CHILD_DIRECTIVES, directives)
-                .children(CHILD_OPERATION_TYPE_DEFINITIONS, operationTypeDefinitions)
-                .build();
-    }
-
-    @Override
-    public SchemaDefinition withNewChildren(NodeChildrenContainer newChildren) {
-        return transform(builder -> builder
+    public SchemaExtensionDefinition withNewChildren(NodeChildrenContainer newChildren) {
+        return transformExtension(builder -> builder
                 .directives(newChildren.getChildren(CHILD_DIRECTIVES))
                 .operationTypeDefinitions(newChildren.getChildren(CHILD_OPERATION_TYPE_DEFINITIONS))
         );
     }
 
     @Override
-    public boolean isEqualTo(Node o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        return true;
-    }
-
-    @Override
-    public SchemaDefinition deepCopy() {
-        return new SchemaDefinition(deepCopy(directives), deepCopy(operationTypeDefinitions), getSourceLocation(), getComments(),
+    public SchemaExtensionDefinition deepCopy() {
+        return new SchemaExtensionDefinition(deepCopy(getDirectives()), deepCopy(getOperationTypeDefinitions()), getSourceLocation(), getComments(),
                 getIgnoredChars(), getAdditionalData());
     }
 
     @Override
     public String toString() {
-        return "SchemaDefinition{" +
-                "directives=" + directives +
-                ", operationTypeDefinitions=" + operationTypeDefinitions +
+        return "SchemaExtensionDefinition{" +
+                "directives=" + getDirectives() +
+                ", operationTypeDefinitions=" + getOperationTypeDefinitions() +
                 "}";
     }
 
-    @Override
-    public TraversalControl accept(TraverserContext<Node> context, NodeVisitor visitor) {
-        return visitor.visitSchemaDefinition(this, context);
-    }
-
-    public SchemaDefinition transform(Consumer<Builder> builderConsumer) {
+    public SchemaExtensionDefinition transformExtension(Consumer<Builder> builderConsumer) {
         Builder builder = new Builder(this);
         builderConsumer.accept(builder);
         return builder.build();
     }
 
-    public static Builder newSchemaDefinition() {
+    public static Builder newSchemaExtensionDefinition() {
         return new Builder();
     }
 
@@ -184,8 +115,8 @@ public class SchemaDefinition extends AbstractNode<SchemaDefinition> implements 
             return this;
         }
 
-        public SchemaDefinition build() {
-            return new SchemaDefinition(directives,
+        public SchemaExtensionDefinition build() {
+            return new SchemaExtensionDefinition(directives,
                     operationTypeDefinitions,
                     sourceLocation,
                     comments,
@@ -193,4 +124,5 @@ public class SchemaDefinition extends AbstractNode<SchemaDefinition> implements 
                     additionalData);
         }
     }
+
 }

--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -393,8 +393,11 @@ public class GraphqlAntlrToLanguage {
         for (GraphqlParser.DirectivesContext directiveCtx : directivesCtx) {
             directives.addAll(createDirectives(directiveCtx));
         }
-        def.operationTypeDefinitions(ctx.operationTypeDefinition().stream()
-                .map(this::createOperationTypeDefinition).collect(toList()));
+        def.directives(directives);
+
+        List<OperationTypeDefinition> operationTypeDefs = ctx.operationTypeDefinition().stream()
+                .map(this::createOperationTypeDefinition).collect(toList());
+        def.operationTypeDefinitions(operationTypeDefs);
         return def.build();
     }
 

--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -44,6 +44,7 @@ import graphql.language.SDLDefinition;
 import graphql.language.ScalarTypeDefinition;
 import graphql.language.ScalarTypeExtensionDefinition;
 import graphql.language.SchemaDefinition;
+import graphql.language.SchemaExtensionDefinition;
 import graphql.language.Selection;
 import graphql.language.SelectionSet;
 import graphql.language.SourceLocation;
@@ -106,6 +107,8 @@ public class GraphqlAntlrToLanguage {
             return createFragmentDefinition(definitionContext.fragmentDefinition());
         } else if (definitionContext.typeSystemDefinition() != null) {
             return createTypeSystemDefinition(definitionContext.typeSystemDefinition());
+        } else if (definitionContext.typeSystemExtension() != null) {
+            return createTypeSystemExtension(definitionContext.typeSystemExtension());
         } else {
             return assertShouldNeverHappen();
         }
@@ -239,8 +242,16 @@ public class GraphqlAntlrToLanguage {
             return createDirectiveDefinition(ctx.directiveDefinition());
         } else if (ctx.typeDefinition() != null) {
             return createTypeDefinition(ctx.typeDefinition());
-        } else if (ctx.typeExtension() != null) {
+        } else {
+            return assertShouldNeverHappen();
+        }
+    }
+
+    protected SDLDefinition createTypeSystemExtension(GraphqlParser.TypeSystemExtensionContext ctx) {
+        if (ctx.typeExtension() != null) {
             return createTypeExtension(ctx.typeExtension());
+        } else if (ctx.schemaExtension() != null) {
+            return creationSchemaExtension(ctx.schemaExtension());
         } else {
             return assertShouldNeverHappen();
         }
@@ -372,6 +383,21 @@ public class GraphqlAntlrToLanguage {
                 .map(this::createOperationTypeDefinition).collect(toList()));
         return def.build();
     }
+
+    private SDLDefinition creationSchemaExtension(GraphqlParser.SchemaExtensionContext ctx) {
+        SchemaExtensionDefinition.Builder def = SchemaExtensionDefinition.newSchemaExtensionDefinition();
+        addCommonData(def, ctx);
+
+        List<Directive> directives = new ArrayList<>();
+        List<GraphqlParser.DirectivesContext> directivesCtx = ctx.directives();
+        for (GraphqlParser.DirectivesContext directiveCtx : directivesCtx) {
+            directives.addAll(createDirectives(directiveCtx));
+        }
+        def.operationTypeDefinitions(ctx.operationTypeDefinition().stream()
+                .map(this::createOperationTypeDefinition).collect(toList()));
+        return def.build();
+    }
+
 
     protected OperationTypeDefinition createOperationTypeDefinition(GraphqlParser.OperationTypeDefinitionContext ctx) {
         OperationTypeDefinition.Builder def = OperationTypeDefinition.newOperationTypeDefinition();

--- a/src/main/java/graphql/schema/DelegatingDataFetchingEnvironment.java
+++ b/src/main/java/graphql/schema/DelegatingDataFetchingEnvironment.java
@@ -137,11 +137,6 @@ public class DelegatingDataFetchingEnvironment implements DataFetchingEnvironmen
         return delegateEnvironment.getCacheControl();
     }
 
-    @Override
-    public Locale getLocale() {
-        return delegateEnvironment.getLocale();
-    }
-
     public OperationDefinition getOperationDefinition() {
         return delegateEnvironment.getOperationDefinition();
     }

--- a/src/main/java/graphql/schema/DelegatingDataFetchingEnvironment.java
+++ b/src/main/java/graphql/schema/DelegatingDataFetchingEnvironment.java
@@ -14,6 +14,7 @@ import org.dataloader.DataLoader;
 import org.dataloader.DataLoaderRegistry;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 
@@ -32,7 +33,6 @@ public class DelegatingDataFetchingEnvironment implements DataFetchingEnvironmen
      * Called to wrap an existing {@link graphql.schema.DataFetchingEnvironment}.
      *
      * @param delegateEnvironment the environment to wrap and delegate all method called to
-     * @return a wrapped environment
      */
     public DelegatingDataFetchingEnvironment(DataFetchingEnvironment delegateEnvironment) {
         this.delegateEnvironment = delegateEnvironment;
@@ -126,6 +126,11 @@ public class DelegatingDataFetchingEnvironment implements DataFetchingEnvironmen
     @Override
     public DataLoaderRegistry getDataLoaderRegistry() {
         return delegateEnvironment.getDataLoaderRegistry();
+    }
+
+    @Override
+    public Locale getLocale() {
+        return delegateEnvironment.getLocale();
     }
 
     public CacheControl getCacheControl() {

--- a/src/main/java/graphql/schema/GraphQLSchema.java
+++ b/src/main/java/graphql/schema/GraphQLSchema.java
@@ -12,6 +12,7 @@ import graphql.schema.visibility.GraphqlFieldVisibility;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -29,7 +30,7 @@ import static java.util.Arrays.asList;
 /**
  * The schema represents the combined type system of the graphql engine.  This is how the engine knows
  * what graphql queries represent what data.
- *
+ * <p>
  * See http://graphql.org/learn/schema/#type-language for more details
  */
 @PublicApi
@@ -41,6 +42,7 @@ public class GraphQLSchema {
     private final GraphQLObjectType subscriptionType;
     private final Set<GraphQLType> additionalTypes = new LinkedHashSet<>();
     private final Set<GraphQLDirective> directives = new LinkedHashSet<>();
+    private final Map<String, GraphQLDirective> schemaDirectives = new LinkedHashMap<>();
     private final GraphQLCodeRegistry codeRegistry;
 
     private final Map<String, GraphQLNamedType> typeMap;
@@ -48,7 +50,6 @@ public class GraphQLSchema {
 
     /**
      * @param queryType the query type
-     *
      * @deprecated use the {@link #newSchema()} builder pattern instead, as this constructor will be made private in a future version.
      */
     @Internal
@@ -61,7 +62,6 @@ public class GraphQLSchema {
      * @param queryType       the query type
      * @param mutationType    the mutation type
      * @param additionalTypes additional types
-     *
      * @deprecated use the {@link #newSchema()} builder pattern instead, as this constructor will be made private in a future version.
      */
     @Internal
@@ -75,13 +75,12 @@ public class GraphQLSchema {
      * @param mutationType     the mutation type
      * @param subscriptionType the subscription type
      * @param additionalTypes  additional types
-     *
      * @deprecated use the {@link #newSchema()} builder pattern instead, as this constructor will be made private in a future version.
      */
     @Internal
     @Deprecated
     public GraphQLSchema(GraphQLObjectType queryType, GraphQLObjectType mutationType, GraphQLObjectType subscriptionType, Set<GraphQLType> additionalTypes) {
-        this(queryType, mutationType, subscriptionType, additionalTypes, Collections.emptySet(), GraphQLCodeRegistry.newCodeRegistry().build(), false);
+        this(queryType, mutationType, subscriptionType, additionalTypes, Collections.emptySet(), Collections.emptyMap(), GraphQLCodeRegistry.newCodeRegistry().build(), false);
     }
 
     @Internal
@@ -90,6 +89,7 @@ public class GraphQLSchema {
                           GraphQLObjectType subscriptionType,
                           Set<GraphQLType> additionalTypes,
                           Set<GraphQLDirective> directives,
+                          Map<String, GraphQLDirective> schemaDirectives,
                           GraphQLCodeRegistry codeRegistry,
                           boolean afterTransform) {
         assertNotNull(additionalTypes, "additionalTypes can't be null");
@@ -103,6 +103,7 @@ public class GraphQLSchema {
         this.subscriptionType = subscriptionType;
         this.additionalTypes.addAll(additionalTypes);
         this.directives.addAll(directives);
+        this.schemaDirectives.putAll(schemaDirectives);
         // sorted by type name
         SchemaUtil schemaUtil = new SchemaUtil();
         this.typeMap = new TreeMap<>(schemaUtil.allTypes(this, additionalTypes, afterTransform));
@@ -141,9 +142,7 @@ public class GraphQLSchema {
      * Called to return a named {@link graphql.schema.GraphQLObjectType} from the schema
      *
      * @param typeName the name of the type
-     *
      * @return a graphql object type or null if there is one
-     *
      * @throws graphql.GraphQLException if the type is NOT a object type
      */
     public GraphQLObjectType getObjectType(String typeName) {
@@ -168,7 +167,6 @@ public class GraphQLSchema {
      * interface type.
      *
      * @param type interface type to obtain implementations of.
-     *
      * @return list of types implementing provided interface
      */
     public List<GraphQLObjectType> getImplementations(GraphQLInterfaceType type) {
@@ -186,7 +184,6 @@ public class GraphQLSchema {
      *
      * @param abstractType abstract type either interface or union
      * @param concreteType concrete type
-     *
      * @return true if possible type, false otherwise.
      */
     public boolean isPossibleType(GraphQLNamedType abstractType, GraphQLObjectType concreteType) {
@@ -217,7 +214,6 @@ public class GraphQLSchema {
 
     /**
      * @return the field visibility
-     *
      * @deprecated use {@link GraphQLCodeRegistry#getFieldVisibility()} instead
      */
     @Deprecated
@@ -238,6 +234,30 @@ public class GraphQLSchema {
         return null;
     }
 
+    /**
+     * This returns the list of directives that have been explicitly put on the
+     * schema object.  Note that {@link {@link #getDirectives()}} will return
+     * directives for all schema elements, whereas this is just for the schema
+     * element itself
+     *
+     * @return a list of directives
+     */
+    public List<GraphQLDirective> getSchemaDirectives() {
+        return new ArrayList<>(schemaDirectives.values());
+    }
+
+    /**
+     * This returns the named directive that have been explicitly put on the
+     * schema object.  Note that {@link {@link #getDirective(String)} ()}} will return
+     * directives for all schema elements, whereas this is just for the schema
+     * element itself
+     *
+     * @return a named directive
+     */
+    public GraphQLDirective getSchemaDirective(String name) {
+        return schemaDirectives.get(name);
+    }
+
     public boolean isSupportingMutations() {
         return mutationType != null;
     }
@@ -251,7 +271,6 @@ public class GraphQLSchema {
      * the current values and allows you to transform it how you want.
      *
      * @param builderConsumer the consumer code that will be given a builder to transform
-     *
      * @return a new GraphQLSchema object based on calling build on that builder
      */
     public GraphQLSchema transform(Consumer<Builder> builderConsumer) {
@@ -272,7 +291,6 @@ public class GraphQLSchema {
      * schema and then allows you to replace them.
      *
      * @param existingSchema the existing schema
-     *
      * @return a new schema builder
      */
     public static Builder newSchema(GraphQLSchema existingSchema) {
@@ -284,7 +302,14 @@ public class GraphQLSchema {
                 .clearAdditionalTypes()
                 .clearDirectives()
                 .additionalDirectives(existingSchema.directives)
+                .clearSchemaDirectives()
+                .withSchemaDirectives(schemaDirectivesArray(existingSchema))
                 .additionalTypes(existingSchema.additionalTypes);
+    }
+
+    private static GraphQLDirective[] schemaDirectivesArray(GraphQLSchema existingSchema) {
+        return existingSchema.schemaDirectives.values()
+                .toArray(new GraphQLDirective[0]);
     }
 
     public static class Builder {
@@ -297,6 +322,7 @@ public class GraphQLSchema {
         private Set<GraphQLDirective> additionalDirectives = new LinkedHashSet<>(
                 asList(Directives.IncludeDirective, Directives.SkipDirective)
         );
+        private Map<String, GraphQLDirective> schemaDirectives = new LinkedHashMap<>();
 
         private SchemaUtil schemaUtil = new SchemaUtil();
 
@@ -329,9 +355,7 @@ public class GraphQLSchema {
 
         /**
          * @param fieldVisibility the field visibility
-         *
          * @return this builder
-         *
          * @deprecated use {@link graphql.schema.GraphQLCodeRegistry.Builder#fieldVisibility(graphql.schema.visibility.GraphqlFieldVisibility)} instead
          */
         @Deprecated
@@ -375,13 +399,39 @@ public class GraphQLSchema {
             return this;
         }
 
+
+        public Builder withSchemaDirectives(GraphQLDirective... directives) {
+            for (GraphQLDirective directive : directives) {
+                withSchemaDirective(directive);
+            }
+            return this;
+        }
+
+        public Builder withSchemaDirective(GraphQLDirective directive) {
+            assertNotNull(directive, "directive can't be null");
+            schemaDirectives.put(directive.getName(), directive);
+            return this;
+        }
+
+        public Builder withSchemaDirective(GraphQLDirective.Builder builder) {
+            return withSchemaDirective(builder.build());
+        }
+
+        /**
+         * This is used to clear all the directives in the builder so far.
+         *
+         * @return the builder
+         */
+        public Builder clearSchemaDirectives() {
+            schemaDirectives.clear();
+            return this;
+        }
+
         /**
          * Builds the schema
          *
          * @param additionalTypes - please dont use this any more
-         *
          * @return the built schema
-         *
          * @deprecated - Use the {@link #additionalType(GraphQLType)} methods
          */
         @Deprecated
@@ -394,9 +444,7 @@ public class GraphQLSchema {
          *
          * @param additionalTypes      - please don't use this any more
          * @param additionalDirectives - please don't use this any more
-         *
          * @return the built schema
-         *
          * @deprecated - Use the {@link #additionalType(GraphQLType)} and {@link #additionalDirective(GraphQLDirective)} methods
          */
         @Deprecated
@@ -418,7 +466,7 @@ public class GraphQLSchema {
             assertNotNull(additionalDirectives, "additionalDirectives can't be null");
 
             // grab the legacy code things from types
-            final GraphQLSchema tempSchema = new GraphQLSchema(queryType, mutationType, subscriptionType, additionalTypes, additionalDirectives, codeRegistry, afterTransform);
+            final GraphQLSchema tempSchema = new GraphQLSchema(queryType, mutationType, subscriptionType, additionalTypes, additionalDirectives, schemaDirectives, codeRegistry, afterTransform);
             codeRegistry = codeRegistry.transform(codeRegistryBuilder -> schemaUtil.extractCodeFromTypes(codeRegistryBuilder, tempSchema));
 
             GraphQLSchema graphQLSchema = new GraphQLSchema(tempSchema, codeRegistry);

--- a/src/main/java/graphql/schema/GraphQLSchema.java
+++ b/src/main/java/graphql/schema/GraphQLSchema.java
@@ -25,6 +25,7 @@ import java.util.function.Consumer;
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertShouldNeverHappen;
 import static graphql.Assert.assertTrue;
+import static graphql.DirectivesUtil.directivesByName;
 import static graphql.schema.GraphqlTypeComparators.byNameAsc;
 import static graphql.schema.GraphqlTypeComparators.sortTypes;
 import static java.util.Arrays.asList;
@@ -225,8 +226,24 @@ public class GraphQLSchema {
         return codeRegistry.getFieldVisibility();
     }
 
+    /**
+     * This returns the list of directives that are associated with this schema object including
+     * built in ones.
+     *
+     * @return a list of directives
+     */
     public List<GraphQLDirective> getDirectives() {
         return new ArrayList<>(directives);
+    }
+
+    /**
+     * This returns a map of directives that are associated with this schema object including
+     * built in ones.
+     *
+     * @return a map of directives
+     */
+    public Map<String, GraphQLDirective> getDirectiveByName() {
+        return directivesByName(getDirectives());
     }
 
     public GraphQLDirective getDirective(String name) {
@@ -248,6 +265,18 @@ public class GraphQLSchema {
      */
     public List<GraphQLDirective> getSchemaDirectives() {
         return new ArrayList<>(schemaDirectives.values());
+    }
+
+    /**
+     * This returns a map of directives that have been explicitly put on the
+     * schema object.  Note that {@link {@link #getDirectives()}} will return
+     * directives for all schema elements, whereas this is just for the schema
+     * element itself
+     *
+     * @return a list of directives
+     */
+    public Map<String, GraphQLDirective> getSchemaDirectiveByName() {
+        return directivesByName(getSchemaDirectives());
     }
 
     /**

--- a/src/main/java/graphql/schema/idl/SchemaExtensionsChecker.java
+++ b/src/main/java/graphql/schema/idl/SchemaExtensionsChecker.java
@@ -1,0 +1,128 @@
+package graphql.schema.idl;
+
+import graphql.Assert;
+import graphql.GraphQLError;
+import graphql.language.Directive;
+import graphql.language.ObjectTypeDefinition;
+import graphql.language.OperationTypeDefinition;
+import graphql.language.SchemaDefinition;
+import graphql.language.SchemaExtensionDefinition;
+import graphql.language.Type;
+import graphql.language.TypeDefinition;
+import graphql.language.TypeName;
+import graphql.schema.idl.errors.MissingTypeError;
+import graphql.schema.idl.errors.OperationRedefinitionError;
+import graphql.schema.idl.errors.OperationTypesMustBeObjects;
+import graphql.schema.idl.errors.QueryOperationMissingError;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+public class SchemaExtensionsChecker {
+
+    static Map<String, OperationTypeDefinition> gatherOperationDefs(TypeDefinitionRegistry typeRegistry) {
+        List<GraphQLError> noErrors = new ArrayList<>();
+        Map<String, OperationTypeDefinition> operationTypeDefinitionMap = gatherOperationDefs(noErrors, typeRegistry.schemaDefinition().orElse(null), typeRegistry.getSchemaExtensionDefinitions());
+        Assert.assertTrue(noErrors.isEmpty(), "If you call this method it MUST have previously been error checked");
+        return operationTypeDefinitionMap;
+    }
+
+    static Map<String, OperationTypeDefinition> gatherOperationDefs(List<GraphQLError> errors, SchemaDefinition schema, List<SchemaExtensionDefinition> schemaExtensionDefinitions) {
+        Map<String, OperationTypeDefinition> operationDefs = new LinkedHashMap<>();
+        if (schema != null) {
+            defineOperationDefs(errors, schema.getOperationTypeDefinitions(), operationDefs);
+        }
+        for (SchemaExtensionDefinition schemaExtensionDefinition : schemaExtensionDefinitions) {
+            defineOperationDefs(errors, schemaExtensionDefinition.getOperationTypeDefinitions(), operationDefs);
+        }
+        return operationDefs;
+    }
+
+    static void defineOperationDefs(List<GraphQLError> errors, Collection<OperationTypeDefinition> newOperationDefs, Map<String, OperationTypeDefinition> existingOperationDefs) {
+        for (OperationTypeDefinition operationTypeDefinition : newOperationDefs) {
+            OperationTypeDefinition oldEntry = existingOperationDefs.get(operationTypeDefinition.getName());
+            if (oldEntry != null) {
+                errors.add(new OperationRedefinitionError(oldEntry, operationTypeDefinition));
+            } else {
+                existingOperationDefs.put(operationTypeDefinition.getName(), operationTypeDefinition);
+            }
+        }
+    }
+
+    static List<OperationTypeDefinition> checkSchemaInvariants(List<GraphQLError> errors, TypeDefinitionRegistry typeRegistry) {
+        /*
+            https://github.com/facebook/graphql/pull/90/files#diff-fe406b08746616e2f5f00909488cce66R1000
+
+            GraphQL type system definitions can omit the schema definition when the query
+            and mutation root types are named `Query` and `Mutation`, respectively.
+         */
+        // schema
+        SchemaDefinition schemaDef = typeRegistry.schemaDefinition().orElse(null);
+        Map<String, OperationTypeDefinition> operationTypeMap = SchemaExtensionsChecker.gatherOperationDefs(errors, schemaDef, typeRegistry.getSchemaExtensionDefinitions());
+        List<OperationTypeDefinition> operationTypeDefinitions = new ArrayList<>(operationTypeMap.values());
+
+        operationTypeDefinitions
+                .forEach(checkOperationTypesExist(typeRegistry, errors));
+
+        operationTypeDefinitions
+                .forEach(checkOperationTypesAreObjects(typeRegistry, errors));
+
+        // ensure we have a "query" one
+        Optional<OperationTypeDefinition> query = operationTypeDefinitions.stream().filter(op -> "query".equals(op.getName())).findFirst();
+        if (!query.isPresent()) {
+            // its ok if they have a type named Query
+            Optional<TypeDefinition> queryType = typeRegistry.getType("Query");
+            if (!queryType.isPresent()) {
+                errors.add(new QueryOperationMissingError());
+            }
+        }
+        return operationTypeDefinitions;
+    }
+
+    static List<Directive> gatherSchemaDirectives(TypeDefinitionRegistry typeRegistry) {
+        List<GraphQLError> noErrors = new ArrayList<>();
+        List<Directive> directiveList = gatherSchemaDirectives(typeRegistry, noErrors);
+        Assert.assertTrue(noErrors.isEmpty(), "If you call this method it MUST have previously been error checked");
+        return directiveList;
+    }
+
+    static List<Directive> gatherSchemaDirectives(TypeDefinitionRegistry typeRegistry, List<GraphQLError> errors) {
+        List<Directive> directiveList = new ArrayList<>();
+        SchemaDefinition schemaDefinition = typeRegistry.schemaDefinition().orElse(null);
+        if (schemaDefinition != null) {
+            directiveList.addAll(schemaDefinition.getDirectives());
+        }
+        for (SchemaExtensionDefinition schemaExtensionDefinition : typeRegistry.getSchemaExtensionDefinitions()) {
+            directiveList.addAll(schemaExtensionDefinition.getDirectives());
+        }
+        return directiveList;
+    }
+
+    private static Consumer<OperationTypeDefinition> checkOperationTypesExist(TypeDefinitionRegistry typeRegistry, List<GraphQLError> errors) {
+        return op -> {
+            TypeName unwrapped = TypeInfo.typeInfo(op.getTypeName()).getTypeName();
+            if (!typeRegistry.hasType(unwrapped)) {
+                errors.add(new MissingTypeError("operation", op, op.getName(), unwrapped));
+            }
+        };
+    }
+
+    private static Consumer<OperationTypeDefinition> checkOperationTypesAreObjects(TypeDefinitionRegistry typeRegistry, List<GraphQLError> errors) {
+        return op -> {
+            // make sure it is defined as a ObjectTypeDef
+            Type queryType = op.getTypeName();
+            Optional<TypeDefinition> type = typeRegistry.getType(queryType);
+            type.ifPresent(typeDef -> {
+                if (!(typeDef instanceof ObjectTypeDefinition)) {
+                    errors.add(new OperationTypesMustBeObjects(op));
+                }
+            });
+        };
+    }
+
+}

--- a/src/main/java/graphql/schema/idl/SchemaExtensionsChecker.java
+++ b/src/main/java/graphql/schema/idl/SchemaExtensionsChecker.java
@@ -2,6 +2,7 @@ package graphql.schema.idl;
 
 import graphql.Assert;
 import graphql.GraphQLError;
+import graphql.Internal;
 import graphql.language.Directive;
 import graphql.language.ObjectTypeDefinition;
 import graphql.language.OperationTypeDefinition;
@@ -23,6 +24,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 
+@Internal
 public class SchemaExtensionsChecker {
 
     static Map<String, OperationTypeDefinition> gatherOperationDefs(TypeDefinitionRegistry typeRegistry) {

--- a/src/main/java/graphql/schema/idl/SchemaGenerator.java
+++ b/src/main/java/graphql/schema/idl/SchemaGenerator.java
@@ -18,7 +18,6 @@ import graphql.language.ObjectTypeExtensionDefinition;
 import graphql.language.OperationTypeDefinition;
 import graphql.language.ScalarTypeDefinition;
 import graphql.language.ScalarTypeExtensionDefinition;
-import graphql.language.SchemaDefinition;
 import graphql.language.Type;
 import graphql.language.TypeDefinition;
 import graphql.language.TypeName;
@@ -60,7 +59,6 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Deque;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -122,7 +120,6 @@ public class SchemaGenerator {
          * directive definition syntax before use.
          *
          * @param flag the value to use
-         *
          * @return the new options
          */
         public Options enforceSchemaDirectives(boolean flag) {
@@ -146,11 +143,13 @@ public class SchemaGenerator {
         private final Map<String, Object> directiveBehaviourContext = new LinkedHashMap<>();
         private final Set<GraphQLDirective> directiveDefinitions = new LinkedHashSet<>();
         private final GraphQLCodeRegistry.Builder codeRegistry;
+        public final Map<String, OperationTypeDefinition> operationTypeDefs;
 
-        BuildContext(TypeDefinitionRegistry typeRegistry, RuntimeWiring wiring) {
+        BuildContext(TypeDefinitionRegistry typeRegistry, RuntimeWiring wiring, Map<String, OperationTypeDefinition> operationTypeDefinitions) {
             this.typeRegistry = typeRegistry;
             this.wiring = wiring;
             this.codeRegistry = GraphQLCodeRegistry.newCodeRegistry(wiring.getCodeRegistry());
+            this.operationTypeDefs = operationTypeDefinitions;
         }
 
         public TypeDefinitionRegistry getTypeRegistry() {
@@ -237,9 +236,7 @@ public class SchemaGenerator {
      *
      * @param typeRegistry this can be obtained via {@link SchemaParser#parse(String)}
      * @param wiring       this can be built using {@link RuntimeWiring#newRuntimeWiring()}
-     *
      * @return an executable schema
-     *
      * @throws SchemaProblem if there are problems in assembling a schema such as missing type resolvers or no operations defined
      */
     public GraphQLSchema makeExecutableSchema(TypeDefinitionRegistry typeRegistry, RuntimeWiring wiring) throws SchemaProblem {
@@ -253,9 +250,7 @@ public class SchemaGenerator {
      * @param options      the controlling options
      * @param typeRegistry this can be obtained via {@link SchemaParser#parse(String)}
      * @param wiring       this can be built using {@link RuntimeWiring#newRuntimeWiring()}
-     *
      * @return an executable schema
-     *
      * @throws SchemaProblem if there are problems in assembling a schema such as missing type resolvers or no operations defined
      */
     public GraphQLSchema makeExecutableSchema(Options options, TypeDefinitionRegistry typeRegistry, RuntimeWiring wiring) throws SchemaProblem {
@@ -269,15 +264,14 @@ public class SchemaGenerator {
         if (!errors.isEmpty()) {
             throw new SchemaProblem(errors);
         }
-        BuildContext buildCtx = new BuildContext(typeRegistryCopy, wiring);
+
+        Map<String, OperationTypeDefinition> operationTypeDefinitions = SchemaExtensionsChecker.gatherOperationDefs(typeRegistry);
+        BuildContext buildCtx = new BuildContext(typeRegistryCopy, wiring, operationTypeDefinitions);
 
         return makeExecutableSchemaImpl(buildCtx);
     }
 
     private GraphQLSchema makeExecutableSchemaImpl(BuildContext buildCtx) {
-        GraphQLObjectType query;
-        GraphQLObjectType mutation;
-        GraphQLObjectType subscription;
 
         GraphQLSchema.Builder schemaBuilder = GraphQLSchema.newSchema();
 
@@ -285,49 +279,12 @@ public class SchemaGenerator {
         schemaBuilder.additionalDirectives(additionalDirectives);
         buildCtx.setDirectiveDefinitions(additionalDirectives);
 
-        //
-        // Schema can be missing if the type is called 'Query'.  Pre flight checks have checked that!
-        //
-        TypeDefinitionRegistry typeRegistry = buildCtx.getTypeRegistry();
-        if (!typeRegistry.schemaDefinition().isPresent()) {
-            @SuppressWarnings({"OptionalGetWithoutIsPresent", "ConstantConditions"})
-            TypeDefinition queryTypeDef = typeRegistry.getType("Query").get();
+        List<Directive> schemaDirectiveList = SchemaExtensionsChecker.gatherSchemaDirectives(buildCtx.getTypeRegistry());
+        schemaBuilder.withSchemaDirectives(
+                buildDirectives(schemaDirectiveList, emptyList(), DirectiveLocation.SCHEMA, buildCtx.getDirectiveDefinitions(), buildCtx.getComparatorRegistry())
+        );
 
-            query = buildOutputType(buildCtx, TypeName.newTypeName().name(queryTypeDef.getName()).build());
-            schemaBuilder.query(query);
-
-            Optional<TypeDefinition> mutationTypeDef = typeRegistry.getType("Mutation");
-            if (mutationTypeDef.isPresent()) {
-                mutation = buildOutputType(buildCtx, TypeName.newTypeName().name((mutationTypeDef.get().getName())).build());
-                schemaBuilder.mutation(mutation);
-            }
-            Optional<TypeDefinition> subscriptionTypeDef = typeRegistry.getType("Subscription");
-            if (subscriptionTypeDef.isPresent()) {
-                subscription = buildOutputType(buildCtx, TypeName.newTypeName().name(subscriptionTypeDef.get().getName()).build());
-                schemaBuilder.subscription(subscription);
-            }
-        } else {
-            SchemaDefinition schemaDefinition = typeRegistry.schemaDefinition().get();
-            List<OperationTypeDefinition> operationTypes = schemaDefinition.getOperationTypeDefinitions();
-
-            // pre-flight checked via checker
-            @SuppressWarnings({"OptionalGetWithoutIsPresent", "ConstantConditions"})
-            OperationTypeDefinition queryOp = operationTypes.stream().filter(op -> "query".equals(op.getName())).findFirst().get();
-            Optional<OperationTypeDefinition> mutationOp = operationTypes.stream().filter(op -> "mutation".equals(op.getName())).findFirst();
-            Optional<OperationTypeDefinition> subscriptionOp = operationTypes.stream().filter(op -> "subscription".equals(op.getName())).findFirst();
-
-            query = buildOperation(buildCtx, queryOp);
-            schemaBuilder.query(query);
-
-            if (mutationOp.isPresent()) {
-                mutation = buildOperation(buildCtx, mutationOp.get());
-                schemaBuilder.mutation(mutation);
-            }
-            if (subscriptionOp.isPresent()) {
-                subscription = buildOperation(buildCtx, subscriptionOp.get());
-                schemaBuilder.subscription(subscription);
-            }
-        }
+        buildOperations(buildCtx, schemaBuilder);
 
         Set<GraphQLType> additionalTypes = buildAdditionalTypes(buildCtx);
         schemaBuilder.additionalTypes(additionalTypes);
@@ -346,6 +303,58 @@ public class SchemaGenerator {
         return graphQLSchema;
     }
 
+    private void buildOperations(BuildContext buildCtx, GraphQLSchema.Builder schemaBuilder) {
+        //
+        // Schema can be missing if the type is called 'Query'.  Pre flight checks have checked that!
+        //
+        TypeDefinitionRegistry typeRegistry = buildCtx.getTypeRegistry();
+        Map<String, OperationTypeDefinition> operationTypeDefs = buildCtx.operationTypeDefs;
+
+        GraphQLObjectType query;
+        GraphQLObjectType mutation;
+        GraphQLObjectType subscription;
+
+        Optional<OperationTypeDefinition> queryOperation = getOperationNamed("query", operationTypeDefs);
+        if (!queryOperation.isPresent()) {
+            @SuppressWarnings({"OptionalGetWithoutIsPresent", "ConstantConditions"})
+            TypeDefinition queryTypeDef = typeRegistry.getType("Query").get();
+
+            query = buildOutputType(buildCtx, TypeName.newTypeName().name(queryTypeDef.getName()).build());
+            schemaBuilder.query(query);
+        } else {
+            query = buildOperation(buildCtx, queryOperation.get());
+            schemaBuilder.query(query);
+        }
+
+        Optional<OperationTypeDefinition> mutationOperation = getOperationNamed("mutation", operationTypeDefs);
+        if (!mutationOperation.isPresent()) {
+            Optional<TypeDefinition> mutationTypeDef = typeRegistry.getType("Mutation");
+            if (mutationTypeDef.isPresent()) {
+                mutation = buildOutputType(buildCtx, TypeName.newTypeName().name(mutationTypeDef.get().getName()).build());
+                schemaBuilder.mutation(mutation);
+            }
+        } else {
+            mutation = buildOperation(buildCtx, mutationOperation.get());
+            schemaBuilder.mutation(mutation);
+        }
+
+        Optional<OperationTypeDefinition> subscriptionOperation = getOperationNamed("subscription", operationTypeDefs);
+        if (!subscriptionOperation.isPresent()) {
+            Optional<TypeDefinition> subscriptionTypeDef = typeRegistry.getType("Subscription");
+            if (subscriptionTypeDef.isPresent()) {
+                subscription = buildOutputType(buildCtx, TypeName.newTypeName().name(subscriptionTypeDef.get().getName()).build());
+                schemaBuilder.subscription(subscription);
+            }
+        } else {
+            subscription = buildOperation(buildCtx, subscriptionOperation.get());
+            schemaBuilder.subscription(subscription);
+        }
+    }
+
+    private Optional<OperationTypeDefinition> getOperationNamed(String name, Map<String, OperationTypeDefinition> operationTypeDefs) {
+        return Optional.ofNullable(operationTypeDefs.get(name));
+    }
+
     private GraphQLObjectType buildOperation(BuildContext buildCtx, OperationTypeDefinition operation) {
         Type type = operation.getTypeName();
 
@@ -357,7 +366,6 @@ public class SchemaGenerator {
      * but then we build the rest of the types specified and put them in as additional types
      *
      * @param buildCtx the context we need to work out what we are doing
-     *
      * @return the additional types not referenced from the top level operations
      */
     private Set<GraphQLType> buildAdditionalTypes(BuildContext buildCtx) {
@@ -394,7 +402,6 @@ public class SchemaGenerator {
      *
      * @param buildCtx the context we need to work out what we are doing
      * @param rawType  the type to be built
-     *
      * @return an output type
      */
     @SuppressWarnings({"unchecked", "TypeParameterUnusedInFormals"})
@@ -502,7 +509,8 @@ public class SchemaGenerator {
         return objectType;
     }
 
-    private void buildObjectTypeInterfaces(BuildContext buildCtx, ObjectTypeDefinition typeDefinition, GraphQLObjectType.Builder builder, List<ObjectTypeExtensionDefinition> extensions) {
+    private void buildObjectTypeInterfaces(BuildContext buildCtx, ObjectTypeDefinition
+            typeDefinition, GraphQLObjectType.Builder builder, List<ObjectTypeExtensionDefinition> extensions) {
         Map<String, GraphQLOutputType> interfaces = new LinkedHashMap<>();
         typeDefinition.getImplements().forEach(type -> {
             GraphQLNamedOutputType newInterfaceType = buildOutputType(buildCtx, type);
@@ -589,7 +597,7 @@ public class SchemaGenerator {
         );
 
         extensions.forEach(extension -> extension.getMemberTypes().forEach(mt -> {
-            GraphQLNamedOutputType outputType = buildOutputType(buildCtx, mt);
+                    GraphQLNamedOutputType outputType = buildOutputType(buildCtx, mt);
                     if (!builder.containType(outputType.getName())) {
                         if (outputType instanceof GraphQLTypeReference) {
                             builder.possibleType((GraphQLTypeReference) outputType);
@@ -642,7 +650,8 @@ public class SchemaGenerator {
         return enumType;
     }
 
-    private GraphQLEnumValueDefinition buildEnumValue(BuildContext buildCtx, EnumTypeDefinition typeDefinition, EnumValuesProvider enumValuesProvider, EnumValueDefinition evd) {
+    private GraphQLEnumValueDefinition buildEnumValue(BuildContext buildCtx, EnumTypeDefinition
+            typeDefinition, EnumValuesProvider enumValuesProvider, EnumValueDefinition evd) {
         String description = schemaGeneratorHelper.buildDescription(evd, evd.getDescription());
         String deprecation = schemaGeneratorHelper.buildDeprecationReason(evd.getDirectives());
 
@@ -697,7 +706,8 @@ public class SchemaGenerator {
         return scalar;
     }
 
-    private GraphQLFieldDefinition buildField(BuildContext buildCtx, TypeDefinition parentType, FieldDefinition fieldDef) {
+    private GraphQLFieldDefinition buildField(BuildContext buildCtx, TypeDefinition parentType, FieldDefinition
+            fieldDef) {
         GraphQLFieldDefinition.Builder builder = GraphQLFieldDefinition.newFieldDefinition();
         builder.definition(fieldDef);
         builder.name(fieldDef.getName());
@@ -706,7 +716,7 @@ public class SchemaGenerator {
         builder.comparatorRegistry(buildCtx.getComparatorRegistry());
 
         GraphQLDirective[] directives = buildDirectives(fieldDef.getDirectives(),
-                Collections.emptyList(), DirectiveLocation.FIELD_DEFINITION,
+                emptyList(), DirectiveLocation.FIELD_DEFINITION,
                 buildCtx.getDirectiveDefinitions(),
                 buildCtx.getComparatorRegistry());
         builder.withDirectives(
@@ -729,7 +739,8 @@ public class SchemaGenerator {
         return fieldDefinition;
     }
 
-    private DataFetcherFactory buildDataFetcherFactory(BuildContext buildCtx, TypeDefinition parentType, FieldDefinition fieldDef, GraphQLOutputType fieldType, List<GraphQLDirective> directives) {
+    private DataFetcherFactory buildDataFetcherFactory(BuildContext buildCtx, TypeDefinition
+            parentType, FieldDefinition fieldDef, GraphQLOutputType fieldType, List<GraphQLDirective> directives) {
         String fieldName = fieldDef.getName();
         String parentTypeName = parentType.getName();
         TypeDefinitionRegistry typeRegistry = buildCtx.getTypeRegistry();
@@ -771,7 +782,8 @@ public class SchemaGenerator {
         return new PropertyDataFetcher(fieldName);
     }
 
-    private GraphQLInputObjectType buildInputObjectType(BuildContext buildCtx, InputObjectTypeDefinition typeDefinition) {
+    private GraphQLInputObjectType buildInputObjectType(BuildContext buildCtx, InputObjectTypeDefinition
+            typeDefinition) {
         GraphQLInputObjectType.Builder builder = GraphQLInputObjectType.newInputObject();
         builder.definition(typeDefinition);
         builder.name(typeDefinition.getName());
@@ -896,7 +908,10 @@ public class SchemaGenerator {
     }
 
 
-    private GraphQLDirective[] buildDirectives(List<Directive> directives, List<Directive> extensionDirectives, DirectiveLocation directiveLocation, Set<GraphQLDirective> directiveDefinitions, GraphqlTypeComparatorRegistry comparatorRegistry) {
+    private GraphQLDirective[] buildDirectives
+            (List<Directive> directives, List<Directive> extensionDirectives, DirectiveLocation
+                    directiveLocation, Set<GraphQLDirective> directiveDefinitions, GraphqlTypeComparatorRegistry
+                     comparatorRegistry) {
         directives = directives == null ? emptyList() : directives;
         extensionDirectives = extensionDirectives == null ? emptyList() : extensionDirectives;
         Set<String> names = new LinkedHashSet<>();
@@ -918,27 +933,33 @@ public class SchemaGenerator {
     }
 
 
-    private List<ObjectTypeExtensionDefinition> objectTypeExtensions(ObjectTypeDefinition typeDefinition, BuildContext buildCtx) {
+    private List<ObjectTypeExtensionDefinition> objectTypeExtensions(ObjectTypeDefinition
+                                                                             typeDefinition, BuildContext buildCtx) {
         return nvl(buildCtx.typeRegistry.objectTypeExtensions().get(typeDefinition.getName()));
     }
 
-    private List<InterfaceTypeExtensionDefinition> interfaceTypeExtensions(InterfaceTypeDefinition typeDefinition, BuildContext buildCtx) {
+    private List<InterfaceTypeExtensionDefinition> interfaceTypeExtensions(InterfaceTypeDefinition
+                                                                                   typeDefinition, BuildContext buildCtx) {
         return nvl(buildCtx.typeRegistry.interfaceTypeExtensions().get(typeDefinition.getName()));
     }
 
-    private List<UnionTypeExtensionDefinition> unionTypeExtensions(UnionTypeDefinition typeDefinition, BuildContext buildCtx) {
+    private List<UnionTypeExtensionDefinition> unionTypeExtensions(UnionTypeDefinition typeDefinition, BuildContext
+            buildCtx) {
         return nvl(buildCtx.typeRegistry.unionTypeExtensions().get(typeDefinition.getName()));
     }
 
-    private List<EnumTypeExtensionDefinition> enumTypeExtensions(EnumTypeDefinition typeDefinition, BuildContext buildCtx) {
+    private List<EnumTypeExtensionDefinition> enumTypeExtensions(EnumTypeDefinition typeDefinition, BuildContext
+            buildCtx) {
         return nvl(buildCtx.typeRegistry.enumTypeExtensions().get(typeDefinition.getName()));
     }
 
-    private List<ScalarTypeExtensionDefinition> scalarTypeExtensions(ScalarTypeDefinition typeDefinition, BuildContext buildCtx) {
+    private List<ScalarTypeExtensionDefinition> scalarTypeExtensions(ScalarTypeDefinition
+                                                                             typeDefinition, BuildContext buildCtx) {
         return nvl(buildCtx.typeRegistry.scalarTypeExtensions().get(typeDefinition.getName()));
     }
 
-    private List<InputObjectTypeExtensionDefinition> inputObjectTypeExtensions(InputObjectTypeDefinition typeDefinition, BuildContext buildCtx) {
+    private List<InputObjectTypeExtensionDefinition> inputObjectTypeExtensions(InputObjectTypeDefinition
+                                                                                       typeDefinition, BuildContext buildCtx) {
         return nvl(buildCtx.typeRegistry.inputObjectTypeExtensions().get(typeDefinition.getName()));
     }
 

--- a/src/main/java/graphql/schema/idl/SchemaGenerator.java
+++ b/src/main/java/graphql/schema/idl/SchemaGenerator.java
@@ -279,10 +279,7 @@ public class SchemaGenerator {
         schemaBuilder.additionalDirectives(additionalDirectives);
         buildCtx.setDirectiveDefinitions(additionalDirectives);
 
-        List<Directive> schemaDirectiveList = SchemaExtensionsChecker.gatherSchemaDirectives(buildCtx.getTypeRegistry());
-        schemaBuilder.withSchemaDirectives(
-                buildDirectives(schemaDirectiveList, emptyList(), DirectiveLocation.SCHEMA, buildCtx.getDirectiveDefinitions(), buildCtx.getComparatorRegistry())
-        );
+        buildSchemaDirectivesAndExtensions(buildCtx, schemaBuilder);
 
         buildOperations(buildCtx, schemaBuilder);
 
@@ -301,6 +298,17 @@ public class SchemaGenerator {
             graphQLSchema = schemaTransformer.transform(graphQLSchema);
         }
         return graphQLSchema;
+    }
+
+    private void buildSchemaDirectivesAndExtensions(BuildContext buildCtx, GraphQLSchema.Builder schemaBuilder) {
+        TypeDefinitionRegistry typeRegistry = buildCtx.getTypeRegistry();
+        List<Directive> schemaDirectiveList = SchemaExtensionsChecker.gatherSchemaDirectives(typeRegistry);
+        schemaBuilder.withSchemaDirectives(
+                buildDirectives(schemaDirectiveList, emptyList(), DirectiveLocation.SCHEMA, buildCtx.getDirectiveDefinitions(), buildCtx.getComparatorRegistry())
+        );
+
+        schemaBuilder.definition(typeRegistry.schemaDefinition().orElse(null));
+        schemaBuilder.extensionDefinitions(typeRegistry.getSchemaExtensionDefinitions());
     }
 
     private void buildOperations(BuildContext buildCtx, GraphQLSchema.Builder schemaBuilder) {

--- a/src/main/java/graphql/schema/idl/SchemaTypeChecker.java
+++ b/src/main/java/graphql/schema/idl/SchemaTypeChecker.java
@@ -38,7 +38,6 @@ import graphql.schema.idl.errors.NonUniqueDirectiveError;
 import graphql.schema.idl.errors.NonUniqueNameError;
 import graphql.schema.idl.errors.OperationTypesMustBeObjects;
 import graphql.schema.idl.errors.QueryOperationMissingError;
-import graphql.schema.idl.errors.SchemaMissingError;
 import graphql.schema.idl.errors.SchemaProblem;
 
 import java.util.ArrayList;
@@ -75,7 +74,7 @@ public class SchemaTypeChecker {
 
         checkInterfacesAreImplemented(errors, typeRegistry);
 
-        checkSchemaInvariants(errors, typeRegistry);
+        SchemaExtensionsChecker.checkSchemaInvariants(errors, typeRegistry);
 
         checkScalarImplementationsArePresent(errors, typeRegistry, wiring);
         checkTypeResolversArePresent(errors, typeRegistry, wiring);
@@ -92,38 +91,6 @@ public class SchemaTypeChecker {
 
         return errors;
     }
-
-    private void checkSchemaInvariants(List<GraphQLError> errors, TypeDefinitionRegistry typeRegistry) {
-        /*
-            https://github.com/facebook/graphql/pull/90/files#diff-fe406b08746616e2f5f00909488cce66R1000
-
-            GraphQL type system definitions can omit the schema definition when the query
-            and mutation root types are named `Query` and `Mutation`, respectively.
-         */
-        // schema
-        if (!typeRegistry.schemaDefinition().isPresent()) {
-            if (!typeRegistry.getType("Query").isPresent()) {
-                errors.add(new SchemaMissingError());
-            }
-        } else {
-            SchemaDefinition schemaDefinition = typeRegistry.schemaDefinition().get();
-            List<OperationTypeDefinition> operationTypeDefinitions = schemaDefinition.getOperationTypeDefinitions();
-
-            operationTypeDefinitions
-                    .forEach(checkOperationTypesExist(typeRegistry, errors));
-
-            operationTypeDefinitions
-                    .forEach(checkOperationTypesAreObjects(typeRegistry, errors));
-
-            // ensure we have a "query" one
-            Optional<OperationTypeDefinition> query = operationTypeDefinitions.stream().filter(op -> "query".equals(op.getName())).findFirst();
-            if (!query.isPresent()) {
-                errors.add(new QueryOperationMissingError());
-            }
-
-        }
-    }
-
 
     private void checkForMissingTypes(List<GraphQLError> errors, TypeDefinitionRegistry typeRegistry) {
         // type extensions
@@ -511,7 +478,6 @@ public class SchemaTypeChecker {
         };
     }
 
-
     private void checkArgumentConsistency(String typeOfType, ObjectTypeDefinition objectTypeDef, InterfaceTypeDefinition interfaceTypeDef, FieldDefinition objectFieldDef, FieldDefinition interfaceFieldDef, List<GraphQLError> errors) {
         List<InputValueDefinition> objectArgs = objectFieldDef.getInputValueDefinitions();
         List<InputValueDefinition> interfaceArgs = interfaceFieldDef.getInputValueDefinitions();
@@ -524,28 +490,6 @@ public class SchemaTypeChecker {
                 errors.add(new InterfaceFieldArgumentRedefinitionError(typeOfType, objectTypeDef, interfaceTypeDef, objectFieldDef, objectArgStr, interfaceArgStr));
             }
         }
-    }
-
-    private Consumer<OperationTypeDefinition> checkOperationTypesExist(TypeDefinitionRegistry typeRegistry, List<GraphQLError> errors) {
-        return op -> {
-            TypeName unwrapped = TypeInfo.typeInfo(op.getTypeName()).getTypeName();
-            if (!typeRegistry.hasType(unwrapped)) {
-                errors.add(new MissingTypeError("operation", op, op.getName(), unwrapped));
-            }
-        };
-    }
-
-    private Consumer<OperationTypeDefinition> checkOperationTypesAreObjects(TypeDefinitionRegistry typeRegistry, List<GraphQLError> errors) {
-        return op -> {
-            // make sure it is defined as a ObjectTypeDef
-            Type queryType = op.getTypeName();
-            Optional<TypeDefinition> type = typeRegistry.getType(queryType);
-            type.ifPresent(typeDef -> {
-                if (!(typeDef instanceof ObjectTypeDefinition)) {
-                    errors.add(new OperationTypesMustBeObjects(op));
-                }
-            });
-        };
     }
 
     private <T extends TypeDefinition> List<T> filterTo(Map<String, TypeDefinition> types, Class<? extends T> clazz) {

--- a/src/main/java/graphql/schema/idl/SchemaTypeDirectivesChecker.java
+++ b/src/main/java/graphql/schema/idl/SchemaTypeDirectivesChecker.java
@@ -15,6 +15,7 @@ import graphql.language.InterfaceTypeDefinition;
 import graphql.language.Node;
 import graphql.language.NonNullType;
 import graphql.language.ObjectTypeDefinition;
+import graphql.language.SchemaDefinition;
 import graphql.language.TypeDefinition;
 import graphql.language.UnionTypeDefinition;
 import graphql.schema.idl.errors.DirectiveIllegalLocationError;
@@ -85,6 +86,10 @@ class SchemaTypeDirectivesChecker {
         typeRegistry.scalars().values()
                 .forEach(typeDef -> checkDirectives(SCALAR, errors, typeDef));
 
+        List<Directive> schemaDirectives = SchemaExtensionsChecker.gatherSchemaDirectives(typeRegistry, errors);
+        // we need to have a Node for error reporting so we make one in case there is not one
+        SchemaDefinition schemaDefinition = typeRegistry.schemaDefinition().orElse(SchemaDefinition.newSchemaDefinition().build());
+        checkDirectives(DirectiveLocation.SCHEMA, errors, typeRegistry, schemaDefinition, "schema", schemaDirectives);
     }
 
 

--- a/src/main/java/graphql/schema/idl/errors/OperationRedefinitionError.java
+++ b/src/main/java/graphql/schema/idl/errors/OperationRedefinitionError.java
@@ -1,0 +1,14 @@
+package graphql.schema.idl.errors;
+
+import graphql.language.OperationTypeDefinition;
+import graphql.language.SchemaDefinition;
+
+import static java.lang.String.format;
+
+public class OperationRedefinitionError extends BaseError {
+
+    public OperationRedefinitionError(OperationTypeDefinition oldEntry, OperationTypeDefinition newEntry) {
+        super(oldEntry, format("There is already an operation '%s' defined %s.  The offending new one is here %s",
+                oldEntry.getName(), lineCol(oldEntry), lineCol(newEntry)));
+    }
+}

--- a/src/main/java/graphql/schema/idl/errors/SchemaRedefinitionError.java
+++ b/src/main/java/graphql/schema/idl/errors/SchemaRedefinitionError.java
@@ -7,7 +7,7 @@ import static java.lang.String.format;
 public class SchemaRedefinitionError extends BaseError {
 
     public SchemaRedefinitionError(SchemaDefinition oldEntry, SchemaDefinition newEntry) {
-        super(oldEntry, format("There is already a schema defined %s.  The offending new new ones is here %s",
+        super(oldEntry, format("There is already a schema defined %s.  The offending new one is here %s",
                 lineCol(oldEntry), lineCol(newEntry)));
     }
 }

--- a/src/test/groovy/graphql/schema/idl/SchemaExtensionsCheckerTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaExtensionsCheckerTest.groovy
@@ -1,0 +1,171 @@
+package graphql.schema.idl
+
+import graphql.schema.idl.errors.MissingTypeError
+import graphql.schema.idl.errors.OperationRedefinitionError
+import graphql.schema.idl.errors.OperationTypesMustBeObjects
+import graphql.schema.idl.errors.QueryOperationMissingError
+import graphql.schema.idl.errors.SchemaProblem
+import spock.lang.Specification
+
+class SchemaExtensionsCheckerTest extends Specification {
+
+    static TypeDefinitionRegistry typeRegistry(String sdl) {
+        def registry = new SchemaParser().parse(sdl)
+        registry
+    }
+
+    def "schema def missing query operation and query type"() {
+        def sdl = '''
+        type Foo { f : String }
+        '''
+
+        when:
+        def errors = []
+        SchemaExtensionsChecker.checkSchemaInvariants(errors, typeRegistry(sdl))
+
+        then:
+        !errors.isEmpty()
+        errors[0] instanceof QueryOperationMissingError
+    }
+
+    def "schema def missing query operation and query type but has extensions but without query op"() {
+        def sdl = '''
+        type Foo { f : String }
+        
+        extend schema {
+            mutation : Foo
+        }
+        '''
+
+        when:
+        def errors = []
+        SchemaExtensionsChecker.checkSchemaInvariants(errors, typeRegistry(sdl))
+
+        then:
+        !errors.isEmpty()
+        errors[0] instanceof QueryOperationMissingError
+    }
+
+    def "schema def missing query operation and has query type"() {
+        def sdl = '''
+        type Query { f : String }
+        '''
+
+        when:
+        def errors = []
+        SchemaExtensionsChecker.checkSchemaInvariants(errors, typeRegistry(sdl))
+
+        then:
+        errors.isEmpty()
+    }
+
+    def "schema def missing query operation and query type but has extensions with query op"() {
+        def sdl = '''
+        type Foo { f : String }
+        
+        extend schema {
+            query : Foo
+        }
+        '''
+
+        when:
+        def errors = []
+        SchemaExtensionsChecker.checkSchemaInvariants(errors, typeRegistry(sdl))
+
+        then:
+        errors.isEmpty()
+    }
+
+    def "schema def present with query operation but extension redefines its"() {
+        def sdl = '''
+        type Foo { f : String }
+        
+        schema {
+            query : Foo
+        }
+        
+        extend schema {
+            query : Foo
+        }
+        '''
+
+        when:
+        typeRegistry(sdl)
+
+        then:
+        //parsing picks this up but via SchemaExtensionsChecker
+        def schemaProblem = thrown(SchemaProblem)
+        schemaProblem.errors[0] instanceof OperationRedefinitionError
+    }
+
+
+    def "operation is not a defined type"() {
+        def sdl = '''
+        type Foo { f : String }
+        
+        schema {
+            query : Bar
+        }
+        '''
+
+        when:
+        def errors = []
+        SchemaExtensionsChecker.checkSchemaInvariants(errors, typeRegistry(sdl))
+
+        then:
+        !errors.isEmpty()
+        errors[0] instanceof MissingTypeError
+    }
+
+    def "operation is not an object type"() {
+        def sdl = '''
+        input Foo { f : String }
+        
+        schema {
+            query : Foo
+        }
+        '''
+
+        when:
+        def errors = []
+        SchemaExtensionsChecker.checkSchemaInvariants(errors, typeRegistry(sdl))
+
+        then:
+        !errors.isEmpty()
+        errors[0] instanceof OperationTypesMustBeObjects
+    }
+
+    def "can gather all the different types"() {
+        def sdl = '''
+        type Foo { f : String }
+        
+        type Mutate { f : String }
+        
+        type Subscribe { f : String }
+        
+        schema {
+            query : Foo
+        }
+        
+        extend schema {
+            mutation : Mutate   
+        }
+
+        extend schema {
+            subscription : Subscribe   
+        }
+        '''
+
+        when:
+        def errors = []
+        def typeRegistry = typeRegistry(sdl)
+        def operationDefs = SchemaExtensionsChecker.checkSchemaInvariants(errors, typeRegistry)
+
+        then:
+        errors.isEmpty()
+        operationDefs.size() == 3
+        operationDefs.collect { opTypeDef -> opTypeDef.getName() }.contains("query")
+        operationDefs.collect { opTypeDef -> opTypeDef.getName() }.contains("mutation")
+        operationDefs.collect { opTypeDef -> opTypeDef.getName() }.contains("subscription")
+    }
+}

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -1945,14 +1945,47 @@ class SchemaGeneratorTest extends Specification {
         schema.getQueryType().name == 'Query'
         schema.getMutationType().name == 'Mutation'
 
+        when:
         def directives = schema.getSchemaDirectives()
-        directives.size() == 3
 
+        then:
+        directives.size() == 3
         schema.getSchemaDirective("sd1") != null
         schema.getSchemaDirective("sd2") != null
         schema.getSchemaDirective("sd3") != null
 
+        when:
+        def directivesMap = schema.getSchemaDirectiveByName()
+        then:
+        directives.size() == 3
+        directivesMap["sd1"] != null
+        directivesMap["sd2"] != null
+        directivesMap["sd3"] != null
 
+        when:
+        directives = schema.getDirectives()
+
+        then:
+        directives.size() == 6 // built in ones :  include / skip and deprecated
+        def directiveNames = directives.collect { it.name }
+        directiveNames.contains("include")
+        directiveNames.contains("skip")
+        directiveNames.contains("deprecated")
+        directiveNames.contains("sd1")
+        directiveNames.contains("sd2")
+        directiveNames.contains("sd3")
+
+        when:
+        directivesMap = schema.getDirectiveByName()
+
+        then:
+        directivesMap.size() == 6 // built in ones
+        directivesMap.containsKey("include")
+        directivesMap.containsKey("skip")
+        directivesMap.containsKey("deprecated")
+        directivesMap.containsKey("sd1")
+        directivesMap.containsKey("sd2")
+        directivesMap.containsKey("sd3")
     }
 
     def "directive arg descriptions are captured correctly"() {

--- a/src/test/groovy/graphql/schema/idl/SchemaTypeCheckerTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaTypeCheckerTest.groovy
@@ -14,6 +14,7 @@ import graphql.schema.idl.errors.DirectiveIllegalLocationError
 import graphql.schema.idl.errors.DirectiveUndeclaredError
 import graphql.schema.idl.errors.MissingTypeError
 import graphql.schema.idl.errors.NonUniqueNameError
+import graphql.schema.idl.errors.QueryOperationMissingError
 import graphql.schema.idl.errors.SchemaMissingError
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -254,7 +255,7 @@ class SchemaTypeCheckerTest extends Specification {
 
         expect:
 
-        result.get(0) instanceof SchemaMissingError
+        result.get(0) instanceof QueryOperationMissingError
     }
 
     def "test missing schema operation types"() {

--- a/src/test/groovy/graphql/schema/idl/SchemaTypeCheckerTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaTypeCheckerTest.groovy
@@ -307,7 +307,7 @@ class SchemaTypeCheckerTest extends Specification {
 
         expect:
 
-        result.get(0) instanceof SchemaMissingError
+        result.get(0) instanceof QueryOperationMissingError
     }
 
     def "test operation type is not an object"() {


### PR DESCRIPTION
This adds support for schema extensions into graphql-java

```
extend schema {
    mutation : SomeNewType
}
```

This also captures the schema extension definition objects and puts them into the runtime schema

This will allow Apollo to do their funky extension trick when stitching together schemas