### PR TITLE
Add a lazy assert to prevent unnecessary function calls. 

### DIFF
--- a/src/main/java/graphql/Assert.java
+++ b/src/main/java/graphql/Assert.java
@@ -1,6 +1,8 @@
 package graphql;
 
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.function.Supplier;
 
 import static java.lang.String.format;
 
@@ -74,6 +76,13 @@ public class Assert {
             return;
         }
         throw new AssertException(format(format, args));
+    }
+
+    public static void assertTrueLazily(boolean condition, String format, Supplier<?>... args) {
+        if (condition) {
+            return;
+        }
+        throw new AssertException(format(format, Arrays.stream(args).map(Supplier::get).toArray()));
     }
 
     public static void assertTrue(boolean condition) {

--- a/src/main/java/graphql/schema/GraphQLNonNull.java
+++ b/src/main/java/graphql/schema/GraphQLNonNull.java
@@ -7,9 +7,10 @@ import graphql.util.TraverserContext;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Supplier;
 
 import static graphql.Assert.assertNotNull;
-import static graphql.Assert.assertTrue;
+import static graphql.Assert.assertTrueLazily;
 
 /**
  * A modified type that indicates there the underlying wrapped type will not be null.
@@ -46,8 +47,8 @@ public class GraphQLNonNull implements GraphQLType, GraphQLInputType, GraphQLOut
     }
 
     private void assertNonNullWrapping(GraphQLType wrappedType) {
-        assertTrue(!GraphQLTypeUtil.isNonNull(wrappedType), String.format("A non null type cannot wrap an existing non null type '%s'",
-                GraphQLTypeUtil.simplePrint(wrappedType)));
+        assertTrueLazily(!GraphQLTypeUtil.isNonNull(wrappedType), "A non null type cannot wrap an existing non null type '%s'",
+             () -> GraphQLTypeUtil.simplePrint(wrappedType));
     }
 
     @Override

--- a/src/test/groovy/graphql/AssertTest.groovy
+++ b/src/test/groovy/graphql/AssertTest.groovy
@@ -2,6 +2,8 @@ package graphql
 
 import spock.lang.Specification
 
+import java.util.function.Supplier
+
 class AssertTest extends Specification {
     def "assertNull should not throw on none null value"() {
         when:
@@ -108,6 +110,29 @@ class AssertTest extends Specification {
     def "assertTrue with error message should throw on false value with formatted message"() {
         when:
         Assert.assertTrue(false, format, arg)
+
+        then:
+        def error = thrown(AssertException)
+        error.message == expectedMessage
+
+        where:
+        format     | arg   || expectedMessage
+        "error %s" | "msg" || "error msg"
+        "code %d"  | 1     || "code 1"
+        "code"     | null  || "code"
+    }
+
+    def "assertTrueLazily should not throw on true value"() {
+        when:
+        Assert.assertTrueLazily(true, "error message")
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "assertTrueLazily with error message should throw on false value with formatted message"() {
+        when:
+        Assert.assertTrueLazily(false, format, { _ -> arg} as Supplier)
 
         then:
         def error = thrown(AssertException)


### PR DESCRIPTION
This lazy assert is to improve the performance of `GraphQLNonNull.assertNonNullWrapping()`.

When performance testing our execution engine that uses graphql-java, `GraphQLTypeUtil.simplePrint()` stood out as a hot method. The hot code path is when `simplePrint` is called to supply a parameter to `Assert.assertTrue()`:

```
   private void assertNonNullWrapping(GraphQLType wrappedType) {
        assertTrue(!GraphQLTypeUtil.isNonNull(wrappedType), String.format("A non null type cannot wrap an existing non null type '%s'",
                GraphQLTypeUtil.simplePrint(wrappedType)));
    }
```
However, the result of `simplePrint` is only used if there's an error. I added a new lazy assertTrue function and used it in the above code snippet so that `simplePrint` will only be called if it is actually used.