### PR TITLE
This reduces the memory overhead of NonNullableFieldWasNullException …

### DIFF
--- a/src/main/java/graphql/GraphQLException.java
+++ b/src/main/java/graphql/GraphQLException.java
@@ -18,5 +18,9 @@ public class GraphQLException extends RuntimeException {
         super(cause);
     }
 
+    @Override
+    public String toString() {
+        return getMessage();
+    }
 
 }

--- a/src/main/java/graphql/GraphQLException.java
+++ b/src/main/java/graphql/GraphQLException.java
@@ -18,9 +18,4 @@ public class GraphQLException extends RuntimeException {
         super(cause);
     }
 
-    @Override
-    public String toString() {
-        return getMessage();
-    }
-
 }

--- a/src/main/java/graphql/analysis/FieldComplexityEnvironment.java
+++ b/src/main/java/graphql/analysis/FieldComplexityEnvironment.java
@@ -49,7 +49,6 @@ public class FieldComplexityEnvironment {
                 "field=" + field +
                 ", fieldDefinition=" + fieldDefinition +
                 ", parentType=" + parentType +
-                ", parentEnvironment=" + parentEnvironment +
                 ", arguments=" + arguments +
                 '}';
     }

--- a/src/main/java/graphql/analysis/QueryVisitorFieldArgumentEnvironmentImpl.java
+++ b/src/main/java/graphql/analysis/QueryVisitorFieldArgumentEnvironmentImpl.java
@@ -80,7 +80,6 @@ public class QueryVisitorFieldArgumentEnvironmentImpl implements QueryVisitorFie
                 ", graphQLArgument=" + graphQLArgument +
                 ", argumentValue=" + argumentValue +
                 ", variables=" + variables +
-                ", parentEnvironment=" + parentEnvironment +
                 ", traverserContext=" + traverserContext +
                 ", schema=" + schema +
                 '}';

--- a/src/main/java/graphql/analysis/QueryVisitorFieldArgumentInputValueImpl.java
+++ b/src/main/java/graphql/analysis/QueryVisitorFieldArgumentInputValueImpl.java
@@ -64,7 +64,6 @@ public class QueryVisitorFieldArgumentInputValueImpl implements QueryVisitorFiel
         return "QueryVisitorFieldArgumentInputValueImpl{" +
                 "inputValue=" + inputValueDefinition +
                 ", value=" + value +
-                ", parent=" + parent +
                 '}';
     }
 }

--- a/src/main/java/graphql/analysis/QueryVisitorFieldEnvironmentImpl.java
+++ b/src/main/java/graphql/analysis/QueryVisitorFieldEnvironmentImpl.java
@@ -129,7 +129,6 @@ public class QueryVisitorFieldEnvironmentImpl implements QueryVisitorFieldEnviro
                 "field=" + field +
                 ", fieldDefinition=" + fieldDefinition +
                 ", parentType=" + parentType +
-                ", parentEnvironment=" + parentEnvironment +
                 ", arguments=" + arguments +
                 '}';
     }

--- a/src/main/java/graphql/execution/ExecutionStepInfo.java
+++ b/src/main/java/graphql/execution/ExecutionStepInfo.java
@@ -188,7 +188,6 @@ public class ExecutionStepInfo {
         return "ExecutionStepInfo{" +
                 " path=" + path +
                 ", type=" + type +
-                ", parent=" + parent +
                 ", fieldDefinition=" + fieldDefinition +
                 '}';
     }

--- a/src/main/java/graphql/execution/NonNullableFieldWasNullException.java
+++ b/src/main/java/graphql/execution/NonNullableFieldWasNullException.java
@@ -57,9 +57,6 @@ public class NonNullableFieldWasNullException extends RuntimeException {
 
     @Override
     public String toString() {
-        return "NonNullableFieldWasNullException{" +
-                " path=" + path +
-                " executionStepInfo=" + executionStepInfo +
-                '}';
+        return getMessage();
     }
 }


### PR DESCRIPTION
This reduces the memory overhead of NonNullableFieldWasNullException and also the ExecutionStepInfo and other places that use parent hierarchies in their `.toString`


See #1788 


This should be back ported to stable I think