### PR TITLE
Bugfix: multiple GraphQL sub types printing #1709

### DIFF
--- a/src/main/java/graphql/schema/idl/SchemaPrinter.java
+++ b/src/main/java/graphql/schema/idl/SchemaPrinter.java
@@ -817,18 +817,19 @@ public class SchemaPrinter {
 
     @SuppressWarnings("unchecked")
     private <T> TypePrinter<T> printer(Class<?> clazz) {
-        TypePrinter typePrinter = printers.computeIfAbsent(clazz, k -> {
+        TypePrinter typePrinter = printers.get(clazz);
+        if (typePrinter == null) {
             Class<?> superClazz = clazz.getSuperclass();
-            TypePrinter result;
             if (superClazz != Object.class) {
-                result = printer(superClazz);
+                typePrinter = printer(superClazz);
             } else {
-                result = (out, type, visibility) -> out.println("Type not implemented : " + type);
+                typePrinter = (out, type, visibility) -> out.println("Type not implemented : " + type);
             }
-            return result;
-        });
+            printers.put(clazz, typePrinter);
+        }
         return (TypePrinter<T>) typePrinter;
     }
+
 
     public String print(GraphQLType type) {
         StringWriter sw = new StringWriter();

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -83,6 +83,14 @@ class SchemaPrinterTest extends Specification {
         }
     }
 
+    static class MyTestGraphQLObjectType extends MyGraphQLObjectType {
+
+        MyTestGraphQLObjectType(String name, String description, List<GraphQLFieldDefinition> fieldDefinitions) {
+            super(name, description, fieldDefinitions)
+        }
+    }
+
+
     def "typeString"() {
 
         GraphQLType type1 = nonNull(list(nonNull(list(nonNull(Scalars.GraphQLInt)))))
@@ -589,6 +597,23 @@ scalar Scalar
 About Query
 Second Line
 """
+type Query {
+  field: String
+}
+'''
+    }
+
+    def "concurrentModificationException should not occur"() {
+        given:
+        GraphQLFieldDefinition fieldDefinition = newFieldDefinition().name("field").type(GraphQLString).build()
+        def queryType = new MyTestGraphQLObjectType("Query", "test", Arrays.asList(fieldDefinition))
+        def schema = GraphQLSchema.newSchema().query(queryType).build()
+
+        when:
+        def result = new SchemaPrinter(noDirectivesOption).print(schema)
+
+        then:
+        result == '''"test"
 type Query {
   field: String
 }

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -603,7 +603,7 @@ type Query {
 '''
     }
 
-    def "concurrentModificationException should not occur"() {
+    def "concurrentModificationException should not occur when multiple extended graphQL types are used"() {
         given:
         GraphQLFieldDefinition fieldDefinition = newFieldDefinition().name("field").type(GraphQLString).build()
         def queryType = new MyTestGraphQLObjectType("Query", "test", Arrays.asList(fieldDefinition))


### PR DESCRIPTION
This PR re-implements the printer() function to prevent an exception (ConcurrentModificationException) from happening due to a possible new, extended GraphQL type class used in schemaPrinter. The issue was happening due to the Map#computeIfAbsent() function and adding keys while still being modified. This issue can be found at https://github.com/graphql-java/graphql-java/issues/1709 . 