### PR TITLE
Have subscriptions apply result instrumentation

### DIFF
--- a/src/main/java/graphql/execution/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncExecutionStrategy.java
@@ -8,6 +8,7 @@ import graphql.execution.instrumentation.DeferredFieldInstrumentationContext;
 import graphql.execution.instrumentation.ExecutionStrategyInstrumentationContext;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.parameters.InstrumentationDeferredFieldParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionStrategyParameters;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLObjectType;
@@ -46,7 +47,7 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
 
     @Override
     @SuppressWarnings("FutureReturnValueIgnored")
-    public CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) throws NonNullableFieldWasNullException {
+    public CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters, InstrumentationExecutionParameters instrumentationExecutionParameters) throws NonNullableFieldWasNullException {
 
         Instrumentation instrumentation = executionContext.getInstrumentation();
         InstrumentationExecutionStrategyParameters instrumentationParameters = new InstrumentationExecutionStrategyParameters(executionContext, parameters);

--- a/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
@@ -3,6 +3,7 @@ package graphql.execution;
 import graphql.ExecutionResult;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationContext;
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionStrategyParameters;
 
 import java.util.ArrayList;
@@ -25,7 +26,7 @@ public class AsyncSerialExecutionStrategy extends AbstractAsyncExecutionStrategy
 
     @Override
     @SuppressWarnings({"TypeParameterUnusedInFormals","FutureReturnValueIgnored"})
-    public CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) throws NonNullableFieldWasNullException {
+    public CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters, InstrumentationExecutionParameters instrumentationExecutionParameters) throws NonNullableFieldWasNullException {
 
         Instrumentation instrumentation = executionContext.getInstrumentation();
         InstrumentationExecutionStrategyParameters instrumentationParameters = new InstrumentationExecutionStrategyParameters(executionContext, parameters);

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -162,7 +162,7 @@ public class Execution {
                 executionStrategy = executionContext.getQueryStrategy();
             }
             logNotSafe.debug("Executing '{}' query operation: '{}' using '{}' execution strategy", executionContext.getExecutionId(), operation, executionStrategy.getClass().getName());
-            result = executionStrategy.execute(executionContext, parameters);
+            result = executionStrategy.execute(executionContext, parameters, instrumentationExecutionParameters);
         } catch (NonNullableFieldWasNullException e) {
             // this means it was non null types all the way from an offending non null type
             // up to the root object type and there was a a null value some where.

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -12,6 +12,7 @@ import graphql.UnresolvedTypeError;
 import graphql.execution.directives.QueryDirectivesImpl;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationContext;
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldCompleteParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldParameters;
@@ -151,7 +152,7 @@ public abstract class ExecutionStrategy {
      *
      * @throws NonNullableFieldWasNullException in the future if a non null field resolves to a null value
      */
-    public abstract CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) throws NonNullableFieldWasNullException;
+    public abstract CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters, InstrumentationExecutionParameters instrumentationExecutionParameters) throws NonNullableFieldWasNullException;
 
     /**
      * Called to fetch a value for a field and resolve it further in terms of the graphql query.  This will call
@@ -653,7 +654,7 @@ public abstract class ExecutionStrategy {
 
         // Calling this from the executionContext to ensure we shift back from mutation strategy to the query strategy.
 
-        return executionContext.getQueryStrategy().execute(executionContext, newParameters);
+        return executionContext.getQueryStrategy().execute(executionContext, newParameters, null);
     }
 
     @SuppressWarnings("SameReturnValue")

--- a/src/main/java/graphql/execution/ExecutorServiceExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutorServiceExecutionStrategy.java
@@ -6,6 +6,7 @@ import graphql.GraphQLException;
 import graphql.PublicApi;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationContext;
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionStrategyParameters;
 
 import java.util.LinkedHashMap;
@@ -59,9 +60,9 @@ public class ExecutorServiceExecutionStrategy extends ExecutionStrategy {
 
 
     @Override
-    public CompletableFuture<ExecutionResult> execute(final ExecutionContext executionContext, final ExecutionStrategyParameters parameters) {
+    public CompletableFuture<ExecutionResult> execute(final ExecutionContext executionContext, final ExecutionStrategyParameters parameters, InstrumentationExecutionParameters instrumentationExecutionParameters) {
         if (executorService == null) {
-            return new AsyncExecutionStrategy().execute(executionContext, parameters);
+            return new AsyncExecutionStrategy().execute(executionContext, parameters, instrumentationExecutionParameters);
         }
 
         Instrumentation instrumentation = executionContext.getInstrumentation();

--- a/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
+++ b/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
@@ -23,6 +23,7 @@ import graphql.execution.SimpleDataFetcherExceptionHandler;
 import graphql.execution.directives.QueryDirectivesImpl;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationContext;
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionStrategyParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldParameters;
@@ -105,7 +106,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
 
     @Override
     @SuppressWarnings("FutureReturnValueIgnored")
-    public CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
+    public CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters, InstrumentationExecutionParameters instrumentationExecutionParameters) {
         InstrumentationContext<ExecutionResult> executionStrategyCtx = executionContext.getInstrumentation()
                 .beginExecutionStrategy(new InstrumentationExecutionStrategyParameters(executionContext, parameters));
 

--- a/src/test/groovy/graphql/GraphQLTest.groovy
+++ b/src/test/groovy/graphql/GraphQLTest.groovy
@@ -13,6 +13,7 @@ import graphql.execution.instrumentation.ChainedInstrumentation
 import graphql.execution.instrumentation.Instrumentation
 import graphql.execution.instrumentation.SimpleInstrumentation
 import graphql.execution.instrumentation.dataloader.DataLoaderDispatcherInstrumentation
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters
 import graphql.language.SourceLocation
 import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironment
@@ -838,10 +839,10 @@ class GraphQLTest extends Specification {
         Instrumentation instrumentation = null
 
         @Override
-        CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
+        CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters, InstrumentationExecutionParameters instrumentationExecutionParameters) {
             executionId = executionContext.executionId
             instrumentation = executionContext.instrumentation
-            return super.execute(executionContext, parameters)
+            return super.execute(executionContext, parameters, instrumentationExecutionParameters)
         }
     }
 

--- a/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy
@@ -91,7 +91,7 @@ class AsyncExecutionStrategyTest extends Specification {
 
         AsyncExecutionStrategy asyncExecutionStrategy = new AsyncExecutionStrategy()
         when:
-        def result = asyncExecutionStrategy.execute(executionContext, executionStrategyParameters)
+        def result = asyncExecutionStrategy.execute(executionContext, executionStrategyParameters, null)
 
 
         then:
@@ -130,7 +130,7 @@ class AsyncExecutionStrategyTest extends Specification {
 
         AsyncExecutionStrategy asyncExecutionStrategy = new AsyncExecutionStrategy()
         when:
-        def result = asyncExecutionStrategy.execute(executionContext, executionStrategyParameters)
+        def result = asyncExecutionStrategy.execute(executionContext, executionStrategyParameters, null)
 
 
         then:
@@ -171,7 +171,7 @@ class AsyncExecutionStrategyTest extends Specification {
 
         AsyncExecutionStrategy asyncExecutionStrategy = new AsyncExecutionStrategy()
         when:
-        def result = asyncExecutionStrategy.execute(executionContext, executionStrategyParameters)
+        def result = asyncExecutionStrategy.execute(executionContext, executionStrategyParameters, null)
 
 
         then:
@@ -211,7 +211,7 @@ class AsyncExecutionStrategyTest extends Specification {
 
         AsyncExecutionStrategy asyncExecutionStrategy = new AsyncExecutionStrategy()
         when:
-        def result = asyncExecutionStrategy.execute(executionContext, executionStrategyParameters)
+        def result = asyncExecutionStrategy.execute(executionContext, executionStrategyParameters, null)
 
 
         then:
@@ -271,7 +271,7 @@ class AsyncExecutionStrategyTest extends Specification {
 
         AsyncExecutionStrategy asyncExecutionStrategy = new AsyncExecutionStrategy()
         when:
-        def result = asyncExecutionStrategy.execute(executionContext, executionStrategyParameters)
+        def result = asyncExecutionStrategy.execute(executionContext, executionStrategyParameters, null)
 
         then: "result should be completed"
         result.isCompletedExceptionally()

--- a/src/test/groovy/graphql/execution/AsyncSerialExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/AsyncSerialExecutionStrategyTest.groovy
@@ -95,7 +95,7 @@ class AsyncSerialExecutionStrategyTest extends Specification {
 
         AsyncSerialExecutionStrategy strategy = new AsyncSerialExecutionStrategy()
         when:
-        def result = strategy.execute(executionContext, executionStrategyParameters)
+        def result = strategy.execute(executionContext, executionStrategyParameters, null)
 
 
         then:
@@ -139,7 +139,7 @@ class AsyncSerialExecutionStrategyTest extends Specification {
 
         AsyncSerialExecutionStrategy strategy = new AsyncSerialExecutionStrategy()
         when:
-        def result = strategy.execute(executionContext, executionStrategyParameters)
+        def result = strategy.execute(executionContext, executionStrategyParameters, null)
 
 
         then:

--- a/src/test/groovy/graphql/execution/BreadthFirstExecutionTestStrategy.java
+++ b/src/test/groovy/graphql/execution/BreadthFirstExecutionTestStrategy.java
@@ -3,6 +3,7 @@ package graphql.execution;
 import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.Internal;
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -19,7 +20,7 @@ public class BreadthFirstExecutionTestStrategy extends ExecutionStrategy {
     }
 
     @Override
-    public CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) throws NonNullableFieldWasNullException {
+    public CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters, InstrumentationExecutionParameters instrumentationExecutionParameters) throws NonNullableFieldWasNullException {
         MergedSelectionSet fields = parameters.getFields();
 
         Map<String, FetchedValue> fetchedValues = new LinkedHashMap<>();

--- a/src/test/groovy/graphql/execution/BreadthFirstTestStrategy.java
+++ b/src/test/groovy/graphql/execution/BreadthFirstTestStrategy.java
@@ -3,6 +3,7 @@ package graphql.execution;
 import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.Internal;
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
 
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -25,7 +26,7 @@ public class BreadthFirstTestStrategy extends ExecutionStrategy {
     }
 
     @Override
-    public CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) throws NonNullableFieldWasNullException {
+    public CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters, InstrumentationExecutionParameters instrumentationExecutionParameters) throws NonNullableFieldWasNullException {
 
         Map<String, FetchedValue> fetchedValues = fetchFields(executionContext, parameters);
 

--- a/src/test/groovy/graphql/execution/ExecutionIdTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionIdTest.groovy
@@ -3,6 +3,7 @@ package graphql.execution
 import graphql.ExecutionResult
 import graphql.GraphQL
 import graphql.StarWarsSchema
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters
 import spock.lang.Specification
 
 import java.util.concurrent.CompletableFuture
@@ -13,9 +14,9 @@ class ExecutionIdTest extends Specification {
         ExecutionId executionId = null
 
         @Override
-        CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
+        CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters, InstrumentationExecutionParameters instrumentationExecutionParameters) {
             executionId = executionContext.executionId
-            return super.execute(executionContext, parameters)
+            return super.execute(executionContext, parameters, instrumentationExecutionParameters)
         }
     }
 

--- a/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
@@ -9,6 +9,7 @@ import graphql.SerializationError
 import graphql.StarWarsSchema
 import graphql.TypeMismatchError
 import graphql.execution.instrumentation.SimpleInstrumentation
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters
 import graphql.language.Argument
 import graphql.language.Field
 import graphql.language.OperationDefinition
@@ -50,7 +51,7 @@ class ExecutionStrategyTest extends Specification {
         executionStrategy = new ExecutionStrategy(dataFetcherExceptionHandler) {
 
             @Override
-            CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
+            CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters, InstrumentationExecutionParameters instrumentationExecutionParameters) {
                 return Assert.assertShouldNeverHappen("should not be called")
             }
         }
@@ -108,9 +109,9 @@ class ExecutionStrategyTest extends Specification {
         executionStrategy.completeValue(executionContext, parameters)
 
         then:
-        1 * executionContext.queryStrategy.execute(_, _)
-        0 * executionContext.mutationStrategy.execute(_, _)
-        0 * executionContext.subscriptionStrategy.execute(_, _)
+        1 * executionContext.queryStrategy.execute(_, _, _)
+        0 * executionContext.mutationStrategy.execute(_, _, _)
+        0 * executionContext.subscriptionStrategy.execute(_, _, _)
     }
 
 
@@ -571,7 +572,7 @@ class ExecutionStrategyTest extends Specification {
             }
         }) {
             @Override
-            CompletableFuture<ExecutionResult> execute(ExecutionContext ec, ExecutionStrategyParameters p) throws NonNullableFieldWasNullException {
+            CompletableFuture<ExecutionResult> execute(ExecutionContext ec, ExecutionStrategyParameters p, InstrumentationExecutionParameters instrumentationExecutionParameters) throws NonNullableFieldWasNullException {
                 null
             }
         }
@@ -597,7 +598,7 @@ class ExecutionStrategyTest extends Specification {
 
         ExecutionStrategy overridingStrategy = new ExecutionStrategy() {
             @Override
-            CompletableFuture<ExecutionResult> execute(ExecutionContext ec, ExecutionStrategyParameters p) throws NonNullableFieldWasNullException {
+            CompletableFuture<ExecutionResult> execute(ExecutionContext ec, ExecutionStrategyParameters p, InstrumentationExecutionParameters instrumentationExecutionParameters) throws NonNullableFieldWasNullException {
                 null
             }
         }

--- a/src/test/groovy/graphql/execution/ExecutionTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionTest.groovy
@@ -21,7 +21,7 @@ class ExecutionTest extends Specification {
 
 
         @Override
-        CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) throws NonNullableFieldWasNullException {
+        CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters, InstrumentationExecutionParameters instrumentationExecutionParameters) throws NonNullableFieldWasNullException {
             execute++
             return CompletableFuture.completedFuture(result())
         }

--- a/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentationTest.groovy
@@ -37,9 +37,9 @@ class DataLoaderDispatcherInstrumentationTest extends Specification {
         Instrumentation instrumentation = null
 
         @Override
-        CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
+        CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters, InstrumentationExecutionParameters instrumentationExecutionParameters) {
             instrumentation = executionContext.instrumentation
-            return super.execute(executionContext, parameters)
+            return super.execute(executionContext, parameters, instrumentationExecutionParameters)
         }
     }
 


### PR DESCRIPTION
ExecutionResults sent to Publisher subscribers do not currently
apply any configured Instrumentations.  This applies the
instrumentation before returning the result.

Fixes #1568, at least for simple Instrumentation implementations.