### PR TITLE
1898 fix field redefinition in extensions

### DIFF
--- a/src/main/antlr/GraphqlSDL.g4
+++ b/src/main/antlr/GraphqlSDL.g4
@@ -76,7 +76,8 @@ interfaceTypeDefinition : description? INTERFACE name implementsInterfaces? dire
 
 interfaceTypeExtensionDefinition :
     EXTEND INTERFACE name implementsInterfaces? directives? extensionFieldsDefinition |
-    EXTEND INTERFACE name implementsInterfaces? directives emptyParentheses?
+    EXTEND INTERFACE name implementsInterfaces? directives emptyParentheses? |
+    EXTEND INTERFACE name implementsInterfaces
 ;
 
 

--- a/src/main/antlr/GraphqlSDL.g4
+++ b/src/main/antlr/GraphqlSDL.g4
@@ -72,11 +72,11 @@ argumentsDefinition : '(' inputValueDefinition+ ')';
 
 inputValueDefinition : description? name ':' type defaultValue? directives?;
 
-interfaceTypeDefinition : description? INTERFACE name directives? fieldsDefinition?;
+interfaceTypeDefinition : description? INTERFACE name implementsInterfaces? directives? fieldsDefinition?;
 
 interfaceTypeExtensionDefinition :
-    EXTEND INTERFACE name directives? extensionFieldsDefinition |
-    EXTEND INTERFACE name directives emptyParentheses?
+    EXTEND INTERFACE name implementsInterfaces? directives? extensionFieldsDefinition |
+    EXTEND INTERFACE name implementsInterfaces? directives emptyParentheses?
 ;
 
 

--- a/src/main/java/graphql/introspection/IntrospectionResultToSchema.java
+++ b/src/main/java/graphql/introspection/IntrospectionResultToSchema.java
@@ -20,7 +20,6 @@ import graphql.language.ObjectTypeDefinition;
 import graphql.language.OperationTypeDefinition;
 import graphql.language.ScalarTypeDefinition;
 import graphql.language.SchemaDefinition;
-import graphql.language.SourceLocation;
 import graphql.language.StringValue;
 import graphql.language.Type;
 import graphql.language.TypeDefinition;
@@ -185,6 +184,13 @@ public class IntrospectionResultToSchema {
 
         InterfaceTypeDefinition.Builder interfaceTypeDefinition = InterfaceTypeDefinition.newInterfaceTypeDefinition().name((String) input.get("name"));
         interfaceTypeDefinition.description(toDescription(input));
+        if (input.containsKey("interfaces") && input.get("interfaces") != null) {
+            interfaceTypeDefinition.implementz(
+                    ((List<Map<String, Object>>) input.get("interfaces")).stream()
+                            .map(this::createTypeIndirection)
+                            .collect(Collectors.toList())
+            );
+        }
         List<Map<String, Object>> fields = (List<Map<String, Object>>) input.get("fields");
         interfaceTypeDefinition.definitions(createFields(fields));
 

--- a/src/main/java/graphql/introspection/IntrospectionResultToSchema.java
+++ b/src/main/java/graphql/introspection/IntrospectionResultToSchema.java
@@ -27,6 +27,7 @@ import graphql.language.TypeName;
 import graphql.language.UnionTypeDefinition;
 import graphql.language.Value;
 import graphql.schema.idl.ScalarInfo;
+import graphql.util.FpKit;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -186,9 +187,10 @@ public class IntrospectionResultToSchema {
         interfaceTypeDefinition.description(toDescription(input));
         if (input.containsKey("interfaces") && input.get("interfaces") != null) {
             interfaceTypeDefinition.implementz(
-                    ((List<Map<String, Object>>) input.get("interfaces")).stream()
-                            .map(this::createTypeIndirection)
-                            .collect(Collectors.toList())
+                    FpKit.map(
+                            (List<Map<String, Object>>) input.get("interfaces"),
+                            this::createTypeIndirection
+                    )
             );
         }
         List<Map<String, Object>> fields = (List<Map<String, Object>>) input.get("fields");

--- a/src/main/java/graphql/language/AstSorter.java
+++ b/src/main/java/graphql/language/AstSorter.java
@@ -178,6 +178,7 @@ public class AstSorter {
             public TraversalControl visitInterfaceTypeDefinition(InterfaceTypeDefinition node, TraverserContext<Node> context) {
                 InterfaceTypeDefinition changedNode = node.transform(builder -> {
                     builder.directives(sort(node.getDirectives(), comparing(Directive::getName)));
+                    builder.implementz(sort(node.getImplements(), comparingTypes()));
                     builder.definitions(sort(node.getFieldDefinitions(), comparing(FieldDefinition::getName)));
                 });
                 return changeNode(context, changedNode);

--- a/src/main/java/graphql/language/ImplementingTypeDefinition.java
+++ b/src/main/java/graphql/language/ImplementingTypeDefinition.java
@@ -1,0 +1,19 @@
+package graphql.language;
+
+
+import graphql.PublicApi;
+
+import java.util.List;
+
+/**
+ * A {@link TypeDefinition} that might implement interfaces
+ *
+ * @param <T>
+ */
+@PublicApi
+public interface ImplementingTypeDefinition<T extends ImplementingTypeDefinition> extends TypeDefinition<T> {
+
+    List<Type> getImplements();
+
+    List<FieldDefinition> getFieldDefinitions();
+}

--- a/src/main/java/graphql/language/ImplementingTypeDefinition.java
+++ b/src/main/java/graphql/language/ImplementingTypeDefinition.java
@@ -11,7 +11,7 @@ import java.util.List;
  * @param <T>
  */
 @PublicApi
-public interface ImplementingTypeDefinition<T extends ImplementingTypeDefinition> extends TypeDefinition<T> {
+public interface ImplementingTypeDefinition<T extends TypeDefinition> extends TypeDefinition<T> {
 
     List<Type> getImplements();
 

--- a/src/main/java/graphql/language/InterfaceTypeDefinition.java
+++ b/src/main/java/graphql/language/InterfaceTypeDefinition.java
@@ -17,17 +17,20 @@ import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 import static java.util.Collections.emptyMap;
 
 @PublicApi
-public class InterfaceTypeDefinition extends AbstractDescribedNode<InterfaceTypeDefinition> implements TypeDefinition<InterfaceTypeDefinition>, DirectivesContainer<InterfaceTypeDefinition>, NamedNode<InterfaceTypeDefinition> {
+public class InterfaceTypeDefinition extends AbstractDescribedNode<InterfaceTypeDefinition> implements ImplementingTypeDefinition<InterfaceTypeDefinition>, DirectivesContainer<InterfaceTypeDefinition>, NamedNode<InterfaceTypeDefinition> {
 
     private final String name;
+    private final List<Type> implementz;
     private final List<FieldDefinition> definitions;
     private final List<Directive> directives;
 
+    public static final String CHILD_IMPLEMENTZ = "implementz";
     public static final String CHILD_DEFINITIONS = "definitions";
     public static final String CHILD_DIRECTIVES = "directives";
 
     @Internal
     protected InterfaceTypeDefinition(String name,
+                                      List<Type> implementz,
                                       List<FieldDefinition> definitions,
                                       List<Directive> directives,
                                       Description description,
@@ -37,6 +40,7 @@ public class InterfaceTypeDefinition extends AbstractDescribedNode<InterfaceType
                                       Map<String, String> additionalData) {
         super(sourceLocation, comments, ignoredChars, additionalData, description);
         this.name = name;
+        this.implementz = implementz;
         this.definitions = definitions;
         this.directives = directives;
     }
@@ -47,9 +51,15 @@ public class InterfaceTypeDefinition extends AbstractDescribedNode<InterfaceType
      * @param name of the interface
      */
     public InterfaceTypeDefinition(String name) {
-        this(name, new ArrayList<>(), new ArrayList<>(), null, null, new ArrayList<>(), IgnoredChars.EMPTY, emptyMap());
+        this(name, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), null, null, new ArrayList<>(), IgnoredChars.EMPTY, emptyMap());
     }
 
+    @Override
+    public List<Type> getImplements() {
+        return new ArrayList<>(implementz);
+    }
+
+    @Override
     public List<FieldDefinition> getFieldDefinitions() {
         return new ArrayList<>(definitions);
     }
@@ -67,6 +77,7 @@ public class InterfaceTypeDefinition extends AbstractDescribedNode<InterfaceType
     @Override
     public List<Node> getChildren() {
         List<Node> result = new ArrayList<>();
+        result.addAll(implementz);
         result.addAll(definitions);
         result.addAll(directives);
         return result;
@@ -75,6 +86,7 @@ public class InterfaceTypeDefinition extends AbstractDescribedNode<InterfaceType
     @Override
     public NodeChildrenContainer getNamedChildren() {
         return newNodeChildrenContainer()
+                .children(CHILD_IMPLEMENTZ, implementz)
                 .children(CHILD_DEFINITIONS, definitions)
                 .children(CHILD_DIRECTIVES, directives)
                 .build();
@@ -83,6 +95,7 @@ public class InterfaceTypeDefinition extends AbstractDescribedNode<InterfaceType
     @Override
     public InterfaceTypeDefinition withNewChildren(NodeChildrenContainer newChildren) {
         return transform(builder -> builder
+                .implementz(newChildren.getChildren(CHILD_IMPLEMENTZ))
                 .definitions(newChildren.getChildren(CHILD_DEFINITIONS))
                 .directives(newChildren.getChildren(CHILD_DIRECTIVES))
         );
@@ -105,6 +118,7 @@ public class InterfaceTypeDefinition extends AbstractDescribedNode<InterfaceType
     @Override
     public InterfaceTypeDefinition deepCopy() {
         return new InterfaceTypeDefinition(name,
+                deepCopy(implementz),
                 deepCopy(definitions),
                 deepCopy(directives),
                 description,
@@ -118,6 +132,7 @@ public class InterfaceTypeDefinition extends AbstractDescribedNode<InterfaceType
     public String toString() {
         return "InterfaceTypeDefinition{" +
                 "name='" + name + '\'' +
+                ", implements=" + implementz +
                 ", fieldDefinitions=" + definitions +
                 ", directives=" + directives +
                 '}';
@@ -144,6 +159,7 @@ public class InterfaceTypeDefinition extends AbstractDescribedNode<InterfaceType
         private List<Comment> comments = new ArrayList<>();
         private String name;
         private Description description;
+        private List<Type> implementz = new ArrayList<>();
         private List<FieldDefinition> definitions = new ArrayList<>();
         private List<Directive> directives = new ArrayList<>();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
@@ -185,6 +201,17 @@ public class InterfaceTypeDefinition extends AbstractDescribedNode<InterfaceType
             return this;
         }
 
+        public Builder implementz(List<Type> implementz) {
+            this.implementz = implementz;
+            return this;
+        }
+
+        public Builder implementz(Type implement) {
+            this.implementz.add(implement);
+            return this;
+        }
+
+
         public Builder definitions(List<FieldDefinition> definitions) {
             this.definitions = definitions;
             return this;
@@ -223,6 +250,7 @@ public class InterfaceTypeDefinition extends AbstractDescribedNode<InterfaceType
 
         public InterfaceTypeDefinition build() {
             return new InterfaceTypeDefinition(name,
+                    implementz,
                     definitions,
                     directives,
                     description,

--- a/src/main/java/graphql/language/InterfaceTypeExtensionDefinition.java
+++ b/src/main/java/graphql/language/InterfaceTypeExtensionDefinition.java
@@ -16,6 +16,7 @@ public class InterfaceTypeExtensionDefinition extends InterfaceTypeDefinition {
 
     @Internal
     protected InterfaceTypeExtensionDefinition(String name,
+                                               List<Type> implementz,
                                                List<FieldDefinition> definitions,
                                                List<Directive> directives,
                                                Description description,
@@ -23,12 +24,13 @@ public class InterfaceTypeExtensionDefinition extends InterfaceTypeDefinition {
                                                List<Comment> comments,
                                                IgnoredChars ignoredChars,
                                                Map<String, String> additionalData) {
-        super(name, definitions, directives, description, sourceLocation, comments, ignoredChars, additionalData);
+        super(name, implementz, definitions, directives, description, sourceLocation, comments, ignoredChars, additionalData);
     }
 
     @Override
     public InterfaceTypeExtensionDefinition deepCopy() {
         return new InterfaceTypeExtensionDefinition(getName(),
+                getImplements(),
                 deepCopy(getFieldDefinitions()),
                 deepCopy(getDirectives()),
                 getDescription(),
@@ -63,6 +65,7 @@ public class InterfaceTypeExtensionDefinition extends InterfaceTypeDefinition {
         private List<Comment> comments = new ArrayList<>();
         private String name;
         private Description description;
+        private List<Type> implementz = new ArrayList<>();
         private List<FieldDefinition> definitions = new ArrayList<>();
         private List<Directive> directives = new ArrayList<>();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
@@ -77,6 +80,7 @@ public class InterfaceTypeExtensionDefinition extends InterfaceTypeDefinition {
             this.name = existing.getName();
             this.description = existing.getDescription();
             this.directives = existing.getDirectives();
+            this.implementz = existing.getImplements();
             this.definitions = existing.getFieldDefinitions();
             this.ignoredChars = existing.getIgnoredChars();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
@@ -99,6 +103,16 @@ public class InterfaceTypeExtensionDefinition extends InterfaceTypeDefinition {
 
         public Builder description(Description description) {
             this.description = description;
+            return this;
+        }
+
+        public Builder implementz(List<Type> implementz) {
+            this.implementz = implementz;
+            return this;
+        }
+
+        public Builder implementz(Type implementz) {
+            this.implementz.add(implementz);
             return this;
         }
 
@@ -130,6 +144,7 @@ public class InterfaceTypeExtensionDefinition extends InterfaceTypeDefinition {
 
         public InterfaceTypeExtensionDefinition build() {
             return new InterfaceTypeExtensionDefinition(name,
+                    implementz,
                     definitions,
                     directives,
                     description,

--- a/src/main/java/graphql/language/ObjectTypeDefinition.java
+++ b/src/main/java/graphql/language/ObjectTypeDefinition.java
@@ -17,7 +17,7 @@ import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 import static java.util.Collections.emptyMap;
 
 @PublicApi
-public class ObjectTypeDefinition extends AbstractDescribedNode<ObjectTypeDefinition> implements TypeDefinition<ObjectTypeDefinition>, DirectivesContainer<ObjectTypeDefinition>, NamedNode<ObjectTypeDefinition> {
+public class ObjectTypeDefinition extends AbstractDescribedNode<ObjectTypeDefinition> implements ImplementingTypeDefinition<ObjectTypeDefinition>, DirectivesContainer<ObjectTypeDefinition>, NamedNode<ObjectTypeDefinition> {
     private final String name;
     private final List<Type> implementz;
     private final List<Directive> directives;
@@ -53,6 +53,7 @@ public class ObjectTypeDefinition extends AbstractDescribedNode<ObjectTypeDefini
         this(name, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), null, null, new ArrayList<>(), IgnoredChars.EMPTY, emptyMap());
     }
 
+    @Override
     public List<Type> getImplements() {
         return new ArrayList<>(implementz);
     }
@@ -62,6 +63,7 @@ public class ObjectTypeDefinition extends AbstractDescribedNode<ObjectTypeDefini
         return new ArrayList<>(directives);
     }
 
+    @Override
     public List<FieldDefinition> getFieldDefinitions() {
         return new ArrayList<>(fieldDefinitions);
     }

--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -60,6 +60,7 @@ import graphql.language.VariableDefinition;
 import graphql.language.VariableReference;
 import graphql.parser.antlr.GraphqlLexer;
 import graphql.parser.antlr.GraphqlParser;
+import graphql.util.FpKit;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
@@ -882,7 +883,8 @@ public class GraphqlAntlrToLanguage {
     private List<Type> getImplementz(GraphqlParser.ImplementsInterfacesContext implementsInterfacesContext) {
         List<Type> implementz = new ArrayList<>();
         while (implementsInterfacesContext != null) {
-            List<TypeName> typeNames = implementsInterfacesContext.typeName().stream().map(this::createTypeName).collect(toList());
+            List<TypeName> typeNames = FpKit.map(implementsInterfacesContext.typeName(), this::createTypeName);
+
             implementz.addAll(0, typeNames);
             implementsInterfacesContext = implementsInterfacesContext.implementsInterfaces();
         }

--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -433,6 +433,7 @@ public class GraphqlAntlrToLanguage {
         def.description(newDescription(ctx.description()));
         def.directives(createDirectives(ctx.directives()));
         GraphqlParser.ImplementsInterfacesContext implementsInterfacesContext = ctx.implementsInterfaces();
+        // TODO maybe extract to private method to avoid duplication
         List<Type> implementz = new ArrayList<>();
         while (implementsInterfacesContext != null) {
             List<TypeName> typeNames = implementsInterfacesContext.typeName().stream().map(this::createTypeName).collect(toList());
@@ -517,6 +518,14 @@ public class GraphqlAntlrToLanguage {
         addCommonData(def, ctx);
         def.description(newDescription(ctx.description()));
         def.directives(createDirectives(ctx.directives()));
+        GraphqlParser.ImplementsInterfacesContext implementsInterfacesContext = ctx.implementsInterfaces();
+        List<Type> implementz = new ArrayList<>();
+        while (implementsInterfacesContext != null) {
+            List<TypeName> typeNames = implementsInterfacesContext.typeName().stream().map(this::createTypeName).collect(toList());
+            implementz.addAll(0, typeNames);
+            implementsInterfacesContext = implementsInterfacesContext.implementsInterfaces();
+        }
+        def.implementz(implementz);
         def.definitions(createFieldDefinitions(ctx.fieldsDefinition()));
         return def.build();
     }
@@ -526,6 +535,14 @@ public class GraphqlAntlrToLanguage {
         def.name(ctx.name().getText());
         addCommonData(def, ctx);
         def.directives(createDirectives(ctx.directives()));
+        GraphqlParser.ImplementsInterfacesContext implementsInterfacesContext = ctx.implementsInterfaces();
+        List<Type> implementz = new ArrayList<>();
+        while (implementsInterfacesContext != null) {
+            List<TypeName> typeNames = implementsInterfacesContext.typeName().stream().map(this::createTypeName).collect(toList());
+            implementz.addAll(0, typeNames);
+            implementsInterfacesContext = implementsInterfacesContext.implementsInterfaces();
+        }
+        def.implementz(implementz);
         def.definitions(createFieldDefinitions(ctx.extensionFieldsDefinition()));
         return def.build();
     }

--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -433,13 +433,7 @@ public class GraphqlAntlrToLanguage {
         def.description(newDescription(ctx.description()));
         def.directives(createDirectives(ctx.directives()));
         GraphqlParser.ImplementsInterfacesContext implementsInterfacesContext = ctx.implementsInterfaces();
-        // TODO maybe extract to private method to avoid duplication
-        List<Type> implementz = new ArrayList<>();
-        while (implementsInterfacesContext != null) {
-            List<TypeName> typeNames = implementsInterfacesContext.typeName().stream().map(this::createTypeName).collect(toList());
-            implementz.addAll(0, typeNames);
-            implementsInterfacesContext = implementsInterfacesContext.implementsInterfaces();
-        }
+        List<Type> implementz = getImplementz(implementsInterfacesContext);
         def.implementz(implementz);
         if (ctx.fieldsDefinition() != null) {
             def.fieldDefinitions(createFieldDefinitions(ctx.fieldsDefinition()));
@@ -453,12 +447,7 @@ public class GraphqlAntlrToLanguage {
         addCommonData(def, ctx);
         def.directives(createDirectives(ctx.directives()));
         GraphqlParser.ImplementsInterfacesContext implementsInterfacesContext = ctx.implementsInterfaces();
-        List<Type> implementz = new ArrayList<>();
-        while (implementsInterfacesContext != null) {
-            List<TypeName> typeNames = implementsInterfacesContext.typeName().stream().map(this::createTypeName).collect(toList());
-            implementz.addAll(0, typeNames);
-            implementsInterfacesContext = implementsInterfacesContext.implementsInterfaces();
-        }
+        List<Type> implementz = getImplementz(implementsInterfacesContext);
         def.implementz(implementz);
         if (ctx.extensionFieldsDefinition() != null) {
             def.fieldDefinitions(createFieldDefinitions(ctx.extensionFieldsDefinition()));
@@ -519,12 +508,7 @@ public class GraphqlAntlrToLanguage {
         def.description(newDescription(ctx.description()));
         def.directives(createDirectives(ctx.directives()));
         GraphqlParser.ImplementsInterfacesContext implementsInterfacesContext = ctx.implementsInterfaces();
-        List<Type> implementz = new ArrayList<>();
-        while (implementsInterfacesContext != null) {
-            List<TypeName> typeNames = implementsInterfacesContext.typeName().stream().map(this::createTypeName).collect(toList());
-            implementz.addAll(0, typeNames);
-            implementsInterfacesContext = implementsInterfacesContext.implementsInterfaces();
-        }
+        List<Type> implementz = getImplementz(implementsInterfacesContext);
         def.implementz(implementz);
         def.definitions(createFieldDefinitions(ctx.fieldsDefinition()));
         return def.build();
@@ -536,12 +520,7 @@ public class GraphqlAntlrToLanguage {
         addCommonData(def, ctx);
         def.directives(createDirectives(ctx.directives()));
         GraphqlParser.ImplementsInterfacesContext implementsInterfacesContext = ctx.implementsInterfaces();
-        List<Type> implementz = new ArrayList<>();
-        while (implementsInterfacesContext != null) {
-            List<TypeName> typeNames = implementsInterfacesContext.typeName().stream().map(this::createTypeName).collect(toList());
-            implementz.addAll(0, typeNames);
-            implementsInterfacesContext = implementsInterfacesContext.implementsInterfaces();
-        }
+        List<Type> implementz = getImplementz(implementsInterfacesContext);
         def.implementz(implementz);
         def.definitions(createFieldDefinitions(ctx.extensionFieldsDefinition()));
         return def.build();
@@ -899,4 +878,14 @@ public class GraphqlAntlrToLanguage {
         return comments;
     }
 
+
+    private List<Type> getImplementz(GraphqlParser.ImplementsInterfacesContext implementsInterfacesContext) {
+        List<Type> implementz = new ArrayList<>();
+        while (implementsInterfacesContext != null) {
+            List<TypeName> typeNames = implementsInterfacesContext.typeName().stream().map(this::createTypeName).collect(toList());
+            implementz.addAll(0, typeNames);
+            implementsInterfacesContext = implementsInterfacesContext.implementsInterfaces();
+        }
+        return implementz;
+    }
 }

--- a/src/main/java/graphql/schema/idl/ImplementingTypesChecker.java
+++ b/src/main/java/graphql/schema/idl/ImplementingTypesChecker.java
@@ -1,0 +1,207 @@
+package graphql.schema.idl;
+
+import graphql.GraphQLError;
+import graphql.Internal;
+import graphql.language.AstPrinter;
+import graphql.language.FieldDefinition;
+import graphql.language.ImplementingTypeDefinition;
+import graphql.language.InputValueDefinition;
+import graphql.language.InterfaceTypeDefinition;
+import graphql.language.InterfaceTypeExtensionDefinition;
+import graphql.language.NonNullType;
+import graphql.language.ObjectTypeDefinition;
+import graphql.language.ObjectTypeExtensionDefinition;
+import graphql.language.Type;
+import graphql.language.TypeDefinition;
+import graphql.language.TypeName;
+import graphql.schema.idl.errors.InterfaceFieldArgumentNotOptionalError;
+import graphql.schema.idl.errors.InterfaceFieldArgumentRedefinitionError;
+import graphql.schema.idl.errors.InterfaceFieldRedefinitionError;
+import graphql.schema.idl.errors.MissingInterfaceFieldArgumentsError;
+import graphql.schema.idl.errors.MissingInterfaceFieldError;
+import graphql.schema.idl.errors.MissingTransitiveInterfaceError;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BinaryOperator;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * A support class to help break up the large SchemaTypeChecker class.  This handles
+ * the checking of {@link graphql.language.ImplementingTypeDefinition}s.
+ */
+@Internal
+class ImplementingTypesChecker {
+
+    void checkImplementingTypes(List<GraphQLError> errors, TypeDefinitionRegistry typeRegistry) {
+        Map<String, TypeDefinition> typesMap = typeRegistry.types();
+
+        // objects
+        List<ObjectTypeDefinition> objectTypes = filterTo(typesMap, ObjectTypeDefinition.class);
+        objectTypes.forEach(type -> {
+            checkImplementingType(errors, typeRegistry, type, "object");
+        });
+
+
+        List<ObjectTypeExtensionDefinition> objectExtensions = typeRegistry.objectTypeExtensions().values()
+                .stream().flatMap(Collection::stream).collect(toList());
+
+        objectExtensions.forEach(type -> {
+            checkImplementingType(errors, typeRegistry, type, "object extension");
+        });
+
+        // interfaces
+        List<InterfaceTypeDefinition> interfacesTypes = filterTo(typesMap, InterfaceTypeDefinition.class);
+        interfacesTypes.forEach(type -> {
+            checkImplementingType(errors, typeRegistry, type, "interface");
+        });
+
+        List<InterfaceTypeExtensionDefinition> interfaceExtensions = typeRegistry.interfaceTypeExtensions().values()
+                .stream().flatMap(Collection::stream).collect(toList());
+
+        interfaceExtensions.forEach(type -> {
+            checkImplementingType(errors, typeRegistry, type, "interface extension");
+        });
+    }
+
+    private void checkImplementingType(
+            List<GraphQLError> errors,
+            TypeDefinitionRegistry typeRegistry,
+            ImplementingTypeDefinition type,
+            String typeName) {
+
+        List<Type> implementsTypes = type.getImplements();
+        implementsTypes.forEach(checkInterfaceIsImplemented(typeName, typeRegistry, errors, type));
+
+        checkTransitiveInterfacesAreDeclared(typeName, typeRegistry, errors, type, implementsTypes);
+    }
+
+
+    private Consumer<? super Type> checkInterfaceIsImplemented(String typeOfType, TypeDefinitionRegistry typeRegistry, List<GraphQLError> errors, ImplementingTypeDefinition typeDefinition) {
+        return t -> {
+            List<FieldDefinition> fieldDefinitions = typeDefinition.getFieldDefinitions();
+
+            // previous checks handle the missing case and wrong type case
+            toInterfaceTypeDefinition(t, typeRegistry)
+                    .ifPresent(interfaceTypeDef -> {
+                        Map<String, FieldDefinition> objectFields = fieldDefinitions.stream()
+                                .collect(Collectors.toMap(
+                                        FieldDefinition::getName, Function.identity(), mergeFirstValue()
+                                ));
+
+                        interfaceTypeDef.getFieldDefinitions().forEach(interfaceFieldDef -> {
+                            FieldDefinition objectFieldDef = objectFields.get(interfaceFieldDef.getName());
+                            if (objectFieldDef == null) {
+                                errors.add(new MissingInterfaceFieldError(typeOfType, typeDefinition, interfaceTypeDef, interfaceFieldDef));
+                            } else {
+                                if (!typeRegistry.isSubTypeOf(objectFieldDef.getType(), interfaceFieldDef.getType())) {
+                                    String interfaceFieldType = AstPrinter.printAst(interfaceFieldDef.getType());
+                                    String objectFieldType = AstPrinter.printAst(objectFieldDef.getType());
+                                    errors.add(new InterfaceFieldRedefinitionError(typeOfType, typeDefinition, interfaceTypeDef, objectFieldDef, objectFieldType, interfaceFieldType));
+                                }
+
+                                // look at arguments
+                                List<InputValueDefinition> objectArgs = objectFieldDef.getInputValueDefinitions();
+                                List<InputValueDefinition> interfaceArgs = interfaceFieldDef.getInputValueDefinitions();
+                                if (objectArgs.size() < interfaceArgs.size()) {
+                                    errors.add(new MissingInterfaceFieldArgumentsError(typeOfType, typeDefinition, interfaceTypeDef, objectFieldDef));
+                                } else {
+                                    checkArgumentConsistency(typeOfType, typeDefinition, interfaceTypeDef, objectFieldDef, interfaceFieldDef, errors);
+                                }
+                            }
+                        });
+                    });
+        };
+    }
+
+    private void checkTransitiveInterfacesAreDeclared(
+            String typeOfType,
+            TypeDefinitionRegistry typeRegistry,
+            List<GraphQLError> errors,
+            ImplementingTypeDefinition typeDefinition,
+            List<Type> implementsInterfaces
+    ) {
+        Set<String> interfacesToBeImplemented = new HashSet<>();
+
+        findImplementingInterfaces(typeDefinition, typeRegistry, interfacesToBeImplemented);
+
+        Set<String> implementsInterfacesNames = implementsInterfaces.stream()
+                .map(t -> toInterfaceTypeDefinition(t, typeRegistry))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .map(TypeDefinition::getName)
+                .collect(Collectors.toSet());
+
+        Set<String> missingInterfaces = interfacesToBeImplemented.stream()
+                .filter(i -> !implementsInterfacesNames.contains(i))
+                .collect(Collectors.toSet());
+
+        if (!missingInterfaces.isEmpty()) {
+            errors.add(new MissingTransitiveInterfaceError(typeOfType, typeDefinition, missingInterfaces));
+        }
+    }
+
+    private void checkArgumentConsistency(String typeOfType, TypeDefinition objectTypeDef, InterfaceTypeDefinition interfaceTypeDef, FieldDefinition objectFieldDef, FieldDefinition interfaceFieldDef, List<GraphQLError> errors) {
+        List<InputValueDefinition> objectArgs = objectFieldDef.getInputValueDefinitions();
+        List<InputValueDefinition> interfaceArgs = interfaceFieldDef.getInputValueDefinitions();
+        for (int i = 0; i < interfaceArgs.size(); i++) {
+            InputValueDefinition interfaceArg = interfaceArgs.get(i);
+            InputValueDefinition objectArg = objectArgs.get(i);
+            String interfaceArgStr = AstPrinter.printAstCompact(interfaceArg);
+            String objectArgStr = AstPrinter.printAstCompact(objectArg);
+            if (!interfaceArgStr.equals(objectArgStr)) {
+                errors.add(new InterfaceFieldArgumentRedefinitionError(typeOfType, objectTypeDef, interfaceTypeDef, objectFieldDef, objectArgStr, interfaceArgStr));
+            }
+        }
+
+        if (objectArgs.size() > interfaceArgs.size()) {
+            for (int i = interfaceArgs.size(); i < objectArgs.size(); i++) {
+                InputValueDefinition objectArg = objectArgs.get(i);
+                if (objectArg.getType() instanceof NonNullType) {
+                    String objectArgStr = AstPrinter.printAst(objectArg);
+                    errors.add(new InterfaceFieldArgumentNotOptionalError(typeOfType, objectTypeDef, interfaceTypeDef, objectFieldDef, objectArgStr));
+                }
+            }
+        }
+    }
+
+    private <T extends TypeDefinition> List<T> filterTo(Map<String, TypeDefinition> types, Class<? extends T> clazz) {
+        return types.values().stream()
+                .filter(t -> clazz.equals(t.getClass()))
+                .map(clazz::cast)
+                .collect(toList());
+    }
+
+    private <T> BinaryOperator<T> mergeFirstValue() {
+        return (v1, v2) -> v1;
+    }
+
+    private void findImplementingInterfaces(ImplementingTypeDefinition type, TypeDefinitionRegistry typeRegistry, Set<String> allInterfaces) {
+        final List<Type> implementsTypes = type.getImplements();
+
+        implementsTypes.stream()
+                .map(t -> toInterfaceTypeDefinition(t, typeRegistry))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .forEach(t -> {
+                    allInterfaces.add(t.getName());
+                    findImplementingInterfaces(t, typeRegistry, allInterfaces);
+                });
+    }
+
+    private Optional<InterfaceTypeDefinition> toInterfaceTypeDefinition(Type type, TypeDefinitionRegistry typeRegistry) {
+        TypeInfo typeInfo = TypeInfo.typeInfo(type);
+        TypeName unwrapped = typeInfo.getTypeName();
+
+        return typeRegistry.getType(unwrapped, InterfaceTypeDefinition.class);
+    }
+
+}

--- a/src/main/java/graphql/schema/idl/SchemaTypeChecker.java
+++ b/src/main/java/graphql/schema/idl/SchemaTypeChecker.java
@@ -4,7 +4,6 @@ import graphql.GraphQLError;
 import graphql.Internal;
 import graphql.introspection.Introspection;
 import graphql.language.Argument;
-import graphql.language.AstPrinter;
 import graphql.language.Directive;
 import graphql.language.DirectiveDefinition;
 import graphql.language.EnumTypeDefinition;
@@ -14,7 +13,6 @@ import graphql.language.InputObjectTypeDefinition;
 import graphql.language.InputValueDefinition;
 import graphql.language.InterfaceTypeDefinition;
 import graphql.language.Node;
-import graphql.language.NonNullType;
 import graphql.language.ObjectTypeDefinition;
 import graphql.language.ObjectTypeExtensionDefinition;
 import graphql.language.StringValue;
@@ -23,12 +21,7 @@ import graphql.language.TypeDefinition;
 import graphql.language.TypeName;
 import graphql.language.UnionTypeDefinition;
 import graphql.schema.idl.errors.DirectiveIllegalLocationError;
-import graphql.schema.idl.errors.InterfaceFieldArgumentNotOptionalError;
-import graphql.schema.idl.errors.InterfaceFieldArgumentRedefinitionError;
-import graphql.schema.idl.errors.InterfaceFieldRedefinitionError;
 import graphql.schema.idl.errors.InvalidDeprecationDirectiveError;
-import graphql.schema.idl.errors.MissingInterfaceFieldArgumentsError;
-import graphql.schema.idl.errors.MissingInterfaceFieldError;
 import graphql.schema.idl.errors.MissingInterfaceTypeError;
 import graphql.schema.idl.errors.MissingScalarImplementationError;
 import graphql.schema.idl.errors.MissingTypeError;
@@ -47,12 +40,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
-import java.util.function.BinaryOperator;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toList;
 
 /**
  * This helps pre check the state of the type system to ensure it can be made into an executable schema.
@@ -70,7 +63,9 @@ public class SchemaTypeChecker {
 
         typeExtensionsChecker.checkTypeExtensions(errors, typeRegistry);
 
-        checkInterfacesAreImplemented(errors, typeRegistry);
+        ImplementingTypesChecker implementingTypesChecker = new ImplementingTypesChecker();
+
+        implementingTypesChecker.checkImplementingTypes(errors, typeRegistry);
 
         SchemaExtensionsChecker.checkSchemaInvariants(errors, typeRegistry);
 
@@ -90,7 +85,7 @@ public class SchemaTypeChecker {
 
     private void checkForMissingTypes(List<GraphQLError> errors, TypeDefinitionRegistry typeRegistry) {
         // type extensions
-        List<ObjectTypeExtensionDefinition> typeExtensions = typeRegistry.objectTypeExtensions().values().stream().flatMap(Collection::stream).collect(Collectors.toList());
+        List<ObjectTypeExtensionDefinition> typeExtensions = typeRegistry.objectTypeExtensions().values().stream().flatMap(Collection::stream).collect(toList());
         typeExtensions.forEach(typeExtension -> {
 
             List<Type> implementsTypes = typeExtension.getImplements();
@@ -138,7 +133,7 @@ public class SchemaTypeChecker {
             List<InputValueDefinition> inputValueDefinitions = inputType.getInputValueDefinitions();
             List<Type> inputValueTypes = inputValueDefinitions.stream()
                     .map(InputValueDefinition::getType)
-                    .collect(Collectors.toList());
+                    .collect(toList());
 
             inputValueTypes.forEach(checkTypeExists("input value", typeRegistry, errors, inputType));
 
@@ -157,7 +152,7 @@ public class SchemaTypeChecker {
 
             List<Type> inputValueTypes = arguments.stream()
                     .map(InputValueDefinition::getType)
-                    .collect(Collectors.toList());
+                    .collect(toList());
 
             inputValueTypes.forEach(
                     checkTypeExists(typeRegistry, errors, "directive definition", directiveDefinition, directiveDefinition.getName())
@@ -372,16 +367,16 @@ public class SchemaTypeChecker {
     }
 
     private void checkFieldTypesPresent(TypeDefinitionRegistry typeRegistry, List<GraphQLError> errors, TypeDefinition typeDefinition, List<FieldDefinition> fields) {
-        List<Type> fieldTypes = fields.stream().map(FieldDefinition::getType).collect(Collectors.toList());
+        List<Type> fieldTypes = fields.stream().map(FieldDefinition::getType).collect(toList());
         fieldTypes.forEach(checkTypeExists("field", typeRegistry, errors, typeDefinition));
 
         List<Type> fieldInputValues = fields.stream()
                 .map(f -> f.getInputValueDefinitions()
                         .stream()
                         .map(InputValueDefinition::getType)
-                        .collect(Collectors.toList()))
+                        .collect(toList()))
                 .flatMap(Collection::stream)
-                .collect(Collectors.toList());
+                .collect(toList());
 
         fieldInputValues.forEach(checkTypeExists("field input", typeRegistry, errors, typeDefinition));
     }
@@ -418,94 +413,10 @@ public class SchemaTypeChecker {
         };
     }
 
-    private void checkInterfacesAreImplemented(List<GraphQLError> errors, TypeDefinitionRegistry typeRegistry) {
-        Map<String, TypeDefinition> typesMap = typeRegistry.types();
-
-        // objects
-        List<ObjectTypeDefinition> objectTypes = filterTo(typesMap, ObjectTypeDefinition.class);
-        objectTypes.forEach(objectType -> {
-            List<Type> implementsTypes = objectType.getImplements();
-            implementsTypes.forEach(checkInterfaceIsImplemented("object", typeRegistry, errors, objectType));
-        });
-
-        Map<String, List<ObjectTypeExtensionDefinition>> typeExtensions = typeRegistry.objectTypeExtensions();
-        typeExtensions.values().forEach(extList -> extList.forEach(typeExtension -> {
-            List<Type> implementsTypes = typeExtension.getImplements();
-            implementsTypes.forEach(checkInterfaceIsImplemented("extension", typeRegistry, errors, typeExtension));
-        }));
-    }
-
-    private Consumer<? super Type> checkInterfaceIsImplemented(String typeOfType, TypeDefinitionRegistry typeRegistry, List<GraphQLError> errors, ObjectTypeDefinition objectTypeDef) {
-        return t -> {
-            TypeInfo typeInfo = TypeInfo.typeInfo(t);
-            TypeName unwrapped = typeInfo.getTypeName();
-            Optional<TypeDefinition> type = typeRegistry.getType(unwrapped);
-            // previous checks handle the missing case and wrong type case
-            if (type.isPresent() && type.get() instanceof InterfaceTypeDefinition) {
-                InterfaceTypeDefinition interfaceTypeDef = (InterfaceTypeDefinition) type.get();
-
-                Map<String, FieldDefinition> objectFields = objectTypeDef.getFieldDefinitions().stream()
-                        .collect(Collectors.toMap(
-                                FieldDefinition::getName, Function.identity(), mergeFirstValue()
-                        ));
-
-                interfaceTypeDef.getFieldDefinitions().forEach(interfaceFieldDef -> {
-                    FieldDefinition objectFieldDef = objectFields.get(interfaceFieldDef.getName());
-                    if (objectFieldDef == null) {
-                        errors.add(new MissingInterfaceFieldError(typeOfType, objectTypeDef, interfaceTypeDef, interfaceFieldDef));
-                    } else {
-                        if (!typeRegistry.isSubTypeOf(objectFieldDef.getType(), interfaceFieldDef.getType())) {
-                            String interfaceFieldType = AstPrinter.printAst(interfaceFieldDef.getType());
-                            String objectFieldType = AstPrinter.printAst(objectFieldDef.getType());
-                            errors.add(new InterfaceFieldRedefinitionError(typeOfType, objectTypeDef, interfaceTypeDef, objectFieldDef, objectFieldType, interfaceFieldType));
-                        }
-
-                        // look at arguments
-                        List<InputValueDefinition> objectArgs = objectFieldDef.getInputValueDefinitions();
-                        List<InputValueDefinition> interfaceArgs = interfaceFieldDef.getInputValueDefinitions();
-                        if (objectArgs.size() < interfaceArgs.size()) {
-                            errors.add(new MissingInterfaceFieldArgumentsError(typeOfType, objectTypeDef, interfaceTypeDef, objectFieldDef));
-                        } else {
-                            checkArgumentConsistency(typeOfType, objectTypeDef, interfaceTypeDef, objectFieldDef, interfaceFieldDef, errors);
-                        }
-                    }
-                });
-            }
-        };
-    }
-
-    private void checkArgumentConsistency(String typeOfType, ObjectTypeDefinition objectTypeDef, InterfaceTypeDefinition interfaceTypeDef, FieldDefinition objectFieldDef, FieldDefinition interfaceFieldDef, List<GraphQLError> errors) {
-        List<InputValueDefinition> objectArgs = objectFieldDef.getInputValueDefinitions();
-        List<InputValueDefinition> interfaceArgs = interfaceFieldDef.getInputValueDefinitions();
-        for (int i = 0; i < interfaceArgs.size(); i++) {
-            InputValueDefinition interfaceArg = interfaceArgs.get(i);
-            InputValueDefinition objectArg = objectArgs.get(i);
-            String interfaceArgStr = AstPrinter.printAstCompact(interfaceArg);
-            String objectArgStr = AstPrinter.printAstCompact(objectArg);
-            if (!interfaceArgStr.equals(objectArgStr)) {
-                errors.add(new InterfaceFieldArgumentRedefinitionError(typeOfType, objectTypeDef, interfaceTypeDef, objectFieldDef, objectArgStr, interfaceArgStr));
-            }
-        }
-
-        if (objectArgs.size() > interfaceArgs.size()) {
-            for (int i = interfaceArgs.size(); i < objectArgs.size(); i++) {
-                InputValueDefinition objectArg = objectArgs.get(i);
-                if (objectArg.getType() instanceof NonNullType) {
-                    String objectArgStr = AstPrinter.printAst(objectArg);
-                    errors.add(new InterfaceFieldArgumentNotOptionalError(typeOfType, objectTypeDef, interfaceTypeDef, objectFieldDef, objectArgStr));
-                }
-            }
-        }
-    }
-
     private <T extends TypeDefinition> List<T> filterTo(Map<String, TypeDefinition> types, Class<? extends T> clazz) {
         return types.values().stream()
                 .filter(t -> clazz.equals(t.getClass()))
                 .map(clazz::cast)
-                .collect(Collectors.toList());
-    }
-
-    private <T> BinaryOperator<T> mergeFirstValue() {
-        return (v1, v2) -> v1;
+                .collect(toList());
     }
 }

--- a/src/main/java/graphql/schema/idl/SchemaTypeExtensionsChecker.java
+++ b/src/main/java/graphql/schema/idl/SchemaTypeExtensionsChecker.java
@@ -3,7 +3,6 @@ package graphql.schema.idl;
 import graphql.GraphQLError;
 import graphql.Internal;
 import graphql.language.Argument;
-import graphql.language.AstPrinter;
 import graphql.language.Directive;
 import graphql.language.EnumTypeDefinition;
 import graphql.language.EnumValueDefinition;
@@ -14,7 +13,6 @@ import graphql.language.InputValueDefinition;
 import graphql.language.InterfaceTypeDefinition;
 import graphql.language.ObjectTypeDefinition;
 import graphql.language.ScalarTypeDefinition;
-import graphql.language.Type;
 import graphql.language.TypeDefinition;
 import graphql.language.TypeName;
 import graphql.language.UnionTypeDefinition;
@@ -328,10 +326,7 @@ class SchemaTypeExtensionsChecker {
         fieldDefinitions.forEach(fld -> {
             FieldDefinition reference = referenceMap.get(fld.getName());
             if (referenceMap.containsKey(fld.getName())) {
-                // ok they have the same field but is it the same type
-                if (!isSameType(fld.getType(), reference.getType())) {
-                    errors.add(new TypeExtensionFieldRedefinitionError(typeDefinition, fld));
-                }
+                errors.add(new TypeExtensionFieldRedefinitionError(typeDefinition, fld));
             }
         });
     }
@@ -342,10 +337,7 @@ class SchemaTypeExtensionsChecker {
         inputValueDefinitions.forEach(fld -> {
             InputValueDefinition reference = referenceMap.get(fld.getName());
             if (referenceMap.containsKey(fld.getName())) {
-                // ok they have the same field but is it the same type
-                if (!isSameType(fld.getType(), reference.getType())) {
-                    errors.add(new TypeExtensionFieldRedefinitionError(typeDefinition, fld));
-                }
+                errors.add(new TypeExtensionFieldRedefinitionError(typeDefinition, fld));
             }
         });
     }
@@ -369,12 +361,4 @@ class SchemaTypeExtensionsChecker {
             consumer.accept(t);
         }
     }
-
-
-    private boolean isSameType(Type type1, Type type2) {
-        String s1 = AstPrinter.printAst(type1);
-        String s2 = AstPrinter.printAst(type2);
-        return s1.equals(s2);
-    }
-
 }

--- a/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java
+++ b/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java
@@ -5,6 +5,7 @@ import graphql.GraphQLError;
 import graphql.PublicApi;
 import graphql.language.DirectiveDefinition;
 import graphql.language.EnumTypeExtensionDefinition;
+import graphql.language.ImplementingTypeDefinition;
 import graphql.language.InputObjectTypeExtensionDefinition;
 import graphql.language.InterfaceTypeDefinition;
 import graphql.language.InterfaceTypeExtensionDefinition;
@@ -453,13 +454,13 @@ public class TypeDefinitionRegistry {
     }
 
     /**
-     * Returns the list of object types that implement the given interface type
+     * Returns the list of object and interface types that implement the given interface type
      *
      * @param targetInterface the target to search for
      * @return the list of object types that implement the given interface type
      */
-    public List<ObjectTypeDefinition> getImplementationsOf(InterfaceTypeDefinition targetInterface) {
-        List<ObjectTypeDefinition> objectTypeDefinitions = getTypes(ObjectTypeDefinition.class);
+    public List<ImplementingTypeDefinition> getImplementationsOf(InterfaceTypeDefinition targetInterface) {
+        List<ImplementingTypeDefinition> objectTypeDefinitions = getTypes(ImplementingTypeDefinition.class);
         return objectTypeDefinitions.stream().filter(objectTypeDefinition -> {
             List<Type> implementsList = objectTypeDefinition.getImplements();
             for (Type iFace : implementsList) {
@@ -476,7 +477,7 @@ public class TypeDefinitionRegistry {
     }
 
     /**
-     * Returns true of the abstract type is in implemented by the object type
+     * Returns true of the abstract type is in implemented by the object or interface type
      *
      * @param abstractType       the abstract type to check (interface or union)
      * @param possibleObjectType the object type to check
@@ -505,7 +506,7 @@ public class TypeDefinitionRegistry {
             return false;
         } else {
             InterfaceTypeDefinition iFace = (InterfaceTypeDefinition) abstractTypeDef;
-            List<ObjectTypeDefinition> objectTypeDefinitions = getImplementationsOf(iFace);
+            List<ImplementingTypeDefinition> objectTypeDefinitions = getImplementationsOf(iFace);
             return objectTypeDefinitions.stream()
                     .anyMatch(od -> od.getName().equals(targetObjectTypeDef.getName()));
         }

--- a/src/main/java/graphql/schema/idl/errors/InterfaceFieldArgumentNotOptionalError.java
+++ b/src/main/java/graphql/schema/idl/errors/InterfaceFieldArgumentNotOptionalError.java
@@ -1,16 +1,14 @@
 package graphql.schema.idl.errors;
 
 import graphql.language.FieldDefinition;
+import graphql.language.ImplementingTypeDefinition;
 import graphql.language.InterfaceTypeDefinition;
-import graphql.language.ObjectTypeDefinition;
-import graphql.language.TypeDefinition;
 
 import static java.lang.String.format;
 
 public class InterfaceFieldArgumentNotOptionalError extends BaseError {
-    // TODO maybe duplicate this method, one for ObjectTypeDefinition and another for InterfaceTypeDefinition
-    public InterfaceFieldArgumentNotOptionalError(String typeOfType, TypeDefinition objectTypeDef, InterfaceTypeDefinition interfaceTypeDef, FieldDefinition objectFieldDef, String objectArgStr) {
-        super(objectTypeDef, format("The %s type '%s' %s field '%s' defines an additional non-optional argument '%s' which is not allowed because field is also defined in interface '%s' %s.",
-                typeOfType, objectTypeDef.getName(), lineCol(objectTypeDef), objectFieldDef.getName(), objectArgStr, interfaceTypeDef.getName(), lineCol(interfaceTypeDef)));
+    public InterfaceFieldArgumentNotOptionalError(String typeOfType, ImplementingTypeDefinition typeDefinition, InterfaceTypeDefinition interfaceTypeDef, FieldDefinition objectFieldDef, String objectArgStr) {
+        super(typeDefinition, format("The %s type '%s' %s field '%s' defines an additional non-optional argument '%s' which is not allowed because field is also defined in interface '%s' %s.",
+                typeOfType, typeDefinition.getName(), lineCol(typeDefinition), objectFieldDef.getName(), objectArgStr, interfaceTypeDef.getName(), lineCol(interfaceTypeDef)));
     }
 }

--- a/src/main/java/graphql/schema/idl/errors/InterfaceFieldArgumentNotOptionalError.java
+++ b/src/main/java/graphql/schema/idl/errors/InterfaceFieldArgumentNotOptionalError.java
@@ -3,11 +3,13 @@ package graphql.schema.idl.errors;
 import graphql.language.FieldDefinition;
 import graphql.language.InterfaceTypeDefinition;
 import graphql.language.ObjectTypeDefinition;
+import graphql.language.TypeDefinition;
 
 import static java.lang.String.format;
 
 public class InterfaceFieldArgumentNotOptionalError extends BaseError {
-    public InterfaceFieldArgumentNotOptionalError(String typeOfType, ObjectTypeDefinition objectTypeDef, InterfaceTypeDefinition interfaceTypeDef, FieldDefinition objectFieldDef, String objectArgStr) {
+    // TODO maybe duplicate this method, one for ObjectTypeDefinition and another for InterfaceTypeDefinition
+    public InterfaceFieldArgumentNotOptionalError(String typeOfType, TypeDefinition objectTypeDef, InterfaceTypeDefinition interfaceTypeDef, FieldDefinition objectFieldDef, String objectArgStr) {
         super(objectTypeDef, format("The %s type '%s' %s field '%s' defines an additional non-optional argument '%s' which is not allowed because field is also defined in interface '%s' %s.",
                 typeOfType, objectTypeDef.getName(), lineCol(objectTypeDef), objectFieldDef.getName(), objectArgStr, interfaceTypeDef.getName(), lineCol(interfaceTypeDef)));
     }

--- a/src/main/java/graphql/schema/idl/errors/InterfaceFieldArgumentRedefinitionError.java
+++ b/src/main/java/graphql/schema/idl/errors/InterfaceFieldArgumentRedefinitionError.java
@@ -1,17 +1,15 @@
 package graphql.schema.idl.errors;
 
 import graphql.language.FieldDefinition;
+import graphql.language.ImplementingTypeDefinition;
 import graphql.language.InterfaceTypeDefinition;
-import graphql.language.ObjectTypeDefinition;
-import graphql.language.TypeDefinition;
 
 import static java.lang.String.format;
 
 
 public class InterfaceFieldArgumentRedefinitionError extends BaseError {
-    // TODO maybe duplicate this method, one for ObjectTypeDefinition and another for InterfaceTypeDefinition
-    public InterfaceFieldArgumentRedefinitionError(String typeOfType, TypeDefinition objectTypeDef, InterfaceTypeDefinition interfaceTypeDef, FieldDefinition objectFieldDef, String objectArgStr, String interfaceArgStr) {
-        super(objectTypeDef, format("The %s type '%s' %s has tried to redefine field '%s' arguments defined via interface '%s' %s from '%s' to '%s",
-                typeOfType, objectTypeDef.getName(), lineCol(objectTypeDef), objectFieldDef.getName(), interfaceTypeDef.getName(), lineCol(interfaceTypeDef), interfaceArgStr, objectArgStr));
+    public InterfaceFieldArgumentRedefinitionError(String typeOfType, ImplementingTypeDefinition typeDefinition, InterfaceTypeDefinition interfaceTypeDef, FieldDefinition objectFieldDef, String objectArgStr, String interfaceArgStr) {
+        super(typeDefinition, format("The %s type '%s' %s has tried to redefine field '%s' arguments defined via interface '%s' %s from '%s' to '%s",
+                typeOfType, typeDefinition.getName(), lineCol(typeDefinition), objectFieldDef.getName(), interfaceTypeDef.getName(), lineCol(interfaceTypeDef), interfaceArgStr, objectArgStr));
     }
 }

--- a/src/main/java/graphql/schema/idl/errors/InterfaceFieldArgumentRedefinitionError.java
+++ b/src/main/java/graphql/schema/idl/errors/InterfaceFieldArgumentRedefinitionError.java
@@ -3,12 +3,14 @@ package graphql.schema.idl.errors;
 import graphql.language.FieldDefinition;
 import graphql.language.InterfaceTypeDefinition;
 import graphql.language.ObjectTypeDefinition;
+import graphql.language.TypeDefinition;
 
 import static java.lang.String.format;
 
 
 public class InterfaceFieldArgumentRedefinitionError extends BaseError {
-    public InterfaceFieldArgumentRedefinitionError(String typeOfType, ObjectTypeDefinition objectTypeDef, InterfaceTypeDefinition interfaceTypeDef, FieldDefinition objectFieldDef, String objectArgStr, String interfaceArgStr) {
+    // TODO maybe duplicate this method, one for ObjectTypeDefinition and another for InterfaceTypeDefinition
+    public InterfaceFieldArgumentRedefinitionError(String typeOfType, TypeDefinition objectTypeDef, InterfaceTypeDefinition interfaceTypeDef, FieldDefinition objectFieldDef, String objectArgStr, String interfaceArgStr) {
         super(objectTypeDef, format("The %s type '%s' %s has tried to redefine field '%s' arguments defined via interface '%s' %s from '%s' to '%s",
                 typeOfType, objectTypeDef.getName(), lineCol(objectTypeDef), objectFieldDef.getName(), interfaceTypeDef.getName(), lineCol(interfaceTypeDef), interfaceArgStr, objectArgStr));
     }

--- a/src/main/java/graphql/schema/idl/errors/InterfaceFieldRedefinitionError.java
+++ b/src/main/java/graphql/schema/idl/errors/InterfaceFieldRedefinitionError.java
@@ -1,16 +1,14 @@
 package graphql.schema.idl.errors;
 
 import graphql.language.FieldDefinition;
+import graphql.language.ImplementingTypeDefinition;
 import graphql.language.InterfaceTypeDefinition;
-import graphql.language.ObjectTypeDefinition;
-import graphql.language.TypeDefinition;
 
 import static java.lang.String.format;
 
 public class InterfaceFieldRedefinitionError extends BaseError {
-    // TODO maybe duplicate this method, one for ObjectTypeDefinition and another for InterfaceTypeDefinition
-    public InterfaceFieldRedefinitionError(String typeOfType, TypeDefinition objectType, InterfaceTypeDefinition interfaceTypeDef, FieldDefinition objectFieldDef, String objectFieldType, String interfaceFieldType) {
-        super(objectType, format("The %s type '%s' %s has tried to redefine field '%s' defined via interface '%s' %s from '%s' to '%s'",
-                typeOfType, objectType.getName(), lineCol(objectType), objectFieldDef.getName(), interfaceTypeDef.getName(), lineCol(interfaceTypeDef), interfaceFieldType, objectFieldType));
+    public InterfaceFieldRedefinitionError(String typeOfType, ImplementingTypeDefinition typeDefinition, InterfaceTypeDefinition interfaceTypeDef, FieldDefinition objectFieldDef, String objectFieldType, String interfaceFieldType) {
+        super(typeDefinition, format("The %s type '%s' %s has tried to redefine field '%s' defined via interface '%s' %s from '%s' to '%s'",
+                typeOfType, typeDefinition.getName(), lineCol(typeDefinition), objectFieldDef.getName(), interfaceTypeDef.getName(), lineCol(interfaceTypeDef), interfaceFieldType, objectFieldType));
     }
 }

--- a/src/main/java/graphql/schema/idl/errors/InterfaceFieldRedefinitionError.java
+++ b/src/main/java/graphql/schema/idl/errors/InterfaceFieldRedefinitionError.java
@@ -3,11 +3,13 @@ package graphql.schema.idl.errors;
 import graphql.language.FieldDefinition;
 import graphql.language.InterfaceTypeDefinition;
 import graphql.language.ObjectTypeDefinition;
+import graphql.language.TypeDefinition;
 
 import static java.lang.String.format;
 
 public class InterfaceFieldRedefinitionError extends BaseError {
-    public InterfaceFieldRedefinitionError(String typeOfType, ObjectTypeDefinition objectType, InterfaceTypeDefinition interfaceTypeDef, FieldDefinition objectFieldDef, String objectFieldType, String interfaceFieldType) {
+    // TODO maybe duplicate this method, one for ObjectTypeDefinition and another for InterfaceTypeDefinition
+    public InterfaceFieldRedefinitionError(String typeOfType, TypeDefinition objectType, InterfaceTypeDefinition interfaceTypeDef, FieldDefinition objectFieldDef, String objectFieldType, String interfaceFieldType) {
         super(objectType, format("The %s type '%s' %s has tried to redefine field '%s' defined via interface '%s' %s from '%s' to '%s'",
                 typeOfType, objectType.getName(), lineCol(objectType), objectFieldDef.getName(), interfaceTypeDef.getName(), lineCol(interfaceTypeDef), interfaceFieldType, objectFieldType));
     }

--- a/src/main/java/graphql/schema/idl/errors/InterfaceImplementedMoreThanOnceError.java
+++ b/src/main/java/graphql/schema/idl/errors/InterfaceImplementedMoreThanOnceError.java
@@ -1,0 +1,13 @@
+package graphql.schema.idl.errors;
+
+import graphql.language.ImplementingTypeDefinition;
+import graphql.language.InterfaceTypeDefinition;
+
+import static java.lang.String.format;
+
+public class InterfaceImplementedMoreThanOnceError extends BaseError {
+    public InterfaceImplementedMoreThanOnceError(String typeOfType, ImplementingTypeDefinition typeDefinition, InterfaceTypeDefinition implementedInterface) {
+        super(typeDefinition, format("The %s type '%s' %s can only implement '%s' %s once.",
+                typeOfType, typeDefinition.getName(), lineCol(typeDefinition), implementedInterface.getName(), lineCol(implementedInterface)));
+    }
+}

--- a/src/main/java/graphql/schema/idl/errors/InterfaceImplementingItselfError.java
+++ b/src/main/java/graphql/schema/idl/errors/InterfaceImplementingItselfError.java
@@ -1,0 +1,12 @@
+package graphql.schema.idl.errors;
+
+import graphql.language.ImplementingTypeDefinition;
+
+import static java.lang.String.format;
+
+public class InterfaceImplementingItselfError extends BaseError {
+    public InterfaceImplementingItselfError(String typeOfType, ImplementingTypeDefinition typeDefinition) {
+        super(typeDefinition, format("The %s type '%s' %s cannot implement itself",
+                typeOfType, typeDefinition.getName(), lineCol(typeDefinition)));
+    }
+}

--- a/src/main/java/graphql/schema/idl/errors/InterfaceWithCircularImplementationHierarchyError.java
+++ b/src/main/java/graphql/schema/idl/errors/InterfaceWithCircularImplementationHierarchyError.java
@@ -1,16 +1,15 @@
 package graphql.schema.idl.errors;
 
 import graphql.language.ImplementingTypeDefinition;
-
-import java.util.Set;
+import graphql.language.InterfaceTypeDefinition;
 
 import static java.lang.String.format;
 
 public class InterfaceWithCircularImplementationHierarchyError extends BaseError {
-    public InterfaceWithCircularImplementationHierarchyError(String typeOfType, ImplementingTypeDefinition typeDefinition, Set<String> interfacesToImplement) {
-        super(typeDefinition, format("The interface hierarchy in %s type '%s' %s results in a circular dependency [%s]",
+    public InterfaceWithCircularImplementationHierarchyError(String typeOfType, ImplementingTypeDefinition typeDefinition, InterfaceTypeDefinition implementedInterface) {
+        super(typeDefinition, format("The %s type '%s' %s cannot implement '%s' %s as this would result in a circular reference",
                 typeOfType, typeDefinition.getName(), lineCol(typeDefinition),
-                typeDefinition.getName() + " -> " + String.join(" -> ", interfacesToImplement)
+                implementedInterface.getName(), lineCol(implementedInterface)
         ));
     }
 }

--- a/src/main/java/graphql/schema/idl/errors/InterfaceWithCircularImplementationHierarchyError.java
+++ b/src/main/java/graphql/schema/idl/errors/InterfaceWithCircularImplementationHierarchyError.java
@@ -1,0 +1,16 @@
+package graphql.schema.idl.errors;
+
+import graphql.language.ImplementingTypeDefinition;
+
+import java.util.Set;
+
+import static java.lang.String.format;
+
+public class InterfaceWithCircularImplementationHierarchyError extends BaseError {
+    public InterfaceWithCircularImplementationHierarchyError(String typeOfType, ImplementingTypeDefinition typeDefinition, Set<String> interfacesToImplement) {
+        super(typeDefinition, format("The interface hierarchy in %s type '%s' %s results in a circular dependency [%s]",
+                typeOfType, typeDefinition.getName(), lineCol(typeDefinition),
+                typeDefinition.getName() + " -> " + String.join(" -> ", interfacesToImplement)
+        ));
+    }
+}

--- a/src/main/java/graphql/schema/idl/errors/MissingInterfaceFieldArgumentsError.java
+++ b/src/main/java/graphql/schema/idl/errors/MissingInterfaceFieldArgumentsError.java
@@ -1,16 +1,14 @@
 package graphql.schema.idl.errors;
 
 import graphql.language.FieldDefinition;
+import graphql.language.ImplementingTypeDefinition;
 import graphql.language.InterfaceTypeDefinition;
-import graphql.language.ObjectTypeDefinition;
-import graphql.language.TypeDefinition;
 
 import static java.lang.String.format;
 
 public class MissingInterfaceFieldArgumentsError extends BaseError {
-    // TODO maybe duplicate this method, one for ObjectTypeDefinition and another for InterfaceTypeDefinition
-    public MissingInterfaceFieldArgumentsError(String typeOfType, TypeDefinition objectTypeDef, InterfaceTypeDefinition interfaceTypeDef, FieldDefinition objectFieldDef) {
-        super(objectTypeDef, format("The %s type '%s' %s field '%s' does not have the same number of arguments as specified via interface '%s' %s",
-                typeOfType, objectTypeDef.getName(), lineCol(objectTypeDef), objectFieldDef.getName(), interfaceTypeDef.getName(), lineCol(interfaceTypeDef)));
+    public MissingInterfaceFieldArgumentsError(String typeOfType, ImplementingTypeDefinition typeDefinition, InterfaceTypeDefinition interfaceTypeDef, FieldDefinition objectFieldDef) {
+        super(typeDefinition, format("The %s type '%s' %s field '%s' does not have the same number of arguments as specified via interface '%s' %s",
+                typeOfType, typeDefinition.getName(), lineCol(typeDefinition), objectFieldDef.getName(), interfaceTypeDef.getName(), lineCol(interfaceTypeDef)));
     }
 }

--- a/src/main/java/graphql/schema/idl/errors/MissingInterfaceFieldArgumentsError.java
+++ b/src/main/java/graphql/schema/idl/errors/MissingInterfaceFieldArgumentsError.java
@@ -3,11 +3,13 @@ package graphql.schema.idl.errors;
 import graphql.language.FieldDefinition;
 import graphql.language.InterfaceTypeDefinition;
 import graphql.language.ObjectTypeDefinition;
+import graphql.language.TypeDefinition;
 
 import static java.lang.String.format;
 
 public class MissingInterfaceFieldArgumentsError extends BaseError {
-    public MissingInterfaceFieldArgumentsError(String typeOfType, ObjectTypeDefinition objectTypeDef, InterfaceTypeDefinition interfaceTypeDef, FieldDefinition objectFieldDef) {
+    // TODO maybe duplicate this method, one for ObjectTypeDefinition and another for InterfaceTypeDefinition
+    public MissingInterfaceFieldArgumentsError(String typeOfType, TypeDefinition objectTypeDef, InterfaceTypeDefinition interfaceTypeDef, FieldDefinition objectFieldDef) {
         super(objectTypeDef, format("The %s type '%s' %s field '%s' does not have the same number of arguments as specified via interface '%s' %s",
                 typeOfType, objectTypeDef.getName(), lineCol(objectTypeDef), objectFieldDef.getName(), interfaceTypeDef.getName(), lineCol(interfaceTypeDef)));
     }

--- a/src/main/java/graphql/schema/idl/errors/MissingInterfaceFieldError.java
+++ b/src/main/java/graphql/schema/idl/errors/MissingInterfaceFieldError.java
@@ -1,15 +1,13 @@
 package graphql.schema.idl.errors;
 
 import graphql.language.FieldDefinition;
+import graphql.language.ImplementingTypeDefinition;
 import graphql.language.InterfaceTypeDefinition;
-import graphql.language.ObjectTypeDefinition;
-import graphql.language.TypeDefinition;
 
 import static java.lang.String.format;
 
 public class MissingInterfaceFieldError extends BaseError {
-    // TODO maybe duplicate this method, one for ObjectTypeDefinition and another for InterfaceTypeDefinition
-    public MissingInterfaceFieldError(String typeOfType, TypeDefinition objectType, InterfaceTypeDefinition interfaceTypeDef, FieldDefinition interfaceFieldDef) {
+    public MissingInterfaceFieldError(String typeOfType, ImplementingTypeDefinition objectType, InterfaceTypeDefinition interfaceTypeDef, FieldDefinition interfaceFieldDef) {
         super(objectType, format("The %s type '%s' %s does not have a field '%s' required via interface '%s' %s",
                 typeOfType, objectType.getName(), lineCol(objectType), interfaceFieldDef.getName(), interfaceTypeDef.getName(), lineCol(interfaceTypeDef)));
     }

--- a/src/main/java/graphql/schema/idl/errors/MissingInterfaceFieldError.java
+++ b/src/main/java/graphql/schema/idl/errors/MissingInterfaceFieldError.java
@@ -3,11 +3,13 @@ package graphql.schema.idl.errors;
 import graphql.language.FieldDefinition;
 import graphql.language.InterfaceTypeDefinition;
 import graphql.language.ObjectTypeDefinition;
+import graphql.language.TypeDefinition;
 
 import static java.lang.String.format;
 
 public class MissingInterfaceFieldError extends BaseError {
-    public MissingInterfaceFieldError(String typeOfType, ObjectTypeDefinition objectType, InterfaceTypeDefinition interfaceTypeDef, FieldDefinition interfaceFieldDef) {
+    // TODO maybe duplicate this method, one for ObjectTypeDefinition and another for InterfaceTypeDefinition
+    public MissingInterfaceFieldError(String typeOfType, TypeDefinition objectType, InterfaceTypeDefinition interfaceTypeDef, FieldDefinition interfaceFieldDef) {
         super(objectType, format("The %s type '%s' %s does not have a field '%s' required via interface '%s' %s",
                 typeOfType, objectType.getName(), lineCol(objectType), interfaceFieldDef.getName(), interfaceTypeDef.getName(), lineCol(interfaceTypeDef)));
     }

--- a/src/main/java/graphql/schema/idl/errors/MissingTransitiveInterfaceError.java
+++ b/src/main/java/graphql/schema/idl/errors/MissingTransitiveInterfaceError.java
@@ -1,14 +1,16 @@
 package graphql.schema.idl.errors;
 
 import graphql.language.ImplementingTypeDefinition;
+import graphql.language.InterfaceTypeDefinition;
 
 import java.util.Collection;
 
 import static java.lang.String.format;
+import static java.util.stream.Collectors.joining;
 
 public class MissingTransitiveInterfaceError extends BaseError {
-    public MissingTransitiveInterfaceError(String typeOfType, ImplementingTypeDefinition typeDefinition, Collection<String> missingInterfaces) {
-        super(typeDefinition, format("The %s type '%s' %s does not implement the following transitive interfaces: %s",
-                typeOfType, typeDefinition.getName(), lineCol(typeDefinition), "[" + String.join(", ", missingInterfaces) + "]"));
+    public MissingTransitiveInterfaceError(String typeOfType, ImplementingTypeDefinition typeDefinition, InterfaceTypeDefinition implementedInterface, Collection<InterfaceTypeDefinition> missingInterfaces) {
+        super(typeDefinition, format("The %s type '%s' %s must implement %s because it is implemented by '%s' %s",
+                typeOfType, typeDefinition.getName(), lineCol(typeDefinition), "[" + missingInterfaces.stream().map(InterfaceTypeDefinition::getName).collect(joining()) + "]", implementedInterface.getName(), lineCol(implementedInterface)));
     }
 }

--- a/src/main/java/graphql/schema/idl/errors/MissingTransitiveInterfaceError.java
+++ b/src/main/java/graphql/schema/idl/errors/MissingTransitiveInterfaceError.java
@@ -1,0 +1,17 @@
+package graphql.schema.idl.errors;
+
+import graphql.language.InterfaceTypeDefinition;
+import graphql.language.TypeDefinition;
+
+import java.util.Collection;
+import java.util.Set;
+
+import static java.lang.String.format;
+
+public class MissingTransitiveInterfaceError extends BaseError {
+    // TODO maybe duplicate this method, one for ObjectTypeDefinition and another for InterfaceTypeDefinition
+    public MissingTransitiveInterfaceError(String typeOfType, TypeDefinition objectType, Collection<String> missingInterfaces) {
+        super(objectType, format("The %s type '%s' %s does not implement the following transitive interfaces: %s",
+                typeOfType, objectType.getName(), lineCol(objectType), missingInterfaces));
+    }
+}

--- a/src/main/java/graphql/schema/idl/errors/MissingTransitiveInterfaceError.java
+++ b/src/main/java/graphql/schema/idl/errors/MissingTransitiveInterfaceError.java
@@ -9,8 +9,8 @@ import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
 
 public class MissingTransitiveInterfaceError extends BaseError {
-    public MissingTransitiveInterfaceError(String typeOfType, ImplementingTypeDefinition typeDefinition, InterfaceTypeDefinition implementedInterface, Collection<InterfaceTypeDefinition> missingInterfaces) {
-        super(typeDefinition, format("The %s type '%s' %s must implement %s because it is implemented by '%s' %s",
-                typeOfType, typeDefinition.getName(), lineCol(typeDefinition), "[" + missingInterfaces.stream().map(InterfaceTypeDefinition::getName).collect(joining()) + "]", implementedInterface.getName(), lineCol(implementedInterface)));
+    public MissingTransitiveInterfaceError(String typeOfType, ImplementingTypeDefinition typeDefinition, InterfaceTypeDefinition implementedInterface, InterfaceTypeDefinition missingInterface) {
+        super(typeDefinition, format("The %s type '%s' %s must implement '%s' %s because it is implemented by '%s' %s",
+                typeOfType, typeDefinition.getName(), lineCol(typeDefinition), missingInterface.getName(), lineCol(missingInterface), implementedInterface.getName(), lineCol(implementedInterface)));
     }
 }

--- a/src/main/java/graphql/schema/idl/errors/MissingTransitiveInterfaceError.java
+++ b/src/main/java/graphql/schema/idl/errors/MissingTransitiveInterfaceError.java
@@ -9,6 +9,6 @@ import static java.lang.String.format;
 public class MissingTransitiveInterfaceError extends BaseError {
     public MissingTransitiveInterfaceError(String typeOfType, ImplementingTypeDefinition typeDefinition, Collection<String> missingInterfaces) {
         super(typeDefinition, format("The %s type '%s' %s does not implement the following transitive interfaces: %s",
-                typeOfType, typeDefinition.getName(), lineCol(typeDefinition), missingInterfaces));
+                typeOfType, typeDefinition.getName(), lineCol(typeDefinition), "[" + String.join(", ", missingInterfaces) + "]"));
     }
 }

--- a/src/main/java/graphql/schema/idl/errors/MissingTransitiveInterfaceError.java
+++ b/src/main/java/graphql/schema/idl/errors/MissingTransitiveInterfaceError.java
@@ -1,17 +1,14 @@
 package graphql.schema.idl.errors;
 
-import graphql.language.InterfaceTypeDefinition;
-import graphql.language.TypeDefinition;
+import graphql.language.ImplementingTypeDefinition;
 
 import java.util.Collection;
-import java.util.Set;
 
 import static java.lang.String.format;
 
 public class MissingTransitiveInterfaceError extends BaseError {
-    // TODO maybe duplicate this method, one for ObjectTypeDefinition and another for InterfaceTypeDefinition
-    public MissingTransitiveInterfaceError(String typeOfType, TypeDefinition objectType, Collection<String> missingInterfaces) {
-        super(objectType, format("The %s type '%s' %s does not implement the following transitive interfaces: %s",
-                typeOfType, objectType.getName(), lineCol(objectType), missingInterfaces));
+    public MissingTransitiveInterfaceError(String typeOfType, ImplementingTypeDefinition typeDefinition, Collection<String> missingInterfaces) {
+        super(typeDefinition, format("The %s type '%s' %s does not implement the following transitive interfaces: %s",
+                typeOfType, typeDefinition.getName(), lineCol(typeDefinition), missingInterfaces));
     }
 }

--- a/src/test/groovy/graphql/InterfacesImplementingInterfacesTest.groovy
+++ b/src/test/groovy/graphql/InterfacesImplementingInterfacesTest.groovy
@@ -4,8 +4,6 @@ package graphql
 import spock.lang.Specification
 
 class InterfacesImplementingInterfacesTest extends Specification {
-
-    // TODO: maybe parameterized this test
     def 'Simple interface implementing interface'() {
         when:
         TestUtil.schema("""
@@ -193,8 +191,8 @@ class InterfacesImplementingInterfacesTest extends Specification {
 
 
         then:
-        // TODO: Assert error message
-        thrown(AssertionError)
+        def error = thrown(AssertionError)
+        error.getMessage() ==~ ".*The interface type 'Node' .* cannot implement itself, The interface type 'Named' .* cannot implement itself.*";
     }
 
     def 'When interface extension implements interface and declares required field, then parsing is successful'() {

--- a/src/test/groovy/graphql/InterfacesImplementingInterfacesTest.groovy
+++ b/src/test/groovy/graphql/InterfacesImplementingInterfacesTest.groovy
@@ -366,4 +366,36 @@ class InterfacesImplementingInterfacesTest extends Specification {
         def error = thrown(AssertionError)
         error.getMessage() ==~ ".*The interface extension type 'Image'.*does not implement the following transitive interfaces: \\[Node\\].*"
     }
+
+    def 'When hierarchy results in circular reference, then parsing fails'() {
+        when:
+        TestUtil.schema("""
+            type Query {
+               find(id: String!): Interface1
+            }
+            
+            interface Interface1 implements Interface3 & Interface2 {
+              field1: String
+              field2: String
+              field3: String
+            }
+            
+            interface Interface2 implements Interface1 & Interface3 {
+              field1: String
+              field2: String
+              field3: String
+            }
+            
+            interface Interface3 implements Interface2 & Interface1 {
+              field1: String
+              field2: String
+              field3: String
+            }
+
+            """)
+        then:
+        def error = thrown(AssertionError)
+        println(error.getMessage())
+        error.getMessage() ==~ ".*The interface hierarchy in interface type 'Interface1' .* results in a circular dependency.*"
+    }
 }

--- a/src/test/groovy/graphql/InterfacesImplementingInterfacesTest.groovy
+++ b/src/test/groovy/graphql/InterfacesImplementingInterfacesTest.groovy
@@ -47,7 +47,8 @@ class InterfacesImplementingInterfacesTest extends Specification {
 
 
         then:
-        thrown(AssertionError)
+        def error = thrown(AssertionError)
+        error.getMessage() ==~ ".*The interface type 'Resource'.*does not have a field 'id' required via interface 'Node'.*"
     }
 
     def 'Transitively implemented interfaces defined in implementing interface'() {
@@ -139,8 +140,8 @@ class InterfacesImplementingInterfacesTest extends Specification {
 
 
         then:
-        // TODO: Assert error message
         def error = thrown(AssertionError)
+        error.getMessage() ==~ ".*The interface type 'LargeImage'.*does not implement the following transitive interfaces: \\[Node\\].*"
     }
 
     def 'When not all transitively implemented interfaces are defined in implementing type, then parsing fails'() {
@@ -168,8 +169,8 @@ class InterfacesImplementingInterfacesTest extends Specification {
 
 
         then:
-        // TODO: Assert error message
-        thrown(AssertionError)
+        def error = thrown(AssertionError)
+        error.getMessage() ==~ ".*The object type 'Image'.*does not implement the following transitive interfaces: \\[Node\\].*"
     }
 
     def 'When interface implements itself, then parsing fails'() {
@@ -185,30 +186,6 @@ class InterfacesImplementingInterfacesTest extends Specification {
             }
             
             interface Named implements Node & Named {
-              id: ID!
-              name: String
-            }
-            """)
-
-
-        then:
-        // TODO: Assert error message
-        thrown(AssertionError)
-    }
-
-    def 'When interface implements same interface twice, then parsing fails'() {
-        when:
-        TestUtil.schema("""
-            type Query {
-               find(id: String!): Node
-            }
-            
-            interface Node {
-              id: ID!
-              name: String
-            }
-            
-            interface Named implements Node & Node {
               id: ID!
               name: String
             }
@@ -266,8 +243,8 @@ class InterfacesImplementingInterfacesTest extends Specification {
 
 
         then:
-        // TODO: Assert error message
-        thrown(AssertionError)
+        def error = thrown(AssertionError)
+        error.getMessage() ==~ ".*The interface extension type 'Resource'.*does not have a field 'extraField' required via interface 'Node'.*"
     }
 
     def 'When object extension implements all transitive interfaces, then parsing is successful'() {
@@ -327,8 +304,8 @@ class InterfacesImplementingInterfacesTest extends Specification {
             }
             """)
         then:
-        // TODO: assert error message
-        thrown(AssertionError)
+        def error = thrown(AssertionError)
+        error.getMessage() ==~ ".*The object extension type 'Image'.*does not implement the following transitive interfaces: \\[Node\\].*"
     }
 
     def 'When interface extension implements all transitive interfaces, then parsing is successful'() {
@@ -388,7 +365,7 @@ class InterfacesImplementingInterfacesTest extends Specification {
             }
             """)
         then:
-        // TODO: assert error message
-        thrown(AssertionError)
+        def error = thrown(AssertionError)
+        error.getMessage() ==~ ".*The interface extension type 'Image'.*does not implement the following transitive interfaces: \\[Node\\].*"
     }
 }

--- a/src/test/groovy/graphql/InterfacesImplementingInterfacesTest.groovy
+++ b/src/test/groovy/graphql/InterfacesImplementingInterfacesTest.groovy
@@ -1,0 +1,394 @@
+package graphql
+
+
+import spock.lang.Specification
+
+class InterfacesImplementingInterfacesTest extends Specification {
+
+    // TODO: maybe parameterized this test
+    def 'Simple interface implementing interface'() {
+        when:
+        TestUtil.schema("""
+            type Query {
+               find(id: String!): Node
+            }
+            
+            interface Node {
+              id: ID!
+            }
+
+            interface Resource implements Node {
+              id: ID!
+              url: String
+            }
+
+            """)
+
+
+        then:
+        noExceptionThrown()
+    }
+
+    def 'When implementing interface does not declare required field, then parsing fails'() {
+        when:
+        TestUtil.schema("""
+            type Query {
+               find(id: String!): Node
+            }
+            
+            interface Node {
+              id: ID!
+            }
+
+            interface Resource implements Node {
+              url: String
+            }
+            """)
+
+
+        then:
+        thrown(AssertionError)
+    }
+
+    def 'Transitively implemented interfaces defined in implementing interface'() {
+        when:
+        TestUtil.schema("""
+            type Query {
+               find(id: String!): Node
+            }
+            
+            interface Node {
+              id: ID!
+            }
+            
+            interface Resource implements Node {
+              id: ID!
+              url: String
+            }
+
+            interface Image implements Resource & Node {
+              id: ID!
+              url: String
+              thumbnail: String
+            }
+            """)
+
+
+        then:
+        noExceptionThrown()
+    }
+
+
+    def 'Transitively implemented interfaces defined in implementing type'() {
+        when:
+        TestUtil.schema("""
+            type Query {
+               find(id: String!): Node
+            }
+            
+            interface Node {
+              id: ID!
+            }
+            
+            interface Resource implements Node {
+              id: ID!
+              url: String
+            }
+
+            type Image implements Resource & Node {
+              id: ID!
+              url: String
+              thumbnail: String
+            }
+            """)
+
+
+        then:
+        noExceptionThrown()
+    }
+
+    def 'When not all transitively implemented interfaces are defined in implementing interface, then parsing fails'() {
+        when:
+        TestUtil.schema("""
+            type Query {
+               find(id: String!): Node
+            }
+            
+            interface Node {
+              id: ID!
+            }
+            
+            interface Resource implements Node {
+              id: ID!
+              url: String
+            }
+
+            interface Image implements Resource & Node {
+              id: ID!
+              url: String
+              thumbnail: String
+            }
+            
+            interface LargeImage implements Image & Resource {
+              id: ID!
+              url: String
+              thumbnail: String
+              large: String
+            }
+            """)
+
+
+        then:
+        // TODO: Assert error message
+        def error = thrown(AssertionError)
+    }
+
+    def 'When not all transitively implemented interfaces are defined in implementing type, then parsing fails'() {
+        when:
+        TestUtil.schema("""
+            type Query {
+               find(id: String!): Node
+            }
+            
+            interface Node {
+              id: ID!
+            }
+            
+            interface Resource implements Node {
+              id: ID!
+              url: String
+            }
+
+            type Image implements Resource {
+              id: ID!
+              url: String
+              thumbnail: String
+            }
+            """)
+
+
+        then:
+        // TODO: Assert error message
+        thrown(AssertionError)
+    }
+
+    def 'When interface implements itself, then parsing fails'() {
+        when:
+        TestUtil.schema("""
+            type Query {
+               find(id: String!): Node
+            }
+            
+            interface Node implements Named & Node {
+              id: ID!
+              name: String
+            }
+            
+            interface Named implements Node & Named {
+              id: ID!
+              name: String
+            }
+            """)
+
+
+        then:
+        // TODO: Assert error message
+        thrown(AssertionError)
+    }
+
+    def 'When interface implements same interface twice, then parsing fails'() {
+        when:
+        TestUtil.schema("""
+            type Query {
+               find(id: String!): Node
+            }
+            
+            interface Node {
+              id: ID!
+              name: String
+            }
+            
+            interface Named implements Node & Node {
+              id: ID!
+              name: String
+            }
+            """)
+
+
+        then:
+        // TODO: Assert error message
+        thrown(AssertionError)
+    }
+
+    def 'When interface extension implements interface and declares required field, then parsing is successful'() {
+        when:
+        TestUtil.schema("""
+            type Query {
+               find(id: String!): Node
+            }
+            
+            interface Node {
+              id: ID!
+            }
+
+            interface Resource {
+              url: String
+            }
+            
+            extend interface Resource implements Node {
+                id: ID!
+            }
+            """)
+        then:
+        noExceptionThrown()
+    }
+
+    def 'When interface extension implements interface but doesn\'t declare required field, then parsing fails'() {
+        when:
+        TestUtil.schema("""
+            type Query {
+               find(id: String!): Node
+            }
+            
+            interface Node {
+              id: ID!
+              extraField: String
+            }
+
+            interface Resource {
+              url: String
+            }
+            
+            extend interface Resource implements Node {
+                id: ID!
+            }
+            """)
+
+
+        then:
+        // TODO: Assert error message
+        thrown(AssertionError)
+    }
+
+    def 'When object extension implements all transitive interfaces, then parsing is successful'() {
+        when:
+        TestUtil.schema("""
+            type Query {
+               find(id: String!): Node
+            }
+            
+            interface Node {
+              id: ID!
+            }
+
+            interface Resource implements Node {
+              id: ID!
+              url: String
+            }
+            
+            type Image {
+                thumbnail: String!
+            }
+            
+            extend type Image implements Node & Resource {
+                id: ID!
+                url: String
+                thumbnail: String!
+            }
+            """)
+        then:
+        noExceptionThrown()
+    }
+
+    def 'When object extension does not implement all transitive interfaces, then parsing fails'() {
+        when:
+        TestUtil.schema("""
+            type Query {
+               find(id: String!): Node
+            }
+            
+            interface Node {
+              id: ID!
+            }
+
+            interface Resource implements Node {
+              id: ID!
+              url: String
+            }
+            
+            type Image {
+                thumbnail: String!
+            }
+            
+            extend type Image implements Resource {
+                id: ID!
+                url: String
+                thumbnail: String!
+            }
+            """)
+        then:
+        // TODO: assert error message
+        thrown(AssertionError)
+    }
+
+    def 'When interface extension implements all transitive interfaces, then parsing is successful'() {
+        when:
+        TestUtil.schema("""
+            type Query {
+               find(id: String!): Node
+            }
+            
+            interface Node {
+              id: ID!
+            }
+
+            interface Resource implements Node {
+              id: ID!
+              url: String
+            }
+            
+            interface Image {
+                thumbnail: String!
+            }
+            
+            extend interface Image implements Node & Resource {
+                id: ID!
+                url: String
+                thumbnail: String!
+            }
+            """)
+        then:
+        noExceptionThrown()
+    }
+
+    def 'When interface extension does not implement all transitive interfaces, then parsing fails'() {
+        when:
+        TestUtil.schema("""
+            type Query {
+               find(id: String!): Node
+            }
+            
+            interface Node {
+              id: ID!
+            }
+
+            interface Resource implements Node {
+              id: ID!
+              url: String
+            }
+            
+            interface Image {
+                thumbnail: String!
+            }
+            
+            extend interface Image implements Resource {
+                id: ID!
+                url: String
+                thumbnail: String!
+            }
+            """)
+        then:
+        // TODO: assert error message
+        thrown(AssertionError)
+    }
+}

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -542,13 +542,6 @@ class SchemaGeneratorTest extends Specification {
             extend type BaseType {
                extraField5 : Boolean!
             }
-            #
-            # if we repeat a definition, that's ok as long as its the same types as before
-            # they will be de-duped since the effect is the same
-            #
-            extend type BaseType implements Interface1 {
-               extraField1 : String
-            }
             
             schema {
               query: BaseType

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -529,11 +529,9 @@ class SchemaGeneratorTest extends Specification {
                extraField1 : String
             }
             extend type BaseType implements Interface2 {
-               extraField1 : String
                extraField2 : Int
             }
             extend type BaseType implements Interface3 {
-               extraField1 : String
                extraField3 : ID
             }
             extend type BaseType {
@@ -602,7 +600,6 @@ class SchemaGeneratorTest extends Specification {
                 name: String!
             }
             extend type Human implements Character {
-                name: String!
                 friends: [Character]
             }
             extend type Human {

--- a/src/test/groovy/graphql/schema/idl/TypeDefinitionRegistryTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/TypeDefinitionRegistryTest.groovy
@@ -383,7 +383,7 @@ class TypeDefinitionRegistryTest extends Specification {
         when:
         def registry = parse(spec)
         def interfaceDef = registry.getType("Interface", InterfaceTypeDefinition.class).get()
-        def objectTypeDefinitions = registry.getImplementationsOf(interfaceDef)
+        def objectTypeDefinitions = registry.getAllImplementationsOf(interfaceDef)
         def names = objectTypeDefinitions.collect { it.getName() }
         then:
         names == ["Type1", "Type2", "Type3"]


### PR DESCRIPTION
Change validation logic so it doesn't allow field redefinition by extensions even if the field types are the same.

This change will make the validation of GraphQL Java more aligned with the validation done by the reference graphql-js implementation.

This should be merged after #1884 is merged.