### PR TITLE
Scalars validation fix (#1686) and errors extensions merging #1725 with #1727

### DIFF
--- a/src/main/java/graphql/Scalars.java
+++ b/src/main/java/graphql/Scalars.java
@@ -5,11 +5,8 @@ import graphql.language.BooleanValue;
 import graphql.language.FloatValue;
 import graphql.language.IntValue;
 import graphql.language.StringValue;
-import graphql.schema.Coercing;
-import graphql.schema.CoercingParseLiteralException;
-import graphql.schema.CoercingParseValueException;
-import graphql.schema.CoercingSerializeException;
-import graphql.schema.GraphQLScalarType;
+import graphql.schema.*;
+import graphql.validation.ValidationUtil;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -248,9 +245,7 @@ public class Scalars {
         @Override
         public Boolean parseLiteral(Object input) {
             if (!(input instanceof BooleanValue)) {
-                throw new CoercingParseLiteralException(
-                        "Expected AST type 'BooleanValue' but was '" + typeName(input) + "'."
-                );
+                throw new CoercingParseLiteralException(String.format("'%s' is not a valid Boolean", ValidationUtil.renderValue(input)));
             }
             return ((BooleanValue) input).isValue();
         }

--- a/src/main/java/graphql/SerializationError.java
+++ b/src/main/java/graphql/SerializationError.java
@@ -6,6 +6,7 @@ import graphql.language.SourceLocation;
 import graphql.schema.CoercingSerializeException;
 
 import java.util.List;
+import java.util.Map;
 
 import static graphql.Assert.assertNotNull;
 import static java.lang.String.format;
@@ -31,7 +32,6 @@ public class SerializationError implements GraphQLError {
         return exception;
     }
 
-
     @Override
     public String getMessage() {
         return message;
@@ -39,7 +39,7 @@ public class SerializationError implements GraphQLError {
 
     @Override
     public List<SourceLocation> getLocations() {
-        return null;
+        return exception.getLocations();
     }
 
     @Override
@@ -50,6 +50,11 @@ public class SerializationError implements GraphQLError {
     @Override
     public List<Object> getPath() {
         return path;
+    }
+
+    @Override
+    public Map<String, Object> getExtensions() {
+        return exception.getExtensions();
     }
 
     @Override

--- a/src/main/java/graphql/schema/CoercingParseLiteralException.java
+++ b/src/main/java/graphql/schema/CoercingParseLiteralException.java
@@ -1,36 +1,44 @@
 package graphql.schema;
 
-import java.util.Collections;
-import java.util.List;
-
 import graphql.ErrorType;
 import graphql.GraphQLError;
 import graphql.GraphQLException;
 import graphql.PublicApi;
 import graphql.language.SourceLocation;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
 @PublicApi
-public class    CoercingParseLiteralException extends GraphQLException implements GraphQLError {
-    private List<SourceLocation> sourceLocations;
+public class CoercingParseLiteralException extends GraphQLException implements GraphQLError {
+    private final List<SourceLocation> sourceLocations;
+    private final Map<String, Object> extensions;
 
     public CoercingParseLiteralException() {
+        this(newCoercingParseLiteralException());
     }
 
     public CoercingParseLiteralException(String message) {
-        super(message);
+        this(newCoercingParseLiteralException().message(message));
     }
 
     public CoercingParseLiteralException(String message, Throwable cause) {
-        super(message, cause);
+        this(newCoercingParseLiteralException().message(message).cause(cause));
     }
 
     public CoercingParseLiteralException(String message, Throwable cause, SourceLocation sourceLocation) {
-        super(message, cause);
-        this.sourceLocations = Collections.singletonList(sourceLocation);
+        this(newCoercingParseLiteralException().message(message).cause(cause).sourceLocation(sourceLocation));
     }
 
     public CoercingParseLiteralException(Throwable cause) {
-        super(cause);
+        this(newCoercingParseLiteralException().cause(cause));
+    }
+
+    private CoercingParseLiteralException(Builder builder) {
+        super(builder.message, builder.cause);
+        this.sourceLocations = builder.sourceLocations;
+        this.extensions = builder.extensions;
     }
 
     @Override
@@ -41,5 +49,45 @@ public class    CoercingParseLiteralException extends GraphQLException implement
     @Override
     public ErrorType getErrorType() {
         return ErrorType.ValidationError;
+    }
+
+    @Override
+    public Map<String, Object> getExtensions() {
+        return extensions;
+    }
+
+    public static Builder newCoercingParseLiteralException() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String message;
+        private Throwable cause;
+        private List<SourceLocation> sourceLocations;
+        private Map<String, Object> extensions;
+
+        public Builder message(String message) {
+            this.message = message;
+            return this;
+        }
+
+        public Builder cause(Throwable cause) {
+            this.cause = cause;
+            return this;
+        }
+
+        public Builder sourceLocation(SourceLocation sourceLocation) {
+            this.sourceLocations = sourceLocation == null ? null : Collections.singletonList(sourceLocation);
+            return this;
+        }
+
+        public Builder extensions(Map<String, Object> extensions) {
+            this.extensions = extensions;
+            return this;
+        }
+
+        public CoercingParseLiteralException build() {
+            return new CoercingParseLiteralException(this);
+        }
     }
 }

--- a/src/main/java/graphql/schema/CoercingParseValueException.java
+++ b/src/main/java/graphql/schema/CoercingParseValueException.java
@@ -1,36 +1,44 @@
 package graphql.schema;
 
-import java.util.Collections;
-import java.util.List;
-
 import graphql.ErrorType;
 import graphql.GraphQLError;
 import graphql.GraphQLException;
 import graphql.PublicApi;
 import graphql.language.SourceLocation;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
 @PublicApi
 public class CoercingParseValueException extends GraphQLException implements GraphQLError {
-    private List<SourceLocation> sourceLocations;
+    private final List<SourceLocation> sourceLocations;
+    private final Map<String, Object> extensions;
 
     public CoercingParseValueException() {
+        this(newCoercingParseValueException());
     }
 
     public CoercingParseValueException(String message) {
-        super(message);
+        this(newCoercingParseValueException().message(message));
     }
 
     public CoercingParseValueException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
-    public CoercingParseValueException(String message, Throwable cause, SourceLocation sourceLocation) {
-        super(message, cause);
-        this.sourceLocations = Collections.singletonList(sourceLocation);
+        this(newCoercingParseValueException().message(message).cause(cause));
     }
 
     public CoercingParseValueException(Throwable cause) {
-        super(cause);
+        this(newCoercingParseValueException().cause(cause));
+    }
+
+    public CoercingParseValueException(String message, Throwable cause, SourceLocation sourceLocation) {
+        this(newCoercingParseValueException().message(message).cause(cause).sourceLocation(sourceLocation));
+    }
+
+    private CoercingParseValueException(Builder builder) {
+        super(builder.message, builder.cause);
+        this.sourceLocations = builder.sourceLocations;
+        this.extensions = builder.extensions;
     }
 
     @Override
@@ -41,5 +49,50 @@ public class CoercingParseValueException extends GraphQLException implements Gra
     @Override
     public ErrorType getErrorType() {
         return ErrorType.ValidationError;
+    }
+
+    @Override
+    public Map<String, Object> getExtensions() {
+        return extensions;
+    }
+
+    public static Builder newCoercingParseValueException() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String message;
+        private Throwable cause;
+        private List<SourceLocation> sourceLocations;
+        private Map<String, Object> extensions;
+
+        public Builder message(String message) {
+            this.message = message;
+            return this;
+        }
+
+        public Builder cause(Throwable cause) {
+            this.cause = cause;
+            return this;
+        }
+
+        public Builder sourceLocation(SourceLocation sourceLocation) {
+            this.sourceLocations = sourceLocation == null ? null : Collections.singletonList(sourceLocation);
+            return this;
+        }
+
+        public Builder sourceLocations(List<SourceLocation> sourceLocations) {
+            this.sourceLocations = sourceLocations;
+            return this;
+        }
+
+        public Builder extensions(Map<String, Object> extensions) {
+            this.extensions = extensions;
+            return this;
+        }
+
+        public CoercingParseValueException build() {
+            return new CoercingParseValueException(this);
+        }
     }
 }

--- a/src/main/java/graphql/schema/CoercingSerializeException.java
+++ b/src/main/java/graphql/schema/CoercingSerializeException.java
@@ -1,23 +1,90 @@
 package graphql.schema;
 
+import graphql.ErrorClassification;
+import graphql.ErrorType;
+import graphql.GraphQLError;
 import graphql.GraphQLException;
 import graphql.PublicApi;
+import graphql.language.SourceLocation;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 @PublicApi
-public class CoercingSerializeException extends GraphQLException {
+public class CoercingSerializeException extends GraphQLException implements GraphQLError {
+    private final List<SourceLocation> sourceLocations;
+    private final Map<String, Object> extensions;
 
     public CoercingSerializeException() {
+        this(newCoercingSerializeException());
     }
 
     public CoercingSerializeException(String message) {
-        super(message);
+        this(newCoercingSerializeException().message(message));
     }
 
     public CoercingSerializeException(String message, Throwable cause) {
-        super(message, cause);
+        this(newCoercingSerializeException().message(message).cause(cause));
     }
 
     public CoercingSerializeException(Throwable cause) {
-        super(cause);
+        this(newCoercingSerializeException().cause(cause));
+    }
+
+    private CoercingSerializeException(Builder builder) {
+        super(builder.message, builder.cause);
+        this.sourceLocations = builder.sourceLocations;
+        this.extensions = builder.extensions;
+    }
+
+    @Override
+    public List<SourceLocation> getLocations() {
+        return sourceLocations;
+    }
+
+    @Override
+    public ErrorClassification getErrorType() {
+        return ErrorType.DataFetchingException;
+    }
+
+    @Override
+    public Map<String, Object> getExtensions() {
+        return extensions;
+    }
+
+    public static Builder newCoercingSerializeException() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String message;
+        private Throwable cause;
+        private Map<String, Object> extensions;
+        private List<SourceLocation> sourceLocations;
+
+        public Builder message(String message) {
+            this.message = message;
+            return this;
+        }
+
+        public Builder cause(Throwable cause) {
+            this.cause = cause;
+            return this;
+        }
+
+        public Builder sourceLocation(SourceLocation sourceLocation) {
+            this.sourceLocations = sourceLocation == null ? null : Collections.singletonList(sourceLocation);
+            return this;
+        }
+
+        public Builder extensions(Map<String, Object> extensions) {
+            this.extensions = extensions;
+            return this;
+        }
+
+        public CoercingSerializeException build() {
+            return new CoercingSerializeException(this);
+        }
     }
 }

--- a/src/main/java/graphql/schema/idl/errors/NonSDLDefinitionError.java
+++ b/src/main/java/graphql/schema/idl/errors/NonSDLDefinitionError.java
@@ -8,6 +8,6 @@ public class NonSDLDefinitionError extends BaseError {
 
     public NonSDLDefinitionError(Definition definition) {
         super(definition, format("The schema definition text contains a non schema definition language (SDL) element '%s'",
-                definition.getClass().getSimpleName(), lineCol(definition), lineCol(definition)));
+                definition.getClass().getSimpleName()));
     }
 }

--- a/src/main/java/graphql/validation/AbstractRule.java
+++ b/src/main/java/graphql/validation/AbstractRule.java
@@ -1,24 +1,12 @@
 package graphql.validation;
 
 
+import graphql.Internal;
+import graphql.language.*;
+
 import java.util.ArrayList;
 import java.util.List;
-
-import graphql.Internal;
-import graphql.language.Argument;
-import graphql.language.Directive;
-import graphql.language.Document;
-import graphql.language.Field;
-import graphql.language.FragmentDefinition;
-import graphql.language.FragmentSpread;
-import graphql.language.InlineFragment;
-import graphql.language.Node;
-import graphql.language.OperationDefinition;
-import graphql.language.SelectionSet;
-import graphql.language.SourceLocation;
-import graphql.language.TypeName;
-import graphql.language.VariableDefinition;
-import graphql.language.VariableReference;
+import java.util.Map;
 
 @Internal
 public class AbstractRule {
@@ -63,6 +51,10 @@ public class AbstractRule {
 
     public void addError(ValidationErrorType validationErrorType, SourceLocation location, String description) {
         validationErrorCollector.addError(new ValidationError(validationErrorType, location, description, getQueryPath()));
+    }
+
+    public void addError(ValidationErrorType validationErrorType, SourceLocation location, String description, Map<String, Object> extensions) {
+        validationErrorCollector.addError(new ValidationError(validationErrorType, location, description, getQueryPath(), extensions));
     }
 
     public List<ValidationError> getErrors() {

--- a/src/main/java/graphql/validation/ArgumentValidationUtil.java
+++ b/src/main/java/graphql/validation/ArgumentValidationUtil.java
@@ -3,21 +3,21 @@ package graphql.validation;
 import graphql.language.Argument;
 import graphql.language.ObjectField;
 import graphql.language.Value;
-import graphql.schema.GraphQLEnumType;
-import graphql.schema.GraphQLInputObjectType;
-import graphql.schema.GraphQLScalarType;
-import graphql.schema.GraphQLType;
+import graphql.schema.*;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class ArgumentValidationUtil extends ValidationUtil {
 
     private final List<String> argumentNames = new ArrayList<>();
-    private Value argumentValue;
+    private Value<?> argumentValue;
     private String errorMessage;
     private final List<Object> arguments = new ArrayList<>();
+    private GraphQLType requiredType;
+    private GraphQLType objectType;
 
     private final String argumentName;
 
@@ -28,15 +28,17 @@ public class ArgumentValidationUtil extends ValidationUtil {
 
     @Override
     protected void handleNullError(Value value, GraphQLType type) {
-        errorMessage = "must not be null";
+        errorMessage = "Value must not be null";
         argumentValue = value;
+        setObjectField(type);
     }
 
     @Override
-    protected void handleScalarError(Value value, GraphQLScalarType type) {
-        errorMessage = "is not a valid '%s'";
+    protected void handleScalarError(Value value, GraphQLScalarType type, String message) {
+        errorMessage = message;
         arguments.add(type.getName());
         argumentValue = value;
+        setObjectField(type);
     }
 
     @Override
@@ -44,50 +46,73 @@ public class ArgumentValidationUtil extends ValidationUtil {
         errorMessage = "is not a valid '%s'";
         arguments.add(type.getName());
         argumentValue = value;
+        requiredType = type;
     }
 
     @Override
     protected void handleNotObjectError(Value value, GraphQLInputObjectType type) {
-        errorMessage = "must be an object type";
+        errorMessage = "Value must be an object type";
+        setObjectField(type);
     }
 
     @Override
     protected void handleMissingFieldsError(Value value, GraphQLInputObjectType type, Set<String> missingFields) {
-        errorMessage = "is missing required fields '%s'";
+        errorMessage = String.format("Required fields are missing: '%s'", missingFields.stream().collect(Collectors.joining(", ", "[", "]")));
         arguments.add(missingFields);
+        setObjectField(type);
     }
 
     @Override
     protected void handleExtraFieldError(Value value, GraphQLInputObjectType type, ObjectField objectField) {
-        errorMessage = "contains a field not in '%s': '%s'";
+        errorMessage = String.format("Value contains a field not in '%s': '%s'", ValidationUtil.renderType(type), objectField.getName());
         arguments.add(type.getName());
         arguments.add(objectField.getName());
+        setObjectField(type);
     }
 
     @Override
     protected void handleFieldNotValidError(ObjectField objectField, GraphQLInputObjectType type) {
         argumentNames.add(0, objectField.getName());
+        setObjectField(type);
     }
 
     @Override
     protected void handleFieldNotValidError(Value value, GraphQLType type, int index) {
         argumentNames.add(0, String.format("[%s]", index));
+        setObjectField(type);
     }
 
-    public String getMessage() {
+    private void setObjectField(GraphQLType type) {
+        objectType = type;
+        if (requiredType == null) {
+            requiredType = type;
+        }
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public Value<?> getArgumentValue() {
+        return argumentValue;
+    }
+
+    public GraphQLType getRequiredType() {
+        return requiredType;
+    }
+
+    public GraphQLType getObjectType() {
+        return objectType;
+    }
+
+    public String renderArgument() {
         StringBuilder argument = new StringBuilder(argumentName);
         for (String name : argumentNames) {
-            if (name.startsWith("[")) {
-                argument.append(name);
-            } else {
-                argument.append(".").append(name);
+            if (!name.startsWith("[")) {
+                argument.append('.');
             }
+            argument.append(name);
         }
-        arguments.add(0, argument.toString());
-        arguments.add(1, argumentValue);
-
-        String message = "argument '%s' with value '%s'" + " " + errorMessage;
-
-        return String.format(message, arguments.toArray());
+        return argument.toString();
     }
 }

--- a/src/main/java/graphql/validation/rules/ArgumentsOfCorrectType.java
+++ b/src/main/java/graphql/validation/rules/ArgumentsOfCorrectType.java
@@ -3,11 +3,10 @@ package graphql.validation.rules;
 
 import graphql.language.Argument;
 import graphql.schema.GraphQLArgument;
-import graphql.validation.AbstractRule;
-import graphql.validation.ArgumentValidationUtil;
-import graphql.validation.ValidationContext;
-import graphql.validation.ValidationErrorCollector;
-import graphql.validation.ValidationErrorType;
+import graphql.validation.*;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class ArgumentsOfCorrectType extends AbstractRule {
 
@@ -21,7 +20,12 @@ public class ArgumentsOfCorrectType extends AbstractRule {
         if (fieldArgument == null) return;
         ArgumentValidationUtil validationUtil = new ArgumentValidationUtil(argument);
         if (!validationUtil.isValidLiteralValue(argument.getValue(), fieldArgument.getType(), getValidationContext().getSchema())) {
-            addError(ValidationErrorType.WrongType, argument.getSourceLocation(), validationUtil.getMessage());
+            Map<String, Object> extensions = new HashMap<>();
+            extensions.put("argument", validationUtil.renderArgument());
+            extensions.put("value", ValidationUtil.renderValue(validationUtil.getArgumentValue()));
+            extensions.put("requiredType", ValidationUtil.renderType(validationUtil.getRequiredType()));
+            extensions.put("objectType", ValidationUtil.renderType(validationUtil.getObjectType()));
+            addError(ValidationErrorType.WrongType, argument.getSourceLocation(), validationUtil.getErrorMessage(), extensions);
         }
     }
 }

--- a/src/main/java/graphql/validation/rules/VariablesAreInputTypes.java
+++ b/src/main/java/graphql/validation/rules/VariablesAreInputTypes.java
@@ -4,10 +4,7 @@ package graphql.validation.rules;
 import graphql.language.TypeName;
 import graphql.language.VariableDefinition;
 import graphql.schema.GraphQLType;
-import graphql.validation.AbstractRule;
-import graphql.validation.ValidationContext;
-import graphql.validation.ValidationErrorCollector;
-import graphql.validation.ValidationErrorType;
+import graphql.validation.*;
 
 import static graphql.schema.GraphQLTypeUtil.isInput;
 
@@ -19,7 +16,7 @@ public class VariablesAreInputTypes extends AbstractRule {
 
     @Override
     public void checkVariableDefinition(VariableDefinition variableDefinition) {
-        TypeName unmodifiedAstType = getValidationUtil().getUnmodifiedType(variableDefinition.getType());
+        TypeName unmodifiedAstType = ValidationUtil.getUnmodifiedType(variableDefinition.getType());
 
         GraphQLType type = getValidationContext().getSchema().getType(unmodifiedAstType.getName());
         if (type == null) return;

--- a/src/test/groovy/graphql/GraphQLErrorTest.groovy
+++ b/src/test/groovy/graphql/GraphQLErrorTest.groovy
@@ -28,8 +28,8 @@ class GraphQLErrorTest extends Specification {
         new ValidationError(ValidationErrorType.UnknownType, mkLocations(), "Test ValidationError")    |
                 [
                         locations: [[line: 666, column: 999], [line: 333, column: 0]],
-                        message  : "Validation error of type UnknownType: Test ValidationError",
-                        extensions:[classification:"ValidationError"],
+                        message  : "Test ValidationError",
+                        extensions:[validationErrorType: "UnknownType", classification:"ValidationError"],
                 ]
 
         new MissingRootTypeException("Mutations are not supported on this schema", null)               |

--- a/src/test/groovy/graphql/GraphQLTest.groovy
+++ b/src/test/groovy/graphql/GraphQLTest.groovy
@@ -308,7 +308,10 @@ class GraphQLTest extends Specification {
 
         then:
         result.errors.size() == 1
-        result.errors[0].description == "argument 'bar' with value 'IntValue{value=12345678910}' is not a valid 'Int'"
+        result.errors[0].description == "Expected value to be in the Integer range but it was '12345678910'"
+        result.errors[0].getExtensions()["argument"] == "bar"
+        result.errors[0].getExtensions()["value"] == "12345678910"
+        result.errors[0].getExtensions()["requiredType"] == "Int"
     }
 
     @SuppressWarnings("GroovyAssignabilityCheck")

--- a/src/test/groovy/graphql/GraphQLTest.groovy
+++ b/src/test/groovy/graphql/GraphQLTest.groovy
@@ -2,27 +2,14 @@ package graphql
 
 import graphql.analysis.MaxQueryComplexityInstrumentation
 import graphql.analysis.MaxQueryDepthInstrumentation
-import graphql.execution.AsyncExecutionStrategy
-import graphql.execution.ExecutionContext
-import graphql.execution.ExecutionId
-import graphql.execution.ExecutionIdProvider
-import graphql.execution.ExecutionStrategyParameters
-import graphql.execution.MissingRootTypeException
+import graphql.execution.*
 import graphql.execution.batched.BatchedExecutionStrategy
 import graphql.execution.instrumentation.ChainedInstrumentation
 import graphql.execution.instrumentation.Instrumentation
 import graphql.execution.instrumentation.SimpleInstrumentation
 import graphql.execution.instrumentation.dataloader.DataLoaderDispatcherInstrumentation
 import graphql.language.SourceLocation
-import graphql.schema.DataFetcher
-import graphql.schema.DataFetchingEnvironment
-import graphql.schema.GraphQLEnumType
-import graphql.schema.GraphQLFieldDefinition
-import graphql.schema.GraphQLInterfaceType
-import graphql.schema.GraphQLNonNull
-import graphql.schema.GraphQLObjectType
-import graphql.schema.GraphQLSchema
-import graphql.schema.StaticDataFetcher
+import graphql.schema.*
 import graphql.validation.ValidationError
 import graphql.validation.ValidationErrorType
 import spock.lang.Specification
@@ -308,10 +295,15 @@ class GraphQLTest extends Specification {
 
         then:
         result.errors.size() == 1
-        result.errors[0].description == "Expected value to be in the Integer range but it was '12345678910'"
-        result.errors[0].getExtensions()["argument"] == "bar"
-        result.errors[0].getExtensions()["value"] == "12345678910"
-        result.errors[0].getExtensions()["requiredType"] == "Int"
+        result.errors[0].message == "Expected value to be in the Integer range but it was '12345678910'"
+        result.errors[0].getExtensions() == [
+                argument: "bar",
+                requiredType: "Int",
+                queryPath: ["foo"],
+                value: "12345678910",
+                objectType: "Int",
+                validationErrorType: "WrongType"
+        ]
     }
 
     @SuppressWarnings("GroovyAssignabilityCheck")

--- a/src/test/groovy/graphql/GraphqlErrorHelperTest.groovy
+++ b/src/test/groovy/graphql/GraphqlErrorHelperTest.groovy
@@ -72,9 +72,8 @@ class GraphqlErrorHelperTest extends Specification {
         then:
         specMap == [
                 locations : [[line: 6, column: 9]],
-                message   : "Validation error of type InvalidFragmentType: Things are not valid",
-                extensions: [classification: "ValidationError"],
-
+                message   : "Things are not valid",
+                extensions: [classification: "ValidationError", validationErrorType: "InvalidFragmentType"],
         ]
     }
 

--- a/src/test/groovy/graphql/Issue739.groovy
+++ b/src/test/groovy/graphql/Issue739.groovy
@@ -87,8 +87,7 @@ class Issue739 extends Specification {
         varResult.data == null
         varResult.errors.size() == 1
         varResult.errors[0].errorType == ErrorType.ValidationError
-        varResult.errors[0].message == "Variable 'input' has an invalid value. Expected type 'Map' but was 'Integer'." +
-                " Variables for input objects must be an instance of type 'Map'.";
+        varResult.errors[0].message == "Variable 'input' has an invalid value : Expected type 'Map' but was 'Integer'. Variables for input objects must be an instance of type 'Map'.";
         varResult.errors[0].locations == [new SourceLocation(1, 11)]
 
         when:
@@ -107,7 +106,7 @@ class Issue739 extends Specification {
         varResult.data == null
         varResult.errors.size() == 1
         varResult.errors[0].errorType == ErrorType.ValidationError
-        varResult.errors[0].message == "Variable 'boom' has an invalid value. Expected type 'Int' but was 'String'."
+        varResult.errors[0].message == "Variable 'boom' has an invalid value : Expected type 'Int' but was 'String'."
         varResult.errors[0].locations == [new SourceLocation(1, 11)]
     }
 }

--- a/src/test/groovy/graphql/IssueNonNullDefaultAttribute.groovy
+++ b/src/test/groovy/graphql/IssueNonNullDefaultAttribute.groovy
@@ -65,8 +65,11 @@ class IssueNonNullDefaultAttribute extends Specification {
         then:
         result.errors.size() == 1
         result.errors[0].errorType == ErrorType.ValidationError
-        result.errors[0].message == "Validation error of type WrongType: argument 'characterNumber' with value 'NullValue{}' must not be null @ 'name'"
+        result.errors[0].message == "Value must not be null"
         result.errors[0].locations == [new SourceLocation(3, 26)]
+        result.errors[0].extensions["value"] == "null"
+        result.errors[0].extensions["argument"] == "characterNumber"
+        result.errors[0].extensions["validationErrorType"] == "WrongType"
         result.data == null
 
     }

--- a/src/test/groovy/graphql/execution/defer/DeferredCallTest.groovy
+++ b/src/test/groovy/graphql/execution/defer/DeferredCallTest.groovy
@@ -40,9 +40,9 @@ class DeferredCallTest extends Specification {
 
         then:
         er.errors.size() == 3
-        er.errors[0].message.contains("Validation error of type FieldUndefined")
-        er.errors[1].message.contains("Validation error of type MissingFieldArgument")
-        er.errors[2].message.contains("Validation error of type FieldsConflict")
+        er.errors[0].extensions["validationErrorType"] == "FieldUndefined"
+        er.errors[1].extensions["validationErrorType"] == "MissingFieldArgument"
+        er.errors[2].extensions["validationErrorType"] == "FieldsConflict"
         er.path == ["path"]
     }
 }

--- a/src/test/groovy/graphql/schema/CoercingTest.groovy
+++ b/src/test/groovy/graphql/schema/CoercingTest.groovy
@@ -1,16 +1,8 @@
 package graphql.schema
 
 import graphql.ExecutionInput
-import graphql.GraphQL
 import graphql.TestUtil
-import graphql.language.ArrayValue
-import graphql.language.BooleanValue
-import graphql.language.FloatValue
-import graphql.language.IntValue
-import graphql.language.NullValue
-import graphql.language.ObjectValue
-import graphql.language.StringValue
-import graphql.language.VariableReference
+import graphql.language.*
 import graphql.schema.idl.RuntimeWiring
 import graphql.schema.idl.TypeRuntimeWiring
 import spock.lang.Specification
@@ -90,17 +82,17 @@ class CoercingTest extends Specification {
 
         def runtimeWiring = RuntimeWiring.newRuntimeWiring()
                 .type(TypeRuntimeWiring.newTypeWiring("Query")
-                .dataFetcher("field", df))
+                        .dataFetcher("field", df))
                 .scalar(mapLikeScalar)
                 .build()
 
 
-        def graphQL = TestUtil.graphQL(spec,runtimeWiring).build()
+        def graphQL = TestUtil.graphQL(spec, runtimeWiring).build()
         def executionInput = ExecutionInput.newExecutionInput()
                 .variables([
-                strVar: "strVar",
-                intVar: 999
-        ])
+                        strVar: "strVar",
+                        intVar: 999
+                ])
                 .query('''
         query Q($strVar : String) {
             field(argument : { s : $strVar, i : 666 })
@@ -113,5 +105,110 @@ class CoercingTest extends Specification {
         then:
         er.errors.isEmpty()
         er.data == [field: [s: "strVar", i: 666]]
+    }
+
+    GraphQLScalarType customScalar = new GraphQLScalarType("CustomScalar", "CustomScalar", new Coercing() {
+        @Override
+        Object serialize(Object input) throws CoercingSerializeException {
+            if ("bang" == String.valueOf(input)) {
+                throw CoercingSerializeException.newCoercingSerializeException()
+                        .message("serialize message").extensions([serialize: true]).build()
+            }
+            return input
+        }
+
+        @Override
+        Object parseValue(Object input) throws CoercingParseValueException {
+            if ("bang" == String.valueOf(input)) {
+                throw CoercingParseValueException.newCoercingParseValueException()
+                        .message("parseValue message").extensions([parseValue: true]).build()
+            }
+            return input
+        }
+
+        @Override
+        Object parseLiteral(Object input) throws CoercingParseLiteralException {
+            StringValue sv = (StringValue) input
+            if ("bang" == String.valueOf(sv.getValue())) {
+                throw CoercingParseLiteralException.newCoercingParseLiteralException()
+                        .message("parseLiteral message").extensions([parseLiteral: true]).build()
+            }
+            return new StringValue(String.valueOf("input"))
+        }
+    })
+
+    def customScalarSDL = '''
+            scalar CustomScalar
+            
+            type Query {
+                field(arg1 : CustomScalar, arg2 : CustomScalar) : CustomScalar
+            }
+        '''
+    DataFetcher customScalarDF = { env -> return "bang" }
+
+    def customScalarRuntimeWiring = RuntimeWiring.newRuntimeWiring()
+            .type(TypeRuntimeWiring.newTypeWiring("Query").dataFetcher("field", customScalarDF))
+            .scalar(customScalar)
+            .build()
+
+    def customScalarSchema = TestUtil.graphQL(customScalarSDL, customScalarRuntimeWiring).build()
+
+    def "custom coercing parseValue messages become graphql errors"() {
+
+        when:
+        def ei = ExecutionInput.newExecutionInput().query('''
+                    query($v1 : CustomScalar) {
+                        field(arg1:$v1, arg2:"ok")
+                    }
+                    ''')
+                .variables([v1: "bang"])
+                .build()
+        def er = customScalarSchema.execute(ei)
+        then:
+        er.errors.size() == 1
+        er.errors[0].message.contains("parseValue message")
+        er.errors[0].extensions == [parseValue: true]
+    }
+
+    def "custom coercing parseLiteral messages become graphql errors"() {
+
+        when:
+        def ei = ExecutionInput.newExecutionInput().query('''
+                    query($v1 : CustomScalar) {
+                        field(arg1:$v1, arg2:"bang")
+                    }
+                    ''')
+                .variables([v1: "ok"])
+                .build()
+        def er = customScalarSchema.execute(ei)
+        then:
+        er.errors.size() == 1
+        er.errors[0].message.contains("parseLiteral message")
+        er.errors[0].extensions == [
+                argument: "arg2",
+                requiredType: "CustomScalar",
+                queryPath: ["field"],
+                parseLiteral: true,
+                value: "bang",
+                objectType: "CustomScalar",
+                validationErrorType: "WrongType"
+        ]
+    }
+
+    def "custom coercing serialize messages become graphql errors"() {
+
+        when:
+        def ei = ExecutionInput.newExecutionInput().query('''
+                    query {
+                        field
+                    }
+                    ''')
+                .root([field: "bang"])
+                .build()
+        def er = customScalarSchema.execute(ei)
+        then:
+        er.errors.size() == 1
+        er.errors[0].message.contains("serialize message")
+        er.errors[0].extensions == [serialize: true]
     }
 }

--- a/src/test/groovy/graphql/validation/ValidationUtilTest.groovy
+++ b/src/test/groovy/graphql/validation/ValidationUtilTest.groovy
@@ -32,21 +32,21 @@ class ValidationUtilTest extends Specification {
         given:
         def unmodifiedType = new TypeName("String")
         expect:
-        validationUtil.getUnmodifiedType(new ListType(new NonNullType(unmodifiedType))) == unmodifiedType
+        ValidationUtil.getUnmodifiedType(new ListType(new NonNullType(unmodifiedType))) == unmodifiedType
     }
 
     def "getUnmodified type of string"() {
         given:
         def unmodifiedType = new TypeName("String")
         expect:
-        validationUtil.getUnmodifiedType(unmodifiedType) == unmodifiedType
+        ValidationUtil.getUnmodifiedType(unmodifiedType) == unmodifiedType
     }
 
     def "getUnmodified type of nonNull"() {
         given:
         def unmodifiedType = new TypeName("String")
         expect:
-        validationUtil.getUnmodifiedType(new NonNullType(unmodifiedType)) == unmodifiedType
+        ValidationUtil.getUnmodifiedType(new NonNullType(unmodifiedType)) == unmodifiedType
     }
 
     def "null and NonNull is invalid"() {

--- a/src/test/groovy/graphql/validation/rules/ArgumentsOfCorrectTypeTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/ArgumentsOfCorrectTypeTest.groovy
@@ -56,7 +56,11 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         then:
         errorCollector.containsValidationError(ValidationErrorType.WrongType)
         errorCollector.errors.size() == 1
-        errorCollector.errors[0].message == "Validation error of type WrongType: argument 'arg' with value 'StringValue{value='string'}' is not a valid 'Boolean'"
+        errorCollector.errors[0].message == "'string' is not a valid Boolean"
+        errorCollector.errors[0].getExtensions()["argument"] == "arg"
+        errorCollector.errors[0].getExtensions()["value"] == "string"
+        errorCollector.errors[0].getExtensions()["requiredType"] == "Boolean"
+        errorCollector.errors[0].getExtensions()["objectType"] == "Boolean"
     }
 
     def "invalid input object type results in error"() {
@@ -72,7 +76,11 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         then:
         errorCollector.containsValidationError(ValidationErrorType.WrongType)
         errorCollector.errors.size() == 1
-        errorCollector.errors[0].message == "Validation error of type WrongType: argument 'arg.foo' with value 'StringValue{value='string'}' is not a valid 'Boolean'"
+        errorCollector.errors[0].message == "'string' is not a valid Boolean"
+        errorCollector.errors[0].getExtensions()["argument"] == "arg.foo"
+        errorCollector.errors[0].getExtensions()["value"] == "string"
+        errorCollector.errors[0].getExtensions()["requiredType"] == "Boolean"
+        errorCollector.errors[0].getExtensions()["objectType"] == "ArgumentObjectType"
     }
 
     def "invalid list object type results in error"() {
@@ -92,7 +100,11 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         then:
         errorCollector.containsValidationError(ValidationErrorType.WrongType)
         errorCollector.errors.size() == 1
-        errorCollector.errors[0].message == "Validation error of type WrongType: argument 'arg[1].foo' with value 'StringValue{value='string'}' is not a valid 'Boolean'"
+        errorCollector.errors[0].message == "'string' is not a valid Boolean"
+        errorCollector.errors[0].getExtensions()["argument"] == "arg[1].foo"
+        errorCollector.errors[0].getExtensions()["value"] == "string"
+        errorCollector.errors[0].getExtensions()["requiredType"] == "Boolean"
+        errorCollector.errors[0].getExtensions()["objectType"] == "ArgumentObjectType"
     }
 
     def "invalid list inside object type results in error"() {
@@ -112,7 +124,11 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         then:
         errorCollector.containsValidationError(ValidationErrorType.WrongType)
         errorCollector.errors.size() == 1
-        errorCollector.errors[0].message == "Validation error of type WrongType: argument 'arg[0].foo[1]' with value 'StringValue{value='string'}' is not a valid 'Boolean'"
+        errorCollector.errors[0].message == "'string' is not a valid Boolean"
+        errorCollector.errors[0].getExtensions()["argument"] == "arg[0].foo[1]"
+        errorCollector.errors[0].getExtensions()["value"] == "string"
+        errorCollector.errors[0].getExtensions()["requiredType"] == "Boolean"
+        errorCollector.errors[0].getExtensions()["objectType"] == "ArgumentObjectType"
     }
 
     def "invalid list simple type results in error"() {
@@ -130,7 +146,11 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         then:
         errorCollector.containsValidationError(ValidationErrorType.WrongType)
         errorCollector.errors.size() == 1
-        errorCollector.errors[0].message == "Validation error of type WrongType: argument 'arg[1]' with value 'StringValue{value='string'}' is not a valid 'Boolean'"
+        errorCollector.errors[0].message == "'string' is not a valid Boolean"
+        errorCollector.errors[0].getExtensions()["argument"] == "arg[1]"
+        errorCollector.errors[0].getExtensions()["value"] == "string"
+        errorCollector.errors[0].getExtensions()["requiredType"] == "Boolean"
+        errorCollector.errors[0].getExtensions()["objectType"] == "Boolean"
     }
 
     def "type missing fields results in error"() {
@@ -152,7 +172,11 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         then:
         errorCollector.containsValidationError(ValidationErrorType.WrongType)
         errorCollector.errors.size() == 1
-        errorCollector.errors[0].message == "Validation error of type WrongType: argument 'arg' with value 'ObjectValue{objectFields=[ObjectField{name='foo', value=StringValue{value='string'}}]}' is missing required fields '[bar]'"
+        errorCollector.errors[0].message == "Required fields are missing: '[bar]'"
+        errorCollector.errors[0].getExtensions()["argument"] == "arg"
+        errorCollector.errors[0].getExtensions()["value"] == "ObjectValue{objectFields=[ObjectField{name='foo', value=StringValue{value='string'}}]}"
+        errorCollector.errors[0].getExtensions()["requiredType"] == "ArgumentObjectType"
+        errorCollector.errors[0].getExtensions()["objectType"] == "ArgumentObjectType"
     }
 
     def "type not object results in error"() {
@@ -172,7 +196,11 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         then:
         errorCollector.containsValidationError(ValidationErrorType.WrongType)
         errorCollector.errors.size() == 1
-        errorCollector.errors[0].message == "Validation error of type WrongType: argument 'arg' with value 'StringValue{value='string'}' must be an object type"
+        errorCollector.errors[0].message == "Value must be an object type"
+        errorCollector.errors[0].getExtensions()["argument"] == "arg"
+        errorCollector.errors[0].getExtensions()["value"] == "string"
+        errorCollector.errors[0].getExtensions()["requiredType"] == "ArgumentObjectType"
+        errorCollector.errors[0].getExtensions()["objectType"] == "ArgumentObjectType"
     }
 
     def "type null fields results in error"() {
@@ -194,7 +222,11 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         then:
         errorCollector.containsValidationError(ValidationErrorType.WrongType)
         errorCollector.errors.size() == 1
-        errorCollector.errors[0].message == "Validation error of type WrongType: argument 'arg.bar' with value 'NullValue{}' must not be null"
+        errorCollector.errors[0].message == "Value must not be null"
+        errorCollector.errors[0].getExtensions()["argument"] == "arg.bar"
+        errorCollector.errors[0].getExtensions()["value"] == "null"
+        errorCollector.errors[0].getExtensions()["requiredType"] == "String!"
+        errorCollector.errors[0].getExtensions()["objectType"] == "ArgumentObjectType"
     }
 
     def "type with extra fields results in error"() {
@@ -216,7 +248,11 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         then:
         errorCollector.containsValidationError(ValidationErrorType.WrongType)
         errorCollector.errors.size() == 1
-        errorCollector.errors[0].message == "Validation error of type WrongType: argument 'arg' with value 'ObjectValue{objectFields=[ObjectField{name='foo', value=StringValue{value='string'}}, ObjectField{name='bar', value=StringValue{value='string'}}, ObjectField{name='fooBar', value=BooleanValue{value=true}}]}' contains a field not in 'ArgumentObjectType': 'fooBar'"
+        errorCollector.errors[0].message == "Value contains a field not in 'ArgumentObjectType': 'fooBar'"
+        errorCollector.errors[0].getExtensions()["argument"] == "arg"
+        errorCollector.errors[0].getExtensions()["value"] == "ObjectValue{objectFields=[ObjectField{name='foo', value=StringValue{value='string'}}, ObjectField{name='bar', value=StringValue{value='string'}}, ObjectField{name='fooBar', value=BooleanValue{value=true}}]}"
+        errorCollector.errors[0].getExtensions()["requiredType"] == "ArgumentObjectType"
+        errorCollector.errors[0].getExtensions()["objectType"] == "ArgumentObjectType"
     }
 
     def "current null argument from context is no error"() {

--- a/src/test/groovy/graphql/validation/rules/ArgumentsOfCorrectTypeTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/ArgumentsOfCorrectTypeTest.groovy
@@ -61,6 +61,7 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         errorCollector.errors[0].getExtensions()["value"] == "string"
         errorCollector.errors[0].getExtensions()["requiredType"] == "Boolean"
         errorCollector.errors[0].getExtensions()["objectType"] == "Boolean"
+        errorCollector.errors[0].getExtensions()["validationErrorType"] == "WrongType"
     }
 
     def "invalid input object type results in error"() {
@@ -159,9 +160,9 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         def argumentLiteral = new Argument("arg", objectValue)
         def graphQLArgument = new GraphQLArgument("arg", GraphQLInputObjectType.newInputObject().name("ArgumentObjectType")
                 .field(GraphQLInputObjectField.newInputObjectField()
-                .name("foo").type(GraphQLNonNull.nonNull(GraphQLString)))
+                        .name("foo").type(GraphQLNonNull.nonNull(GraphQLString)))
                 .field(GraphQLInputObjectField.newInputObjectField()
-                .name("bar").type(GraphQLNonNull.nonNull(GraphQLString)))
+                        .name("bar").type(GraphQLNonNull.nonNull(GraphQLString)))
                 .build())
 
         argumentsOfCorrectType.validationContext.getArgument() >> graphQLArgument
@@ -185,9 +186,9 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         def argumentLiteral = new Argument("arg", objectValue)
         def graphQLArgument = new GraphQLArgument("arg", GraphQLInputObjectType.newInputObject().name("ArgumentObjectType")
                 .field(GraphQLInputObjectField.newInputObjectField()
-                .name("foo").type(GraphQLNonNull.nonNull(GraphQLString)))
+                        .name("foo").type(GraphQLNonNull.nonNull(GraphQLString)))
                 .field(GraphQLInputObjectField.newInputObjectField()
-                .name("bar").type(GraphQLNonNull.nonNull(GraphQLString)))
+                        .name("bar").type(GraphQLNonNull.nonNull(GraphQLString)))
                 .build())
 
         argumentsOfCorrectType.validationContext.getArgument() >> graphQLArgument
@@ -209,9 +210,9 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         def argumentLiteral = new Argument("arg", objectValue)
         def graphQLArgument = new GraphQLArgument("arg", GraphQLInputObjectType.newInputObject().name("ArgumentObjectType")
                 .field(GraphQLInputObjectField.newInputObjectField()
-                .name("foo").type(GraphQLNonNull.nonNull(GraphQLString)))
+                        .name("foo").type(GraphQLNonNull.nonNull(GraphQLString)))
                 .field(GraphQLInputObjectField.newInputObjectField()
-                .name("bar").type(GraphQLNonNull.nonNull(GraphQLString)))
+                        .name("bar").type(GraphQLNonNull.nonNull(GraphQLString)))
                 .build())
 
         argumentsOfCorrectType.validationContext.getArgument() >> graphQLArgument
@@ -235,9 +236,9 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         def argumentLiteral = new Argument("arg", objectValue)
         def graphQLArgument = new GraphQLArgument("arg", GraphQLInputObjectType.newInputObject().name("ArgumentObjectType")
                 .field(GraphQLInputObjectField.newInputObjectField()
-                .name("foo").type(GraphQLNonNull.nonNull(GraphQLString)))
+                        .name("foo").type(GraphQLNonNull.nonNull(GraphQLString)))
                 .field(GraphQLInputObjectField.newInputObjectField()
-                .name("bar").type(GraphQLNonNull.nonNull(GraphQLString)))
+                        .name("bar").type(GraphQLNonNull.nonNull(GraphQLString)))
                 .build())
 
         argumentsOfCorrectType.validationContext.getArgument() >> graphQLArgument

--- a/src/test/groovy/graphql/validation/rules/FieldsOnCorrectTypeTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/FieldsOnCorrectTypeTest.groovy
@@ -28,7 +28,8 @@ class FieldsOnCorrectTypeTest extends Specification {
         then:
         errorCollector.containsValidationError(ValidationErrorType.FieldUndefined)
         errorCollector.errors.size() == 1
-        errorCollector.errors[0].message == "Validation error of type FieldUndefined: Field 'name' in type 'parentType' is undefined"
+        errorCollector.errors[0].message == "Field 'name' in type 'parentType' is undefined"
+        errorCollector.errors[0].extensions["validationErrorType"] == "FieldUndefined"
     }
 
     def "should results in no error when field definition is filled"() {

--- a/src/test/groovy/graphql/validation/rules/FragmentsOnCompositeTypeTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/FragmentsOnCompositeTypeTest.groovy
@@ -26,7 +26,8 @@ class FragmentsOnCompositeTypeTest extends Specification {
         then:
         errorCollector.containsValidationError(ValidationErrorType.InlineFragmentTypeConditionInvalid)
         errorCollector.errors.size() == 1
-        errorCollector.errors[0].message == "Validation error of type InlineFragmentTypeConditionInvalid: Inline fragment type condition is invalid, must be on Object/Interface/Union"
+        errorCollector.errors[0].message == "Inline fragment type condition is invalid, must be on Object/Interface/Union"
+        errorCollector.errors[0].extensions["validationErrorType"] == "InlineFragmentTypeConditionInvalid"
     }
 
     def "should results in no error"(InlineFragment inlineFragment) {

--- a/src/test/groovy/graphql/validation/rules/OverlappingFieldsCanBeMergedTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/OverlappingFieldsCanBeMergedTest.groovy
@@ -73,8 +73,10 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
 
         then:
         errorCollector.getErrors().size() == 1
-        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: myName: name and nickname are different fields @ 'f'"
+        errorCollector.getErrors()[0].message == "myName: name and nickname are different fields"
         errorCollector.getErrors()[0].locations == [new SourceLocation(3, 17), new SourceLocation(4, 17)]
+        errorCollector.getErrors()[0].extensions["validationErrorType"] == "FieldsConflict"
+        errorCollector.getErrors()[0].extensions["queryPath"] == ["f"]
     }
 
     GraphQLSchema unionSchema() {
@@ -134,7 +136,9 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
 
         then:
         errorCollector.getErrors().size() == 1
-        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: scalar: they return differing types Int and String @ 'boxUnion'"
+        errorCollector.getErrors()[0].message == "scalar: they return differing types Int and String"
+        errorCollector.getErrors()[0].extensions["validationErrorType"] == "FieldsConflict"
+        errorCollector.getErrors()[0].extensions["queryPath"] == ["boxUnion"]
     }
 
 
@@ -182,7 +186,9 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
 
         then:
         errorCollector.getErrors().size() == 1
-        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: scalar: fields have different nullability shapes @ 'boxUnion'"
+        errorCollector.getErrors()[0].message == "scalar: fields have different nullability shapes"
+        errorCollector.getErrors()[0].extensions["validationErrorType"] == "FieldsConflict"
+        errorCollector.getErrors()[0].extensions["queryPath"] == ["boxUnion"]
     }
 
     def 'not the same list return types'() {
@@ -206,7 +212,9 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
 
         then:
         errorCollector.getErrors().size() == 1
-        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: scalar: fields have different list shapes @ 'boxUnion'"
+        errorCollector.getErrors()[0].message == "scalar: fields have different list shapes"
+        errorCollector.getErrors()[0].extensions["validationErrorType"] == "FieldsConflict"
+        errorCollector.getErrors()[0].extensions["queryPath"] == ["boxUnion"]
     }
 
 
@@ -313,8 +321,10 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
 
         then:
         errorCollector.getErrors().size() == 1
-        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: fido: name and nickname are different fields @ 'sameAliasesWithDifferentFieldTargets'"
+        errorCollector.getErrors()[0].message == "fido: name and nickname are different fields"
         errorCollector.getErrors()[0].locations == [new SourceLocation(3, 13), new SourceLocation(4, 13)]
+        errorCollector.getErrors()[0].extensions["validationErrorType"] == "FieldsConflict"
+        errorCollector.getErrors()[0].extensions["queryPath"] == ["sameAliasesWithDifferentFieldTargets"]
     }
 
     def 'Alias masking direct field access'() {
@@ -330,8 +340,10 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
 
         then:
         errorCollector.getErrors().size() == 1
-        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: name: nickname and name are different fields @ 'aliasMaskingDirectFieldAccess'"
+        errorCollector.getErrors()[0].message == "name: nickname and name are different fields"
         errorCollector.getErrors()[0].locations == [new SourceLocation(3, 13), new SourceLocation(4, 13)]
+        errorCollector.getErrors()[0].extensions["validationErrorType"] == "FieldsConflict"
+        errorCollector.getErrors()[0].extensions["queryPath"] == ["aliasMaskingDirectFieldAccess"]
     }
 
     def 'conflicting args'() {
@@ -347,8 +359,10 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
 
         then:
         errorCollector.getErrors().size() == 1
-        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: doesKnowCommand: they have differing arguments @ 'conflictingArgs'"
+        errorCollector.getErrors()[0].message == "doesKnowCommand: they have differing arguments"
         errorCollector.getErrors()[0].locations == [new SourceLocation(3, 13), new SourceLocation(4, 13)]
+        errorCollector.getErrors()[0].extensions["validationErrorType"] == "FieldsConflict"
+        errorCollector.getErrors()[0].extensions["queryPath"] == ["conflictingArgs"]
     }
 
     //
@@ -390,8 +404,9 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
 
         then:
         errorCollector.getErrors().size() == 1
-        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: x: a and b are different fields"
+        errorCollector.getErrors()[0].message == "x: a and b are different fields"
         errorCollector.getErrors()[0].locations == [new SourceLocation(7, 13), new SourceLocation(10, 13)]
+        errorCollector.getErrors()[0].extensions["validationErrorType"] == "FieldsConflict"
     }
 
     def 'reports each conflict once'() {
@@ -424,14 +439,20 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
         then:
         errorCollector.getErrors().size() == 3
 
-        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: x: a and b are different fields @ 'f1'"
+        errorCollector.getErrors()[0].message == "x: a and b are different fields"
         errorCollector.getErrors()[0].locations == [new SourceLocation(18, 13), new SourceLocation(21, 13)]
+        errorCollector.getErrors()[0].extensions["validationErrorType"] == "FieldsConflict"
+        errorCollector.getErrors()[0].extensions["queryPath"] == ["f1"]
 
-        errorCollector.getErrors()[1].message == "Validation error of type FieldsConflict: x: a and c are different fields @ 'f3'"
+        errorCollector.getErrors()[1].message == "x: a and c are different fields"
         errorCollector.getErrors()[1].locations == [new SourceLocation(18, 13), new SourceLocation(14, 17)]
+        errorCollector.getErrors()[1].extensions["validationErrorType"] == "FieldsConflict"
+        errorCollector.getErrors()[1].extensions["queryPath"] == ["f3"]
 
-        errorCollector.getErrors()[2].message == "Validation error of type FieldsConflict: x: b and c are different fields @ 'f3'"
+        errorCollector.getErrors()[2].message == "x: b and c are different fields"
         errorCollector.getErrors()[2].locations == [new SourceLocation(21, 13), new SourceLocation(14, 17)]
+        errorCollector.getErrors()[2].extensions["validationErrorType"] == "FieldsConflict"
+        errorCollector.getErrors()[2].extensions["queryPath"] == ["f3"]
     }
 
 
@@ -451,8 +472,9 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
 
         then:
         errorCollector.getErrors().size() == 1
-        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: field: (x: a and b are different fields)"
+        errorCollector.getErrors()[0].message == "field: (x: a and b are different fields)"
         errorCollector.getErrors()[0].locations.size() == 4
+        errorCollector.getErrors()[0].extensions["validationErrorType"] == "FieldsConflict"
     }
 
     def 'deep conflict with multiple issues'() {
@@ -473,8 +495,9 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
 
         then:
         errorCollector.getErrors().size() == 1
-        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: field: (x: a and b are different fields, y: c and d are different fields)"
+        errorCollector.getErrors()[0].message == "field: (x: a and b are different fields, y: c and d are different fields)"
         errorCollector.getErrors()[0].locations.size() == 6
+        errorCollector.getErrors()[0].extensions["validationErrorType"] == "FieldsConflict"
     }
 
     def 'very deep conflict'() {
@@ -498,8 +521,9 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
 
         then:
         errorCollector.getErrors().size() == 1
-        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: field: (deepField: (x: a and b are different fields))"
+        errorCollector.getErrors()[0].message == "field: (deepField: (x: a and b are different fields))"
         errorCollector.getErrors()[0].locations.size() == 6
+        errorCollector.getErrors()[0].extensions["validationErrorType"] == "FieldsConflict"
     }
 
     def 'reports deep conflict to nearest common ancestor'() {
@@ -525,8 +549,10 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
 
         then:
         errorCollector.getErrors().size() == 1
-        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: deepField: (x: a and b are different fields) @ 'field'"
+        errorCollector.getErrors()[0].message == "deepField: (x: a and b are different fields)"
         errorCollector.getErrors()[0].locations.size() == 4
+        errorCollector.getErrors()[0].extensions["validationErrorType"] == "FieldsConflict"
+        errorCollector.getErrors()[0].extensions["queryPath"] == ["field"]
     }
 
 

--- a/src/test/groovy/graphql/validation/rules/PossibleFragmentSpreadsTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/PossibleFragmentSpreadsTest.groovy
@@ -179,7 +179,9 @@ class PossibleFragmentSpreadsTest extends Specification {
 
         then:
         errorCollector.getErrors().size() == 1
-        errorCollector.getErrors().get(0).message == 'Validation error of type InvalidFragmentType: Fragment cannot be spread here as objects of type Cat can never be of type Dog @ \'invalidObjectWithinObjectAnon\''
+        errorCollector.getErrors().get(0).message == 'Fragment cannot be spread here as objects of type Cat can never be of type Dog'
+        errorCollector.getErrors()[0].extensions["validationErrorType"] == "InvalidFragmentType"
+        errorCollector.getErrors()[0].extensions["queryPath"] == ["invalidObjectWithinObjectAnon"]
     }
 
     def 'object into not implementing interface'() {
@@ -192,7 +194,9 @@ class PossibleFragmentSpreadsTest extends Specification {
 
         then:
         errorCollector.getErrors().size() == 1
-        errorCollector.getErrors().get(0).message == 'Validation error of type InvalidFragmentType: Fragment humanFragment cannot be spread here as objects of type Pet can never be of type Human @ \'invalidObjectWithinInterface\''
+        errorCollector.getErrors().get(0).message == 'Fragment humanFragment cannot be spread here as objects of type Pet can never be of type Human'
+        errorCollector.getErrors()[0].extensions["validationErrorType"] == "InvalidFragmentType"
+        errorCollector.getErrors()[0].extensions["queryPath"] == ["invalidObjectWithinInterface"]
     }
 
     def 'object into not containing union'() {


### PR DESCRIPTION
This PR merges #1725 with #1727 to address #1686 .

Both PRs improves scalars validation by preserving the original scalar coercion error messages.
 
#1725 allows `CoercingParseLiteralException`, `CoercingParseValueException` & `CoercingSerializeException` to include extensions map that is carried to the serialized errors. That is useful for conveying specific information in particular scalars validation logic (e.g. the allowed pattern).

#1727 automatically populates the extensions map for all errors with the information that is available at the framework level (`validationErrorType`, `queryPath`, `argument`, `value`, `requiredType`, `objectType`). This information is not available at the scalars coercion point. Since this information is provided in the extensions map, this PR simplified error messages by stripping the messages from having that information concatenated to them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/graphql-java/graphql-java/1728)
<!-- Reviewable:end -->
