### PR TITLE
remove the option to have undeclared directives in your SDL

### DIFF
--- a/src/main/java/graphql/schema/idl/SchemaGenerator.java
+++ b/src/main/java/graphql/schema/idl/SchemaGenerator.java
@@ -95,35 +95,12 @@ public class SchemaGenerator {
      * These options control how the schema generation works
      */
     public static class Options {
-        private final boolean enforceSchemaDirectives;
 
-        Options(boolean enforceSchemaDirectives) {
-            this.enforceSchemaDirectives = enforceSchemaDirectives;
-        }
-
-        /**
-         * This controls whether schema directives MUST be declared using
-         * directive definition syntax before use.
-         *
-         * @return true if directives must be fully declared; the default is true
-         */
-        public boolean isEnforceSchemaDirectives() {
-            return enforceSchemaDirectives;
+        Options() {
         }
 
         public static Options defaultOptions() {
-            return new Options(true);
-        }
-
-        /**
-         * This controls whether schema directives MUST be declared using
-         * directive definition syntax before use.
-         *
-         * @param flag the value to use
-         * @return the new options
-         */
-        public Options enforceSchemaDirectives(boolean flag) {
-            return new Options(flag);
+            return new Options();
         }
 
     }
@@ -260,7 +237,7 @@ public class SchemaGenerator {
 
         schemaGeneratorHelper.addDeprecatedDirectiveDefinition(typeRegistryCopy);
 
-        List<GraphQLError> errors = typeChecker.checkTypeRegistry(typeRegistryCopy, wiring, options.enforceSchemaDirectives);
+        List<GraphQLError> errors = typeChecker.checkTypeRegistry(typeRegistryCopy, wiring);
         if (!errors.isEmpty()) {
             throw new SchemaProblem(errors);
         }

--- a/src/main/java/graphql/schema/idl/SchemaTypeChecker.java
+++ b/src/main/java/graphql/schema/idl/SchemaTypeChecker.java
@@ -17,8 +17,6 @@ import graphql.language.Node;
 import graphql.language.NonNullType;
 import graphql.language.ObjectTypeDefinition;
 import graphql.language.ObjectTypeExtensionDefinition;
-import graphql.language.OperationTypeDefinition;
-import graphql.language.SchemaDefinition;
 import graphql.language.StringValue;
 import graphql.language.Type;
 import graphql.language.TypeDefinition;
@@ -38,8 +36,6 @@ import graphql.schema.idl.errors.MissingTypeResolverError;
 import graphql.schema.idl.errors.NonUniqueArgumentError;
 import graphql.schema.idl.errors.NonUniqueDirectiveError;
 import graphql.schema.idl.errors.NonUniqueNameError;
-import graphql.schema.idl.errors.OperationTypesMustBeObjects;
-import graphql.schema.idl.errors.QueryOperationMissingError;
 import graphql.schema.idl.errors.SchemaProblem;
 
 import java.util.ArrayList;
@@ -66,7 +62,7 @@ import java.util.stream.Collectors;
 @Internal
 public class SchemaTypeChecker {
 
-    public List<GraphQLError> checkTypeRegistry(TypeDefinitionRegistry typeRegistry, RuntimeWiring wiring, boolean enforceSchemaDirectives) throws SchemaProblem {
+    public List<GraphQLError> checkTypeRegistry(TypeDefinitionRegistry typeRegistry, RuntimeWiring wiring) throws SchemaProblem {
         List<GraphQLError> errors = new ArrayList<>();
         checkForMissingTypes(errors, typeRegistry);
 
@@ -86,10 +82,8 @@ public class SchemaTypeChecker {
         //check directive definitions before checking directive usages
         checkDirectiveDefinitions(typeRegistry, errors);
 
-        if (enforceSchemaDirectives) {
-            SchemaTypeDirectivesChecker directivesChecker = new SchemaTypeDirectivesChecker(typeRegistry, wiring);
-            directivesChecker.checkTypeDirectives(errors);
-        }
+        SchemaTypeDirectivesChecker directivesChecker = new SchemaTypeDirectivesChecker(typeRegistry, wiring);
+        directivesChecker.checkTypeDirectives(errors);
 
         return errors;
     }

--- a/src/main/java/graphql/schema/idl/SchemaTypeDirectivesChecker.java
+++ b/src/main/java/graphql/schema/idl/SchemaTypeDirectivesChecker.java
@@ -1,5 +1,6 @@
 package graphql.schema.idl;
 
+import graphql.Directives;
 import graphql.GraphQLError;
 import graphql.Internal;
 import graphql.introspection.Introspection.DirectiveLocation;
@@ -125,6 +126,10 @@ class SchemaTypeDirectivesChecker {
 
     private void checkDirectives(DirectiveLocation expectedLocation, List<GraphQLError> errors, TypeDefinitionRegistry typeRegistry, Node<?> element, String elementName, List<Directive> directives) {
         directives.forEach(directive -> {
+            // we have special code for the deprecation directive in SchemaTypeChecker.checkDeprecatedDirective
+            if (Directives.DeprecatedDirective.getName().equals(directive.getName())) {
+                return;
+            }
             Optional<DirectiveDefinition> directiveDefinition = typeRegistry.getDirectiveDefinition(directive.getName());
             if (!directiveDefinition.isPresent()) {
                 errors.add(new DirectiveUndeclaredError(element, elementName, directive.getName()));

--- a/src/main/java/graphql/util/FpKit.java
+++ b/src/main/java/graphql/util/FpKit.java
@@ -58,7 +58,6 @@ public class FpKit {
     }
 
 
-
     //
     // From a list of named things, get a map of them by name, merging them first one added
     public static <T> Map<String, T> getByName(List<T> namedObjects, Function<T, String> nameFn) {
@@ -170,7 +169,7 @@ public class FpKit {
                 .collect(Collectors.toList());
     }
 
-    public static <T> Optional<T> findOne(List<T> list, Predicate<T> filter) {
+    public static <T> Optional<T> findOne(Collection<T> list, Predicate<T> filter) {
         return list
                 .stream()
                 .filter(filter)

--- a/src/test/groovy/graphql/TestUtil.groovy
+++ b/src/test/groovy/graphql/TestUtil.groovy
@@ -69,7 +69,7 @@ class TestUtil {
         def stream = TestUtil.class.getClassLoader().getResourceAsStream(fileName)
 
         def typeRegistry = new SchemaParser().parse(new InputStreamReader(stream))
-        def options = SchemaGenerator.Options.defaultOptions().enforceSchemaDirectives(false)
+        def options = SchemaGenerator.Options.defaultOptions()
         def schema = new SchemaGenerator().makeExecutableSchema(options, typeRegistry, wiring)
         schema
     }
@@ -106,7 +106,7 @@ class TestUtil {
     static GraphQLSchema schema(Reader specReader, RuntimeWiring runtimeWiring) {
         try {
             def registry = new SchemaParser().parse(specReader)
-            def options = SchemaGenerator.Options.defaultOptions().enforceSchemaDirectives(false)
+            def options = SchemaGenerator.Options.defaultOptions()
             return new SchemaGenerator().makeExecutableSchema(options, registry, runtimeWiring)
         } catch (SchemaProblem e) {
             assert false: "The schema could not be compiled : ${e}"

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorDirectiveHelperTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorDirectiveHelperTest.groovy
@@ -60,6 +60,16 @@ class SchemaGeneratorDirectiveHelperTest extends Specification {
     def "will trace down into each directive callback"() {
 
         def sdl = '''
+            directive @fieldDirective(target: String) on FIELD_DEFINITION
+            directive @argumentDirective(target: String) on ARGUMENT_DEFINITION
+            directive @objectDirective(target: String) on OBJECT
+            directive @interfaceDirective(target: String) on INTERFACE 
+            directive @unionDirective(target: String) on UNION
+            directive @enumDirective(target: String) on ENUM
+            directive @enumValueDirective(target: String) on ENUM_VALUE
+            directive @inputDirective(target: String) on INPUT_OBJECT
+            directive @inputFieldDirective(target: String) on INPUT_FIELD_DEFINITION
+            directive @scalarDirective(target: String) on SCALAR
             type Query {
                 f : ObjectType
                 s : ScalarType
@@ -275,6 +285,11 @@ class SchemaGeneratorDirectiveHelperTest extends Specification {
 
     def "can modify the existing behaviour"() {
         def sdl = '''
+            directive @uppercase on FIELD_DEFINITION
+            directive @lowercase on FIELD_DEFINITION
+            directive @mixedcase on FIELD_DEFINITION
+            directive @echoFieldName on FIELD_DEFINITION
+            directive @reverse on FIELD_DEFINITION
             type Query {
                 lowerCaseValue : String @uppercase
                 upperCaseValue : String @lowercase
@@ -384,6 +399,7 @@ class SchemaGeneratorDirectiveHelperTest extends Specification {
     def "ensure the readme examples work"() {
 
         def sdl = '''
+            directive @dateFormat on FIELD_DEFINITION
             type Query {
                 dateField : String @dateFormat
             }
@@ -421,6 +437,7 @@ class SchemaGeneratorDirectiveHelperTest extends Specification {
 
     def "can state-fully track wrapped elements"() {
         def sdl = '''
+            directive @secret on FIELD_DEFINITION | OBJECT
             type Query {
                 secret : Secret
                 nonSecret : NonSecret
@@ -541,6 +558,10 @@ class SchemaGeneratorDirectiveHelperTest extends Specification {
 
     def "ordering of directive wiring is locked in place"() {
         def sdl = '''
+            directive @generalDirective on FIELD_DEFINITION
+            directive @factoryDirective on FIELD_DEFINITION
+            directive @namedDirective1 on FIELD_DEFINITION
+            directive @namedDirective2 on FIELD_DEFINITION
             type Query {
                 field : String @generalDirective @factoryDirective @namedDirective1 @namedDirective2 
             }
@@ -634,6 +655,10 @@ class SchemaGeneratorDirectiveHelperTest extends Specification {
 
     def "all directives are available to all callbacks"() {
         def sdl = '''
+            directive @generalDirective on FIELD_DEFINITION
+            directive @factoryDirective on FIELD_DEFINITION
+            directive @namedDirective1 on FIELD_DEFINITION
+            directive @namedDirective2 on FIELD_DEFINITION
             type Query {
                 field : String @generalDirective @factoryDirective @namedDirective1 @namedDirective2 
             }
@@ -721,6 +746,10 @@ class SchemaGeneratorDirectiveHelperTest extends Specification {
 
     def "parent and child element directives can be accessed"() {
         def sdl = '''
+            directive @argDirective1 on ARGUMENT_DEFINITION
+            directive @argDirective2 on ARGUMENT_DEFINITION
+            directive @argDirective3 on ARGUMENT_DEFINITION
+            directive @fieldDirective on FIELD_DEFINITION
             type Query {
                 field(arg1 : String @argDirective1 @argDirective2, arg2 : String @argDirective3) : String @fieldDirective 
             }
@@ -784,6 +813,10 @@ class SchemaGeneratorDirectiveHelperTest extends Specification {
 
     def "data fetchers can be changed in argument and object callbacks"() {
         def sdl = '''
+            directive @argDirective1 on ARGUMENT_DEFINITION
+            directive @argDirective2 on ARGUMENT_DEFINITION
+            directive @argDirective3 on ARGUMENT_DEFINITION
+            directive @fieldDirective on FIELD_DEFINITION
             type Query {
                 field1(arg1 : String @argDirective1 @argDirective2, arg2 : String @argDirective3) : String @fieldDirective
                 field2 : String 

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -1530,12 +1530,7 @@ class SchemaGeneratorTest extends Specification {
         """
 
         when:
-        def options = SchemaGenerator.Options.defaultOptions().enforceSchemaDirectives(true)
-
-        then:
-        options.isEnforceSchemaDirectives()
-
-        when:
+        def options = SchemaGenerator.Options.defaultOptions()
         def registry = new SchemaParser().parse(spec)
         def schema = new SchemaGenerator().makeExecutableSchema(options, registry, TestUtil.mockRuntimeWiring)
 
@@ -1572,7 +1567,7 @@ class SchemaGeneratorTest extends Specification {
         """
 
         when:
-        def options = SchemaGenerator.Options.defaultOptions().enforceSchemaDirectives(true)
+        def options = SchemaGenerator.Options.defaultOptions()
 
         def registry = new SchemaParser().parse(spec)
         def schema = new SchemaGenerator().makeExecutableSchema(options, registry, TestUtil.mockRuntimeWiring)
@@ -1604,12 +1599,7 @@ class SchemaGeneratorTest extends Specification {
         """
 
         when:
-        def options = SchemaGenerator.Options.defaultOptions().enforceSchemaDirectives(true)
-
-        then:
-        options.isEnforceSchemaDirectives()
-
-        when:
+        def options = SchemaGenerator.Options.defaultOptions()
         def registry = new SchemaParser().parse(spec)
         def schema = new SchemaGenerator().makeExecutableSchema(options, registry, TestUtil.mockRuntimeWiring)
 
@@ -1637,7 +1627,7 @@ class SchemaGeneratorTest extends Specification {
             }
         """
 
-        def options = SchemaGenerator.Options.defaultOptions().enforceSchemaDirectives(true)
+        def options = SchemaGenerator.Options.defaultOptions()
 
         when:
         def registry = new SchemaParser().parse(spec)
@@ -1889,7 +1879,7 @@ class SchemaGeneratorTest extends Specification {
                 .wiringFactory(wiringFactory)
                 .build()
 
-        def options = SchemaGenerator.Options.defaultOptions().enforceSchemaDirectives(false)
+        def options = SchemaGenerator.Options.defaultOptions()
 
         def types = new SchemaParser().parse(sdl)
         GraphQLSchema schema = new SchemaGenerator().makeExecutableSchema(options, types, runtimeWiring)

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -1,6 +1,6 @@
 package graphql.schema.idl
 
-import graphql.AssertException
+
 import graphql.TestUtil
 import graphql.introspection.Introspection
 import graphql.schema.GraphQLArgument
@@ -25,7 +25,6 @@ import graphql.schema.idl.errors.NotAnInputTypeError
 import graphql.schema.idl.errors.NotAnOutputTypeError
 import graphql.schema.visibility.GraphqlFieldVisibility
 import spock.lang.Specification
-import spock.lang.Unroll
 
 import java.util.function.UnaryOperator
 
@@ -33,7 +32,6 @@ import static graphql.Scalars.GraphQLBoolean
 import static graphql.Scalars.GraphQLFloat
 import static graphql.Scalars.GraphQLInt
 import static graphql.Scalars.GraphQLString
-import static graphql.schema.GraphQLList.list
 
 class SchemaGeneratorTest extends Specification {
 
@@ -923,61 +921,6 @@ class SchemaGeneratorTest extends Specification {
 
     }
 
-    @Unroll
-    def "when using implicit directive (w/o definition), #argumentName is supported"() {
-        setup:
-        def spec = """
-            type Query @myDirective($argumentName: $argumentValue) {
-                foo: String 
-            }
-        """
-        when:
-        def wiring = RuntimeWiring.newRuntimeWiring()
-                .build()
-
-        def schema = schema(spec, wiring)
-        def queryType = schema.queryType
-
-        then:
-        def directive = queryType.getDirective("myDirective")
-        directive.getArgument(argumentName).type == expectedArgumentType
-
-        where:
-        argumentName        | argumentValue     || expectedArgumentType
-        "stringArg"         | '"a string"'      || GraphQLString
-        "boolArg"           | "true"            || GraphQLBoolean
-        "floatArg"          | "4.5"             || GraphQLFloat
-        "intArg"            | "5"               || GraphQLInt
-        "nullArg"           | "null"            || GraphQLString
-        "emptyArrayArg"     | "[]"              || list(GraphQLString)
-        "arrayNullsArg"     | "[null, null]"    || list(GraphQLString)
-        "arrayArg"          | "[3,4,6]"         || list(GraphQLInt)
-        "arrayWithNullsArg" | "[null,3,null,6]" || list(GraphQLInt)
-    }
-
-    @Unroll
-    def "when using implicit directive (w/o definition), #argumentName is NOT supported"() {
-        setup:
-        def spec = """
-            type Query @myDirective($argumentName: $argumentValue) {
-                foo: String 
-            }
-        """
-        when:
-        def wiring = RuntimeWiring.newRuntimeWiring()
-                .build()
-        schema(spec, wiring)
-
-        then:
-        def ex = thrown(AssertException)
-        ex.message == expectedErrorMessage
-
-        where:
-        argumentName          | argumentValue               || expectedErrorMessage
-        "objArg"              | '{ hi: "John"}'             || "Internal error: should never happen: Directive values of type 'ObjectValue' are not supported yet"
-        "enumArg"             | "MONDAY"                    || "Internal error: should never happen: Directive values of type 'EnumValue' are not supported yet"
-        "polymorphicArrayArg" | '["one", { hi: "John"}, 5]' || "Arrays containing multiple types of values are not supported yet. Detected the following types [IntValue,ObjectValue,StringValue]"
-    }
 
     def "deprecated directive is supported"() {
         given:
@@ -1153,6 +1096,13 @@ class SchemaGeneratorTest extends Specification {
 
     def "object type directives are gathered and turned into runtime objects with arguments"() {
         def spec = """
+            directive @directive1 on OBJECT
+            directive @fieldDirective1 on FIELD_DEFINITION
+            directive @directive2 on OBJECT
+            directive @directive3 on OBJECT
+            directive @directiveWithArgs(strArg: String, intArg: Int, boolArg: Boolean, floatArg: Float,nullArg: String) on OBJECT
+            directive @fieldDirective2 on FIELD_DEFINITION
+            
             type Query @directive1 {
               field1 : String @fieldDirective1
             }
@@ -1222,18 +1172,21 @@ class SchemaGeneratorTest extends Specification {
             type B  {
                 fieldB : String
             }
-            
+            directive @IFaceDirective on INTERFACE
             interface IFace @IFaceDirective {
                 field1 : String
             }
-            
+            directive @OnionDirective on UNION 
             union Onion @OnionDirective = A | B
             
+            directive @EnumValueDirective on ENUM_VALUE
+            directive @NumbDirective on ENUM 
             enum Numb @NumbDirective {
                 X @EnumValueDirective,
                 Y
             }
-            
+            directive @PuterDirective on INPUT_OBJECT
+            directive @InputFieldDirective on INPUT_FIELD_DEFINITION
             input Puter @PuterDirective {
                 inputField : String @InputFieldDirective
             }
@@ -1351,10 +1304,12 @@ class SchemaGeneratorTest extends Specification {
             }
             
             
+            directive @directive on INTERFACE 
             interface IAgeAndHeight @directive {
                 age : Int
             }
 
+            directive @directiveField on FIELD_DEFINITION 
             extend interface IAgeAndHeight {
                 height : Int @directiveField
             }
@@ -1395,7 +1350,7 @@ class SchemaGeneratorTest extends Specification {
             union FooBar = Foo
             
             extend union FooBar = Bar | Baz
-            
+            directive @directive on UNION 
             extend union FooBar @directive
             
         """
@@ -1425,7 +1380,7 @@ class SchemaGeneratorTest extends Specification {
             extend enum Numb {
                 C
             }
-
+            directive @directive on ENUM
             extend enum Numb @directive{
                 D
             }
@@ -1462,6 +1417,7 @@ class SchemaGeneratorTest extends Specification {
                 fieldC : String
             }
 
+            directive @directive on INPUT_OBJECT
             extend input Puter @directive {
                 fieldD : String
             }
@@ -1485,7 +1441,10 @@ class SchemaGeneratorTest extends Specification {
             type Query {
                 obj : Object
             }
-            
+            directive @strDirective on ARGUMENT_DEFINITION    
+            directive @secondDirective on ARGUMENT_DEFINITION    
+            directive @intDirective(inception: Boolean) on ARGUMENT_DEFINITION    
+            directive @thirdDirective on ARGUMENT_DEFINITION    
             type Object {
                 field(argStr : String @strDirective @secondDirective, argInt : Int @intDirective(inception : true) @thirdDirective ) : String
             }
@@ -1778,6 +1737,7 @@ class SchemaGeneratorTest extends Specification {
 
     def "extensions are captured into runtime objects"() {
         def sdl = '''
+            directive @directive1 on SCALAR
             ######## Objects
              
             type Query {

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -846,7 +846,7 @@ type Query {
                 .type(mockTypeRuntimeWiring("SomeInterface", true))
                 .type(mockTypeRuntimeWiring("SomeUnion", true))
                 .build()
-        def options = SchemaGenerator.Options.defaultOptions().enforceSchemaDirectives(false)
+        def options = SchemaGenerator.Options.defaultOptions()
         def schema = new SchemaGenerator().makeExecutableSchema(options, registry, runtimeWiring)
 
         when:
@@ -971,7 +971,7 @@ input SomeInput {
         """
         def registry = new SchemaParser().parse(idl)
         def runtimeWiring = newRuntimeWiring().build()
-        def options = SchemaGenerator.Options.defaultOptions().enforceSchemaDirectives(false)
+        def options = SchemaGenerator.Options.defaultOptions()
         def schema = new SchemaGenerator().makeExecutableSchema(options, registry, runtimeWiring)
 
         when:
@@ -1031,7 +1031,7 @@ enum Enum {
         given:
         def registry = new SchemaParser().parse(simpleIdlWithDirective)
         def runtimeWiring = newRuntimeWiring().build()
-        def options = SchemaGenerator.Options.defaultOptions().enforceSchemaDirectives(true)
+        def options = SchemaGenerator.Options.defaultOptions()
         def schema = new SchemaGenerator().makeExecutableSchema(options, registry, runtimeWiring)
 
         when:
@@ -1177,7 +1177,7 @@ type Query {
                 .wiringFactory(wiringFactory)
                 .build()
 
-        def options = SchemaGenerator.Options.defaultOptions().enforceSchemaDirectives(false)
+        def options = SchemaGenerator.Options.defaultOptions()
         def types = new SchemaParser().parse(sdl)
         GraphQLSchema schema = new SchemaGenerator().makeExecutableSchema(options, types, runtimeWiring)
 
@@ -1309,7 +1309,7 @@ extend type Query {
         """
         def registry = new SchemaParser().parse(idl)
         def runtimeWiring = newRuntimeWiring().build()
-        def options = SchemaGenerator.Options.defaultOptions().enforceSchemaDirectives(false)
+        def options = SchemaGenerator.Options.defaultOptions()
         def schema = new SchemaGenerator().makeExecutableSchema(options, registry, runtimeWiring)
 
         when:
@@ -1349,7 +1349,7 @@ enum Enum {
         '''
         def registry = new SchemaParser().parse(idl)
         def runtimeWiring = newRuntimeWiring().build()
-        def options = SchemaGenerator.Options.defaultOptions().enforceSchemaDirectives(false)
+        def options = SchemaGenerator.Options.defaultOptions()
         def schema = new SchemaGenerator().makeExecutableSchema(options, registry, runtimeWiring)
 
         when:
@@ -1377,7 +1377,7 @@ type Query {
         '''
         def registry = new SchemaParser().parse(idl)
         def runtimeWiring = newRuntimeWiring().build()
-        def options = SchemaGenerator.Options.defaultOptions().enforceSchemaDirectives(false)
+        def options = SchemaGenerator.Options.defaultOptions()
         def schema = new SchemaGenerator().makeExecutableSchema(options, registry, runtimeWiring)
 
         when:

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -801,6 +801,23 @@ type Query {
 
     def idlWithDirectives() {
         return """
+            directive @interfaceFieldDirective on FIELD_DEFINITION
+            directive @unionTypeDirective on UNION
+            directive @query1 on OBJECT
+            directive @query2(arg1: String) on OBJECT
+            directive @fieldDirective1 on FIELD_DEFINITION
+            directive @fieldDirective2(argStr: String, argInt: Int, argFloat: Float, argBool: Boolean) on FIELD_DEFINITION
+            directive @argDirective on ARGUMENT_DEFINITION
+            directive @interfaceImplementingTypeDirective on OBJECT
+            directive @enumTypeDirective on ENUM
+            directive @single on OBJECT
+            directive @singleField on FIELD_DEFINITION
+            directive @interfaceImplementingFieldDirective on FIELD_DEFINITION
+            directive @enumValueDirective on ENUM_VALUE
+            directive @inputTypeDirective on INPUT_OBJECT
+            directive @inputFieldDirective on INPUT_FIELD_DEFINITION
+            directive @interfaceTypeDirective on INTERFACE
+            directive @scalarDirective on SCALAR
             
             interface SomeInterface @interfaceTypeDirective {
                 fieldA : String @interfaceFieldDirective
@@ -865,6 +882,40 @@ directive @skip(
     "Skipped when true."
     if: Boolean!
   ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+directive @interfaceFieldDirective on FIELD_DEFINITION
+
+directive @unionTypeDirective on UNION
+
+directive @query1 on OBJECT
+
+directive @query2(arg1: String) on OBJECT
+
+directive @fieldDirective1 on FIELD_DEFINITION
+
+directive @fieldDirective2(argBool: Boolean, argFloat: Float, argInt: Int, argStr: String) on FIELD_DEFINITION
+
+directive @argDirective on ARGUMENT_DEFINITION
+
+directive @interfaceImplementingTypeDirective on OBJECT
+
+directive @enumTypeDirective on ENUM
+
+directive @single on OBJECT
+
+directive @singleField on FIELD_DEFINITION
+
+directive @interfaceImplementingFieldDirective on FIELD_DEFINITION
+
+directive @enumValueDirective on ENUM_VALUE
+
+directive @inputTypeDirective on INPUT_OBJECT
+
+directive @inputFieldDirective on INPUT_FIELD_DEFINITION
+
+directive @interfaceTypeDirective on INTERFACE
+
+directive @scalarDirective on SCALAR
 
 "Marks the field or enum value as deprecated"
 directive @deprecated(
@@ -1088,6 +1139,7 @@ type Query {
 
     def "can print a schema as AST elements"() {
         def sdl = '''
+            directive @directive1 on SCALAR
             type Query {
                 foo : String
             }
@@ -1196,6 +1248,8 @@ directive @skip(
     "Skipped when true."
     if: Boolean!
   ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+directive @directive1 on SCALAR
 
 "Marks the field or enum value as deprecated"
 directive @deprecated(

--- a/src/test/groovy/graphql/schema/idl/SchemaTypeCheckerTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaTypeCheckerTest.groovy
@@ -16,7 +16,6 @@ import graphql.schema.idl.errors.DirectiveUndeclaredError
 import graphql.schema.idl.errors.MissingTypeError
 import graphql.schema.idl.errors.NonUniqueNameError
 import graphql.schema.idl.errors.QueryOperationMissingError
-import graphql.schema.idl.errors.SchemaMissingError
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -34,7 +33,6 @@ import static java.lang.String.format
 
 class SchemaTypeCheckerTest extends Specification {
 
-    def enforceSchemaDirectives = false
 
 
     TypeDefinitionRegistry parse(String spec) {
@@ -142,7 +140,7 @@ class SchemaTypeCheckerTest extends Specification {
         for (String name : resolvingNames) {
             runtimeBuilder.type(TypeRuntimeWiring.newTypeWiring(name).typeResolver(resolver))
         }
-        return new SchemaTypeChecker().checkTypeRegistry(types, runtimeBuilder.build(), enforceSchemaDirectives)
+        return new SchemaTypeChecker().checkTypeRegistry(types, runtimeBuilder.build())
     }
 
     def "test missing type in object"() {
@@ -1378,7 +1376,6 @@ class SchemaTypeCheckerTest extends Specification {
             }
         """
 
-        enforceSchemaDirectives = true
         def result = check(spec)
 
         expect:
@@ -1395,7 +1392,6 @@ class SchemaTypeCheckerTest extends Specification {
             }
         """
 
-        enforceSchemaDirectives = true
         def result = check(spec)
 
         expect:
@@ -1412,7 +1408,6 @@ class SchemaTypeCheckerTest extends Specification {
             }
         """
 
-        enforceSchemaDirectives = true
         def result = check(spec)
 
         expect:
@@ -1433,7 +1428,6 @@ class SchemaTypeCheckerTest extends Specification {
             }
         """
 
-        enforceSchemaDirectives = true
         def result = check(spec)
 
         expect:
@@ -1454,7 +1448,6 @@ class SchemaTypeCheckerTest extends Specification {
             }
         """
 
-        enforceSchemaDirectives = true
         def result = check(spec)
 
         expect:
@@ -1495,7 +1488,6 @@ class SchemaTypeCheckerTest extends Specification {
 
         """
 
-        enforceSchemaDirectives = true
         def result = check(spec)
 
         expect:
@@ -1555,7 +1547,6 @@ class SchemaTypeCheckerTest extends Specification {
             }
         """
 
-        enforceSchemaDirectives = true
         def result = check(spec)
 
         expect:

--- a/src/test/groovy/graphql/schema/idl/SchemaTypeCheckerTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaTypeCheckerTest.groovy
@@ -948,11 +948,7 @@ class SchemaTypeCheckerTest extends Specification {
                 enumA @deprecated(badName : "must be called reason"),
                 enumB @deprecated(reason : "it must have", one : "argument value")
             }
-
-            input InputType {
-                inputFieldA : String @deprecated(badName : "must be called reason")
-                inputFieldB : String @deprecated(reason : "it must have", one : "argument value")
-            }
+            # deprecation is no allowed on input field definitions and args atm, see: https://github.com/graphql-java/graphql-java/issues/1770
         """
 
         def result = check(spec)
@@ -960,13 +956,14 @@ class SchemaTypeCheckerTest extends Specification {
         expect:
 
         !result.isEmpty()
-        result.size() == 8
+        result.size() == 6
     }
 
     def "test that directives are valid"() {
 
         def spec = """                        
-            
+            directive @directiveA on FIELD_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+            directive @directiveOK on FIELD_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
             interface InterfaceType1 {
                 fieldA : String @directiveA @directiveA 
             }
@@ -1005,7 +1002,7 @@ class SchemaTypeCheckerTest extends Specification {
     def "test that directives args are valid"() {
 
         def spec = """                        
-            
+            directive @directive(arg1: Int,argOK: Int) on FIELD_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION 
             interface InterfaceType1 {
                 fieldA : String @directive(arg1 : 1, arg1 : 2) 
             }
@@ -1097,7 +1094,7 @@ class SchemaTypeCheckerTest extends Specification {
     def "interface type extensions invariants are enforced"() {
 
         def spec = """                        
-
+            directive @directive on INTERFACE
             type Query implements InterfaceType1 {
                 fieldA : String
                 fieldC : String
@@ -1145,7 +1142,7 @@ class SchemaTypeCheckerTest extends Specification {
             type Baz {
                 baz : String
             }
-
+            directive @directive on UNION
             union FooBar @directive = Foo | Bar
 
             extend union FooBar @directive

--- a/src/test/groovy/graphql/schema/transform/FieldVisibilitySchemaTransformationTest.groovy
+++ b/src/test/groovy/graphql/schema/transform/FieldVisibilitySchemaTransformationTest.groovy
@@ -736,7 +736,7 @@ class FieldVisibilitySchemaTransformationTest extends Specification {
         given:
         GraphQLSchema schema = TestUtil.schema("""
 
-        directive @private on FIELD_DEFINITION
+        directive @private on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
         
         type Query {
             foo: Foo 
@@ -774,7 +774,7 @@ class FieldVisibilitySchemaTransformationTest extends Specification {
         given:
         GraphQLSchema schema = TestUtil.schema("""
 
-        directive @private on FIELD_DEFINITION
+        directive @private on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
         
         type Query {
             foo: Foo 


### PR DESCRIPTION
We have an old flag to allow SDLs not to declare directives. This was done before SDL was part of the official spec.

This PR removes this features as it is not spec conform.
