### PR TITLE
Use descriptions instead of comments for AstPrinter and IntrospectionResultToSchema

### DIFF
--- a/src/main/java/graphql/introspection/IntrospectionResultToSchema.java
+++ b/src/main/java/graphql/introspection/IntrospectionResultToSchema.java
@@ -145,7 +145,7 @@ public class IntrospectionResultToSchema {
 
         UnionTypeDefinition.Builder unionTypeDefinition = UnionTypeDefinition.newUnionTypeDefinition();
         unionTypeDefinition.name((String) input.get("name"));
-        unionTypeDefinition.description(toDescription((String) input.get("description")));
+        unionTypeDefinition.description(toDescription(input));
 
         List<Map<String, Object>> possibleTypes = (List<Map<String, Object>>) input.get("possibleTypes");
 
@@ -162,14 +162,14 @@ public class IntrospectionResultToSchema {
         assertTrue(input.get("kind").equals("ENUM"), "wrong input");
 
         EnumTypeDefinition.Builder enumTypeDefinition = EnumTypeDefinition.newEnumTypeDefinition().name((String) input.get("name"));
-        enumTypeDefinition.description(toDescription((String) input.get("description")));
+        enumTypeDefinition.description(toDescription(input));
 
         List<Map<String, Object>> enumValues = (List<Map<String, Object>>) input.get("enumValues");
 
         for (Map<String, Object> enumValue : enumValues) {
 
             EnumValueDefinition.Builder enumValueDefinition = EnumValueDefinition.newEnumValueDefinition().name((String) enumValue.get("name"));
-            enumTypeDefinition.description(toDescription((String) input.get("description")));
+            enumTypeDefinition.description(toDescription(input));
 
             createDeprecatedDirective(enumValue, enumValueDefinition);
 
@@ -184,7 +184,7 @@ public class IntrospectionResultToSchema {
         assertTrue(input.get("kind").equals("INTERFACE"), "wrong input");
 
         InterfaceTypeDefinition.Builder interfaceTypeDefinition = InterfaceTypeDefinition.newInterfaceTypeDefinition().name((String) input.get("name"));
-        interfaceTypeDefinition.description(toDescription((String) input.get("description")));
+        interfaceTypeDefinition.description(toDescription(input));
         List<Map<String, Object>> fields = (List<Map<String, Object>>) input.get("fields");
         interfaceTypeDefinition.definitions(createFields(fields));
 
@@ -198,7 +198,7 @@ public class IntrospectionResultToSchema {
 
         InputObjectTypeDefinition.Builder inputObjectTypeDefinition = InputObjectTypeDefinition.newInputObjectDefinition()
                 .name((String) input.get("name"))
-                .description(toDescription((String) input.get("description")));
+                .description(toDescription(input));
 
         List<Map<String, Object>> fields = (List<Map<String, Object>>) input.get("inputFields");
         List<InputValueDefinition> inputValueDefinitions = createInputValueDefinitions(fields);
@@ -212,7 +212,7 @@ public class IntrospectionResultToSchema {
         assertTrue(input.get("kind").equals("OBJECT"), "wrong input");
 
         ObjectTypeDefinition.Builder objectTypeDefinition = ObjectTypeDefinition.newObjectTypeDefinition().name((String) input.get("name"));
-        objectTypeDefinition.description(toDescription((String) input.get("description")));
+        objectTypeDefinition.description(toDescription(input));
         if (input.containsKey("interfaces")) {
             objectTypeDefinition.implementz(
                     ((List<Map<String, Object>>) input.get("interfaces")).stream()
@@ -231,7 +231,7 @@ public class IntrospectionResultToSchema {
         List<FieldDefinition> result = new ArrayList<>();
         for (Map<String, Object> field : fields) {
             FieldDefinition.Builder fieldDefinition = FieldDefinition.newFieldDefinition().name((String) field.get("name"));
-            fieldDefinition.description(toDescription((String) field.get("description")));
+            fieldDefinition.description(toDescription(field));
             fieldDefinition.type(createTypeIndirection((Map<String, Object>) field.get("type")));
 
             createDeprecatedDirective(field, fieldDefinition);
@@ -264,7 +264,7 @@ public class IntrospectionResultToSchema {
         for (Map<String, Object> arg : args) {
             Type argType = createTypeIndirection((Map<String, Object>) arg.get("type"));
             InputValueDefinition.Builder inputValueDefinition = InputValueDefinition.newInputValueDefinition().name((String) arg.get("name")).type(argType);
-            inputValueDefinition.description(toDescription((String) arg.get("description")));
+            inputValueDefinition.description(toDescription(arg));
 
             String valueLiteral = (String) arg.get("defaultValue");
             if (valueLiteral != null) {
@@ -296,7 +296,8 @@ public class IntrospectionResultToSchema {
         }
     }
 
-    private Description toDescription(String description) {
+    private Description toDescription(Map<String, Object> input) {
+        String description = (String) input.get("description");
         if (description == null) {
             return null;
         }

--- a/src/main/java/graphql/introspection/IntrospectionResultToSchema.java
+++ b/src/main/java/graphql/introspection/IntrospectionResultToSchema.java
@@ -4,7 +4,7 @@ import graphql.ExecutionResult;
 import graphql.PublicApi;
 import graphql.language.Argument;
 import graphql.language.AstValueHelper;
-import graphql.language.Comment;
+import graphql.language.Description;
 import graphql.language.Directive;
 import graphql.language.Document;
 import graphql.language.EnumTypeDefinition;
@@ -145,7 +145,7 @@ public class IntrospectionResultToSchema {
 
         UnionTypeDefinition.Builder unionTypeDefinition = UnionTypeDefinition.newUnionTypeDefinition();
         unionTypeDefinition.name((String) input.get("name"));
-        unionTypeDefinition.comments(toComment((String) input.get("description")));
+        unionTypeDefinition.description(toDescription((String) input.get("description")));
 
         List<Map<String, Object>> possibleTypes = (List<Map<String, Object>>) input.get("possibleTypes");
 
@@ -162,14 +162,14 @@ public class IntrospectionResultToSchema {
         assertTrue(input.get("kind").equals("ENUM"), "wrong input");
 
         EnumTypeDefinition.Builder enumTypeDefinition = EnumTypeDefinition.newEnumTypeDefinition().name((String) input.get("name"));
-        enumTypeDefinition.comments(toComment((String) input.get("description")));
+        enumTypeDefinition.description(toDescription((String) input.get("description")));
 
         List<Map<String, Object>> enumValues = (List<Map<String, Object>>) input.get("enumValues");
 
         for (Map<String, Object> enumValue : enumValues) {
 
             EnumValueDefinition.Builder enumValueDefinition = EnumValueDefinition.newEnumValueDefinition().name((String) enumValue.get("name"));
-            enumValueDefinition.comments(toComment((String) enumValue.get("description")));
+            enumTypeDefinition.description(toDescription((String) input.get("description")));
 
             createDeprecatedDirective(enumValue, enumValueDefinition);
 
@@ -184,7 +184,7 @@ public class IntrospectionResultToSchema {
         assertTrue(input.get("kind").equals("INTERFACE"), "wrong input");
 
         InterfaceTypeDefinition.Builder interfaceTypeDefinition = InterfaceTypeDefinition.newInterfaceTypeDefinition().name((String) input.get("name"));
-        interfaceTypeDefinition.comments(toComment((String) input.get("description")));
+        interfaceTypeDefinition.description(toDescription((String) input.get("description")));
         List<Map<String, Object>> fields = (List<Map<String, Object>>) input.get("fields");
         interfaceTypeDefinition.definitions(createFields(fields));
 
@@ -198,7 +198,7 @@ public class IntrospectionResultToSchema {
 
         InputObjectTypeDefinition.Builder inputObjectTypeDefinition = InputObjectTypeDefinition.newInputObjectDefinition()
                 .name((String) input.get("name"))
-                .comments(toComment((String) input.get("description")));
+                .description(toDescription((String) input.get("description")));
 
         List<Map<String, Object>> fields = (List<Map<String, Object>>) input.get("inputFields");
         List<InputValueDefinition> inputValueDefinitions = createInputValueDefinitions(fields);
@@ -212,7 +212,7 @@ public class IntrospectionResultToSchema {
         assertTrue(input.get("kind").equals("OBJECT"), "wrong input");
 
         ObjectTypeDefinition.Builder objectTypeDefinition = ObjectTypeDefinition.newObjectTypeDefinition().name((String) input.get("name"));
-        objectTypeDefinition.comments(toComment((String) input.get("description")));
+        objectTypeDefinition.description(toDescription((String) input.get("description")));
         if (input.containsKey("interfaces")) {
             objectTypeDefinition.implementz(
                     ((List<Map<String, Object>>) input.get("interfaces")).stream()
@@ -231,7 +231,7 @@ public class IntrospectionResultToSchema {
         List<FieldDefinition> result = new ArrayList<>();
         for (Map<String, Object> field : fields) {
             FieldDefinition.Builder fieldDefinition = FieldDefinition.newFieldDefinition().name((String) field.get("name"));
-            fieldDefinition.comments(toComment((String) field.get("description")));
+            fieldDefinition.description(toDescription((String) field.get("description")));
             fieldDefinition.type(createTypeIndirection((Map<String, Object>) field.get("type")));
 
             createDeprecatedDirective(field, fieldDefinition);
@@ -264,7 +264,7 @@ public class IntrospectionResultToSchema {
         for (Map<String, Object> arg : args) {
             Type argType = createTypeIndirection((Map<String, Object>) arg.get("type"));
             InputValueDefinition.Builder inputValueDefinition = InputValueDefinition.newInputValueDefinition().name((String) arg.get("name")).type(argType);
-            inputValueDefinition.comments(toComment((String) arg.get("description")));
+            inputValueDefinition.description(toDescription((String) arg.get("description")));
 
             String valueLiteral = (String) arg.get("defaultValue");
             if (valueLiteral != null) {
@@ -296,18 +296,17 @@ public class IntrospectionResultToSchema {
         }
     }
 
-    private List<Comment> toComment(String description) {
+    private Description toDescription(String description) {
         if (description == null) {
-            return Collections.emptyList();
+            return null;
         }
-        List<Comment> comments = new ArrayList<>();
+
         String[] lines = description.split("\n");
-        int lineNumber = 0;
-        for (String line : lines) {
-            Comment comment = new Comment(line, new SourceLocation(++lineNumber, 1));
-            comments.add(comment);
+        if (lines.length > 1) {
+            return new Description(description, null, true);
+        } else {
+            return new Description(description, null, false);
         }
-        return comments;
     }
 
 }

--- a/src/main/java/graphql/language/AbstractDescribedNode.java
+++ b/src/main/java/graphql/language/AbstractDescribedNode.java
@@ -1,8 +1,11 @@
 package graphql.language;
 
+import graphql.PublicApi;
+
 import java.util.List;
 import java.util.Map;
 
+@PublicApi
 public abstract class AbstractDescribedNode<T extends Node> extends AbstractNode<T> implements DescribedNode<T>  {
 
     private Description description;

--- a/src/main/java/graphql/language/AbstractDescribedNode.java
+++ b/src/main/java/graphql/language/AbstractDescribedNode.java
@@ -1,0 +1,19 @@
+package graphql.language;
+
+import java.util.List;
+import java.util.Map;
+
+public abstract class AbstractDescribedNode<T extends Node> extends AbstractNode<T> implements DescribedNode<T>  {
+
+    private Description description;
+
+    public AbstractDescribedNode(SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars, Map<String, String> additionalData, Description description) {
+        super(sourceLocation, comments, ignoredChars, additionalData);
+        this.description = description;
+    }
+
+    @Override
+    public Description getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/graphql/language/AbstractDescribedNode.java
+++ b/src/main/java/graphql/language/AbstractDescribedNode.java
@@ -8,7 +8,7 @@ import java.util.Map;
 @PublicApi
 public abstract class AbstractDescribedNode<T extends Node> extends AbstractNode<T> implements DescribedNode<T>  {
 
-    private Description description;
+    protected Description description;
 
     public AbstractDescribedNode(SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars, Map<String, String> additionalData, Description description) {
         super(sourceLocation, comments, ignoredChars, additionalData);

--- a/src/main/java/graphql/language/AstPrinter.java
+++ b/src/main/java/graphql/language/AstPrinter.java
@@ -184,14 +184,6 @@ public class AstPrinter {
         };
     }
 
-//    private boolean hasDescription(Node<?> node) {
-//        Description description = ((AbstractDescribedNode) node).getDescription();
-//        if (description == null || description.getContent() == null || description.getContent().length() == 0 ) {
-//                return false;
-//        }
-//        return true;
-//    }
-
     private boolean hasDescription(List<? extends Node> nodes) {
         return nodes.stream().anyMatch(it -> ((AbstractDescribedNode) it).getDescription() != null);
     }

--- a/src/main/java/graphql/language/AstPrinter.java
+++ b/src/main/java/graphql/language/AstPrinter.java
@@ -110,7 +110,7 @@ public class AstPrinter {
 
     private NodePrinter<EnumTypeDefinition> enumTypeDefinition() {
         return (out, node) -> {
-            out.printf("%s", comments(node));
+            out.printf("%s", description(node));
             out.printf("%s",
                     spaced(
                             "enum",
@@ -127,7 +127,7 @@ public class AstPrinter {
 
     private NodePrinter<EnumValueDefinition> enumValueDefinition() {
         return (out, node) -> {
-            out.printf("%s", comments(node));
+            out.printf("%s", description(node));
             out.printf("%s",
                     spaced(
                             node.getName(),
@@ -158,12 +158,12 @@ public class AstPrinter {
     private NodePrinter<FieldDefinition> fieldDefinition() {
         final String argSep = compactMode ? "," : ", ";
         return (out, node) -> {
-            out.printf("%s", comments(node));
             String args;
-            if (hasComments(node.getInputValueDefinitions()) && !compactMode) {
+            if (hasDescription(node.getInputValueDefinitions()) && !compactMode) {
+                out.printf("%s", description(node));
                 args = join(node.getInputValueDefinitions(), "\n");
                 out.printf("%s", node.getName() +
-                        wrap("(\n", args, "\n)") +
+                        wrap("(\n", args, ")") +
                         ": " +
                         spaced(
                                 type(node.getType()),
@@ -173,7 +173,7 @@ public class AstPrinter {
             } else {
                 args = join(node.getInputValueDefinitions(), argSep);
                 out.printf("%s", node.getName() +
-                        wrap("(", args, ")") +
+                        wrap( "(", args, ")") +
                         ": " +
                         spaced(
                                 type(node.getType()),
@@ -184,8 +184,16 @@ public class AstPrinter {
         };
     }
 
-    private boolean hasComments(List<? extends Node> nodes) {
-        return nodes.stream().anyMatch(it -> it.getComments().size() > 0);
+//    private boolean hasDescription(Node<?> node) {
+//        Description description = ((AbstractDescribedNode) node).getDescription();
+//        if (description == null || description.getContent() == null || description.getContent().length() == 0 ) {
+//                return false;
+//        }
+//        return true;
+//    }
+
+    private boolean hasDescription(List<? extends Node> nodes) {
+        return nodes.stream().anyMatch(it -> ((AbstractDescribedNode) it).getDescription() != null);
     }
 
     private NodePrinter<FragmentDefinition> fragmentDefinition() {
@@ -217,7 +225,6 @@ public class AstPrinter {
             String directives = directives(node.getDirectives());
             String selectionSet = node(node.getSelectionSet());
 
-            out.printf("%s", comments(node));
             out.printf("%s", spaced(
                     "...",
                     typeCondition,
@@ -229,7 +236,7 @@ public class AstPrinter {
 
     private NodePrinter<InputObjectTypeDefinition> inputObjectTypeDefinition() {
         return (out, node) -> {
-            out.printf("%s", comments(node));
+            out.printf("%s", description(node));
             out.printf("%s", spaced(
                     "input",
                     node.getName(),
@@ -245,7 +252,7 @@ public class AstPrinter {
         String defaultValueEquals = compactMode ? "=" : "= ";
         return (out, node) -> {
             Value defaultValue = node.getDefaultValue();
-            out.printf("%s", comments(node));
+            out.printf("%s", description(node));
             out.printf("%s", spaced(
                     node.getName() + nameTypeSep + type(node.getType()),
                     wrap(defaultValueEquals, defaultValue, ""),
@@ -257,7 +264,7 @@ public class AstPrinter {
 
     private NodePrinter<InterfaceTypeDefinition> interfaceTypeDefinition() {
         return (out, node) -> {
-            out.printf("%s", comments(node));
+            out.printf("%s", description(node));
             out.printf("%s", spaced(
                     "interface",
                     node.getName(),
@@ -300,7 +307,7 @@ public class AstPrinter {
 
     private NodePrinter<ObjectTypeDefinition> objectTypeDefinition() {
         return (out, node) -> {
-            out.printf("%s", comments(node));
+            out.printf("%s", description(node));
             out.printf("%s", spaced(
                     "type",
                     node.getName(),
@@ -313,14 +320,13 @@ public class AstPrinter {
 
     private NodePrinter<SelectionSet> selectionSet() {
         return (out, node) -> {
-            out.printf("%s", comments(node));
             out.printf("%s", block(node.getSelections()));
         };
     }
 
     private NodePrinter<ScalarTypeDefinition> scalarTypeDefinition() {
         return (out, node) -> {
-            out.printf("%s", comments(node));
+            out.printf("%s", description(node));
             out.printf("%s", spaced(
                     "scalar",
                     node.getName(),
@@ -331,7 +337,6 @@ public class AstPrinter {
 
     private NodePrinter<SchemaDefinition> schemaDefinition() {
         return (out, node) -> {
-            out.printf("%s", comments(node));
             out.printf("%s", spaced(
                     "schema",
                     directives(node.getDirectives()),
@@ -387,7 +392,7 @@ public class AstPrinter {
         String barSep = compactMode ? "|" : " | ";
         String equals = compactMode ? "=" : "= ";
         return (out, node) -> {
-            out.printf("%s", comments(node));
+            out.printf("%s", description(node));
             out.printf("%s", spaced(
                     "union",
                     node.getName(),
@@ -489,15 +494,20 @@ public class AstPrinter {
         return "";
     }
 
-    private String comments(Node<?> node) {
-        List<Comment> comments = nvl(node.getComments());
-        if (isEmpty(comments) || compactMode) {
+    private String description(Node<?> node) {
+        Description description = ((AbstractDescribedNode) node).getDescription();
+        if (description == null || description.getContent() == null || compactMode) {
             return "";
         }
-        String s = comments.stream().map(c -> "#" + c.getContent()).collect(joining("\n", "", "\n"));
+        String s;
+        boolean startNewLine = description.getContent().charAt(0) == '\n';
+        if (description.isMultiLine()) {
+            s =  "\"\"\"" + (startNewLine ? "" : "\n") + description.getContent() + "\n\"\"\"\n";
+        } else {
+            s = "\"" + description.getContent() + "\"\n";
+        }
         return s;
     }
-
 
     private String directives(List<Directive> directives) {
         return join(nvl(directives), " ");

--- a/src/main/java/graphql/language/AstPrinter.java
+++ b/src/main/java/graphql/language/AstPrinter.java
@@ -185,7 +185,7 @@ public class AstPrinter {
     }
 
     private boolean hasDescription(List<? extends Node> nodes) {
-        return nodes.stream().anyMatch(it -> ((AbstractDescribedNode) it).getDescription() != null);
+        return nodes.stream().filter(it -> it instanceof AbstractDescribedNode).anyMatch(it -> ((AbstractDescribedNode) it).getDescription() != null);
     }
 
     private NodePrinter<FragmentDefinition> fragmentDefinition() {

--- a/src/main/java/graphql/language/DescribedNode.java
+++ b/src/main/java/graphql/language/DescribedNode.java
@@ -1,5 +1,11 @@
 package graphql.language;
 
+import graphql.PublicApi;
+
+/**
+ * Represents a node that can contain a description.
+ */
+@PublicApi
 public interface DescribedNode<T extends Node> extends Node<T> {
 
     /**

--- a/src/main/java/graphql/language/DescribedNode.java
+++ b/src/main/java/graphql/language/DescribedNode.java
@@ -1,0 +1,10 @@
+package graphql.language;
+
+public interface DescribedNode<T extends Node> extends Node<T> {
+
+    /**
+     * @return the description of this node
+     */
+    Description getDescription();
+
+}

--- a/src/main/java/graphql/language/DirectiveDefinition.java
+++ b/src/main/java/graphql/language/DirectiveDefinition.java
@@ -17,7 +17,7 @@ import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 import static java.util.Collections.emptyMap;
 
 @PublicApi
-public class DirectiveDefinition extends AbstractNode<DirectiveDefinition> implements SDLDefinition<DirectiveDefinition>, NamedNode<DirectiveDefinition> {
+public class DirectiveDefinition extends AbstractDescribedNode<DirectiveDefinition> implements SDLDefinition<DirectiveDefinition>, NamedNode<DirectiveDefinition> {
     private final String name;
     private final Description description;
     private final List<InputValueDefinition> inputValueDefinitions;
@@ -35,7 +35,7 @@ public class DirectiveDefinition extends AbstractNode<DirectiveDefinition> imple
                                   List<Comment> comments,
                                   IgnoredChars ignoredChars,
                                   Map<String, String> additionalData) {
-        super(sourceLocation, comments, ignoredChars, additionalData);
+        super(sourceLocation, comments, ignoredChars, additionalData, description);
         this.name = name;
         this.description = description;
         this.inputValueDefinitions = inputValueDefinitions;

--- a/src/main/java/graphql/language/DirectiveDefinition.java
+++ b/src/main/java/graphql/language/DirectiveDefinition.java
@@ -19,7 +19,6 @@ import static java.util.Collections.emptyMap;
 @PublicApi
 public class DirectiveDefinition extends AbstractDescribedNode<DirectiveDefinition> implements SDLDefinition<DirectiveDefinition>, NamedNode<DirectiveDefinition> {
     private final String name;
-    private final Description description;
     private final List<InputValueDefinition> inputValueDefinitions;
     private final List<DirectiveLocation> directiveLocations;
 
@@ -37,7 +36,6 @@ public class DirectiveDefinition extends AbstractDescribedNode<DirectiveDefiniti
                                   Map<String, String> additionalData) {
         super(sourceLocation, comments, ignoredChars, additionalData, description);
         this.name = name;
-        this.description = description;
         this.inputValueDefinitions = inputValueDefinitions;
         this.directiveLocations = directiveLocations;
     }
@@ -54,10 +52,6 @@ public class DirectiveDefinition extends AbstractDescribedNode<DirectiveDefiniti
     @Override
     public String getName() {
         return name;
-    }
-
-    public Description getDescription() {
-        return description;
     }
 
     public List<InputValueDefinition> getInputValueDefinitions() {

--- a/src/main/java/graphql/language/EnumTypeDefinition.java
+++ b/src/main/java/graphql/language/EnumTypeDefinition.java
@@ -18,7 +18,6 @@ import static java.util.Collections.emptyMap;
 @PublicApi
 public class EnumTypeDefinition extends AbstractDescribedNode<EnumTypeDefinition> implements TypeDefinition<EnumTypeDefinition>, DirectivesContainer<EnumTypeDefinition>, NamedNode<EnumTypeDefinition> {
     private final String name;
-    private final Description description;
     private final List<EnumValueDefinition> enumValueDefinitions;
     private final List<Directive> directives;
 
@@ -35,7 +34,6 @@ public class EnumTypeDefinition extends AbstractDescribedNode<EnumTypeDefinition
                                  IgnoredChars ignoredChars, Map<String, String> additionalData) {
         super(sourceLocation, comments, ignoredChars, additionalData, description);
         this.name = name;
-        this.description = description;
         this.directives = (null == directives) ? new ArrayList<>() : directives;
         this.enumValueDefinitions = enumValueDefinitions;
     }
@@ -61,10 +59,6 @@ public class EnumTypeDefinition extends AbstractDescribedNode<EnumTypeDefinition
     @Override
     public String getName() {
         return name;
-    }
-
-    public Description getDescription() {
-        return description;
     }
 
     @Override

--- a/src/main/java/graphql/language/EnumTypeDefinition.java
+++ b/src/main/java/graphql/language/EnumTypeDefinition.java
@@ -16,7 +16,7 @@ import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 import static java.util.Collections.emptyMap;
 
 @PublicApi
-public class EnumTypeDefinition extends AbstractNode<EnumTypeDefinition> implements TypeDefinition<EnumTypeDefinition>, DirectivesContainer<EnumTypeDefinition>, NamedNode<EnumTypeDefinition> {
+public class EnumTypeDefinition extends AbstractDescribedNode<EnumTypeDefinition> implements TypeDefinition<EnumTypeDefinition>, DirectivesContainer<EnumTypeDefinition>, NamedNode<EnumTypeDefinition> {
     private final String name;
     private final Description description;
     private final List<EnumValueDefinition> enumValueDefinitions;
@@ -33,7 +33,7 @@ public class EnumTypeDefinition extends AbstractNode<EnumTypeDefinition> impleme
                                  SourceLocation sourceLocation,
                                  List<Comment> comments,
                                  IgnoredChars ignoredChars, Map<String, String> additionalData) {
-        super(sourceLocation, comments, ignoredChars, additionalData);
+        super(sourceLocation, comments, ignoredChars, additionalData, description);
         this.name = name;
         this.description = description;
         this.directives = (null == directives) ? new ArrayList<>() : directives;

--- a/src/main/java/graphql/language/EnumValueDefinition.java
+++ b/src/main/java/graphql/language/EnumValueDefinition.java
@@ -19,7 +19,6 @@ import static java.util.Collections.emptyMap;
 @PublicApi
 public class EnumValueDefinition extends AbstractDescribedNode<EnumValueDefinition> implements DirectivesContainer<EnumValueDefinition>, NamedNode<EnumValueDefinition> {
     private final String name;
-    private final Description description;
     private final List<Directive> directives;
 
     public static final String CHILD_DIRECTIVES = "directives";
@@ -33,7 +32,6 @@ public class EnumValueDefinition extends AbstractDescribedNode<EnumValueDefiniti
                                   IgnoredChars ignoredChars, Map<String, String> additionalData) {
         super(sourceLocation, comments, ignoredChars, additionalData, description);
         this.name = name;
-        this.description = description;
         this.directives = (null == directives) ? new ArrayList<>() : directives;
     }
 
@@ -59,10 +57,6 @@ public class EnumValueDefinition extends AbstractDescribedNode<EnumValueDefiniti
     @Override
     public String getName() {
         return name;
-    }
-
-    public Description getDescription() {
-        return description;
     }
 
     @Override

--- a/src/main/java/graphql/language/EnumValueDefinition.java
+++ b/src/main/java/graphql/language/EnumValueDefinition.java
@@ -17,7 +17,7 @@ import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 import static java.util.Collections.emptyMap;
 
 @PublicApi
-public class EnumValueDefinition extends AbstractNode<EnumValueDefinition> implements DirectivesContainer<EnumValueDefinition>, NamedNode<EnumValueDefinition> {
+public class EnumValueDefinition extends AbstractDescribedNode<EnumValueDefinition> implements DirectivesContainer<EnumValueDefinition>, NamedNode<EnumValueDefinition> {
     private final String name;
     private final Description description;
     private final List<Directive> directives;
@@ -31,7 +31,7 @@ public class EnumValueDefinition extends AbstractNode<EnumValueDefinition> imple
                                   SourceLocation sourceLocation,
                                   List<Comment> comments,
                                   IgnoredChars ignoredChars, Map<String, String> additionalData) {
-        super(sourceLocation, comments, ignoredChars, additionalData);
+        super(sourceLocation, comments, ignoredChars, additionalData, description);
         this.name = name;
         this.description = description;
         this.directives = (null == directives) ? new ArrayList<>() : directives;

--- a/src/main/java/graphql/language/FieldDefinition.java
+++ b/src/main/java/graphql/language/FieldDefinition.java
@@ -20,7 +20,6 @@ import static java.util.Collections.emptyMap;
 public class FieldDefinition extends AbstractDescribedNode<FieldDefinition> implements DirectivesContainer<FieldDefinition>, NamedNode<FieldDefinition> {
     private final String name;
     private final Type type;
-    private final Description description;
     private final List<InputValueDefinition> inputValueDefinitions;
     private final List<Directive> directives;
 
@@ -39,7 +38,6 @@ public class FieldDefinition extends AbstractDescribedNode<FieldDefinition> impl
                               IgnoredChars ignoredChars,
                               Map<String, String> additionalData) {
         super(sourceLocation, comments, ignoredChars, additionalData, description);
-        this.description = description;
         this.name = name;
         this.type = type;
         this.inputValueDefinitions = inputValueDefinitions;
@@ -58,10 +56,6 @@ public class FieldDefinition extends AbstractDescribedNode<FieldDefinition> impl
     @Override
     public String getName() {
         return name;
-    }
-
-    public Description getDescription() {
-        return description;
     }
 
     public List<InputValueDefinition> getInputValueDefinitions() {

--- a/src/main/java/graphql/language/FieldDefinition.java
+++ b/src/main/java/graphql/language/FieldDefinition.java
@@ -17,7 +17,7 @@ import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 import static java.util.Collections.emptyMap;
 
 @PublicApi
-public class FieldDefinition extends AbstractNode<FieldDefinition> implements DirectivesContainer<FieldDefinition>, NamedNode<FieldDefinition> {
+public class FieldDefinition extends AbstractDescribedNode<FieldDefinition> implements DirectivesContainer<FieldDefinition>, NamedNode<FieldDefinition> {
     private final String name;
     private final Type type;
     private final Description description;
@@ -38,7 +38,7 @@ public class FieldDefinition extends AbstractNode<FieldDefinition> implements Di
                               List<Comment> comments,
                               IgnoredChars ignoredChars,
                               Map<String, String> additionalData) {
-        super(sourceLocation, comments, ignoredChars, additionalData);
+        super(sourceLocation, comments, ignoredChars, additionalData, description);
         this.description = description;
         this.name = name;
         this.type = type;

--- a/src/main/java/graphql/language/InputObjectTypeDefinition.java
+++ b/src/main/java/graphql/language/InputObjectTypeDefinition.java
@@ -16,7 +16,7 @@ import static graphql.Assert.assertNotNull;
 import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 
 @PublicApi
-public class InputObjectTypeDefinition extends AbstractNode<InputObjectTypeDefinition> implements TypeDefinition<InputObjectTypeDefinition>, DirectivesContainer<InputObjectTypeDefinition>, NamedNode<InputObjectTypeDefinition> {
+public class InputObjectTypeDefinition extends AbstractDescribedNode<InputObjectTypeDefinition> implements TypeDefinition<InputObjectTypeDefinition>, DirectivesContainer<InputObjectTypeDefinition>, NamedNode<InputObjectTypeDefinition> {
 
     private final String name;
     private final Description description;
@@ -35,7 +35,7 @@ public class InputObjectTypeDefinition extends AbstractNode<InputObjectTypeDefin
                                         List<Comment> comments,
                                         IgnoredChars ignoredChars,
                                         Map<String, String> additionalData) {
-        super(sourceLocation, comments, ignoredChars, additionalData);
+        super(sourceLocation, comments, ignoredChars, additionalData, description);
         this.name = name;
         this.description = description;
         this.directives = directives;

--- a/src/main/java/graphql/language/InputObjectTypeDefinition.java
+++ b/src/main/java/graphql/language/InputObjectTypeDefinition.java
@@ -19,7 +19,6 @@ import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 public class InputObjectTypeDefinition extends AbstractDescribedNode<InputObjectTypeDefinition> implements TypeDefinition<InputObjectTypeDefinition>, DirectivesContainer<InputObjectTypeDefinition>, NamedNode<InputObjectTypeDefinition> {
 
     private final String name;
-    private final Description description;
     private final List<Directive> directives;
     private final List<InputValueDefinition> inputValueDefinitions;
 
@@ -37,7 +36,6 @@ public class InputObjectTypeDefinition extends AbstractDescribedNode<InputObject
                                         Map<String, String> additionalData) {
         super(sourceLocation, comments, ignoredChars, additionalData, description);
         this.name = name;
-        this.description = description;
         this.directives = directives;
         this.inputValueDefinitions = inputValueDefinitions;
     }
@@ -54,10 +52,6 @@ public class InputObjectTypeDefinition extends AbstractDescribedNode<InputObject
     @Override
     public String getName() {
         return name;
-    }
-
-    public Description getDescription() {
-        return description;
     }
 
     @Override

--- a/src/main/java/graphql/language/InputValueDefinition.java
+++ b/src/main/java/graphql/language/InputValueDefinition.java
@@ -17,7 +17,7 @@ import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 import static java.util.Collections.emptyMap;
 
 @PublicApi
-public class InputValueDefinition extends AbstractNode<InputValueDefinition> implements DirectivesContainer<InputValueDefinition>, NamedNode<InputValueDefinition> {
+public class InputValueDefinition extends AbstractDescribedNode<InputValueDefinition> implements DirectivesContainer<InputValueDefinition>, NamedNode<InputValueDefinition>{
     private final String name;
     private final Type type;
     private final Value defaultValue;
@@ -38,7 +38,7 @@ public class InputValueDefinition extends AbstractNode<InputValueDefinition> imp
                                    List<Comment> comments,
                                    IgnoredChars ignoredChars,
                                    Map<String, String> additionalData) {
-        super(sourceLocation, comments, ignoredChars, additionalData);
+        super(sourceLocation, comments, ignoredChars, additionalData, description);
         this.name = name;
         this.type = type;
         this.defaultValue = defaultValue;

--- a/src/main/java/graphql/language/InputValueDefinition.java
+++ b/src/main/java/graphql/language/InputValueDefinition.java
@@ -21,7 +21,6 @@ public class InputValueDefinition extends AbstractDescribedNode<InputValueDefini
     private final String name;
     private final Type type;
     private final Value defaultValue;
-    private final Description description;
     private final List<Directive> directives;
 
     public static final String CHILD_TYPE = "type";
@@ -43,8 +42,6 @@ public class InputValueDefinition extends AbstractDescribedNode<InputValueDefini
         this.type = type;
         this.defaultValue = defaultValue;
         this.directives = directives;
-        this.description = description;
-
     }
 
     /**
@@ -81,10 +78,6 @@ public class InputValueDefinition extends AbstractDescribedNode<InputValueDefini
     @Override
     public String getName() {
         return name;
-    }
-
-    public Description getDescription() {
-        return description;
     }
 
     public Value getDefaultValue() {

--- a/src/main/java/graphql/language/InterfaceTypeDefinition.java
+++ b/src/main/java/graphql/language/InterfaceTypeDefinition.java
@@ -17,7 +17,7 @@ import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 import static java.util.Collections.emptyMap;
 
 @PublicApi
-public class InterfaceTypeDefinition extends AbstractNode<InterfaceTypeDefinition> implements TypeDefinition<InterfaceTypeDefinition>, DirectivesContainer<InterfaceTypeDefinition>, NamedNode<InterfaceTypeDefinition> {
+public class InterfaceTypeDefinition extends AbstractDescribedNode<InterfaceTypeDefinition> implements TypeDefinition<InterfaceTypeDefinition>, DirectivesContainer<InterfaceTypeDefinition>, NamedNode<InterfaceTypeDefinition> {
 
     private final String name;
     private final Description description;
@@ -36,7 +36,7 @@ public class InterfaceTypeDefinition extends AbstractNode<InterfaceTypeDefinitio
                                       List<Comment> comments,
                                       IgnoredChars ignoredChars,
                                       Map<String, String> additionalData) {
-        super(sourceLocation, comments, ignoredChars, additionalData);
+        super(sourceLocation, comments, ignoredChars, additionalData, description);
         this.name = name;
         this.definitions = definitions;
         this.directives = directives;

--- a/src/main/java/graphql/language/InterfaceTypeDefinition.java
+++ b/src/main/java/graphql/language/InterfaceTypeDefinition.java
@@ -20,7 +20,6 @@ import static java.util.Collections.emptyMap;
 public class InterfaceTypeDefinition extends AbstractDescribedNode<InterfaceTypeDefinition> implements TypeDefinition<InterfaceTypeDefinition>, DirectivesContainer<InterfaceTypeDefinition>, NamedNode<InterfaceTypeDefinition> {
 
     private final String name;
-    private final Description description;
     private final List<FieldDefinition> definitions;
     private final List<Directive> directives;
 
@@ -40,7 +39,6 @@ public class InterfaceTypeDefinition extends AbstractDescribedNode<InterfaceType
         this.name = name;
         this.definitions = definitions;
         this.directives = directives;
-        this.description = description;
     }
 
     /**
@@ -64,10 +62,6 @@ public class InterfaceTypeDefinition extends AbstractDescribedNode<InterfaceType
     @Override
     public String getName() {
         return name;
-    }
-
-    public Description getDescription() {
-        return description;
     }
 
     @Override

--- a/src/main/java/graphql/language/ObjectTypeDefinition.java
+++ b/src/main/java/graphql/language/ObjectTypeDefinition.java
@@ -17,7 +17,7 @@ import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 import static java.util.Collections.emptyMap;
 
 @PublicApi
-public class ObjectTypeDefinition extends AbstractNode<ObjectTypeDefinition> implements TypeDefinition<ObjectTypeDefinition>, DirectivesContainer<ObjectTypeDefinition>, NamedNode<ObjectTypeDefinition> {
+public class ObjectTypeDefinition extends AbstractDescribedNode<ObjectTypeDefinition> implements TypeDefinition<ObjectTypeDefinition>, DirectivesContainer<ObjectTypeDefinition>, NamedNode<ObjectTypeDefinition> {
     private final String name;
     private final Description description;
     private final List<Type> implementz;
@@ -38,7 +38,7 @@ public class ObjectTypeDefinition extends AbstractNode<ObjectTypeDefinition> imp
                                    List<Comment> comments,
                                    IgnoredChars ignoredChars,
                                    Map<String, String> additionalData) {
-        super(sourceLocation, comments, ignoredChars, additionalData);
+        super(sourceLocation, comments, ignoredChars, additionalData, description);
         this.name = name;
         this.implementz = implementz;
         this.directives = directives;

--- a/src/main/java/graphql/language/ObjectTypeDefinition.java
+++ b/src/main/java/graphql/language/ObjectTypeDefinition.java
@@ -19,7 +19,6 @@ import static java.util.Collections.emptyMap;
 @PublicApi
 public class ObjectTypeDefinition extends AbstractDescribedNode<ObjectTypeDefinition> implements TypeDefinition<ObjectTypeDefinition>, DirectivesContainer<ObjectTypeDefinition>, NamedNode<ObjectTypeDefinition> {
     private final String name;
-    private final Description description;
     private final List<Type> implementz;
     private final List<Directive> directives;
     private final List<FieldDefinition> fieldDefinitions;
@@ -43,7 +42,6 @@ public class ObjectTypeDefinition extends AbstractDescribedNode<ObjectTypeDefini
         this.implementz = implementz;
         this.directives = directives;
         this.fieldDefinitions = fieldDefinitions;
-        this.description = description;
     }
 
     /**
@@ -71,10 +69,6 @@ public class ObjectTypeDefinition extends AbstractDescribedNode<ObjectTypeDefini
     @Override
     public String getName() {
         return name;
-    }
-
-    public Description getDescription() {
-        return description;
     }
 
     @Override

--- a/src/main/java/graphql/language/ScalarTypeDefinition.java
+++ b/src/main/java/graphql/language/ScalarTypeDefinition.java
@@ -20,7 +20,6 @@ import static java.util.Collections.emptyMap;
 public class ScalarTypeDefinition extends AbstractDescribedNode<ScalarTypeDefinition> implements TypeDefinition<ScalarTypeDefinition>, DirectivesContainer<ScalarTypeDefinition>, NamedNode<ScalarTypeDefinition> {
 
     private final String name;
-    private final Description description;
     private final List<Directive> directives;
 
     public static final String CHILD_DIRECTIVES = "directives";
@@ -36,7 +35,6 @@ public class ScalarTypeDefinition extends AbstractDescribedNode<ScalarTypeDefini
         super(sourceLocation, comments, ignoredChars, additionalData, description);
         this.name = name;
         this.directives = directives;
-        this.description = description;
     }
 
     /**
@@ -56,11 +54,6 @@ public class ScalarTypeDefinition extends AbstractDescribedNode<ScalarTypeDefini
     @Override
     public String getName() {
         return name;
-    }
-
-
-    public Description getDescription() {
-        return description;
     }
 
     @Override

--- a/src/main/java/graphql/language/ScalarTypeDefinition.java
+++ b/src/main/java/graphql/language/ScalarTypeDefinition.java
@@ -17,7 +17,7 @@ import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 import static java.util.Collections.emptyMap;
 
 @PublicApi
-public class ScalarTypeDefinition extends AbstractNode<ScalarTypeDefinition> implements TypeDefinition<ScalarTypeDefinition>, DirectivesContainer<ScalarTypeDefinition>, NamedNode<ScalarTypeDefinition> {
+public class ScalarTypeDefinition extends AbstractDescribedNode<ScalarTypeDefinition> implements TypeDefinition<ScalarTypeDefinition>, DirectivesContainer<ScalarTypeDefinition>, NamedNode<ScalarTypeDefinition> {
 
     private final String name;
     private final Description description;
@@ -33,7 +33,7 @@ public class ScalarTypeDefinition extends AbstractNode<ScalarTypeDefinition> imp
                                    List<Comment> comments,
                                    IgnoredChars ignoredChars,
                                    Map<String, String> additionalData) {
-        super(sourceLocation, comments, ignoredChars, additionalData);
+        super(sourceLocation, comments, ignoredChars, additionalData, description);
         this.name = name;
         this.directives = directives;
         this.description = description;

--- a/src/main/java/graphql/language/UnionTypeDefinition.java
+++ b/src/main/java/graphql/language/UnionTypeDefinition.java
@@ -20,7 +20,6 @@ import static java.util.Collections.emptyMap;
 public class UnionTypeDefinition extends AbstractDescribedNode<UnionTypeDefinition> implements TypeDefinition<UnionTypeDefinition>, DirectivesContainer<UnionTypeDefinition>, NamedNode<UnionTypeDefinition> {
 
     private final String name;
-    private final Description description;
     private final List<Directive> directives;
     private final List<Type> memberTypes;
 
@@ -39,7 +38,6 @@ public class UnionTypeDefinition extends AbstractDescribedNode<UnionTypeDefiniti
         this.name = name;
         this.directives = directives;
         this.memberTypes = memberTypes;
-        this.description = description;
     }
 
     /**
@@ -74,10 +72,6 @@ public class UnionTypeDefinition extends AbstractDescribedNode<UnionTypeDefiniti
     @Override
     public String getName() {
         return name;
-    }
-
-    public Description getDescription() {
-        return description;
     }
 
     @Override

--- a/src/main/java/graphql/language/UnionTypeDefinition.java
+++ b/src/main/java/graphql/language/UnionTypeDefinition.java
@@ -17,7 +17,7 @@ import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 import static java.util.Collections.emptyMap;
 
 @PublicApi
-public class UnionTypeDefinition extends AbstractNode<UnionTypeDefinition> implements TypeDefinition<UnionTypeDefinition>, DirectivesContainer<UnionTypeDefinition>, NamedNode<UnionTypeDefinition> {
+public class UnionTypeDefinition extends AbstractDescribedNode<UnionTypeDefinition> implements TypeDefinition<UnionTypeDefinition>, DirectivesContainer<UnionTypeDefinition>, NamedNode<UnionTypeDefinition> {
 
     private final String name;
     private final Description description;
@@ -35,7 +35,7 @@ public class UnionTypeDefinition extends AbstractNode<UnionTypeDefinition> imple
                                   SourceLocation sourceLocation,
                                   List<Comment> comments,
                                   IgnoredChars ignoredChars, Map<String, String> additionalData) {
-        super(sourceLocation, comments, ignoredChars, additionalData);
+        super(sourceLocation, comments, ignoredChars, additionalData, description);
         this.name = name;
         this.directives = directives;
         this.memberTypes = memberTypes;

--- a/src/test/groovy/graphql/introspection/IntrospectionResultToSchemaTest.groovy
+++ b/src/test/groovy/graphql/introspection/IntrospectionResultToSchemaTest.groovy
@@ -92,11 +92,12 @@ class IntrospectionResultToSchemaTest extends Specification {
         then:
         result == """type QueryType implements Query {
   hero(
-  #comment about episode
-  #on two lines
+  \"\"\"
+  comment about episode
+  on two lines
+  \"\"\"
   episode: Episode
-  foo: String = \"bar\"
-  ): Character @deprecated(reason: "killed off character")
+  foo: String = \"bar\"): Character @deprecated(reason: "killed off character")
 }"""
 
     }
@@ -196,15 +197,11 @@ class IntrospectionResultToSchemaTest extends Specification {
         def result = printAst(interfaceTypeDefinition)
 
         then:
-        result == """#A character in the Star Wars Trilogy
+        result == """"A character in the Star Wars Trilogy"
 interface Character {
-  #The id of the character.
   id: String!
-  #The name of the character.
   name: String
-  #The friends of the character, or an empty list if they have none.
   friends: [Character]
-  #Which movies they appear in.
   appearsIn: [Episode]
 }"""
 
@@ -248,13 +245,10 @@ interface Character {
         def result = printAst(enumTypeDef)
 
         then:
-        result == """#One of the films in the Star Wars Trilogy
+        result == """"One of the films in the Star Wars Trilogy"
 enum Episode {
-  #Released in 1977.
   NEWHOPE
-  #Released in 1980.
   EMPIRE
-  #Released in 1983.
   JEDI @deprecated(reason: "killed by clones")
 }"""
 
@@ -290,7 +284,7 @@ enum Episode {
         def result = printAst(unionTypeDefinition)
 
         then:
-        result == """#all the stuff
+        result == """"all the stuff"
 union Everything = Character | Episode"""
 
     }
@@ -345,9 +339,9 @@ union Everything = Character | Episode"""
         def result = printAst(inputObjectTypeDefinition)
 
         then:
-        result == """#input for characters
+        result == """"input for characters"
 input CharacterInput {
-  #first name
+  "first name"
   firstName: String
   lastName: String
   family: Boolean
@@ -379,7 +373,6 @@ input CharacterInput {
   subscription: SubscriptionType
 }
 """
-
     }
 
     def "test starwars introspection result"() {
@@ -399,141 +392,47 @@ input CharacterInput {
 
 type QueryType {
   hero(
-  #If omitted, returns the hero of the whole saga. If provided, returns the hero of that particular episode.
-  episode: Episode
-  ): Character
+  "If omitted, returns the hero of the whole saga. If provided, returns the hero of that particular episode."
+  episode: Episode): Character
   human(
-  #id of the human
-  id: String!
-  ): Human
+  "id of the human"
+  id: String!): Human
   droid(
-  #id of the droid
-  id: String!
-  ): Droid
+  "id of the droid"
+  id: String!): Droid
 }
 
-#A character in the Star Wars Trilogy
+"A character in the Star Wars Trilogy"
 interface Character {
-  #The id of the character.
   id: String!
-  #The name of the character.
   name: String
-  #The friends of the character, or an empty list if they have none.
   friends: [Character]
-  #Which movies they appear in.
   appearsIn: [Episode]
 }
 
-#One of the films in the Star Wars Trilogy
+"One of the films in the Star Wars Trilogy"
 enum Episode {
-  #Released in 1977.
   NEWHOPE
-  #Released in 1980.
   EMPIRE
-  #Released in 1983.
   JEDI
 }
 
-#A humanoid creature in the Star Wars universe.
+"A humanoid creature in the Star Wars universe."
 type Human implements Character {
-  #The id of the human.
   id: String!
-  #The name of the human.
   name: String
-  #The friends of the human, or an empty list if they have none.
   friends: [Character]
-  #Which movies they appear in.
   appearsIn: [Episode]
-  #The home planet of the human, or null if unknown.
   homePlanet: String
 }
 
-#A mechanical creature in the Star Wars universe.
+"A mechanical creature in the Star Wars universe."
 type Droid implements Character {
-  #The id of the droid.
   id: String!
-  #The name of the droid.
   name: String
-  #The friends of the droid, or an empty list if they have none.
   friends: [Character]
-  #Which movies they appear in.
   appearsIn: [Episode]
-  #The primary function of the droid.
   primaryFunction: String
-}
-"""
-    }
-
-    def "test simpsons introspection result"() {
-        given:
-        String simpsons = this.getClass().getResource('/simpsons-introspection.json').text
-
-        def parsed = slurp(simpsons)
-
-        when:
-        Document document = introspectionResultToSchema.createSchemaDefinition(parsed)
-        def result = printAst(document)
-
-        then:
-        result == """schema {
-  query: QueryType
-  mutation: MutationType
-}
-
-type QueryType {
-  character(firstName: String): Character
-  characters: [Character]
-  episodes: [Episode]
-  search(searchFor: String): [Everything]
-}
-
-type Character {
-  id: ID!
-  firstName: String
-  lastName: String
-  family: Boolean
-  episodes: [Episode]
-}
-
-type Episode {
-  id: ID!
-  name: String
-  season: Season
-  number: Int
-  numberOverall: Int
-  characters: [Character]
-}
-
-# Simpson seasons
-enum Season {
-  # the beginning
-  Season1
-  Season2
-  Season3
-  Season4
-  # Another one
-  Season5
-  Season6
-  Season7
-  Season8
-  # Not really the last one :-)
-  Season9
-}
-
-union Everything = Character | Episode
-
-type MutationType {
-  addCharacter(character: CharacterInput): MutationResult
-}
-
-type MutationResult {
-  success: Boolean
-}
-
-input CharacterInput {
-  firstName: String
-  lastName: String
-  family: Boolean
 }
 """
     }
@@ -695,4 +594,3 @@ input InputType {
     }
 
 }
-

--- a/src/test/groovy/graphql/introspection/IntrospectionResultToSchemaTest.groovy
+++ b/src/test/groovy/graphql/introspection/IntrospectionResultToSchemaTest.groovy
@@ -437,6 +437,76 @@ type Droid implements Character {
 """
     }
 
+    def "test simpsons introspection result"() {
+        given:
+        String simpsons = this.getClass().getResource('/simpsons-introspection.json').text
+
+        def parsed = slurp(simpsons)
+
+        when:
+        Document document = introspectionResultToSchema.createSchemaDefinition(parsed)
+        def result = printAst(document)
+
+        then:
+        result == """schema {
+  query: QueryType
+  mutation: MutationType
+}
+
+type QueryType {
+  character(firstName: String): Character
+  characters: [Character]
+  episodes: [Episode]
+  search(searchFor: String): [Everything]
+}
+
+type Character {
+  id: ID!
+  firstName: String
+  lastName: String
+  family: Boolean
+  episodes: [Episode]
+}
+
+type Episode {
+  id: ID!
+  name: String
+  season: Season
+  number: Int
+  numberOverall: Int
+  characters: [Character]
+}
+
+" Simpson seasons"
+enum Season {
+  Season1
+  Season2
+  Season3
+  Season4
+  Season5
+  Season6
+  Season7
+  Season8
+  Season9
+}
+
+union Everything = Character | Episode
+
+type MutationType {
+  addCharacter(character: CharacterInput): MutationResult
+}
+
+type MutationResult {
+  success: Boolean
+}
+
+input CharacterInput {
+  firstName: String
+  lastName: String
+  family: Boolean
+}
+"""
+    }
 
     def "test complete round trip"() {
         given:

--- a/src/test/groovy/graphql/language/AstPrinterTest.groovy
+++ b/src/test/groovy/graphql/language/AstPrinterTest.groovy
@@ -95,15 +95,12 @@ scalar DateTime
         //
         // notice how it tightens everything up
         //
-        output == """# objects can have comments
-# over a number of lines
-schema {
+        output == """schema {
   query: QueryType
   mutation: Mutation
 }
 
 type QueryType {
-  # the hero of the film
   hero(episode: Episode): Character
   human(id: String): Human
   droid(id: ID!): Droid
@@ -169,9 +166,7 @@ scalar DateTime
         String output = printAst(document.getDefinitions().get(0))
 
         expect:
-        output == """# objects can have comments
-# over a number of lines
-schema {
+        output == """schema {
   query: QueryType
   mutation: Mutation
 }"""
@@ -183,7 +178,6 @@ schema {
 
         expect:
         output == """type QueryType {
-  # the hero of the film
   hero(episode: Episode): Character
   human(id: String): Human
   droid(id: ID!): Droid
@@ -452,13 +446,7 @@ type Query {
 
         expect:
         output == '''type Query {
-  field(
-  #description1
-  arg1: String
-  arg2: String
-  #description3
-  arg3: String
-  ): String
+  field(arg1: String, arg2: String, arg3: String): String
 }
 '''
 


### PR DESCRIPTION
Changed comments to descriptions according the issue https://github.com/graphql-java/graphql-java/issues/1759 . The previous standard uses `#` to include comments and this PR includes descriptions wrapped around quotations.