### PR TITLE
Removing java types as standard scalars

### DIFF
--- a/src/main/java/graphql/introspection/IntrospectionResultToSchema.java
+++ b/src/main/java/graphql/introspection/IntrospectionResultToSchema.java
@@ -132,7 +132,7 @@ public class IntrospectionResultToSchema {
 
     private TypeDefinition createScalar(Map<String, Object> input) {
         String name = (String) input.get("name");
-        if (ScalarInfo.isStandardScalar(name)) {
+        if (ScalarInfo.isGraphqlSpecifiedScalar(name)) {
             return null;
         }
         return ScalarTypeDefinition.newScalarTypeDefinition().name(name).build();

--- a/src/main/java/graphql/schema/idl/RuntimeWiring.java
+++ b/src/main/java/graphql/schema/idl/RuntimeWiring.java
@@ -129,7 +129,7 @@ public class RuntimeWiring {
         private GraphqlTypeComparatorRegistry comparatorRegistry = GraphqlTypeComparatorRegistry.AS_IS_REGISTRY;
 
         private Builder() {
-            ScalarInfo.STANDARD_SCALARS.forEach(this::scalar);
+            ScalarInfo.GRAPHQL_SPECIFICATION_SCALARS.forEach(this::scalar);
             // we give this out by default
             registeredDirectiveWiring.put(FetchSchemaDirectiveWiring.FETCH, new FetchSchemaDirectiveWiring());
         }

--- a/src/main/java/graphql/schema/idl/ScalarInfo.java
+++ b/src/main/java/graphql/schema/idl/ScalarInfo.java
@@ -26,7 +26,7 @@ public class ScalarInfo {
     /**
      * A map of scalar type definitions provided by graphql-java
      */
-    public static final Map<String, ScalarTypeDefinition> STANDARD_SCALAR_DEFINITIONS = new LinkedHashMap<>();
+    public static final Map<String, ScalarTypeDefinition> GRAPHQL_SPECIFICATION_SCALARS_DEFINITIONS = new LinkedHashMap<>();
 
     static {
         GRAPHQL_SPECIFICATION_SCALARS.add(Scalars.GraphQLInt);
@@ -34,59 +34,16 @@ public class ScalarInfo {
         GRAPHQL_SPECIFICATION_SCALARS.add(Scalars.GraphQLString);
         GRAPHQL_SPECIFICATION_SCALARS.add(Scalars.GraphQLBoolean);
         GRAPHQL_SPECIFICATION_SCALARS.add(Scalars.GraphQLID);
-
-        STANDARD_SCALARS.add(Scalars.GraphQLInt);
-        STANDARD_SCALARS.add(Scalars.GraphQLFloat);
-        STANDARD_SCALARS.add(Scalars.GraphQLString);
-        STANDARD_SCALARS.add(Scalars.GraphQLBoolean);
-        STANDARD_SCALARS.add(Scalars.GraphQLID);
-
-        STANDARD_SCALARS.add(Scalars.GraphQLBigDecimal);
-        STANDARD_SCALARS.add(Scalars.GraphQLBigInteger);
-        STANDARD_SCALARS.add(Scalars.GraphQLByte);
-        STANDARD_SCALARS.add(Scalars.GraphQLChar);
-        STANDARD_SCALARS.add(Scalars.GraphQLShort);
-        STANDARD_SCALARS.add(Scalars.GraphQLLong);
     }
 
     static {
         // graphql standard scalars
-        STANDARD_SCALAR_DEFINITIONS.put("Int", ScalarTypeDefinition.newScalarTypeDefinition().name("Int").build());
-        STANDARD_SCALAR_DEFINITIONS.put("Float", ScalarTypeDefinition.newScalarTypeDefinition().name("Float").build());
-        STANDARD_SCALAR_DEFINITIONS.put("String", ScalarTypeDefinition.newScalarTypeDefinition().name("String").build());
-        STANDARD_SCALAR_DEFINITIONS.put("Boolean", ScalarTypeDefinition.newScalarTypeDefinition().name("Boolean").build());
-        STANDARD_SCALAR_DEFINITIONS.put("ID", ScalarTypeDefinition.newScalarTypeDefinition().name("ID").build());
+        GRAPHQL_SPECIFICATION_SCALARS_DEFINITIONS.put("Int", ScalarTypeDefinition.newScalarTypeDefinition().name("Int").build());
+        GRAPHQL_SPECIFICATION_SCALARS_DEFINITIONS.put("Float", ScalarTypeDefinition.newScalarTypeDefinition().name("Float").build());
+        GRAPHQL_SPECIFICATION_SCALARS_DEFINITIONS.put("String", ScalarTypeDefinition.newScalarTypeDefinition().name("String").build());
+        GRAPHQL_SPECIFICATION_SCALARS_DEFINITIONS.put("Boolean", ScalarTypeDefinition.newScalarTypeDefinition().name("Boolean").build());
+        GRAPHQL_SPECIFICATION_SCALARS_DEFINITIONS.put("ID", ScalarTypeDefinition.newScalarTypeDefinition().name("ID").build());
 
-        // graphql-java library extensions
-        STANDARD_SCALAR_DEFINITIONS.put("Long", ScalarTypeDefinition.newScalarTypeDefinition().name("Long").build());
-        STANDARD_SCALAR_DEFINITIONS.put("BigInteger", ScalarTypeDefinition.newScalarTypeDefinition().name("BigInteger").build());
-        STANDARD_SCALAR_DEFINITIONS.put("BigDecimal", ScalarTypeDefinition.newScalarTypeDefinition().name("BigDecimal").build());
-        STANDARD_SCALAR_DEFINITIONS.put("Byte", ScalarTypeDefinition.newScalarTypeDefinition().name("Byte").build());
-        STANDARD_SCALAR_DEFINITIONS.put("Short", ScalarTypeDefinition.newScalarTypeDefinition().name("Short").build());
-        STANDARD_SCALAR_DEFINITIONS.put("Char", ScalarTypeDefinition.newScalarTypeDefinition().name("Char").build());
-
-    }
-
-    /**
-     * Returns true if the scalar type is a standard one provided by graphql-java
-     *
-     * @param scalarType the type in question
-     *
-     * @return true if the scalar type is a graphql-java provided scalar
-     */
-    public static boolean isStandardScalar(GraphQLScalarType scalarType) {
-        return inList(STANDARD_SCALARS, scalarType.getName());
-    }
-
-    /**
-     * Returns true if the scalar type is a standard one provided by graphql-java
-     *
-     * @param scalarTypeName the name of the scalar type in question
-     *
-     * @return true if the scalar type is a graphql-java provided scalar
-     */
-    public static boolean isStandardScalar(String scalarTypeName) {
-        return inList(STANDARD_SCALARS, scalarTypeName);
     }
 
     /**

--- a/src/main/java/graphql/schema/idl/ScalarInfo.java
+++ b/src/main/java/graphql/schema/idl/ScalarInfo.java
@@ -13,10 +13,6 @@ import java.util.Map;
  * Info on all the standard scalar objects provided by graphql-java
  */
 public class ScalarInfo {
-    /**
-     * A list of the scalar types provided by graphql-java
-     */
-    public static final List<GraphQLScalarType> STANDARD_SCALARS = new ArrayList<>();
 
     /**
      * A list of the built-in scalar types as defined by the graphql specification

--- a/src/main/java/graphql/schema/idl/SchemaGenerator.java
+++ b/src/main/java/graphql/schema/idl/SchemaGenerator.java
@@ -714,7 +714,7 @@ public class SchemaGenerator {
             scalar = buildCtx.getWiring().getScalars().get(typeDefinition.getName());
         }
 
-        if (!ScalarInfo.isStandardScalar(scalar) && !ScalarInfo.isGraphqlSpecifiedScalar(scalar)) {
+        if (!ScalarInfo.isGraphqlSpecifiedScalar(scalar)) {
             scalar = scalar.transform(builder -> builder
                     .definition(typeDefinition)
                     .comparatorRegistry(buildCtx.getComparatorRegistry())

--- a/src/main/java/graphql/schema/idl/SchemaGenerator.java
+++ b/src/main/java/graphql/schema/idl/SchemaGenerator.java
@@ -398,7 +398,7 @@ public class SchemaGenerator {
             }
         });
         typeRegistry.scalars().values().forEach(scalarTypeDefinition -> {
-            if (ScalarInfo.isStandardScalar(scalarTypeDefinition.getName())) {
+            if (ScalarInfo.isGraphqlSpecifiedScalar(scalarTypeDefinition.getName())) {
                 return;
             }
             if (buildCtx.hasInputType(scalarTypeDefinition) == null && buildCtx.hasOutputType(scalarTypeDefinition) == null) {

--- a/src/main/java/graphql/schema/idl/SchemaPrinter.java
+++ b/src/main/java/graphql/schema/idl/SchemaPrinter.java
@@ -84,9 +84,7 @@ public class SchemaPrinter {
         private final boolean includeScalars;
 
         private final boolean useAstDefinitions;
-
-        private final boolean includeExtendedScalars;
-
+        
         private final boolean includeSchemaDefinition;
 
         private final boolean descriptionsAsHashComments;
@@ -97,7 +95,6 @@ public class SchemaPrinter {
 
         private Options(boolean includeIntrospectionTypes,
                         boolean includeScalars,
-                        boolean includeExtendedScalars,
                         boolean includeSchemaDefinition,
                         boolean useAstDefinitions,
                         boolean descriptionsAsHashComments,
@@ -105,7 +102,6 @@ public class SchemaPrinter {
                         GraphqlTypeComparatorRegistry comparatorRegistry) {
             this.includeIntrospectionTypes = includeIntrospectionTypes;
             this.includeScalars = includeScalars;
-            this.includeExtendedScalars = includeExtendedScalars;
             this.includeSchemaDefinition = includeSchemaDefinition;
             this.includeDirective = includeDirective;
             this.useAstDefinitions = useAstDefinitions;
@@ -120,11 +116,7 @@ public class SchemaPrinter {
         public boolean isIncludeScalars() {
             return includeScalars;
         }
-
-        public boolean isIncludeExtendedScalars() {
-            return includeExtendedScalars;
-        }
-
+        
         public boolean isIncludeSchemaDefinition() {
             return includeSchemaDefinition;
         }
@@ -146,7 +138,7 @@ public class SchemaPrinter {
         }
 
         public static Options defaultOptions() {
-            return new Options(false, false, false,
+            return new Options(false, true,
                     false, false, false,
                     directive -> true, DefaultGraphqlTypeComparatorRegistry.defaultComparators());
         }
@@ -158,7 +150,7 @@ public class SchemaPrinter {
          * @return options
          */
         public Options includeIntrospectionTypes(boolean flag) {
-            return new Options(flag, this.includeScalars, this.includeExtendedScalars, this.includeSchemaDefinition, this.useAstDefinitions, this.descriptionsAsHashComments, this.includeDirective, this.comparatorRegistry);
+            return new Options(flag, this.includeScalars, this.includeSchemaDefinition, this.useAstDefinitions, this.descriptionsAsHashComments, this.includeDirective, this.comparatorRegistry);
         }
 
         /**
@@ -168,20 +160,10 @@ public class SchemaPrinter {
          * @return options
          */
         public Options includeScalarTypes(boolean flag) {
-            return new Options(this.includeIntrospectionTypes, flag, this.includeExtendedScalars, this.includeSchemaDefinition, this.useAstDefinitions, this.descriptionsAsHashComments, this.includeDirective, this.comparatorRegistry);
+            return new Options(this.includeIntrospectionTypes, flag, this.includeSchemaDefinition, this.useAstDefinitions, this.descriptionsAsHashComments, this.includeDirective, this.comparatorRegistry);
         }
 
-        /**
-         * This will allow you to include the graphql 'extended' scalar types that come with graphql-java such as
-         * GraphQLBigDecimal or GraphQLBigInteger
-         *
-         * @param flag whether to include them
-         * @return options
-         */
-        public Options includeExtendedScalarTypes(boolean flag) {
-            return new Options(this.includeIntrospectionTypes, this.includeScalars, flag, this.includeSchemaDefinition, this.useAstDefinitions, this.descriptionsAsHashComments, this.includeDirective, this.comparatorRegistry);
-        }
-
+        
         /**
          * This will force the printing of the graphql schema definition even if the query, mutation, and/or subscription
          * types use the default names.  Some graphql parsers require this information even if the schema uses the
@@ -192,7 +174,7 @@ public class SchemaPrinter {
          * @return options
          */
         public Options includeSchemaDefinition(boolean flag) {
-            return new Options(this.includeIntrospectionTypes, this.includeScalars, this.includeExtendedScalars, flag, this.useAstDefinitions, this.descriptionsAsHashComments, this.includeDirective, this.comparatorRegistry);
+            return new Options(this.includeIntrospectionTypes, this.includeScalars, flag, this.useAstDefinitions, this.descriptionsAsHashComments, this.includeDirective, this.comparatorRegistry);
         }
 
         /**
@@ -203,11 +185,11 @@ public class SchemaPrinter {
          * @return new instance of options
          */
         public Options includeDirectives(boolean flag) {
-            return new Options(this.includeIntrospectionTypes, this.includeScalars, this.includeExtendedScalars, this.includeSchemaDefinition, this.useAstDefinitions, this.descriptionsAsHashComments, directive -> flag, this.comparatorRegistry);
+            return new Options(this.includeIntrospectionTypes, this.includeScalars, this.includeSchemaDefinition, this.useAstDefinitions, this.descriptionsAsHashComments, directive -> flag, this.comparatorRegistry);
         }
 
         public Options includeDirectives(Predicate<GraphQLDirective> includeDirective) {
-            return new Options(this.includeIntrospectionTypes, this.includeScalars, this.includeExtendedScalars, this.includeSchemaDefinition, this.useAstDefinitions, this.descriptionsAsHashComments, includeDirective, this.comparatorRegistry);
+            return new Options(this.includeIntrospectionTypes, this.includeScalars, this.includeSchemaDefinition, this.useAstDefinitions, this.descriptionsAsHashComments, includeDirective, this.comparatorRegistry);
         }
 
         /**
@@ -218,7 +200,7 @@ public class SchemaPrinter {
          * @return new instance of options
          */
         public Options useAstDefinitions(boolean flag) {
-            return new Options(this.includeIntrospectionTypes, this.includeScalars, this.includeExtendedScalars, this.includeSchemaDefinition, flag, this.descriptionsAsHashComments, this.includeDirective, this.comparatorRegistry);
+            return new Options(this.includeIntrospectionTypes, this.includeScalars, this.includeSchemaDefinition, flag, this.descriptionsAsHashComments, this.includeDirective, this.comparatorRegistry);
         }
 
         /**
@@ -231,7 +213,7 @@ public class SchemaPrinter {
          * @return new instance of options
          */
         public Options descriptionsAsHashComments(boolean flag) {
-            return new Options(this.includeIntrospectionTypes, this.includeScalars, this.includeExtendedScalars, this.includeSchemaDefinition, this.useAstDefinitions, flag, this.includeDirective, this.comparatorRegistry);
+            return new Options(this.includeIntrospectionTypes, this.includeScalars, this.includeSchemaDefinition, this.useAstDefinitions, flag, this.includeDirective, this.comparatorRegistry);
         }
 
         /**
@@ -243,7 +225,7 @@ public class SchemaPrinter {
          * @return options
          */
         public Options setComparators(GraphqlTypeComparatorRegistry comparatorRegistry) {
-            return new Options(this.includeIntrospectionTypes, this.includeScalars, this.includeExtendedScalars, this.includeSchemaDefinition, this.useAstDefinitions, this.descriptionsAsHashComments, this.includeDirective, comparatorRegistry);
+            return new Options(this.includeIntrospectionTypes, this.includeScalars, this.includeSchemaDefinition, this.useAstDefinitions, this.descriptionsAsHashComments, this.includeDirective, comparatorRegistry);
         }
     }
 
@@ -329,10 +311,10 @@ public class SchemaPrinter {
                 return;
             }
             boolean printScalar;
-            if (ScalarInfo.isStandardScalar(type)) {
+            if (ScalarInfo.isGraphqlSpecifiedScalar(type)) {
                 printScalar = false;
                 //noinspection RedundantIfStatement
-                if (options.isIncludeExtendedScalars() && !ScalarInfo.isGraphqlSpecifiedScalar(type)) {
+                if (!ScalarInfo.isGraphqlSpecifiedScalar(type)) {
                     printScalar = true;
                 }
             } else {

--- a/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java
+++ b/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java
@@ -309,7 +309,7 @@ public class TypeDefinitionRegistry {
     }
 
     public Map<String, ScalarTypeDefinition> scalars() {
-        LinkedHashMap<String, ScalarTypeDefinition> scalars = new LinkedHashMap<>(ScalarInfo.STANDARD_SCALAR_DEFINITIONS);
+        LinkedHashMap<String, ScalarTypeDefinition> scalars = new LinkedHashMap<>(ScalarInfo.GRAPHQL_SPECIFICATION_SCALARS_DEFINITIONS);
         scalars.putAll(scalarTypes);
         return scalars;
     }
@@ -364,7 +364,7 @@ public class TypeDefinitionRegistry {
 
     public boolean hasType(TypeName typeName) {
         String name = typeName.getName();
-        return types.containsKey(name) || ScalarInfo.STANDARD_SCALAR_DEFINITIONS.containsKey(name) || scalarTypes.containsKey(name) || objectTypeExtensions.containsKey(name);
+        return types.containsKey(name) || ScalarInfo.GRAPHQL_SPECIFICATION_SCALARS_DEFINITIONS.containsKey(name) || scalarTypes.containsKey(name) || objectTypeExtensions.containsKey(name);
     }
 
     public Optional<TypeDefinition> getType(Type type) {

--- a/src/main/java/graphql/schema/idl/UnExecutableSchemaGenerator.java
+++ b/src/main/java/graphql/schema/idl/UnExecutableSchemaGenerator.java
@@ -19,7 +19,7 @@ public class UnExecutableSchemaGenerator {
         RuntimeWiring runtimeWiring = EchoingWiringFactory.newEchoingWiring(wiring -> {
             Map<String, ScalarTypeDefinition> scalars = registry.scalars();
             scalars.forEach((name, v) -> {
-                if (!ScalarInfo.isStandardScalar(name)) {
+                if (!ScalarInfo.isGraphqlSpecifiedScalar(name)) {
                     wiring.scalar(fakeScalar(name));
                 }
             });

--- a/src/test/groovy/graphql/schema/SchemaPrinterComparatorsTest.groovy
+++ b/src/test/groovy/graphql/schema/SchemaPrinterComparatorsTest.groovy
@@ -30,7 +30,7 @@ class SchemaPrinterComparatorsTest extends Specification {
                 .build()
 
         when:
-        def options = defaultOptions().includeScalarTypes(true).includeExtendedScalarTypes(true)
+        def options = defaultOptions().includeScalarTypes(true)
         def result = new SchemaPrinter(options).print(scalarType)
 
         then:
@@ -202,7 +202,7 @@ scalar TestScalar @a(a : 0, bb : 0) @bb(a : 0, bb : 0)
                 .addComparator({ it.parentType(GraphQLDirective.class).elementType(GraphQLArgument.class) }, GraphQLArgument.class, TestUtil.byGreatestLength)
                 .build()
 
-        def options = defaultOptions().includeScalarTypes(true).includeExtendedScalarTypes(true).setComparators(registry)
+        def options = defaultOptions().includeScalarTypes(true).setComparators(registry)
         def result = new SchemaPrinter(options).print(scalarType)
 
         then:
@@ -224,7 +224,7 @@ scalar TestScalar @bb(bb : 0, a : 0) @a(bb : 0, a : 0)
                 .addComparator({ it.elementType(GraphQLArgument.class) }, GraphQLArgument.class, TestUtil.byGreatestLength)
                 .build()
 
-        def options = defaultOptions().includeScalarTypes(true).includeExtendedScalarTypes(true).setComparators(registry)
+        def options = defaultOptions().includeScalarTypes(true).setComparators(registry)
         def result = new SchemaPrinter(options).print(scalarType)
 
         then:
@@ -680,7 +680,7 @@ scalar TestScalar @bb(bb : 0, a : 0) @a(bb : 0, a : 0)
                 .addComparator({ it.elementType(GraphQLDirective.class) }, GraphQLDirective.class, TestUtil.byGreatestLength)
                 .addComparator({ it.elementType(GraphQLArgument.class) }, GraphQLArgument.class, TestUtil.byGreatestLength)
                 .build()
-        def options = defaultOptions().includeScalarTypes(true).includeExtendedScalarTypes(true).setComparators(registry)
+        def options = defaultOptions().includeScalarTypes(true).setComparators(registry)
         def printer = new SchemaPrinter(options)
 
         def scalarResult = printer.print(scalarType)
@@ -761,7 +761,7 @@ scalar TestScalar @bb(bb : 0, a : 0) @a(bb : 0, a : 0)
                 .build()
 
         when:
-        def options = defaultOptions().includeScalarTypes(true).includeExtendedScalarTypes(true)
+        def options = defaultOptions().includeScalarTypes(true)
         def result = new SchemaPrinter(options).print(scalarType)
 
         then:

--- a/src/test/groovy/graphql/schema/idl/MockedWiringFactory.groovy
+++ b/src/test/groovy/graphql/schema/idl/MockedWiringFactory.groovy
@@ -55,7 +55,7 @@ class MockedWiringFactory implements WiringFactory {
 
     @Override
     boolean providesScalar(ScalarWiringEnvironment environment) {
-        if (ScalarInfo.isStandardScalar(environment.getScalarTypeDefinition().getName())) {
+        if (ScalarInfo.isGraphqlSpecifiedScalar(environment.getScalarTypeDefinition().getName())) {
             return false
         }
         return true

--- a/src/test/groovy/graphql/schema/idl/RuntimeWiringTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/RuntimeWiringTest.groovy
@@ -113,11 +113,5 @@ class RuntimeWiringTest extends Specification {
         wiring.getScalars().get("String").name == "String"
         wiring.getScalars().get("Boolean").name == "Boolean"
         wiring.getScalars().get("ID").name == "ID"
-        wiring.getScalars().get("BigDecimal").name == "BigDecimal"
-        wiring.getScalars().get("BigInteger").name == "BigInteger"
-        wiring.getScalars().get("Byte").name == "Byte"
-        wiring.getScalars().get("Char").name == "Char"
-        wiring.getScalars().get("Short").name == "Short"
-        wiring.getScalars().get("Long").name == "Long"
     }
 }

--- a/src/test/groovy/graphql/schema/idl/SchemaParserTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaParserTest.groovy
@@ -114,7 +114,7 @@ class SchemaParserTest extends Specification {
         typeExtensions.size() == 1
         typeExtensions.get("Query") != null
 
-        scalarTypes.size() == 12 // includes standard scalars
+        scalarTypes.size() == 6 // includes standard scalars
         scalarTypes.get("Url") instanceof ScalarTypeDefinition
 
 

--- a/src/test/groovy/graphql/schema/idl/SchemaParserTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaParserTest.groovy
@@ -114,7 +114,7 @@ class SchemaParserTest extends Specification {
         typeExtensions.size() == 1
         typeExtensions.get("Query") != null
 
-        scalarTypes.size() == 6 // includes standard scalars
+        scalarTypes.size() == 6 // only contains the 5 graphql standard types and URL
         scalarTypes.get("Url") instanceof ScalarTypeDefinition
 
 

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -165,7 +165,6 @@ class SchemaPrinterTest extends Specification {
 
         expect:
         result != null
-        !result.contains("scalar")
         !result.contains("__TypeKind")
     }
 
@@ -620,41 +619,6 @@ type Query {
 '''
     }
 
-    def "prints extended types"() {
-        given:
-        def idl = '''
-            type Query {
-                field : CustomScalar
-                bigDecimal : BigDecimal
-            }
-            
-            scalar CustomScalar
-        '''
-
-        def schema = TestUtil.schema(idl, newRuntimeWiring().scalar(mockScalar("CustomScalar")))
-
-
-        when:
-        def result = new SchemaPrinter(options).print(schema)
-
-        then:
-
-        if (expectedStrs.isEmpty()) {
-            assert !result.contains("scalar")
-        } else {
-            expectedStrs.forEach({ s -> assert result.contains(s) })
-        }
-
-
-        where:
-        expectedStrs                                 | options
-        []                                           | defaultOptions()
-        ["scalar CustomScalar"]                      | defaultOptions().includeScalarTypes(true).includeExtendedScalarTypes(false)
-        ["scalar BigDecimal", "scalar CustomScalar"] | defaultOptions().includeScalarTypes(true).includeExtendedScalarTypes(true)
-        ["scalar CustomScalar"]                      | defaultOptions().includeScalarTypes(true).includeExtendedScalarTypes(false)
-    }
-
-
     def "schema will be sorted"() {
         def schema = TestUtil.schema("""
             type Query {
@@ -766,6 +730,9 @@ enum Episode {
   JEDI
   NEWHOPE
 }
+
+"Asteroid"
+scalar Asteroid
 """
     }
 

--- a/src/test/groovy/graphql/schema/idl/TypeDefinitionRegistryTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/TypeDefinitionRegistryTest.groovy
@@ -44,13 +44,6 @@ class TypeDefinitionRegistryTest extends Specification {
         scalars.containsKey("Boolean")
         scalars.containsKey("ID")
 
-        // graphql-java library extensions
-        scalars.containsKey("Long")
-        scalars.containsKey("BigInteger")
-        scalars.containsKey("BigDecimal")
-        scalars.containsKey("Short")
-        scalars.containsKey("Char")
-
     }
 
     def "adding 2 schemas is not allowed"() {

--- a/src/test/groovy/graphql/schema/idl/WiringFactoryTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/WiringFactoryTest.groovy
@@ -1,5 +1,6 @@
 package graphql.schema.idl
 
+import graphql.Scalars
 import graphql.TestUtil
 import graphql.TypeResolutionEnvironment
 import graphql.schema.Coercing
@@ -160,7 +161,7 @@ class WiringFactoryTest extends Specification {
                 appearsIn: [Episode]!
                 homePlanet: String
                 cyborg: Cyborg
-            }
+            }            
         """
 
 
@@ -174,6 +175,7 @@ class WiringFactoryTest extends Specification {
 
         def wiring = RuntimeWiring.newRuntimeWiring()
                 .wiringFactory(combinedWiringFactory)
+                .scalar(Scalars.GraphQLLong)
                 .build()
 
         def schema = TestUtil.schema(spec, wiring)


### PR DESCRIPTION
* Removed flag for SchemaPrinting to include Extended Schema types
* Removed types from ScalarInfo so java types are treated as a custom scalar