### PR TITLE
GraphQLEnumType does not not use the Coercing interface anymore

### DIFF
--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -607,7 +607,7 @@ public abstract class ExecutionStrategy {
     protected CompletableFuture<ExecutionResult> completeValueForEnum(ExecutionContext executionContext, ExecutionStrategyParameters parameters, GraphQLEnumType enumType, Object result) {
         Object serialized;
         try {
-            serialized = enumType.getCoercing().serialize(result);
+            serialized = enumType.serialize(result);
         } catch (CoercingSerializeException e) {
             serialized = handleCoercionProblem(executionContext, parameters, e);
         }

--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -208,7 +208,7 @@ public class ValuesResolver {
     }
 
     private Object coerceValueForEnum(GraphQLEnumType graphQLEnumType, Object value) {
-        return graphQLEnumType.getCoercing().parseValue(value);
+        return graphQLEnumType.parseValue(value);
     }
 
     private List coerceValueForList(GraphqlFieldVisibility fieldVisibility, VariableDefinition variableDefinition, String inputName, GraphQLList graphQLList, Object value) {
@@ -240,7 +240,7 @@ public class ValuesResolver {
             return coerceValueAstForInputObject(fieldVisibility, (GraphQLInputObjectType) type, (ObjectValue) inputValue, variables);
         }
         if (type instanceof GraphQLEnumType) {
-            return parseLiteral(inputValue, ((GraphQLEnumType) type).getCoercing(), variables);
+            return ((GraphQLEnumType) type).parseLiteral(inputValue);
         }
         if (isList(type)) {
             return coerceValueAstForList(fieldVisibility, (GraphQLList) type, inputValue, variables);

--- a/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
+++ b/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
@@ -468,7 +468,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
             return null;
         }
         if (type instanceof GraphQLEnumType) {
-            return ((GraphQLEnumType) type).getCoercing().serialize(value);
+            return ((GraphQLEnumType) type).serialize(value);
         } else {
             return ((GraphQLScalarType) type).getCoercing().serialize(value);
         }

--- a/src/main/java/graphql/execution/nextgen/FetchedValueAnalyzer.java
+++ b/src/main/java/graphql/execution/nextgen/FetchedValueAnalyzer.java
@@ -189,7 +189,7 @@ public class FetchedValueAnalyzer {
         }
         Object serialized;
         try {
-            serialized = enumType.getCoercing().serialize(toAnalyze);
+            serialized = enumType.serialize(toAnalyze);
         } catch (CoercingSerializeException e) {
             SerializationError error = new SerializationError(executionInfo.getPath(), e);
             return newFetchedValueAnalysis(SCALAR)

--- a/src/main/java/graphql/language/AstValueHelper.java
+++ b/src/main/java/graphql/language/AstValueHelper.java
@@ -198,7 +198,7 @@ public class AstValueHelper {
         if (type instanceof GraphQLScalarType) {
             return ((GraphQLScalarType) type).getCoercing().serialize(value);
         } else {
-            return ((GraphQLEnumType) type).getCoercing().serialize(value);
+            return ((GraphQLEnumType) type).serialize(value);
         }
     }
 

--- a/src/main/java/graphql/schema/GraphQLEnumType.java
+++ b/src/main/java/graphql/schema/GraphQLEnumType.java
@@ -44,41 +44,6 @@ public class GraphQLEnumType implements GraphQLNamedInputType, GraphQLNamedOutpu
     public static final String CHILD_VALUES = "values";
     public static final String CHILD_DIRECTIVES = "directives";
 
-    private final Coercing coercing = new Coercing() {
-        @Override
-        public Object serialize(Object input) {
-            return getNameByValue(input);
-        }
-
-        @Override
-        public Object parseValue(Object input) {
-            return getValueByName(input);
-        }
-
-        private String typeName(Object input) {
-            if (input == null) {
-                return "null";
-            }
-            return input.getClass().getSimpleName();
-        }
-
-        @Override
-        public Object parseLiteral(Object input) {
-            if (!(input instanceof EnumValue)) {
-                throw new CoercingParseLiteralException(
-                        "Expected AST type 'EnumValue' but was '" + typeName(input) + "'."
-                );
-            }
-            EnumValue enumValue = (EnumValue) input;
-            GraphQLEnumValueDefinition enumValueDefinition = valueDefinitionMap.get(enumValue.getName());
-            if (enumValueDefinition == null) {
-                throw new CoercingParseLiteralException(
-                        "Expected enum literal value not in allowable values -  '" + String.valueOf(input) + "'."
-                );
-            }
-            return enumValueDefinition.getValue();
-        }
-    };
 
 
     /**
@@ -119,6 +84,40 @@ public class GraphQLEnumType implements GraphQLNamedInputType, GraphQLNamedOutpu
         this.extensionDefinitions = Collections.unmodifiableList(new ArrayList<>(extensionDefinitions));
         this.directives = directives;
         buildMap(values);
+    }
+
+    @Internal
+    public Object serialize(Object input) {
+        return getNameByValue(input);
+    }
+
+    @Internal
+    public Object parseValue(Object input) {
+        return getValueByName(input);
+    }
+
+    private String typeName(Object input) {
+        if (input == null) {
+            return "null";
+        }
+        return input.getClass().getSimpleName();
+    }
+
+    @Internal
+    public Object parseLiteral(Object input) {
+        if (!(input instanceof EnumValue)) {
+            throw new CoercingParseLiteralException(
+                    "Expected AST type 'EnumValue' but was '" + typeName(input) + "'."
+            );
+        }
+        EnumValue enumValue = (EnumValue) input;
+        GraphQLEnumValueDefinition enumValueDefinition = valueDefinitionMap.get(enumValue.getName());
+        if (enumValueDefinition == null) {
+            throw new CoercingParseLiteralException(
+                    "Expected enum literal value not in allowable values -  '" + String.valueOf(input) + "'."
+            );
+        }
+        return enumValueDefinition.getValue();
     }
 
     public List<GraphQLEnumValueDefinition> getValues() {
@@ -180,10 +179,6 @@ public class GraphQLEnumType implements GraphQLNamedInputType, GraphQLNamedOutpu
 
     public String getDescription() {
         return description;
-    }
-
-    public Coercing getCoercing() {
-        return coercing;
     }
 
     public EnumTypeDefinition getDefinition() {

--- a/src/main/java/graphql/validation/ValidationUtil.java
+++ b/src/main/java/graphql/validation/ValidationUtil.java
@@ -93,7 +93,7 @@ public class ValidationUtil {
             return !invalid.isPresent();
         }
         if (type instanceof GraphQLEnumType) {
-            Optional<GraphQLError> invalid = parseLiteral(value, ((GraphQLEnumType) type).getCoercing());
+            Optional<GraphQLError> invalid = parseLiteralEnum(value,(GraphQLEnumType) type);
             invalid.ifPresent(graphQLError -> handleEnumError(value, (GraphQLEnumType) type, graphQLError));
             return !invalid.isPresent();
         }
@@ -103,6 +103,14 @@ public class ValidationUtil {
         }
         return type instanceof GraphQLInputObjectType && isValidLiteralValue(value, (GraphQLInputObjectType) type, schema);
 
+    }
+    private Optional<GraphQLError> parseLiteralEnum(Value<?> value, GraphQLEnumType graphQLEnumType) {
+        try {
+            graphQLEnumType.parseLiteral(value);
+            return Optional.empty();
+        } catch (CoercingParseLiteralException e) {
+            return Optional.of(e);
+        }
     }
 
     private Optional<GraphQLError> parseLiteral(Value<?> value, Coercing<?,?> coercing) {

--- a/src/test/groovy/graphql/schema/GraphQLEnumTypeTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLEnumTypeTest.groovy
@@ -19,7 +19,7 @@ class GraphQLEnumTypeTest extends Specification {
 
     def "parse throws exception for unknown value"() {
         when:
-        enumType.getCoercing().parseValue("UNKNOWN")
+        enumType.parseValue("UNKNOWN")
 
         then:
         thrown(CoercingParseValueException)
@@ -28,17 +28,17 @@ class GraphQLEnumTypeTest extends Specification {
 
     def "parse value return value for the name"() {
         expect:
-        enumType.getCoercing().parseValue("NAME") == 42
+        enumType.parseValue("NAME") == 42
     }
 
     def "serialize returns name for value"() {
         expect:
-        enumType.getCoercing().serialize(42) == "NAME"
+        enumType.serialize(42) == "NAME"
     }
 
     def "serialize throws exception for unknown value"() {
         when:
-        enumType.getCoercing().serialize(12)
+        enumType.serialize(12)
         then:
         thrown(CoercingSerializeException)
     }
@@ -46,21 +46,21 @@ class GraphQLEnumTypeTest extends Specification {
 
     def "parseLiteral return null for invalid input"() {
         when:
-        enumType.getCoercing().parseLiteral(StringValue.newStringValue("foo").build())
+        enumType.parseLiteral(StringValue.newStringValue("foo").build())
         then:
         thrown(CoercingParseLiteralException)
     }
 
     def "parseLiteral return null for invalid enum name"() {
         when:
-        enumType.getCoercing().parseLiteral(EnumValue.newEnumValue("NOT_NAME").build())
+        enumType.parseLiteral(EnumValue.newEnumValue("NOT_NAME").build())
         then:
         thrown(CoercingParseLiteralException)
     }
 
     def "parseLiteral returns value for 'NAME'"() {
         expect:
-        enumType.getCoercing().parseLiteral(EnumValue.newEnumValue("NAME").build()) == 42
+        enumType.parseLiteral(EnumValue.newEnumValue("NAME").build()) == 42
     }
 
 
@@ -96,7 +96,7 @@ class GraphQLEnumTypeTest extends Specification {
                 .build()
 
         when:
-        def serialized = enumType.coercing.serialize(Episode.EMPIRE)
+        def serialized = enumType.serialize(Episode.EMPIRE)
 
         then:
         serialized == "EMPIRE"
@@ -111,7 +111,7 @@ class GraphQLEnumTypeTest extends Specification {
                 .build()
 
         when:
-        def serialized = enumType.coercing.serialize(Episode.NEWHOPE)
+        def serialized = enumType.serialize(Episode.NEWHOPE)
 
         then:
         serialized == "NEWHOPE"
@@ -128,7 +128,7 @@ class GraphQLEnumTypeTest extends Specification {
         String stringInput = Episode.NEWHOPE.toString()
 
         when:
-        def serialized = enumType.coercing.serialize(stringInput)
+        def serialized = enumType.serialize(stringInput)
 
         then:
         serialized == "NEWHOPE"


### PR DESCRIPTION
The Coercion for Scalars resembles the Coercion of Enum values, but GraphQLEnumType should not use the same `Coercing` interface and there is actually no need for it at all. The methods are just pulled up into the class in this PR
`Coercing` is actually an SPI and should only be used for  Scalars. 


Technical breaking change, but no normal user should be affected.