### PR TITLE
timeunit_for_tracinginstrumentation

### DIFF
--- a/src/main/java/graphql/execution/instrumentation/tracing/TracingInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/tracing/TracingInstrumentation.java
@@ -18,6 +18,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 import static graphql.execution.instrumentation.SimpleInstrumentationContext.whenCompleted;
 
@@ -31,28 +32,35 @@ public class TracingInstrumentation extends SimpleInstrumentation {
     public static class Options {
         private final boolean includeTrivialDataFetchers;
 
-        private Options(boolean includeTrivialDataFetchers) {
+        private final TimeUnit timeUnit;
+
+        private Options(boolean includeTrivialDataFetchers, TimeUnit timeUnit) {
             this.includeTrivialDataFetchers = includeTrivialDataFetchers;
+            this.timeUnit=timeUnit;
         }
 
         public boolean isIncludeTrivialDataFetchers() {
             return includeTrivialDataFetchers;
         }
 
+        public TimeUnit getTimeUnit() {
+            return timeUnit;
+        }
+
         /**
-         * By default trivial data fetchers (those that simple pull data from an object into field) are included
-         * in tracing but you can control this behavior.
+         * In tracing, by default trivial data fetchers (those that simple pull data from an object into field) are included
+         * and time unit of result is TimeUnit.NANOSECONDS but you can control this behavior.
          *
          * @param flag the flag on whether to trace trivial data fetchers
-         *
-         * @return a new options object
+         * @param timeUnit the timeUnit of
+         * @return  a new options object
          */
-        public Options includeTrivialDataFetchers(boolean flag) {
-            return new Options(flag);
+        public Options newOptions(boolean flag, TimeUnit timeUnit) {
+            return new Options(flag,timeUnit);
         }
 
         public static Options newOptions() {
-            return new Options(true);
+            return new Options(true, TimeUnit.NANOSECONDS);
         }
 
     }
@@ -69,7 +77,7 @@ public class TracingInstrumentation extends SimpleInstrumentation {
 
     @Override
     public InstrumentationState createState() {
-        return new TracingSupport(options.includeTrivialDataFetchers);
+        return new TracingSupport(options.includeTrivialDataFetchers, options.timeUnit);
     }
 
     @Override

--- a/src/test/groovy/graphql/execution/instrumentation/TracingInstrumentationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/TracingInstrumentationTest.groovy
@@ -11,6 +11,8 @@ import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironment
 import spock.lang.Specification
 
+import java.util.concurrent.TimeUnit
+
 import static graphql.execution.instrumentation.tracing.TracingInstrumentation.Options.newOptions
 
 class TracingInstrumentationTest extends Specification {
@@ -126,7 +128,7 @@ class TracingInstrumentationTest extends Specification {
         }
 
         def instrumentation = new TracingInstrumentation(
-                newOptions().includeTrivialDataFetchers(false)) // defaults to true
+                newOptions().newOptions(false, TimeUnit.MICROSECONDS)) // defaults to true
 
         def graphQL = TestUtil.graphQL(spec, [Query: [hero: df]])
                 .queryExecutionStrategy(testExecutionStrategy)


### PR DESCRIPTION
TracingInstrumentation is a wonderful tool to take performance analysis, but NANOSECONDS is not suit for all scene, and it is hard to convert timestamp which included in ExecutionResultImpl.extensions to other timeunit.

Is it nessary to take TimeUnit as property of Options? 