### PR TITLE
More performant data fetching lookup mechanism

### DIFF
--- a/src/main/java/graphql/schema/GraphQLSchema.java
+++ b/src/main/java/graphql/schema/GraphQLSchema.java
@@ -535,6 +535,10 @@ public class GraphQLSchema {
             if (errors.size() > 0) {
                 throw new InvalidSchemaException(errors);
             }
+            // one last defensive copy just to make sure the DF cache inside the code registry is clean.  The code above should do this
+            // but should we ever remove that code then this line will make sure we start clean per schema
+            codeRegistry = codeRegistry.transform(codeRegistryBuilder -> {
+            });
             return graphQLSchema;
         }
     }

--- a/src/test/java/benchmark/FetchDataFetcherFromCodeRegistryBenchMark.java
+++ b/src/test/java/benchmark/FetchDataFetcherFromCodeRegistryBenchMark.java
@@ -1,0 +1,39 @@
+package benchmark;
+
+import graphql.Scalars;
+import graphql.schema.DataFetcher;
+import graphql.schema.GraphQLCodeRegistry;
+import graphql.schema.GraphQLFieldDefinition;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import static graphql.schema.FieldCoordinates.coordinates;
+
+@State(Scope.Benchmark)
+public class FetchDataFetcherFromCodeRegistryBenchMark {
+
+    DataFetcher<?> df = env -> env;
+    private GraphQLCodeRegistry codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+            .dataFetcher(coordinates("Query", "f1"), df)
+            .dataFetcher(coordinates("Query", "f2"), df)
+            .dataFetcher(coordinates("Query", "f3"), df)
+            .build();
+
+    private GraphQLFieldDefinition nameField = GraphQLFieldDefinition.newFieldDefinition().name("f").type(Scalars.GraphQLString).build();
+
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @Warmup(iterations = 1, batchSize = 500)
+    @Measurement(iterations = 2, batchSize = 500)
+    public void benchMarkGetDF() {
+        for (int i = 0; i < 3; i++) {
+            codeRegistry.getDataFetcher(coordinates("Query", "f" + i), nameField);
+        }
+    }
+}


### PR DESCRIPTION
This will build out the cache per schema such that 1 lookup is required not and once a PropertyDataFetcher is instantiated then its never created again