### PR TITLE
Update the exception message for invalid types

### DIFF
--- a/src/main/java/graphql/language/AstValueHelper.java
+++ b/src/main/java/graphql/language/AstValueHelper.java
@@ -79,7 +79,7 @@ public class AstValueHelper {
         }
 
         if (!(type instanceof GraphQLScalarType || type instanceof GraphQLEnumType)) {
-            throw new AssertException("Must provide Input Type, cannot use: " + type.getClass());
+            throw new AssertException("Must provide input type, type " + type.getName() + " cannot be: " + type.getClass());
         }
 
         // Since value is an internally represented value, it must be serialized


### PR DESCRIPTION
Include the type name that is invalid when throwing exceptions to make debugging slightly easier

Here is an example stack trace. As you can see we just got an error when printing the schema but no information about what field or type is causing that exception

```
Caused by: graphql.AssertException: Must provide Input Type, cannot use: class graphql.schema.GraphQLInterfaceType
	at graphql.language.AstValueHelper.astFromValue(AstValueHelper.java:82)
	at graphql.language.AstValueHelper.handleNonNull(AstValueHelper.java:163)
	at graphql.language.AstValueHelper.astFromValue(AstValueHelper.java:66)
	at graphql.schema.idl.SchemaPrinter.printAst(SchemaPrinter.java:450)
	at graphql.schema.idl.SchemaPrinter.directiveString(SchemaPrinter.java:633)
	at graphql.schema.idl.SchemaPrinter.directivesString(SchemaPrinter.java:599)
	at graphql.schema.idl.SchemaPrinter.lambda$objectPrinter$6(SchemaPrinter.java:378)
	at graphql.schema.idl.SchemaPrinter.printType(SchemaPrinter.java:722)
	at graphql.schema.idl.SchemaPrinter.lambda$printType$19(SchemaPrinter.java:717)
	at java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:184)
	at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175)
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1382)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
	at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
	at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:418)
	at graphql.schema.idl.SchemaPrinter.printType(SchemaPrinter.java:717)
	at graphql.schema.idl.SchemaPrinter.print(SchemaPrinter.java:245)
	at com.expediagroup.graphql.extensions.GraphQLSchemaExtensionsKt.print(GraphQLSchemaExtensions.kt:54)
	at com.expediagroup.graphql.extensions.GraphQLSchemaExtensionsKt.print$default(GraphQLSchemaExtensions.kt:43)
	at com.expediagroup.graphql.spring.SchemaAutoConfiguration.schema(SchemaAutoConfiguration.kt:81)
	at com.expediagroup.graphql.spring.SchemaAutoConfiguration$$EnhancerBySpringCGLIB$$a37521c9.CGLIB$schema$0(<generated>)
	at com.expediagroup.graphql.spring.SchemaAutoConfiguration$$EnhancerBySpringCGLIB$$a37521c9$$FastClassBySpringCGLIB$$6a5725be.invoke(<generated>)
	at org.springframework.cglib.proxy.MethodProxy.invokeSuper(MethodProxy.java:244)
	at org.springframework.context.annotation.ConfigurationClassEnhancer$BeanMethodInterceptor.intercept(ConfigurationClassEnhancer.java:363)
	at com.expediagroup.graphql.spring.SchemaAutoConfiguration$$EnhancerBySpringCGLIB$$a37521c9.schema(<generated>)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:154)
	... 70 more
```