### PR TITLE
allow directives to be exposed via Introspection

### DIFF
--- a/src/main/java/graphql/introspection/Introspection.java
+++ b/src/main/java/graphql/introspection/Introspection.java
@@ -13,6 +13,7 @@ import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLCodeRegistry;
 import graphql.schema.GraphQLCompositeType;
 import graphql.schema.GraphQLDirective;
+import graphql.schema.GraphQLDirectiveContainer;
 import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLEnumValueDefinition;
 import graphql.schema.GraphQLFieldDefinition;
@@ -36,6 +37,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static graphql.Assert.assertTrue;
 import static graphql.Scalars.GraphQLBoolean;
@@ -129,6 +131,16 @@ public class Introspection {
         return null;
     };
 
+    private static final DataFetcher directivesDataFetcherForType = environment -> {
+        Object type = environment.getSource();
+        if (type instanceof GraphQLDirectiveContainer) {
+            return ((GraphQLDirectiveContainer) type).getDirectives()
+                    .stream()
+                    .filter(GraphQLDirective::isExposeViaIntrospection)
+                    .collect(Collectors.toList());
+        }
+        return null;
+    };
     public static final GraphQLObjectType __InputValue = newObject()
             .name("__InputValue")
             .field(newFieldDefinition()
@@ -143,6 +155,9 @@ public class Introspection {
             .field(newFieldDefinition()
                     .name("defaultValue")
                     .type(GraphQLString))
+            .field(newFieldDefinition()
+                    .name("value_GJ_API")
+                    .type(GraphQLString))
             .build();
 
     static {
@@ -153,6 +168,13 @@ public class Introspection {
             } else if (environment.getSource() instanceof GraphQLInputObjectField) {
                 GraphQLInputObjectField inputField = environment.getSource();
                 return inputField.getDefaultValue() != null ? print(inputField.getDefaultValue(), inputField.getType()) : null;
+            }
+            return null;
+        });
+        register(__InputValue, "value_GJ_API", environment -> {
+            if (environment.getSource() instanceof GraphQLArgument) {
+                GraphQLArgument inputField = environment.getSource();
+                return inputField.getValue() != null ? print(inputField.getValue(), inputField.getType()) : null;
             }
             return null;
         });
@@ -185,6 +207,9 @@ public class Introspection {
             .field(newFieldDefinition()
                     .name("deprecationReason")
                     .type(GraphQLString))
+            .field(newFieldDefinition()
+                    .name("directives_GJ_API")
+                    .type(list(typeRef("__Directive"))))
             .build();
 
     static {
@@ -198,6 +223,7 @@ public class Introspection {
         });
         register(__Field, "name", nameDataFetcher);
         register(__Field, "description", descriptionDataFetcher);
+        register(__Field, "directives_GJ_API", directivesDataFetcherForType);
     }
 
 
@@ -215,6 +241,9 @@ public class Introspection {
             .field(newFieldDefinition()
                     .name("deprecationReason")
                     .type(GraphQLString))
+            .field(newFieldDefinition()
+                    .name("directives_GJ_API")
+                    .type(list(typeRef("__Directive"))))
             .build();
 
     static {
@@ -224,6 +253,7 @@ public class Introspection {
         });
         register(__EnumValue, "name", nameDataFetcher);
         register(__EnumValue, "description", descriptionDataFetcher);
+        register(__EnumValue, "directives_GJ_API", directivesDataFetcherForType);
     }
 
 
@@ -309,6 +339,7 @@ public class Introspection {
     };
 
 
+
     public static final GraphQLObjectType __Type = newObject()
             .name("__Type")
             .field(newFieldDefinition()
@@ -346,6 +377,9 @@ public class Introspection {
             .field(newFieldDefinition()
                     .name("ofType")
                     .type(typeRef("__Type")))
+            .field(newFieldDefinition()
+                    .name("directives_GJ_API")
+                    .type(list(typeRef("__Directive"))))
             .build();
 
     static {
@@ -358,6 +392,7 @@ public class Introspection {
         register(__Type, "ofType", OfTypeFetcher);
         register(__Type, "name", nameDataFetcher);
         register(__Type, "description", descriptionDataFetcher);
+        register(__Type, "directives_GJ_API", directivesDataFetcherForType);
     }
 
 
@@ -411,7 +446,6 @@ public class Introspection {
             .build();
 
 
-    @SuppressWarnings("deprecation") // because graphql spec still has the deprecated fields
     public static final GraphQLObjectType __Directive = newObject()
             .name("__Directive")
             .field(newFieldDefinition()

--- a/src/main/java/graphql/schema/GraphQLDirective.java
+++ b/src/main/java/graphql/schema/GraphQLDirective.java
@@ -37,6 +37,7 @@ public class GraphQLDirective implements GraphQLNamedSchemaElement {
     private final boolean onFragment;
     private final boolean onField;
     private final DirectiveDefinition definition;
+    private final boolean exposeViaIntrospection;
 
 
     public static final String CHILD_ARGUMENTS = "arguments";
@@ -52,7 +53,7 @@ public class GraphQLDirective implements GraphQLNamedSchemaElement {
                             boolean onOperation,
                             boolean onFragment,
                             boolean onField) {
-        this(name, description, locations, arguments, onOperation, onFragment, onField, null);
+        this(name, description, locations, arguments, onOperation, onFragment, onField, null, false);
     }
 
     private GraphQLDirective(String name,
@@ -62,7 +63,8 @@ public class GraphQLDirective implements GraphQLNamedSchemaElement {
                              boolean onOperation,
                              boolean onFragment,
                              boolean onField,
-                             DirectiveDefinition definition) {
+                             DirectiveDefinition definition,
+                             boolean exposeViaIntrospection) {
         assertValidName(name);
         assertNotNull(arguments, "arguments can't be null");
         this.name = name;
@@ -73,6 +75,7 @@ public class GraphQLDirective implements GraphQLNamedSchemaElement {
         this.onFragment = onFragment;
         this.onField = onField;
         this.definition = definition;
+        this.exposeViaIntrospection = exposeViaIntrospection;
     }
 
     @Override
@@ -91,6 +94,10 @@ public class GraphQLDirective implements GraphQLNamedSchemaElement {
             }
         }
         return null;
+    }
+
+    public boolean isExposeViaIntrospection() {
+        return exposeViaIntrospection;
     }
 
     public EnumSet<DirectiveLocation> validLocations() {
@@ -198,6 +205,7 @@ public class GraphQLDirective implements GraphQLNamedSchemaElement {
         private EnumSet<DirectiveLocation> locations = EnumSet.noneOf(DirectiveLocation.class);
         private final Map<String, GraphQLArgument> arguments = new LinkedHashMap<>();
         private DirectiveDefinition definition;
+        private boolean exposeViaIntrospection;
 
         public Builder() {
         }
@@ -211,6 +219,7 @@ public class GraphQLDirective implements GraphQLNamedSchemaElement {
             this.onField = existing.isOnField();
             this.locations = existing.validLocations();
             this.arguments.putAll(getByName(existing.getArguments(), GraphQLArgument::getName));
+            this.exposeViaIntrospection = existing.isExposeViaIntrospection();
         }
 
         @Override
@@ -222,6 +231,11 @@ public class GraphQLDirective implements GraphQLNamedSchemaElement {
         @Override
         public Builder description(String description) {
             super.description(description);
+            return this;
+        }
+
+        public Builder exposeViaIntrospection(boolean exposeViaIntrospection) {
+            this.exposeViaIntrospection = exposeViaIntrospection;
             return this;
         }
 
@@ -356,7 +370,8 @@ public class GraphQLDirective implements GraphQLNamedSchemaElement {
                     onOperation,
                     onFragment,
                     onField,
-                    definition);
+                    definition,
+                    exposeViaIntrospection);
         }
 
 


### PR DESCRIPTION
This is a new experimental extension to the normal Introspection API which allows Directives on schema elements to be queried.

Each Directive must be marked as `exposedViaIntrospection` to be allowed to be queried. 

The Introspection API has new fields `directives_GJ_API` and `value_GJ_API` which return the declared Directives on a SDL element and also the argument values. 

See https://github.com/graphql-java/graphql-java/pull/1775/files#diff-642a8f70520c01cd21e8ed7611318306R68 for a test how it works.