### PR TITLE
Make PropertyDataFetcherHelpder#mkKey rely on Class#getName instead of Class#getCanonicalName

### DIFF
--- a/src/main/java/graphql/schema/PropertyDataFetcherHelper.java
+++ b/src/main/java/graphql/schema/PropertyDataFetcherHelper.java
@@ -252,7 +252,7 @@ public class PropertyDataFetcherHelper {
     }
 
     private static String mkKey(Class<?> clazz, String propertyName) {
-        return clazz.getCanonicalName() + "__" + propertyName;
+        return clazz.getName() + "__" + propertyName;
     }
 
     // by not filling out the stack trace, we gain speed when using the exception as flow control


### PR DESCRIPTION
Fixes https://github.com/graphql-java/graphql-java/issues/1784.