### PR TITLE
bugfix: description for arg directives are captured correctly from SDL

### DIFF
--- a/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
+++ b/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
@@ -145,7 +145,9 @@ public class SchemaGeneratorHelper {
                 lines.add(commentLine);
             }
         }
-        if (lines.size() == 0) return null;
+        if (lines.size() == 0) {
+            return null;
+        }
         return lines.stream().collect(joining("\n"));
     }
 
@@ -175,6 +177,7 @@ public class SchemaGeneratorHelper {
      * We support the basic types as directive types
      *
      * @param value the value to use
+     *
      * @return a graphql input type
      */
     public GraphQLInputType buildDirectiveInputType(Value value) {
@@ -325,6 +328,7 @@ public class SchemaGeneratorHelper {
         builder.type(inputType);
         builder.value(buildValue(arg.getDefaultValue(), inputType));
         builder.defaultValue(buildValue(arg.getDefaultValue(), inputType));
+        builder.description(buildDescription(arg, arg.getDescription()));
         return builder.build();
     }
 

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -1910,4 +1910,23 @@ class SchemaGeneratorTest extends Specification {
         (schema.getType("Scalar") as GraphQLScalarType).getExtensionDefinitions().size() == 1
 
     }
+
+    def "directive arg descriptions are captured correctly"() {
+        given:
+        def spec = '''
+        type Query {
+            foo: String
+        }
+        directive @MyDirective(
+        """
+            DOC
+        """
+        arg: String) on FIELD
+        '''
+        when:
+        def schema = schema(spec)
+
+        then:
+        schema.getDirective("MyDirective").getArgument("arg").description == "DOC"
+    }
 }


### PR DESCRIPTION
Bugfix:
Description of Directive arguments were not captured when you create a GraphQLSchema from SDL.