### PR TITLE
1865: Do not visit a variable definition value node

### DIFF
--- a/src/main/java/graphql/analysis/NodeVisitorWithTypeTracking.java
+++ b/src/main/java/graphql/analysis/NodeVisitorWithTypeTracking.java
@@ -15,6 +15,7 @@ import graphql.language.NodeVisitorStub;
 import graphql.language.ObjectField;
 import graphql.language.TypeName;
 import graphql.language.Value;
+import graphql.language.VariableDefinition;
 import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLCodeRegistry;
 import graphql.schema.GraphQLCompositeType;
@@ -232,6 +233,10 @@ public class NodeVisitorWithTypeTracking extends NodeVisitorStub {
 
     @Override
     protected TraversalControl visitValue(Value<?> value, TraverserContext<Node> context) {
+        if (context.getParentNode() instanceof VariableDefinition) {
+            return TraversalControl.CONTINUE;
+        }
+
         QueryVisitorFieldArgumentEnvironment fieldArgEnv = context.getVarFromParents(QueryVisitorFieldArgumentEnvironment.class);
         QueryVisitorFieldArgumentInputValueImpl inputValue = context.getVarFromParents(QueryVisitorFieldArgumentInputValue.class);
         // previous visits have set up the previous information

--- a/src/test/groovy/graphql/analysis/MaxQueryComplexityInstrumentationTest.groovy
+++ b/src/test/groovy/graphql/analysis/MaxQueryComplexityInstrumentationTest.groovy
@@ -189,6 +189,30 @@ class MaxQueryComplexityInstrumentationTest extends Specification {
         test == true
         notThrown(Exception)
     }
+
+    def "complexity with default query variables"() {
+        given:
+        def schema = TestUtil.schema("""
+            type Query{
+                hello(name: String): String
+            }            
+        """)
+        def query = createQuery("""
+            query Hello(\$name:String = "Someone") {
+                hello(name: \$name)
+            } 
+            """)
+
+        MaxQueryComplexityInstrumentation queryComplexityInstrumentation = new MaxQueryComplexityInstrumentation(0)
+        ExecutionInput executionInput = Mock(ExecutionInput)
+        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, null)
+        InstrumentationContext instrumentationContext = queryComplexityInstrumentation.beginValidation(validationParameters)
+        when:
+        instrumentationContext.onCompleted(null, null)
+        then:
+        def e = thrown(AbortExecutionException)
+        e.message == "maximum query complexity exceeded 1 > 0"
+    }
 }
 
 


### PR DESCRIPTION
There are no visitors for Variable Definitions, so trying to visit
its value to extract data in order to create an environment object
will throw an NPE.

fix #1865