### PR TITLE
backport #1797: add missing WiringFactory methods

### DIFF
--- a/src/main/java/graphql/schema/idl/CombinedWiringFactory.java
+++ b/src/main/java/graphql/schema/idl/CombinedWiringFactory.java
@@ -2,6 +2,7 @@ package graphql.schema.idl;
 
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetcherFactory;
+import graphql.schema.GraphQLScalarType;
 import graphql.schema.TypeResolver;
 
 import java.util.ArrayList;
@@ -101,4 +102,57 @@ public class CombinedWiringFactory implements WiringFactory {
         }
         return assertShouldNeverHappen();
     }
+
+
+    @Override
+    public boolean providesScalar(ScalarWiringEnvironment environment) {
+        for (WiringFactory factory : factories) {
+            if (factory.providesScalar(environment)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public GraphQLScalarType getScalar(ScalarWiringEnvironment environment) {
+        for (WiringFactory factory : factories) {
+            if (factory.providesScalar(environment)) {
+                return factory.getScalar(environment);
+            }
+        }
+        return assertShouldNeverHappen();
+    }
+
+    @Override
+    public boolean providesSchemaDirectiveWiring(SchemaDirectiveWiringEnvironment environment) {
+        for (WiringFactory factory : factories) {
+            if (factory.providesSchemaDirectiveWiring(environment)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public SchemaDirectiveWiring getSchemaDirectiveWiring(SchemaDirectiveWiringEnvironment environment) {
+        for (WiringFactory factory : factories) {
+            if (factory.providesSchemaDirectiveWiring(environment)) {
+                return factory.getSchemaDirectiveWiring(environment);
+            }
+        }
+        return assertShouldNeverHappen();
+    }
+
+    @Override
+    public DataFetcher getDefaultDataFetcher(FieldWiringEnvironment environment) {
+        for (WiringFactory factory : factories) {
+            if (factory.getDefaultDataFetcher(environment) != null) {
+                return factory.getDefaultDataFetcher(environment);
+            }
+        }
+        return null;
+    }
+
+
 }

--- a/src/test/groovy/graphql/schema/idl/WiringFactoryTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/WiringFactoryTest.groovy
@@ -52,7 +52,7 @@ class WiringFactoryTest extends Specification {
 
         @Override
         boolean providesScalar(ScalarWiringEnvironment environment) {
-            return name == environment.getInterfaceTypeDefinition().getName()
+            return name == environment.getScalarTypeDefinition().getName()
         }
 
         @Override
@@ -124,6 +124,29 @@ class WiringFactoryTest extends Specification {
         }
     }
 
+    class NamedDefaultDataFetcherWiringFactory implements WiringFactory {
+        def fields = []
+
+        @Override
+        boolean providesDataFetcher(FieldWiringEnvironment environment) {
+            if (environment.getFieldDefinition().getName() == "name") {
+                return true
+            }
+            return false
+        }
+
+        @Override
+        DataFetcher getDataFetcher(FieldWiringEnvironment environment) {
+            new PropertyDataFetcher("name")
+        }
+
+        @Override
+        DataFetcher getDefaultDataFetcher(FieldWiringEnvironment environment) {
+            def name = environment.getFieldDefinition().getName()
+            fields.add(name)
+            new PropertyDataFetcher(name)
+        }
+    }
 
     def "ensure that wiring factory is called to resolve and create data fetchers"() {
 
@@ -161,16 +184,23 @@ class WiringFactoryTest extends Specification {
                 homePlanet: String
                 cyborg: Cyborg
             }
+            
+            type Other implements Character {
+                name: String!
+                fetchedByDefaultDataFetcher: String!
+            }
         """
 
-
+        WiringFactory defaultDataFetcherWiringFactory = new NamedDefaultDataFetcherWiringFactory()
 
         def combinedWiringFactory = new CombinedWiringFactory([
                 new NamedWiringFactory("Character"),
                 new NamedWiringFactory("Cyborg"),
                 new NamedWiringFactory("Long"),
                 new NamedDataFetcherFactoryWiringFactory("cyborg"),
-                new NamedWiringFactory("friends")])
+                new NamedWiringFactory("friends"),
+                defaultDataFetcherWiringFactory
+        ])
 
         def wiring = RuntimeWiring.newRuntimeWiring()
                 .wiringFactory(combinedWiringFactory)
@@ -201,6 +231,8 @@ class WiringFactoryTest extends Specification {
 
         GraphQLScalarType longScalar = schema.getType("Long") as GraphQLScalarType
         longScalar.name == "Long"
+
+        defaultDataFetcherWiringFactory.fields.contains("fetchedByDefaultDataFetcher")
     }
 
     def "ensure field wiring environment makes sense"() {
@@ -257,30 +289,8 @@ class WiringFactoryTest extends Specification {
             }
         """
 
+        def wiringFactory = new NamedDefaultDataFetcherWiringFactory()
 
-        def fields = []
-
-        def wiringFactory = new WiringFactory() {
-            @Override
-            boolean providesDataFetcher(FieldWiringEnvironment environment) {
-                if (environment.getFieldDefinition().getName() == "name") {
-                    return true
-                }
-                return false
-            }
-
-            @Override
-            DataFetcher getDataFetcher(FieldWiringEnvironment environment) {
-                new PropertyDataFetcher("name")
-            }
-
-            @Override
-            DataFetcher getDefaultDataFetcher(FieldWiringEnvironment environment) {
-                def name = environment.getFieldDefinition().getName()
-                fields.add(name)
-                new PropertyDataFetcher(name)
-            }
-        }
         def wiring = RuntimeWiring.newRuntimeWiring()
                 .wiringFactory(wiringFactory)
                 .build()
@@ -289,7 +299,7 @@ class WiringFactoryTest extends Specification {
 
         expect:
 
-        fields == ["id", "homePlanet"]
+        wiringFactory.fields == ["id", "homePlanet"]
     }
 
     def "@fetch directive is respected by default data fetcher wiring"() {


### PR DESCRIPTION
This provides the backport of #1797 to the 9.x branch.