### PR TITLE
Skip DeferredMustBeOnAllFields rule if a fragment cycle has been detected

### DIFF
--- a/src/main/java/graphql/validation/rules/DeferredMustBeOnAllFields.java
+++ b/src/main/java/graphql/validation/rules/DeferredMustBeOnAllFields.java
@@ -17,7 +17,6 @@ import graphql.validation.ValidationErrorType;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -74,6 +73,11 @@ public class DeferredMustBeOnAllFields extends AbstractRule {
         if (path == null) {
             path = Collections.emptyList();
         }
+
+        if (getValidationErrorCollector().containsValidationError(ValidationErrorType.FragmentCycle)) {
+            return;
+        }
+
         for (Selection selection : selectionSet.getSelections()) {
             if (selection instanceof Field) {
                 List<Field> fields = fieldsByPath.getOrDefault(path, new ArrayList<>());

--- a/src/test/groovy/graphql/Issue1817.groovy
+++ b/src/test/groovy/graphql/Issue1817.groovy
@@ -1,0 +1,47 @@
+package graphql
+
+import graphql.language.Document
+import graphql.parser.Parser
+import graphql.validation.LanguageTraversal
+import graphql.validation.RulesVisitor
+import graphql.validation.ValidationContext
+import graphql.validation.ValidationErrorCollector
+import graphql.validation.ValidationErrorType
+import graphql.validation.rules.DeferredMustBeOnAllFields
+import graphql.validation.rules.NoFragmentCycles
+import spock.lang.Specification
+
+class Issue1817 extends Specification {
+
+    ValidationErrorCollector errorCollector = new ValidationErrorCollector()
+
+    def traverse(String query) {
+        Document document = new Parser().parseDocument(query)
+        ValidationContext validationContext = new ValidationContext(TestUtil.dummySchema, document)
+        NoFragmentCycles noFragmentCycles = new NoFragmentCycles(validationContext, errorCollector)
+        DeferredMustBeOnAllFields deferredMustBeOnAllFields = new DeferredMustBeOnAllFields(validationContext, errorCollector)
+        LanguageTraversal languageTraversal = new LanguageTraversal()
+        languageTraversal.traverse(document, new RulesVisitor(validationContext, [noFragmentCycles, deferredMustBeOnAllFields]))
+    }
+
+    def '#1817 - Do not check if deferred is on all fields when a fragment cycle has been encountered'() {
+        given:
+        def query = """
+                fragment MyFrag on SomeType {
+                   text @defer
+                   ...MyFrag
+                }
+                query {
+                   MyFrag {
+                      text
+                  }
+                }
+        """
+
+        when:
+        traverse(query)
+        then:
+        errorCollector.getErrors().size() == 1
+        errorCollector.containsValidationError(ValidationErrorType.FragmentCycle)
+    }
+}


### PR DESCRIPTION
The DeferredMustBeOnAllFields rule recursively checks every field, which causes an infinite loop and eventually a stack overflow if a fragment cycle is present in the input. This PR fixes #1817 by exiting out of this validation step if fragment cycles have previously been encountered.

The current fix solves the infinite loop by simply returning out of the method; not sure if something could/should be done to inform the user that this has happened?