### PR TITLE
Improved ExecutionPath construction performance

### DIFF
--- a/src/main/java/graphql/util/LazyReference.java
+++ b/src/main/java/graphql/util/LazyReference.java
@@ -1,0 +1,57 @@
+package graphql.util;
+
+import java.util.function.Supplier;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A lazy value that is computed once and once only.  Useful for effectively final values
+ * that dont need to be computed on creation but on first time use.
+ *
+ * @param <T> for two
+ */
+public final class LazyReference<T> {
+
+    private final Supplier<T> valueSupplier;
+    private volatile T value;
+
+    public LazyReference(Supplier<T> valueSupplier) {
+        this.valueSupplier = requireNonNull(valueSupplier);
+    }
+
+    /**
+     * @return the computed lazy value
+     */
+    public T get() {
+        final T result = value;
+        return result == null ? maybeCompute(valueSupplier) : result;
+    }
+
+    private synchronized T maybeCompute(Supplier<T> valueSupplier) {
+        if (value == null) {
+            value = requireNonNull(valueSupplier.get());
+        }
+        return value;
+    }
+
+    @Override
+    public int hashCode() {
+        return get().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null) return false;
+        if (getClass() != obj.getClass()) {
+            return get().equals(obj);
+        }
+        LazyReference<?> that = (LazyReference<?>) obj;
+        return this.get().equals(that.get());
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+}

--- a/src/test/groovy/graphql/execution/ExecutionPathTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionPathTest.groovy
@@ -322,4 +322,22 @@ class ExecutionPathTest extends Specification {
         then:
         newPath.toList() == ["a", "b", "x"]
     }
+
+    @SuppressWarnings("ChangeToOperator")
+    @Unroll
+    def ".equals works for #executionPath equals #comparedTo"() {
+
+        expect:
+        executionPath.equals(comparedTo) == expectedResult
+
+        where:
+        executionPath                  | comparedTo                     | expectedResult
+        ExecutionPath.rootPath()       | ExecutionPath.rootPath()       | true
+        ExecutionPath.parse("/a/b[1]") | ExecutionPath.parse("/a/b[1]") | true
+        ExecutionPath.parse("/a/b[1]") | ExecutionPath.parse("/a/b")    | false
+        ExecutionPath.parse("/a/b[1]") | ExecutionPath.rootPath()       | false
+        ExecutionPath.parse("/a/b[1]") | ExecutionPath.rootPath()       | false
+        ExecutionPath.rootPath()       | ExecutionPath.parse("/a/b[1]") | false
+    }
+
 }

--- a/src/test/groovy/graphql/util/LazyReferenceTest.groovy
+++ b/src/test/groovy/graphql/util/LazyReferenceTest.groovy
@@ -1,0 +1,58 @@
+package graphql.util
+
+import spock.lang.Specification
+
+class LazyReferenceTest extends Specification {
+
+    def "it can get values"() {
+        when:
+        LazyReference<String> lazyString = new LazyReference<>({ -> "hi" })
+
+        then:
+        lazyString.toString() == "null"
+
+        then:
+        lazyString.get() == "hi"
+        lazyString.toString() == "hi"
+    }
+
+    def "null checks"() {
+        when:
+        new LazyReference<>(null)
+        then:
+        thrown(NullPointerException)
+
+        when:
+        LazyReference<String> lazyString = new LazyReference<>({ -> null })
+        lazyString.get()
+        then:
+        thrown(NullPointerException)
+    }
+
+    @SuppressWarnings(["ChangeToOperator", "GrEqualsBetweenInconvertibleTypes"])
+    def ".equals works as expected"() {
+        when:
+        def lA = new LazyReference({ -> "A" })
+        def lA1 = new LazyReference({ -> "A" })
+        def lB = new LazyReference({ -> "B" })
+
+        then:
+        lA.equals(lA)
+        lA.equals(lA1)
+        lA.equals("A") // controversial choice but I think it makes sense
+        !lA.equals(lB)
+        !lA.equals("B")
+        !lA.equals(null)
+    }
+
+    def "hashCode delegates to value"() {
+
+        when:
+        def lA = new LazyReference({ -> "A" })
+
+        then:
+
+        lA.hashCode() == "A".hashCode()
+
+    }
+}

--- a/src/test/java/benchmark/ExecutionPathBenchMark.java
+++ b/src/test/java/benchmark/ExecutionPathBenchMark.java
@@ -1,0 +1,62 @@
+package benchmark;
+
+import graphql.execution.ExecutionPath;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+public class ExecutionPathBenchMark {
+
+    private static final List<String> sixLenPath = Arrays.asList("parent", "child", "grandchild", "greatgrandchild", "greatgreatgrandchild", "greatgreatgreatgrandchild");
+    private static final List<String> fiveLenPath = Arrays.asList("parent", "child", "grandchild", "greatgrandchild", "greatgreatgrandchild");
+
+    private static ExecutionPath sixPath = mkPath(sixLenPath);
+    private static List<ExecutionPath> sixers = Arrays.asList(sixPath, sixPath, sixPath, sixPath);
+    private static List<ExecutionPath> fivers = Arrays.asList(mkPath(fiveLenPath), mkPath(fiveLenPath), mkPath(fiveLenPath), mkPath(fiveLenPath));
+
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    @Warmup(iterations = 2, time = 1, batchSize = 3)
+    @Measurement(iterations = 3, time = 5, batchSize = 5)
+    public void benchExecutionPathHandling() {
+
+        mkPath(sixLenPath);
+
+        // use .equals
+        //noinspection ResultOfMethodCallIgnored
+        sixers.equals(fivers);
+
+        // use hash code
+        new HashSet<>(sixers);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    @Warmup(iterations = 2, time = 1, batchSize = 3)
+    @Measurement(iterations = 3, time = 5, batchSize = 5)
+    public void toListBenchmarking() {
+        sixPath.toList();
+    }
+
+    static ExecutionPath mkPath(List<String> segments) {
+        ExecutionPath path = ExecutionPath.rootPath();
+        for (String segment : segments) {
+            path = path.segment(segment);
+        }
+        return path;
+    }
+}


### PR DESCRIPTION
This makes the list construction lazy and with a custom .equals / .hashCode method

See #1809