### PR TITLE
AstValueHelper: fixed jsonStringify() to NOT escape forward slashes

### DIFF
--- a/src/main/java/graphql/language/AstValueHelper.java
+++ b/src/main/java/graphql/language/AstValueHelper.java
@@ -180,9 +180,6 @@ public class AstValueHelper {
                 case '\\':
                     sb.append("\\\\");
                     break;
-                case '/':
-                    sb.append("\\/");
-                    break;
                 case '\b':
                     sb.append("\\b");
                     break;

--- a/src/test/groovy/graphql/language/AstValueHelperTest.groovy
+++ b/src/test/groovy/graphql/language/AstValueHelperTest.groovy
@@ -63,8 +63,6 @@ class AstValueHelperTest extends Specification {
 
         astFromValue('VA\n\t\f\r\b\\LUE', GraphQLString).isEqualTo(new StringValue('VA\\n\\t\\f\\r\\b\\\\LUE'))
 
-        astFromValue('VA/LUE', GraphQLString).isEqualTo(new StringValue('VA\\/LUE'))
-
         astFromValue('VA\\L\"UE', GraphQLString).isEqualTo(new StringValue('VA\\\\L\\"UE'))
 
         astFromValue(123, GraphQLString).isEqualTo(new StringValue('123'))
@@ -193,7 +191,6 @@ class AstValueHelperTest extends Specification {
         'json'                                    | 'json'
         'quotation-"'                             | 'quotation-\\"'
         'reverse-solidus-\\'                      | 'reverse-solidus-\\\\'
-        'solidus-/'                               | 'solidus-\\/'
         'backspace-\b'                            | 'backspace-\\b'
         'formfeed-\f'                             | 'formfeed-\\f'
         'newline-\n'                              | 'newline-\\n'


### PR DESCRIPTION
I've made a PR to address this [issue](https://github.com/graphql-java/graphql-java/issues/1712)

Actually the code for `jsonStringify()` can be refactored into using a Map<>. But I think we should NOT complicate this PR with such refactor 