### PR TITLE
Experimental fast overlapping-fields-can-be-merged algorithm

### DIFF
--- a/src/main/java/graphql/validation/Validator.java
+++ b/src/main/java/graphql/validation/Validator.java
@@ -1,6 +1,5 @@
 package graphql.validation;
 
-
 import graphql.Internal;
 import graphql.language.Document;
 import graphql.schema.GraphQLSchema;
@@ -30,6 +29,7 @@ import graphql.validation.rules.UniqueOperationNames;
 import graphql.validation.rules.VariableDefaultValuesOfCorrectType;
 import graphql.validation.rules.VariableTypesMatchRule;
 import graphql.validation.rules.VariablesAreInputTypes;
+import graphql.validation.rules.experimental.overlappingfieldsmerge.OverlappingFieldsCanBeMergedEx;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,7 +39,6 @@ public class Validator {
 
     public List<ValidationError> validateDocument(GraphQLSchema schema, Document document) {
         ValidationContext validationContext = new ValidationContext(schema, document);
-
 
         ValidationErrorCollector validationErrorCollector = new ValidationErrorCollector();
         List<AbstractRule> rules = createRules(validationContext, validationErrorCollector);
@@ -81,8 +80,15 @@ public class Validator {
         NoUnusedVariables noUnusedVariables = new NoUnusedVariables(validationContext, validationErrorCollector);
         rules.add(noUnusedVariables);
 
-        OverlappingFieldsCanBeMerged overlappingFieldsCanBeMerged = new OverlappingFieldsCanBeMerged(validationContext, validationErrorCollector);
-        rules.add(overlappingFieldsCanBeMerged);
+        if (System.getProperty("graphql.experimental.validation.overlappingFieldsCanBeMerged", Boolean.FALSE.toString()).equals(Boolean.TRUE.toString())) {
+            OverlappingFieldsCanBeMergedEx overlappingFieldsCanBeMerged =
+                    new OverlappingFieldsCanBeMergedEx(validationContext, validationErrorCollector);
+            rules.add(overlappingFieldsCanBeMerged);
+        } else {
+            OverlappingFieldsCanBeMerged overlappingFieldsCanBeMerged =
+                    new OverlappingFieldsCanBeMerged(validationContext, validationErrorCollector);
+            rules.add(overlappingFieldsCanBeMerged);
+        }
 
         PossibleFragmentSpreads possibleFragmentSpreads = new PossibleFragmentSpreads(validationContext, validationErrorCollector);
         rules.add(possibleFragmentSpreads);

--- a/src/main/java/graphql/validation/rules/experimental/overlappingfieldsmerge/CachedCheck.java
+++ b/src/main/java/graphql/validation/rules/experimental/overlappingfieldsmerge/CachedCheck.java
@@ -1,0 +1,270 @@
+package graphql.validation.rules.experimental.overlappingfieldsmerge;
+
+import graphql.language.Field;
+import graphql.language.Node;
+import graphql.language.SourceLocation;
+import graphql.validation.AbstractRule;
+import graphql.validation.ValidationError;
+import graphql.validation.rules.OverlappingFieldsCanBeMerged;
+import graphql.validation.rules.OverlappingFieldsCanBeMerged.Conflict;
+import graphql.validation.rules.OverlappingFieldsCanBeMerged.FieldAndType;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import static graphql.validation.ValidationError.newValidationError;
+import static graphql.validation.ValidationErrorType.FieldsConflict;
+
+/**
+ * Inspired by Simon Adameit's implementation in Sangria https://github.com/sangria-graphql-org/sangria/pull/12
+ */
+class CachedCheck {
+
+    static BiFunction<Field, Field, Boolean> alwaysCheck = (f1, f2) -> false;
+
+    private final AbstractRule rule;
+
+    /**
+     * We cache by FieldSet and use SortedArraySet, as it is fast to compare and iterate over
+     */
+    private HashMap<SortedArraySet<SelectionField>, FieldSetCache> cache = new HashMap<>();
+
+    public CachedCheck(AbstractRule rule) {
+        this.rule = rule;
+    }
+
+    void checkFieldsInSetCanMerge(SortedArraySet<SelectionField> fields) {
+        getCacheLine(fields).checkFieldsInSetCanMerge();
+    }
+
+    private FieldSetCache getCacheLine(SortedArraySet<SelectionField> fields) {
+        return cache.computeIfAbsent(fields, FieldSetCache::new);
+    }
+
+    private class FieldSetCache {
+
+        private final SortedArraySet<SelectionField> fields;
+
+        private ArrayList<FieldSetCache> cacheGroupByOutputNames;
+        private FieldSetCache cacheMergeChildSelections;
+        private ArrayList<FieldSetCache> cacheGroupByCommonParentTypes;
+
+        private boolean didRequireSameResponseShape = false;
+        private boolean didRequireSameFieldNameAndArguments = false;
+        private boolean didCheckSameResponseShape = false;
+        private boolean didCheckSameFieldsForCoincidentParentTypes = false;
+
+        private FieldSetCache(SortedArraySet<SelectionField> fields) {
+            this.fields = fields;
+        }
+
+        void checkFieldsInSetCanMerge() {
+            checkSameResponseShape();
+            checkSameFieldsForCoincidentParentTypes();
+        }
+
+        private void checkSameResponseShape() {
+            if (didCheckSameResponseShape) {
+                return;
+            }
+            didCheckSameResponseShape = true;
+            groupByOutputNames().forEach(fieldSet ->
+                    fieldSet
+                            .requireSameResponseShape()
+                            .mergeChildSelections()
+                            .checkSameResponseShape()
+            );
+        }
+
+        private void checkSameFieldsForCoincidentParentTypes() {
+            if (didCheckSameFieldsForCoincidentParentTypes) {
+                return;
+            }
+            didCheckSameFieldsForCoincidentParentTypes = true;
+            groupByOutputNames().forEach(fieldSet -> {
+                fieldSet.groupByCommonParentTypes().forEach(fieldSet2 -> {
+                    fieldSet2
+                            .requireSameFieldNameAndArguments()
+                            .mergeChildSelections()
+                            .checkSameFieldsForCoincidentParentTypes();
+                });
+            });
+        }
+
+        private FieldSetCache requireSameResponseShape() {
+            if (didRequireSameResponseShape) {
+                return this;
+            }
+            didRequireSameResponseShape = true;
+            Map<TypeShape.Known, ArrayList<SelectionField>> fieldsWithKnownResponseShapes = groupByKnownResponseShape();
+            int responseShapesNumber = fieldsWithKnownResponseShapes.size();
+            if (responseShapesNumber > 1) {
+                List<Map.Entry<TypeShape.Known, ArrayList<SelectionField>>> buckets =
+                        new ArrayList<>(fieldsWithKnownResponseShapes.entrySet());
+                String outputName = buckets.get(0).getValue().get(0).getOutputName();
+                for (int i = 0; i < buckets.size() - 1; i++) {
+                    for (int j = i + 1; j < buckets.size(); j++) {
+                        Map.Entry<TypeShape.Known, ArrayList<SelectionField>> a = buckets.get(i);
+                        Map.Entry<TypeShape.Known, ArrayList<SelectionField>> b = buckets.get(j);
+
+                        checkConflict(outputName, a.getValue(), b.getValue());
+                    }
+                }
+            }
+            return this;
+        }
+
+        private Map<TypeShape.Known, ArrayList<SelectionField>> groupByKnownResponseShape() {
+            Map<TypeShape.Known, ArrayList<SelectionField>> fieldsWithKnownResponseShapes = new LinkedHashMap<>();
+            fields.forEach(field -> {
+                TypeShape typeShape = field.outputTypeShape();
+                if (typeShape instanceof TypeShape.Known) {
+                    fieldsWithKnownResponseShapes.computeIfAbsent((TypeShape.Known) typeShape, key -> new ArrayList<>())
+                            .add(field);
+                }
+            });
+            return fieldsWithKnownResponseShapes;
+        }
+
+        private FieldSetCache requireSameFieldNameAndArguments() {
+            if (didRequireSameFieldNameAndArguments) {
+                return this;
+            }
+            didRequireSameFieldNameAndArguments = true;
+            Map<FieldNameAndArguments, ArrayList<SelectionField>> fieldsWithSameNameAndArguments = groupByFieldNameAndArguments();
+            int fieldNameAndArgumentsNumber = fieldsWithSameNameAndArguments.size();
+            if (fieldNameAndArgumentsNumber > 1) {
+                List<Map.Entry<FieldNameAndArguments, ArrayList<SelectionField>>> buckets =
+                        new ArrayList<>(fieldsWithSameNameAndArguments.entrySet());
+                String outputName = buckets.get(0).getValue().get(0).getOutputName();
+                for (int i = 0; i < buckets.size() - 1; i++) {
+                    for (int j = i + 1; j < buckets.size(); j++) {
+                        Map.Entry<FieldNameAndArguments, ArrayList<SelectionField>> a = buckets.get(i);
+                        Map.Entry<FieldNameAndArguments, ArrayList<SelectionField>> b = buckets.get(j);
+
+                        checkConflict(outputName, a.getValue(), b.getValue());
+                    }
+                }
+            }
+            return this;
+        }
+
+        private Map<FieldNameAndArguments, ArrayList<SelectionField>> groupByFieldNameAndArguments() {
+            Map<FieldNameAndArguments, ArrayList<SelectionField>> fieldsWithSameNameAndArguments = new LinkedHashMap<>();
+            fields.forEach(field -> {
+                fieldsWithSameNameAndArguments
+                        .computeIfAbsent(field.fieldNameAndArguments(), key -> new ArrayList<>())
+                        .add(field);
+            });
+            return fieldsWithSameNameAndArguments;
+        }
+
+        private ArrayList<FieldSetCache> groupByOutputNames() {
+            if (cacheGroupByOutputNames == null) {
+                Map<String, SortedArraySet.Builder<SelectionField>> outputNames = new LinkedHashMap<>();
+                fields.forEach(field -> {
+                    outputNames
+                            .computeIfAbsent(field.getOutputName(), t -> newFieldSetBuilder())
+                            .add(field);
+                });
+                ArrayList<FieldSetCache> result = new ArrayList<>(outputNames.size());
+                outputNames.values()
+                        .forEach(builder -> result.add(getCacheLine(builder.build())));
+                cacheGroupByOutputNames = result;
+            }
+            return cacheGroupByOutputNames;
+        }
+
+        private void checkConflict(String outputName, ArrayList<SelectionField> a, ArrayList<SelectionField> b) {
+            SelectionField selectionFieldA = a.get(0);
+            SelectionField selectionFieldB = b.get(0);
+
+            Conflict conflict = OverlappingFieldsCanBeMerged.findConflict(
+                    alwaysCheck, outputName,
+                    new FieldAndType(selectionFieldA.astField, selectionFieldA.outputType, selectionFieldA.parentType),
+                    new FieldAndType(selectionFieldB.astField, selectionFieldB.outputType, selectionFieldB.parentType));
+            if (conflict != null) {
+                List<SourceLocation> locationList = new ArrayList<>();
+                for (Node<?> node : conflict.fields) {
+                    locationList.add(node.getSourceLocation());
+                }
+                ValidationError.Builder error = newValidationError()
+                        .validationErrorType(FieldsConflict)
+                        .sourceLocations(locationList)
+                        //.queryPath(queryPath); // TODO we are missing query path here
+                        .description(conflict.reason);
+                rule.getValidationErrorCollector().addError(error.build());
+            }
+        }
+
+        private FieldSetCache mergeChildSelections() {
+            if (cacheMergeChildSelections == null) {
+                cacheMergeChildSelections = getCacheLine(SelectionField.children(fields));
+            }
+            return cacheMergeChildSelections;
+        }
+
+        private ArrayList<FieldSetCache> groupByCommonParentTypes() {
+            if (cacheGroupByCommonParentTypes == null) {
+                ArrayList<SelectionField> fieldsWithAbstractParentTypes = new ArrayList<>();
+                LinkedHashMap<TypeAbstractness.Concrete, SortedArraySet.Builder<SelectionField>> fieldsWithConcreteParents =
+                        new LinkedHashMap<>();
+                fields.forEach(field -> {
+                    TypeAbstractness typeAbstractness = field.parentTypeAbstractness();
+                    if (typeAbstractness.equals(TypeAbstractness.Abstract.INSTANCE)) {
+                        fieldsWithAbstractParentTypes.add(field);
+                    } else if (typeAbstractness instanceof TypeAbstractness.Concrete) {
+                        fieldsWithConcreteParents.computeIfAbsent((TypeAbstractness.Concrete) typeAbstractness, t -> newFieldSetBuilder())
+                                .add(field);
+                    }
+                });
+                cacheGroupByCommonParentTypes = combineAbstractAndConcreteParentTypes(fieldsWithAbstractParentTypes,
+                        fieldsWithConcreteParents);
+            }
+            return cacheGroupByCommonParentTypes;
+        }
+
+        private ArrayList<FieldSetCache> combineAbstractAndConcreteParentTypes(
+                ArrayList<SelectionField> fieldsWithAbstractParentTypes,
+                LinkedHashMap<TypeAbstractness.Concrete, SortedArraySet.Builder<SelectionField>> fieldsWithConreteParents
+        ) {
+            if (fieldsWithConreteParents.isEmpty()) {
+                if (fieldsWithAbstractParentTypes.isEmpty()) {
+                    return new ArrayList<>(0);
+                } else {
+                    ArrayList<FieldSetCache> list = new ArrayList<>(1);
+                    SortedArraySet<SelectionField> set = newFieldSetBuilder(fieldsWithAbstractParentTypes.size())
+                            .addAll(fieldsWithAbstractParentTypes)
+                            .build();
+                    list.add(getCacheLine(set));
+                    return list;
+                }
+            } else {
+                ArrayList<FieldSetCache> list = new ArrayList<>(fieldsWithConreteParents.size());
+                if (fieldsWithAbstractParentTypes.isEmpty()) {
+                    fieldsWithConreteParents.values().forEach(builder -> {
+                        list.add(getCacheLine(builder.build()));
+                    });
+                } else {
+                    fieldsWithConreteParents.values().forEach(builder -> {
+                        SortedArraySet<SelectionField> set = builder.addAll(fieldsWithAbstractParentTypes).build();
+                        list.add(getCacheLine(set));
+                    });
+                }
+                return list;
+            }
+        }
+    }
+
+    private SortedArraySet.Builder<SelectionField> newFieldSetBuilder() {
+        return SortedArraySet.newBuilder(SelectionField.comparator());
+    }
+
+    private SortedArraySet.Builder<SelectionField> newFieldSetBuilder(int sizeHint) {
+        return SortedArraySet.newBuilder(sizeHint, SelectionField.comparator());
+    }
+}

--- a/src/main/java/graphql/validation/rules/experimental/overlappingfieldsmerge/FieldNameAndArguments.java
+++ b/src/main/java/graphql/validation/rules/experimental/overlappingfieldsmerge/FieldNameAndArguments.java
@@ -1,0 +1,48 @@
+package graphql.validation.rules.experimental.overlappingfieldsmerge;
+
+import graphql.language.Argument;
+import graphql.language.AstPrinter;
+import graphql.language.Field;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Inspired by Simon Adameit's implementation in Sangria https://github.com/sangria-graphql-org/sangria/pull/12
+ */
+final class FieldNameAndArguments {
+
+    private String fieldName;
+    private List<String> argumentStringRepresentations;
+
+    public FieldNameAndArguments(Field astField) {
+        this.fieldName = astField.getName();
+        this.argumentStringRepresentations = astField.getArguments().stream()
+                .map(this::toStringRepresentation)
+                .sorted()
+                .collect(Collectors.toList());
+    }
+
+    private String toStringRepresentation(Argument arg) {
+        return arg.getName() + ";;" + AstPrinter.printAstCompact(arg.getValue());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof FieldNameAndArguments)) {
+            return false;
+        }
+        FieldNameAndArguments that = (FieldNameAndArguments) o;
+        return Objects.equals(fieldName, that.fieldName) &&
+                Objects.equals(argumentStringRepresentations, that.argumentStringRepresentations);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fieldName, argumentStringRepresentations);
+    }
+}

--- a/src/main/java/graphql/validation/rules/experimental/overlappingfieldsmerge/OverlappingFieldsCanBeMergedEx.java
+++ b/src/main/java/graphql/validation/rules/experimental/overlappingfieldsmerge/OverlappingFieldsCanBeMergedEx.java
@@ -1,0 +1,68 @@
+package graphql.validation.rules.experimental.overlappingfieldsmerge;
+
+import graphql.language.Document;
+import graphql.language.Field;
+import graphql.language.FragmentDefinition;
+import graphql.language.FragmentSpread;
+import graphql.language.SelectionSet;
+import graphql.schema.GraphQLCompositeType;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLFieldsContainer;
+import graphql.schema.GraphQLOutputType;
+import graphql.validation.AbstractRule;
+import graphql.validation.ValidationContext;
+import graphql.validation.ValidationErrorCollector;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+/**
+ * Inspired by Simon Adameit's implementation in Sangria https://github.com/sangria-graphql-org/sangria/pull/12
+ * See http://facebook.github.io/graphql/June2018/#sec-Field-Selection-Merging
+ */
+public class OverlappingFieldsCanBeMergedEx extends AbstractRule {
+
+    private SelectionBuilder selectionBuilder = new SelectionBuilder();
+
+    public OverlappingFieldsCanBeMergedEx(ValidationContext validationContext, ValidationErrorCollector validationErrorCollector) {
+        super(validationContext, validationErrorCollector);
+    }
+
+    @Override
+    public void checkFragmentDefinition(FragmentDefinition fragmentDefinition) {
+        selectionBuilder.enterFragmentDefinition(fragmentDefinition, getValidationContext().getQueryPath());
+    }
+
+    @Override
+    public void checkFragmentSpread(FragmentSpread fragmentSpread) {
+        selectionBuilder.spreadFragment(fragmentSpread);
+    }
+
+    @Override
+    public void checkSelectionSet(SelectionSet selectionSet) {
+        selectionBuilder.enterGenericSelectionContainer(selectionSet);
+    }
+
+    @Override
+    public void leaveSelectionSet(SelectionSet selectionSet) {
+        selectionBuilder.leaveSelectionContainer();
+    }
+
+    @Override
+    public void checkField(Field field) {
+        GraphQLCompositeType parentType = getValidationContext().getParentType();
+        GraphQLOutputType outputType = Optional.ofNullable(parentType)
+                .filter(parent -> parent instanceof GraphQLFieldsContainer)
+                .map(parent -> ((GraphQLFieldsContainer) parent).getFieldDefinition(field.getName()))
+                .map(GraphQLFieldDefinition::getType)
+                .orElse(null);
+        selectionBuilder.enterField(parentType, field, outputType);
+    }
+
+    @Override
+    public void documentFinished(Document document) {
+        ArrayList<SelectionContainer> roots = selectionBuilder.build();
+        CachedCheck check = new CachedCheck(this);
+        roots.forEach(root -> check.checkFieldsInSetCanMerge(root.fieldSet()));
+    }
+}

--- a/src/main/java/graphql/validation/rules/experimental/overlappingfieldsmerge/SelectionBuilder.java
+++ b/src/main/java/graphql/validation/rules/experimental/overlappingfieldsmerge/SelectionBuilder.java
@@ -1,0 +1,84 @@
+package graphql.validation.rules.experimental.overlappingfieldsmerge;
+
+import graphql.language.Field;
+import graphql.language.FragmentDefinition;
+import graphql.language.FragmentSpread;
+import graphql.language.SelectionSet;
+import graphql.schema.GraphQLCompositeType;
+import graphql.schema.GraphQLOutputType;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * For the validation we need another representation of the query that
+ * already contains the effective selection sets for each field and
+ * certain properties of the fields. As we don't want to adapt the graphql-java
+ * representation, we build our own here during traversal of the query.
+ *
+ * Inspired by Simon Adameit's implementation in Sangria https://github.com/sangria-graphql-org/sangria/pull/12
+ */
+public class SelectionBuilder {
+
+    private SelectionField.Builder fieldBuilder = new SelectionField.Builder();
+    private Map<String, SelectionContainer> fragments = new HashMap<>();
+    private ArrayList<SelectionContainer> roots = new ArrayList<>();
+    private ArrayDeque<SelectionContainer> stack = new ArrayDeque<>();
+
+    void enterField(GraphQLCompositeType parentType, Field astField, GraphQLOutputType outputType) {
+        SelectionField field = fieldBuilder.build(astField, parentType, outputType);
+        if (!stack.isEmpty()) {
+            stack.peek().addField(field);
+        }
+        if (astField.getSelectionSet() != null) {
+            stack.push(field.getChildSelection());
+        }
+    }
+
+    void spreadFragment(FragmentSpread fragmentSpread) {
+        if (!stack.isEmpty()) {
+            stack.peek().addSpread(getOrInitFragment(fragmentSpread.getName(), null));
+        }
+    }
+
+    void enterFragmentDefinition(FragmentDefinition fragmentDefinition, List<String> queryPath) {
+        SelectionContainer fragment = getOrInitFragment(fragmentDefinition.getName(), fragmentDefinition.getSelectionSet());
+        if (stack.isEmpty()) {
+            roots.add(fragment);
+        }
+        stack.push(fragment);
+    }
+
+    void enterGenericSelectionContainer(SelectionSet source) {
+        if (stack.isEmpty()) {
+            SelectionContainer selectionContainer = new SelectionContainer(source);
+            roots.add(selectionContainer);
+            stack.push(selectionContainer);
+        } else {
+            if (stack.peek().getSourceSelectionSet() != source) {
+                SelectionContainer selectionContainer = new SelectionContainer(source);
+                stack.peek().addSpread(selectionContainer);
+                stack.push(selectionContainer);
+            }
+        }
+    }
+
+    void leaveSelectionContainer() {
+        stack.pop();
+    }
+
+    /**
+     * @return A list of roots of the document
+     */
+    ArrayList<SelectionContainer> build() {
+        roots.forEach(SelectionContainer::computeEffectiveSelections);
+        return roots;
+    }
+
+    private SelectionContainer getOrInitFragment(String name, SelectionSet selectionSet) {
+        return fragments.computeIfAbsent(name, key -> new SelectionContainer(selectionSet));
+    }
+}

--- a/src/main/java/graphql/validation/rules/experimental/overlappingfieldsmerge/SelectionContainer.java
+++ b/src/main/java/graphql/validation/rules/experimental/overlappingfieldsmerge/SelectionContainer.java
@@ -1,0 +1,98 @@
+package graphql.validation.rules.experimental.overlappingfieldsmerge;
+
+import graphql.language.SelectionSet;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+/**
+ * Inspired by Simon Adameit's implementation in Sangria https://github.com/sangria-graphql-org/sangria/pull/12
+ */
+class SelectionContainer {
+
+    private final SelectionSet sourceSelectionSet;
+
+    // Tracking the state of computeEffectiveSelections
+    private boolean inProgress = false;
+    private boolean done = false;
+
+    private List<SelectionContainer> directSpreads = new ArrayList<>();
+
+    private List<SelectionField> directFields = new ArrayList<>();
+
+    /**
+     * This selection set and all directly or indirectly included spreads.
+     * Indirectly included spreads come from spreads in directly included
+     * spreads, etc.
+     */
+    private final LinkedHashSet<SelectionContainer> effectiveSelections;
+
+    SelectionContainer(SelectionSet sourceSelectionSet) {
+        this.sourceSelectionSet = sourceSelectionSet;
+        effectiveSelections = new LinkedHashSet<>();
+        effectiveSelections.add(SelectionContainer.this);
+    }
+
+    public List<SelectionField> getDirectFields() {
+        return directFields;
+    }
+
+    public Object getSourceSelectionSet() {
+        return sourceSelectionSet;
+    }
+
+    public void addSpread(SelectionContainer selectionContainer) {
+        directSpreads.add(selectionContainer);
+    }
+
+    public void addField(SelectionField field) {
+        directFields.add(field);
+    }
+
+    public SortedArraySet<SelectionField> fieldSet() {
+        return SelectionContainer.fieldSet(effectiveSelections);
+    }
+
+    public void computeEffectiveSelections() {
+        if (inProgress || done) {
+            return;
+        }
+        inProgress = true;
+        directFields.forEach(field -> {
+            field.getChildSelection().computeEffectiveSelections();
+        });
+        directSpreads.forEach(spread -> {
+            // prevent building cycles
+            if (!spread.inProgress) {
+                // prevent doing work twice
+                if (spread.done) {
+                    if (!effectiveSelections.contains(spread)) {
+                        effectiveSelections.addAll(spread.effectiveSelections);
+                    }
+                } else {
+                    spread.computeEffectiveSelections();
+                    //effective selections of spread are also done after spread.computeEffectiveSelections()
+                    effectiveSelections.addAll(spread.effectiveSelections);
+                }
+            }
+        });
+        inProgress = false;
+        done = true;
+    }
+
+    static SortedArraySet<SelectionField> children(SortedArraySet<SelectionField> fields) {
+        LinkedHashSet<SelectionContainer> childSelections = new LinkedHashSet<>();
+        fields.forEach(f -> childSelections.addAll(f.getChildSelection().effectiveSelections));
+        return SelectionContainer.fieldSet(childSelections);
+    }
+
+    static SortedArraySet<SelectionField> fieldSet(LinkedHashSet<SelectionContainer> effectiveSelections) {
+        int expectedSize = effectiveSelections.stream()
+                .mapToInt(selection -> selection.getDirectFields().size())
+                .sum();
+        SortedArraySet.Builder<SelectionField> builder = SortedArraySet.newBuilder(expectedSize, SelectionField.comparator());
+        effectiveSelections.forEach(selection -> builder.addAll(selection.directFields));
+        return builder.build();
+    }
+}

--- a/src/main/java/graphql/validation/rules/experimental/overlappingfieldsmerge/SelectionField.java
+++ b/src/main/java/graphql/validation/rules/experimental/overlappingfieldsmerge/SelectionField.java
@@ -1,0 +1,88 @@
+package graphql.validation.rules.experimental.overlappingfieldsmerge;
+
+import graphql.language.Field;
+import graphql.schema.GraphQLCompositeType;
+import graphql.schema.GraphQLOutputType;
+
+import java.util.Comparator;
+
+/**
+ * Inspired by Simon Adameit's implementation in Sangria https://github.com/sangria-graphql-org/sangria/pull/12
+ */
+class SelectionField {
+
+    int id;
+    Field astField;
+    GraphQLCompositeType parentType;
+    GraphQLOutputType outputType;
+
+    final SelectionContainer selectionContainer;
+
+    public SelectionField(int id, Field astField, GraphQLCompositeType parentType, GraphQLOutputType outputType) {
+        this.id = id;
+        this.astField = astField;
+        this.parentType = parentType;
+        this.outputType = outputType;
+        this.selectionContainer = new SelectionContainer(astField.getSelectionSet());
+    }
+
+    String getOutputName() {
+        return astField.getAlias() == null ? astField.getName() : astField.getAlias();
+    }
+
+    TypeAbstractness parentTypeAbstractness() {
+        return TypeAbstractness.apply(parentType);
+    }
+
+    TypeShape outputTypeShape() {
+        return TypeShape.apply(outputType);
+    }
+
+    FieldNameAndArguments fieldNameAndArguments() {
+        return new FieldNameAndArguments(astField);
+    }
+
+    public SelectionContainer getChildSelection() {
+        return selectionContainer;
+    }
+
+    @Override
+    public String toString() {
+        return "SelectionField{" +
+                "id=" + id +
+                ",name=" + astField.getName() +
+                ",out=" + getOutputName() +
+                '}';
+    }
+
+    static class Builder {
+
+        private int id = 0;
+
+        SelectionField build(
+                Field astField,
+                GraphQLCompositeType parentType,
+                GraphQLOutputType outputType
+        ) {
+            id += 1;
+            return new SelectionField(
+                    id,
+                    astField,
+                    parentType,
+                    outputType
+            );
+        }
+    }
+
+    /**
+     * This gives us a stable order of fields in sets.
+     * It is determined by the order of traversal of the query.
+     */
+    public static Comparator<SelectionField> comparator() {
+        return Comparator.comparingInt(x -> x.id);
+    }
+
+    static SortedArraySet<SelectionField> children(SortedArraySet<SelectionField> fields) {
+        return SelectionContainer.children(fields);
+    }
+}

--- a/src/main/java/graphql/validation/rules/experimental/overlappingfieldsmerge/SortedArraySet.java
+++ b/src/main/java/graphql/validation/rules/experimental/overlappingfieldsmerge/SortedArraySet.java
@@ -1,0 +1,112 @@
+package graphql.validation.rules.experimental.overlappingfieldsmerge;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * A set representation that is well suited to hash and equality comparisons and fast iteration over members
+ * Inspired by Simon Adameit's implementation in Sangria https://github.com/sangria-graphql-org/sangria/pull/12
+ */
+class SortedArraySet<T> implements Iterable<T> {
+
+    private ArrayList<T> sortedMembers;
+
+    public SortedArraySet(ArrayList<T> sortedMembers) {
+        this.sortedMembers = sortedMembers;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof SortedArraySet)) {
+            return false;
+        }
+        SortedArraySet<?> that = (SortedArraySet<?>) o;
+        return Objects.equals(sortedMembers, that.sortedMembers);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(sortedMembers);
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return sortedMembers.iterator();
+    }
+
+    @Override
+    public void forEach(Consumer<? super T> action) {
+        sortedMembers.forEach(action);
+    }
+
+    @Override
+    public String toString() {
+        return sortedMembers.toString();
+    }
+
+    //Beware:
+    //The comparator wont be used in the final set for equality or removing duplicates, it's only here for sorting.
+    //As such it has to be compatible with the standard equality and hashCode implementations.
+    static class Builder<T> {
+
+        private ArrayList<T> members = new ArrayList<T>();
+        private Comparator<T> comparator;
+
+        Builder(int sizeHint, Comparator<T> comparator) {
+            this.members = new ArrayList<>(sizeHint);
+            this.comparator = comparator;
+        }
+
+        Builder(Comparator<T> comparator) {
+            this.members = new ArrayList<>();
+            this.comparator = comparator;
+        }
+
+        Builder<T> add(T value) {
+            members.add(value);
+            return this;
+        }
+
+        Builder<T> addAll(Collection<T> values) {
+            members.addAll(values);
+            return this;
+        }
+
+        SortedArraySet<T> build() {
+            sortAndRemoveDuplicates();
+            return new SortedArraySet<>(members);
+        }
+
+        private void sortAndRemoveDuplicates() {
+            members.sort(comparator);
+            int into = 0;
+            int from = 0;
+            while (from < members.size()) {
+                T firstFrom = members.get(from);
+                members.set(into, firstFrom);
+                into += 1;
+                do {
+                    from += 1;
+                } while (from < members.size() && members.get(from) == firstFrom);
+            }
+            members.subList(into, members.size()).clear();
+        }
+    }
+
+    public static <T> Builder<T> newBuilder(int sizeHint, Comparator<T> comparator) {
+        return new Builder<T>(sizeHint, comparator);
+    }
+
+    public static <T> Builder<T> newBuilder(Comparator<T> comparator) {
+        return new Builder<T>(comparator);
+    }
+
+}
+

--- a/src/main/java/graphql/validation/rules/experimental/overlappingfieldsmerge/TypeAbstractness.java
+++ b/src/main/java/graphql/validation/rules/experimental/overlappingfieldsmerge/TypeAbstractness.java
@@ -1,0 +1,54 @@
+package graphql.validation.rules.experimental.overlappingfieldsmerge;
+
+import graphql.schema.GraphQLCompositeType;
+import graphql.schema.GraphQLObjectType;
+
+import java.util.Objects;
+
+/**
+ * Inspired by Simon Adameit's implementation in Sangria https://github.com/sangria-graphql-org/sangria/pull/12
+ */
+interface TypeAbstractness {
+
+    static TypeAbstractness apply(GraphQLCompositeType parentType) {
+        if (parentType instanceof GraphQLObjectType) {
+            return new Concrete(parentType.getName());
+        }
+        return Abstract.INSTANCE;
+    }
+
+    /**
+     * For the purpose of grouping types for the validation,
+     * we consider abstract types to constitute one group
+     */
+    class Abstract implements TypeAbstractness {
+
+        public static final Abstract INSTANCE = new Abstract();
+    }
+
+    class Concrete implements TypeAbstractness {
+
+        private String name;
+
+        public Concrete(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof Concrete)) {
+                return false;
+            }
+            Concrete concrete = (Concrete) o;
+            return name.equals(concrete.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name);
+        }
+    }
+}

--- a/src/main/java/graphql/validation/rules/experimental/overlappingfieldsmerge/TypeShape.java
+++ b/src/main/java/graphql/validation/rules/experimental/overlappingfieldsmerge/TypeShape.java
@@ -1,0 +1,160 @@
+package graphql.validation.rules.experimental.overlappingfieldsmerge;
+
+import graphql.schema.GraphQLCompositeType;
+import graphql.schema.GraphQLList;
+import graphql.schema.GraphQLNamedOutputType;
+import graphql.schema.GraphQLNonNull;
+import graphql.schema.GraphQLOutputType;
+
+import java.util.Objects;
+
+/**
+ * Inspired by Simon Adameit's implementation in Sangria https://github.com/sangria-graphql-org/sangria/pull/12
+ */
+interface TypeShape {
+
+    static TypeShape apply(GraphQLOutputType outputType) {
+        if (outputType != null) {
+            return new Known(outputType);
+        }
+        return Unknown.INSTANCE;
+    }
+
+    /**
+     * Unknown types are ignored by the validation
+     */
+    class Unknown implements TypeShape {
+
+        public static final Unknown INSTANCE = new Unknown();
+    }
+
+    class Known implements TypeShape {
+
+        private Shape typeShape;
+
+        public Known(GraphQLOutputType outputType) {
+            this.typeShape = Shape.apply(outputType);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o instanceof Known) {
+                return typeShape.equals(((Known) o).typeShape);
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return typeShape.hashCode();
+        }
+    }
+
+    class Shape {
+
+        static Shape apply(GraphQLOutputType type) {
+            if (type instanceof GraphQLNonNull) {
+                return new NonNullShape(Shape.apply((GraphQLOutputType) ((GraphQLNonNull) type).getWrappedType()));
+            }
+            if (type instanceof GraphQLList) {
+                return new ListShape(Shape.apply((GraphQLOutputType) ((GraphQLList) type).getWrappedType()));
+            }
+            if (type instanceof GraphQLCompositeType) {
+                return CompositeShape.INSTANCE;
+            }
+            if (type instanceof GraphQLNamedOutputType) {
+                return new LeafShape(((GraphQLNamedOutputType) type).getName());
+            }
+            throw new IllegalStateException("No mapping for type " + type.getChildren());
+        }
+    }
+
+    class ListShape extends Shape {
+
+        Shape type;
+
+        public ListShape(Shape type) {
+            this.type = type;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof ListShape)) {
+                return false;
+            }
+            ListShape that = (ListShape) o;
+            return type.equals(that.type);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(type);
+        }
+    }
+
+    class NonNullShape extends Shape {
+
+        Known.Shape type;
+
+        public NonNullShape(Shape type) {
+            this.type = type;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof NonNullShape)) {
+                return false;
+            }
+            NonNullShape that = (NonNullShape) o;
+            return type.equals(that.type);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(type);
+        }
+    }
+
+    class LeafShape extends Shape {
+
+        String name;
+
+        public LeafShape(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof LeafShape)) {
+                return false;
+            }
+            LeafShape leafShape = (LeafShape) o;
+            return name.equals(leafShape.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name);
+        }
+    }
+
+    /**
+     * Composite types do not need to match, as we require that the individual selected
+     * fields match recursively.
+     */
+    class CompositeShape extends Shape {
+
+        private static final CompositeShape INSTANCE = new CompositeShape();
+    }
+
+}

--- a/src/test/groovy/graphql/validation/rules/experimental/overlappingfieldsmerge/OverlappingFieldsCanBeMergedExTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/experimental/overlappingfieldsmerge/OverlappingFieldsCanBeMergedExTest.groovy
@@ -1,0 +1,651 @@
+package graphql.validation.rules.experimental.overlappingfieldsmerge
+
+import graphql.TestUtil
+import graphql.TypeResolutionEnvironment
+import graphql.language.Document
+import graphql.language.SourceLocation
+import graphql.parser.Parser
+import graphql.schema.GraphQLObjectType
+import graphql.schema.GraphQLSchema
+import graphql.schema.TypeResolver
+import graphql.validation.LanguageTraversal
+import graphql.validation.RulesVisitor
+import graphql.validation.ValidationContext
+import graphql.validation.ValidationErrorCollector
+import spock.lang.Specification
+
+import static graphql.Scalars.GraphQLInt
+import static graphql.Scalars.GraphQLString
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
+import static graphql.schema.GraphQLList.list
+import static graphql.schema.GraphQLNonNull.nonNull
+import static graphql.schema.GraphQLObjectType.newObject
+import static graphql.schema.GraphQLUnionType.newUnionType
+
+class OverlappingFieldsCanBeMergedExTest extends Specification {
+
+    ValidationErrorCollector errorCollector = new ValidationErrorCollector()
+
+
+    def traverse(String query, GraphQLSchema schema) {
+        if (schema == null) {
+            def objectType3 = newObject()
+                    .name("Test3")
+                    .field(newFieldDefinition().name("a").type(GraphQLString))
+                    .field(newFieldDefinition().name("b").type(GraphQLString))
+                    .build()
+            def objectType2 = newObject()
+                    .name("Test2")
+                    .field(newFieldDefinition().name("a").type(GraphQLString))
+                    .field(newFieldDefinition().name("b").type(GraphQLString))
+                    .field(newFieldDefinition().name("c").type(GraphQLString))
+                    .field(newFieldDefinition().name("d").type(GraphQLString))
+                    .field(newFieldDefinition().name("deepField").type(objectType3))
+
+                    .build()
+            def objectType = newObject()
+                    .name("Test")
+                    .field(newFieldDefinition().name("name").type(GraphQLString))
+                    .field(newFieldDefinition().name("nickname").type(GraphQLString))
+                    .field(newFieldDefinition().name("field").type(objectType2))
+                    .build()
+            schema = GraphQLSchema.newSchema().query(objectType).build()
+        }
+
+        Document document = new Parser().parseDocument(query)
+        ValidationContext validationContext = new ValidationContext(schema, document)
+        OverlappingFieldsCanBeMergedEx overlappingFieldsCanBeMerged = new OverlappingFieldsCanBeMergedEx(validationContext, errorCollector)
+        LanguageTraversal languageTraversal = new LanguageTraversal()
+
+        languageTraversal.traverse(document, new RulesVisitor(validationContext, [overlappingFieldsCanBeMerged]))
+    }
+
+    def "identical fields are ok"() {
+        given:
+        def query = """
+            fragment f on Test{
+                name
+                name
+            }
+        """
+        when:
+        traverse(query, null)
+
+        then:
+        errorCollector.errors.isEmpty()
+    }
+
+    def "two aliases with different targets"() {
+        given:
+        def query = """
+            fragment f on Test{
+                myName : name
+                myName : nickname
+            }
+        """
+        when:
+        traverse(query, null)
+
+        then:
+        errorCollector.getErrors().size() == 1
+        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: myName: name and nickname are different fields"
+        errorCollector.getErrors()[0].locations == [new SourceLocation(3, 17), new SourceLocation(4, 17)]
+    }
+
+    GraphQLSchema unionSchema() {
+        def StringBox = newObject().name("StringBox")
+                .field(newFieldDefinition().name("scalar").type(GraphQLString))
+                .build()
+        def IntBox = newObject().name("IntBox")
+                .field(newFieldDefinition().name("scalar").type(GraphQLInt))
+                .build()
+
+        def NonNullStringBox1 = newObject().name("NonNullStringBox1")
+                .field(newFieldDefinition().name("scalar").type(nonNull(GraphQLString)))
+                .build()
+
+        def NonNullStringBox2 = newObject().name("NonNullStringBox2")
+                .field(newFieldDefinition().name("scalar").type(nonNull(GraphQLString)))
+                .build()
+
+        def ListStringBox1 = newObject().name("ListStringBox1")
+                .field(newFieldDefinition().name("scalar").type(list(GraphQLString)))
+                .build()
+
+        def BoxUnion = newUnionType()
+                .name("BoxUnion")
+                .possibleTypes(StringBox, IntBox, NonNullStringBox1, NonNullStringBox2, ListStringBox1)
+                .typeResolver(new TypeResolver() {
+                    @Override
+                    GraphQLObjectType getType(TypeResolutionEnvironment env) {
+                        return null
+                    }
+                })
+                .build()
+        def QueryRoot = newObject()
+                .name("QueryRoot")
+                .field(newFieldDefinition().name("boxUnion").type(BoxUnion)).build()
+        return GraphQLSchema.newSchema().query(QueryRoot).build()
+    }
+
+    def 'conflicting scalar return types'() {
+        given:
+        def schema = unionSchema()
+        def query = """
+                {
+                    boxUnion {
+                        ...on IntBox {
+                            scalar
+                        }
+                        ...on StringBox {
+                            scalar
+                        }
+                    }
+                }
+        """
+
+        when:
+        traverse(query, schema)
+
+        then:
+        errorCollector.getErrors().size() == 1
+        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: scalar: they return differing types Int and String"
+    }
+
+
+    def 'same wrapped scalar return types'() {
+        given:
+        def schema = unionSchema()
+        def query = """
+                {
+                    boxUnion {
+                        ...on NonNullStringBox1 {
+                            scalar
+                        }
+                        ...on NonNullStringBox2 {
+                            scalar
+                        }
+                    }
+                }
+                """
+
+        when:
+        traverse(query, schema)
+
+        then:
+        errorCollector.errors.isEmpty()
+    }
+
+    def 'not the same non null return types'() {
+        given:
+        def schema = unionSchema()
+        def query = """
+                {
+                    boxUnion {
+                        ...on StringBox {
+                            scalar
+                        }
+                        ...on NonNullStringBox1 {
+                            scalar
+                        }
+                    }
+                }
+                """
+
+        when:
+        traverse(query, schema)
+
+        then:
+        errorCollector.getErrors().size() == 1
+        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: scalar: fields have different nullability shapes"
+    }
+
+    def 'not the same list return types'() {
+        given:
+        def schema = unionSchema()
+        def query = """
+                {
+                    boxUnion {
+                        ...on StringBox {
+                            scalar
+                        }
+                        ...on ListStringBox1 {
+                            scalar
+                        }
+                    }
+                }
+                """
+
+        when:
+        traverse(query, schema)
+
+        then:
+        errorCollector.getErrors().size() == 1
+        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: scalar: fields have different list shapes"
+    }
+
+
+    def 'unique fields'() {
+        given:
+        def query = """
+        fragment uniqueFields on Dog {
+            name
+            nickname
+        }
+        """
+        when:
+        traverse(query, null)
+
+        then:
+        errorCollector.getErrors().isEmpty()
+    }
+
+    def 'identical fields'() {
+        given:
+        def query = """
+        fragment mergeIdenticalFields on Dog {
+            name
+            name
+        }
+        """
+        when:
+        traverse(query, null)
+
+        then:
+        errorCollector.getErrors().isEmpty()
+    }
+
+    def 'identical fields with identical args'() {
+        given:
+        def query = """
+        fragment mergeIdenticalFieldsWithIdenticalArgs on Dog {
+            doesKnowCommand(speed: 5, dogCommand: SIT)
+            doesKnowCommand(dogCommand: SIT, speed: 5)
+        }
+        """
+        when:
+        traverse(query, null)
+
+        then:
+        errorCollector.getErrors().isEmpty()
+    }
+
+    def 'identical fields with identical directives'() {
+        given:
+        def query = """
+        fragment mergeSameFieldsWithSameDirectives on Dog {
+            name @include(if: true)
+            name @include(if: true)
+        }
+        """
+        when:
+        traverse(query, null)
+
+        then:
+        errorCollector.getErrors().isEmpty()
+    }
+
+    def 'different args with different aliases'() {
+        given:
+        def query = """
+        fragment differentArgsWithDifferentAliases on Dog {
+            knowsSit: doesKnowCommand(dogCommand: SIT)
+            knowsDown: doesKnowCommand(dogCommand: DOWN)
+        }
+        """
+        when:
+        traverse(query, null)
+
+        then:
+        errorCollector.getErrors().isEmpty()
+    }
+
+    def 'different directives with different aliases'() {
+        given:
+        def query = """
+                fragment differentDirectivesWithDifferentAliases on Dog {
+            nameIfTrue: name @include(if: true)
+            nameIfFalse: name @include(if: false)
+        }
+        """
+        when:
+        traverse(query, null)
+
+        then:
+        errorCollector.getErrors().isEmpty()
+    }
+
+    def 'Same aliases with different field targets'() {
+        given:
+        def query = """
+        fragment sameAliasesWithDifferentFieldTargets on Dog {
+            fido: name
+            fido: nickname
+        }
+        """
+        when:
+        traverse(query, null)
+
+        then:
+        errorCollector.getErrors().size() == 1
+        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: fido: name and nickname are different fields"
+        errorCollector.getErrors()[0].locations == [new SourceLocation(3, 13), new SourceLocation(4, 13)]
+    }
+
+    def 'Alias masking direct field access'() {
+        given:
+        def query = """
+        fragment aliasMaskingDirectFieldAccess on Dog {
+            name: nickname
+            name
+        }
+         """
+        when:
+        traverse(query, null)
+
+        then:
+        errorCollector.getErrors().size() == 1
+        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: name: nickname and name are different fields"
+        errorCollector.getErrors()[0].locations == [new SourceLocation(3, 13), new SourceLocation(4, 13)]
+    }
+
+    def 'conflicting args'() {
+        given:
+        def query = """
+                fragment conflictingArgs on Dog {
+            doesKnowCommand(dogCommand: SIT)
+            doesKnowCommand(dogCommand: HEEL)
+        }
+        """
+        when:
+        traverse(query, null)
+
+        then:
+        errorCollector.getErrors().size() == 1
+        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: doesKnowCommand: they have differing arguments"
+        errorCollector.getErrors()[0].locations == [new SourceLocation(3, 13), new SourceLocation(4, 13)]
+    }
+
+    //
+    // The rules have been relaxed regarding fragment uniqueness.
+    //
+    // see https://github.com/facebook/graphql/pull/120/files
+    // and https://github.com/graphql/graphql-js/pull/230/files
+    //
+    def "different skip/include directives accepted"() {
+        given:
+        def query = """
+            fragment differentDirectivesWithDifferentAliases on Dog {
+                name @include(if: true)
+                name @include(if: false)
+            }
+        """
+        when:
+        traverse(query, null)
+
+        then:
+        errorCollector.getErrors().isEmpty()
+    }
+
+    def 'encounters conflict in fragments'() {
+        def query = """
+        {
+            ...A
+            ...B
+        }
+        fragment A on Type {
+            x: a
+        }
+        fragment B on Type {
+            x: b
+        }
+        """
+        when:
+        traverse(query, null)
+
+        then:
+        errorCollector.getErrors().size() == 1
+        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: x: a and b are different fields"
+        errorCollector.getErrors()[0].locations == [new SourceLocation(7, 13), new SourceLocation(10, 13)]
+    }
+
+    def 'reports each conflict once'() {
+        def query = """
+        {
+            f1 {
+                ...A
+                ...B
+            }
+            f2 {
+                ...B
+                ...A
+            }
+            f3 {
+                ...A
+                ...B
+                x: c
+            }
+        }
+        fragment A on Type {
+            x: a
+        }
+        fragment B on Type {
+            x: b
+        }
+        """
+        when:
+        traverse(query, null)
+
+        then:
+        errorCollector.getErrors().size() == 4
+
+        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: x: a and b are different fields"
+        errorCollector.getErrors()[0].locations == [new SourceLocation(18, 13), new SourceLocation(21, 13)]
+
+        errorCollector.getErrors()[1].message == "Validation error of type FieldsConflict: x: c and a are different fields"
+        errorCollector.getErrors()[1].locations == [new SourceLocation(14, 17), new SourceLocation(18, 13)]
+
+        errorCollector.getErrors()[2].message == "Validation error of type FieldsConflict: x: c and b are different fields"
+        errorCollector.getErrors()[2].locations == [new SourceLocation(14, 17), new SourceLocation(21, 13)]
+
+        errorCollector.getErrors()[3].message == "Validation error of type FieldsConflict: x: a and b are different fields"
+        errorCollector.getErrors()[3].locations == [new SourceLocation(18, 13), new SourceLocation(21, 13)]
+    }
+
+
+    def 'deep conflict'() {
+        def query = """
+        {
+            field {
+                x: a
+            },
+            field {
+                x: b
+            }
+        }
+        """
+        when:
+        traverse(query, null)
+
+        then:
+        errorCollector.getErrors().size() == 1
+        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: x: a and b are different fields"
+        errorCollector.getErrors()[0].locations.size() == 2
+    }
+
+    def 'deep conflict with multiple issues'() {
+        def query = """
+                {
+                    field {
+                        x: a
+                        y: c
+                    },
+                    field {
+                        x: b
+                        y: d
+                    }
+                }
+                """
+        when:
+        traverse(query, null)
+
+        then:
+        errorCollector.getErrors().size() == 2
+        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: x: a and b are different fields"
+        errorCollector.getErrors()[0].locations.size() == 2
+
+        errorCollector.getErrors()[1].message == "Validation error of type FieldsConflict: y: c and d are different fields"
+        errorCollector.getErrors()[1].locations.size() == 2
+    }
+
+    def 'very deep conflict'() {
+        given:
+        def query = """
+                {
+                    field {
+                        deepField {
+                            x: a
+                        }
+                    },
+                    field {
+                        deepField {
+                            x: b
+                        }
+                    }
+                }
+                """
+        when:
+        traverse(query, null)
+
+        then:
+        errorCollector.getErrors().size() == 1
+        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: x: a and b are different fields"
+        errorCollector.getErrors()[0].locations.size() == 2
+    }
+
+    def 'reports deep conflict to nearest common ancestor'() {
+        def query = """
+                {
+                    field {
+                        deepField {
+                            x: a
+                        }
+                        deepField {
+                            x: b
+                        }
+                    },
+                    field {
+                        deepField {
+                            y
+                        }
+                    }
+                }
+                """
+        when:
+        traverse(query, null)
+
+        then:
+        errorCollector.getErrors().size() == 1
+        errorCollector.getErrors()[0].message == "Validation error of type FieldsConflict: x: a and b are different fields"
+        errorCollector.getErrors()[0].locations.size() == 2
+    }
+
+
+    def "parent type is of List NonNull"() {
+        given:
+        def query = """
+        query (\$id: String!) {
+          services(ids: [\$id]) {
+            componentInfoLocationUrl
+            ...ComponentInformation
+          }
+        }
+
+        fragment ComponentInformation on Component {
+          componentInfoLocationUrl
+        }
+"""
+        def schema = TestUtil.schema("""
+    type Query {
+      services(ids: [String!]): [Component!]
+    }
+
+    type Component {
+      componentInfoLocationUrl: String!
+    }
+""")
+        when:
+        traverse(query, schema)
+
+
+        then:
+        errorCollector.getErrors().size() == 0
+
+    }
+
+    def "parent type is of List List NonNull"() {
+        given:
+        def query = """
+        query (\$id: String!) {
+          services(ids: [\$id]) {
+            componentInfoLocationUrl
+            ...ComponentInformation
+          }
+        }
+
+        fragment ComponentInformation on Component {
+          componentInfoLocationUrl
+        }
+"""
+        def schema = TestUtil.schema("""
+    type Query {
+      services(ids: [String!]): [[Component!]]
+    }
+
+    type Component {
+      componentInfoLocationUrl: String!
+    }
+""")
+        when:
+        traverse(query, schema)
+
+
+        then:
+        errorCollector.getErrors().size() == 0
+
+    }
+
+    def "parent type is of List NonNull and field is nullable"() {
+        given:
+        def query = """
+        query (\$id: String!) {
+          services(ids: [\$id]) {
+            componentInfoLocationUrl
+            ...ComponentInformation
+          }
+        }
+
+        fragment ComponentInformation on Component {
+          componentInfoLocationUrl
+        }
+"""
+        def schema = TestUtil.schema("""
+    type Query {
+      services(ids: [String!]): [Component!]
+    }
+
+    type Component {
+      componentInfoLocationUrl: String
+    }
+""")
+        when:
+        traverse(query, schema)
+
+
+        then:
+        errorCollector.getErrors().size() == 0
+
+    }
+
+
+}


### PR DESCRIPTION
fixes #1786

Largely based on scala implementation in sangria project: https://github.com/sangria-graphql-org/sangria/pull/12

The code is almost one-to-one rewrite from scala implementation in sangria to graphql-java. Most of the stuff still has scala-like flavour to it (wanted to leave as close to the scala for syncing further development, if any).

See below the performance improvement on our most complex query.

![old](https://user-images.githubusercontent.com/158482/78688587-b491dc00-78f5-11ea-8d93-7977f371dc5a.png)
![new](https://user-images.githubusercontent.com/158482/78688592-b5c30900-78f5-11ea-92cf-76181ea3a676.png)
