### PR TITLE
backport of #1637 to 9.x: Print directive argument only when it has a value

### DIFF
--- a/src/main/java/graphql/schema/idl/SchemaPrinter.java
+++ b/src/main/java/graphql/schema/idl/SchemaPrinter.java
@@ -474,16 +474,19 @@ public class SchemaPrinter {
             sb.append("(");
             for (int i = 0; i < args.size(); i++) {
                 GraphQLArgument arg = args.get(i);
-                sb.append(arg.getName());
+                String argValue = null;
                 if (arg.getValue() != null) {
-                    sb.append(" : ");
-                    sb.append(printAst(arg.getValue(), arg.getType()));
+                    argValue = printAst(arg.getValue(), arg.getType());
                 } else if (arg.getDefaultValue() != null) {
-                    sb.append(" : ");
-                    sb.append(printAst(arg.getDefaultValue(), arg.getType()));
+                    argValue = printAst(arg.getDefaultValue(), arg.getType());
                 }
-                if (i < args.size() - 1) {
-                    sb.append(", ");
+                if (!isNullOrEmpty(argValue)) {
+                    sb.append(arg.getName());
+                    sb.append(" : ");
+                    sb.append(argValue);
+                    if (i < args.size() - 1) {
+                        sb.append(", ");
+                    }
                 }
             }
             sb.append(")");

--- a/src/test/groovy/graphql/TestUtil.groovy
+++ b/src/test/groovy/graphql/TestUtil.groovy
@@ -24,8 +24,10 @@ import graphql.schema.idl.errors.SchemaProblem
 
 import java.util.stream.Collectors
 
+import static graphql.Scalars.GraphQLInt
 import static graphql.Scalars.GraphQLString
 import static graphql.schema.GraphQLArgument.newArgument
+import static graphql.schema.GraphQLDirective.newDirective
 
 class TestUtil {
 
@@ -171,6 +173,28 @@ class TestUtil {
 
     static Document parseQuery(String query) {
         new Parser().parseDocument(query)
+    }
+
+    static GraphQLDirective[] mockDirectivesWithArguments(String... names) {
+        return names.collect { directiveName ->
+            def builder = newDirective().name(directiveName)
+
+            names.each { argName ->
+                builder.argument(newArgument().name(argName).type(GraphQLInt).value(BigInteger.valueOf(0)).build())
+            }
+            return builder.build()
+        }.toArray() as GraphQLDirective[]
+    }
+
+    static GraphQLDirective[] mockDirectivesWithNoValueArguments(String... names) {
+        return names.collect { directiveName ->
+            def builder = newDirective().name(directiveName)
+
+            names.each { argName ->
+                builder.argument(newArgument().name(argName).type(GraphQLInt).build())
+            }
+            return builder.build()
+        }.toArray() as GraphQLDirective[]
     }
 
 }

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -8,7 +8,6 @@ import graphql.introspection.IntrospectionQuery
 import graphql.introspection.IntrospectionResultToSchema
 import graphql.schema.Coercing
 import graphql.schema.GraphQLArgument
-import graphql.schema.GraphQLDirective
 import graphql.schema.GraphQLEnumType
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLInputObjectType
@@ -23,11 +22,10 @@ import graphql.schema.GraphQLUnionType
 import graphql.schema.TypeResolver
 import spock.lang.Specification
 
-import java.util.Collections
 import java.util.function.UnaryOperator
 
 import static graphql.Scalars.GraphQLString
-import static graphql.TestUtil.mockDirective
+import static graphql.TestUtil.mockDirectivesWithNoValueArguments
 import static graphql.TestUtil.mockScalar
 import static graphql.TestUtil.mockTypeRuntimeWiring
 import static graphql.schema.GraphQLArgument.newArgument
@@ -880,5 +878,21 @@ enum Enum {
 '''
     }
 
+    def "directive string when argument has no value"() {
+        given:
+        GraphQLScalarType scalarType = GraphQLScalarType.newScalar(mockScalar("TestScalar"))
+                .withDirectives(mockDirectivesWithNoValueArguments("a", "bb"))
+                .build()
+
+        when:
+        def options = defaultOptions().includeScalarTypes(true).includeExtendedScalarTypes(true)
+        def result = new SchemaPrinter(options).print(scalarType)
+
+        then:
+        result == '''#TestScalar
+scalar TestScalar @a() @bb()
+
+'''
+    }
 }
 


### PR DESCRIPTION
Bugfix SchemaPrinter: Print directive argument only when it has a value