### PR TITLE
backport of #1694: additional optional arguments fields defined by interfaces

### DIFF
--- a/src/main/java/graphql/schema/idl/errors/InterfaceFieldArgumentNotOptionalError.java
+++ b/src/main/java/graphql/schema/idl/errors/InterfaceFieldArgumentNotOptionalError.java
@@ -1,0 +1,14 @@
+package graphql.schema.idl.errors;
+
+import graphql.language.FieldDefinition;
+import graphql.language.InterfaceTypeDefinition;
+import graphql.language.ObjectTypeDefinition;
+
+import static java.lang.String.format;
+
+public class InterfaceFieldArgumentNotOptionalError extends BaseError {
+    public InterfaceFieldArgumentNotOptionalError(String typeOfType, ObjectTypeDefinition objectTypeDef, InterfaceTypeDefinition interfaceTypeDef, FieldDefinition objectFieldDef, String objectArgStr) {
+        super(objectTypeDef, format("The %s type '%s' %s field '%s' defines an additional non-optional argument '%s' which is not allowed because field is also defined in interface '%s' %s.",
+                typeOfType, objectTypeDef.getName(), lineCol(objectTypeDef), objectFieldDef.getName(), objectArgStr, interfaceTypeDef.getName(), lineCol(interfaceTypeDef)));
+    }
+}

--- a/src/test/groovy/graphql/schema/idl/SchemaTypeCheckerTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaTypeCheckerTest.groovy
@@ -1526,4 +1526,55 @@ class SchemaTypeCheckerTest extends Specification {
         "UserInput"    | '{ fieldNonNull: "str", fieldNestedInput: { street: "nestedStr"} }'
     }
 
+    def "test field arguments on object can contain additional optional arguments"() {
+        def spec = """
+            interface InterfaceType {
+                fieldA : Int
+                fieldB(arg1 : String = "defaultVal") : String
+            }
+            type BaseType {
+                fieldX : Int
+            }
+            extend type BaseType implements InterfaceType {
+                fieldA(arg1 : String) : Int
+                fieldB(arg1 : String = "defaultVal", arg2 : String) : String
+            }
+            schema {
+              query : BaseType
+            }
+        """
+
+        def result = check(spec)
+
+        expect:
+
+        result.isEmpty()
+    }
+
+    def "test field arguments on object cannot contain additional required arguments"() {
+        def spec = """
+            interface InterfaceType {
+                fieldA : Int
+                fieldB(arg1 : String = "defaultVal") : String
+            }
+            type BaseType {
+                fieldX : Int
+            }
+            extend type BaseType implements InterfaceType {
+                fieldA(arg1 : String!) : Int
+                fieldB(arg1 : String = "defaultVal", arg2 : String!) : String
+            }
+            schema {
+              query : BaseType
+            }
+        """
+
+        def result = check(spec)
+
+        expect:
+
+        result.get(0).getMessage().contains("field 'fieldA' defines an additional non-optional argument 'arg1: String!' which is not allowed because field is also defined in interface 'InterfaceType'")
+        result.get(1).getMessage().contains("field 'fieldB' defines an additional non-optional argument 'arg2: String!' which is not allowed because field is also defined in interface 'InterfaceType'")
+    }
+
 }


### PR DESCRIPTION
Correctly support additional optional arguments fields defined by interfaces