### PR TITLE
Preserving custom scalars validation messages and adding validation errors metadata as extensions (#1686)

### DIFF
--- a/src/main/java/graphql/Scalars.java
+++ b/src/main/java/graphql/Scalars.java
@@ -5,11 +5,8 @@ import graphql.language.BooleanValue;
 import graphql.language.FloatValue;
 import graphql.language.IntValue;
 import graphql.language.StringValue;
-import graphql.schema.Coercing;
-import graphql.schema.CoercingParseLiteralException;
-import graphql.schema.CoercingParseValueException;
-import graphql.schema.CoercingSerializeException;
-import graphql.schema.GraphQLScalarType;
+import graphql.schema.*;
+import graphql.validation.ValidationUtil;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -248,9 +245,7 @@ public class Scalars {
         @Override
         public Boolean parseLiteral(Object input) {
             if (!(input instanceof BooleanValue)) {
-                throw new CoercingParseLiteralException(
-                        "Expected AST type 'BooleanValue' but was '" + typeName(input) + "'."
-                );
+                throw new CoercingParseLiteralException(String.format("'%s' is not a valid Boolean", ValidationUtil.renderValue(input)));
             }
             return ((BooleanValue) input).isValue();
         }

--- a/src/main/java/graphql/schema/idl/errors/NonSDLDefinitionError.java
+++ b/src/main/java/graphql/schema/idl/errors/NonSDLDefinitionError.java
@@ -8,6 +8,6 @@ public class NonSDLDefinitionError extends BaseError {
 
     public NonSDLDefinitionError(Definition definition) {
         super(definition, format("The schema definition text contains a non schema definition language (SDL) element '%s'",
-                definition.getClass().getSimpleName(), lineCol(definition), lineCol(definition)));
+                definition.getClass().getSimpleName()));
     }
 }

--- a/src/main/java/graphql/validation/AbstractRule.java
+++ b/src/main/java/graphql/validation/AbstractRule.java
@@ -1,24 +1,12 @@
 package graphql.validation;
 
 
+import graphql.Internal;
+import graphql.language.*;
+
 import java.util.ArrayList;
 import java.util.List;
-
-import graphql.Internal;
-import graphql.language.Argument;
-import graphql.language.Directive;
-import graphql.language.Document;
-import graphql.language.Field;
-import graphql.language.FragmentDefinition;
-import graphql.language.FragmentSpread;
-import graphql.language.InlineFragment;
-import graphql.language.Node;
-import graphql.language.OperationDefinition;
-import graphql.language.SelectionSet;
-import graphql.language.SourceLocation;
-import graphql.language.TypeName;
-import graphql.language.VariableDefinition;
-import graphql.language.VariableReference;
+import java.util.Map;
 
 @Internal
 public class AbstractRule {
@@ -63,6 +51,10 @@ public class AbstractRule {
 
     public void addError(ValidationErrorType validationErrorType, SourceLocation location, String description) {
         validationErrorCollector.addError(new ValidationError(validationErrorType, location, description, getQueryPath()));
+    }
+
+    public void addError(ValidationErrorType validationErrorType, SourceLocation location, String description, Map<String, Object> extensions) {
+        validationErrorCollector.addError(new ValidationError(validationErrorType, location, description, getQueryPath(), extensions));
     }
 
     public List<ValidationError> getErrors() {

--- a/src/main/java/graphql/validation/ArgumentValidationUtil.java
+++ b/src/main/java/graphql/validation/ArgumentValidationUtil.java
@@ -3,21 +3,21 @@ package graphql.validation;
 import graphql.language.Argument;
 import graphql.language.ObjectField;
 import graphql.language.Value;
-import graphql.schema.GraphQLEnumType;
-import graphql.schema.GraphQLInputObjectType;
-import graphql.schema.GraphQLScalarType;
-import graphql.schema.GraphQLType;
+import graphql.schema.*;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class ArgumentValidationUtil extends ValidationUtil {
 
     private final List<String> argumentNames = new ArrayList<>();
-    private Value argumentValue;
+    private Value<?> argumentValue;
     private String errorMessage;
     private final List<Object> arguments = new ArrayList<>();
+    private GraphQLType requiredType;
+    private GraphQLType objectType;
 
     private final String argumentName;
 
@@ -28,15 +28,17 @@ public class ArgumentValidationUtil extends ValidationUtil {
 
     @Override
     protected void handleNullError(Value value, GraphQLType type) {
-        errorMessage = "must not be null";
+        errorMessage = "Value must not be null";
         argumentValue = value;
+        setObjectField(type);
     }
 
     @Override
-    protected void handleScalarError(Value value, GraphQLScalarType type) {
-        errorMessage = "is not a valid '%s'";
+    protected void handleScalarError(Value value, GraphQLScalarType type, String message) {
+        errorMessage = message;
         arguments.add(type.getName());
         argumentValue = value;
+        setObjectField(type);
     }
 
     @Override
@@ -44,50 +46,73 @@ public class ArgumentValidationUtil extends ValidationUtil {
         errorMessage = "is not a valid '%s'";
         arguments.add(type.getName());
         argumentValue = value;
+        requiredType = type;
     }
 
     @Override
     protected void handleNotObjectError(Value value, GraphQLInputObjectType type) {
-        errorMessage = "must be an object type";
+        errorMessage = "Value must be an object type";
+        setObjectField(type);
     }
 
     @Override
     protected void handleMissingFieldsError(Value value, GraphQLInputObjectType type, Set<String> missingFields) {
-        errorMessage = "is missing required fields '%s'";
+        errorMessage = String.format("Required fields are missing: '%s'", missingFields.stream().collect(Collectors.joining(", ", "[", "]")));
         arguments.add(missingFields);
+        setObjectField(type);
     }
 
     @Override
     protected void handleExtraFieldError(Value value, GraphQLInputObjectType type, ObjectField objectField) {
-        errorMessage = "contains a field not in '%s': '%s'";
+        errorMessage = String.format("Value contains a field not in '%s': '%s'", ValidationUtil.renderType(type), objectField.getName());
         arguments.add(type.getName());
         arguments.add(objectField.getName());
+        setObjectField(type);
     }
 
     @Override
     protected void handleFieldNotValidError(ObjectField objectField, GraphQLInputObjectType type) {
         argumentNames.add(0, objectField.getName());
+        setObjectField(type);
     }
 
     @Override
     protected void handleFieldNotValidError(Value value, GraphQLType type, int index) {
         argumentNames.add(0, String.format("[%s]", index));
+        setObjectField(type);
     }
 
-    public String getMessage() {
+    private void setObjectField(GraphQLType type) {
+        objectType = type;
+        if (requiredType == null) {
+            requiredType = type;
+        }
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public Value<?> getArgumentValue() {
+        return argumentValue;
+    }
+
+    public GraphQLType getRequiredType() {
+        return requiredType;
+    }
+
+    public GraphQLType getObjectType() {
+        return objectType;
+    }
+
+    public String renderArgument() {
         StringBuilder argument = new StringBuilder(argumentName);
         for (String name : argumentNames) {
-            if (name.startsWith("[")) {
-                argument.append(name);
-            } else {
-                argument.append(".").append(name);
+            if (!name.startsWith("[")) {
+                argument.append('.');
             }
+            argument.append(name);
         }
-        arguments.add(0, argument.toString());
-        arguments.add(1, argumentValue);
-
-        String message = "argument '%s' with value '%s'" + " " + errorMessage;
-
-        return String.format(message, arguments.toArray());
+        return argument.toString();
     }
 }

--- a/src/main/java/graphql/validation/rules/ArgumentsOfCorrectType.java
+++ b/src/main/java/graphql/validation/rules/ArgumentsOfCorrectType.java
@@ -3,11 +3,10 @@ package graphql.validation.rules;
 
 import graphql.language.Argument;
 import graphql.schema.GraphQLArgument;
-import graphql.validation.AbstractRule;
-import graphql.validation.ArgumentValidationUtil;
-import graphql.validation.ValidationContext;
-import graphql.validation.ValidationErrorCollector;
-import graphql.validation.ValidationErrorType;
+import graphql.validation.*;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class ArgumentsOfCorrectType extends AbstractRule {
 
@@ -21,7 +20,12 @@ public class ArgumentsOfCorrectType extends AbstractRule {
         if (fieldArgument == null) return;
         ArgumentValidationUtil validationUtil = new ArgumentValidationUtil(argument);
         if (!validationUtil.isValidLiteralValue(argument.getValue(), fieldArgument.getType(), getValidationContext().getSchema())) {
-            addError(ValidationErrorType.WrongType, argument.getSourceLocation(), validationUtil.getMessage());
+            Map<String, Object> extensions = new HashMap<>();
+            extensions.put("argument", validationUtil.renderArgument());
+            extensions.put("value", ValidationUtil.renderValue(validationUtil.getArgumentValue()));
+            extensions.put("requiredType", ValidationUtil.renderType(validationUtil.getRequiredType()));
+            extensions.put("objectType", ValidationUtil.renderType(validationUtil.getObjectType()));
+            addError(ValidationErrorType.WrongType, argument.getSourceLocation(), validationUtil.getErrorMessage(), extensions);
         }
     }
 }

--- a/src/main/java/graphql/validation/rules/VariablesAreInputTypes.java
+++ b/src/main/java/graphql/validation/rules/VariablesAreInputTypes.java
@@ -4,10 +4,7 @@ package graphql.validation.rules;
 import graphql.language.TypeName;
 import graphql.language.VariableDefinition;
 import graphql.schema.GraphQLType;
-import graphql.validation.AbstractRule;
-import graphql.validation.ValidationContext;
-import graphql.validation.ValidationErrorCollector;
-import graphql.validation.ValidationErrorType;
+import graphql.validation.*;
 
 import static graphql.schema.GraphQLTypeUtil.isInput;
 
@@ -19,7 +16,7 @@ public class VariablesAreInputTypes extends AbstractRule {
 
     @Override
     public void checkVariableDefinition(VariableDefinition variableDefinition) {
-        TypeName unmodifiedAstType = getValidationUtil().getUnmodifiedType(variableDefinition.getType());
+        TypeName unmodifiedAstType = ValidationUtil.getUnmodifiedType(variableDefinition.getType());
 
         GraphQLType type = getValidationContext().getSchema().getType(unmodifiedAstType.getName());
         if (type == null) return;

--- a/src/test/groovy/graphql/GraphQLErrorTest.groovy
+++ b/src/test/groovy/graphql/GraphQLErrorTest.groovy
@@ -28,8 +28,8 @@ class GraphQLErrorTest extends Specification {
         new ValidationError(ValidationErrorType.UnknownType, mkLocations(), "Test ValidationError")    |
                 [
                         locations: [[line: 666, column: 999], [line: 333, column: 0]],
-                        message  : "Validation error of type UnknownType: Test ValidationError",
-                        extensions:[classification:"ValidationError"],
+                        message  : "Test ValidationError",
+                        extensions:[validationErrorType: "UnknownType", classification:"ValidationError"],
                 ]
 
         new MissingRootTypeException("Mutations are not supported on this schema", null)               |

--- a/src/test/groovy/graphql/GraphQLTest.groovy
+++ b/src/test/groovy/graphql/GraphQLTest.groovy
@@ -308,7 +308,10 @@ class GraphQLTest extends Specification {
 
         then:
         result.errors.size() == 1
-        result.errors[0].description == "argument 'bar' with value 'IntValue{value=12345678910}' is not a valid 'Int'"
+        result.errors[0].description == "Expected value to be in the Integer range but it was '12345678910'"
+        result.errors[0].getExtensions()["argument"] == "bar"
+        result.errors[0].getExtensions()["value"] == "12345678910"
+        result.errors[0].getExtensions()["requiredType"] == "Int"
     }
 
     @SuppressWarnings("GroovyAssignabilityCheck")

--- a/src/test/groovy/graphql/GraphqlErrorHelperTest.groovy
+++ b/src/test/groovy/graphql/GraphqlErrorHelperTest.groovy
@@ -72,9 +72,8 @@ class GraphqlErrorHelperTest extends Specification {
         then:
         specMap == [
                 locations : [[line: 6, column: 9]],
-                message   : "Validation error of type InvalidFragmentType: Things are not valid",
-                extensions: [classification: "ValidationError"],
-
+                message   : "Things are not valid",
+                extensions: [classification: "ValidationError", validationErrorType: "InvalidFragmentType"],
         ]
     }
 

--- a/src/test/groovy/graphql/IssueNonNullDefaultAttribute.groovy
+++ b/src/test/groovy/graphql/IssueNonNullDefaultAttribute.groovy
@@ -65,8 +65,11 @@ class IssueNonNullDefaultAttribute extends Specification {
         then:
         result.errors.size() == 1
         result.errors[0].errorType == ErrorType.ValidationError
-        result.errors[0].message == "Validation error of type WrongType: argument 'characterNumber' with value 'NullValue{}' must not be null @ 'name'"
+        result.errors[0].message == "Value must not be null"
         result.errors[0].locations == [new SourceLocation(3, 26)]
+        result.errors[0].extensions["value"] == "null"
+        result.errors[0].extensions["argument"] == "characterNumber"
+        result.errors[0].extensions["validationErrorType"] == "WrongType"
         result.data == null
 
     }

--- a/src/test/groovy/graphql/execution/defer/DeferredCallTest.groovy
+++ b/src/test/groovy/graphql/execution/defer/DeferredCallTest.groovy
@@ -40,9 +40,9 @@ class DeferredCallTest extends Specification {
 
         then:
         er.errors.size() == 3
-        er.errors[0].message.contains("Validation error of type FieldUndefined")
-        er.errors[1].message.contains("Validation error of type MissingFieldArgument")
-        er.errors[2].message.contains("Validation error of type FieldsConflict")
+        er.errors[0].extensions["validationErrorType"] == "FieldUndefined"
+        er.errors[1].extensions["validationErrorType"] == "MissingFieldArgument"
+        er.errors[2].extensions["validationErrorType"] == "FieldsConflict"
         er.path == ["path"]
     }
 }

--- a/src/test/groovy/graphql/validation/ValidationUtilTest.groovy
+++ b/src/test/groovy/graphql/validation/ValidationUtilTest.groovy
@@ -32,21 +32,21 @@ class ValidationUtilTest extends Specification {
         given:
         def unmodifiedType = new TypeName("String")
         expect:
-        validationUtil.getUnmodifiedType(new ListType(new NonNullType(unmodifiedType))) == unmodifiedType
+        ValidationUtil.getUnmodifiedType(new ListType(new NonNullType(unmodifiedType))) == unmodifiedType
     }
 
     def "getUnmodified type of string"() {
         given:
         def unmodifiedType = new TypeName("String")
         expect:
-        validationUtil.getUnmodifiedType(unmodifiedType) == unmodifiedType
+        ValidationUtil.getUnmodifiedType(unmodifiedType) == unmodifiedType
     }
 
     def "getUnmodified type of nonNull"() {
         given:
         def unmodifiedType = new TypeName("String")
         expect:
-        validationUtil.getUnmodifiedType(new NonNullType(unmodifiedType)) == unmodifiedType
+        ValidationUtil.getUnmodifiedType(new NonNullType(unmodifiedType)) == unmodifiedType
     }
 
     def "null and NonNull is invalid"() {

--- a/src/test/groovy/graphql/validation/rules/ArgumentsOfCorrectTypeTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/ArgumentsOfCorrectTypeTest.groovy
@@ -56,7 +56,11 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         then:
         errorCollector.containsValidationError(ValidationErrorType.WrongType)
         errorCollector.errors.size() == 1
-        errorCollector.errors[0].message == "Validation error of type WrongType: argument 'arg' with value 'StringValue{value='string'}' is not a valid 'Boolean'"
+        errorCollector.errors[0].message == "'string' is not a valid Boolean"
+        errorCollector.errors[0].getExtensions()["argument"] == "arg"
+        errorCollector.errors[0].getExtensions()["value"] == "string"
+        errorCollector.errors[0].getExtensions()["requiredType"] == "Boolean"
+        errorCollector.errors[0].getExtensions()["objectType"] == "Boolean"
     }
 
     def "invalid input object type results in error"() {
@@ -72,7 +76,11 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         then:
         errorCollector.containsValidationError(ValidationErrorType.WrongType)
         errorCollector.errors.size() == 1
-        errorCollector.errors[0].message == "Validation error of type WrongType: argument 'arg.foo' with value 'StringValue{value='string'}' is not a valid 'Boolean'"
+        errorCollector.errors[0].message == "'string' is not a valid Boolean"
+        errorCollector.errors[0].getExtensions()["argument"] == "arg.foo"
+        errorCollector.errors[0].getExtensions()["value"] == "string"
+        errorCollector.errors[0].getExtensions()["requiredType"] == "Boolean"
+        errorCollector.errors[0].getExtensions()["objectType"] == "ArgumentObjectType"
     }
 
     def "invalid list object type results in error"() {
@@ -92,7 +100,11 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         then:
         errorCollector.containsValidationError(ValidationErrorType.WrongType)
         errorCollector.errors.size() == 1
-        errorCollector.errors[0].message == "Validation error of type WrongType: argument 'arg[1].foo' with value 'StringValue{value='string'}' is not a valid 'Boolean'"
+        errorCollector.errors[0].message == "'string' is not a valid Boolean"
+        errorCollector.errors[0].getExtensions()["argument"] == "arg[1].foo"
+        errorCollector.errors[0].getExtensions()["value"] == "string"
+        errorCollector.errors[0].getExtensions()["requiredType"] == "Boolean"
+        errorCollector.errors[0].getExtensions()["objectType"] == "ArgumentObjectType"
     }
 
     def "invalid list inside object type results in error"() {
@@ -112,7 +124,11 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         then:
         errorCollector.containsValidationError(ValidationErrorType.WrongType)
         errorCollector.errors.size() == 1
-        errorCollector.errors[0].message == "Validation error of type WrongType: argument 'arg[0].foo[1]' with value 'StringValue{value='string'}' is not a valid 'Boolean'"
+        errorCollector.errors[0].message == "'string' is not a valid Boolean"
+        errorCollector.errors[0].getExtensions()["argument"] == "arg[0].foo[1]"
+        errorCollector.errors[0].getExtensions()["value"] == "string"
+        errorCollector.errors[0].getExtensions()["requiredType"] == "Boolean"
+        errorCollector.errors[0].getExtensions()["objectType"] == "ArgumentObjectType"
     }
 
     def "invalid list simple type results in error"() {
@@ -130,7 +146,11 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         then:
         errorCollector.containsValidationError(ValidationErrorType.WrongType)
         errorCollector.errors.size() == 1
-        errorCollector.errors[0].message == "Validation error of type WrongType: argument 'arg[1]' with value 'StringValue{value='string'}' is not a valid 'Boolean'"
+        errorCollector.errors[0].message == "'string' is not a valid Boolean"
+        errorCollector.errors[0].getExtensions()["argument"] == "arg[1]"
+        errorCollector.errors[0].getExtensions()["value"] == "string"
+        errorCollector.errors[0].getExtensions()["requiredType"] == "Boolean"
+        errorCollector.errors[0].getExtensions()["objectType"] == "Boolean"
     }
 
     def "type missing fields results in error"() {
@@ -152,7 +172,11 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         then:
         errorCollector.containsValidationError(ValidationErrorType.WrongType)
         errorCollector.errors.size() == 1
-        errorCollector.errors[0].message == "Validation error of type WrongType: argument 'arg' with value 'ObjectValue{objectFields=[ObjectField{name='foo', value=StringValue{value='string'}}]}' is missing required fields '[bar]'"
+        errorCollector.errors[0].message == "Required fields are missing: '[bar]'"
+        errorCollector.errors[0].getExtensions()["argument"] == "arg"
+        errorCollector.errors[0].getExtensions()["value"] == "ObjectValue{objectFields=[ObjectField{name='foo', value=StringValue{value='string'}}]}"
+        errorCollector.errors[0].getExtensions()["requiredType"] == "ArgumentObjectType"
+        errorCollector.errors[0].getExtensions()["objectType"] == "ArgumentObjectType"
     }
 
     def "type not object results in error"() {
@@ -172,7 +196,11 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         then:
         errorCollector.containsValidationError(ValidationErrorType.WrongType)
         errorCollector.errors.size() == 1
-        errorCollector.errors[0].message == "Validation error of type WrongType: argument 'arg' with value 'StringValue{value='string'}' must be an object type"
+        errorCollector.errors[0].message == "Value must be an object type"
+        errorCollector.errors[0].getExtensions()["argument"] == "arg"
+        errorCollector.errors[0].getExtensions()["value"] == "string"
+        errorCollector.errors[0].getExtensions()["requiredType"] == "ArgumentObjectType"
+        errorCollector.errors[0].getExtensions()["objectType"] == "ArgumentObjectType"
     }
 
     def "type null fields results in error"() {
@@ -194,7 +222,11 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         then:
         errorCollector.containsValidationError(ValidationErrorType.WrongType)
         errorCollector.errors.size() == 1
-        errorCollector.errors[0].message == "Validation error of type WrongType: argument 'arg.bar' with value 'NullValue{}' must not be null"
+        errorCollector.errors[0].message == "Value must not be null"
+        errorCollector.errors[0].getExtensions()["argument"] == "arg.bar"
+        errorCollector.errors[0].getExtensions()["value"] == "null"
+        errorCollector.errors[0].getExtensions()["requiredType"] == "String!"
+        errorCollector.errors[0].getExtensions()["objectType"] == "ArgumentObjectType"
     }
 
     def "type with extra fields results in error"() {
@@ -216,7 +248,11 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         then:
         errorCollector.containsValidationError(ValidationErrorType.WrongType)
         errorCollector.errors.size() == 1
-        errorCollector.errors[0].message == "Validation error of type WrongType: argument 'arg' with value 'ObjectValue{objectFields=[ObjectField{name='foo', value=StringValue{value='string'}}, ObjectField{name='bar', value=StringValue{value='string'}}, ObjectField{name='fooBar', value=BooleanValue{value=true}}]}' contains a field not in 'ArgumentObjectType': 'fooBar'"
+        errorCollector.errors[0].message == "Value contains a field not in 'ArgumentObjectType': 'fooBar'"
+        errorCollector.errors[0].getExtensions()["argument"] == "arg"
+        errorCollector.errors[0].getExtensions()["value"] == "ObjectValue{objectFields=[ObjectField{name='foo', value=StringValue{value='string'}}, ObjectField{name='bar', value=StringValue{value='string'}}, ObjectField{name='fooBar', value=BooleanValue{value=true}}]}"
+        errorCollector.errors[0].getExtensions()["requiredType"] == "ArgumentObjectType"
+        errorCollector.errors[0].getExtensions()["objectType"] == "ArgumentObjectType"
     }
 
     def "current null argument from context is no error"() {

--- a/src/test/groovy/graphql/validation/rules/FieldsOnCorrectTypeTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/FieldsOnCorrectTypeTest.groovy
@@ -28,7 +28,8 @@ class FieldsOnCorrectTypeTest extends Specification {
         then:
         errorCollector.containsValidationError(ValidationErrorType.FieldUndefined)
         errorCollector.errors.size() == 1
-        errorCollector.errors[0].message == "Validation error of type FieldUndefined: Field 'name' in type 'parentType' is undefined"
+        errorCollector.errors[0].message == "Field 'name' in type 'parentType' is undefined"
+        errorCollector.errors[0].extensions["validationErrorType"] == "FieldUndefined"
     }
 
     def "should results in no error when field definition is filled"() {

--- a/src/test/groovy/graphql/validation/rules/FragmentsOnCompositeTypeTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/FragmentsOnCompositeTypeTest.groovy
@@ -26,7 +26,8 @@ class FragmentsOnCompositeTypeTest extends Specification {
         then:
         errorCollector.containsValidationError(ValidationErrorType.InlineFragmentTypeConditionInvalid)
         errorCollector.errors.size() == 1
-        errorCollector.errors[0].message == "Validation error of type InlineFragmentTypeConditionInvalid: Inline fragment type condition is invalid, must be on Object/Interface/Union"
+        errorCollector.errors[0].message == "Inline fragment type condition is invalid, must be on Object/Interface/Union"
+        errorCollector.errors[0].extensions["validationErrorType"] == "InlineFragmentTypeConditionInvalid"
     }
 
     def "should results in no error"(InlineFragment inlineFragment) {

--- a/src/test/groovy/graphql/validation/rules/OverlappingFieldsCanBeMergedTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/OverlappingFieldsCanBeMergedTest.groovy
@@ -73,8 +73,10 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
 
         then:
         errorCollector.getErrors().size() == 1
-        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: myName: name and nickname are different fields @ 'f'"
+        errorCollector.getErrors()[0].message == "myName: name and nickname are different fields"
         errorCollector.getErrors()[0].locations == [new SourceLocation(3, 17), new SourceLocation(4, 17)]
+        errorCollector.getErrors()[0].extensions["validationErrorType"] == "FieldsConflict"
+        errorCollector.getErrors()[0].extensions["queryPath"] == ["f"]
     }
 
     GraphQLSchema unionSchema() {
@@ -134,7 +136,9 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
 
         then:
         errorCollector.getErrors().size() == 1
-        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: scalar: they return differing types Int and String @ 'boxUnion'"
+        errorCollector.getErrors()[0].message == "scalar: they return differing types Int and String"
+        errorCollector.getErrors()[0].extensions["validationErrorType"] == "FieldsConflict"
+        errorCollector.getErrors()[0].extensions["queryPath"] == ["boxUnion"]
     }
 
 
@@ -182,7 +186,9 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
 
         then:
         errorCollector.getErrors().size() == 1
-        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: scalar: fields have different nullability shapes @ 'boxUnion'"
+        errorCollector.getErrors()[0].message == "scalar: fields have different nullability shapes"
+        errorCollector.getErrors()[0].extensions["validationErrorType"] == "FieldsConflict"
+        errorCollector.getErrors()[0].extensions["queryPath"] == ["boxUnion"]
     }
 
     def 'not the same list return types'() {
@@ -206,7 +212,9 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
 
         then:
         errorCollector.getErrors().size() == 1
-        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: scalar: fields have different list shapes @ 'boxUnion'"
+        errorCollector.getErrors()[0].message == "scalar: fields have different list shapes"
+        errorCollector.getErrors()[0].extensions["validationErrorType"] == "FieldsConflict"
+        errorCollector.getErrors()[0].extensions["queryPath"] == ["boxUnion"]
     }
 
 
@@ -313,8 +321,10 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
 
         then:
         errorCollector.getErrors().size() == 1
-        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: fido: name and nickname are different fields @ 'sameAliasesWithDifferentFieldTargets'"
+        errorCollector.getErrors()[0].message == "fido: name and nickname are different fields"
         errorCollector.getErrors()[0].locations == [new SourceLocation(3, 13), new SourceLocation(4, 13)]
+        errorCollector.getErrors()[0].extensions["validationErrorType"] == "FieldsConflict"
+        errorCollector.getErrors()[0].extensions["queryPath"] == ["sameAliasesWithDifferentFieldTargets"]
     }
 
     def 'Alias masking direct field access'() {
@@ -330,8 +340,10 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
 
         then:
         errorCollector.getErrors().size() == 1
-        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: name: nickname and name are different fields @ 'aliasMaskingDirectFieldAccess'"
+        errorCollector.getErrors()[0].message == "name: nickname and name are different fields"
         errorCollector.getErrors()[0].locations == [new SourceLocation(3, 13), new SourceLocation(4, 13)]
+        errorCollector.getErrors()[0].extensions["validationErrorType"] == "FieldsConflict"
+        errorCollector.getErrors()[0].extensions["queryPath"] == ["aliasMaskingDirectFieldAccess"]
     }
 
     def 'conflicting args'() {
@@ -347,8 +359,10 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
 
         then:
         errorCollector.getErrors().size() == 1
-        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: doesKnowCommand: they have differing arguments @ 'conflictingArgs'"
+        errorCollector.getErrors()[0].message == "doesKnowCommand: they have differing arguments"
         errorCollector.getErrors()[0].locations == [new SourceLocation(3, 13), new SourceLocation(4, 13)]
+        errorCollector.getErrors()[0].extensions["validationErrorType"] == "FieldsConflict"
+        errorCollector.getErrors()[0].extensions["queryPath"] == ["conflictingArgs"]
     }
 
     //
@@ -390,8 +404,9 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
 
         then:
         errorCollector.getErrors().size() == 1
-        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: x: a and b are different fields"
+        errorCollector.getErrors()[0].message == "x: a and b are different fields"
         errorCollector.getErrors()[0].locations == [new SourceLocation(7, 13), new SourceLocation(10, 13)]
+        errorCollector.getErrors()[0].extensions["validationErrorType"] == "FieldsConflict"
     }
 
     def 'reports each conflict once'() {
@@ -424,14 +439,20 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
         then:
         errorCollector.getErrors().size() == 3
 
-        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: x: a and b are different fields @ 'f1'"
+        errorCollector.getErrors()[0].message == "x: a and b are different fields"
         errorCollector.getErrors()[0].locations == [new SourceLocation(18, 13), new SourceLocation(21, 13)]
+        errorCollector.getErrors()[0].extensions["validationErrorType"] == "FieldsConflict"
+        errorCollector.getErrors()[0].extensions["queryPath"] == ["f1"]
 
-        errorCollector.getErrors()[1].message == "Validation error of type FieldsConflict: x: a and c are different fields @ 'f3'"
+        errorCollector.getErrors()[1].message == "x: a and c are different fields"
         errorCollector.getErrors()[1].locations == [new SourceLocation(18, 13), new SourceLocation(14, 17)]
+        errorCollector.getErrors()[1].extensions["validationErrorType"] == "FieldsConflict"
+        errorCollector.getErrors()[1].extensions["queryPath"] == ["f3"]
 
-        errorCollector.getErrors()[2].message == "Validation error of type FieldsConflict: x: b and c are different fields @ 'f3'"
+        errorCollector.getErrors()[2].message == "x: b and c are different fields"
         errorCollector.getErrors()[2].locations == [new SourceLocation(21, 13), new SourceLocation(14, 17)]
+        errorCollector.getErrors()[2].extensions["validationErrorType"] == "FieldsConflict"
+        errorCollector.getErrors()[2].extensions["queryPath"] == ["f3"]
     }
 
 
@@ -451,8 +472,9 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
 
         then:
         errorCollector.getErrors().size() == 1
-        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: field: (x: a and b are different fields)"
+        errorCollector.getErrors()[0].message == "field: (x: a and b are different fields)"
         errorCollector.getErrors()[0].locations.size() == 4
+        errorCollector.getErrors()[0].extensions["validationErrorType"] == "FieldsConflict"
     }
 
     def 'deep conflict with multiple issues'() {
@@ -473,8 +495,9 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
 
         then:
         errorCollector.getErrors().size() == 1
-        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: field: (x: a and b are different fields, y: c and d are different fields)"
+        errorCollector.getErrors()[0].message == "field: (x: a and b are different fields, y: c and d are different fields)"
         errorCollector.getErrors()[0].locations.size() == 6
+        errorCollector.getErrors()[0].extensions["validationErrorType"] == "FieldsConflict"
     }
 
     def 'very deep conflict'() {
@@ -498,8 +521,9 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
 
         then:
         errorCollector.getErrors().size() == 1
-        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: field: (deepField: (x: a and b are different fields))"
+        errorCollector.getErrors()[0].message == "field: (deepField: (x: a and b are different fields))"
         errorCollector.getErrors()[0].locations.size() == 6
+        errorCollector.getErrors()[0].extensions["validationErrorType"] == "FieldsConflict"
     }
 
     def 'reports deep conflict to nearest common ancestor'() {
@@ -525,8 +549,10 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
 
         then:
         errorCollector.getErrors().size() == 1
-        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: deepField: (x: a and b are different fields) @ 'field'"
+        errorCollector.getErrors()[0].message == "deepField: (x: a and b are different fields)"
         errorCollector.getErrors()[0].locations.size() == 4
+        errorCollector.getErrors()[0].extensions["validationErrorType"] == "FieldsConflict"
+        errorCollector.getErrors()[0].extensions["queryPath"] == ["field"]
     }
 
 

--- a/src/test/groovy/graphql/validation/rules/PossibleFragmentSpreadsTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/PossibleFragmentSpreadsTest.groovy
@@ -179,7 +179,9 @@ class PossibleFragmentSpreadsTest extends Specification {
 
         then:
         errorCollector.getErrors().size() == 1
-        errorCollector.getErrors().get(0).message == 'Validation error of type InvalidFragmentType: Fragment cannot be spread here as objects of type Cat can never be of type Dog @ \'invalidObjectWithinObjectAnon\''
+        errorCollector.getErrors().get(0).message == 'Fragment cannot be spread here as objects of type Cat can never be of type Dog'
+        errorCollector.getErrors()[0].extensions["validationErrorType"] == "InvalidFragmentType"
+        errorCollector.getErrors()[0].extensions["queryPath"] == ["invalidObjectWithinObjectAnon"]
     }
 
     def 'object into not implementing interface'() {
@@ -192,7 +194,9 @@ class PossibleFragmentSpreadsTest extends Specification {
 
         then:
         errorCollector.getErrors().size() == 1
-        errorCollector.getErrors().get(0).message == 'Validation error of type InvalidFragmentType: Fragment humanFragment cannot be spread here as objects of type Pet can never be of type Human @ \'invalidObjectWithinInterface\''
+        errorCollector.getErrors().get(0).message == 'Fragment humanFragment cannot be spread here as objects of type Pet can never be of type Human'
+        errorCollector.getErrors()[0].extensions["validationErrorType"] == "InvalidFragmentType"
+        errorCollector.getErrors()[0].extensions["queryPath"] == ["invalidObjectWithinInterface"]
     }
 
     def 'object into not containing union'() {


### PR DESCRIPTION
This addresses #1686 .

Custom scalars coercion error messages are preserved in the resulting error. 
Also, validation messages have been simplified so they no longer carry concatenated pieces of relevant information to be parsed by clients (arguably making the message less coherent). The relevant information is provided as extensions to the resulting errors.

As an example, instead of:
`"Validation error of type WrongType: argument 'arg.foo' with value 'StringValue{value='string'}' is not a valid 'Boolean'"`
The validation message would be:
`"'string' is not a valid Boolean"`
(the original message from the failed scalar coercion) and other aspects of the validation are provided in the error extensions for clients to use directly as values:
```
"extensions": {
    "argument": "arg.foo",
    "value": "string", 
  	"requiredType": "Boolean", 
  	"objectType": "ArgumentObjectType",
  	"validationErrorType": "WrongType"
}
```

or in another example, instead of:
`"Validation error of type FieldsConflict: scalar: they return differing types Int and String @ 'boxUnion'"`
The message would be:
`"scalar: they return differing types Int and String"`
and the extensions would include: 
```
"extensions": {
    "queryPath": "boxUnion",
  	"validationErrorType": "FieldsConflict"
}
```

All in accordance with [GraphQL errors spec](https://graphql.github.io/graphql-spec/June2018/#sec-Errors).

Disclaimer: I worked on this before having seen #1725 . I will submit another PR merging the 2 PRs as I see the value of both.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/graphql-java/graphql-java/1727)
<!-- Reviewable:end -->
