### PR TITLE
Removing the single instance of NullValue 

### DIFF
--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -292,7 +292,7 @@ public class ValuesResolver {
                 }
 
                 if (fieldObject == null) {
-                    if (!field.getValue().isEqualTo(NullValue.Null)) {
+                    if (! (field.getValue() instanceof NullValue)) {
                         fieldObject = inputTypeField.getDefaultValue();
                     }
                 }

--- a/src/main/java/graphql/language/NullValue.java
+++ b/src/main/java/graphql/language/NullValue.java
@@ -21,8 +21,6 @@ import static java.util.Collections.emptyMap;
 @PublicApi
 public class NullValue extends AbstractNode<NullValue> implements Value<NullValue> {
 
-    public static final NullValue Null = new NullValue(null, Collections.emptyList(), IgnoredChars.EMPTY, emptyMap());
-
     @Internal
     protected NullValue(SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars, Map<String, String> additionalData) {
         super(sourceLocation, comments, ignoredChars, additionalData);

--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -112,7 +112,6 @@ public class GraphqlAntlrToLanguage {
         } else {
             return assertShouldNeverHappen();
         }
-
     }
 
     protected OperationDefinition createOperationDefinition(GraphqlParser.OperationDefinitionContext ctx) {
@@ -663,7 +662,9 @@ public class GraphqlAntlrToLanguage {
             addCommonData(booleanValue, ctx);
             return booleanValue.build();
         } else if (ctx.NullValue() != null) {
-            return NullValue.newNullValue().build();
+            NullValue.Builder nullValue = NullValue.newNullValue();
+            addCommonData(nullValue, ctx);
+            return nullValue.build();
         } else if (ctx.stringValue() != null) {
             StringValue.Builder stringValue = StringValue.newStringValue().value(quotedString(ctx.stringValue()));
             addCommonData(stringValue, ctx);
@@ -716,7 +717,9 @@ public class GraphqlAntlrToLanguage {
             addCommonData(booleanValue, ctx);
             return booleanValue.build();
         } else if (ctx.NullValue() != null) {
-            return NullValue.newNullValue().build();
+            NullValue.Builder nullValue = NullValue.newNullValue();
+            addCommonData(nullValue, ctx);
+            return nullValue.build();
         } else if (ctx.stringValue() != null) {
             StringValue.Builder stringValue = StringValue.newStringValue().value(quotedString(ctx.stringValue()));
             addCommonData(stringValue, ctx);

--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -34,6 +34,7 @@ import graphql.language.InterfaceTypeExtensionDefinition;
 import graphql.language.ListType;
 import graphql.language.NodeBuilder;
 import graphql.language.NonNullType;
+import graphql.language.NullValue;
 import graphql.language.ObjectField;
 import graphql.language.ObjectTypeDefinition;
 import graphql.language.ObjectTypeExtensionDefinition;
@@ -70,7 +71,6 @@ import java.util.Collections;
 import java.util.List;
 
 import static graphql.Assert.assertShouldNeverHappen;
-import static graphql.language.NullValue.Null;
 import static graphql.parser.StringValueParsing.parseSingleQuotedString;
 import static graphql.parser.StringValueParsing.parseTripleQuotedString;
 import static java.util.stream.Collectors.toList;
@@ -663,7 +663,7 @@ public class GraphqlAntlrToLanguage {
             addCommonData(booleanValue, ctx);
             return booleanValue.build();
         } else if (ctx.NullValue() != null) {
-            return Null;
+            return NullValue.newNullValue().build();
         } else if (ctx.stringValue() != null) {
             StringValue.Builder stringValue = StringValue.newStringValue().value(quotedString(ctx.stringValue()));
             addCommonData(stringValue, ctx);
@@ -716,7 +716,7 @@ public class GraphqlAntlrToLanguage {
             addCommonData(booleanValue, ctx);
             return booleanValue.build();
         } else if (ctx.NullValue() != null) {
-            return Null;
+            return NullValue.newNullValue().build();
         } else if (ctx.stringValue() != null) {
             StringValue.Builder stringValue = StringValue.newStringValue().value(quotedString(ctx.stringValue()));
             addCommonData(stringValue, ctx);

--- a/src/test/groovy/graphql/language/NodeVisitorStubTest.groovy
+++ b/src/test/groovy/graphql/language/NodeVisitorStubTest.groovy
@@ -48,7 +48,7 @@ class NodeVisitorStubTest extends Specification {
         ArrayValue.newArrayValue().build()               | 'visitArrayValue'
         IntValue.newIntValue().build()                   | 'visitIntValue'
         new BooleanValue(true)                           | 'visitBooleanValue'
-        NullValue.Null                                   | 'visitNullValue'
+        NullValue.newNullValue().build()                 | 'visitNullValue'
         ObjectValue.newObjectValue().build()             | 'visitObjectValue'
         VariableReference.newVariableReference().build() | 'visitVariableReference'
         EnumValue.newEnumValue().build()                 | 'visitEnumValue'

--- a/src/test/groovy/graphql/parser/ParserTest.groovy
+++ b/src/test/groovy/graphql/parser/ParserTest.groovy
@@ -526,11 +526,11 @@ class ParserTest extends Specification {
         def selection = operation.selectionSet.selections[0] as Field
 
         then:
-        assert selection.arguments[0].value instanceof NullValue
-        assert selection.arguments[1].value instanceof NullValue
+        selection.arguments[0].value instanceof NullValue
+        selection.arguments[1].value instanceof NullValue
 
-        assert selection.arguments[0].sourceLocation.toString() == "SourceLocation{line=1, column=7}"
-        assert selection.arguments[1].sourceLocation.toString() == "SourceLocation{line=1, column=18}"
+        selection.arguments[0].value.sourceLocation.toString() == "SourceLocation{line=1, column=12}"
+        selection.arguments[1].value.sourceLocation.toString() == "SourceLocation{line=1, column=25}"
 
     }
 

--- a/src/test/groovy/graphql/parser/ParserTest.groovy
+++ b/src/test/groovy/graphql/parser/ParserTest.groovy
@@ -529,6 +529,9 @@ class ParserTest extends Specification {
         assert selection.arguments[0].value instanceof NullValue
         assert selection.arguments[1].value instanceof NullValue
 
+        assert selection.arguments[0].sourceLocation.toString() == "SourceLocation{line=1, column=7}"
+        assert selection.arguments[1].sourceLocation.toString() == "SourceLocation{line=1, column=18}"
+
     }
 
 

--- a/src/test/groovy/graphql/parser/ParserTest.groovy
+++ b/src/test/groovy/graphql/parser/ParserTest.groovy
@@ -516,9 +516,9 @@ class ParserTest extends Specification {
     }
 
 
-    def "parses null value"() {
+    def "parses null values"() {
         given:
-        def input = "{ foo(bar: null) }"
+        def input = "{ foo(bar: null, bell : null) }"
 
         when:
         def document = new Parser().parseDocument(input)
@@ -526,7 +526,8 @@ class ParserTest extends Specification {
         def selection = operation.selectionSet.selections[0] as Field
 
         then:
-        selection.arguments[0].value == NullValue.Null
+        assert selection.arguments[0].value instanceof NullValue
+        assert selection.arguments[1].value instanceof NullValue
 
     }
 

--- a/src/test/groovy/graphql/validation/ValidationUtilTest.groovy
+++ b/src/test/groovy/graphql/validation/ValidationUtilTest.groovy
@@ -56,7 +56,7 @@ class ValidationUtilTest extends Specification {
 
     def "NullValue and NonNull is invalid"() {
         expect:
-        !validationUtil.isValidLiteralValue(NullValue.Null, nonNull(GraphQLString),schema)
+        !validationUtil.isValidLiteralValue(NullValue.newNullValue().build(), nonNull(GraphQLString),schema)
     }
 
     def "a nonNull value for a NonNull type is valid"() {
@@ -71,7 +71,7 @@ class ValidationUtilTest extends Specification {
 
     def "NullValue is valid when type is NonNull"() {
         expect:
-        validationUtil.isValidLiteralValue(NullValue.Null, GraphQLString,schema)
+        validationUtil.isValidLiteralValue(NullValue.newNullValue().build(), GraphQLString,schema)
     }
 
     def "variables are valid"() {

--- a/src/test/groovy/graphql/validation/rules/ArgumentsOfCorrectTypeTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/ArgumentsOfCorrectTypeTest.groovy
@@ -184,7 +184,7 @@ class ArgumentsOfCorrectTypeTest extends Specification {
 
     def "type null fields results in error"() {
         given:
-        def objectValue = new ObjectValue([new ObjectField("foo", new StringValue("string")), new ObjectField("bar", NullValue.Null)])
+        def objectValue = new ObjectValue([new ObjectField("foo", new StringValue("string")), new ObjectField("bar", NullValue.newNullValue().build())])
         def argumentLiteral = new Argument("arg", objectValue)
         def graphQLArgument = new GraphQLArgument("arg", GraphQLInputObjectType.newInputObject().name("ArgumentObjectType")
                 .field(GraphQLInputObjectField.newInputObjectField()


### PR DESCRIPTION
NullValue represent a certain Ast element, therefore it should not be used as a singleton.