### PR TITLE
CodeRegistry can now have a default data fetcher factory

### DIFF
--- a/src/main/java/graphql/schema/GraphQLCodeRegistry.java
+++ b/src/main/java/graphql/schema/GraphQLCodeRegistry.java
@@ -1,5 +1,6 @@
 package graphql.schema;
 
+import graphql.Assert;
 import graphql.PublicApi;
 import graphql.schema.visibility.GraphqlFieldVisibility;
 
@@ -20,23 +21,25 @@ import static graphql.schema.visibility.DefaultGraphqlFieldVisibility.DEFAULT_FI
  * The {@link graphql.schema.GraphQLCodeRegistry} holds that execution code that is associated with graphql types, namely
  * the {@link graphql.schema.DataFetcher}s associated with fields, the {@link graphql.schema.TypeResolver}s associated with
  * abstract types and the {@link graphql.schema.visibility.GraphqlFieldVisibility}
- *
+ * <p>
  * For legacy reasons these code functions can still exist on the original type objects but this will be removed in a future version.  Once
  * removed the type system objects will be able have proper hashCode/equals methods and be checked for proper equality.
  */
 @PublicApi
 public class GraphQLCodeRegistry {
 
-    private final Map<FieldCoordinates, DataFetcherFactory> dataFetcherMap;
-    private final Map<String, DataFetcherFactory> systemDataFetcherMap;
+    private final Map<FieldCoordinates, DataFetcherFactory<?>> dataFetcherMap;
+    private final Map<String, DataFetcherFactory<?>> systemDataFetcherMap;
     private final Map<String, TypeResolver> typeResolverMap;
     private final GraphqlFieldVisibility fieldVisibility;
+    private final DataFetcherFactory<?> defaultDataFetcherFactory;
 
-    private GraphQLCodeRegistry(Map<FieldCoordinates, DataFetcherFactory> dataFetcherMap, Map<String, DataFetcherFactory> systemDataFetcherMap, Map<String, TypeResolver> typeResolverMap, GraphqlFieldVisibility fieldVisibility) {
-        this.dataFetcherMap = dataFetcherMap;
-        this.systemDataFetcherMap = systemDataFetcherMap;
-        this.typeResolverMap = typeResolverMap;
-        this.fieldVisibility = fieldVisibility;
+    private GraphQLCodeRegistry(Builder builder) {
+        this.dataFetcherMap = builder.dataFetcherMap;
+        this.systemDataFetcherMap = builder.systemDataFetcherMap;
+        this.typeResolverMap = builder.typeResolverMap;
+        this.fieldVisibility = builder.fieldVisibility;
+        this.defaultDataFetcherFactory = builder.defaultDataFetcherFactory;
     }
 
     /**
@@ -51,11 +54,10 @@ public class GraphQLCodeRegistry {
      *
      * @param parentType      the container type
      * @param fieldDefinition the field definition
-     *
      * @return the DataFetcher associated with this field.  All fields have data fetchers
      */
-    public DataFetcher getDataFetcher(GraphQLFieldsContainer parentType, GraphQLFieldDefinition fieldDefinition) {
-        return getDataFetcherImpl(FieldCoordinates.coordinates(parentType, fieldDefinition), fieldDefinition, dataFetcherMap, systemDataFetcherMap);
+    public DataFetcher<?> getDataFetcher(GraphQLFieldsContainer parentType, GraphQLFieldDefinition fieldDefinition) {
+        return getDataFetcherImpl(FieldCoordinates.coordinates(parentType, fieldDefinition), fieldDefinition, dataFetcherMap, systemDataFetcherMap, defaultDataFetcherFactory);
     }
 
     /**
@@ -63,22 +65,21 @@ public class GraphQLCodeRegistry {
      *
      * @param coordinates     the field coordinates
      * @param fieldDefinition the field definition
-     *
      * @return the DataFetcher associated with this field.  All fields have data fetchers
      */
-    public DataFetcher getDataFetcher(FieldCoordinates coordinates, GraphQLFieldDefinition fieldDefinition) {
-        return getDataFetcherImpl(coordinates, fieldDefinition, dataFetcherMap, systemDataFetcherMap);
+    public DataFetcher<?> getDataFetcher(FieldCoordinates coordinates, GraphQLFieldDefinition fieldDefinition) {
+        return getDataFetcherImpl(coordinates, fieldDefinition, dataFetcherMap, systemDataFetcherMap, defaultDataFetcherFactory);
     }
 
-    private static DataFetcher getDataFetcherImpl(FieldCoordinates coordinates, GraphQLFieldDefinition fieldDefinition, Map<FieldCoordinates, DataFetcherFactory> dataFetcherMap, Map<String, DataFetcherFactory> systemDataFetcherMap) {
+    private static DataFetcher<?> getDataFetcherImpl(FieldCoordinates coordinates, GraphQLFieldDefinition fieldDefinition, Map<FieldCoordinates, DataFetcherFactory<?>> dataFetcherMap, Map<String, DataFetcherFactory<?>> systemDataFetcherMap, DataFetcherFactory<?> defaultDataFetcherFactory) {
         assertNotNull(coordinates);
         assertNotNull(fieldDefinition);
 
-        DataFetcherFactory dataFetcherFactory = systemDataFetcherMap.get(fieldDefinition.getName());
+        DataFetcherFactory<?> dataFetcherFactory = systemDataFetcherMap.get(fieldDefinition.getName());
         if (dataFetcherFactory == null) {
             dataFetcherFactory = dataFetcherMap.get(coordinates);
             if (dataFetcherFactory == null) {
-                dataFetcherFactory = DataFetcherFactories.useDataFetcher(new PropertyDataFetcher<>(fieldDefinition.getName()));
+                dataFetcherFactory = defaultDataFetcherFactory;
             }
         }
         return dataFetcherFactory.get(newDataFetchingFactoryEnvironment()
@@ -86,10 +87,10 @@ public class GraphQLCodeRegistry {
                 .build());
     }
 
-    private static boolean hasDataFetcherImpl(FieldCoordinates coords, Map<FieldCoordinates, DataFetcherFactory> dataFetcherMap, Map<String, DataFetcherFactory> systemDataFetcherMap) {
+    private static boolean hasDataFetcherImpl(FieldCoordinates coords, Map<FieldCoordinates, DataFetcherFactory<?>> dataFetcherMap, Map<String, DataFetcherFactory<?>> systemDataFetcherMap) {
         assertNotNull(coords);
 
-        DataFetcherFactory dataFetcherFactory = systemDataFetcherMap.get(coords.getFieldName());
+        DataFetcherFactory<?> dataFetcherFactory = systemDataFetcherMap.get(coords.getFieldName());
         if (dataFetcherFactory == null) {
             dataFetcherFactory = dataFetcherMap.get(coords);
         }
@@ -101,7 +102,6 @@ public class GraphQLCodeRegistry {
      * Returns the type resolver associated with this interface type
      *
      * @param interfaceType the interface type
-     *
      * @return a non null {@link graphql.schema.TypeResolver}
      */
     public TypeResolver getTypeResolver(GraphQLInterfaceType interfaceType) {
@@ -112,7 +112,6 @@ public class GraphQLCodeRegistry {
      * Returns the type resolver associated with this union type
      *
      * @param unionType the union type
-     *
      * @return a non null {@link graphql.schema.TypeResolver}
      */
 
@@ -143,7 +142,6 @@ public class GraphQLCodeRegistry {
      * the current values and allows you to transform it how you want.
      *
      * @param builderConsumer the consumer code that will be given a builder to transform
-     *
      * @return a new GraphQLCodeRegistry object based on calling build on that builder
      */
     public GraphQLCodeRegistry transform(Consumer<Builder> builderConsumer) {
@@ -163,7 +161,6 @@ public class GraphQLCodeRegistry {
      * Returns a new builder of {@link graphql.schema.GraphQLCodeRegistry} objects based on the existing one
      *
      * @param existingCodeRegistry the existing code registry to use
-     *
      * @return a new builder of {@link graphql.schema.GraphQLCodeRegistry} objects
      */
     public static Builder newCodeRegistry(GraphQLCodeRegistry existingCodeRegistry) {
@@ -171,10 +168,11 @@ public class GraphQLCodeRegistry {
     }
 
     public static class Builder {
-        private final Map<FieldCoordinates, DataFetcherFactory> dataFetcherMap = new LinkedHashMap<>();
-        private final Map<String, DataFetcherFactory> systemDataFetcherMap = new LinkedHashMap<>();
+        private final Map<FieldCoordinates, DataFetcherFactory<?>> dataFetcherMap = new LinkedHashMap<>();
+        private final Map<String, DataFetcherFactory<?>> systemDataFetcherMap = new LinkedHashMap<>();
         private final Map<String, TypeResolver> typeResolverMap = new HashMap<>();
         private GraphqlFieldVisibility fieldVisibility = DEFAULT_FIELD_VISIBILITY;
+        private DataFetcherFactory<?> defaultDataFetcherFactory = env -> PropertyDataFetcher.fetching(env.getFieldDefinition().getName());
 
 
         private Builder() {
@@ -184,6 +182,7 @@ public class GraphQLCodeRegistry {
             this.dataFetcherMap.putAll(codeRegistry.dataFetcherMap);
             this.typeResolverMap.putAll(codeRegistry.typeResolverMap);
             this.fieldVisibility = codeRegistry.fieldVisibility;
+            this.defaultDataFetcherFactory = codeRegistry.defaultDataFetcherFactory;
         }
 
         /**
@@ -191,11 +190,10 @@ public class GraphQLCodeRegistry {
          *
          * @param parentType      the container type
          * @param fieldDefinition the field definition
-         *
          * @return the DataFetcher associated with this field.  All fields have data fetchers
          */
-        public DataFetcher getDataFetcher(GraphQLFieldsContainer parentType, GraphQLFieldDefinition fieldDefinition) {
-            return getDataFetcherImpl(FieldCoordinates.coordinates(parentType, fieldDefinition), fieldDefinition, dataFetcherMap, systemDataFetcherMap);
+        public DataFetcher<?> getDataFetcher(GraphQLFieldsContainer parentType, GraphQLFieldDefinition fieldDefinition) {
+            return getDataFetcherImpl(FieldCoordinates.coordinates(parentType, fieldDefinition), fieldDefinition, dataFetcherMap, systemDataFetcherMap, defaultDataFetcherFactory);
         }
 
         /**
@@ -203,18 +201,16 @@ public class GraphQLCodeRegistry {
          *
          * @param coordinates     the field coordinates
          * @param fieldDefinition the field definition
-         *
          * @return the DataFetcher associated with this field.  All fields have data fetchers
          */
-        public DataFetcher getDataFetcher(FieldCoordinates coordinates, GraphQLFieldDefinition fieldDefinition) {
-            return getDataFetcherImpl(coordinates, fieldDefinition, dataFetcherMap, systemDataFetcherMap);
+        public DataFetcher<?> getDataFetcher(FieldCoordinates coordinates, GraphQLFieldDefinition fieldDefinition) {
+            return getDataFetcherImpl(coordinates, fieldDefinition, dataFetcherMap, systemDataFetcherMap, defaultDataFetcherFactory);
         }
 
         /**
          * Returns a data fetcher associated with a field within a container type
          *
          * @param coordinates the field coordinates
-         *
          * @return the true if there is a data fetcher already for this field
          */
         public boolean hasDataFetcher(FieldCoordinates coordinates) {
@@ -225,7 +221,6 @@ public class GraphQLCodeRegistry {
          * Returns the type resolver associated with this interface type
          *
          * @param interfaceType the interface type
-         *
          * @return a non null {@link graphql.schema.TypeResolver}
          */
         public TypeResolver getTypeResolver(GraphQLInterfaceType interfaceType) {
@@ -236,7 +231,6 @@ public class GraphQLCodeRegistry {
          * Returns true of a type resolver has been registered for this type name
          *
          * @param typeName the name to check
-         *
          * @return true if there is already a type resolver
          */
         public boolean hasTypeResolver(String typeName) {
@@ -247,7 +241,6 @@ public class GraphQLCodeRegistry {
          * Returns the type resolver associated with this union type
          *
          * @param unionType the union type
-         *
          * @return a non null {@link graphql.schema.TypeResolver}
          */
         public TypeResolver getTypeResolver(GraphQLUnionType unionType) {
@@ -259,7 +252,6 @@ public class GraphQLCodeRegistry {
          *
          * @param coordinates the field coordinates
          * @param dataFetcher the data fetcher code for that field
-         *
          * @return this builder
          */
         public Builder dataFetcher(FieldCoordinates coordinates, DataFetcher<?> dataFetcher) {
@@ -273,7 +265,6 @@ public class GraphQLCodeRegistry {
          * @param parentType      the container type
          * @param fieldDefinition the field definition
          * @param dataFetcher     the data fetcher code for that field
-         *
          * @return this builder
          */
         public Builder dataFetcher(GraphQLFieldsContainer parentType, GraphQLFieldDefinition fieldDefinition, DataFetcher<?> dataFetcher) {
@@ -285,7 +276,6 @@ public class GraphQLCodeRegistry {
          *
          * @param coordinates the field coordinates
          * @param dataFetcher the data fetcher code for that field
-         *
          * @return this builder
          */
         public Builder systemDataFetcher(FieldCoordinates coordinates, DataFetcher<?> dataFetcher) {
@@ -301,7 +291,6 @@ public class GraphQLCodeRegistry {
          *
          * @param coordinates        the field coordinates
          * @param dataFetcherFactory the data fetcher factory code for that field
-         *
          * @return this builder
          */
         public Builder dataFetcher(FieldCoordinates coordinates, DataFetcherFactory<?> dataFetcherFactory) {
@@ -315,7 +304,6 @@ public class GraphQLCodeRegistry {
          *
          * @param coordinates the field coordinates
          * @param dataFetcher the data fetcher code for that field
-         *
          * @return this builder
          */
         public Builder dataFetcherIfAbsent(FieldCoordinates coordinates, DataFetcher<?> dataFetcher) {
@@ -328,14 +316,23 @@ public class GraphQLCodeRegistry {
          *
          * @param parentTypeName    the parent container type
          * @param fieldDataFetchers the map of field names to data fetchers
-         *
          * @return this builder
          */
-        public Builder dataFetchers(String parentTypeName, Map<String, DataFetcher> fieldDataFetchers) {
+        public Builder dataFetchers(String parentTypeName, Map<String, DataFetcher<?>> fieldDataFetchers) {
             assertNotNull(fieldDataFetchers);
-            fieldDataFetchers.forEach((fieldName, dataFetcher) -> {
-                dataFetcher(coordinates(parentTypeName, fieldName), dataFetcher);
-            });
+            fieldDataFetchers.forEach((fieldName, dataFetcher) -> dataFetcher(coordinates(parentTypeName, fieldName), dataFetcher));
+            return this;
+        }
+
+        /**
+         * This is the default data fetcher factory that will be used for fields that do not have specific data fetchers attached.  By default
+         * {@link graphql.schema.PropertyDataFetcher} is used but you can have your own default via this method.
+         *
+         * @param defaultDataFetcherFactory the default data fetcher factory used
+         * @return this builder
+         */
+        public Builder defaultDataFetcher(DataFetcherFactory<?> defaultDataFetcherFactory) {
+            this.defaultDataFetcherFactory = Assert.assertNotNull(defaultDataFetcherFactory);
             return this;
         }
 
@@ -390,7 +387,7 @@ public class GraphQLCodeRegistry {
         }
 
         public GraphQLCodeRegistry build() {
-            return new GraphQLCodeRegistry(dataFetcherMap, systemDataFetcherMap, typeResolverMap, fieldVisibility);
+            return new GraphQLCodeRegistry(this);
         }
     }
 }

--- a/src/test/groovy/graphql/GraphQLTest.groovy
+++ b/src/test/groovy/graphql/GraphQLTest.groovy
@@ -3,6 +3,7 @@ package graphql
 import graphql.analysis.MaxQueryComplexityInstrumentation
 import graphql.analysis.MaxQueryDepthInstrumentation
 import graphql.execution.AsyncExecutionStrategy
+import graphql.execution.DataFetcherResult
 import graphql.execution.ExecutionContext
 import graphql.execution.ExecutionId
 import graphql.execution.ExecutionIdProvider
@@ -1015,4 +1016,19 @@ many lines''']
 
     }
 
+    def "test DFR and CF"() {
+        def sdl = 'type Query { f : String } '
+
+        DataFetcher df = { env ->
+
+            def dfr = DataFetcherResult.newResult().data("hi").build()
+            return CompletableFuture.supplyAsync({ -> dfr })
+        }
+        def schema = TestUtil.schema(sdl, [Query: [f: df]])
+        def graphQL = GraphQL.newGraphQL(schema).build()
+        when:
+        def er = graphQL.execute("{f}")
+        then:
+        er.data["f"] == "hi"
+    }
 }


### PR DESCRIPTION
For those who construct a CodeRegistry / type system by hand (eg not from SDL) then they have no way to provide the default data fetcher which is always the PropertyDataFetcher.

This opens that up

See https://spectrum.chat/graphql-java/general/question-about-the-default-data-fetcher~e023aded-ed95-4c34-aa47-02fc6cfc44ec