### PR TITLE
Lazy data fetcher values support for arguments and execution step info

### DIFF
--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -9,6 +9,7 @@ import graphql.SerializationError;
 import graphql.TrivialDataFetcher;
 import graphql.TypeMismatchError;
 import graphql.UnresolvedTypeError;
+import graphql.execution.directives.QueryDirectives;
 import graphql.execution.directives.QueryDirectivesImpl;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationContext;
@@ -43,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.function.Supplier;
 
 import static graphql.execution.Async.exceptionallyCompletedFuture;
 import static graphql.execution.ExecutionStepInfo.newExecutionStepInfo;
@@ -235,13 +237,17 @@ public abstract class ExecutionStrategy {
         GraphQLFieldDefinition fieldDef = getFieldDef(executionContext.getGraphQLSchema(), parentType, field.getSingleField());
 
         GraphQLCodeRegistry codeRegistry = executionContext.getGraphQLSchema().getCodeRegistry();
-        Map<String, Object> argumentValues = valuesResolver.getArgumentValues(codeRegistry, fieldDef.getArguments(), field.getArguments(), executionContext.getVariables());
-
-        QueryDirectivesImpl queryDirectives = new QueryDirectivesImpl(field, executionContext.getGraphQLSchema(), executionContext.getVariables());
-
         GraphQLOutputType fieldType = fieldDef.getType();
+
+        // DataFetchingFieldSelectionSet and QueryDirectives is a supplier of sorts - eg a lazy pattern
         DataFetchingFieldSelectionSet fieldCollector = DataFetchingFieldSelectionSetImpl.newCollector(executionContext, fieldType, parameters.getField());
-        ExecutionStepInfo executionStepInfo = createExecutionStepInfo(executionContext, parameters, fieldDef, parentType);
+        QueryDirectives queryDirectives = new QueryDirectivesImpl(field, executionContext.getGraphQLSchema(), executionContext.getVariables());
+
+        // if the DF (like PropertyDataFetcher) does not use the arguments of execution step info then dont build any
+        Supplier<Map<String, Object>> argumentValues = FpKit.memoize(
+                () -> valuesResolver.getArgumentValues(codeRegistry, fieldDef.getArguments(), field.getArguments(), executionContext.getVariables()));
+        Supplier<ExecutionStepInfo> executionStepInfo = FpKit.memoize(
+                () -> createExecutionStepInfo(executionContext, parameters, fieldDef, parentType));
 
 
         DataFetchingEnvironment environment = newDataFetchingEnvironment(executionContext)
@@ -257,7 +263,7 @@ public abstract class ExecutionStrategy {
                 .queryDirectives(queryDirectives)
                 .build();
 
-        DataFetcher dataFetcher = codeRegistry.getDataFetcher(parentType, fieldDef);
+        DataFetcher<?> dataFetcher = codeRegistry.getDataFetcher(parentType, fieldDef);
 
         Instrumentation instrumentation = executionContext.getInstrumentation();
 
@@ -268,13 +274,10 @@ public abstract class ExecutionStrategy {
         dataFetcher = instrumentation.instrumentDataFetcher(dataFetcher, instrumentationFieldFetchParams);
         ExecutionId executionId = executionContext.getExecutionId();
         try {
-            log.debug("'{}' fetching field '{}' using data fetcher '{}'...", executionId, executionStepInfo.getPath(), dataFetcher.getClass().getName());
             Object fetchedValueRaw = dataFetcher.get(environment);
-            logNotSafe.debug("'{}' field '{}' fetch returned '{}'", executionId, executionStepInfo.getPath(), fetchedValueRaw == null ? "null" : fetchedValueRaw.getClass().getName());
-
             fetchedValue = Async.toCompletableFuture(fetchedValueRaw);
         } catch (Exception e) {
-            logNotSafe.debug(String.format("'%s', field '%s' fetch threw exception", executionId, executionStepInfo.getPath()), e);
+            logNotSafe.debug(String.format("'%s', field '%s' fetch threw exception", executionId, executionStepInfo.get().getPath()), e);
 
             fetchedValue = new CompletableFuture<>();
             fetchedValue.completeExceptionally(e);

--- a/src/main/java/graphql/execution/nextgen/ValueFetcher.java
+++ b/src/main/java/graphql/execution/nextgen/ValueFetcher.java
@@ -27,6 +27,7 @@ import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLFieldsContainer;
 import graphql.schema.GraphQLOutputType;
 import graphql.schema.GraphQLTypeUtil;
+import graphql.util.FpKit;
 import graphql.util.LogKit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static graphql.schema.DataFetchingEnvironmentImpl.newDataFetchingEnvironment;
@@ -115,7 +117,7 @@ public class ValueFetcher {
         GraphQLCodeRegistry codeRegistry = executionContext.getGraphQLSchema().getCodeRegistry();
         GraphQLFieldsContainer parentType = getFieldsContainer(executionInfo);
 
-        Map<String, Object> argumentValues = valuesResolver.getArgumentValues(codeRegistry, fieldDef.getArguments(), field.getArguments(), executionContext.getVariables());
+        Supplier<Map<String, Object>> argumentValues = FpKit.memoize(() -> valuesResolver.getArgumentValues(codeRegistry, fieldDef.getArguments(), field.getArguments(), executionContext.getVariables()));
 
         QueryDirectivesImpl queryDirectives = new QueryDirectivesImpl(sameFields, executionContext.getGraphQLSchema(), executionContext.getVariables());
 

--- a/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
@@ -19,12 +19,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Supplier;
 
 @SuppressWarnings({"unchecked", "TypeParameterUnusedInFormals"})
 @Internal
 public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
     private final Object source;
-    private final Map<String, Object> arguments;
+    private final Supplier<Map<String, Object>> arguments;
     private final Object context;
     private final Object localContext;
     private final Object root;
@@ -36,7 +37,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
     private final Map<String, FragmentDefinition> fragmentsByName;
     private final ExecutionId executionId;
     private final DataFetchingFieldSelectionSet selectionSet;
-    private final ExecutionStepInfo executionStepInfo;
+    private final Supplier<ExecutionStepInfo> executionStepInfo;
     private final DataLoaderRegistry dataLoaderRegistry;
     private final CacheControl cacheControl;
     private final Locale locale;
@@ -47,7 +48,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
 
     private DataFetchingEnvironmentImpl(Builder builder) {
         this.source = builder.source;
-        this.arguments = builder.arguments == null ? Collections.emptyMap() : builder.arguments;
+        this.arguments = builder.arguments == null ? Collections::emptyMap : builder.arguments;
         this.context = builder.context;
         this.localContext = builder.localContext;
         this.root = builder.root;
@@ -103,22 +104,22 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
 
     @Override
     public Map<String, Object> getArguments() {
-        return Collections.unmodifiableMap(arguments);
+        return Collections.unmodifiableMap(arguments.get());
     }
 
     @Override
     public boolean containsArgument(String name) {
-        return arguments.containsKey(name);
+        return arguments.get().containsKey(name);
     }
 
     @Override
     public <T> T getArgument(String name) {
-        return (T) arguments.get(name);
+        return (T) arguments.get().get(name);
     }
 
     @Override
     public <T> T getArgumentOrDefault(String name, T defaultValue) {
-        return (T) arguments.getOrDefault(name, defaultValue);
+        return (T) arguments.get().getOrDefault(name, defaultValue);
     }
 
     @Override
@@ -193,7 +194,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
 
     @Override
     public ExecutionStepInfo getExecutionStepInfo() {
-        return executionStepInfo;
+        return executionStepInfo.get();
     }
 
     @Override
@@ -251,13 +252,13 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
         private GraphQLSchema graphQLSchema;
         private ExecutionId executionId;
         private DataFetchingFieldSelectionSet selectionSet;
-        private ExecutionStepInfo executionStepInfo;
+        private Supplier<ExecutionStepInfo> executionStepInfo;
         private DataLoaderRegistry dataLoaderRegistry;
         private CacheControl cacheControl;
         private Locale locale;
         private OperationDefinition operationDefinition;
         private Document document;
-        private Map<String, Object> arguments;
+        private Supplier<Map<String, Object>> arguments;
         private Map<String, FragmentDefinition> fragmentsByName;
         private Map<String, Object> variables;
         private QueryDirectives queryDirectives;
@@ -295,6 +296,10 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
         }
 
         public Builder arguments(Map<String, Object> arguments) {
+            return arguments(() -> arguments);
+        }
+
+        public Builder arguments(Supplier<Map<String, Object>> arguments) {
             this.arguments = arguments;
             return this;
         }
@@ -355,6 +360,10 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
         }
 
         public Builder executionStepInfo(ExecutionStepInfo executionStepInfo) {
+            return executionStepInfo(() -> executionStepInfo);
+        }
+
+        public Builder executionStepInfo(Supplier<ExecutionStepInfo> executionStepInfo) {
             this.executionStepInfo = executionStepInfo;
             return this;
         }

--- a/src/main/java/graphql/schema/PropertyDataFetcherHelper.java
+++ b/src/main/java/graphql/schema/PropertyDataFetcherHelper.java
@@ -37,9 +37,6 @@ public class PropertyDataFetcherHelper {
     }
 
     public static Object getPropertyValue(String propertyName, Object object, GraphQLType graphQLType, DataFetchingEnvironment environment) {
-        if (object == null) {
-            return null;
-        }
         if (object instanceof Map) {
             return ((Map<?, ?>) object).get(propertyName);
         }

--- a/src/main/java/graphql/util/FpKit.java
+++ b/src/main/java/graphql/util/FpKit.java
@@ -16,6 +16,7 @@ import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -189,5 +190,18 @@ public class FpKit {
         return -1;
     }
 
+    /**
+     * This will memoize the Supplier within the current thread's visibility, that is it does not
+     * use volatile reads but rather use a sentinel check and re-reads the delegate supplier
+     * value if the read has not stuck to this thread.  This means that its possible that your delegate
+     * supplier MAY be called more than once across threads, but only once on the same thread.
+     *
+     * @param delegate the supplier to delegate to
+     * @param <T>      for two
+     * @return a supplier that will memoize values in the context of the current thread
+     */
+    public static <T> Supplier<T> memoize(Supplier<T> delegate) {
+        return new MemoizedSupplier<>(delegate);
+    }
 
 }

--- a/src/main/java/graphql/util/MemoizedSupplier.java
+++ b/src/main/java/graphql/util/MemoizedSupplier.java
@@ -1,0 +1,28 @@
+package graphql.util;
+
+import java.util.function.Supplier;
+
+import static graphql.Assert.assertNotNull;
+
+class MemoizedSupplier<T> implements Supplier<T> {
+    private final static Object SENTINEL = new Object() {
+    };
+
+    @SuppressWarnings("unchecked")
+    private T value = (T) SENTINEL;
+    private final Supplier<T> delegate;
+
+    MemoizedSupplier(Supplier<T> delegate) {
+        this.delegate = assertNotNull(delegate);
+    }
+
+    @Override
+    public T get() {
+        T t = value;
+        if (t == SENTINEL) {
+            t = delegate.get();
+            value = t;
+        }
+        return t;
+    }
+}

--- a/src/test/groovy/graphql/util/FpKitTest.groovy
+++ b/src/test/groovy/graphql/util/FpKitTest.groovy
@@ -1,6 +1,9 @@
 package graphql.util
 
+
 import spock.lang.Specification
+
+import java.util.function.Supplier
 
 class FpKitTest extends Specification {
 
@@ -40,5 +43,25 @@ class FpKitTest extends Specification {
         actual = FpKit.toCollection(iterableThing)
         then:
         actual == expected
+    }
+
+    void "memoized supplier"() {
+
+        def count = 0
+        Supplier<Integer> supplier = { -> count++; return count }
+
+        when:
+        def memoizeSupplier = FpKit.memoize(supplier)
+        def val1 = supplier.get()
+        def val2 = supplier.get()
+        def memoVal1 = memoizeSupplier.get()
+        def memoVal2 = memoizeSupplier.get()
+
+        then:
+        val1 == 1
+        val2 == 2
+
+        memoVal1 == 3
+        memoVal2 == 3
     }
 }


### PR DESCRIPTION
Why do work when many (most) data fetchers such as PropertyDataFetcher never used the arguments not all of the execution step info.

Like the DataSelectionSetimpl - this is a lazy pattern