### PR TITLE
Provides an interface for getting ID values

### DIFF
--- a/src/main/java/graphql/GraphQLIDValue.java
+++ b/src/main/java/graphql/GraphQLIDValue.java
@@ -1,0 +1,20 @@
+package graphql;
+
+/**
+ * The {@link graphql.Scalars#GraphQLID} scalar can turn values that implement this interface into
+ * IDs.  The specification says this about the ID scalar:
+ *
+ * <pre>
+ *     The ID scalar type represents a unique identifier, often used to re-fetch an object or as the key for a cache.
+ *
+ *     The ID type is serialized in the same way as a String; however, it is not
+ *     intended to be human‐readable.
+ * </pre>
+ */
+public interface GraphQLIDValue {
+
+    /**
+     * @return an opaque string that represents this ID value.
+     */
+    String getValue();
+}

--- a/src/main/java/graphql/Scalars.java
+++ b/src/main/java/graphql/Scalars.java
@@ -21,7 +21,7 @@ import static graphql.Assert.assertShouldNeverHappen;
  * This contains the implementations of the Scalar types that ship with graphql-java.  Some are proscribed
  * by the graphql specification (Int, Float, String, Boolean and ID) while others are offer because they are common on
  * Java platforms.
- *
+ * <p>
  * For more info see http://graphql.org/learn/schema/#scalar-types and more specifically http://facebook.github.io/graphql/#sec-Scalars
  */
 public class Scalars {
@@ -50,7 +50,7 @@ public class Scalars {
 
     /**
      * This represents the "Int" type as defined in the graphql specification : http://facebook.github.io/graphql/#sec-Int
-     *
+     * <p>
      * The Int scalar type represents a signed 32‐bit numeric non‐fractional value.
      */
     public static final GraphQLScalarType GraphQLInt = new GraphQLScalarType("Int", "Built-in Int", new Coercing<Integer, Integer>() {
@@ -116,7 +116,7 @@ public class Scalars {
 
     /**
      * This represents the "Float" type as defined in the graphql specification : http://facebook.github.io/graphql/#sec-Float
-     *
+     * <p>
      * Note: The Float type in GraphQL is equivalent to Double in Java. (double precision IEEE 754)
      */
     public static final GraphQLScalarType GraphQLFloat = new GraphQLScalarType("Float", "Built-in Float", new Coercing<Double, Double>() {
@@ -258,7 +258,7 @@ public class Scalars {
 
     /**
      * This represents the "ID" type as defined in the graphql specification : http://facebook.github.io/graphql/#sec-ID
-     *
+     * <p>
      * The ID scalar type represents a unique identifier, often used to re-fetch an object or as the key for a cache. The
      * ID type is serialized in the same way as a String; however, it is not intended to be human‐readable. While it is
      * often numeric, it should always serialize as a String.
@@ -280,6 +280,9 @@ public class Scalars {
             }
             if (input instanceof BigInteger) {
                 return String.valueOf(input);
+            }
+            if (input instanceof GraphQLIDValue) {
+                return ((GraphQLIDValue) input).getValue();
             }
             return null;
 

--- a/src/main/java/graphql/relay/ConnectionCursor.java
+++ b/src/main/java/graphql/relay/ConnectionCursor.java
@@ -1,5 +1,6 @@
 package graphql.relay;
 
+import graphql.GraphQLIDValue;
 import graphql.PublicApi;
 
 /**
@@ -11,7 +12,7 @@ import graphql.PublicApi;
  * See <a href="https://facebook.github.io/relay/graphql/connections.htm#sec-Cursor">https://facebook.github.io/relay/graphql/connections.htm#sec-Cursor</a>
  */
 @PublicApi
-public interface ConnectionCursor {
+public interface ConnectionCursor extends GraphQLIDValue {
 
     /**
      * @return an opaque string that represents this cursor.

--- a/src/test/groovy/graphql/ScalarsIDTest.groovy
+++ b/src/test/groovy/graphql/ScalarsIDTest.groovy
@@ -3,6 +3,7 @@ package graphql
 import graphql.language.BooleanValue
 import graphql.language.IntValue
 import graphql.language.StringValue
+import graphql.relay.DefaultConnectionCursor
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
@@ -48,6 +49,8 @@ class ScalarsIDTest extends Specification {
         123123123123123123L                                     | "123123123123123123"
         new BigInteger("123123123123123123")                    | "123123123123123123"
         UUID.fromString("037ebc7a-f9b8-4d76-89f6-31b34a40e10b") | "037ebc7a-f9b8-4d76-89f6-31b34a40e10b"
+        new IdValueInstance("xyz")                              | "xyz"
+        new DefaultConnectionCursor("cursor123")                | "cursor123"
     }
 
     @Unroll
@@ -76,5 +79,18 @@ class ScalarsIDTest extends Specification {
 
     }
 
+
+    class IdValueInstance implements GraphQLIDValue {
+        String val
+
+        IdValueInstance(String val) {
+            this.val = val
+        }
+
+        @Override
+        String getValue() {
+            return val
+        }
+    }
 
 }


### PR DESCRIPTION
Tomek and others have wanted to have objects that are in fact IDs.  They allow validation of shape and cache key structure.

However the graphql-java ID scalar wont accept them at all.

This adds an interface that allows them to give out a value that will be used to power the ID scalar

See #1704 