### PR TITLE
rename SDL schema transformer into SchemaGeneratorPostProcessing

### DIFF
--- a/src/main/java/graphql/schema/idl/RuntimeWiring.java
+++ b/src/main/java/graphql/schema/idl/RuntimeWiring.java
@@ -34,7 +34,7 @@ public class RuntimeWiring {
     private final List<SchemaDirectiveWiring> directiveWiring;
     private final WiringFactory wiringFactory;
     private final Map<String, EnumValuesProvider> enumValuesProviders;
-    private final Collection<SchemaTransformer> schemaTransformers;
+    private final Collection<SchemaGeneratorPostProcessing> schemaGeneratorPostProcessings;
     private final GraphqlFieldVisibility fieldVisibility;
     private final GraphQLCodeRegistry codeRegistry;
     private final GraphqlTypeComparatorRegistry comparatorRegistry;
@@ -48,7 +48,7 @@ public class RuntimeWiring {
         this.directiveWiring = builder.directiveWiring;
         this.wiringFactory = builder.wiringFactory;
         this.enumValuesProviders = builder.enumValuesProviders;
-        this.schemaTransformers = builder.schemaTransformers;
+        this.schemaGeneratorPostProcessings = builder.schemaGeneratorPostProcessings;
         this.fieldVisibility = builder.fieldVisibility;
         this.codeRegistry = builder.codeRegistry;
         this.comparatorRegistry = builder.comparatorRegistry;
@@ -105,8 +105,8 @@ public class RuntimeWiring {
         return directiveWiring;
     }
 
-    public Collection<SchemaTransformer> getSchemaTransformers() {
-        return schemaTransformers;
+    public Collection<SchemaGeneratorPostProcessing> getSchemaGeneratorPostProcessings() {
+        return schemaGeneratorPostProcessings;
     }
 
     public GraphqlTypeComparatorRegistry getComparatorRegistry() {
@@ -122,7 +122,7 @@ public class RuntimeWiring {
         private final Map<String, EnumValuesProvider> enumValuesProviders = new LinkedHashMap<>();
         private final Map<String, SchemaDirectiveWiring> registeredDirectiveWiring = new LinkedHashMap<>();
         private final List<SchemaDirectiveWiring> directiveWiring = new ArrayList<>();
-        private final Collection<SchemaTransformer> schemaTransformers = new ArrayList<>();
+        private final Collection<SchemaGeneratorPostProcessing> schemaGeneratorPostProcessings = new ArrayList<>();
         private WiringFactory wiringFactory = new NoopWiringFactory();
         private GraphqlFieldVisibility fieldVisibility = DEFAULT_FIELD_VISIBILITY;
         private GraphQLCodeRegistry codeRegistry = GraphQLCodeRegistry.newCodeRegistry().build();
@@ -304,12 +304,12 @@ public class RuntimeWiring {
         /**
          * Adds a schema transformer into the mix
          *
-         * @param schemaTransformer the non null schema transformer to add
+         * @param schemaGeneratorPostProcessing the non null schema transformer to add
          *
          * @return the runtime wiring builder
          */
-        public Builder transformer(SchemaTransformer schemaTransformer) {
-            this.schemaTransformers.add(assertNotNull(schemaTransformer));
+        public Builder transformer(SchemaGeneratorPostProcessing schemaGeneratorPostProcessing) {
+            this.schemaGeneratorPostProcessings.add(assertNotNull(schemaGeneratorPostProcessing));
             return this;
         }
 

--- a/src/main/java/graphql/schema/idl/SchemaGenerator.java
+++ b/src/main/java/graphql/schema/idl/SchemaGenerator.java
@@ -339,9 +339,9 @@ public class SchemaGenerator {
 
         GraphQLSchema graphQLSchema = schemaBuilder.build();
 
-        Collection<SchemaTransformer> schemaTransformers = buildCtx.getWiring().getSchemaTransformers();
-        for (SchemaTransformer schemaTransformer : schemaTransformers) {
-            graphQLSchema = schemaTransformer.transform(graphQLSchema);
+        Collection<SchemaGeneratorPostProcessing> schemaGeneratorPostProcessings = buildCtx.getWiring().getSchemaGeneratorPostProcessings();
+        for (SchemaGeneratorPostProcessing schemaGeneratorPostProcessing : schemaGeneratorPostProcessings) {
+            graphQLSchema = schemaGeneratorPostProcessing.process(graphQLSchema);
         }
         return graphQLSchema;
     }

--- a/src/main/java/graphql/schema/idl/SchemaGeneratorPostProcessing.java
+++ b/src/main/java/graphql/schema/idl/SchemaGeneratorPostProcessing.java
@@ -6,7 +6,7 @@ import graphql.schema.GraphQLSchema;
  * These are called by the {@link SchemaGenerator} after a valid schema has been built
  * and they can then adjust it accordingly with some sort of post processing.
  */
-public interface SchemaTransformer {
+public interface SchemaGeneratorPostProcessing {
 
     /**
      * Called to transform the schema from its built state into something else
@@ -15,5 +15,5 @@ public interface SchemaTransformer {
      *
      * @return a non null schema
      */
-    GraphQLSchema transform(GraphQLSchema originalSchema);
+    GraphQLSchema process(GraphQLSchema originalSchema);
 }

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -1741,9 +1741,9 @@ class SchemaGeneratorTest extends Specification {
 
         def extraDirective = (GraphQLDirective.newDirective()).name("extra")
                 .argument(GraphQLArgument.newArgument().name("value").type(GraphQLString)).build()
-        def transformer = new SchemaTransformer() {
+        def transformer = new SchemaGeneratorPostProcessing() {
             @Override
-            GraphQLSchema transform(GraphQLSchema originalSchema) {
+            GraphQLSchema process(GraphQLSchema originalSchema) {
                 originalSchema.transform({ builder -> builder.additionalDirective(extraDirective) })
             }
         }


### PR DESCRIPTION
We introduced recently the general `SchemaTransformer` class, therefore we rename this SDL specific post processor.