### PR TITLE
id scalar will now use String.valueOf on serialise

### DIFF
--- a/src/main/java/graphql/Scalars.java
+++ b/src/main/java/graphql/Scalars.java
@@ -281,7 +281,7 @@ public class Scalars {
             if (input instanceof BigInteger) {
                 return String.valueOf(input);
             }
-            return null;
+            return String.valueOf(input);
 
         }
 

--- a/src/main/java/graphql/Scalars.java
+++ b/src/main/java/graphql/Scalars.java
@@ -287,7 +287,7 @@ public class Scalars {
 
         @Override
         public String serialize(Object input) {
-            String result = convertImpl(input);
+            String result = String.valueOf(input);
             if (result == null) {
                 throw new CoercingSerializeException(
                         "Expected type 'ID' but was '" + typeName(input) + "'."

--- a/src/main/java/graphql/relay/DefaultConnectionCursor.java
+++ b/src/main/java/graphql/relay/DefaultConnectionCursor.java
@@ -3,6 +3,8 @@ package graphql.relay;
 import graphql.Assert;
 import graphql.PublicApi;
 
+import java.util.Objects;
+
 @PublicApi
 public class DefaultConnectionCursor implements ConnectionCursor {
 
@@ -27,7 +29,7 @@ public class DefaultConnectionCursor implements ConnectionCursor {
             return false;
         }
         DefaultConnectionCursor that = (DefaultConnectionCursor) o;
-        return value != null ? value.equals(that.value) : that.value == null;
+        return Objects.equals(value, that.value);
     }
 
     @Override

--- a/src/test/groovy/graphql/ScalarsIDTest.groovy
+++ b/src/test/groovy/graphql/ScalarsIDTest.groovy
@@ -51,11 +51,11 @@ class ScalarsIDTest extends Specification {
     }
 
     @Unroll
-    def "serialize throws exception for invalid input #value"() {
+    def "serialize allows any object via String.valueOf #value"() {
         when:
         Scalars.GraphQLID.getCoercing().serialize(value)
         then:
-        thrown(CoercingSerializeException)
+        noExceptionThrown()
 
         where:
         value        | _

--- a/src/test/groovy/graphql/ScalarsIDTest.groovy
+++ b/src/test/groovy/graphql/ScalarsIDTest.groovy
@@ -3,9 +3,9 @@ package graphql
 import graphql.language.BooleanValue
 import graphql.language.IntValue
 import graphql.language.StringValue
+import graphql.relay.DefaultConnectionCursor
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
-import graphql.schema.CoercingSerializeException
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -48,6 +48,7 @@ class ScalarsIDTest extends Specification {
         123123123123123123L                                     | "123123123123123123"
         new BigInteger("123123123123123123")                    | "123123123123123123"
         UUID.fromString("037ebc7a-f9b8-4d76-89f6-31b34a40e10b") | "037ebc7a-f9b8-4d76-89f6-31b34a40e10b"
+        new DefaultConnectionCursor("cursor123")                | "cursor123"
     }
 
     @Unroll

--- a/src/test/groovy/graphql/ScalarsIDTest.groovy
+++ b/src/test/groovy/graphql/ScalarsIDTest.groovy
@@ -65,11 +65,11 @@ class ScalarsIDTest extends Specification {
     }
 
     @Unroll
-    def "parseValue throws exception for invalid input #value"() {
+    def "parseValue allows any object via String.valueOf #value"() {
         when:
         Scalars.GraphQLID.getCoercing().parseValue(value)
         then:
-        thrown(CoercingParseValueException)
+        noExceptionThrown()
 
         where:
         value        | _


### PR DESCRIPTION
This is in response to Tomkes issue about ID scalars

That is if you return an object that generates specific ids (via its toString) then today you cant use them.

This allows String.valueOf() on any object