### PR TITLE
Stable backport of 1801

### DIFF
--- a/src/test/groovy/graphql/execution/pubsub/CapturingSubscriber.java
+++ b/src/test/groovy/graphql/execution/pubsub/CapturingSubscriber.java
@@ -19,24 +19,28 @@ public class CapturingSubscriber<T> implements Subscriber<T> {
 
     @Override
     public void onSubscribe(Subscription subscription) {
+        System.out.println("onSubscribe called at " + System.nanoTime());
         this.subscription = subscription;
         subscription.request(1);
     }
 
     @Override
     public void onNext(T t) {
+        System.out.println("onNext called at " + System.nanoTime());
         events.add(t);
         subscription.request(1);
     }
 
     @Override
     public void onError(Throwable t) {
+        System.out.println("onError called at " + System.nanoTime());
         this.throwable = t;
         done.set(true);
     }
 
     @Override
     public void onComplete() {
+        System.out.println("onComplete called at " + System.nanoTime());
         done.set(true);
     }
 


### PR DESCRIPTION
This fixes the Subscription publisher so that it does not drop values… that have been received but not yet mapped by the graphql layer (#1801)