### PR TITLE
backport of #1589 to 9.x: Non-null input object fields with default values should be valid

### DIFF
--- a/src/main/java/graphql/validation/ValidationUtil.java
+++ b/src/main/java/graphql/validation/ValidationUtil.java
@@ -150,6 +150,7 @@ public class ValidationUtil {
     private Set<String> getMissingFields(GraphQLInputObjectType type, Map<String, ObjectField> objectFieldMap, GraphqlFieldVisibility fieldVisibility) {
         return fieldVisibility.getFieldDefinitions(type).stream()
                 .filter(field -> isNonNull(field.getType()))
+                .filter(value -> (value.getDefaultValue() == null) && !objectFieldMap.containsKey(value.getName()))
                 .map(GraphQLInputObjectField::getName)
                 .filter(((Predicate<String>) objectFieldMap::containsKey).negate())
                 .collect(Collectors.toSet());


### PR DESCRIPTION
Backport of #1589: Non-null input object fields with default values should be valid