### PR TITLE
Negative cache of Property fetch misses

### DIFF
--- a/src/test/groovy/graphql/schema/PropertyDataFetcherTest.groovy
+++ b/src/test/groovy/graphql/schema/PropertyDataFetcherTest.groovy
@@ -18,6 +18,7 @@ class PropertyDataFetcherTest extends Specification {
 
     void setup() {
         PropertyDataFetcher.setUseSetAccessible(true)
+        PropertyDataFetcher.setUseNegativeCache(true)
         PropertyDataFetcher.clearReflectionCache()
     }
 
@@ -355,6 +356,35 @@ class PropertyDataFetcherTest extends Specification {
         result = fetcher.get(environment)
         then:
         result == "value2"
+    }
+
+    def "negative caching works as expected"() {
+        def environment = env(new ClassWithDFEMethods())
+        def fetcher = new PropertyDataFetcher("doesNotExist")
+        when:
+        def result = fetcher.get(environment)
+        then:
+        result == null
+
+        when:
+        result = fetcher.get(environment)
+        then:
+        result == null
+
+        when:
+        PropertyDataFetcher.setUseNegativeCache(false)
+        PropertyDataFetcher.clearReflectionCache()
+        result = fetcher.get(environment)
+        then:
+        result == null
+
+        when:
+        PropertyDataFetcher.setUseNegativeCache(true)
+        PropertyDataFetcher.clearReflectionCache()
+        result = fetcher.get(environment)
+        then:
+        result == null
+
     }
 
     class ProductDTO {


### PR DESCRIPTION
This PR changes the way a missed property is handled for performance reasons.

Previously if a field `foo` is defined in a schema but the underlying object did not have a `getFoo()` method / field then a null would be correctly returned however all the java reflection would be repeated on the next call and so on.

This means that for misconfigured SDL  -> runtime code you pay a high performance penalty.

This PR fixes it so that we negatively cache missing reflection look ups and hence are more performany in certain cases (where a field is defined by not possible to retrieve)

This is much like we do for positive caching (where we keep the method/field in memory for next time)

The drawbacks of this approach is that in contrived cases, you can change the underlying class and it wont be reflected.  We consider this acceptable since dynamically changing classes in Java is a tricky business at best.   We provide a clear() method to reset the caches for those mucking around with dynamic classes.