### PR TITLE
Fine grained directive filtering in printing

### DIFF
--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -1019,6 +1019,17 @@ enum Enum {
 '''
 
         when:
+        def resultWithSomeDirectives = new SchemaPrinter(defaultOptions().includeDirectives({it.name == "example" })).print(schema)
+
+        then:
+        resultWithSomeDirectives == '''directive @example on FIELD_DEFINITION
+
+type Query {
+  fieldA: String @example
+}
+'''
+
+        when:
         def resultWithDirectives = new SchemaPrinter(defaultOptions().includeDirectives(true)).print(schema)
 
         then:


### PR DESCRIPTION
Further ability to filter what directives get printed. My use-case is hiding individual internal directives (while exposing the rest) from SDL processing tools, like Apollo Federation. It potentially helps with #1017 as well. Relates to #1587 too.

Not sure if this is ready to merge, opened it more as a discussion point.