### PR TITLE
Remove toString

### DIFF
--- a/src/main/java/graphql/execution/ExecutionStepInfo.java
+++ b/src/main/java/graphql/execution/ExecutionStepInfo.java
@@ -183,16 +183,6 @@ public class ExecutionStepInfo {
         return GraphQLTypeUtil.simplePrint(type);
     }
 
-    @Override
-    public String toString() {
-        return "ExecutionStepInfo{" +
-                " path=" + path +
-                ", type=" + type +
-                ", parent=" + parent +
-                ", fieldDefinition=" + fieldDefinition +
-                '}';
-    }
-
     public ExecutionStepInfo transform(Consumer<Builder> builderConsumer) {
         Builder builder = new Builder(this);
         builderConsumer.accept(builder);

--- a/src/main/java/graphql/execution/NonNullableFieldWasNullError.java
+++ b/src/main/java/graphql/execution/NonNullableFieldWasNullError.java
@@ -42,14 +42,6 @@ public class NonNullableFieldWasNullError implements GraphQLError {
         return ErrorType.DataFetchingException;
     }
 
-    @Override
-    public String toString() {
-        return "NonNullableFieldWasNullError{" +
-                "message='" + message + '\'' +
-                ", path=" + path +
-                '}';
-    }
-
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/graphql/execution/NonNullableFieldWasNullException.java
+++ b/src/main/java/graphql/execution/NonNullableFieldWasNullException.java
@@ -54,12 +54,4 @@ public class NonNullableFieldWasNullException extends RuntimeException {
     public ExecutionPath getPath() {
         return path;
     }
-
-    @Override
-    public String toString() {
-        return "NonNullableFieldWasNullException{" +
-                " path=" + path +
-                " executionStepInfo=" + executionStepInfo +
-                '}';
-    }
 }


### PR DESCRIPTION
Removing toString greatly reduces garbage collection times when exceptions are thrown.
This get really expensive when you return list items.
toString is being called by the Throwable class and is not used in the graphql error reporting returned to the caller.

This should improve/fix #1788 