### PR TITLE
Add new schema printer option includeDirectiveDefinitions

### DIFF
--- a/src/main/java/graphql/schema/idl/SchemaPrinter.java
+++ b/src/main/java/graphql/schema/idl/SchemaPrinter.java
@@ -89,6 +89,8 @@ public class SchemaPrinter {
 
         private final boolean includeSchemaDefinition;
 
+        private final boolean includeDirectiveDefinitions;
+
         private final boolean descriptionsAsHashComments;
 
         private final Predicate<GraphQLDirective> includeDirective;
@@ -98,6 +100,7 @@ public class SchemaPrinter {
         private Options(boolean includeIntrospectionTypes,
                         boolean includeScalars,
                         boolean includeSchemaDefinition,
+                        boolean includeDirectiveDefinitions,
                         boolean useAstDefinitions,
                         boolean descriptionsAsHashComments,
                         Predicate<GraphQLDirective> includeDirective,
@@ -105,6 +108,7 @@ public class SchemaPrinter {
             this.includeIntrospectionTypes = includeIntrospectionTypes;
             this.includeScalars = includeScalars;
             this.includeSchemaDefinition = includeSchemaDefinition;
+            this.includeDirectiveDefinitions = includeDirectiveDefinitions;
             this.includeDirective = includeDirective;
             this.useAstDefinitions = useAstDefinitions;
             this.descriptionsAsHashComments = descriptionsAsHashComments;
@@ -121,6 +125,10 @@ public class SchemaPrinter {
 
         public boolean isIncludeSchemaDefinition() {
             return includeSchemaDefinition;
+        }
+
+        public boolean isIncludeDirectiveDefinitions() {
+            return includeDirectiveDefinitions;
         }
 
         public Predicate<GraphQLDirective> getIncludeDirective() {
@@ -141,7 +149,7 @@ public class SchemaPrinter {
 
         public static Options defaultOptions() {
             return new Options(false, true,
-                    false, false, false,
+                    false, true, false, false,
                     directive -> true, DefaultGraphqlTypeComparatorRegistry.defaultComparators());
         }
 
@@ -152,7 +160,7 @@ public class SchemaPrinter {
          * @return options
          */
         public Options includeIntrospectionTypes(boolean flag) {
-            return new Options(flag, this.includeScalars, this.includeSchemaDefinition, this.useAstDefinitions, this.descriptionsAsHashComments, this.includeDirective, this.comparatorRegistry);
+            return new Options(flag, this.includeScalars, this.includeSchemaDefinition, this.includeDirectiveDefinitions, this.useAstDefinitions, this.descriptionsAsHashComments, this.includeDirective, this.comparatorRegistry);
         }
 
         /**
@@ -162,7 +170,7 @@ public class SchemaPrinter {
          * @return options
          */
         public Options includeScalarTypes(boolean flag) {
-            return new Options(this.includeIntrospectionTypes, flag, this.includeSchemaDefinition, this.useAstDefinitions, this.descriptionsAsHashComments, this.includeDirective, this.comparatorRegistry);
+            return new Options(this.includeIntrospectionTypes, flag, this.includeSchemaDefinition, this.includeDirectiveDefinitions, this.useAstDefinitions, this.descriptionsAsHashComments, this.includeDirective, this.comparatorRegistry);
         }
 
         /**
@@ -175,7 +183,22 @@ public class SchemaPrinter {
          * @return options
          */
         public Options includeSchemaDefinition(boolean flag) {
-            return new Options(this.includeIntrospectionTypes, this.includeScalars, flag, this.useAstDefinitions, this.descriptionsAsHashComments, this.includeDirective, this.comparatorRegistry);
+            return new Options(this.includeIntrospectionTypes, this.includeScalars, flag, this.includeDirectiveDefinitions, this.useAstDefinitions, this.descriptionsAsHashComments, this.includeDirective, this.comparatorRegistry);
+        }
+
+        /**
+         * This flag controls whether schema printer will include directive definitions at the top of the schema, but does not remove them from the field or type usage.
+         * <p>
+         * In some scema defintions, like Apollo Federation, the schema should be printed without the directive defintions.
+         * This simplified schema is retured by a GraphQL query to other services, in a format that is different that the introspection query.
+         * <p>
+         * On by default.
+         *
+         * @param flag whether to print directive definitions
+         * @return new instance of options
+         */
+        public Options includeDirectiveDefinitions(boolean flag) {
+            return new Options(this.includeIntrospectionTypes, this.includeScalars, this.includeSchemaDefinition, flag, this.useAstDefinitions, this.descriptionsAsHashComments, this.includeDirective, this.comparatorRegistry);
         }
 
         /**
@@ -186,11 +209,11 @@ public class SchemaPrinter {
          * @return new instance of options
          */
         public Options includeDirectives(boolean flag) {
-            return new Options(this.includeIntrospectionTypes, this.includeScalars, this.includeSchemaDefinition, this.useAstDefinitions, this.descriptionsAsHashComments, directive -> flag, this.comparatorRegistry);
+            return new Options(this.includeIntrospectionTypes, this.includeScalars, this.includeSchemaDefinition, this.includeDirectiveDefinitions, this.useAstDefinitions, this.descriptionsAsHashComments, directive -> flag, this.comparatorRegistry);
         }
 
         public Options includeDirectives(Predicate<GraphQLDirective> includeDirective) {
-            return new Options(this.includeIntrospectionTypes, this.includeScalars, this.includeSchemaDefinition, this.useAstDefinitions, this.descriptionsAsHashComments, includeDirective, this.comparatorRegistry);
+            return new Options(this.includeIntrospectionTypes, this.includeScalars, this.includeSchemaDefinition, this.includeDirectiveDefinitions, this.useAstDefinitions, this.descriptionsAsHashComments, includeDirective, this.comparatorRegistry);
         }
 
         /**
@@ -201,7 +224,7 @@ public class SchemaPrinter {
          * @return new instance of options
          */
         public Options useAstDefinitions(boolean flag) {
-            return new Options(this.includeIntrospectionTypes, this.includeScalars, this.includeSchemaDefinition, flag, this.descriptionsAsHashComments, this.includeDirective, this.comparatorRegistry);
+            return new Options(this.includeIntrospectionTypes, this.includeScalars, this.includeSchemaDefinition, this.includeDirectiveDefinitions, flag, this.descriptionsAsHashComments, this.includeDirective, this.comparatorRegistry);
         }
 
         /**
@@ -214,7 +237,7 @@ public class SchemaPrinter {
          * @return new instance of options
          */
         public Options descriptionsAsHashComments(boolean flag) {
-            return new Options(this.includeIntrospectionTypes, this.includeScalars, this.includeSchemaDefinition, this.useAstDefinitions, flag, this.includeDirective, this.comparatorRegistry);
+            return new Options(this.includeIntrospectionTypes, this.includeScalars, this.includeSchemaDefinition, this.includeDirectiveDefinitions, this.useAstDefinitions, flag, this.includeDirective, this.comparatorRegistry);
         }
 
         /**
@@ -226,7 +249,7 @@ public class SchemaPrinter {
          * @return options
          */
         public Options setComparators(GraphqlTypeComparatorRegistry comparatorRegistry) {
-            return new Options(this.includeIntrospectionTypes, this.includeScalars, this.includeSchemaDefinition, this.useAstDefinitions, this.descriptionsAsHashComments, this.includeDirective, comparatorRegistry);
+            return new Options(this.includeIntrospectionTypes, this.includeScalars, this.includeSchemaDefinition, this.includeDirectiveDefinitions, this.useAstDefinitions, this.descriptionsAsHashComments, this.includeDirective, comparatorRegistry);
         }
     }
 
@@ -586,9 +609,11 @@ public class SchemaPrinter {
                 out.format("}\n\n");
             }
 
-            List<GraphQLDirective> directives = getSchemaDirectives(schema);
-            if (!directives.isEmpty()) {
-                out.format("%s", directiveDefinitions(directives));
+            if (options.isIncludeDirectiveDefinitions()) {
+                List<GraphQLDirective> directives = getSchemaDirectives(schema);
+                if (!directives.isEmpty()) {
+                    out.format("%s", directiveDefinitions(directives));
+                }
             }
         };
     }

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -1105,6 +1105,65 @@ type Query {
 '''
     }
 
+    def "directive definitions are not printed when the includeDirectiveDefinitions flag is set"() {
+        def simpleIdlWithDirective = '''
+                directive @example on FIELD_DEFINITION
+                
+                directive @moreComplex(arg1 : String = "default", arg2 : Int) 
+                    on FIELD_DEFINITION | 
+                        INPUT_FIELD_DEFINITION
+               
+                type Query {
+                    fieldA : String @example @moreComplex(arg2 : 666)
+                }
+            '''
+        given:
+        def registry = new SchemaParser().parse(simpleIdlWithDirective)
+        def runtimeWiring = newRuntimeWiring().build()
+        def options = SchemaGenerator.Options.defaultOptions().enforceSchemaDirectives(true)
+        def schema = new SchemaGenerator().makeExecutableSchema(options, registry, runtimeWiring)
+
+        when:
+        def resultWithNoDirectiveDefinitions = new SchemaPrinter(defaultOptions().includeDirectiveDefinitions(false)).print(schema)
+
+        then:
+        resultWithNoDirectiveDefinitions == '''type Query {
+  fieldA: String @example @moreComplex(arg1 : "default", arg2 : 666)
+}
+'''
+
+        when:
+        def resultWithDirectiveDefinitions = new SchemaPrinter(defaultOptions().includeDirectiveDefinitions(true)).print(schema)
+
+        then:
+        resultWithDirectiveDefinitions == '''"Directs the executor to include this field or fragment only when the `if` argument is true"
+directive @include(
+    "Included when true."
+    if: Boolean!
+  ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"Directs the executor to skip this field or fragment when the `if`'argument is true."
+directive @skip(
+    "Skipped when true."
+    if: Boolean!
+  ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+directive @example on FIELD_DEFINITION
+
+directive @moreComplex(arg1: String = "default", arg2: Int) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+"Marks the field or enum value as deprecated"
+directive @deprecated(
+    "The reason for the deprecation"
+    reason: String = "No longer supported"
+  ) on FIELD_DEFINITION | ENUM_VALUE
+
+type Query {
+  fieldA: String @example @moreComplex(arg1 : "default", arg2 : 666)
+}
+'''
+    }
+
     def "can print a schema as AST elements"() {
         def sdl = '''
             directive @directive1 on SCALAR

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -1105,7 +1105,7 @@ type Query {
 '''
     }
 
-    def "directive definitions are not printed when the includeDirectiveDefinitions flag is set"() {
+    def "directive definitions are not printed when the includeDirectiveDefinitions flag is set to false"() {
         def simpleIdlWithDirective = '''
                 directive @example on FIELD_DEFINITION
                 
@@ -1120,7 +1120,7 @@ type Query {
         given:
         def registry = new SchemaParser().parse(simpleIdlWithDirective)
         def runtimeWiring = newRuntimeWiring().build()
-        def options = SchemaGenerator.Options.defaultOptions().enforceSchemaDirectives(true)
+        def options = SchemaGenerator.Options.defaultOptions()
         def schema = new SchemaGenerator().makeExecutableSchema(options, registry, runtimeWiring)
 
         when:


### PR DESCRIPTION
Apollo Federation requires that we return the schema as part of the _Service field to help the gateway understand all the fields. See 'Fetch Service Capabilities' https://www.apollographql.com/docs/apollo-server/federation/federation-spec/#fetch-service-capabilities. 

This schema should not contain the directive definitions but should contain all the directives on the types and fields. This PR adds a new option to the `SchemaPrinter`, `includeDirectiveDefinitions`, which is on by default. Setting it to false will remove the definitions from the top of the schema