### PR TITLE
Escape single line comments

### DIFF
--- a/src/main/java/graphql/language/AstPrinter.java
+++ b/src/main/java/graphql/language/AstPrinter.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 
 import static graphql.Assert.assertTrue;
+import static graphql.util.EscapeUtil.escapeJsonString;
 import static java.lang.String.valueOf;
 import static java.util.stream.Collectors.joining;
 
@@ -173,7 +174,7 @@ public class AstPrinter {
             } else {
                 args = join(node.getInputValueDefinitions(), argSep);
                 out.printf("%s", node.getName() +
-                        wrap( "(", args, ")") +
+                        wrap("(", args, ")") +
                         ": " +
                         spaced(
                                 type(node.getType()),
@@ -469,7 +470,7 @@ public class AstPrinter {
         } else if (value instanceof FloatValue) {
             return valueOf(((FloatValue) value).getValue());
         } else if (value instanceof StringValue) {
-            return wrap("\"", valueOf(escapeString(((StringValue) value).getValue())), "\"");
+            return wrap("\"", escapeJsonString(((StringValue) value).getValue()), "\"");
         } else if (value instanceof EnumValue) {
             return valueOf(((EnumValue) value).getName());
         } else if (value instanceof BooleanValue) {
@@ -494,7 +495,7 @@ public class AstPrinter {
         String s;
         boolean startNewLine = description.getContent().charAt(0) == '\n';
         if (description.isMultiLine()) {
-            s =  "\"\"\"" + (startNewLine ? "" : "\n") + description.getContent() + "\n\"\"\"\n";
+            s = "\"\"\"" + (startNewLine ? "" : "\n") + description.getContent() + "\n\"\"\"\n";
         } else {
             s = "\"" + description.getContent() + "\"\n";
         }
@@ -526,45 +527,6 @@ public class AstPrinter {
     private String join(String delim, String... args) {
         String s = Arrays.stream(args).filter(arg -> !isEmpty(arg)).collect(joining(delim));
         return s;
-    }
-
-    /**
-     * Encodes the value as a JSON string according to http://json.org/ rules
-     *
-     * @param stringValue the value to encode as a JSON string
-     *
-     * @return the encoded string
-     */
-    static String escapeString(String stringValue) {
-        StringBuilder sb = new StringBuilder();
-        for (char ch : stringValue.toCharArray()) {
-            switch (ch) {
-                case '"':
-                    sb.append("\\\"");
-                    break;
-                case '\\':
-                    sb.append("\\\\");
-                    break;
-                case '\b':
-                    sb.append("\\b");
-                    break;
-                case '\f':
-                    sb.append("\\f");
-                    break;
-                case '\n':
-                    sb.append("\\n");
-                    break;
-                case '\r':
-                    sb.append("\\r");
-                    break;
-                case '\t':
-                    sb.append("\\t");
-                    break;
-                default:
-                    sb.append(ch);
-            }
-        }
-        return sb.toString();
     }
 
     String wrap(String start, String maybeString, String end) {

--- a/src/main/java/graphql/schema/idl/SchemaPrinter.java
+++ b/src/main/java/graphql/schema/idl/SchemaPrinter.java
@@ -39,6 +39,7 @@ import graphql.schema.GraphQLUnionType;
 import graphql.schema.GraphqlTypeComparatorEnvironment;
 import graphql.schema.GraphqlTypeComparatorRegistry;
 import graphql.schema.visibility.GraphqlFieldVisibility;
+import graphql.util.EscapeUtil;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -56,6 +57,7 @@ import static graphql.Directives.DeprecatedDirective;
 import static graphql.introspection.Introspection.DirectiveLocation.ENUM_VALUE;
 import static graphql.introspection.Introspection.DirectiveLocation.FIELD_DEFINITION;
 import static graphql.schema.visibility.DefaultGraphqlFieldVisibility.DEFAULT_FIELD_VISIBILITY;
+import static graphql.util.EscapeUtil.escapeJsonString;
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
@@ -84,7 +86,7 @@ public class SchemaPrinter {
         private final boolean includeScalars;
 
         private final boolean useAstDefinitions;
-        
+
         private final boolean includeSchemaDefinition;
 
         private final boolean descriptionsAsHashComments;
@@ -116,7 +118,7 @@ public class SchemaPrinter {
         public boolean isIncludeScalars() {
             return includeScalars;
         }
-        
+
         public boolean isIncludeSchemaDefinition() {
             return includeSchemaDefinition;
         }
@@ -163,7 +165,6 @@ public class SchemaPrinter {
             return new Options(this.includeIntrospectionTypes, flag, this.includeSchemaDefinition, this.useAstDefinitions, this.descriptionsAsHashComments, this.includeDirective, this.comparatorRegistry);
         }
 
-        
         /**
          * This will force the printing of the graphql schema definition even if the query, mutation, and/or subscription
          * types use the default names.  Some graphql parsers require this information even if the schema uses the
@@ -874,7 +875,9 @@ public class SchemaPrinter {
     }
 
     private void printSingleLineDescription(PrintWriter out, String prefix, String s) {
-        out.printf("%s\"%s\"\n", prefix, s);
+        // See: https://github.com/graphql/graphql-spec/issues/148
+        String desc = escapeJsonString(s);
+        out.printf("%s\"%s\"\n", prefix, desc);
     }
 
     private boolean hasDescription(Object descriptionHolder) {

--- a/src/main/java/graphql/util/EscapeUtil.java
+++ b/src/main/java/graphql/util/EscapeUtil.java
@@ -1,0 +1,49 @@
+package graphql.util;
+
+public final class EscapeUtil {
+
+    private EscapeUtil() {
+    }
+
+    /**
+     * Encodes the value as a JSON string according to http://json.org/ rules
+     *
+     * @param stringValue the value to encode as a JSON string
+     *
+     * @return the encoded string
+     */
+    public static String escapeJsonString(String stringValue) {
+        int len = stringValue.length();
+        StringBuilder sb = new StringBuilder(len);
+        for (int i = 0; i < len; i++) {
+            char ch = stringValue.charAt(i);
+            switch (ch) {
+                case '"':
+                    sb.append("\\\"");
+                    break;
+                case '\\':
+                    sb.append("\\\\");
+                    break;
+                case '\b':
+                    sb.append("\\b");
+                    break;
+                case '\f':
+                    sb.append("\\f");
+                    break;
+                case '\n':
+                    sb.append("\\n");
+                    break;
+                case '\r':
+                    sb.append("\\r");
+                    break;
+                case '\t':
+                    sb.append("\\t");
+                    break;
+                default:
+                    sb.append(ch);
+            }
+        }
+        return sb.toString();
+    }
+
+}

--- a/src/test/groovy/graphql/language/AstPrinterTest.groovy
+++ b/src/test/groovy/graphql/language/AstPrinterTest.groovy
@@ -567,28 +567,4 @@ extend input Input @directive {
         'VA\\L"UE'                                | '"VA\\\\L\\"UE"'
     }
 
-    def "1105 - encoding of json strings"() {
-
-        when:
-        def json = AstPrinter.escapeString(strValue)
-
-        then:
-        json == expected
-
-        where:
-        strValue                                  | expected
-        ''                                        | ''
-        'json'                                    | 'json'
-        'quotation-"'                             | 'quotation-\\"'
-        'reverse-solidus-\\'                      | 'reverse-solidus-\\\\'
-        'backspace-\b'                            | 'backspace-\\b'
-        'formfeed-\f'                             | 'formfeed-\\f'
-        'newline-\n'                              | 'newline-\\n'
-        'carriage-return-\r'                      | 'carriage-return-\\r'
-        'horizontal-tab-\t'                       | 'horizontal-tab-\\t'
-
-        // this is some AST from issue 1105
-        '''"{"operator":"eq", "operands": []}"''' | '''\\"{\\"operator\\":\\"eq\\", \\"operands\\": []}\\"'''
-    }
-
 }

--- a/src/test/groovy/graphql/util/EscapeUtilTest.groovy
+++ b/src/test/groovy/graphql/util/EscapeUtilTest.groovy
@@ -1,0 +1,31 @@
+package graphql.util
+
+
+import spock.lang.Specification
+
+class EscapeUtilTest extends Specification {
+
+    def "1105 - encoding of json strings"() {
+        when:
+        def json = EscapeUtil.escapeJsonString(strValue)
+
+        then:
+        json == expected
+
+        where:
+        strValue                                  | expected
+        ''                                        | ''
+        'json'                                    | 'json'
+        'quotation-"'                             | 'quotation-\\"'
+        'reverse-solidus-\\'                      | 'reverse-solidus-\\\\'
+        'backspace-\b'                            | 'backspace-\\b'
+        'formfeed-\f'                             | 'formfeed-\\f'
+        'newline-\n'                              | 'newline-\\n'
+        'carriage-return-\r'                      | 'carriage-return-\\r'
+        'horizontal-tab-\t'                       | 'horizontal-tab-\\t'
+
+        // this is some AST from issue 1105
+        '''"{"operator":"eq", "operands": []}"''' | '''\\"{\\"operator\\":\\"eq\\", \\"operands\\": []}\\"'''
+    }
+
+}


### PR DESCRIPTION
Not too sure on pulling in `commons-text` just to do this, but couldn't find a comprehensive solution without reinventing the wheel. Thoughts?

Need this for auto deploying schema to Apollo. Alternatively I could add an option to force multi line comments as a temporary fix, but that still leaves this functionality in a broken state.