### PR TITLE
Added test that shows NPE issue with query complexity 

### DIFF
--- a/src/test/groovy/graphql/analysis/MaxQueryComplexityInstrumentationTest.groovy
+++ b/src/test/groovy/graphql/analysis/MaxQueryComplexityInstrumentationTest.groovy
@@ -189,6 +189,28 @@ class MaxQueryComplexityInstrumentationTest extends Specification {
         test == true
         notThrown(Exception)
     }
+
+    def "complexity with default query variables"() {
+        given:
+        def schema = TestUtil.schema("""
+            type Query{
+                hello(name: String): String
+            }            
+        """)
+        def query = createQuery("""
+            query Hello(\$name:String="Someone") {
+                hello(name: \$name)
+            } 
+            """)
+        MaxQueryComplexityInstrumentation queryComplexityInstrumentation = new MaxQueryComplexityInstrumentation(0)
+        ExecutionInput executionInput = Mock(ExecutionInput)
+        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, null)
+        InstrumentationContext instrumentationContext = queryComplexityInstrumentation.beginValidation(validationParameters)
+        when:
+        instrumentationContext.onCompleted(null, null)
+        then:
+        notThrown(NullPointerException)
+    }
 }
 
 


### PR DESCRIPTION
Calculating query complexity for the following query fails with a NullPointerException.

```
query Hello($name:String="Someone") {
    hello(name: $name)
}
```
The critical bit is the default value for the `$name` variable. Without a default value the NPE doesn't happen.

I've added a test that currently fails and shows the issue. The NPE is thrown in `NodeVisitorWithTypeTracking` (line 238). I don't understand the visitor code well enough to correctly fix the issue, but the test should be helpful doing so.