### PR TITLE
1847: Fix circular reference between input object field/type (#1864)

### DIFF
--- a/src/main/java/graphql/schema/GraphQLInputObjectField.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectField.java
@@ -170,12 +170,18 @@ public class GraphQLInputObjectField implements GraphQLNamedSchemaElement, Graph
         return "GraphQLInputObjectField{" +
                 "name='" + name + '\'' +
                 ", description='" + description + '\'' +
-                ", originalType=" + originalType +
+                ", originalType=" + inputTypeToStringAvoidingCircularReference(originalType) +
                 ", defaultValue=" + defaultValue +
                 ", definition=" + definition +
                 ", directives=" + directives +
-                ", replacedType=" + replacedType +
+                ", replacedType=" + inputTypeToStringAvoidingCircularReference(replacedType) +
                 '}';
+    }
+
+    private static Object inputTypeToStringAvoidingCircularReference(GraphQLInputType graphQLInputType) {
+        return (graphQLInputType instanceof GraphQLInputObjectType)
+                ? String.format("[%s]", GraphQLInputObjectType.class.getSimpleName())
+                : graphQLInputType;
     }
 
     public static Builder newInputObjectField(GraphQLInputObjectField existing) {

--- a/src/test/groovy/graphql/Issue1847.groovy
+++ b/src/test/groovy/graphql/Issue1847.groovy
@@ -1,0 +1,42 @@
+package graphql
+
+import spock.lang.Specification
+
+class Issue1847 extends Specification {
+    def schema = TestUtil.schema('''
+                type Query {
+                    listWithCircularReference(filter : TypeWithCircularReference) : String 
+                    list(filter : Type) : String 
+                }
+                input TypeWithCircularReference {
+                    circularField : TypeWithCircularReference
+                }
+                input Type {
+                    field: String
+                }
+            ''')
+
+    def "#1847 when there is a circular reference between Input Type and Input Field - not StackOverflowError"() {
+        when:
+        def type = schema.getType("TypeWithCircularReference")
+
+        def string = type.toString()
+
+        println(string)
+
+        then:
+        string.contains("[GraphQLInputObjectType]")
+    }
+
+    def "#1847 when there is no circular reference between Input Type and Input Field - toString returns all data"() {
+        when:
+        def type = schema.getType("Type")
+
+        def string = type.toString()
+        println(string)
+
+        then:
+        !string.contains("[GraphQLInputObjectType]")
+        string.contains("GraphQLScalarType")
+    }
+}


### PR DESCRIPTION
* 1847: Fix circular reference between input object field/type
Fixes #1847

* 1847: Add circular reference back on test

Co-authored-by: Felipe Reis <freis@atlassian.com>