### PR TITLE
Allows the messages from a scalar to be sent back to the user

### DIFF
--- a/src/main/java/graphql/SerializationError.java
+++ b/src/main/java/graphql/SerializationError.java
@@ -6,6 +6,7 @@ import graphql.language.SourceLocation;
 import graphql.schema.CoercingSerializeException;
 
 import java.util.List;
+import java.util.Map;
 
 import static graphql.Assert.assertNotNull;
 import static java.lang.String.format;
@@ -31,7 +32,6 @@ public class SerializationError implements GraphQLError {
         return exception;
     }
 
-
     @Override
     public String getMessage() {
         return message;
@@ -39,7 +39,7 @@ public class SerializationError implements GraphQLError {
 
     @Override
     public List<SourceLocation> getLocations() {
-        return null;
+        return exception.getLocations();
     }
 
     @Override
@@ -50,6 +50,11 @@ public class SerializationError implements GraphQLError {
     @Override
     public List<Object> getPath() {
         return path;
+    }
+
+    @Override
+    public Map<String, Object> getExtensions() {
+        return exception.getExtensions();
     }
 
     @Override

--- a/src/main/java/graphql/schema/CoercingParseLiteralException.java
+++ b/src/main/java/graphql/schema/CoercingParseLiteralException.java
@@ -1,36 +1,44 @@
 package graphql.schema;
 
-import java.util.Collections;
-import java.util.List;
-
 import graphql.ErrorType;
 import graphql.GraphQLError;
 import graphql.GraphQLException;
 import graphql.PublicApi;
 import graphql.language.SourceLocation;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
 @PublicApi
-public class    CoercingParseLiteralException extends GraphQLException implements GraphQLError {
-    private List<SourceLocation> sourceLocations;
+public class CoercingParseLiteralException extends GraphQLException implements GraphQLError {
+    private final List<SourceLocation> sourceLocations;
+    private final Map<String, Object> extensions;
 
     public CoercingParseLiteralException() {
+        this(newCoercingParseLiteralException());
     }
 
     public CoercingParseLiteralException(String message) {
-        super(message);
+        this(newCoercingParseLiteralException().message(message));
     }
 
     public CoercingParseLiteralException(String message, Throwable cause) {
-        super(message, cause);
+        this(newCoercingParseLiteralException().message(message).cause(cause));
     }
 
     public CoercingParseLiteralException(String message, Throwable cause, SourceLocation sourceLocation) {
-        super(message, cause);
-        this.sourceLocations = Collections.singletonList(sourceLocation);
+        this(newCoercingParseLiteralException().message(message).cause(cause).sourceLocation(sourceLocation));
     }
 
     public CoercingParseLiteralException(Throwable cause) {
-        super(cause);
+        this(newCoercingParseLiteralException().cause(cause));
+    }
+
+    private CoercingParseLiteralException(Builder builder) {
+        super(builder.message, builder.cause);
+        this.sourceLocations = builder.sourceLocations;
+        this.extensions = builder.extensions;
     }
 
     @Override
@@ -41,5 +49,45 @@ public class    CoercingParseLiteralException extends GraphQLException implement
     @Override
     public ErrorType getErrorType() {
         return ErrorType.ValidationError;
+    }
+
+    @Override
+    public Map<String, Object> getExtensions() {
+        return extensions;
+    }
+
+    public static Builder newCoercingParseLiteralException() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String message;
+        private Throwable cause;
+        private List<SourceLocation> sourceLocations;
+        private Map<String, Object> extensions;
+
+        public Builder message(String message) {
+            this.message = message;
+            return this;
+        }
+
+        public Builder cause(Throwable cause) {
+            this.cause = cause;
+            return this;
+        }
+
+        public Builder sourceLocation(SourceLocation sourceLocation) {
+            this.sourceLocations = sourceLocation == null ? null : Collections.singletonList(sourceLocation);
+            return this;
+        }
+
+        public Builder extensions(Map<String, Object> extensions) {
+            this.extensions = extensions;
+            return this;
+        }
+
+        public CoercingParseLiteralException build() {
+            return new CoercingParseLiteralException(this);
+        }
     }
 }

--- a/src/main/java/graphql/schema/CoercingParseValueException.java
+++ b/src/main/java/graphql/schema/CoercingParseValueException.java
@@ -1,36 +1,44 @@
 package graphql.schema;
 
-import java.util.Collections;
-import java.util.List;
-
 import graphql.ErrorType;
 import graphql.GraphQLError;
 import graphql.GraphQLException;
 import graphql.PublicApi;
 import graphql.language.SourceLocation;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
 @PublicApi
 public class CoercingParseValueException extends GraphQLException implements GraphQLError {
-    private List<SourceLocation> sourceLocations;
+    private final List<SourceLocation> sourceLocations;
+    private final Map<String, Object> extensions;
 
     public CoercingParseValueException() {
+        this(newCoercingParseValueException());
     }
 
     public CoercingParseValueException(String message) {
-        super(message);
+        this(newCoercingParseValueException().message(message));
     }
 
     public CoercingParseValueException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
-    public CoercingParseValueException(String message, Throwable cause, SourceLocation sourceLocation) {
-        super(message, cause);
-        this.sourceLocations = Collections.singletonList(sourceLocation);
+        this(newCoercingParseValueException().message(message).cause(cause));
     }
 
     public CoercingParseValueException(Throwable cause) {
-        super(cause);
+        this(newCoercingParseValueException().cause(cause));
+    }
+
+    public CoercingParseValueException(String message, Throwable cause, SourceLocation sourceLocation) {
+        this(newCoercingParseValueException().message(message).cause(cause).sourceLocation(sourceLocation));
+    }
+
+    private CoercingParseValueException(Builder builder) {
+        super(builder.message, builder.cause);
+        this.sourceLocations = builder.sourceLocations;
+        this.extensions = builder.extensions;
     }
 
     @Override
@@ -41,5 +49,50 @@ public class CoercingParseValueException extends GraphQLException implements Gra
     @Override
     public ErrorType getErrorType() {
         return ErrorType.ValidationError;
+    }
+
+    @Override
+    public Map<String, Object> getExtensions() {
+        return extensions;
+    }
+
+    public static Builder newCoercingParseValueException() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String message;
+        private Throwable cause;
+        private List<SourceLocation> sourceLocations;
+        private Map<String, Object> extensions;
+
+        public Builder message(String message) {
+            this.message = message;
+            return this;
+        }
+
+        public Builder cause(Throwable cause) {
+            this.cause = cause;
+            return this;
+        }
+
+        public Builder sourceLocation(SourceLocation sourceLocation) {
+            this.sourceLocations = sourceLocation == null ? null : Collections.singletonList(sourceLocation);
+            return this;
+        }
+
+        public Builder sourceLocations(List<SourceLocation> sourceLocations) {
+            this.sourceLocations = sourceLocations;
+            return this;
+        }
+
+        public Builder extensions(Map<String, Object> extensions) {
+            this.extensions = extensions;
+            return this;
+        }
+
+        public CoercingParseValueException build() {
+            return new CoercingParseValueException(this);
+        }
     }
 }

--- a/src/main/java/graphql/schema/CoercingSerializeException.java
+++ b/src/main/java/graphql/schema/CoercingSerializeException.java
@@ -1,23 +1,90 @@
 package graphql.schema;
 
+import graphql.ErrorClassification;
+import graphql.ErrorType;
+import graphql.GraphQLError;
 import graphql.GraphQLException;
 import graphql.PublicApi;
+import graphql.language.SourceLocation;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 @PublicApi
-public class CoercingSerializeException extends GraphQLException {
+public class CoercingSerializeException extends GraphQLException implements GraphQLError {
+    private final List<SourceLocation> sourceLocations;
+    private final Map<String, Object> extensions;
 
     public CoercingSerializeException() {
+        this(newCoercingSerializeException());
     }
 
     public CoercingSerializeException(String message) {
-        super(message);
+        this(newCoercingSerializeException().message(message));
     }
 
     public CoercingSerializeException(String message, Throwable cause) {
-        super(message, cause);
+        this(newCoercingSerializeException().message(message).cause(cause));
     }
 
     public CoercingSerializeException(Throwable cause) {
-        super(cause);
+        this(newCoercingSerializeException().cause(cause));
+    }
+
+    private CoercingSerializeException(Builder builder) {
+        super(builder.message, builder.cause);
+        this.sourceLocations = builder.sourceLocations;
+        this.extensions = builder.extensions;
+    }
+
+    @Override
+    public List<SourceLocation> getLocations() {
+        return sourceLocations;
+    }
+
+    @Override
+    public ErrorClassification getErrorType() {
+        return ErrorType.DataFetchingException;
+    }
+
+    @Override
+    public Map<String, Object> getExtensions() {
+        return extensions;
+    }
+
+    public static Builder newCoercingSerializeException() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String message;
+        private Throwable cause;
+        private Map<String, Object> extensions;
+        private List<SourceLocation> sourceLocations;
+
+        public Builder message(String message) {
+            this.message = message;
+            return this;
+        }
+
+        public Builder cause(Throwable cause) {
+            this.cause = cause;
+            return this;
+        }
+
+        public Builder sourceLocation(SourceLocation sourceLocation) {
+            this.sourceLocations = sourceLocation == null ? null : Collections.singletonList(sourceLocation);
+            return this;
+        }
+
+        public Builder extensions(Map<String, Object> extensions) {
+            this.extensions = extensions;
+            return this;
+        }
+
+        public CoercingSerializeException build() {
+            return new CoercingSerializeException(this);
+        }
     }
 }

--- a/src/main/java/graphql/validation/AbstractRule.java
+++ b/src/main/java/graphql/validation/AbstractRule.java
@@ -1,9 +1,6 @@
 package graphql.validation;
 
 
-import java.util.ArrayList;
-import java.util.List;
-
 import graphql.Internal;
 import graphql.language.Argument;
 import graphql.language.Directive;
@@ -19,6 +16,11 @@ import graphql.language.SourceLocation;
 import graphql.language.TypeName;
 import graphql.language.VariableDefinition;
 import graphql.language.VariableReference;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static graphql.validation.ValidationError.newValidationError;
 
 @Internal
 public class AbstractRule {
@@ -49,20 +51,26 @@ public class AbstractRule {
         return validationUtil;
     }
 
-    public void setValidationUtil(ValidationUtil validationUtil) {
-        this.validationUtil = validationUtil;
-    }
-
-    public void addError(ValidationErrorType validationErrorType, List<? extends Node> locations, String description) {
+    public void addError(ValidationErrorType validationErrorType, List<? extends Node<?>> locations, String description) {
         List<SourceLocation> locationList = new ArrayList<>();
-        for (Node node : locations) {
+        for (Node<?> node : locations) {
             locationList.add(node.getSourceLocation());
         }
-        validationErrorCollector.addError(new ValidationError(validationErrorType, locationList, description, getQueryPath()));
+        addError(newValidationError()
+                .validationErrorType(validationErrorType)
+                .sourceLocations(locationList)
+                .description(description));
     }
 
     public void addError(ValidationErrorType validationErrorType, SourceLocation location, String description) {
-        validationErrorCollector.addError(new ValidationError(validationErrorType, location, description, getQueryPath()));
+        addError(newValidationError()
+                .validationErrorType(validationErrorType)
+                .sourceLocation(location)
+                .description(description));
+    }
+
+    public void addError(ValidationError.Builder validationError) {
+        validationErrorCollector.addError(validationError.queryPath(getQueryPath()).build());
     }
 
     public List<ValidationError> getErrors() {

--- a/src/main/java/graphql/validation/ValidationError.java
+++ b/src/main/java/graphql/validation/ValidationError.java
@@ -9,7 +9,7 @@ import graphql.language.SourceLocation;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Map;
 
 public class ValidationError implements GraphQLError {
 
@@ -18,34 +18,52 @@ public class ValidationError implements GraphQLError {
     private final String description;
     private final ValidationErrorType validationErrorType;
     private final List<String> queryPath;
+    private final Map<String, Object> extensions;
 
     public ValidationError(ValidationErrorType validationErrorType) {
-        this(validationErrorType, (SourceLocation) null, null);
+        this(newValidationError()
+                .validationErrorType(validationErrorType));
     }
 
     public ValidationError(ValidationErrorType validationErrorType, SourceLocation sourceLocation, String description) {
-        this(validationErrorType, nullOrList(sourceLocation), description, null);
+        this(newValidationError()
+                .validationErrorType(validationErrorType)
+                .sourceLocation(sourceLocation)
+                .description(description));
     }
 
     public ValidationError(ValidationErrorType validationErrorType, SourceLocation sourceLocation, String description, List<String> queryPath) {
-        this(validationErrorType, nullOrList(sourceLocation), description, queryPath);
+        this(newValidationError()
+                .validationErrorType(validationErrorType)
+                .sourceLocation(sourceLocation)
+                .description(description)
+                .queryPath(queryPath));
     }
 
     public ValidationError(ValidationErrorType validationErrorType, List<SourceLocation> sourceLocations, String description) {
-        this(validationErrorType, sourceLocations, description, null);
+        this(newValidationError()
+                .validationErrorType(validationErrorType)
+                .sourceLocations(sourceLocations)
+                .description(description));
     }
 
     public ValidationError(ValidationErrorType validationErrorType, List<SourceLocation> sourceLocations, String description, List<String> queryPath) {
-        this.validationErrorType = validationErrorType;
-        if (sourceLocations != null)
-            this.locations.addAll(sourceLocations);
-        this.description = description;
-        this.message = mkMessage(validationErrorType, description, queryPath);
-        this.queryPath = queryPath;
+        this(newValidationError()
+                .validationErrorType(validationErrorType)
+                .sourceLocations(sourceLocations)
+                .description(description)
+                .queryPath(queryPath));
     }
 
-    private static List<SourceLocation> nullOrList(SourceLocation sourceLocation) {
-        return sourceLocation == null ? null : Collections.singletonList(sourceLocation);
+    private ValidationError(Builder builder) {
+        this.validationErrorType = builder.validationErrorType;
+        if (builder.sourceLocations != null) {
+            this.locations.addAll(builder.sourceLocations);
+        }
+        this.description = builder.description;
+        this.message = mkMessage(builder.validationErrorType, builder.description, builder.queryPath);
+        this.queryPath = builder.queryPath;
+        this.extensions = builder.extensions;
     }
 
     private String mkMessage(ValidationErrorType validationErrorType, String description, List<String> queryPath) {
@@ -56,7 +74,7 @@ public class ValidationError implements GraphQLError {
         if (queryPath == null) {
             return "";
         }
-        return String.format(" @ '%s'", queryPath.stream().collect(Collectors.joining("/")));
+        return String.format(" @ '%s'", String.join("/", queryPath));
     }
 
     public ValidationErrorType getValidationErrorType() {
@@ -86,6 +104,10 @@ public class ValidationError implements GraphQLError {
         return queryPath;
     }
 
+    @Override
+    public Map<String, Object> getExtensions() {
+        return extensions;
+    }
 
     @Override
     public String toString() {
@@ -109,4 +131,51 @@ public class ValidationError implements GraphQLError {
         return GraphqlErrorHelper.hashCode(this);
     }
 
+
+    public static Builder newValidationError() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private List<SourceLocation> sourceLocations;
+        private Map<String, Object> extensions;
+        private String description;
+        private ValidationErrorType validationErrorType;
+        private List<String> queryPath;
+
+
+        public Builder validationErrorType(ValidationErrorType validationErrorType) {
+            this.validationErrorType = validationErrorType;
+            return this;
+        }
+
+        public Builder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public Builder queryPath(List<String> queryPath) {
+            this.queryPath = queryPath;
+            return this;
+        }
+
+        public Builder sourceLocation(SourceLocation sourceLocation) {
+            this.sourceLocations = sourceLocation == null ? null : Collections.singletonList(sourceLocation);
+            return this;
+        }
+
+        public Builder sourceLocations(List<SourceLocation> sourceLocations) {
+            this.sourceLocations = sourceLocations;
+            return this;
+        }
+
+        public Builder extensions(Map<String, Object> extensions) {
+            this.extensions = extensions;
+            return this;
+        }
+
+        public ValidationError build() {
+            return new ValidationError(this);
+        }
+    }
 }

--- a/src/main/java/graphql/validation/rules/ArgumentsOfCorrectType.java
+++ b/src/main/java/graphql/validation/rules/ArgumentsOfCorrectType.java
@@ -6,6 +6,7 @@ import graphql.schema.GraphQLArgument;
 import graphql.validation.AbstractRule;
 import graphql.validation.ArgumentValidationUtil;
 import graphql.validation.ValidationContext;
+import graphql.validation.ValidationError;
 import graphql.validation.ValidationErrorCollector;
 import graphql.validation.ValidationErrorType;
 
@@ -18,10 +19,16 @@ public class ArgumentsOfCorrectType extends AbstractRule {
     @Override
     public void checkArgument(Argument argument) {
         GraphQLArgument fieldArgument = getValidationContext().getArgument();
-        if (fieldArgument == null) return;
+        if (fieldArgument == null) {
+            return;
+        }
         ArgumentValidationUtil validationUtil = new ArgumentValidationUtil(argument);
         if (!validationUtil.isValidLiteralValue(argument.getValue(), fieldArgument.getType(), getValidationContext().getSchema())) {
-            addError(ValidationErrorType.WrongType, argument.getSourceLocation(), validationUtil.getMessage());
+            addError(ValidationError.newValidationError()
+                    .validationErrorType(ValidationErrorType.WrongType)
+                    .sourceLocation(argument.getSourceLocation())
+                    .description(validationUtil.getMessage())
+                    .extensions(validationUtil.getErrorExtensions()));
         }
     }
 }

--- a/src/test/groovy/graphql/GraphQLTest.groovy
+++ b/src/test/groovy/graphql/GraphQLTest.groovy
@@ -308,7 +308,7 @@ class GraphQLTest extends Specification {
 
         then:
         result.errors.size() == 1
-        result.errors[0].description == "argument 'bar' with value 'IntValue{value=12345678910}' is not a valid 'Int'"
+        result.errors[0].message == "Validation error of type WrongType: argument 'bar' with value 'IntValue{value=12345678910}' is not a valid 'Int' - Expected value to be in the Integer range but it was '12345678910' @ 'foo'"
     }
 
     @SuppressWarnings("GroovyAssignabilityCheck")

--- a/src/test/groovy/graphql/Issue739.groovy
+++ b/src/test/groovy/graphql/Issue739.groovy
@@ -87,8 +87,7 @@ class Issue739 extends Specification {
         varResult.data == null
         varResult.errors.size() == 1
         varResult.errors[0].errorType == ErrorType.ValidationError
-        varResult.errors[0].message == "Variable 'input' has an invalid value. Expected type 'Map' but was 'Integer'." +
-                " Variables for input objects must be an instance of type 'Map'.";
+        varResult.errors[0].message == "Variable 'input' has an invalid value : Expected type 'Map' but was 'Integer'. Variables for input objects must be an instance of type 'Map'.";
         varResult.errors[0].locations == [new SourceLocation(1, 11)]
 
         when:
@@ -107,7 +106,7 @@ class Issue739 extends Specification {
         varResult.data == null
         varResult.errors.size() == 1
         varResult.errors[0].errorType == ErrorType.ValidationError
-        varResult.errors[0].message == "Variable 'boom' has an invalid value. Expected type 'Int' but was 'String'."
+        varResult.errors[0].message == "Variable 'boom' has an invalid value : Expected type 'Int' but was 'String'."
         varResult.errors[0].locations == [new SourceLocation(1, 11)]
     }
 }

--- a/src/test/groovy/graphql/schema/CoercingTest.groovy
+++ b/src/test/groovy/graphql/schema/CoercingTest.groovy
@@ -1,7 +1,6 @@
 package graphql.schema
 
 import graphql.ExecutionInput
-import graphql.GraphQL
 import graphql.TestUtil
 import graphql.language.ArrayValue
 import graphql.language.BooleanValue
@@ -90,17 +89,17 @@ class CoercingTest extends Specification {
 
         def runtimeWiring = RuntimeWiring.newRuntimeWiring()
                 .type(TypeRuntimeWiring.newTypeWiring("Query")
-                .dataFetcher("field", df))
+                        .dataFetcher("field", df))
                 .scalar(mapLikeScalar)
                 .build()
 
 
-        def graphQL = TestUtil.graphQL(spec,runtimeWiring).build()
+        def graphQL = TestUtil.graphQL(spec, runtimeWiring).build()
         def executionInput = ExecutionInput.newExecutionInput()
                 .variables([
-                strVar: "strVar",
-                intVar: 999
-        ])
+                        strVar: "strVar",
+                        intVar: 999
+                ])
                 .query('''
         query Q($strVar : String) {
             field(argument : { s : $strVar, i : 666 })
@@ -113,5 +112,102 @@ class CoercingTest extends Specification {
         then:
         er.errors.isEmpty()
         er.data == [field: [s: "strVar", i: 666]]
+    }
+
+    GraphQLScalarType customScalar = new GraphQLScalarType("CustomScalar", "CustomScalar", new Coercing() {
+        @Override
+        Object serialize(Object input) throws CoercingSerializeException {
+            if ("bang" == String.valueOf(input)) {
+                throw CoercingSerializeException.newCoercingSerializeException()
+                        .message("serialize message").extensions([serialize: true]).build()
+            }
+            return input
+        }
+
+        @Override
+        Object parseValue(Object input) throws CoercingParseValueException {
+            if ("bang" == String.valueOf(input)) {
+                throw CoercingParseValueException.newCoercingParseValueException()
+                        .message("parseValue message").extensions([parseValue: true]).build()
+            }
+            return input
+        }
+
+        @Override
+        Object parseLiteral(Object input) throws CoercingParseLiteralException {
+            StringValue sv = (StringValue) input
+            if ("bang" == String.valueOf(sv.getValue())) {
+                throw CoercingParseLiteralException.newCoercingParseLiteralException()
+                        .message("parseLiteral message").extensions([parseLiteral: true]).build()
+            }
+            return new StringValue(String.valueOf("input"))
+        }
+    })
+
+    def customScalarSDL = '''
+            scalar CustomScalar
+            
+            type Query {
+                field(arg1 : CustomScalar, arg2 : CustomScalar) : CustomScalar
+            }
+        '''
+    DataFetcher customScalarDF = { env -> return "bang" }
+
+    def customScalarRuntimeWiring = RuntimeWiring.newRuntimeWiring()
+            .type(TypeRuntimeWiring.newTypeWiring("Query").dataFetcher("field", customScalarDF))
+            .scalar(customScalar)
+            .build()
+
+    def customScalarSchema = TestUtil.graphQL(customScalarSDL, customScalarRuntimeWiring).build()
+
+    def "custom coercing parseValue messages become graphql errors"() {
+
+        when:
+        def ei = ExecutionInput.newExecutionInput().query('''
+                    query($v1 : CustomScalar) {
+                        field(arg1:$v1, arg2:"ok")
+                    }
+                    ''')
+                .variables([v1: "bang"])
+                .build()
+        def er = customScalarSchema.execute(ei)
+        then:
+        er.errors.size() == 1
+        er.errors[0].message.contains("parseValue message")
+        er.errors[0].extensions == [parseValue: true]
+    }
+
+    def "custom coercing parseLiteral messages become graphql errors"() {
+
+        when:
+        def ei = ExecutionInput.newExecutionInput().query('''
+                    query($v1 : CustomScalar) {
+                        field(arg1:$v1, arg2:"bang")
+                    }
+                    ''')
+                .variables([v1: "ok"])
+                .build()
+        def er = customScalarSchema.execute(ei)
+        then:
+        er.errors.size() == 1
+        er.errors[0].message.contains("parseLiteral message")
+        er.errors[0].extensions == [parseLiteral: true]
+    }
+
+    def "custom coercing serialize messages become graphql errors"() {
+
+        when:
+        def ei = ExecutionInput.newExecutionInput().query('''
+                    query {
+                        field
+                    }
+                    ''')
+                .root([field: "bang"])
+                .build()
+        def er = customScalarSchema.execute(ei)
+        then:
+        er.errors.size() == 1
+        er.errors[0].message.contains("serialize message")
+        er.errors[0].extensions == [serialize: true]
     }
 }

--- a/src/test/groovy/graphql/validation/rules/ArgumentsOfCorrectTypeTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/ArgumentsOfCorrectTypeTest.groovy
@@ -56,7 +56,8 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         then:
         errorCollector.containsValidationError(ValidationErrorType.WrongType)
         errorCollector.errors.size() == 1
-        errorCollector.errors[0].message == "Validation error of type WrongType: argument 'arg' with value 'StringValue{value='string'}' is not a valid 'Boolean'"
+        errorCollector.errors[0].message ==
+                "Validation error of type WrongType: argument 'arg' with value 'StringValue{value='string'}' is not a valid 'Boolean' - Expected AST type 'BooleanValue' but was 'StringValue'."
     }
 
     def "invalid input object type results in error"() {
@@ -72,7 +73,8 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         then:
         errorCollector.containsValidationError(ValidationErrorType.WrongType)
         errorCollector.errors.size() == 1
-        errorCollector.errors[0].message == "Validation error of type WrongType: argument 'arg.foo' with value 'StringValue{value='string'}' is not a valid 'Boolean'"
+        errorCollector.errors[0].message ==
+                "Validation error of type WrongType: argument 'arg.foo' with value 'StringValue{value='string'}' is not a valid 'Boolean' - Expected AST type 'BooleanValue' but was 'StringValue'."
     }
 
     def "invalid list object type results in error"() {
@@ -92,7 +94,8 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         then:
         errorCollector.containsValidationError(ValidationErrorType.WrongType)
         errorCollector.errors.size() == 1
-        errorCollector.errors[0].message == "Validation error of type WrongType: argument 'arg[1].foo' with value 'StringValue{value='string'}' is not a valid 'Boolean'"
+        errorCollector.errors[0].message ==
+                "Validation error of type WrongType: argument 'arg[1].foo' with value 'StringValue{value='string'}' is not a valid 'Boolean' - Expected AST type 'BooleanValue' but was 'StringValue'."
     }
 
     def "invalid list inside object type results in error"() {
@@ -112,7 +115,8 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         then:
         errorCollector.containsValidationError(ValidationErrorType.WrongType)
         errorCollector.errors.size() == 1
-        errorCollector.errors[0].message == "Validation error of type WrongType: argument 'arg[0].foo[1]' with value 'StringValue{value='string'}' is not a valid 'Boolean'"
+        errorCollector.errors[0].message ==
+                "Validation error of type WrongType: argument 'arg[0].foo[1]' with value 'StringValue{value='string'}' is not a valid 'Boolean' - Expected AST type 'BooleanValue' but was 'StringValue'."
     }
 
     def "invalid list simple type results in error"() {
@@ -130,7 +134,8 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         then:
         errorCollector.containsValidationError(ValidationErrorType.WrongType)
         errorCollector.errors.size() == 1
-        errorCollector.errors[0].message == "Validation error of type WrongType: argument 'arg[1]' with value 'StringValue{value='string'}' is not a valid 'Boolean'"
+        errorCollector.errors[0].message ==
+                "Validation error of type WrongType: argument 'arg[1]' with value 'StringValue{value='string'}' is not a valid 'Boolean' - Expected AST type 'BooleanValue' but was 'StringValue'."
     }
 
     def "type missing fields results in error"() {
@@ -139,9 +144,9 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         def argumentLiteral = new Argument("arg", objectValue)
         def graphQLArgument = new GraphQLArgument("arg", GraphQLInputObjectType.newInputObject().name("ArgumentObjectType")
                 .field(GraphQLInputObjectField.newInputObjectField()
-                .name("foo").type(GraphQLNonNull.nonNull(GraphQLString)))
+                        .name("foo").type(GraphQLNonNull.nonNull(GraphQLString)))
                 .field(GraphQLInputObjectField.newInputObjectField()
-                .name("bar").type(GraphQLNonNull.nonNull(GraphQLString)))
+                        .name("bar").type(GraphQLNonNull.nonNull(GraphQLString)))
                 .build())
 
         argumentsOfCorrectType.validationContext.getArgument() >> graphQLArgument
@@ -152,7 +157,8 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         then:
         errorCollector.containsValidationError(ValidationErrorType.WrongType)
         errorCollector.errors.size() == 1
-        errorCollector.errors[0].message == "Validation error of type WrongType: argument 'arg' with value 'ObjectValue{objectFields=[ObjectField{name='foo', value=StringValue{value='string'}}]}' is missing required fields '[bar]'"
+        errorCollector.errors[0].message ==
+                "Validation error of type WrongType: argument 'arg' with value 'ObjectValue{objectFields=[ObjectField{name='foo', value=StringValue{value='string'}}]}' is missing required fields '[bar]'"
     }
 
     def "type not object results in error"() {
@@ -161,9 +167,9 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         def argumentLiteral = new Argument("arg", objectValue)
         def graphQLArgument = new GraphQLArgument("arg", GraphQLInputObjectType.newInputObject().name("ArgumentObjectType")
                 .field(GraphQLInputObjectField.newInputObjectField()
-                .name("foo").type(GraphQLNonNull.nonNull(GraphQLString)))
+                        .name("foo").type(GraphQLNonNull.nonNull(GraphQLString)))
                 .field(GraphQLInputObjectField.newInputObjectField()
-                .name("bar").type(GraphQLNonNull.nonNull(GraphQLString)))
+                        .name("bar").type(GraphQLNonNull.nonNull(GraphQLString)))
                 .build())
 
         argumentsOfCorrectType.validationContext.getArgument() >> graphQLArgument
@@ -172,7 +178,8 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         then:
         errorCollector.containsValidationError(ValidationErrorType.WrongType)
         errorCollector.errors.size() == 1
-        errorCollector.errors[0].message == "Validation error of type WrongType: argument 'arg' with value 'StringValue{value='string'}' must be an object type"
+        errorCollector.errors[0].message ==
+                "Validation error of type WrongType: argument 'arg' with value 'StringValue{value='string'}' must be an object type"
     }
 
     def "type null fields results in error"() {
@@ -181,9 +188,9 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         def argumentLiteral = new Argument("arg", objectValue)
         def graphQLArgument = new GraphQLArgument("arg", GraphQLInputObjectType.newInputObject().name("ArgumentObjectType")
                 .field(GraphQLInputObjectField.newInputObjectField()
-                .name("foo").type(GraphQLNonNull.nonNull(GraphQLString)))
+                        .name("foo").type(GraphQLNonNull.nonNull(GraphQLString)))
                 .field(GraphQLInputObjectField.newInputObjectField()
-                .name("bar").type(GraphQLNonNull.nonNull(GraphQLString)))
+                        .name("bar").type(GraphQLNonNull.nonNull(GraphQLString)))
                 .build())
 
         argumentsOfCorrectType.validationContext.getArgument() >> graphQLArgument
@@ -194,7 +201,8 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         then:
         errorCollector.containsValidationError(ValidationErrorType.WrongType)
         errorCollector.errors.size() == 1
-        errorCollector.errors[0].message == "Validation error of type WrongType: argument 'arg.bar' with value 'NullValue{}' must not be null"
+        errorCollector.errors[0].message ==
+                "Validation error of type WrongType: argument 'arg.bar' with value 'NullValue{}' must not be null"
     }
 
     def "type with extra fields results in error"() {
@@ -203,9 +211,9 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         def argumentLiteral = new Argument("arg", objectValue)
         def graphQLArgument = new GraphQLArgument("arg", GraphQLInputObjectType.newInputObject().name("ArgumentObjectType")
                 .field(GraphQLInputObjectField.newInputObjectField()
-                .name("foo").type(GraphQLNonNull.nonNull(GraphQLString)))
+                        .name("foo").type(GraphQLNonNull.nonNull(GraphQLString)))
                 .field(GraphQLInputObjectField.newInputObjectField()
-                .name("bar").type(GraphQLNonNull.nonNull(GraphQLString)))
+                        .name("bar").type(GraphQLNonNull.nonNull(GraphQLString)))
                 .build())
 
         argumentsOfCorrectType.validationContext.getArgument() >> graphQLArgument
@@ -216,7 +224,8 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         then:
         errorCollector.containsValidationError(ValidationErrorType.WrongType)
         errorCollector.errors.size() == 1
-        errorCollector.errors[0].message == "Validation error of type WrongType: argument 'arg' with value 'ObjectValue{objectFields=[ObjectField{name='foo', value=StringValue{value='string'}}, ObjectField{name='bar', value=StringValue{value='string'}}, ObjectField{name='fooBar', value=BooleanValue{value=true}}]}' contains a field not in 'ArgumentObjectType': 'fooBar'"
+        errorCollector.errors[0].message ==
+                "Validation error of type WrongType: argument 'arg' with value 'ObjectValue{objectFields=[ObjectField{name='foo', value=StringValue{value='string'}}, ObjectField{name='bar', value=StringValue{value='string'}}, ObjectField{name='fooBar', value=BooleanValue{value=true}}]}' contains a field not in 'ArgumentObjectType': 'fooBar'"
     }
 
     def "current null argument from context is no error"() {


### PR DESCRIPTION
This goes some way to addressing #1686 

This means that the coercing exception from a scalar implementation is carried into the error messages.

Previously this was not the case at all and custom information would be lost