### PR TITLE
Add transform-like methods to GraphQLSchema.Builder and GraphQLObjectType.Builder 

### DIFF
--- a/src/main/java/graphql/schema/GraphQLObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLObjectType.java
@@ -309,6 +309,17 @@ public class GraphQLObjectType implements GraphQLNamedDescriptionType, GraphQLNa
             return field(builder.build());
         }
 
+        public Builder field(String name, Consumer<GraphQLFieldDefinition.Builder> transformer) {
+            assertNotNull(transformer, "builderFunction can't be null");
+            GraphQLFieldDefinition.Builder builder;
+            if (name != null && fields.containsKey(name)) {
+                builder = GraphQLFieldDefinition.newFieldDefinition(fields.get(name));
+            } else {
+                builder = GraphQLFieldDefinition.newFieldDefinition().name(name);
+            }
+            transformer.accept(builder);
+            return field(builder);
+        }
         /**
          * Same effect as the field(GraphQLFieldDefinition). Builder.build() is called
          * from within
@@ -320,6 +331,8 @@ public class GraphQLObjectType implements GraphQLNamedDescriptionType, GraphQLNa
         public Builder field(GraphQLFieldDefinition.Builder builder) {
             return field(builder.build());
         }
+
+
 
         public Builder fields(List<GraphQLFieldDefinition> fieldDefinitions) {
             assertNotNull(fieldDefinitions, "fieldDefinitions can't be null");

--- a/src/main/java/graphql/schema/GraphQLSchema.java
+++ b/src/main/java/graphql/schema/GraphQLSchema.java
@@ -15,6 +15,8 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Consumer;
@@ -304,6 +306,17 @@ public class GraphQLSchema {
             return query(builder.build());
         }
 
+        /**
+         * Transform the query type. If query type is not yet defined a new instance
+         * of {@link GraphQLObjectType.Builder} with default type name "Query" is used
+         * @param transformer a {@link Consumer} instance that performs transformation on {@link GraphQLObjectType.Builder}
+         * @return this builder
+         * @see GraphQLObjectType#transform(Consumer)
+         */
+        public Builder query(Consumer<GraphQLObjectType.Builder> transformer) {
+            return query(transform0(queryType, transformer, "Query"));
+        }
+
         public Builder query(GraphQLObjectType queryType) {
             this.queryType = queryType;
             return this;
@@ -312,6 +325,17 @@ public class GraphQLSchema {
         public Builder mutation(GraphQLObjectType.Builder builder) {
             return mutation(builder.build());
         }
+        /**
+         * Transform the mutation type. If mutation type is not yet defined, a new instance
+         * of {@link GraphQLObjectType.Builder} with default type name "Mutation" is used
+         * @param transformer a {@link Consumer} instance that performs transformation on {@link GraphQLObjectType.Builder}
+         * @return this builder
+         * @see GraphQLObjectType#transform(Consumer)
+         */
+        public Builder mutation(Consumer<GraphQLObjectType.Builder> transformer) {
+            return mutation(transform0(mutationType, transformer, "Mutation"));
+        }
+
 
         public Builder mutation(GraphQLObjectType mutationType) {
             this.mutationType = mutationType;
@@ -325,6 +349,16 @@ public class GraphQLSchema {
         public Builder subscription(GraphQLObjectType subscriptionType) {
             this.subscriptionType = subscriptionType;
             return this;
+        }
+        /**
+         * Transform the subscription type. If subscription type is not yet defined, a new instance
+         * of {@link GraphQLObjectType.Builder} with default type name "Subscription" is used
+         * @param transformer a {@link Consumer} instance that performs transformation on {@link GraphQLObjectType.Builder}
+         * @return this builder
+         * @see GraphQLObjectType#transform(Consumer)
+         */
+        public Builder subscription(Consumer<GraphQLObjectType.Builder> transformer) {
+            return subscription(transform0(subscriptionType, transformer, "Subscription"));
         }
 
         /**
@@ -434,6 +468,13 @@ public class GraphQLSchema {
                 throw new InvalidSchemaException(errors);
             }
             return graphQLSchema;
+        }
+
+        private GraphQLObjectType transform0(GraphQLObjectType type, Consumer<GraphQLObjectType.Builder> transformer, String typeName) {
+            GraphQLObjectType.Builder builder = Optional.ofNullable(type).map(GraphQLObjectType::newObject).orElseGet(() -> GraphQLObjectType.newObject().name(typeName));
+            transformer.accept(builder);
+            return builder.build();
+
         }
     }
 }

--- a/src/test/groovy/graphql/schema/SchemaTransformerTest.groovy
+++ b/src/test/groovy/graphql/schema/SchemaTransformerTest.groovy
@@ -171,7 +171,7 @@ type SubChildChanged {
             type QueryType {
                 dummy: String
             }
-//            """)
+            """)
             GraphQLSchema schema2 = schema.transform {
                 it.query { it.field("dummy") { it.argument  { it.name("testQuery").type(typeRef("String"))}}}
                 .mutation { it.field("testMutation") {it.type(typeRef("Boolean"))}}

--- a/src/test/groovy/graphql/schema/SchemaTransformerTest.groovy
+++ b/src/test/groovy/graphql/schema/SchemaTransformerTest.groovy
@@ -160,4 +160,28 @@ type SubChildChanged {
 
 
     }
+
+    def "test query, mutation and subscription transformers in schema.builder and field transformers in object type.builder"() {
+        when:
+            GraphQLSchema schema = TestUtil.schema("""
+            schema {
+                query: QueryType
+            }
+            
+            type QueryType {
+                dummy: String
+            }
+//            """)
+            GraphQLSchema schema2 = schema.transform {
+                it.query { it.field("dummy") { it.argument  { it.name("testQuery").type(typeRef("String"))}}}
+                .mutation { it.field("testMutation") {it.type(typeRef("Boolean"))}}
+                .subscription { it.field("testSubscription") {it.type(typeRef("Boolean"))}}}
+        then:
+            schema2.queryType?.name == "QueryType"
+            schema2.queryType.getFieldDefinition("dummy")?.arguments[0]?.name == "testQuery"
+            schema2.mutationType?.name == "Mutation"
+            schema2.mutationType.getFieldDefinition("testMutation")?.type instanceof GraphQLScalarType
+            schema2.subscriptionType?.name == "Subscription"
+            schema2.subscriptionType.getFieldDefinition("testSubscription")?.type instanceof GraphQLScalarType
+    }
 }


### PR DESCRIPTION
In order to improve `schema.transform()` and `objectType.transform()` fluency, I suggest this pull request with the following changes:

Add the following methods to GraphQLSchema.Builder. 
* `GraphQLSchema.Builder query(Consumer<GraphQLObjectType.Builder> transformer)`
* `GraphQLSchema.Builder mutation(Consumer<GraphQLObjectType.Builder> transformer)`
* `GraphQLSchema.Builder subscription(Consumer<GraphQLObjectType.Builder> transformer)`
When invoked they transform existing operation type or create a new one 

Add `GraphQLObjectType.Builder.field(String name, <GraphQLFieldDefinition.Builder> transformer)`
When invoked transforms existing object type field or creates a new one 
