### PR TITLE
#1839: Implemented isIntrospectionQuery method

### DIFF
--- a/src/main/java/graphql/introspection/IntrospectionQuery.java
+++ b/src/main/java/graphql/introspection/IntrospectionQuery.java
@@ -1,9 +1,10 @@
 package graphql.introspection;
 
 public interface IntrospectionQuery {
+    String INTROSPECTION_QUERY_NAME = "IntrospectionQuery";
 
     String INTROSPECTION_QUERY = "\n" +
-            "  query IntrospectionQuery {\n" +
+            "  query " + INTROSPECTION_QUERY_NAME + "{\n" +
             "    __schema {\n" +
             "      queryType { name }\n" +
             "      mutationType { name }\n" +

--- a/src/main/java/graphql/introspection/IntrospectionQuery.java
+++ b/src/main/java/graphql/introspection/IntrospectionQuery.java
@@ -3,26 +3,7 @@ package graphql.introspection;
 public interface IntrospectionQuery {
     String INTROSPECTION_QUERY_NAME = "IntrospectionQuery";
 
-    String INTROSPECTION_QUERY = "\n" +
-            "  query " + INTROSPECTION_QUERY_NAME + "{\n" +
-            "    __schema {\n" +
-            "      queryType { name }\n" +
-            "      mutationType { name }\n" +
-            "      subscriptionType { name }\n" +
-            "      types {\n" +
-            "        ...FullType\n" +
-            "      }\n" +
-            "      directives {\n" +
-            "        name\n" +
-            "        description\n" +
-            "        locations\n" +
-            "        args {\n" +
-            "          ...InputValue\n" +
-            "        }\n" +
-            "      }\n" +
-            "    }\n" +
-            "  }\n" +
-            "\n" +
+    String INTROSPECTION_QUERY_FRAGMENTS =
             "  fragment FullType on __Type {\n" +
             "    kind\n" +
             "    name\n" +
@@ -101,4 +82,29 @@ public interface IntrospectionQuery {
             "    }\n" +
             "  }\n" +
             "\n";
+
+    String INTROSPECTION_QUERY_SCHEMA_SNIPPET =
+                    "      queryType { name }\n" +
+                    "      mutationType { name }\n" +
+                    "      subscriptionType { name }\n" +
+                    "      types {\n" +
+                    "        ...FullType\n" +
+                    "      }\n" +
+                    "      directives {\n" +
+                    "        name\n" +
+                    "        description\n" +
+                    "        locations\n" +
+                    "        args {\n" +
+                    "          ...InputValue\n" +
+                    "        }\n" +
+                    "      }\n";
+
+    String INTROSPECTION_QUERY = "\n" +
+            "  query " + INTROSPECTION_QUERY_NAME + "{\n" +
+            "    __schema {\n" +
+                   INTROSPECTION_QUERY_SCHEMA_SNIPPET +
+            "    }\n" +
+            "  }\n" +
+            "\n" +
+               INTROSPECTION_QUERY_FRAGMENTS;
 }

--- a/src/main/java/graphql/introspection/IntrospectionUtils.java
+++ b/src/main/java/graphql/introspection/IntrospectionUtils.java
@@ -1,32 +1,203 @@
 package graphql.introspection;
 
+import graphql.Assert;
 import graphql.PublicApi;
+import graphql.execution.MergedField;
+import graphql.execution.nextgen.FieldSubSelection;
+import graphql.language.Document;
+import graphql.language.NamedNode;
+import graphql.language.NodeUtil;
+import graphql.language.OperationDefinition;
+import graphql.language.Selection;
+import graphql.language.SelectionSet;
 
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * This class provides several utilities for testing whether a GraphQL operation represents some form of an
+ * introspection query.  The varying methods can have different affects on performance based on the method used for
+ * testing as well as how frequent the tests are performed.
+ */
 @PublicApi
-public class IntrospectionUtils {
-    public static final String INTROSPECTION_SCHEMA_STRING = "__schema";
+public final class IntrospectionUtils {
+    private IntrospectionUtils() {
+    }
+
+    public enum ScanType {
+        // Note:  The scan type applies only to TESTED fields.  The algorithms below do not necessary test every
+        // field in the operation.  Most of the time, top-level fields are examined and that is enough to deterimine
+        // introspection.
+
+        // All tested fields in the operation must be system fields
+        ALL,
+        // There must be a mixture of both system and non-system for the tested fields in the operation
+        MIXED,
+        // Any tested field in the operation can be a system field
+        ANY
+    }
+
+    public static final String SYSTEM_FIELD_PREFIX = "__";
+    public static final String INTROSPECTION_SCHEMA_FIELD_NAME = SYSTEM_FIELD_PREFIX + "schema";
 
     /**
-     * Tests whether the provided {@code query} represents a GraphQL introspection query or not.  Whether or not
-     * the query is the introspection query is determined by the following in the order given:
+     * Tests whether the provided {@code operationName} is equal to the traditional operation name used to represent the
+     * GraphQL introspection query.
      *
-     * 1.  If the operation name is equal {@link IntrospectionQuery#INTROSPECTION_QUERY_NAME} or
-     * 2.  If query contains operation name {@link IntrospectionQuery#INTROSPECTION_QUERY_NAME} or
-     * 3.  If query contains {@link IntrospectionUtils#INTROSPECTION_SCHEMA_STRING}
+     * Note:  This method makes no claim that the operation being executed is actually the introspection query, only
+     * that its name matches the traditional name.  While this could lead to false-positives, this method is meant
+     * to act as a quick and more performant check rather than some of the other versions.  If you don't have access
+     * to the GraphQL document, need something to check for introspection, and are ok with potential false-positives,
+     * this is a suitable choice.
      *
-     * @param operationName The operation name of the query.
-     * @param query         Optional query to test.  If provided, and the operationName is not
-     *                      IntrospectionQuery.INTROSPECTION_QUERY_NAME, then query is scanned to check for the
-     *                      name or the existence of __schema
-     *
-     * @return {@code true} if the operation name or query represent the introspection query, false otherwise.
+     * @param operationName The operation name to test.
+     * @return {@code true} if the operation name equals {@link IntrospectionQuery#INTROSPECTION_QUERY_NAME}, false
+     *   otherwise
      */
-    public static boolean isIntrospectionQuery(final String operationName, final String query) {
-        boolean isIntrospectionQueryName = IntrospectionQuery.INTROSPECTION_QUERY_NAME.equals(operationName);
+    public static boolean isIntrospectionOperationName(final String operationName) {
+        return IntrospectionQuery.INTROSPECTION_QUERY_NAME.equals(operationName);
+    }
 
-        return isIntrospectionQueryName ||
-            ((null != query) &&
-             !query.isEmpty() &&
-             (query.contains(IntrospectionQuery.INTROSPECTION_QUERY_NAME) || query.contains(IntrospectionUtils.INTROSPECTION_SCHEMA_STRING)));
+    /**
+     * Tests whether the provided {@code query} represents a GraphQL introspection query or not.
+     *
+     * Note:  This method scans for "__schema" in the query to determine if this is an introspection query.  This
+     * method makes no claim that the query is a "pure" introspection query.  That is, solely uses schema/system
+     * type fields.  The query could still be a mixture of fields.  It should be noted that this method can perform
+     * poorly.  Its performance is directly tied to the length of the query and where in the query __schema is
+     * found, if at all.  For this reason, this method is not a suitable choice when it would be invoked in high
+     * volume instances.
+     *
+     * @param query Query to test
+     * @return {@code true} if the query contains {@link IntrospectionUtils#INTROSPECTION_SCHEMA_FIELD_NAME}, false
+     *   otherwise.
+     */
+    public static boolean isIntrospectionQuery(final String query) {
+        return (null != query) && !query.isEmpty() && query.contains(IntrospectionUtils.INTROSPECTION_SCHEMA_FIELD_NAME);
+    }
+
+    /**
+     * Tests whether the provided {@code document} represents a GraphQL introspection query or not.
+     *
+     * Note:  The method searches for system fields using the system field prefix, "__", by finding the
+     *   {@code OperationDefinition} associated with {@code operationName} and testing its selection set.
+     *
+     * Note 2:  The method also provides different types of scanning for introspection.  The ALL scan type ensures all
+     * tested fields are system fields, the MIXED type checks if some but not all tested fields are system fields, and
+     * the ANY type checks if at least one tested field is a system field.  The scan type can have an effect on
+     * performance.
+     *
+     * @param document The GraphQL document to test
+     * @param operationName The name of the operation to be tested
+     * @param scanType The type of scan used to test for introspection
+     * @return {@code true} if the selection set in the {@code OperationDefinition} retrieved from the {@code Document}
+     * based on {@code operationName} represents an introspection query, {@code false} otherwise
+     */
+    public static boolean isIntrospectionDocument(final Document document,
+                                                  final String operationName,
+                                                  final ScanType scanType) {
+        Assert.assertNotNull(scanType);
+        if (null == document || null == operationName || operationName.isEmpty()) {
+            return false;
+        }
+
+        NodeUtil.GetOperationResult getOperationResult = NodeUtil.getOperation(document, operationName);
+        OperationDefinition operationDefinition = getOperationResult.operationDefinition;
+
+        return isIntrospectionOperationDefinition(operationDefinition, scanType);
+    }
+
+    /**
+     * Tests whether the provided {@code operationDefinition} represents a GraphQL introspection query or not.
+     *
+     * Note:  The method searches for system fields using the system field prefix, "__", by testing the selection set
+     * of the {@code operationDefinition}.
+     *
+     * Note 2:  The method also provides different types of scanning for introspection.  The ALL scan type ensures all
+     * tested fields are system fields, the MIXED type checks if some but not all tested fields are system fields, and
+     * the ANY type checks if at least one tested field is a system field.  The scan type can have an effect on
+     * performance.
+     *
+     * @param operationDefinition The GraphQL {@code OperationDefinition} to test
+     * @param scanType The type of scan used to test for introspection
+     * @return {@code true} if this {@code OperationDefinition} represents an introspection query, {@code false}
+     * otherwise
+     */
+    public static boolean isIntrospectionOperationDefinition(final OperationDefinition operationDefinition,
+                                                             final ScanType scanType) {
+        Assert.assertNotNull(scanType);
+        if (null == operationDefinition) {
+            return false;
+        }
+
+        final SelectionSet selectionSet = operationDefinition.getSelectionSet();
+
+        switch (scanType) {
+            case ANY:
+                return selectionSet.getSelections().stream().anyMatch(IntrospectionUtils::isSystemSelection);
+            case MIXED:
+                final Set<Boolean> fieldTypes = new HashSet<>();
+                return selectionSet.getSelections().stream().anyMatch(selection -> {
+                    fieldTypes.add(isSystemSelection(selection));
+                    return 1 < fieldTypes.size();
+                });
+            case ALL:
+            default:
+                return selectionSet.getSelections().stream().allMatch(IntrospectionUtils::isSystemSelection);
+        }
+    }
+
+    /**
+     * Tests whether the provided {@code FieldSubSelection} has GraphQL introspection/system fields or not.
+     *
+     * Note:  The method searches the {@code FieldSubSelection} sub field values for system fields using the system
+     * field prefix, "__".
+     *
+     * Note 2:  The method also provides different types of scanning for introspection.  The ALL scan type ensures all
+     * tested fields are system fields, the MIXED type checks if some but not all tested fields are system fields, and
+     * the ANY type checks if at least one tested field is a system field.  The scan type can have an effect on
+     * performance.
+     *
+     * @param fieldSubSelection The field sub selection to test
+     * @param scanType The type of scan used to test for introspection
+     * @return {@code true} if this {@code FieldSubSelection} represents an introspection query, {@code false} otherwise
+     */
+    public static boolean isIntrospectionFieldSubSelection(final FieldSubSelection fieldSubSelection,
+                                                           final ScanType scanType) {
+        Assert.assertNotNull(scanType);
+        if (null == fieldSubSelection) {
+            return false;
+        }
+
+        // Use the values instead of keys to account for aliasing
+        final Collection<MergedField> fieldValues = fieldSubSelection.getSubFields().values();
+
+        switch (scanType) {
+            case ANY:
+                return fieldValues.stream().anyMatch(IntrospectionUtils::isSystemMergedField);
+            case MIXED:
+                final Set<Boolean> fieldTypes = new HashSet<>();
+                return fieldValues.stream().anyMatch(mergedField -> {
+                    fieldTypes.add(isSystemMergedField(mergedField));
+                    return 1 < fieldTypes.size();
+                });
+            case ALL:
+            default:
+                return fieldValues.stream().allMatch(IntrospectionUtils::isSystemMergedField);
+        }
+    }
+
+    private static boolean isSystemSelection(final Selection selection) {
+        if (selection instanceof NamedNode) {
+            final NamedNode node = (NamedNode) selection;
+            return node.getName().startsWith(SYSTEM_FIELD_PREFIX);
+        }
+
+        return false;
+    }
+
+    private static boolean isSystemMergedField(final MergedField mergedField) {
+        return mergedField.getName().startsWith(IntrospectionUtils.SYSTEM_FIELD_PREFIX);
     }
 }

--- a/src/main/java/graphql/introspection/IntrospectionUtils.java
+++ b/src/main/java/graphql/introspection/IntrospectionUtils.java
@@ -1,0 +1,32 @@
+package graphql.introspection;
+
+import graphql.PublicApi;
+
+@PublicApi
+public class IntrospectionUtils {
+    public static final String INTROSPECTION_SCHEMA_STRING = "__schema";
+
+    /**
+     * Tests whether the provided {@code query} represents a GraphQL introspection query or not.  Whether or not
+     * the query is the introspection query is determined by the following in the order given:
+     *
+     * 1.  If the operation name is equal {@link IntrospectionQuery#INTROSPECTION_QUERY_NAME} or
+     * 2.  If query contains operation name {@link IntrospectionQuery#INTROSPECTION_QUERY_NAME} or
+     * 3.  If query contains {@link IntrospectionUtils#INTROSPECTION_SCHEMA_STRING}
+     *
+     * @param operationName The operation name of the query.
+     * @param query         Optional query to test.  If provided, and the operationName is not
+     *                      IntrospectionQuery.INTROSPECTION_QUERY_NAME, then query is scanned to check for the
+     *                      name or the existence of __schema
+     *
+     * @return {@code true} if the operation name or query represent the introspection query, false otherwise.
+     */
+    public static boolean isIntrospectionQuery(final String operationName, final String query) {
+        boolean isIntrospectionQueryName = IntrospectionQuery.INTROSPECTION_QUERY_NAME.equals(operationName);
+
+        return isIntrospectionQueryName ||
+            ((null != query) &&
+             !query.isEmpty() &&
+             (query.contains(IntrospectionQuery.INTROSPECTION_QUERY_NAME) || query.contains(IntrospectionUtils.INTROSPECTION_SCHEMA_STRING)));
+    }
+}

--- a/src/test/groovy/graphql/introspection/IntrospectionUtilsTest.groovy
+++ b/src/test/groovy/graphql/introspection/IntrospectionUtilsTest.groovy
@@ -1,0 +1,51 @@
+package graphql.introspection
+
+import spock.lang.Specification
+
+import static graphql.introspection.IntrospectionUtils.isIntrospectionQuery;
+
+class IntrospectionUtilsTest extends Specification {
+    def TEST_INTROSPECTION_QUERY_SNIPPET =
+            "    " + IntrospectionUtils.INTROSPECTION_SCHEMA_STRING + " {\n" +
+                    "      queryType { name }\n" +
+                    "    }";
+    def HELLO_WORLD_QUERY_NAME = "hello";
+    def HELLO_WORLD_QUERY = "query " + HELLO_WORLD_QUERY_NAME + " { helloWorld }";
+    def INTROSPECTION_QUERY_BY_NAME = "query " + IntrospectionQuery.INTROSPECTION_QUERY_NAME + " { helloWorld }";
+    def INTROSPECTION_QUERY_BY_SCHEMA_TYPE = "query " + HELLO_WORLD_QUERY_NAME + " { " + TEST_INTROSPECTION_QUERY_SNIPPET + "}";
+
+    def "should detect introspection query based on operation name"() {
+        expect:
+        isIntrospectionQuery(IntrospectionQuery.INTROSPECTION_QUERY_NAME, null);
+    }
+
+    def "should detect introspection query based on query name"() {
+        expect:
+        isIntrospectionQuery(null, INTROSPECTION_QUERY_BY_NAME);
+    }
+
+    def "should detect introspection query based on query schema type"() {
+        expect:
+        isIntrospectionQuery(null, INTROSPECTION_QUERY_BY_SCHEMA_TYPE);
+    }
+
+    def "should NOT detect introspection query based on null inputs"() {
+        expect:
+        !isIntrospectionQuery(null, null);
+    }
+
+    def "should NOT detect introspection query based on empty inputs"() {
+        expect:
+        !isIntrospectionQuery("", "");
+    }
+
+    def "should NOT detect introspection query based on operation name"() {
+        expect:
+            !isIntrospectionQuery(HELLO_WORLD_QUERY_NAME, null);
+    }
+
+    def "should NOT detect introspection query based on query"() {
+        expect:
+        !isIntrospectionQuery(HELLO_WORLD_QUERY_NAME, HELLO_WORLD_QUERY);
+    }
+}

--- a/src/test/groovy/graphql/introspection/IntrospectionUtilsTest.groovy
+++ b/src/test/groovy/graphql/introspection/IntrospectionUtilsTest.groovy
@@ -1,51 +1,602 @@
 package graphql.introspection
 
+import graphql.TestUtil
+import graphql.execution.FieldCollector
+import graphql.execution.FieldCollectorParameters
+import graphql.execution.nextgen.Common
+import graphql.execution.nextgen.FieldSubSelection
+import graphql.language.Document
+import graphql.language.NodeUtil
+import graphql.schema.GraphQLObjectType
+import graphql.schema.GraphQLSchema
 import spock.lang.Specification
 
-import static graphql.introspection.IntrospectionUtils.isIntrospectionQuery;
+import java.util.function.Supplier
+
+import static graphql.introspection.IntrospectionUtils.isIntrospectionDocument
+import static graphql.introspection.IntrospectionUtils.isIntrospectionFieldSubSelection
+import static graphql.introspection.IntrospectionUtils.isIntrospectionOperationDefinition
+import static graphql.introspection.IntrospectionUtils.isIntrospectionOperationName
+import static graphql.introspection.IntrospectionUtils.isIntrospectionQuery
 
 class IntrospectionUtilsTest extends Specification {
-    def TEST_INTROSPECTION_QUERY_SNIPPET =
-            "    " + IntrospectionUtils.INTROSPECTION_SCHEMA_STRING + " {\n" +
-                    "      queryType { name }\n" +
-                    "    }";
-    def HELLO_WORLD_QUERY_NAME = "hello";
-    def HELLO_WORLD_QUERY = "query " + HELLO_WORLD_QUERY_NAME + " { helloWorld }";
-    def INTROSPECTION_QUERY_BY_NAME = "query " + IntrospectionQuery.INTROSPECTION_QUERY_NAME + " { helloWorld }";
-    def INTROSPECTION_QUERY_BY_SCHEMA_TYPE = "query " + HELLO_WORLD_QUERY_NAME + " { " + TEST_INTROSPECTION_QUERY_SNIPPET + "}";
+    private static final def WARMING_CYCLES = 3;
+    private static final def LOOPS = 1
+    private static final def NANOS_IN_MILLIS = 1000000
+    private static final def MICROS_IN_MILLIS = 1000
 
-    def "should detect introspection query based on operation name"() {
+    // The max times below are based on 1 loop with 3 warming cycles.  The values below give are set far higher than
+    // what the usual 1 loop, 3 cycle test usually performs.  To the right, of the constant are values indicative of
+    // what most tests run at.  However, occasionally you will have tests that hiccups and go higher, hence the
+    // raised settings.  Increasing the number of loops, greatly reduces the average microseconds for each test but a
+    // single loop with 3 warming cycles should at least be able to attain the below numbers consistently.  The unit
+    // tests will always validate the correctness of the utility methods but performance testing is off by default.
+    // To enable performance test by setting ENABLE_PERFORMANCE_CHECK to 1 (warmup cycles are not checked for time
+    // validation when performance checks are enabled).  Unit tests should be run with performance check on whenever
+    // IntrospectionUtils class is modified.  Measurements were taken on a MacBook Pro 15-inch, 2017 with 3.1 GHz
+    // Intel Core i7, 16 GB 2133 MHz LPDDR3, and 500 GB SSD.
+    private static final def ENABLE_PERFORMANCE_CHECK = 0;
+    private static final def MAX_AVG_MICROS_BASELINE = 100L * ENABLE_PERFORMANCE_CHECK // Usually < ~20 μs
+    private static final def MAX_AVG_MICROS_OPNAME = 200L * ENABLE_PERFORMANCE_CHECK   // Usually from ~20 to 50 μs
+    private static final def MAX_AVG_MICROS_QUERY = 2500L * ENABLE_PERFORMANCE_CHECK   // Usually from ~20 to 800 μs
+    private static final def MAX_AVG_MICROS_DOCUMENT = 500L * ENABLE_PERFORMANCE_CHECK // Usually from ~30 to 100 μs
+    private static final def MAX_AVG_MICROS_OPDEF = 450L * ENABLE_PERFORMANCE_CHECK    // Usually from ~20 to 80 μs
+    private static final def MAX_AVG_MICROS_FSS = 400L * ENABLE_PERFORMANCE_CHECK      // Usually from ~20 to 50 μs
+
+    private static final def INTROSPECTION_SCHEMA = GraphQLSchema.newSchema()
+            .query(GraphQLObjectType.newObject().name("Query").build())
+            .mutation(GraphQLObjectType.newObject().name("Mutation").build())
+            .subscription(GraphQLObjectType.newObject().name("Subscription").build())
+            .build();
+    private static final def FIELD_COLLECTOR = new FieldCollector();
+
+    private static final def INTROSPECTION_DOCUMENT = TestUtil.parseQuery(IntrospectionQuery.INTROSPECTION_QUERY)
+    private static final def INTROSPECTION_DOCUMENT_WITH_SCHEMA_FRAGMENT =
+            TestUtil.parseQuery(TestQueries.INTROSPECTION_QUERY_WITH_SCHEMA_FRAGMENT)
+    private static final def INTROSPECTION_DOCUMENT_WITH_ALIAS =
+            TestUtil.parseQuery(TestQueries.INTROSPECTION_QUERY_WITH_ALIAS)
+    private static final def INTROSPECTION_DOCUMENT_WITH_ALIAS_AND_MIXED_FIELDS =
+            TestUtil.parseQuery(TestQueries.INTROSPECTION_QUERY_WITH_ALIAS_AND_MIXED_FIELDS)
+    private static final def NON_INTROSPECTION_DOCUMENT =
+            TestUtil.parseQuery(TestQueries.NON_INTROSPECTION_QUERY)
+    private static final def HERO_QUERY_DOCUMENT =
+            TestUtil.parseQuery(TestQueries.HERO_QUERY)
+
+    private static final def INTROSPECTION_OPDEF =
+            getOperationDefinition(INTROSPECTION_DOCUMENT, IntrospectionQuery.INTROSPECTION_QUERY_NAME)
+    private static final def INTROSPECTION_OPDEF_WITH_SCHEMA_FRAGMENT =
+            getOperationDefinition(INTROSPECTION_DOCUMENT_WITH_SCHEMA_FRAGMENT,
+                    TestQueries.INTROSPECTION_QUERY_WITH_SCHEMA_FRAGMENT_NAME)
+    private static final def INTROSPECTION_OPDEF_WITH_ALIAS =
+            getOperationDefinition(INTROSPECTION_DOCUMENT_WITH_ALIAS,
+                    TestQueries.INTROSPECTION_QUERY_WITH_ALIAS_NAME)
+    private static final def INTROSPECTION_OPDEF_WITH_ALIAS_AND_MIXED_FIELDS =
+            getOperationDefinition(INTROSPECTION_DOCUMENT_WITH_ALIAS_AND_MIXED_FIELDS,
+                    TestQueries.INTROSPECTION_QUERY_WITH_ALIAS_AND_MIXED_FIELDS_NAME)
+    private static final def NON_INTROSPECTION_OPDEF =
+            getOperationDefinition(NON_INTROSPECTION_DOCUMENT, TestQueries.NON_INTROSPECTION_QUERY_NAME)
+    private static final def HERO_QUERY_OPDEF =
+            getOperationDefinition(HERO_QUERY_DOCUMENT, TestQueries.HERO_QUERY_NAME)
+
+    private static final def INTROSPECTION_FSS =
+            getFieldSubSelection(INTROSPECTION_DOCUMENT, IntrospectionQuery.INTROSPECTION_QUERY_NAME)
+    private static final def INTROSPECTION_FSS_WITH_SCHEMA_FRAGMENT =
+            getFieldSubSelection(INTROSPECTION_DOCUMENT_WITH_SCHEMA_FRAGMENT,
+                    TestQueries.INTROSPECTION_QUERY_WITH_SCHEMA_FRAGMENT_NAME)
+    private static final def INTROSPECTION_FSS_WITH_ALIAS =
+            getFieldSubSelection(INTROSPECTION_DOCUMENT_WITH_ALIAS,
+                    TestQueries.INTROSPECTION_QUERY_WITH_ALIAS_NAME)
+    private static final def INTROSPECTION_FSS_WITH_ALIAS_AND_MIXED_FIELDS =
+            getFieldSubSelection(INTROSPECTION_DOCUMENT_WITH_ALIAS_AND_MIXED_FIELDS,
+                    TestQueries.INTROSPECTION_QUERY_WITH_ALIAS_AND_MIXED_FIELDS_NAME)
+    private static final def NON_INTROSPECTION_FSS =
+            getFieldSubSelection(NON_INTROSPECTION_DOCUMENT, TestQueries.NON_INTROSPECTION_QUERY_NAME)
+    private static final def HERO_QUERY_FSS =
+            getFieldSubSelection(HERO_QUERY_DOCUMENT,
+                    TestQueries.HERO_QUERY_NAME)
+
+
+    // Test for comparing performance of the introspection utility methods against this baseline which just returns
+    // true
+    def "Baseline true test result TRUE"() {
         expect:
-        isIntrospectionQuery(IntrospectionQuery.INTROSPECTION_QUERY_NAME, null);
+        testAndMeasureTime("Baseline true loop", { -> true }, true, MAX_AVG_MICROS_BASELINE)
     }
 
-    def "should detect introspection query based on query name"() {
+
+    // isIntrospectionOperationName Tests
+    def "isIntrospectionOperationName Tests"() {
         expect:
-        isIntrospectionQuery(null, INTROSPECTION_QUERY_BY_NAME);
+        // False Tests
+        testAndMeasureTime("isIntrospectionOperationName 'null'",
+                { -> isIntrospectionOperationName(null) },
+                false, MAX_AVG_MICROS_OPNAME)
+        testAndMeasureTime("isIntrospectionOperationName ''",
+                { -> isIntrospectionOperationName("") },
+                false, MAX_AVG_MICROS_OPNAME)
+        testAndMeasureTime("isIntrospectionOperationName '${TestQueries.NON_INTROSPECTION_QUERY_NAME}'",
+                { -> isIntrospectionOperationName(TestQueries.NON_INTROSPECTION_QUERY_NAME) },
+                false, MAX_AVG_MICROS_OPNAME)
+
+        // True Tests
+        testAndMeasureTime("isIntrospectionOperationName '${IntrospectionQuery.INTROSPECTION_QUERY_NAME}'",
+                { -> isIntrospectionOperationName(IntrospectionQuery.INTROSPECTION_QUERY_NAME) },
+                true, MAX_AVG_MICROS_OPNAME)
     }
 
-    def "should detect introspection query based on query schema type"() {
+
+    // isIntrospectionQuery Tests
+    def "isIntrospectionQuery Tests"() {
         expect:
-        isIntrospectionQuery(null, INTROSPECTION_QUERY_BY_SCHEMA_TYPE);
+        // False Tests
+        testAndMeasureTime("isIntrospectionQuery 'null'",
+                { -> isIntrospectionQuery((String) null) },
+                false, MAX_AVG_MICROS_QUERY)
+        testAndMeasureTime("isIntrospectionQuery '",
+                { -> isIntrospectionQuery("") },
+                false, MAX_AVG_MICROS_QUERY)
+        testAndMeasureTime("isIntrospectionQuery '${TestQueries.NON_INTROSPECTION_QUERY_NAME}'",
+                { -> isIntrospectionQuery(TestQueries.NON_INTROSPECTION_QUERY) },
+                false, MAX_AVG_MICROS_QUERY)
+        testAndMeasureTime("isIntrospectionQuery '${TestQueries.HERO_QUERY_NAME}'",
+                { -> isIntrospectionQuery(TestQueries.HERO_QUERY) },
+                false, MAX_AVG_MICROS_QUERY)
+
+        // True Tests
+        testAndMeasureTime("isIntrospectionQuery '${IntrospectionQuery.INTROSPECTION_QUERY_NAME}'",
+                { -> isIntrospectionQuery(IntrospectionQuery.INTROSPECTION_QUERY) },
+                true, MAX_AVG_MICROS_QUERY)
+        testAndMeasureTime("isIntrospectionQuery '${TestQueries.INTROSPECTION_QUERY_WITH_ALIAS_NAME}'",
+                { -> isIntrospectionQuery(TestQueries.INTROSPECTION_QUERY_WITH_ALIAS) },
+                true, MAX_AVG_MICROS_QUERY)
+        testAndMeasureTime("isIntrospectionQuery '${TestQueries.INTROSPECTION_QUERY_WITH_ALIAS_AND_MIXED_FIELDS_NAME}'",
+                { -> isIntrospectionQuery(TestQueries.INTROSPECTION_QUERY_WITH_ALIAS_AND_MIXED_FIELDS) },
+                true, MAX_AVG_MICROS_QUERY)
+        testAndMeasureTime("isIntrospectionQuery '${TestQueries.INTROSPECTION_QUERY_WITH_SCHEMA_FRAGMENT_NAME}'",
+                { -> isIntrospectionQuery(TestQueries.INTROSPECTION_QUERY_WITH_SCHEMA_FRAGMENT) },
+                true, MAX_AVG_MICROS_QUERY)
     }
 
-    def "should NOT detect introspection query based on null inputs"() {
+
+    // isIntrospectionDocument Tests
+    def "isIntrospectionDocument Tests"() {
         expect:
-        !isIntrospectionQuery(null, null);
+        // ScanType.ANY Tests
+        testAndMeasureTime("isIntrospectionDocument ANY '${IntrospectionQuery.INTROSPECTION_QUERY_NAME}'",
+                { -> isIntrospectionDocument(
+                        INTROSPECTION_DOCUMENT,
+                        IntrospectionQuery.INTROSPECTION_QUERY_NAME,
+                        IntrospectionUtils.ScanType.ANY
+                ) },
+                true, MAX_AVG_MICROS_DOCUMENT)
+        testAndMeasureTime("isIntrospectionDocument ANY '${TestQueries.INTROSPECTION_QUERY_WITH_ALIAS_NAME}'",
+                { -> isIntrospectionDocument(
+                        INTROSPECTION_DOCUMENT_WITH_ALIAS,
+                        TestQueries.INTROSPECTION_QUERY_WITH_ALIAS_NAME,
+                        IntrospectionUtils.ScanType.ANY
+                ) },
+                true, MAX_AVG_MICROS_DOCUMENT)
+        testAndMeasureTime("isIntrospectionDocument ANY '${TestQueries.INTROSPECTION_QUERY_WITH_SCHEMA_FRAGMENT_NAME}'",
+                { -> isIntrospectionDocument(
+                        INTROSPECTION_DOCUMENT_WITH_SCHEMA_FRAGMENT,
+                        TestQueries.INTROSPECTION_QUERY_WITH_SCHEMA_FRAGMENT_NAME,
+                        IntrospectionUtils.ScanType.ANY
+                ) },
+                true, MAX_AVG_MICROS_DOCUMENT)
+        testAndMeasureTime("isIntrospectionDocument ANY '${TestQueries.INTROSPECTION_QUERY_WITH_ALIAS_AND_MIXED_FIELDS_NAME}'",
+                { -> isIntrospectionDocument(
+                        INTROSPECTION_DOCUMENT_WITH_ALIAS_AND_MIXED_FIELDS,
+                        TestQueries.INTROSPECTION_QUERY_WITH_ALIAS_AND_MIXED_FIELDS_NAME,
+                        IntrospectionUtils.ScanType.ANY
+                ) },
+                true, MAX_AVG_MICROS_DOCUMENT)
+        testAndMeasureTime("isIntrospectionDocument ANY '${TestQueries.NON_INTROSPECTION_QUERY_NAME}'",
+                { -> isIntrospectionDocument(
+                        NON_INTROSPECTION_DOCUMENT,
+                        TestQueries.NON_INTROSPECTION_QUERY_NAME,
+                        IntrospectionUtils.ScanType.ANY
+                ) },
+                false, MAX_AVG_MICROS_DOCUMENT)
+        testAndMeasureTime("isIntrospectionDocument ANY '${TestQueries.HERO_QUERY_NAME}'",
+                { -> isIntrospectionDocument(
+                        HERO_QUERY_DOCUMENT,
+                        TestQueries.HERO_QUERY_NAME,
+                        IntrospectionUtils.ScanType.ANY
+                ) },
+                false, MAX_AVG_MICROS_DOCUMENT)
+
+        testAndMeasureTime("isIntrospectionDocument MIXED '${IntrospectionQuery.INTROSPECTION_QUERY_NAME}'",
+                { -> isIntrospectionDocument(
+                        INTROSPECTION_DOCUMENT,
+                        IntrospectionQuery.INTROSPECTION_QUERY_NAME,
+                        IntrospectionUtils.ScanType.MIXED
+                ) },
+                false, MAX_AVG_MICROS_DOCUMENT)
+        testAndMeasureTime("isIntrospectionDocument MIXED '${TestQueries.INTROSPECTION_QUERY_WITH_ALIAS_NAME}'",
+                { -> isIntrospectionDocument(
+                        INTROSPECTION_DOCUMENT_WITH_ALIAS,
+                        TestQueries.INTROSPECTION_QUERY_WITH_ALIAS_NAME,
+                        IntrospectionUtils.ScanType.MIXED
+                ) },
+                false, MAX_AVG_MICROS_DOCUMENT)
+        testAndMeasureTime("isIntrospectionDocument MIXED '${TestQueries.INTROSPECTION_QUERY_WITH_SCHEMA_FRAGMENT_NAME}'",
+                { -> isIntrospectionDocument(
+                        INTROSPECTION_DOCUMENT_WITH_SCHEMA_FRAGMENT,
+                        TestQueries.INTROSPECTION_QUERY_WITH_SCHEMA_FRAGMENT_NAME,
+                        IntrospectionUtils.ScanType.MIXED
+                ) },
+                false, MAX_AVG_MICROS_DOCUMENT)
+        testAndMeasureTime("isIntrospectionDocument MIXED '${TestQueries.INTROSPECTION_QUERY_WITH_ALIAS_AND_MIXED_FIELDS_NAME}'",
+                { -> isIntrospectionDocument(
+                        INTROSPECTION_DOCUMENT_WITH_ALIAS_AND_MIXED_FIELDS,
+                        TestQueries.INTROSPECTION_QUERY_WITH_ALIAS_AND_MIXED_FIELDS_NAME,
+                        IntrospectionUtils.ScanType.MIXED
+                ) },
+                true, MAX_AVG_MICROS_DOCUMENT)
+        testAndMeasureTime("isIntrospectionDocument MIXED '${TestQueries.NON_INTROSPECTION_QUERY_NAME}'",
+                { -> isIntrospectionDocument(
+                        NON_INTROSPECTION_DOCUMENT,
+                        TestQueries.NON_INTROSPECTION_QUERY_NAME,
+                        IntrospectionUtils.ScanType.MIXED
+                ) },
+                false, MAX_AVG_MICROS_DOCUMENT)
+        testAndMeasureTime("isIntrospectionDocument MIXED '${TestQueries.HERO_QUERY_NAME}'",
+                { -> isIntrospectionDocument(
+                        HERO_QUERY_DOCUMENT,
+                        TestQueries.HERO_QUERY_NAME,
+                        IntrospectionUtils.ScanType.MIXED
+                ) },
+                false, MAX_AVG_MICROS_DOCUMENT)
+
+        // ScanType.ALL Tests
+        testAndMeasureTime("isIntrospectionDocument ALL '${IntrospectionQuery.INTROSPECTION_QUERY_NAME}'",
+                { -> isIntrospectionDocument(
+                        INTROSPECTION_DOCUMENT,
+                        IntrospectionQuery.INTROSPECTION_QUERY_NAME,
+                        IntrospectionUtils.ScanType.ALL
+                ) },
+                true, MAX_AVG_MICROS_DOCUMENT)
+        testAndMeasureTime("isIntrospectionDocument ALL '${TestQueries.INTROSPECTION_QUERY_WITH_ALIAS_NAME}'",
+                { -> isIntrospectionDocument(
+                        INTROSPECTION_DOCUMENT_WITH_ALIAS,
+                        TestQueries.INTROSPECTION_QUERY_WITH_ALIAS_NAME,
+                        IntrospectionUtils.ScanType.ALL
+                ) },
+                true, MAX_AVG_MICROS_DOCUMENT)
+        testAndMeasureTime("isIntrospectionDocument ALL '${TestQueries.INTROSPECTION_QUERY_WITH_SCHEMA_FRAGMENT_NAME}'",
+                { -> isIntrospectionDocument(
+                        INTROSPECTION_DOCUMENT_WITH_SCHEMA_FRAGMENT,
+                        TestQueries.INTROSPECTION_QUERY_WITH_SCHEMA_FRAGMENT_NAME,
+                        IntrospectionUtils.ScanType.ALL
+                ) },
+                true, MAX_AVG_MICROS_DOCUMENT)
+        testAndMeasureTime("isIntrospectionDocument ALL '${TestQueries.INTROSPECTION_QUERY_WITH_ALIAS_AND_MIXED_FIELDS_NAME}'",
+                { -> isIntrospectionDocument(
+                        INTROSPECTION_DOCUMENT_WITH_ALIAS_AND_MIXED_FIELDS,
+                        TestQueries.INTROSPECTION_QUERY_WITH_ALIAS_AND_MIXED_FIELDS_NAME,
+                        IntrospectionUtils.ScanType.ALL
+                ) },
+                false, MAX_AVG_MICROS_DOCUMENT)
+        testAndMeasureTime("isIntrospectionDocument ALL '${TestQueries.NON_INTROSPECTION_QUERY_NAME}'",
+                { -> isIntrospectionDocument(
+                        NON_INTROSPECTION_DOCUMENT,
+                        TestQueries.NON_INTROSPECTION_QUERY_NAME,
+                        IntrospectionUtils.ScanType.ALL
+                ) },
+                false, MAX_AVG_MICROS_DOCUMENT)
+        testAndMeasureTime("isIntrospectionDocument ALL '${TestQueries.HERO_QUERY_NAME}'",
+                { -> isIntrospectionDocument(
+                        HERO_QUERY_DOCUMENT,
+                        TestQueries.HERO_QUERY_NAME,
+                        IntrospectionUtils.ScanType.ALL
+                ) },
+                false, MAX_AVG_MICROS_DOCUMENT)
     }
 
-    def "should NOT detect introspection query based on empty inputs"() {
+
+    // isIntrospectionOperationDefinition Tests
+    def "isIntrospectionOperationDefinition Tests"() {
         expect:
-        !isIntrospectionQuery("", "");
+        // ScanType.ANY Tests
+        testAndMeasureTime("isIntrospectionOperationDefinition ANY '${IntrospectionQuery.INTROSPECTION_QUERY_NAME}'",
+                { -> isIntrospectionOperationDefinition(
+                        INTROSPECTION_OPDEF,
+                        IntrospectionUtils.ScanType.ANY
+                ) },
+                true, MAX_AVG_MICROS_OPDEF)
+        testAndMeasureTime("isIntrospectionOperationDefinition ANY '${TestQueries.INTROSPECTION_QUERY_WITH_ALIAS_NAME}'",
+                { -> isIntrospectionOperationDefinition(
+                        INTROSPECTION_OPDEF_WITH_ALIAS,
+                        IntrospectionUtils.ScanType.ANY
+                ) },
+                true, MAX_AVG_MICROS_OPDEF)
+        testAndMeasureTime("isIntrospectionOperationDefinition ANY '${TestQueries.INTROSPECTION_QUERY_WITH_SCHEMA_FRAGMENT_NAME}'",
+                { -> isIntrospectionOperationDefinition(
+                        INTROSPECTION_OPDEF_WITH_SCHEMA_FRAGMENT,
+                        IntrospectionUtils.ScanType.ANY
+                ) },
+                true, MAX_AVG_MICROS_OPDEF)
+        testAndMeasureTime("isIntrospectionOperationDefinition ANY '${TestQueries.INTROSPECTION_QUERY_WITH_ALIAS_AND_MIXED_FIELDS_NAME}'",
+                { -> isIntrospectionOperationDefinition(
+                        INTROSPECTION_OPDEF_WITH_ALIAS_AND_MIXED_FIELDS,
+                        IntrospectionUtils.ScanType.ANY
+                ) },
+                true, MAX_AVG_MICROS_OPDEF)
+        testAndMeasureTime("isIntrospectionOperationDefinition ANY '${TestQueries.NON_INTROSPECTION_QUERY_NAME}'",
+                { -> isIntrospectionOperationDefinition(
+                        NON_INTROSPECTION_OPDEF,
+                        IntrospectionUtils.ScanType.ANY
+                ) },
+                false, MAX_AVG_MICROS_OPDEF)
+        testAndMeasureTime("isIntrospectionOperationDefinition ANY '${TestQueries.HERO_QUERY_NAME}'",
+                { -> isIntrospectionOperationDefinition(
+                        HERO_QUERY_OPDEF,
+                        IntrospectionUtils.ScanType.ANY
+                ) },
+                false, MAX_AVG_MICROS_OPDEF)
+
+        // ScanType.MIXED Tests
+        testAndMeasureTime("isIntrospectionOperationDefinition MIXED '${IntrospectionQuery.INTROSPECTION_QUERY_NAME}'",
+                { -> isIntrospectionOperationDefinition(
+                        INTROSPECTION_OPDEF,
+                        IntrospectionUtils.ScanType.MIXED
+                ) },
+                false, MAX_AVG_MICROS_OPDEF)
+        testAndMeasureTime("isIntrospectionOperationDefinition MIXED '${TestQueries.INTROSPECTION_QUERY_WITH_ALIAS_NAME}'",
+                { -> isIntrospectionOperationDefinition(
+                        INTROSPECTION_OPDEF_WITH_ALIAS,
+                        IntrospectionUtils.ScanType.MIXED
+                ) },
+                false, MAX_AVG_MICROS_OPDEF)
+        testAndMeasureTime("isIntrospectionOperationDefinition MIXED '${TestQueries.INTROSPECTION_QUERY_WITH_SCHEMA_FRAGMENT_NAME}'",
+                { -> isIntrospectionOperationDefinition(
+                        INTROSPECTION_OPDEF_WITH_SCHEMA_FRAGMENT,
+                        IntrospectionUtils.ScanType.MIXED
+                ) },
+                false, MAX_AVG_MICROS_OPDEF)
+        testAndMeasureTime("isIntrospectionOperationDefinition MIXED '${TestQueries.INTROSPECTION_QUERY_WITH_ALIAS_AND_MIXED_FIELDS_NAME}'",
+                { -> isIntrospectionOperationDefinition(
+                        INTROSPECTION_OPDEF_WITH_ALIAS_AND_MIXED_FIELDS,
+                        IntrospectionUtils.ScanType.MIXED
+                ) },
+                true, MAX_AVG_MICROS_OPDEF)
+        testAndMeasureTime("isIntrospectionOperationDefinition MIXED '${TestQueries.NON_INTROSPECTION_QUERY_NAME}'",
+                { -> isIntrospectionOperationDefinition(
+                        NON_INTROSPECTION_OPDEF,
+                        IntrospectionUtils.ScanType.MIXED
+                ) },
+                false, MAX_AVG_MICROS_OPDEF)
+        testAndMeasureTime("isIntrospectionOperationDefinition MIXED '${TestQueries.HERO_QUERY_NAME}'",
+                { -> isIntrospectionOperationDefinition(
+                        HERO_QUERY_OPDEF,
+                        IntrospectionUtils.ScanType.MIXED
+                ) },
+                false, MAX_AVG_MICROS_OPDEF)
+
+        // ScanType.ALL Tests
+        testAndMeasureTime("isIntrospectionOperationDefinition ALL '${IntrospectionQuery.INTROSPECTION_QUERY_NAME}'",
+                { -> isIntrospectionOperationDefinition(
+                        INTROSPECTION_OPDEF,
+                        IntrospectionUtils.ScanType.ALL
+                ) },
+                true, MAX_AVG_MICROS_OPDEF)
+        testAndMeasureTime("isIntrospectionOperationDefinition ALL '${TestQueries.INTROSPECTION_QUERY_WITH_ALIAS_NAME}'",
+                { -> isIntrospectionOperationDefinition(
+                        INTROSPECTION_OPDEF_WITH_ALIAS,
+                        IntrospectionUtils.ScanType.ALL
+                ) },
+                true, MAX_AVG_MICROS_OPDEF)
+        testAndMeasureTime("isIntrospectionOperationDefinition ALL '${TestQueries.INTROSPECTION_QUERY_WITH_SCHEMA_FRAGMENT_NAME}'",
+                { -> isIntrospectionOperationDefinition(
+                        INTROSPECTION_OPDEF_WITH_SCHEMA_FRAGMENT,
+                        IntrospectionUtils.ScanType.ALL
+                ) },
+                true, MAX_AVG_MICROS_OPDEF)
+        testAndMeasureTime("isIntrospectionOperationDefinition ALL '${TestQueries.INTROSPECTION_QUERY_WITH_ALIAS_AND_MIXED_FIELDS_NAME}'",
+                { -> isIntrospectionOperationDefinition(
+                        INTROSPECTION_OPDEF_WITH_ALIAS_AND_MIXED_FIELDS,
+                        IntrospectionUtils.ScanType.ALL
+                ) },
+                false, MAX_AVG_MICROS_OPDEF)
+        testAndMeasureTime("isIntrospectionOperationDefinition ALL '${TestQueries.NON_INTROSPECTION_QUERY_NAME}'",
+                { -> isIntrospectionOperationDefinition(
+                        NON_INTROSPECTION_OPDEF,
+                        IntrospectionUtils.ScanType.ALL
+                ) },
+                false, MAX_AVG_MICROS_OPDEF)
+        testAndMeasureTime("isIntrospectionOperationDefinition ALL '${TestQueries.HERO_QUERY_NAME}'",
+                { -> isIntrospectionOperationDefinition(
+                        HERO_QUERY_OPDEF,
+                        IntrospectionUtils.ScanType.ALL
+                ) },
+                false, MAX_AVG_MICROS_OPDEF)
     }
 
-    def "should NOT detect introspection query based on operation name"() {
+
+    // isIntrospectionFieldSubSelection Tests
+    def "isIntrospectionFieldSubSelection Tests"() {
         expect:
-            !isIntrospectionQuery(HELLO_WORLD_QUERY_NAME, null);
+        // ScanType.ANY Tests
+        testAndMeasureTime("isIntrospectionFieldSubSelection ANY '${IntrospectionQuery.INTROSPECTION_QUERY_NAME}'",
+                { -> isIntrospectionFieldSubSelection(
+                        INTROSPECTION_FSS,
+                        IntrospectionUtils.ScanType.ANY
+                ) },
+                true, MAX_AVG_MICROS_FSS)
+        testAndMeasureTime("isIntrospectionFieldSubSelection ANY '${TestQueries.INTROSPECTION_QUERY_WITH_ALIAS_NAME}'",
+                { -> isIntrospectionFieldSubSelection(
+                        INTROSPECTION_FSS_WITH_ALIAS,
+                        IntrospectionUtils.ScanType.ANY
+                ) },
+                true, MAX_AVG_MICROS_FSS)
+        testAndMeasureTime("isIntrospectionFieldSubSelection ANY '${TestQueries.INTROSPECTION_QUERY_WITH_SCHEMA_FRAGMENT_NAME}'",
+                { -> isIntrospectionFieldSubSelection(
+                        INTROSPECTION_FSS_WITH_SCHEMA_FRAGMENT,
+                        IntrospectionUtils.ScanType.ANY
+                ) },
+                true, MAX_AVG_MICROS_FSS)
+        testAndMeasureTime("isIntrospectionFieldSubSelection ANY '${TestQueries.INTROSPECTION_QUERY_WITH_ALIAS_AND_MIXED_FIELDS_NAME}'",
+                { -> isIntrospectionFieldSubSelection(
+                        INTROSPECTION_FSS_WITH_ALIAS_AND_MIXED_FIELDS,
+                        IntrospectionUtils.ScanType.ANY
+                ) },
+                true, MAX_AVG_MICROS_FSS)
+        testAndMeasureTime("isIntrospectionFieldSubSelection ANY '${TestQueries.NON_INTROSPECTION_QUERY_NAME}'",
+                { -> isIntrospectionFieldSubSelection(
+                        NON_INTROSPECTION_FSS,
+                        IntrospectionUtils.ScanType.ANY
+                ) },
+                false, MAX_AVG_MICROS_FSS)
+        testAndMeasureTime("isIntrospectionFieldSubSelection ANY '${TestQueries.HERO_QUERY_NAME}'",
+                { -> isIntrospectionFieldSubSelection(
+                        HERO_QUERY_FSS,
+                        IntrospectionUtils.ScanType.ANY
+                ) },
+                false, MAX_AVG_MICROS_FSS)
+
+        // ScanType.MIXED Tests
+        testAndMeasureTime("isIntrospectionFieldSubSelection MIXED '${IntrospectionQuery.INTROSPECTION_QUERY_NAME}'",
+                { -> isIntrospectionFieldSubSelection(
+                        INTROSPECTION_FSS,
+                        IntrospectionUtils.ScanType.MIXED
+                ) },
+                false, MAX_AVG_MICROS_FSS)
+        testAndMeasureTime("isIntrospectionFieldSubSelection MIXED '${TestQueries.INTROSPECTION_QUERY_WITH_ALIAS_NAME}'",
+                { -> isIntrospectionFieldSubSelection(
+                        INTROSPECTION_FSS_WITH_ALIAS,
+                        IntrospectionUtils.ScanType.MIXED
+                ) },
+                false, MAX_AVG_MICROS_FSS)
+        testAndMeasureTime("isIntrospectionFieldSubSelection MIXED '${TestQueries.INTROSPECTION_QUERY_WITH_SCHEMA_FRAGMENT_NAME}'",
+                { -> isIntrospectionFieldSubSelection(
+                        INTROSPECTION_FSS_WITH_SCHEMA_FRAGMENT,
+                        IntrospectionUtils.ScanType.MIXED
+                ) },
+                false, MAX_AVG_MICROS_FSS)
+        testAndMeasureTime("isIntrospectionFieldSubSelection MIXED '${TestQueries.INTROSPECTION_QUERY_WITH_ALIAS_AND_MIXED_FIELDS_NAME}'",
+                { -> isIntrospectionFieldSubSelection(
+                        INTROSPECTION_FSS_WITH_ALIAS_AND_MIXED_FIELDS,
+                        IntrospectionUtils.ScanType.MIXED
+                ) },
+                true, MAX_AVG_MICROS_FSS)
+        testAndMeasureTime("isIntrospectionFieldSubSelection MIXED '${TestQueries.NON_INTROSPECTION_QUERY_NAME}'",
+                { -> isIntrospectionFieldSubSelection(
+                        NON_INTROSPECTION_FSS,
+                        IntrospectionUtils.ScanType.MIXED
+                ) },
+                false, MAX_AVG_MICROS_FSS)
+        testAndMeasureTime("isIntrospectionFieldSubSelection MIXED '${TestQueries.HERO_QUERY_NAME}'",
+                { -> isIntrospectionFieldSubSelection(
+                        HERO_QUERY_FSS,
+                        IntrospectionUtils.ScanType.MIXED
+                ) },
+                false, MAX_AVG_MICROS_FSS)
+
+        // ScanType.ALL Tests
+        testAndMeasureTime("isIntrospectionFieldSubSelection ALL '${IntrospectionQuery.INTROSPECTION_QUERY_NAME}'",
+                { -> isIntrospectionFieldSubSelection(
+                        INTROSPECTION_FSS,
+                        IntrospectionUtils.ScanType.ALL
+                ) },
+                true, MAX_AVG_MICROS_FSS)
+        testAndMeasureTime("isIntrospectionFieldSubSelection ALL '${TestQueries.INTROSPECTION_QUERY_WITH_ALIAS_NAME}'",
+                { -> isIntrospectionFieldSubSelection(
+                        INTROSPECTION_FSS_WITH_ALIAS,
+                        IntrospectionUtils.ScanType.ALL
+                ) },
+                true, MAX_AVG_MICROS_FSS)
+        testAndMeasureTime("isIntrospectionFieldSubSelection ALL '${TestQueries.INTROSPECTION_QUERY_WITH_SCHEMA_FRAGMENT_NAME}'",
+                { -> isIntrospectionFieldSubSelection(
+                        INTROSPECTION_FSS_WITH_SCHEMA_FRAGMENT,
+                        IntrospectionUtils.ScanType.ALL
+                ) },
+                true, MAX_AVG_MICROS_FSS)
+        testAndMeasureTime("isIntrospectionFieldSubSelection ALL '${TestQueries.INTROSPECTION_QUERY_WITH_ALIAS_AND_MIXED_FIELDS_NAME}'",
+                { -> isIntrospectionFieldSubSelection(
+                        INTROSPECTION_FSS_WITH_ALIAS_AND_MIXED_FIELDS,
+                        IntrospectionUtils.ScanType.ALL
+                ) },
+                false, MAX_AVG_MICROS_FSS)
+        testAndMeasureTime("isIntrospectionFieldSubSelection ALL '${TestQueries.NON_INTROSPECTION_QUERY_NAME}'",
+                { -> isIntrospectionFieldSubSelection(
+                        NON_INTROSPECTION_FSS,
+                        IntrospectionUtils.ScanType.ALL
+                ) },
+                false, MAX_AVG_MICROS_FSS)
+        testAndMeasureTime("isIntrospectionFieldSubSelection ALL '${TestQueries.HERO_QUERY_NAME}'",
+                { -> isIntrospectionFieldSubSelection(
+                        HERO_QUERY_FSS,
+                        IntrospectionUtils.ScanType.ALL
+                ) },
+                false, MAX_AVG_MICROS_FSS)
     }
 
-    def "should NOT detect introspection query based on query"() {
-        expect:
-        !isIntrospectionQuery(HELLO_WORLD_QUERY_NAME, HELLO_WORLD_QUERY);
+
+    // Test Helper Methods
+    private static def getOperationDefinition(final Document document, final String operationName) {
+        return NodeUtil.getOperation(document, operationName).operationDefinition
+    }
+
+    private static def getFieldSubSelection(final Document document, final String operationName) {
+        def getOperationResult = NodeUtil.getOperation(document, operationName)
+        def fragmentsByName = getOperationResult.fragmentsByName
+        def operationDefinition = getOperationResult.operationDefinition
+        def operationRootType = Common.getOperationRootType(INTROSPECTION_SCHEMA, operationDefinition)
+
+        // For the purpose of checking for the introspection document, we don't actually need the real
+        //   schema or the variables map so we just use stubs
+        def collectorParameters = FieldCollectorParameters.newParameters()
+                .schema(INTROSPECTION_SCHEMA)
+                .objectType(operationRootType)
+                .fragments(fragmentsByName)
+                .variables(Collections.emptyMap())
+                .build()
+        def mergedSelectionSet = FIELD_COLLECTOR
+                .collectFields(collectorParameters, operationDefinition.getSelectionSet())
+
+        return FieldSubSelection.newFieldSubSelection()
+                .mergedSelectionSet(mergedSelectionSet)
+                .build()
+    }
+
+    private static def testAndMeasureTime(final String testName, Supplier<Boolean> testSupplier,
+                                          boolean expectedResult,
+                                          final long maxAvgMicros) {
+        return testAndMeasureTime(testName, testSupplier, expectedResult, WARMING_CYCLES, maxAvgMicros)
+    }
+
+    private static def testAndMeasureTime(final String testName,
+                                          final Supplier<Boolean> testSupplier,
+                                          final boolean expectedResult,
+                                          final int warmingCycles,
+                                          final long maxAvgMicros) {
+        for (int index = 0; index < warmingCycles; index++) {
+            testAndMeasureTime("${testName} (Warming Cycle ${index})", testSupplier, expectedResult,
+                    true, maxAvgMicros)
+        }
+
+        return testAndMeasureTime(testName, testSupplier, expectedResult, false, maxAvgMicros);
+    }
+
+    private static def testAndMeasureTime(final String testName, Supplier<Boolean> testSupplier, boolean expectedResult,
+                                          final boolean warmingCycle, final long maxAvgMicros) {
+        def start = System.nanoTime()
+        def result = false
+
+        for (int index = 0; index < LOOPS; index++) {
+            result = testSupplier.get()
+        }
+        def end = System.nanoTime()
+        def timeNanos = (end - start)
+        def timeMicros = timeNanos / MICROS_IN_MILLIS
+        def timeMillis = timeNanos / NANOS_IN_MILLIS
+        def avgMicros = timeMicros / LOOPS
+
+        if (!warmingCycle) {
+            println(sprintf('Time Measure: Loops: %d, Time: %.3f ms, Avg: %.3f μs, Result: %b, Expected Result: %b, Name: %s',
+                    LOOPS, timeMillis, avgMicros, result, expectedResult, testName))
+        }
+
+        return (result == expectedResult) && (warmingCycle || (maxAvgMicros <= 0) || (avgMicros <= maxAvgMicros))
     }
 }

--- a/src/test/groovy/graphql/introspection/TestQueries.groovy
+++ b/src/test/groovy/graphql/introspection/TestQueries.groovy
@@ -1,0 +1,80 @@
+package graphql.introspection
+
+class TestQueries {
+    public static def NON_INTROSPECTION_QUERY_NAME = 'NonIntrospectionQuery'
+    public static def INTROSPECTION_QUERY_WITH_ALIAS_NAME = 'IntrospectionQueryWithAlias'
+    public static def INTROSPECTION_QUERY_WITH_ALIAS_AND_MIXED_FIELDS_NAME = 'IntrospectionQueryWithAliasAndMixedFields'
+    public static def INTROSPECTION_QUERY_WITH_SCHEMA_FRAGMENT_NAME = 'IntrospectionQueryWithSchemaFragment'
+    public static def HERO_QUERY_NAME = 'HeroNameAndFriendsQuery'
+
+    static def INTROSPECTION_QUERY_FRAGMENT_SCHEMA = """
+        fragment Schema on __Schema {
+          ${IntrospectionQuery.INTROSPECTION_QUERY_SCHEMA_SNIPPET}
+        }
+    """
+
+    static def HERO_QUERY_VARDEF = '''$varDef'''
+
+    static def HERO_QUERY_SNIPPET = """
+          hero(id : ${HERO_QUERY_VARDEF}) {
+            id
+            ...DroidFields
+          }
+          han: hero(id: "1001") { name }
+          luke: hero(ids: ["1001"]) { name }
+          villain(id: "1") { name }
+    """
+
+    static def HERO_QUERY_FRAGMENT_DROIDFIELDS = '''
+        fragment DroidFields on Droid {
+          primaryFunction
+        }
+    '''
+
+
+    public static def NON_INTROSPECTION_QUERY = """
+        query ${NON_INTROSPECTION_QUERY_NAME} {
+          schema {
+            ${IntrospectionQuery.INTROSPECTION_QUERY_SCHEMA_SNIPPET}
+          }
+        }
+        ${IntrospectionQuery.INTROSPECTION_QUERY_FRAGMENTS}
+    """
+
+    public static def INTROSPECTION_QUERY_WITH_ALIAS = """
+        query ${INTROSPECTION_QUERY_WITH_ALIAS_NAME} {
+          myAlias: __schema {
+            ${IntrospectionQuery.INTROSPECTION_QUERY_SCHEMA_SNIPPET}
+          }
+        }
+        ${IntrospectionQuery.INTROSPECTION_QUERY_FRAGMENTS}
+    """
+
+    public static def INTROSPECTION_QUERY_WITH_ALIAS_AND_MIXED_FIELDS = """
+        query ${INTROSPECTION_QUERY_WITH_ALIAS_AND_MIXED_FIELDS_NAME}(${HERO_QUERY_VARDEF}: VarType) {
+          myAlias: __schema {
+            ${IntrospectionQuery.INTROSPECTION_QUERY_SCHEMA_SNIPPET}
+          }
+          ${HERO_QUERY_SNIPPET}
+        }
+        ${IntrospectionQuery.INTROSPECTION_QUERY_FRAGMENTS}
+        ${HERO_QUERY_FRAGMENT_DROIDFIELDS}
+    """
+
+    public static def INTROSPECTION_QUERY_WITH_SCHEMA_FRAGMENT = """
+        query ${INTROSPECTION_QUERY_WITH_SCHEMA_FRAGMENT_NAME} {
+          __schema {
+            ...Schema
+          }
+        }
+        ${IntrospectionQuery.INTROSPECTION_QUERY_FRAGMENTS}
+        ${INTROSPECTION_QUERY_FRAGMENT_SCHEMA}
+    """
+
+    public static def HERO_QUERY = """
+        query ${HERO_QUERY_NAME}(${HERO_QUERY_VARDEF}: VarType) {
+          ${HERO_QUERY_SNIPPET}
+        }
+        ${HERO_QUERY_FRAGMENT_DROIDFIELDS}
+     """
+}


### PR DESCRIPTION
Description:
Implemented method for determining if a query is the introspection query

Changes:
* Added IntrospectionUtils class
* Implemented IntrospectionUtils.isIntrospectionQuery.  Determination is
made with the following rules.
** If operationName argument is equal to
IntrospectionQuery.INTROSPECTION_QUERY_NAME
** If query contains operation name equal to
IntrospectionQuery.INTROSPECTION_QUERY_NAME
** If query contains the __schema field

Unit Tests:
* Added IntrospectionUtilsTest.groovy file to test all cases of new
IntrospectionUtils class