### PR TITLE
bugfix: comments on interface arguments cause wrong error for schema validation

### DIFF
--- a/src/main/java/graphql/schema/idl/SchemaTypeChecker.java
+++ b/src/main/java/graphql/schema/idl/SchemaTypeChecker.java
@@ -518,8 +518,8 @@ public class SchemaTypeChecker {
         for (int i = 0; i < interfaceArgs.size(); i++) {
             InputValueDefinition interfaceArg = interfaceArgs.get(i);
             InputValueDefinition objectArg = objectArgs.get(i);
-            String interfaceArgStr = AstPrinter.printAst(interfaceArg);
-            String objectArgStr = AstPrinter.printAst(objectArg);
+            String interfaceArgStr = AstPrinter.printAstCompact(interfaceArg);
+            String objectArgStr = AstPrinter.printAstCompact(objectArg);
             if (!interfaceArgStr.equals(objectArgStr)) {
                 errors.add(new InterfaceFieldArgumentRedefinitionError(typeOfType, objectTypeDef, interfaceTypeDef, objectFieldDef, objectArgStr, interfaceArgStr));
             }

--- a/src/test/groovy/graphql/schema/idl/SchemaTypeCheckerTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaTypeCheckerTest.groovy
@@ -1,6 +1,7 @@
 package graphql.schema.idl
 
 import graphql.GraphQLError
+import graphql.TestUtil
 import graphql.TypeResolutionEnvironment
 import graphql.language.StringValue
 import graphql.schema.Coercing
@@ -1522,6 +1523,100 @@ class SchemaTypeCheckerTest extends Specification {
         "UserInput"    | '{ fieldNonNull: "str", fieldArray: ["Hey", "Low"] }'
         "UserInput"    | '{ fieldNonNull: "str", fieldArrayOfArray: [["Hey"], ["Low"]] }'
         "UserInput"    | '{ fieldNonNull: "str", fieldNestedInput: { street: "nestedStr"} }'
+    }
+
+
+    def "different field descriptions on interface vs implementation should not cause an error "() {
+        given:
+        def sdl = """
+        type Query { hello: String }
+        interface Customer {
+            "The display name of the customer"
+            displayName: String!
+        }
+
+        type PersonCustomer implements Customer {
+            "The display name of the customer. For persons, this is the first and last name."
+            displayName: String!
+        }
+
+        type CompanyCustomer implements Customer {
+            "The display name of the customer. For companies, this is the company name and its form."
+            displayName: String!
+        }"""
+
+        when:
+        def schema = TestUtil.schema(sdl);
+
+        then:
+        schema != null
+
+    }
+
+    def "different argument descriptions on interface vs implementation should not cause an error "() {
+        given:
+        def sdl = """
+        type Query { hello: String }
+        
+        interface Customer {
+            displayName(
+            "interface arg"
+            arg: String
+            ): String!
+        }
+
+        type PersonCustomer implements Customer {
+            displayName(
+            "impl arg 1"
+            arg: String
+            ): String!
+        }
+
+        type CompanyCustomer implements Customer {
+            displayName(
+            arg: String
+            ): String!
+        }"""
+
+        when:
+        def schema = TestUtil.schema(sdl);
+
+        then:
+        schema != null
+
+    }
+
+    def "different argument comments on interface vs implementation should not cause an error "() {
+        given:
+        def sdl = """
+        type Query { hello: String }
+        
+        interface Customer {
+            displayName(
+            # interface arg
+            arg: String
+            ): String!
+        }
+
+        type PersonCustomer implements Customer {
+            displayName(
+            # impl arg 1
+            arg: String
+            ): String!
+        }
+
+        type CompanyCustomer implements Customer {
+            displayName(
+            arg: String
+            ): String!
+        }"""
+
+        when:
+        def schema = TestUtil.schema(sdl);
+
+        then:
+        schema != null
+
     }
 
 }


### PR DESCRIPTION
bugfix: comments on nodes should not considered  when comparing arguments of interface vs implementation.

This fixes #1701 