### PR TITLE
Make the graphql-java Asserts truly lazy and hence more efficient

### DIFF
--- a/src/main/java/graphql/Assert.java
+++ b/src/main/java/graphql/Assert.java
@@ -1,6 +1,5 @@
 package graphql;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.Supplier;
 
@@ -10,18 +9,18 @@ import static java.lang.String.format;
 @Internal
 public class Assert {
 
-    public static <T> T assertNotNull(T object, String format, Object... args) {
+    public static <T> T assertNotNull(T object, Supplier<String> msg) {
         if (object != null) {
             return object;
         }
-        throw new AssertException(format(format, args));
+        throw new AssertException(msg.get());
     }
 
-    public static <T> T assertNotNullWithNPE(T object, String format, Object... args) {
+    public static <T> T assertNotNullWithNPE(T object, Supplier<String> msg) {
         if (object != null) {
             return object;
         }
-        throw new NullPointerException(format(format, args));
+        throw new NullPointerException(msg.get());
     }
 
     public static <T> T assertNotNull(T object) {
@@ -31,11 +30,11 @@ public class Assert {
         throw new AssertException("Object required to be not null");
     }
 
-    public static <T> void assertNull(T object, String format, Object... args) {
+    public static <T> void assertNull(T object, Supplier<String> msg) {
         if (object == null) {
             return;
         }
-        throw new AssertException(format(format, args));
+        throw new AssertException(msg.get());
     }
 
     public static <T> void assertNull(T object) {
@@ -64,25 +63,18 @@ public class Assert {
         return collection;
     }
 
-    public static <T> Collection<T> assertNotEmpty(Collection<T> collection, String format, Object... args) {
+    public static <T> Collection<T> assertNotEmpty(Collection<T> collection, Supplier<String> msg) {
         if (collection == null || collection.isEmpty()) {
-            throw new AssertException(format(format, args));
+            throw new AssertException(msg.get());
         }
         return collection;
     }
 
-    public static void assertTrue(boolean condition, String format, Object... args) {
+    public static void assertTrue(boolean condition, Supplier<String> msg) {
         if (condition) {
             return;
         }
-        throw new AssertException(format(format, args));
-    }
-
-    public static void assertTrueLazily(boolean condition, String format, Supplier<?>... args) {
-        if (condition) {
-            return;
-        }
-        throw new AssertException(format(format, Arrays.stream(args).map(Supplier::get).toArray()));
+        throw new AssertException(msg.get());
     }
 
     public static void assertTrue(boolean condition) {
@@ -92,11 +84,18 @@ public class Assert {
         throw new AssertException("condition expected to be true");
     }
 
-    public static void assertFalse(boolean condition, String format, Object... args) {
+    public static void assertFalse(boolean condition, Supplier<String> msg) {
         if (!condition) {
             return;
         }
-        throw new AssertException(format(format, args));
+        throw new AssertException(msg.get());
+    }
+
+    public static void assertFalse(boolean condition) {
+        if (!condition) {
+            return;
+        }
+        throw new AssertException("condition expected to be false");
     }
 
     private static final String invalidNameErrorMessage = "Name must be non-null, non-empty and match [_A-Za-z][_0-9A-Za-z]* - was '%s'";
@@ -106,7 +105,6 @@ public class Assert {
      * currently non null, non empty,
      *
      * @param name - the name to be validated.
-     *
      * @return the name if valid, or AssertException if invalid.
      */
     public static String assertValidName(String name) {

--- a/src/main/java/graphql/ExecutionInput.java
+++ b/src/main/java/graphql/ExecutionInput.java
@@ -31,7 +31,7 @@ public class ExecutionInput {
 
     @Internal
     private ExecutionInput(String query, String operationName, Object context, Object root, Map<String, Object> variables, DataLoaderRegistry dataLoaderRegistry, CacheControl cacheControl, ExecutionId executionId, Locale locale) {
-        this.query = assertNotNull(query, "query can't be null");
+        this.query = assertNotNull(query, () -> "query can't be null");
         this.operationName = operationName;
         this.context = context;
         this.root = root;
@@ -179,7 +179,7 @@ public class ExecutionInput {
         private ExecutionId executionId;
 
         public Builder query(String query) {
-            this.query = assertNotNull(query, "query can't be null");
+            this.query = assertNotNull(query, () -> "query can't be null");
             return this;
         }
 
@@ -240,7 +240,7 @@ public class ExecutionInput {
         }
 
         public Builder variables(Map<String, Object> variables) {
-            this.variables = assertNotNull(variables, "variables map can't be null");
+            this.variables = assertNotNull(variables, () -> "variables map can't be null");
             return this;
         }
 

--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -176,13 +176,13 @@ public class GraphQL {
                     Instrumentation instrumentation,
                     PreparsedDocumentProvider preparsedDocumentProvider,
                     ValueUnboxer valueUnboxer) {
-        this.graphQLSchema = assertNotNull(graphQLSchema, "graphQLSchema must be non null");
+        this.graphQLSchema = assertNotNull(graphQLSchema, () -> "graphQLSchema must be non null");
         this.queryStrategy = queryStrategy != null ? queryStrategy : new AsyncExecutionStrategy();
         this.mutationStrategy = mutationStrategy != null ? mutationStrategy : new AsyncSerialExecutionStrategy();
         this.subscriptionStrategy = subscriptionStrategy != null ? subscriptionStrategy : new SubscriptionExecutionStrategy();
-        this.idProvider = assertNotNull(idProvider, "idProvider must be non null");
+        this.idProvider = assertNotNull(idProvider, () -> "idProvider must be non null");
         this.instrumentation = assertNotNull(instrumentation);
-        this.preparsedDocumentProvider = assertNotNull(preparsedDocumentProvider, "preparsedDocumentProvider must be non null");
+        this.preparsedDocumentProvider = assertNotNull(preparsedDocumentProvider, () -> "preparsedDocumentProvider must be non null");
         this.valueUnboxer = valueUnboxer;
     }
 
@@ -242,37 +242,37 @@ public class GraphQL {
         }
 
         public Builder schema(GraphQLSchema graphQLSchema) {
-            this.graphQLSchema = assertNotNull(graphQLSchema, "GraphQLSchema must be non null");
+            this.graphQLSchema = assertNotNull(graphQLSchema, () -> "GraphQLSchema must be non null");
             return this;
         }
 
         public Builder queryExecutionStrategy(ExecutionStrategy executionStrategy) {
-            this.queryExecutionStrategy = assertNotNull(executionStrategy, "Query ExecutionStrategy must be non null");
+            this.queryExecutionStrategy = assertNotNull(executionStrategy, () -> "Query ExecutionStrategy must be non null");
             return this;
         }
 
         public Builder mutationExecutionStrategy(ExecutionStrategy executionStrategy) {
-            this.mutationExecutionStrategy = assertNotNull(executionStrategy, "Mutation ExecutionStrategy must be non null");
+            this.mutationExecutionStrategy = assertNotNull(executionStrategy, () -> "Mutation ExecutionStrategy must be non null");
             return this;
         }
 
         public Builder subscriptionExecutionStrategy(ExecutionStrategy executionStrategy) {
-            this.subscriptionExecutionStrategy = assertNotNull(executionStrategy, "Subscription ExecutionStrategy must be non null");
+            this.subscriptionExecutionStrategy = assertNotNull(executionStrategy, () -> "Subscription ExecutionStrategy must be non null");
             return this;
         }
 
         public Builder instrumentation(Instrumentation instrumentation) {
-            this.instrumentation = assertNotNull(instrumentation, "Instrumentation must be non null");
+            this.instrumentation = assertNotNull(instrumentation, () -> "Instrumentation must be non null");
             return this;
         }
 
         public Builder preparsedDocumentProvider(PreparsedDocumentProvider preparsedDocumentProvider) {
-            this.preparsedDocumentProvider = assertNotNull(preparsedDocumentProvider, "PreparsedDocumentProvider must be non null");
+            this.preparsedDocumentProvider = assertNotNull(preparsedDocumentProvider, () -> "PreparsedDocumentProvider must be non null");
             return this;
         }
 
         public Builder executionIdProvider(ExecutionIdProvider executionIdProvider) {
-            this.idProvider = assertNotNull(executionIdProvider, "ExecutionIdProvider must be non null");
+            this.idProvider = assertNotNull(executionIdProvider, () -> "ExecutionIdProvider must be non null");
             return this;
         }
 
@@ -299,9 +299,9 @@ public class GraphQL {
         }
 
         public GraphQL build() {
-            assertNotNull(graphQLSchema, "graphQLSchema must be non null");
-            assertNotNull(queryExecutionStrategy, "queryStrategy must be non null");
-            assertNotNull(idProvider, "idProvider must be non null");
+            assertNotNull(graphQLSchema, () -> "graphQLSchema must be non null");
+            assertNotNull(queryExecutionStrategy, () -> "queryStrategy must be non null");
+            assertNotNull(idProvider, () -> "idProvider must be non null");
             final Instrumentation augmentedInstrumentation = checkInstrumentationDefaultState(instrumentation, doNotAddDefaultInstrumentations);
             return new GraphQL(graphQLSchema, queryExecutionStrategy, mutationExecutionStrategy, subscriptionExecutionStrategy, idProvider, augmentedInstrumentation, preparsedDocumentProvider, valueUnboxer);
         }

--- a/src/main/java/graphql/GraphqlErrorBuilder.java
+++ b/src/main/java/graphql/GraphqlErrorBuilder.java
@@ -92,7 +92,7 @@ public class GraphqlErrorBuilder {
      * @return a newly built GraphqlError
      */
     public GraphQLError build() {
-        assertNotNull(message, "You must provide error message");
+        assertNotNull(message, () -> "You must provide error message");
         return new GraphqlErrorImpl(message, locations, errorType, path, extensions);
     }
 

--- a/src/main/java/graphql/analysis/MaxQueryComplexityInstrumentation.java
+++ b/src/main/java/graphql/analysis/MaxQueryComplexityInstrumentation.java
@@ -72,7 +72,7 @@ public class MaxQueryComplexityInstrumentation extends SimpleInstrumentation {
     public MaxQueryComplexityInstrumentation(int maxComplexity, FieldComplexityCalculator fieldComplexityCalculator,
                                              Function<QueryComplexityInfo, Boolean> maxQueryComplexityExceededFunction) {
         this.maxComplexity = maxComplexity;
-        this.fieldComplexityCalculator = assertNotNull(fieldComplexityCalculator, "calculator can't be null");
+        this.fieldComplexityCalculator = assertNotNull(fieldComplexityCalculator, () -> "calculator can't be null");
         this.maxQueryComplexityExceededFunction = maxQueryComplexityExceededFunction;
     }
 

--- a/src/main/java/graphql/analysis/NodeVisitorWithTypeTracking.java
+++ b/src/main/java/graphql/analysis/NodeVisitorWithTypeTracking.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import static graphql.Assert.assertNotNull;
 import static graphql.schema.GraphQLTypeUtil.unwrapAll;
 import static graphql.util.TraverserContext.Phase.LEAVE;
+import static java.lang.String.format;
 
 /**
  * Internally used node visitor which delegates to a {@link QueryVisitor} with type
@@ -138,8 +139,9 @@ public class NodeVisitorWithTypeTracking extends NodeVisitorStub {
         QueryTraversalContext parentEnv = context.getVarFromParents(QueryTraversalContext.class);
 
         GraphQLCompositeType typeCondition = (GraphQLCompositeType) schema.getType(fragmentDefinition.getTypeCondition().getName());
-        assertNotNull(typeCondition, "Invalid type condition '%s' in fragment '%s'", fragmentDefinition.getTypeCondition().getName(),
-                fragmentDefinition.getName());
+        assertNotNull(typeCondition,
+                () -> format("Invalid type condition '%s' in fragment '%s'", fragmentDefinition.getTypeCondition().getName(),
+                        fragmentDefinition.getName()));
         context.setVar(QueryTraversalContext.class, new QueryTraversalContext(typeCondition, parentEnv.getEnvironment(), fragmentDefinition));
         return TraversalControl.CONTINUE;
     }

--- a/src/main/java/graphql/analysis/QueryTransformer.java
+++ b/src/main/java/graphql/analysis/QueryTransformer.java
@@ -44,11 +44,11 @@ public class QueryTransformer {
                              GraphQLCompositeType rootParentType,
                              Map<String, FragmentDefinition> fragmentsByName,
                              Map<String, Object> variables) {
-        this.schema = assertNotNull(schema, "schema can't be null");
-        this.variables = assertNotNull(variables, "variables can't be null");
-        this.root = assertNotNull(root, "root can't be null");
+        this.schema = assertNotNull(schema, () -> "schema can't be null");
+        this.variables = assertNotNull(variables, () -> "variables can't be null");
+        this.root = assertNotNull(root, () -> "root can't be null");
         this.rootParentType = assertNotNull(rootParentType);
-        this.fragmentsByName = assertNotNull(fragmentsByName, "fragmentsByName can't be null");
+        this.fragmentsByName = assertNotNull(fragmentsByName, () -> "fragmentsByName can't be null");
     }
 
     /**

--- a/src/main/java/graphql/analysis/QueryTraverser.java
+++ b/src/main/java/graphql/analysis/QueryTraverser.java
@@ -48,10 +48,10 @@ public class    QueryTraverser {
                            Document document,
                            String operation,
                            Map<String, Object> variables) {
-        assertNotNull(document, "document  can't be null");
+        assertNotNull(document, () -> "document  can't be null");
         NodeUtil.GetOperationResult getOperationResult = NodeUtil.getOperation(document, operation);
-        this.schema = assertNotNull(schema, "schema can't be null");
-        this.variables = assertNotNull(variables, "variables can't be null");
+        this.schema = assertNotNull(schema, () -> "schema can't be null");
+        this.variables = assertNotNull(variables, () -> "variables can't be null");
         this.fragmentsByName = getOperationResult.fragmentsByName;
         this.roots = singletonList(getOperationResult.operationDefinition);
         this.rootParentType = getRootTypeFromOperation(getOperationResult.operationDefinition);
@@ -62,12 +62,12 @@ public class    QueryTraverser {
                            GraphQLCompositeType rootParentType,
                            Map<String, FragmentDefinition> fragmentsByName,
                            Map<String, Object> variables) {
-        this.schema = assertNotNull(schema, "schema can't be null");
-        this.variables = assertNotNull(variables, "variables can't be null");
-        assertNotNull(root, "root can't be null");
+        this.schema = assertNotNull(schema, () -> "schema can't be null");
+        this.variables = assertNotNull(variables, () -> "variables can't be null");
+        assertNotNull(root, () -> "root can't be null");
         this.roots = Collections.singleton(root);
-        this.rootParentType = assertNotNull(rootParentType, "rootParentType can't be null");
-        this.fragmentsByName = assertNotNull(fragmentsByName, "fragmentsByName can't be null");
+        this.rootParentType = assertNotNull(rootParentType, () -> "rootParentType can't be null");
+        this.fragmentsByName = assertNotNull(fragmentsByName, () -> "fragmentsByName can't be null");
     }
 
     public Object visitDepthFirst(QueryVisitor queryVisitor) {

--- a/src/main/java/graphql/execution/Async.java
+++ b/src/main/java/graphql/execution/Async.java
@@ -49,7 +49,7 @@ public class Async {
             CompletableFuture<U> cf;
             try {
                 cf = cfFactory.apply(t, index++);
-                Assert.assertNotNull(cf, "cfFactory must return a non null value");
+                Assert.assertNotNull(cf, () -> "cfFactory must return a non null value");
             } catch (Exception e) {
                 cf = new CompletableFuture<>();
                 // Async.each makes sure that it is not a CompletionException inside a CompletionException
@@ -75,7 +75,7 @@ public class Async {
         CompletableFuture<U> cf;
         try {
             cf = cfFactory.apply(iterator.next(), index, tmpResult);
-            Assert.assertNotNull(cf, "cfFactory must return a non null value");
+            Assert.assertNotNull(cf, () -> "cfFactory must return a non null value");
         } catch (Exception e) {
             cf = new CompletableFuture<>();
             cf.completeExceptionally(new CompletionException(e));

--- a/src/main/java/graphql/execution/ExecutionContextBuilder.java
+++ b/src/main/java/graphql/execution/ExecutionContextBuilder.java
@@ -174,7 +174,7 @@ public class ExecutionContextBuilder {
 
     public ExecutionContext build() {
         // preconditions
-        assertNotNull(executionId, "You must provide a query identifier");
+        assertNotNull(executionId, () -> "You must provide a query identifier");
 
         return new ExecutionContext(
                 instrumentation,

--- a/src/main/java/graphql/execution/ExecutionId.java
+++ b/src/main/java/graphql/execution/ExecutionId.java
@@ -32,7 +32,7 @@ public class ExecutionId {
     private final String id;
 
     private ExecutionId(String id) {
-        Assert.assertNotNull(id, "You must provided a non null id");
+        Assert.assertNotNull(id, () -> "You must provided a non null id");
         this.id = id;
     }
 

--- a/src/main/java/graphql/execution/ExecutionPath.java
+++ b/src/main/java/graphql/execution/ExecutionPath.java
@@ -43,12 +43,12 @@ public class ExecutionPath {
     }
 
     private ExecutionPath(ExecutionPath parent, String segment) {
-        this.parent = assertNotNull(parent, "Must provide a parent path");
-        this.segment = assertNotNull(segment, "Must provide a sub path");
+        this.parent = assertNotNull(parent, () -> "Must provide a parent path");
+        this.segment = assertNotNull(segment, () -> "Must provide a sub path");
     }
 
     private ExecutionPath(ExecutionPath parent, int segment) {
-        this.parent = assertNotNull(parent, "Must provide a parent path");
+        this.parent = assertNotNull(parent, () -> "Must provide a parent path");
         this.segment = segment;
     }
 
@@ -114,19 +114,19 @@ public class ExecutionPath {
      */
     public static ExecutionPath parse(String pathString) {
         pathString = pathString == null ? "" : pathString;
-        pathString = pathString.trim();
-        StringTokenizer st = new StringTokenizer(pathString, "/[]", true);
+        String finalPathString = pathString.trim();
+        StringTokenizer st = new StringTokenizer(finalPathString, "/[]", true);
         ExecutionPath path = ExecutionPath.rootPath();
         while (st.hasMoreTokens()) {
             String token = st.nextToken();
             if ("/".equals(token)) {
-                assertTrue(st.hasMoreTokens(), mkErrMsg(), pathString);
+                assertTrue(st.hasMoreTokens(), () -> String.format(mkErrMsg(), finalPathString));
                 path = path.segment(st.nextToken());
             } else if ("[".equals(token)) {
-                assertTrue(st.countTokens() >= 2, mkErrMsg(), pathString);
+                assertTrue(st.countTokens() >= 2, () -> String.format(mkErrMsg(), finalPathString));
                 path = path.segment(Integer.parseInt(st.nextToken()));
                 String closingBrace = st.nextToken();
-                assertTrue(closingBrace.equals("]"), mkErrMsg(), pathString);
+                assertTrue(closingBrace.equals("]"), () -> String.format(mkErrMsg(), finalPathString));
             } else {
                 throw new AssertException(format(mkErrMsg(), pathString));
             }
@@ -201,7 +201,7 @@ public class ExecutionPath {
      * @return a new path with the last segment replaced
      */
     public ExecutionPath replaceSegment(int segment) {
-        Assert.assertTrue(!ROOT_PATH.equals(this), "You MUST not call this with the root path");
+        Assert.assertTrue(!ROOT_PATH.equals(this), () -> "You MUST not call this with the root path");
         return new ExecutionPath(parent, segment);
     }
 
@@ -214,7 +214,7 @@ public class ExecutionPath {
      * @return a new path with the last segment replaced
      */
     public ExecutionPath replaceSegment(String segment) {
-        Assert.assertTrue(!ROOT_PATH.equals(this), "You MUST not call this with the root path");
+        Assert.assertTrue(!ROOT_PATH.equals(this), () -> "You MUST not call this with the root path");
         return new ExecutionPath(parent, segment);
     }
 
@@ -241,12 +241,12 @@ public class ExecutionPath {
 
 
     public ExecutionPath sibling(String siblingField) {
-        Assert.assertTrue(!ROOT_PATH.equals(this), "You MUST not call this with the root path");
+        Assert.assertTrue(!ROOT_PATH.equals(this), () -> "You MUST not call this with the root path");
         return new ExecutionPath(this.parent, siblingField);
     }
 
     public ExecutionPath sibling(int siblingField) {
-        Assert.assertTrue(!ROOT_PATH.equals(this), "You MUST not call this with the root path");
+        Assert.assertTrue(!ROOT_PATH.equals(this), () -> "You MUST not call this with the root path");
         return new ExecutionPath(this.parent, siblingField);
     }
 

--- a/src/main/java/graphql/execution/ExecutionStepInfo.java
+++ b/src/main/java/graphql/execution/ExecutionStepInfo.java
@@ -77,7 +77,7 @@ public class ExecutionStepInfo {
         this.field = field;
         this.path = path;
         this.parent = parent;
-        this.type = assertNotNull(type, "you must provide a graphql type");
+        this.type = assertNotNull(type, () -> "you must provide a graphql type");
         this.arguments = arguments;
         this.fieldContainer = fieldsContainer;
     }
@@ -196,7 +196,7 @@ public class ExecutionStepInfo {
      * @return a new type info with the same
      */
     public ExecutionStepInfo changeTypeWithPreservedNonNull(GraphQLOutputType newType) {
-        assertTrue(!GraphQLTypeUtil.isNonNull(newType), "newType can't be non null");
+        assertTrue(!GraphQLTypeUtil.isNonNull(newType), () -> "newType can't be non null");
         if (isNonNullType()) {
             return new ExecutionStepInfo(GraphQLNonNull.nonNull(newType), fieldDefinition, field, path, this.parent, arguments, this.fieldContainer);
         } else {

--- a/src/main/java/graphql/execution/ExecutionStrategyParameters.java
+++ b/src/main/java/graphql/execution/ExecutionStrategyParameters.java
@@ -40,9 +40,9 @@ public class ExecutionStrategyParameters {
                                         ExecutionStrategyParameters parent,
                                         DeferredErrorSupport deferredErrorSupport) {
 
-        this.executionStepInfo = assertNotNull(executionStepInfo, "executionStepInfo is null");
+        this.executionStepInfo = assertNotNull(executionStepInfo, () -> "executionStepInfo is null");
         this.localContext = localContext;
-        this.fields = assertNotNull(fields, "fields is null");
+        this.fields = assertNotNull(fields, () -> "fields is null");
         this.source = source;
         this.arguments = arguments;
         this.nonNullableFieldValidator = nonNullableFieldValidator;
@@ -201,7 +201,7 @@ public class ExecutionStrategyParameters {
         }
 
         public Builder nonNullFieldValidator(NonNullableFieldValidator nonNullableFieldValidator) {
-            this.nonNullableFieldValidator = Assert.assertNotNull(nonNullableFieldValidator, "requires a NonNullValidator");
+            this.nonNullableFieldValidator = Assert.assertNotNull(nonNullableFieldValidator, () -> "requires a NonNullValidator");
             return this;
         }
 

--- a/src/main/java/graphql/execution/FieldCollectorParameters.java
+++ b/src/main/java/graphql/execution/FieldCollectorParameters.java
@@ -80,7 +80,7 @@ public class FieldCollectorParameters {
         }
 
         public FieldCollectorParameters build() {
-            Assert.assertNotNull(graphQLSchema, "You must provide a schema");
+            Assert.assertNotNull(graphQLSchema, () -> "You must provide a schema");
             return new FieldCollectorParameters(graphQLSchema, variables, fragmentsByName, objectType);
         }
 

--- a/src/main/java/graphql/execution/FieldValueInfo.java
+++ b/src/main/java/graphql/execution/FieldValueInfo.java
@@ -26,7 +26,7 @@ public class FieldValueInfo {
     private final List<FieldValueInfo> fieldValueInfos;
 
     private FieldValueInfo(CompleteValueType completeValueType, CompletableFuture<ExecutionResult> fieldValue, List<FieldValueInfo> fieldValueInfos) {
-        assertNotNull(fieldValueInfos, "fieldValueInfos can't be null");
+        assertNotNull(fieldValueInfos, () -> "fieldValueInfos can't be null");
         this.completeValueType = completeValueType;
         this.fieldValue = fieldValue;
         this.fieldValueInfos = fieldValueInfos;
@@ -78,7 +78,7 @@ public class FieldValueInfo {
         }
 
         public Builder fieldValueInfos(List<FieldValueInfo> listInfos) {
-            assertNotNull(listInfos, "fieldValueInfos can't be null");
+            assertNotNull(listInfos, () -> "fieldValueInfos can't be null");
             this.listInfos = listInfos;
             return this;
         }

--- a/src/main/java/graphql/execution/SubscriptionExecutionStrategy.java
+++ b/src/main/java/graphql/execution/SubscriptionExecutionStrategy.java
@@ -71,7 +71,7 @@ public class SubscriptionExecutionStrategy extends ExecutionStrategy {
         return fieldFetched.thenApply(fetchedValue -> {
             Object publisher = fetchedValue.getFetchedValue();
             if (publisher != null) {
-                assertTrue(publisher instanceof Publisher, "You data fetcher must return a Publisher of events when using graphql subscriptions");
+                assertTrue(publisher instanceof Publisher, () -> "Your data fetcher must return a Publisher of events when using graphql subscriptions");
             }
             //noinspection unchecked
             return (Publisher<Object>) publisher;

--- a/src/main/java/graphql/execution/nextgen/BatchedExecutionStrategy.java
+++ b/src/main/java/graphql/execution/nextgen/BatchedExecutionStrategy.java
@@ -66,7 +66,7 @@ public class BatchedExecutionStrategy implements ExecutionStrategy {
 
     // all multizipper have the same root
     private CompletableFuture<NodeMultiZipper<ExecutionResultNode>> resolveNodes(ExecutionContext executionContext, List<NodeMultiZipper<ExecutionResultNode>> unresolvedNodes) {
-        assertNotEmpty(unresolvedNodes, "unresolvedNodes can't be empty");
+        assertNotEmpty(unresolvedNodes, () -> "unresolvedNodes can't be empty");
         ExecutionResultNode commonRoot = unresolvedNodes.get(0).getCommonRoot();
         CompletableFuture<List<List<NodeZipper<ExecutionResultNode>>>> listListCF = Async.flatMap(unresolvedNodes,
                 executionResultMultiZipper -> fetchAndAnalyze(executionContext, executionResultMultiZipper.getZippers()));
@@ -81,7 +81,7 @@ public class BatchedExecutionStrategy implements ExecutionStrategy {
     }
 
     private CompletableFuture<List<NodeZipper<ExecutionResultNode>>> fetchAndAnalyze(ExecutionContext executionContext, List<NodeZipper<ExecutionResultNode>> unresolvedNodes) {
-        assertTrue(unresolvedNodes.size() > 0, "unresolvedNodes can't be empty");
+        assertTrue(unresolvedNodes.size() > 0, () -> "unresolvedNodes can't be empty");
 
         List<FieldSubSelection> fieldSubSelections = map(unresolvedNodes,
                 node -> util.createFieldSubSelection(executionContext, node.getCurNode().getExecutionStepInfo(), node.getCurNode().getResolvedValue()));

--- a/src/main/java/graphql/execution/nextgen/ValueFetcher.java
+++ b/src/main/java/graphql/execution/nextgen/ValueFetcher.java
@@ -76,7 +76,7 @@ public class ValueFetcher {
     @SuppressWarnings("unchecked")
     private List<FetchedValue> extractBatchedValues(FetchedValue fetchedValueContainingList, int expectedSize) {
         List<Object> list = (List<Object>) fetchedValueContainingList.getFetchedValue();
-        Assert.assertTrue(list.size() == expectedSize, "Unexpected result size");
+        Assert.assertTrue(list.size() == expectedSize, () -> "Unexpected result size");
         List<FetchedValue> result = new ArrayList<>();
         for (int i = 0; i < list.size(); i++) {
             List<GraphQLError> errors;

--- a/src/main/java/graphql/execution/nextgen/result/ResultNodeAdapter.java
+++ b/src/main/java/graphql/execution/nextgen/result/ResultNodeAdapter.java
@@ -38,7 +38,7 @@ public class ResultNodeAdapter implements NodeAdapter<ExecutionResultNode> {
     public ExecutionResultNode removeChild(ExecutionResultNode parentNode, NodeLocation location) {
         int index = location.getIndex();
         List<ExecutionResultNode> childrenList = new ArrayList<>(parentNode.getChildren());
-        assertTrue(index >= 0 && index < childrenList.size(), "The remove index MUST be within the range of the children");
+        assertTrue(index >= 0 && index < childrenList.size(), () -> "The remove index MUST be within the range of the children");
         childrenList.remove(index);
         return parentNode.withNewChildren(childrenList);
     }

--- a/src/main/java/graphql/execution/reactive/NonBlockingMutexExecutor.java
+++ b/src/main/java/graphql/execution/reactive/NonBlockingMutexExecutor.java
@@ -37,7 +37,7 @@ class NonBlockingMutexExecutor implements Executor {
 
     @Override
     public void execute(final Runnable command) {
-        final RunNode newNode = new RunNode(assertNotNull(command, "Runnable must not be null"));
+        final RunNode newNode = new RunNode(assertNotNull(command, () -> "Runnable must not be null"));
         final RunNode prevLast = last.getAndSet(newNode);
         if (prevLast != null)
             prevLast.lazySet(newNode);

--- a/src/main/java/graphql/execution/reactive/SingleSubscriberPublisher.java
+++ b/src/main/java/graphql/execution/reactive/SingleSubscriberPublisher.java
@@ -102,7 +102,7 @@ public class SingleSubscriberPublisher<T> implements Publisher<T> {
 
     @Override
     public void subscribe(Subscriber<? super T> subscriber) {
-        assertNotNullWithNPE(subscriber, "Subscriber passed to subscribe must not be null");
+        assertNotNullWithNPE(subscriber, () -> "Subscriber passed to subscribe must not be null");
         mutex.execute(() -> {
             if (this.subscriber == null) {
                 this.subscriber = subscriber;

--- a/src/main/java/graphql/introspection/Introspection.java
+++ b/src/main/java/graphql/introspection/Introspection.java
@@ -550,7 +550,6 @@ public class Introspection {
      * @param schema     the schema to use
      * @param parentType the type of the parent object
      * @param fieldName  the field to look up
-     *
      * @return a field definition otherwise throws an assertion exception if its null
      */
     public static GraphQLFieldDefinition getFieldDef(GraphQLSchema schema, GraphQLCompositeType parentType, String fieldName) {
@@ -567,10 +566,10 @@ public class Introspection {
             return TypeNameMetaFieldDef;
         }
 
-        assertTrue(parentType instanceof GraphQLFieldsContainer, "should not happen : parent type must be an object or interface %s", parentType);
+        assertTrue(parentType instanceof GraphQLFieldsContainer, () -> String.format("should not happen : parent type must be an object or interface %s", parentType));
         GraphQLFieldsContainer fieldsContainer = (GraphQLFieldsContainer) parentType;
         GraphQLFieldDefinition fieldDefinition = schema.getCodeRegistry().getFieldVisibility().getFieldDefinition(fieldsContainer, fieldName);
-        Assert.assertTrue(fieldDefinition != null, "Unknown field '%s'", fieldName);
+        Assert.assertTrue(fieldDefinition != null, () -> String.format("Unknown field '%s'", fieldName));
         return fieldDefinition;
     }
 }

--- a/src/main/java/graphql/introspection/IntrospectionResultToSchema.java
+++ b/src/main/java/graphql/introspection/IntrospectionResultToSchema.java
@@ -65,12 +65,12 @@ public class IntrospectionResultToSchema {
      */
     @SuppressWarnings("unchecked")
     public Document createSchemaDefinition(Map<String, Object> introspectionResult) {
-        assertTrue(introspectionResult.get("__schema") != null, "__schema expected");
+        assertTrue(introspectionResult.get("__schema") != null, () -> "__schema expected");
         Map<String, Object> schema = (Map<String, Object>) introspectionResult.get("__schema");
 
 
         Map<String, Object> queryType = (Map<String, Object>) schema.get("queryType");
-        assertNotNull(queryType, "queryType expected");
+        assertNotNull(queryType, () -> "queryType expected");
         TypeName query = TypeName.newTypeName().name((String) queryType.get("name")).build();
         boolean nonDefaultQueryName = !"Query".equals(query.getName());
 
@@ -141,7 +141,7 @@ public class IntrospectionResultToSchema {
 
     @SuppressWarnings("unchecked")
     UnionTypeDefinition createUnion(Map<String, Object> input) {
-        assertTrue(input.get("kind").equals("UNION"), "wrong input");
+        assertTrue(input.get("kind").equals("UNION"), () -> "wrong input");
 
         UnionTypeDefinition.Builder unionTypeDefinition = UnionTypeDefinition.newUnionTypeDefinition();
         unionTypeDefinition.name((String) input.get("name"));
@@ -159,7 +159,7 @@ public class IntrospectionResultToSchema {
 
     @SuppressWarnings("unchecked")
     EnumTypeDefinition createEnum(Map<String, Object> input) {
-        assertTrue(input.get("kind").equals("ENUM"), "wrong input");
+        assertTrue(input.get("kind").equals("ENUM"), () -> "wrong input");
 
         EnumTypeDefinition.Builder enumTypeDefinition = EnumTypeDefinition.newEnumTypeDefinition().name((String) input.get("name"));
         enumTypeDefinition.description(toDescription(input));
@@ -181,7 +181,7 @@ public class IntrospectionResultToSchema {
 
     @SuppressWarnings("unchecked")
     InterfaceTypeDefinition createInterface(Map<String, Object> input) {
-        assertTrue(input.get("kind").equals("INTERFACE"), "wrong input");
+        assertTrue(input.get("kind").equals("INTERFACE"), () -> "wrong input");
 
         InterfaceTypeDefinition.Builder interfaceTypeDefinition = InterfaceTypeDefinition.newInterfaceTypeDefinition().name((String) input.get("name"));
         interfaceTypeDefinition.description(toDescription(input));
@@ -194,7 +194,7 @@ public class IntrospectionResultToSchema {
 
     @SuppressWarnings("unchecked")
     InputObjectTypeDefinition createInputObject(Map<String, Object> input) {
-        assertTrue(input.get("kind").equals("INPUT_OBJECT"), "wrong input");
+        assertTrue(input.get("kind").equals("INPUT_OBJECT"), () -> "wrong input");
 
         InputObjectTypeDefinition.Builder inputObjectTypeDefinition = InputObjectTypeDefinition.newInputObjectDefinition()
                 .name((String) input.get("name"))
@@ -209,7 +209,7 @@ public class IntrospectionResultToSchema {
 
     @SuppressWarnings("unchecked")
     ObjectTypeDefinition createObject(Map<String, Object> input) {
-        assertTrue(input.get("kind").equals("OBJECT"), "wrong input");
+        assertTrue(input.get("kind").equals("OBJECT"), () -> "wrong input");
 
         ObjectTypeDefinition.Builder objectTypeDefinition = ObjectTypeDefinition.newObjectTypeDefinition().name((String) input.get("name"));
         objectTypeDefinition.description(toDescription(input));

--- a/src/main/java/graphql/language/AbstractNode.java
+++ b/src/main/java/graphql/language/AbstractNode.java
@@ -27,9 +27,9 @@ public abstract class AbstractNode<T extends Node> implements Node<T> {
     }
 
     public AbstractNode(SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars, Map<String, String> additionalData) {
-        Assert.assertNotNull(comments, "comments can't be null");
-        Assert.assertNotNull(ignoredChars, "ignoredChars can't be null");
-        Assert.assertNotNull(additionalData, "additionalData can't be null");
+        Assert.assertNotNull(comments, () -> "comments can't be null");
+        Assert.assertNotNull(ignoredChars, () -> "ignoredChars can't be null");
+        Assert.assertNotNull(additionalData, () -> "additionalData can't be null");
 
         this.sourceLocation = sourceLocation;
         this.additionalData = unmodifiableMap(new LinkedHashMap<>(additionalData));

--- a/src/main/java/graphql/language/AstPrinter.java
+++ b/src/main/java/graphql/language/AstPrinter.java
@@ -417,7 +417,7 @@ public class AstPrinter {
 
     private String node(Node node, Class startClass) {
         if (startClass != null) {
-            assertTrue(startClass.isInstance(node), "The starting class must be in the inherit tree");
+            assertTrue(startClass.isInstance(node), () -> "The starting class must be in the inherit tree");
         }
         StringWriter sw = new StringWriter();
         PrintWriter out = new PrintWriter(sw);

--- a/src/main/java/graphql/language/NodeParentTree.java
+++ b/src/main/java/graphql/language/NodeParentTree.java
@@ -28,8 +28,8 @@ public class NodeParentTree<T extends Node> {
 
     @Internal
     public NodeParentTree(Deque<T> nodeStack) {
-        assertNotNull(nodeStack, "You MUST have a non null stack of nodes");
-        assertTrue(!nodeStack.isEmpty(), "You MUST have a non empty stack of nodes");
+        assertNotNull(nodeStack, () -> "You MUST have a non null stack of nodes");
+        assertTrue(!nodeStack.isEmpty(), () -> "You MUST have a non empty stack of nodes");
 
         Deque<T> copy = new ArrayDeque<>(nodeStack);
         path = mkPath(copy);

--- a/src/main/java/graphql/nextgen/GraphQL.java
+++ b/src/main/java/graphql/nextgen/GraphQL.java
@@ -319,32 +319,32 @@ public class GraphQL {
         }
 
         public Builder schema(GraphQLSchema graphQLSchema) {
-            this.graphQLSchema = assertNotNull(graphQLSchema, "GraphQLSchema must be non null");
+            this.graphQLSchema = assertNotNull(graphQLSchema, () -> "GraphQLSchema must be non null");
             return this;
         }
 
         public Builder executionStrategy(ExecutionStrategy executionStrategy) {
-            this.executionStrategy = assertNotNull(executionStrategy, "ExecutionStrategy must be non null");
+            this.executionStrategy = assertNotNull(executionStrategy, () -> "ExecutionStrategy must be non null");
             return this;
         }
 
         public Builder instrumentation(Instrumentation instrumentation) {
-            this.instrumentation = assertNotNull(instrumentation, "Instrumentation must be non null");
+            this.instrumentation = assertNotNull(instrumentation, () -> "Instrumentation must be non null");
             return this;
         }
 
         public Builder preparsedDocumentProvider(PreparsedDocumentProvider preparsedDocumentProvider) {
-            this.preparsedDocumentProvider = assertNotNull(preparsedDocumentProvider, "PreparsedDocumentProvider must be non null");
+            this.preparsedDocumentProvider = assertNotNull(preparsedDocumentProvider, () -> "PreparsedDocumentProvider must be non null");
             return this;
         }
 
         public Builder executionIdProvider(ExecutionIdProvider executionIdProvider) {
-            this.idProvider = assertNotNull(executionIdProvider, "ExecutionIdProvider must be non null");
+            this.idProvider = assertNotNull(executionIdProvider, () -> "ExecutionIdProvider must be non null");
             return this;
         }
 
         public GraphQL build() {
-            assertNotNull(graphQLSchema, "graphQLSchema must be non null");
+            assertNotNull(graphQLSchema, () -> "graphQLSchema must be non null");
             return new GraphQL(this);
         }
     }

--- a/src/main/java/graphql/relay/DefaultConnection.java
+++ b/src/main/java/graphql/relay/DefaultConnection.java
@@ -26,8 +26,8 @@ public class DefaultConnection<T> implements Connection<T> {
      * @throws IllegalArgumentException if edges or page info is null. use {@link Collections#emptyList()} for empty edges.
      */
     public DefaultConnection(List<Edge<T>> edges, PageInfo pageInfo) {
-        this.edges = unmodifiableList(assertNotNull(edges, "edges cannot be null"));
-        this.pageInfo = assertNotNull(pageInfo, "page info cannot be null");
+        this.edges = unmodifiableList(assertNotNull(edges, () -> "edges cannot be null"));
+        this.pageInfo = assertNotNull(pageInfo, () -> "page info cannot be null");
     }
 
     @Override

--- a/src/main/java/graphql/relay/DefaultConnectionCursor.java
+++ b/src/main/java/graphql/relay/DefaultConnectionCursor.java
@@ -11,7 +11,7 @@ public class DefaultConnectionCursor implements ConnectionCursor {
     private final String value;
 
     public DefaultConnectionCursor(String value) {
-        Assert.assertTrue(value != null && !value.isEmpty(), "connection value cannot be null or empty");
+        Assert.assertTrue(value != null && !value.isEmpty(), () -> "connection value cannot be null or empty");
         this.value = value;
     }
 

--- a/src/main/java/graphql/relay/DefaultEdge.java
+++ b/src/main/java/graphql/relay/DefaultEdge.java
@@ -11,7 +11,7 @@ public class DefaultEdge<T> implements Edge<T> {
     private final ConnectionCursor cursor;
 
     public DefaultEdge(T node, ConnectionCursor cursor) {
-        this.cursor = assertNotNull(cursor, "cursor cannot be null");
+        this.cursor = assertNotNull(cursor, () -> "cursor cannot be null");
         this.node = node;
     }
 

--- a/src/main/java/graphql/relay/SimpleListConnection.java
+++ b/src/main/java/graphql/relay/SimpleListConnection.java
@@ -24,8 +24,8 @@ public class SimpleListConnection<T> implements DataFetcher<Connection<T>>, Triv
     private final List<T> data;
 
     public SimpleListConnection(List<T> data, String prefix) {
-        this.data = assertNotNull(data, " data cannot be null");
-        assertTrue(prefix != null && !prefix.isEmpty(), "prefix cannot be null or empty");
+        this.data = assertNotNull(data, () -> " data cannot be null");
+        assertTrue(prefix != null && !prefix.isEmpty(), () -> "prefix cannot be null or empty");
         this.prefix = prefix;
     }
 

--- a/src/main/java/graphql/schema/AsyncDataFetcher.java
+++ b/src/main/java/graphql/schema/AsyncDataFetcher.java
@@ -58,8 +58,8 @@ public class AsyncDataFetcher<T> implements DataFetcher<CompletableFuture<T>> {
     }
 
     public AsyncDataFetcher(DataFetcher<T> wrappedDataFetcher, Executor executor) {
-        this.wrappedDataFetcher = assertNotNull(wrappedDataFetcher, "wrappedDataFetcher can't be null");
-        this.executor = assertNotNull(executor, "executor can't be null");
+        this.wrappedDataFetcher = assertNotNull(wrappedDataFetcher, () -> "wrappedDataFetcher can't be null");
+        this.executor = assertNotNull(executor, () -> "executor can't be null");
     }
 
     @Override

--- a/src/main/java/graphql/schema/CodeRegistryVisitor.java
+++ b/src/main/java/graphql/schema/CodeRegistryVisitor.java
@@ -37,7 +37,8 @@ class CodeRegistryVisitor extends GraphQLTypeVisitorStub {
         if (typeResolver != null) {
             codeRegistry.typeResolverIfAbsent(node, typeResolver);
         }
-        assertTrue(codeRegistry.getTypeResolver(node) != null, "You MUST provide a type resolver for the interface type '" + node.getName() + "'");
+        assertTrue(codeRegistry.getTypeResolver(node) != null,
+                () -> String.format("You MUST provide a type resolver for the interface type '%s'",node.getName()));
         return CONTINUE;
     }
 
@@ -47,7 +48,8 @@ class CodeRegistryVisitor extends GraphQLTypeVisitorStub {
         if (typeResolver != null) {
             codeRegistry.typeResolverIfAbsent(node, typeResolver);
         }
-        assertTrue(codeRegistry.getTypeResolver(node) != null, "You MUST provide a type resolver for the union type '" + node.getName() + "'");
+        assertTrue(codeRegistry.getTypeResolver(node) != null,
+                () -> String.format("You MUST provide a type resolver for the union type '%s'", node.getName()));
         return CONTINUE;
     }
 }

--- a/src/main/java/graphql/schema/DefaultGraphqlTypeComparatorRegistry.java
+++ b/src/main/java/graphql/schema/DefaultGraphqlTypeComparatorRegistry.java
@@ -71,9 +71,9 @@ public class DefaultGraphqlTypeComparatorRegistry implements GraphqlTypeComparat
          * @return The {@code Builder} instance to allow chaining.
          */
         public <T extends GraphQLType> Builder addComparator(GraphqlTypeComparatorEnvironment environment, Class<T> comparatorClass, Comparator<? super T> comparator) {
-            assertNotNull(environment, "environment can't be null");
-            assertNotNull(comparatorClass, "comparatorClass can't be null");
-            assertNotNull(comparator, "comparator can't be null");
+            assertNotNull(environment, () -> "environment can't be null");
+            assertNotNull(comparatorClass, () -> "comparatorClass can't be null");
+            assertNotNull(comparator, () -> "comparator can't be null");
             registry.put(environment, comparator);
             return this;
         }
@@ -92,7 +92,7 @@ public class DefaultGraphqlTypeComparatorRegistry implements GraphqlTypeComparat
          */
         public <T extends GraphQLType> Builder addComparator(UnaryOperator<GraphqlTypeComparatorEnvironment.Builder> builderFunction,
                                                              Class<T> comparatorClass, Comparator<? super T> comparator) {
-            assertNotNull(builderFunction, "builderFunction can't be null");
+            assertNotNull(builderFunction, () -> "builderFunction can't be null");
 
             GraphqlTypeComparatorEnvironment environment = builderFunction.apply(newEnvironment()).build();
             return addComparator(environment, comparatorClass, comparator);

--- a/src/main/java/graphql/schema/FieldCoordinates.java
+++ b/src/main/java/graphql/schema/FieldCoordinates.java
@@ -44,7 +44,7 @@ public class FieldCoordinates {
     public void assertValidNames() throws AssertException {
         if (systemCoordinates) {
             assertTrue((null != fieldName) &&
-                    fieldName.startsWith("__"), "Only __ system fields can be addressed without a parent type");
+                    fieldName.startsWith("__"), () -> "Only __ system fields can be addressed without a parent type");
             assertValidName(fieldName);
         } else {
             assertValidName(typeName);

--- a/src/main/java/graphql/schema/GraphQLArgument.java
+++ b/src/main/java/graphql/schema/GraphQLArgument.java
@@ -94,7 +94,7 @@ public class GraphQLArgument implements GraphQLNamedSchemaElement, GraphQLInputV
 
     private GraphQLArgument(String name, String description, GraphQLInputType type, Object defaultValue, Object value, InputValueDefinition definition, List<GraphQLDirective> directives) {
         assertValidName(name);
-        assertNotNull(type, "type can't be null");
+        assertNotNull(type, () -> "type can't be null");
         this.name = name;
         this.description = description;
         this.originalType = type;
@@ -275,7 +275,7 @@ public class GraphQLArgument implements GraphQLNamedSchemaElement, GraphQLInputV
         }
 
         public Builder withDirectives(GraphQLDirective... directives) {
-            assertNotNull(directives, "directives can't be null");
+            assertNotNull(directives, () -> "directives can't be null");
             for (GraphQLDirective directive : directives) {
                 withDirective(directive);
             }
@@ -283,13 +283,13 @@ public class GraphQLArgument implements GraphQLNamedSchemaElement, GraphQLInputV
         }
 
         public Builder withDirective(GraphQLDirective directive) {
-            assertNotNull(directive, "directive can't be null");
+            assertNotNull(directive, () -> "directive can't be null");
             directives.put(directive.getName(), directive);
             return this;
         }
 
         public Builder replaceDirectives(List<GraphQLDirective> directives) {
-            assertNotNull(directives, "directive can't be null");
+            assertNotNull(directives, () -> "directive can't be null");
             this.directives.clear();
             for (GraphQLDirective directive : directives) {
                 this.directives.put(directive.getName(), directive);

--- a/src/main/java/graphql/schema/GraphQLCodeRegistry.java
+++ b/src/main/java/graphql/schema/GraphQLCodeRegistry.java
@@ -125,7 +125,7 @@ public class GraphQLCodeRegistry {
         if (typeResolver == null) {
             typeResolver = parentType.getTypeResolver();
         }
-        return assertNotNull(typeResolver, "There must be a type resolver for interface " + parentType.getName());
+        return assertNotNull(typeResolver, () -> "There must be a type resolver for interface " + parentType.getName());
     }
 
     private static TypeResolver getTypeResolverForUnion(GraphQLUnionType parentType, Map<String, TypeResolver> typeResolverMap) {
@@ -134,7 +134,7 @@ public class GraphQLCodeRegistry {
         if (typeResolver == null) {
             typeResolver = parentType.getTypeResolver();
         }
-        return assertNotNull(typeResolver, "There must be a type resolver for union " + parentType.getName());
+        return assertNotNull(typeResolver, () -> "There must be a type resolver for union " + parentType.getName());
     }
 
     /**

--- a/src/main/java/graphql/schema/GraphQLDirective.java
+++ b/src/main/java/graphql/schema/GraphQLDirective.java
@@ -55,7 +55,7 @@ public class GraphQLDirective implements GraphQLNamedSchemaElement {
                              List<GraphQLArgument> arguments,
                              DirectiveDefinition definition) {
         assertValidName(name);
-        assertNotNull(arguments, "arguments can't be null");
+        assertNotNull(arguments, () -> "arguments can't be null");
         this.name = name;
         this.description = description;
         this.locations = locations;
@@ -199,13 +199,13 @@ public class GraphQLDirective implements GraphQLNamedSchemaElement {
         }
 
         public Builder argument(GraphQLArgument argument) {
-            assertNotNull(argument, "argument must not be null");
+            assertNotNull(argument, () -> "argument must not be null");
             arguments.put(argument.getName(), argument);
             return this;
         }
 
         public Builder replaceArguments(List<GraphQLArgument> arguments) {
-            assertNotNull(arguments, "arguments must not be null");
+            assertNotNull(arguments, () -> "arguments must not be null");
             this.arguments.clear();
             for (GraphQLArgument argument : arguments) {
                 this.arguments.put(argument.getName(), argument);

--- a/src/main/java/graphql/schema/GraphQLEnumType.java
+++ b/src/main/java/graphql/schema/GraphQLEnumType.java
@@ -76,7 +76,7 @@ public class GraphQLEnumType implements GraphQLNamedInputType, GraphQLNamedOutpu
 
     private GraphQLEnumType(String name, String description, List<GraphQLEnumValueDefinition> values, List<GraphQLDirective> directives, EnumTypeDefinition definition, List<EnumTypeExtensionDefinition> extensionDefinitions) {
         assertValidName(name);
-        assertNotNull(directives, "directives cannot be null");
+        assertNotNull(directives, () -> "directives cannot be null");
 
         this.name = name;
         this.description = description;
@@ -304,7 +304,7 @@ public class GraphQLEnumType implements GraphQLNamedInputType, GraphQLNamedOutpu
         }
 
         public Builder value(String name, Object value) {
-            assertNotNull(value, "value can't be null");
+            assertNotNull(value, () -> "value can't be null");
             return value(newEnumValueDefinition().name(name)
                     .value(value).build());
         }
@@ -327,7 +327,7 @@ public class GraphQLEnumType implements GraphQLNamedInputType, GraphQLNamedOutpu
         }
 
         public Builder value(GraphQLEnumValueDefinition enumValueDefinition) {
-            assertNotNull(enumValueDefinition, "enumValueDefinition can't be null");
+            assertNotNull(enumValueDefinition, () -> "enumValueDefinition can't be null");
             values.put(enumValueDefinition.getName(), enumValueDefinition);
             return this;
         }
@@ -347,7 +347,7 @@ public class GraphQLEnumType implements GraphQLNamedInputType, GraphQLNamedOutpu
         }
 
         public Builder withDirectives(GraphQLDirective... directives) {
-            assertNotNull(directives, "directives can't be null");
+            assertNotNull(directives, () -> "directives can't be null");
             for (GraphQLDirective directive : directives) {
                 withDirective(directive);
             }
@@ -355,13 +355,13 @@ public class GraphQLEnumType implements GraphQLNamedInputType, GraphQLNamedOutpu
         }
 
         public Builder withDirective(GraphQLDirective directive) {
-            assertNotNull(directive, "directive can't be null");
+            assertNotNull(directive, () -> "directive can't be null");
             directives.put(directive.getName(), directive);
             return this;
         }
 
         public Builder replaceDirectives(List<GraphQLDirective> directives) {
-            assertNotNull(directives, "directive can't be null");
+            assertNotNull(directives, () -> "directive can't be null");
             this.directives.clear();
             for (GraphQLDirective directive : directives) {
                 this.directives.put(directive.getName(), directive);

--- a/src/main/java/graphql/schema/GraphQLEnumValueDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLEnumValueDefinition.java
@@ -83,7 +83,7 @@ public class GraphQLEnumValueDefinition implements GraphQLNamedSchemaElement, Gr
 
     private GraphQLEnumValueDefinition(String name, String description, Object value, String deprecationReason, List<GraphQLDirective> directives, EnumValueDefinition definition) {
         assertValidName(name);
-        assertNotNull(directives, "directives cannot be null");
+        assertNotNull(directives, () -> "directives cannot be null");
 
         this.name = name;
         this.description = description;
@@ -231,7 +231,7 @@ public class GraphQLEnumValueDefinition implements GraphQLNamedSchemaElement, Gr
         }
 
         public Builder withDirectives(GraphQLDirective... directives) {
-            assertNotNull(directives, "directives can't be null");
+            assertNotNull(directives, () -> "directives can't be null");
             for (GraphQLDirective directive : directives) {
                 withDirective(directive);
             }
@@ -239,13 +239,13 @@ public class GraphQLEnumValueDefinition implements GraphQLNamedSchemaElement, Gr
         }
 
         public Builder withDirective(GraphQLDirective directive) {
-            assertNotNull(directive, "directive can't be null");
+            assertNotNull(directive, () -> "directive can't be null");
             directives.put(directive.getName(), directive);
             return this;
         }
 
         public Builder replaceDirectives(List<GraphQLDirective> directives) {
-            assertNotNull(directives, "directive can't be null");
+            assertNotNull(directives, () -> "directive can't be null");
             this.directives.clear();
             for (GraphQLDirective directive : directives) {
                 this.directives.put(directive.getName(), directive);

--- a/src/main/java/graphql/schema/GraphQLFieldDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLFieldDefinition.java
@@ -81,9 +81,9 @@ public class GraphQLFieldDefinition implements GraphQLNamedSchemaElement, GraphQ
     @Deprecated
     public GraphQLFieldDefinition(String name, String description, GraphQLOutputType type, DataFetcherFactory dataFetcherFactory, List<GraphQLArgument> arguments, String deprecationReason, List<GraphQLDirective> directives, FieldDefinition definition) {
         assertValidName(name);
-        assertNotNull(dataFetcherFactory, "you have to provide a DataFetcher (or DataFetcherFactory)");
-        assertNotNull(type, "type can't be null");
-        assertNotNull(arguments, "arguments can't be null");
+        assertNotNull(dataFetcherFactory, () -> "you have to provide a DataFetcher (or DataFetcherFactory)");
+        assertNotNull(type, () -> "type can't be null");
+        assertNotNull(arguments, () -> "arguments can't be null");
         this.name = name;
         this.description = description;
         this.originalType = type;
@@ -294,7 +294,7 @@ public class GraphQLFieldDefinition implements GraphQLNamedSchemaElement, GraphQ
          */
         @Deprecated
         public Builder dataFetcher(DataFetcher<?> dataFetcher) {
-            assertNotNull(dataFetcher, "dataFetcher must be not null");
+            assertNotNull(dataFetcher, () -> "dataFetcher must be not null");
             this.dataFetcherFactory = DataFetcherFactories.useDataFetcher(dataFetcher);
             return this;
         }
@@ -310,7 +310,7 @@ public class GraphQLFieldDefinition implements GraphQLNamedSchemaElement, GraphQ
          */
         @Deprecated
         public Builder dataFetcherFactory(DataFetcherFactory dataFetcherFactory) {
-            assertNotNull(dataFetcherFactory, "dataFetcherFactory must be not null");
+            assertNotNull(dataFetcherFactory, () -> "dataFetcherFactory must be not null");
             this.dataFetcherFactory = dataFetcherFactory;
             return this;
         }
@@ -331,7 +331,7 @@ public class GraphQLFieldDefinition implements GraphQLNamedSchemaElement, GraphQ
         }
 
         public Builder argument(GraphQLArgument argument) {
-            assertNotNull(argument, "argument can't be null");
+            assertNotNull(argument, () -> "argument can't be null");
             this.arguments.put(argument.getName(), argument);
             return this;
         }
@@ -390,7 +390,7 @@ public class GraphQLFieldDefinition implements GraphQLNamedSchemaElement, GraphQ
          * @return this
          */
         public Builder arguments(List<GraphQLArgument> arguments) {
-            assertNotNull(arguments, "arguments can't be null");
+            assertNotNull(arguments, () -> "arguments can't be null");
             for (GraphQLArgument argument : arguments) {
                 argument(argument);
             }
@@ -398,7 +398,7 @@ public class GraphQLFieldDefinition implements GraphQLNamedSchemaElement, GraphQ
         }
 
         public Builder replaceArguments(List<GraphQLArgument> arguments) {
-            assertNotNull(arguments, "arguments can't be null");
+            assertNotNull(arguments, () -> "arguments can't be null");
             this.arguments.clear();
             for (GraphQLArgument argument : arguments) {
                 argument(argument);
@@ -423,7 +423,7 @@ public class GraphQLFieldDefinition implements GraphQLNamedSchemaElement, GraphQ
         }
 
         public Builder withDirectives(GraphQLDirective... directives) {
-            assertNotNull(directives, "directives can't be null");
+            assertNotNull(directives, () -> "directives can't be null");
             for (GraphQLDirective directive : directives) {
                 withDirective(directive);
             }
@@ -431,13 +431,13 @@ public class GraphQLFieldDefinition implements GraphQLNamedSchemaElement, GraphQ
         }
 
         public Builder withDirective(GraphQLDirective directive) {
-            assertNotNull(directive, "directive can't be null");
+            assertNotNull(directive, () -> "directive can't be null");
             directives.put(directive.getName(), directive);
             return this;
         }
 
         public Builder replaceDirectives(List<GraphQLDirective> directives) {
-            assertNotNull(directives, "directive can't be null");
+            assertNotNull(directives, () -> "directive can't be null");
             this.directives.clear();
             for (GraphQLDirective directive : directives) {
                 this.directives.put(directive.getName(), directive);

--- a/src/main/java/graphql/schema/GraphQLInputObjectField.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectField.java
@@ -170,12 +170,18 @@ public class GraphQLInputObjectField implements GraphQLNamedSchemaElement, Graph
         return "GraphQLInputObjectField{" +
                 "name='" + name + '\'' +
                 ", description='" + description + '\'' +
-                ", originalType=" + originalType +
+                ", originalType=" + inputTypeToStringAvoidingCircularReference(originalType) +
                 ", defaultValue=" + defaultValue +
                 ", definition=" + definition +
                 ", directives=" + directives +
-                ", replacedType=" + replacedType +
+                ", replacedType=" + inputTypeToStringAvoidingCircularReference(replacedType) +
                 '}';
+    }
+
+    private static Object inputTypeToStringAvoidingCircularReference(GraphQLInputType graphQLInputType) {
+        return (graphQLInputType instanceof GraphQLInputObjectType)
+                ? String.format("[%s]", GraphQLInputObjectType.class.getSimpleName())
+                : graphQLInputType;
     }
 
     public static Builder newInputObjectField(GraphQLInputObjectField existing) {

--- a/src/main/java/graphql/schema/GraphQLInputObjectField.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectField.java
@@ -81,8 +81,8 @@ public class GraphQLInputObjectField implements GraphQLNamedSchemaElement, Graph
     @Deprecated
     public GraphQLInputObjectField(String name, String description, GraphQLInputType type, Object defaultValue, List<GraphQLDirective> directives, InputValueDefinition definition) {
         assertValidName(name);
-        assertNotNull(type, "type can't be null");
-        assertNotNull(directives, "directives cannot be null");
+        assertNotNull(type, () -> "type can't be null");
+        assertNotNull(directives, () -> "directives cannot be null");
 
         this.name = name;
         this.originalType = type;
@@ -250,7 +250,7 @@ public class GraphQLInputObjectField implements GraphQLNamedSchemaElement, Graph
         }
 
         public Builder withDirectives(GraphQLDirective... directives) {
-            assertNotNull(directives, "directives can't be null");
+            assertNotNull(directives, () -> "directives can't be null");
             for (GraphQLDirective directive : directives) {
                 withDirective(directive);
             }
@@ -258,13 +258,13 @@ public class GraphQLInputObjectField implements GraphQLNamedSchemaElement, Graph
         }
 
         public Builder withDirective(GraphQLDirective directive) {
-            assertNotNull(directive, "directive can't be null");
+            assertNotNull(directive, () -> "directive can't be null");
             directives.put(directive.getName(), directive);
             return this;
         }
 
         public Builder replaceDirectives(List<GraphQLDirective> directives) {
-            assertNotNull(directives, "directive can't be null");
+            assertNotNull(directives, () -> "directive can't be null");
             this.directives.clear();
             for (GraphQLDirective directive : directives) {
                 this.directives.put(directive.getName(), directive);

--- a/src/main/java/graphql/schema/GraphQLInputObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectType.java
@@ -70,8 +70,8 @@ public class GraphQLInputObjectType implements GraphQLNamedInputType, GraphQLUnm
 
     public GraphQLInputObjectType(String name, String description, List<GraphQLInputObjectField> fields, List<GraphQLDirective> directives, InputObjectTypeDefinition definition, List<InputObjectTypeExtensionDefinition> extensionDefinitions) {
         assertValidName(name);
-        assertNotNull(fields, "fields can't be null");
-        assertNotNull(directives, "directives cannot be null");
+        assertNotNull(fields, () -> "fields can't be null");
+        assertNotNull(directives, () -> "directives cannot be null");
 
         this.name = name;
         this.description = description;
@@ -240,7 +240,7 @@ public class GraphQLInputObjectType implements GraphQLNamedInputType, GraphQLUnm
         }
 
         public Builder field(GraphQLInputObjectField field) {
-            assertNotNull(field, "field can't be null");
+            assertNotNull(field, () -> "field can't be null");
             fields.put(field.getName(), field);
             return this;
         }
@@ -259,7 +259,7 @@ public class GraphQLInputObjectType implements GraphQLNamedInputType, GraphQLUnm
          * @return this
          */
         public Builder field(UnaryOperator<GraphQLInputObjectField.Builder> builderFunction) {
-            assertNotNull(builderFunction, "builderFunction should not be null");
+            assertNotNull(builderFunction, () -> "builderFunction should not be null");
             GraphQLInputObjectField.Builder builder = GraphQLInputObjectField.newInputObjectField();
             builder = builderFunction.apply(builder);
             return field(builder);
@@ -311,13 +311,13 @@ public class GraphQLInputObjectType implements GraphQLNamedInputType, GraphQLUnm
         }
 
         public Builder withDirective(GraphQLDirective directive) {
-            assertNotNull(directive, "directive can't be null");
+            assertNotNull(directive, () -> "directive can't be null");
             directives.put(directive.getName(), directive);
             return this;
         }
 
         public Builder replaceDirectives(List<GraphQLDirective> directives) {
-            assertNotNull(directives, "directive can't be null");
+            assertNotNull(directives, () -> "directive can't be null");
             this.directives.clear();
             for (GraphQLDirective directive : directives) {
                 this.directives.put(directive.getName(), directive);

--- a/src/main/java/graphql/schema/GraphQLInterfaceType.java
+++ b/src/main/java/graphql/schema/GraphQLInterfaceType.java
@@ -52,7 +52,6 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLFieldsCont
      * @param description      the description
      * @param fieldDefinitions the fields
      * @param typeResolver     the type resolver function
-     *
      * @deprecated use the {@link #newInterface()} builder pattern instead, as this constructor will be made private in a future version.
      */
     @Internal
@@ -68,7 +67,6 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLFieldsCont
      * @param typeResolver     the type resolver function
      * @param directives       the directives on this type element
      * @param definition       the AST definition
-     *
      * @deprecated use the {@link #newInterface()} builder pattern instead, as this constructor will be made private in a future version.
      */
     @Internal
@@ -79,8 +77,8 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLFieldsCont
 
     public GraphQLInterfaceType(String name, String description, List<GraphQLFieldDefinition> fieldDefinitions, TypeResolver typeResolver, List<GraphQLDirective> directives, InterfaceTypeDefinition definition, List<InterfaceTypeExtensionDefinition> extensionDefinitions) {
         assertValidName(name);
-        assertNotNull(fieldDefinitions, "fieldDefinitions can't null");
-        assertNotNull(directives, "directives cannot be null");
+        assertNotNull(fieldDefinitions, () -> "fieldDefinitions can't null");
+        assertNotNull(directives, () -> "directives cannot be null");
 
         this.name = name;
         this.description = description;
@@ -154,7 +152,6 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLFieldsCont
      * the current values and allows you to transform it how you want.
      *
      * @param builderConsumer the consumer code that will be given a builder to transform
-     *
      * @return a new object based on calling build on that builder
      */
     public GraphQLInterfaceType transform(Consumer<Builder> builderConsumer) {
@@ -250,7 +247,7 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLFieldsCont
         }
 
         public Builder field(GraphQLFieldDefinition fieldDefinition) {
-            assertNotNull(fieldDefinition, "fieldDefinition can't be null");
+            assertNotNull(fieldDefinition, () -> "fieldDefinition can't be null");
             this.fields.put(fieldDefinition.getName(), fieldDefinition);
             return this;
         }
@@ -265,11 +262,10 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLFieldsCont
          * </pre>
          *
          * @param builderFunction a supplier for the builder impl
-         *
          * @return this
          */
         public Builder field(UnaryOperator<GraphQLFieldDefinition.Builder> builderFunction) {
-            assertNotNull(builderFunction, "builderFunction can't be null");
+            assertNotNull(builderFunction, () -> "builderFunction can't be null");
             GraphQLFieldDefinition.Builder builder = GraphQLFieldDefinition.newFieldDefinition();
             builder = builderFunction.apply(builder);
             return field(builder);
@@ -280,7 +276,6 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLFieldsCont
          * from within
          *
          * @param builder an un-built/incomplete GraphQLFieldDefinition
-         *
          * @return this
          */
         public Builder field(GraphQLFieldDefinition.Builder builder) {
@@ -288,13 +283,13 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLFieldsCont
         }
 
         public Builder fields(List<GraphQLFieldDefinition> fieldDefinitions) {
-            assertNotNull(fieldDefinitions, "fieldDefinitions can't be null");
+            assertNotNull(fieldDefinitions, () -> "fieldDefinitions can't be null");
             fieldDefinitions.forEach(this::field);
             return this;
         }
 
         public Builder replaceFields(List<GraphQLFieldDefinition> fieldDefinitions) {
-            assertNotNull(fieldDefinitions, "fieldDefinitions can't be null");
+            assertNotNull(fieldDefinitions, () -> "fieldDefinitions can't be null");
             this.fields.clear();
             fieldDefinitions.forEach(this::field);
             return this;
@@ -329,13 +324,13 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLFieldsCont
         }
 
         public Builder withDirective(GraphQLDirective directive) {
-            assertNotNull(directive, "directive can't be null");
+            assertNotNull(directive, () -> "directive can't be null");
             directives.put(directive.getName(), directive);
             return this;
         }
 
         public Builder replaceDirectives(List<GraphQLDirective> directives) {
-            assertNotNull(directives, "directive can't be null");
+            assertNotNull(directives, () -> "directive can't be null");
             this.directives.clear();
             for (GraphQLDirective directive : directives) {
                 this.directives.put(directive.getName(), directive);

--- a/src/main/java/graphql/schema/GraphQLList.java
+++ b/src/main/java/graphql/schema/GraphQLList.java
@@ -40,7 +40,7 @@ public class GraphQLList implements GraphQLType, GraphQLInputType, GraphQLOutput
 
 
     public GraphQLList(GraphQLType wrappedType) {
-        assertNotNull(wrappedType, "wrappedType can't be null");
+        assertNotNull(wrappedType, () -> "wrappedType can't be null");
         this.originalWrappedType = wrappedType;
     }
 

--- a/src/main/java/graphql/schema/GraphQLNonNull.java
+++ b/src/main/java/graphql/schema/GraphQLNonNull.java
@@ -7,14 +7,13 @@ import graphql.util.TraverserContext;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Supplier;
 
 import static graphql.Assert.assertNotNull;
-import static graphql.Assert.assertTrueLazily;
+import static graphql.Assert.assertTrue;
 
 /**
  * A modified type that indicates there the underlying wrapped type will not be null.
- *
+ * <p>
  * See http://graphql.org/learn/schema/#lists-and-non-null for more details on the concept
  */
 @PublicApi
@@ -27,7 +26,6 @@ public class GraphQLNonNull implements GraphQLType, GraphQLInputType, GraphQLOut
      * {@code .type(nonNull(GraphQLString)) }
      *
      * @param wrappedType the type to wrap as being non null
-     *
      * @return a GraphQLNonNull of that wrapped type
      */
     public static GraphQLNonNull nonNull(GraphQLType wrappedType) {
@@ -41,14 +39,14 @@ public class GraphQLNonNull implements GraphQLType, GraphQLInputType, GraphQLOut
 
 
     public GraphQLNonNull(GraphQLType wrappedType) {
-        assertNotNull(wrappedType, "wrappedType can't be null");
+        assertNotNull(wrappedType, () -> "wrappedType can't be null");
         assertNonNullWrapping(wrappedType);
         this.originalWrappedType = wrappedType;
     }
 
     private void assertNonNullWrapping(GraphQLType wrappedType) {
-        assertTrueLazily(!GraphQLTypeUtil.isNonNull(wrappedType), "A non null type cannot wrap an existing non null type '%s'",
-             () -> GraphQLTypeUtil.simplePrint(wrappedType));
+        assertTrue(!GraphQLTypeUtil.isNonNull(wrappedType), () ->
+                String.format("A non null type cannot wrap an existing non null type '%s'", GraphQLTypeUtil.simplePrint(wrappedType)));
     }
 
     @Override

--- a/src/main/java/graphql/schema/GraphQLObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLObjectType.java
@@ -98,8 +98,8 @@ public class GraphQLObjectType implements GraphQLNamedOutputType, GraphQLFieldsC
                               List<ObjectTypeExtensionDefinition> extensionDefinitions,
                               Comparator<? super GraphQLSchemaElement> interfaceComparator) {
         assertValidName(name);
-        assertNotNull(fieldDefinitions, "fieldDefinitions can't be null");
-        assertNotNull(interfaces, "interfaces can't be null");
+        assertNotNull(fieldDefinitions, () -> "fieldDefinitions can't be null");
+        assertNotNull(interfaces, () -> "interfaces can't be null");
         this.name = name;
         this.description = description;
         this.interfaceComparator = interfaceComparator;
@@ -284,7 +284,7 @@ public class GraphQLObjectType implements GraphQLNamedOutputType, GraphQLFieldsC
         }
 
         public Builder field(GraphQLFieldDefinition fieldDefinition) {
-            assertNotNull(fieldDefinition, "fieldDefinition can't be null");
+            assertNotNull(fieldDefinition, () -> "fieldDefinition can't be null");
             this.fields.put(fieldDefinition.getName(), fieldDefinition);
             return this;
         }
@@ -303,7 +303,7 @@ public class GraphQLObjectType implements GraphQLNamedOutputType, GraphQLFieldsC
          * @return this
          */
         public Builder field(UnaryOperator<GraphQLFieldDefinition.Builder> builderFunction) {
-            assertNotNull(builderFunction, "builderFunction can't be null");
+            assertNotNull(builderFunction, () -> "builderFunction can't be null");
             GraphQLFieldDefinition.Builder builder = GraphQLFieldDefinition.newFieldDefinition();
             builder = builderFunction.apply(builder);
             return field(builder.build());
@@ -322,13 +322,13 @@ public class GraphQLObjectType implements GraphQLNamedOutputType, GraphQLFieldsC
         }
 
         public Builder fields(List<GraphQLFieldDefinition> fieldDefinitions) {
-            assertNotNull(fieldDefinitions, "fieldDefinitions can't be null");
+            assertNotNull(fieldDefinitions, () -> "fieldDefinitions can't be null");
             fieldDefinitions.forEach(this::field);
             return this;
         }
 
         public Builder replaceFields(List<GraphQLFieldDefinition> fieldDefinitions) {
-            assertNotNull(fieldDefinitions, "fieldDefinitions can't be null");
+            assertNotNull(fieldDefinitions, () -> "fieldDefinitions can't be null");
             this.fields.clear();
             fieldDefinitions.forEach(this::field);
             return this;
@@ -350,13 +350,13 @@ public class GraphQLObjectType implements GraphQLNamedOutputType, GraphQLFieldsC
 
 
         public Builder withInterface(GraphQLInterfaceType interfaceType) {
-            assertNotNull(interfaceType, "interfaceType can't be null");
+            assertNotNull(interfaceType, () -> "interfaceType can't be null");
             this.interfaces.put(interfaceType.getName(), interfaceType);
             return this;
         }
 
         public Builder replaceInterfaces(List<GraphQLInterfaceType> interfaces) {
-            assertNotNull(interfaces, "interfaces can't be null");
+            assertNotNull(interfaces, () -> "interfaces can't be null");
             this.interfaces.clear();
             for (GraphQLInterfaceType interfaceType : interfaces) {
                 this.interfaces.put(interfaceType.getName(), interfaceType);
@@ -365,7 +365,7 @@ public class GraphQLObjectType implements GraphQLNamedOutputType, GraphQLFieldsC
         }
 
         public Builder withInterface(GraphQLTypeReference reference) {
-            assertNotNull(reference, "reference can't be null");
+            assertNotNull(reference, () -> "reference can't be null");
             this.interfaces.put(reference.getName(), reference);
             return this;
         }
@@ -378,7 +378,7 @@ public class GraphQLObjectType implements GraphQLNamedOutputType, GraphQLFieldsC
         }
 
         public Builder replaceDirectives(List<GraphQLDirective> directives) {
-            assertNotNull(directives, "directive can't be null");
+            assertNotNull(directives, () -> "directive can't be null");
             this.directives.clear();
             for (GraphQLDirective directive : directives) {
                 this.directives.put(directive.getName(), directive);
@@ -412,7 +412,7 @@ public class GraphQLObjectType implements GraphQLNamedOutputType, GraphQLFieldsC
         }
 
         public Builder withDirective(GraphQLDirective directive) {
-            assertNotNull(directive, "directive can't be null");
+            assertNotNull(directive, () -> "directive can't be null");
             directives.put(directive.getName(), directive);
             return this;
         }

--- a/src/main/java/graphql/schema/GraphQLScalarType.java
+++ b/src/main/java/graphql/schema/GraphQLScalarType.java
@@ -78,8 +78,8 @@ public class GraphQLScalarType implements GraphQLNamedInputType, GraphQLNamedOut
 
     private GraphQLScalarType(String name, String description, Coercing coercing, List<GraphQLDirective> directives, ScalarTypeDefinition definition, List<ScalarTypeExtensionDefinition> extensionDefinitions) {
         assertValidName(name);
-        assertNotNull(coercing, "coercing can't be null");
-        assertNotNull(directives, "directives can't be null");
+        assertNotNull(coercing, () -> "coercing can't be null");
+        assertNotNull(directives, () -> "directives can't be null");
 
         this.name = name;
         this.description = description;
@@ -233,13 +233,13 @@ public class GraphQLScalarType implements GraphQLNamedInputType, GraphQLNamedOut
         }
 
         public Builder withDirective(GraphQLDirective directive) {
-            assertNotNull(directive, "directive can't be null");
+            assertNotNull(directive, () -> "directive can't be null");
             directives.put(directive.getName(), directive);
             return this;
         }
 
         public Builder replaceDirectives(List<GraphQLDirective> directives) {
-            assertNotNull(directives, "directive can't be null");
+            assertNotNull(directives, () -> "directive can't be null");
             this.directives.clear();
             for (GraphQLDirective directive : directives) {
                 this.directives.put(directive.getName(), directive);

--- a/src/main/java/graphql/schema/GraphQLSchema.java
+++ b/src/main/java/graphql/schema/GraphQLSchema.java
@@ -91,10 +91,10 @@ public class GraphQLSchema {
 
     @Internal
     private GraphQLSchema(Builder builder, boolean afterTransform) {
-        assertNotNull(builder.additionalTypes, "additionalTypes can't be null");
-        assertNotNull(builder.queryType, "queryType can't be null");
-        assertNotNull(builder.additionalDirectives, "directives can't be null");
-        assertNotNull(builder.codeRegistry, "codeRegistry can't be null");
+        assertNotNull(builder.additionalTypes, () -> "additionalTypes can't be null");
+        assertNotNull(builder.queryType, () -> "queryType can't be null");
+        assertNotNull(builder.additionalDirectives, () -> "directives can't be null");
+        assertNotNull(builder.codeRegistry, () -> "codeRegistry can't be null");
 
 
         this.queryType = builder.queryType;
@@ -154,7 +154,7 @@ public class GraphQLSchema {
         GraphQLType graphQLType = typeMap.get(typeName);
         if (graphQLType != null) {
             assertTrue(graphQLType instanceof GraphQLObjectType,
-                    "You have asked for named object type '%s' but its not an object type but rather a '%s'", typeName, graphQLType.getClass().getName());
+                    () -> String.format("You have asked for named object type '%s' but its not an object type but rather a '%s'", typeName, graphQLType.getClass().getName()));
         }
         return (GraphQLObjectType) graphQLType;
     }
@@ -452,7 +452,7 @@ public class GraphQLSchema {
         }
 
         public Builder withSchemaDirective(GraphQLDirective directive) {
-            assertNotNull(directive, "directive can't be null");
+            assertNotNull(directive, () -> "directive can't be null");
             schemaDirectives.put(directive.getName(), directive);
             return this;
         }
@@ -516,8 +516,8 @@ public class GraphQLSchema {
         }
 
         GraphQLSchema buildImpl(boolean afterTransform) {
-            assertNotNull(additionalTypes, "additionalTypes can't be null");
-            assertNotNull(additionalDirectives, "additionalDirectives can't be null");
+            assertNotNull(additionalTypes, () -> "additionalTypes can't be null");
+            assertNotNull(additionalDirectives, () -> "additionalDirectives can't be null");
 
             // schemas built via the schema generator have the deprecated directive BUT we want it present for hand built
             // schemas - its inherently part of the spec!

--- a/src/main/java/graphql/schema/GraphQLTypeResolvingVisitor.java
+++ b/src/main/java/graphql/schema/GraphQLTypeResolvingVisitor.java
@@ -43,7 +43,7 @@ public class GraphQLTypeResolvingVisitor extends GraphQLTypeVisitorStub {
 
     public TraversalControl handleTypeReference(GraphQLTypeReference node, TraverserContext<GraphQLSchemaElement> context) {
         final GraphQLType resolvedType = typeMap.get(node.getName());
-        assertNotNull(resolvedType, "type %s not found in schema", node.getName());
+        assertNotNull(resolvedType, () -> String.format("type %s not found in schema", node.getName()));
         context.getParentContext().thisNode().accept(context, new TypeRefResolvingVisitor(resolvedType));
         return CONTINUE;
     }

--- a/src/main/java/graphql/schema/GraphQLUnionType.java
+++ b/src/main/java/graphql/schema/GraphQLUnionType.java
@@ -56,7 +56,6 @@ public class GraphQLUnionType implements GraphQLNamedOutputType, GraphQLComposit
      * @param description  the description
      * @param types        the possible types
      * @param typeResolver the type resolver function
-     *
      * @deprecated use the {@link #newUnionType()} builder pattern instead, as this constructor will be made private in a future version.
      */
     @Internal
@@ -72,7 +71,6 @@ public class GraphQLUnionType implements GraphQLNamedOutputType, GraphQLComposit
      * @param typeResolver the type resolver function
      * @param directives   the directives on this type element
      * @param definition   the AST definition
-     *
      * @deprecated use the {@link #newUnionType()} builder pattern instead, as this constructor will be made private in a future version.
      */
     @Internal
@@ -83,9 +81,9 @@ public class GraphQLUnionType implements GraphQLNamedOutputType, GraphQLComposit
 
     private GraphQLUnionType(String name, String description, List<GraphQLNamedOutputType> types, TypeResolver typeResolver, List<GraphQLDirective> directives, UnionTypeDefinition definition, List<UnionTypeExtensionDefinition> extensionDefinitions) {
         assertValidName(name);
-        assertNotNull(types, "types can't be null");
-        assertNotEmpty(types, "A Union type must define one or more member types.");
-        assertNotNull(directives, "directives cannot be null");
+        assertNotNull(types, () -> "types can't be null");
+        assertNotEmpty(types, () -> "A Union type must define one or more member types.");
+        assertNotNull(directives, () -> "directives cannot be null");
 
         this.name = name;
         this.description = description;
@@ -144,7 +142,6 @@ public class GraphQLUnionType implements GraphQLNamedOutputType, GraphQLComposit
      * the current values and allows you to transform it how you want.
      *
      * @param builderConsumer the consumer code that will be given a builder to transform
-     *
      * @return a new object based on calling build on that builder
      */
     public GraphQLUnionType transform(Consumer<Builder> builderConsumer) {
@@ -247,13 +244,13 @@ public class GraphQLUnionType implements GraphQLNamedOutputType, GraphQLComposit
 
 
         public Builder possibleType(GraphQLObjectType type) {
-            assertNotNull(type, "possible type can't be null");
+            assertNotNull(type, () -> "possible type can't be null");
             types.put(type.getName(), type);
             return this;
         }
 
         public Builder possibleType(GraphQLTypeReference reference) {
-            assertNotNull(reference, "reference can't be null");
+            assertNotNull(reference, () -> "reference can't be null");
             types.put(reference.getName(), reference);
             return this;
         }
@@ -302,7 +299,7 @@ public class GraphQLUnionType implements GraphQLNamedOutputType, GraphQLComposit
         }
 
         public Builder replaceDirectives(List<GraphQLDirective> directives) {
-            assertNotNull(directives, "directive can't be null");
+            assertNotNull(directives, () -> "directive can't be null");
             this.directives.clear();
             for (GraphQLDirective directive : directives) {
                 this.directives.put(directive.getName(), directive);
@@ -311,7 +308,7 @@ public class GraphQLUnionType implements GraphQLNamedOutputType, GraphQLComposit
         }
 
         public Builder withDirective(GraphQLDirective directive) {
-            assertNotNull(directive, "directive can't be null");
+            assertNotNull(directive, () -> "directive can't be null");
             directives.put(directive.getName(), directive);
             return this;
         }

--- a/src/main/java/graphql/schema/GraphqlElementParentTree.java
+++ b/src/main/java/graphql/schema/GraphqlElementParentTree.java
@@ -25,8 +25,8 @@ public class GraphqlElementParentTree {
 
     @Internal
     public GraphqlElementParentTree(Deque<GraphQLSchemaElement> nodeStack) {
-        assertNotNull(nodeStack, "You MUST have a non null stack of elements");
-        assertTrue(!nodeStack.isEmpty(), "You MUST have a non empty stack of element");
+        assertNotNull(nodeStack, () -> "You MUST have a non null stack of elements");
+        assertTrue(!nodeStack.isEmpty(), () -> "You MUST have a non empty stack of element");
 
         Deque<GraphQLSchemaElement> copy = new ArrayDeque<>(nodeStack);
         element = copy.pop();

--- a/src/main/java/graphql/schema/GraphqlTypeComparatorEnvironment.java
+++ b/src/main/java/graphql/schema/GraphqlTypeComparatorEnvironment.java
@@ -19,7 +19,7 @@ public class GraphqlTypeComparatorEnvironment {
     private Class<? extends GraphQLSchemaElement> elementType;
 
     private GraphqlTypeComparatorEnvironment(Class<? extends GraphQLSchemaElement> parentType, Class<? extends GraphQLSchemaElement> elementType) {
-        Assert.assertNotNull(elementType, "elementType can't be null");
+        Assert.assertNotNull(elementType, () -> "elementType can't be null");
         this.parentType = parentType;
         this.elementType = elementType;
     }

--- a/src/main/java/graphql/schema/SchemaTransformer.java
+++ b/src/main/java/graphql/schema/SchemaTransformer.java
@@ -287,7 +287,7 @@ public class SchemaTransformer {
             GraphQLSchemaElement parent,
             List<NodeZipper<GraphQLSchemaElement>> sameParent,
             Map<NodeZipper<GraphQLSchemaElement>, List<List<Breadcrumb<GraphQLSchemaElement>>>> breadcrumbsUsed) {
-        assertNotEmpty(sameParent, "expected at least one zipper");
+        assertNotEmpty(sameParent, () -> "expected at least one zipper");
 
         Map<String, List<GraphQLSchemaElement>> childrenMap = new HashMap<>(SCHEMA_ELEMENT_ADAPTER.getNamedChildren(parent));
         Map<String, Integer> indexCorrection = new HashMap<>();

--- a/src/main/java/graphql/schema/diff/DiffSet.java
+++ b/src/main/java/graphql/schema/diff/DiffSet.java
@@ -69,7 +69,7 @@ public class DiffSet {
     private static Map<String, Object> introspect(GraphQLSchema schema) {
         GraphQL gql = GraphQL.newGraphQL(schema).build();
         ExecutionResult result = gql.execute(IntrospectionQuery.INTROSPECTION_QUERY);
-        Assert.assertTrue(result.getErrors().size() == 0, "The schema has errors during Introspection");
+        Assert.assertTrue(result.getErrors().size() == 0, () -> "The schema has errors during Introspection");
         return result.getData();
     }
 }

--- a/src/main/java/graphql/schema/idl/CombinedWiringFactory.java
+++ b/src/main/java/graphql/schema/idl/CombinedWiringFactory.java
@@ -19,7 +19,7 @@ public class CombinedWiringFactory implements WiringFactory {
     private final List<WiringFactory> factories;
 
     public CombinedWiringFactory(List<WiringFactory> factories) {
-        assertNotNull(factories, "You must provide a list of wiring factories");
+        assertNotNull(factories, () -> "You must provide a list of wiring factories");
         this.factories = new ArrayList<>(factories);
     }
 

--- a/src/main/java/graphql/schema/idl/MapEnumValuesProvider.java
+++ b/src/main/java/graphql/schema/idl/MapEnumValuesProvider.java
@@ -12,7 +12,7 @@ public class MapEnumValuesProvider implements EnumValuesProvider {
     private final Map<String, Object> values;
 
     public MapEnumValuesProvider(Map<String, Object> values) {
-        Assert.assertNotNull(values, "values can't be null");
+        Assert.assertNotNull(values, () -> "values can't be null");
         this.values = values;
     }
 

--- a/src/main/java/graphql/schema/idl/NaturalEnumValuesProvider.java
+++ b/src/main/java/graphql/schema/idl/NaturalEnumValuesProvider.java
@@ -13,7 +13,7 @@ public class NaturalEnumValuesProvider<T extends Enum<T>> implements EnumValuesP
     private final Class<T> enumType;
 
     public NaturalEnumValuesProvider(Class<T> enumType) {
-        Assert.assertNotNull(enumType, "enumType can't be null");
+        Assert.assertNotNull(enumType, () -> "enumType can't be null");
         this.enumType = enumType;
     }
 

--- a/src/main/java/graphql/schema/idl/RuntimeWiring.java
+++ b/src/main/java/graphql/schema/idl/RuntimeWiring.java
@@ -142,7 +142,7 @@ public class RuntimeWiring {
          * @return this outer builder
          */
         public Builder wiringFactory(WiringFactory wiringFactory) {
-            assertNotNull(wiringFactory, "You must provide a wiring factory");
+            assertNotNull(wiringFactory, () -> "You must provide a wiring factory");
             this.wiringFactory = wiringFactory;
             return this;
         }

--- a/src/main/java/graphql/schema/idl/SchemaDirectiveWiringEnvironmentImpl.java
+++ b/src/main/java/graphql/schema/idl/SchemaDirectiveWiringEnvironmentImpl.java
@@ -108,15 +108,15 @@ public class SchemaDirectiveWiringEnvironmentImpl<T extends GraphQLDirectiveCont
 
     @Override
     public DataFetcher getFieldDataFetcher() {
-        assertNotNull(fieldDefinition, "An output field must be in context to call this method");
-        assertNotNull(fieldsContainer, "An output field container must be in context to call this method");
+        assertNotNull(fieldDefinition, () -> "An output field must be in context to call this method");
+        assertNotNull(fieldsContainer, () -> "An output field container must be in context to call this method");
         return codeRegistry.getDataFetcher(fieldsContainer, fieldDefinition);
     }
 
     @Override
     public GraphQLFieldDefinition setFieldDataFetcher(DataFetcher newDataFetcher) {
-        assertNotNull(fieldDefinition, "An output field must be in context to call this method");
-        assertNotNull(fieldsContainer, "An output field container must be in context to call this method");
+        assertNotNull(fieldDefinition, () -> "An output field must be in context to call this method");
+        assertNotNull(fieldsContainer, () -> "An output field container must be in context to call this method");
 
         FieldCoordinates coordinates = FieldCoordinates.coordinates(fieldsContainer, fieldDefinition);
         codeRegistry.dataFetcher(coordinates, newDataFetcher);

--- a/src/main/java/graphql/schema/idl/SchemaExtensionsChecker.java
+++ b/src/main/java/graphql/schema/idl/SchemaExtensionsChecker.java
@@ -30,7 +30,7 @@ public class SchemaExtensionsChecker {
     static Map<String, OperationTypeDefinition> gatherOperationDefs(TypeDefinitionRegistry typeRegistry) {
         List<GraphQLError> noErrors = new ArrayList<>();
         Map<String, OperationTypeDefinition> operationTypeDefinitionMap = gatherOperationDefs(noErrors, typeRegistry.schemaDefinition().orElse(null), typeRegistry.getSchemaExtensionDefinitions());
-        Assert.assertTrue(noErrors.isEmpty(), "If you call this method it MUST have previously been error checked");
+        Assert.assertTrue(noErrors.isEmpty(), () -> "If you call this method it MUST have previously been error checked");
         return operationTypeDefinitionMap;
     }
 
@@ -89,7 +89,7 @@ public class SchemaExtensionsChecker {
     static List<Directive> gatherSchemaDirectives(TypeDefinitionRegistry typeRegistry) {
         List<GraphQLError> noErrors = new ArrayList<>();
         List<Directive> directiveList = gatherSchemaDirectives(typeRegistry, noErrors);
-        Assert.assertTrue(noErrors.isEmpty(), "If you call this method it MUST have previously been error checked");
+        Assert.assertTrue(noErrors.isEmpty(), () -> "If you call this method it MUST have previously been error checked");
         return directiveList;
     }
 

--- a/src/main/java/graphql/schema/idl/SchemaGenerator.java
+++ b/src/main/java/graphql/schema/idl/SchemaGenerator.java
@@ -83,6 +83,7 @@ import static graphql.introspection.Introspection.DirectiveLocation.SCALAR;
 import static graphql.introspection.Introspection.DirectiveLocation.UNION;
 import static graphql.schema.GraphQLEnumValueDefinition.newEnumValueDefinition;
 import static graphql.schema.GraphQLTypeReference.typeRef;
+import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 
 /**
@@ -136,7 +137,8 @@ public class SchemaGenerator {
         @SuppressWarnings({"OptionalGetWithoutIsPresent", "ConstantConditions"})
         TypeDefinition getTypeDefinition(Type type) {
             Optional<TypeDefinition> optionalTypeDefinition = typeRegistry.getType(type);
-            assertTrue(optionalTypeDefinition.isPresent(), " type definition for type '" + type + "' not found");
+            assertTrue(optionalTypeDefinition.isPresent(),
+                    () -> format(" type definition for type '%s' not found", type));
             return optionalTypeDefinition.get();
         }
 
@@ -213,9 +215,7 @@ public class SchemaGenerator {
      *
      * @param typeRegistry this can be obtained via {@link SchemaParser#parse(String)}
      * @param wiring       this can be built using {@link RuntimeWiring#newRuntimeWiring()}
-     *
      * @return an executable schema
-     *
      * @throws SchemaProblem if there are problems in assembling a schema such as missing type resolvers or no operations defined
      */
     public GraphQLSchema makeExecutableSchema(TypeDefinitionRegistry typeRegistry, RuntimeWiring wiring) throws SchemaProblem {
@@ -229,9 +229,7 @@ public class SchemaGenerator {
      * @param options      the controlling options
      * @param typeRegistry this can be obtained via {@link SchemaParser#parse(String)}
      * @param wiring       this can be built using {@link RuntimeWiring#newRuntimeWiring()}
-     *
      * @return an executable schema
-     *
      * @throws SchemaProblem if there are problems in assembling a schema such as missing type resolvers or no operations defined
      */
     public GraphQLSchema makeExecutableSchema(Options options, TypeDefinitionRegistry typeRegistry, RuntimeWiring wiring) throws SchemaProblem {
@@ -355,7 +353,6 @@ public class SchemaGenerator {
      * but then we build the rest of the types specified and put them in as additional types
      *
      * @param buildCtx the context we need to work out what we are doing
-     *
      * @return the additional types not referenced from the top level operations
      */
     private Set<GraphQLType> buildAdditionalTypes(BuildContext buildCtx) {
@@ -400,7 +397,6 @@ public class SchemaGenerator {
      *
      * @param buildCtx the context we need to work out what we are doing
      * @param rawType  the type to be built
-     *
      * @return an output type
      */
     @SuppressWarnings({"unchecked", "TypeParameterUnusedInFormals"})
@@ -657,7 +653,8 @@ public class SchemaGenerator {
         Object value;
         if (enumValuesProvider != null) {
             value = enumValuesProvider.getValue(evd.getName());
-            assertNotNull(value, "EnumValuesProvider for %s returned null for %s", typeDefinition.getName(), evd.getName());
+            assertNotNull(value,
+                    () -> format("EnumValuesProvider for %s returned null for %s", typeDefinition.getName(), evd.getName()));
         } else {
             value = evd.getName();
         }
@@ -751,14 +748,14 @@ public class SchemaGenerator {
         DataFetcherFactory<?> dataFetcherFactory;
         if (wiringFactory.providesDataFetcherFactory(wiringEnvironment)) {
             dataFetcherFactory = wiringFactory.getDataFetcherFactory(wiringEnvironment);
-            assertNotNull(dataFetcherFactory, "The WiringFactory indicated it provides a data fetcher factory but then returned null");
+            assertNotNull(dataFetcherFactory, () -> "The WiringFactory indicated it provides a data fetcher factory but then returned null");
         } else {
             //
             // ok they provide a data fetcher directly
             DataFetcher<?> dataFetcher;
             if (wiringFactory.providesDataFetcher(wiringEnvironment)) {
                 dataFetcher = wiringFactory.getDataFetcher(wiringEnvironment);
-                assertNotNull(dataFetcher, "The WiringFactory indicated it provides a data fetcher but then returned null");
+                assertNotNull(dataFetcher, () -> "The WiringFactory indicated it provides a data fetcher but then returned null");
             } else {
                 dataFetcher = runtimeWiring.getDataFetcherForType(parentTypeName).get(fieldName);
                 if (dataFetcher == null) {
@@ -869,7 +866,7 @@ public class SchemaGenerator {
 
         if (wiringFactory.providesTypeResolver(environment)) {
             typeResolver = wiringFactory.getTypeResolver(environment);
-            assertNotNull(typeResolver, "The WiringFactory indicated it union provides a type resolver but then returned null");
+            assertNotNull(typeResolver, () -> "The WiringFactory indicated it union provides a type resolver but then returned null");
 
         } else {
             typeResolver = wiring.getTypeResolvers().get(unionType.getName());
@@ -894,7 +891,7 @@ public class SchemaGenerator {
 
         if (wiringFactory.providesTypeResolver(environment)) {
             typeResolver = wiringFactory.getTypeResolver(environment);
-            assertNotNull(typeResolver, "The WiringFactory indicated it provides a interface type resolver but then returned null");
+            assertNotNull(typeResolver, () -> "The WiringFactory indicated it provides a interface type resolver but then returned null");
 
         } else {
             typeResolver = wiring.getTypeResolvers().get(interfaceType.getName());

--- a/src/main/java/graphql/schema/idl/SchemaGeneratorDirectiveHelper.java
+++ b/src/main/java/graphql/schema/idl/SchemaGeneratorDirectiveHelper.java
@@ -307,7 +307,7 @@ public class SchemaGeneratorDirectiveHelper {
         // wiring factory is last (if present)
         env = envBuilder.apply(outputObject, allDirectives, null);
         if (wiringFactory.providesSchemaDirectiveWiring(env)) {
-            schemaDirectiveWiring = assertNotNull(wiringFactory.getSchemaDirectiveWiring(env), "Your WiringFactory MUST provide a non null SchemaDirectiveWiring");
+            schemaDirectiveWiring = assertNotNull(wiringFactory.getSchemaDirectiveWiring(env), () -> "Your WiringFactory MUST provide a non null SchemaDirectiveWiring");
             outputObject = invokeWiring(outputObject, invoker, schemaDirectiveWiring, env);
         }
 
@@ -316,7 +316,7 @@ public class SchemaGeneratorDirectiveHelper {
 
     private <T extends GraphQLDirectiveContainer> T invokeWiring(T element, EnvInvoker<T> invoker, SchemaDirectiveWiring schemaDirectiveWiring, SchemaDirectiveWiringEnvironment<T> env) {
         T newElement = invoker.apply(schemaDirectiveWiring, env);
-        assertNotNull(newElement, "The SchemaDirectiveWiring MUST return a non null return value for element '" + element.getName() + "'");
+        assertNotNull(newElement, () -> "The SchemaDirectiveWiring MUST return a non null return value for element '" + element.getName() + "'");
         return newElement;
     }
 }

--- a/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java
+++ b/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java
@@ -237,7 +237,7 @@ public class TypeDefinitionRegistry {
     }
 
     public void remove(SDLDefinition definition) {
-        assertNotNull(definition, "definition to remove can't be null");
+        assertNotNull(definition, () -> "definition to remove can't be null");
         if (definition instanceof ObjectTypeExtensionDefinition) {
             removeFromList(objectTypeExtensions, (TypeDefinition) definition);
         } else if (definition instanceof InterfaceTypeExtensionDefinition) {

--- a/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java
+++ b/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java
@@ -22,7 +22,6 @@ import graphql.language.TypeName;
 import graphql.language.UnionTypeDefinition;
 import graphql.language.UnionTypeExtensionDefinition;
 import graphql.schema.idl.errors.DirectiveRedefinitionError;
-import graphql.schema.idl.errors.OperationRedefinitionError;
 import graphql.schema.idl.errors.SchemaProblem;
 import graphql.schema.idl.errors.SchemaRedefinitionError;
 import graphql.schema.idl.errors.TypeRedefinitionError;
@@ -238,6 +237,7 @@ public class TypeDefinitionRegistry {
 
     /**
      * Removes a {@code SDLDefinition} from the definition list.
+     *
      * @param definition
      */
     public void remove(SDLDefinition definition) {
@@ -282,12 +282,13 @@ public class TypeDefinitionRegistry {
 
     /**
      * Removes a {@code SDLDefinition} from a map.
+     *
      * @param key
      * @param definition
      */
     public void remove(String key, SDLDefinition definition) {
-        assertNotNull(definition, "definition to remove can't be null");
-        assertNotNull(key, "key to remove can't be null");
+        assertNotNull(definition, () -> "definition to remove can't be null");
+        assertNotNull(key, () -> "key to remove can't be null");
         if (definition instanceof ObjectTypeExtensionDefinition) {
             removeFromMap(objectTypeExtensions, key);
         } else if (definition instanceof InterfaceTypeExtensionDefinition) {

--- a/src/main/java/graphql/schema/idl/TypeInfo.java
+++ b/src/main/java/graphql/schema/idl/TypeInfo.java
@@ -30,7 +30,7 @@ public class TypeInfo {
     private final Stack<Class<?>> decoration = new Stack<>();
 
     private TypeInfo(Type type) {
-        this.rawType = assertNotNull(type, "type must not be null");
+        this.rawType = assertNotNull(type, () -> "type must not be null");
         while (!(type instanceof TypeName)) {
             if (type instanceof NonNullType) {
                 decoration.push(NonNullType.class);

--- a/src/main/java/graphql/schema/idl/TypeRuntimeWiring.java
+++ b/src/main/java/graphql/schema/idl/TypeRuntimeWiring.java
@@ -38,7 +38,7 @@ public class TypeRuntimeWiring {
      * @return the builder
      */
     public static Builder newTypeWiring(String typeName) {
-        assertNotNull(typeName, "You must provide a type name");
+        assertNotNull(typeName, () -> "You must provide a type name");
         return new Builder().typeName(typeName);
     }
 
@@ -102,8 +102,8 @@ public class TypeRuntimeWiring {
          * @return the current type wiring
          */
         public Builder dataFetcher(String fieldName, DataFetcher dataFetcher) {
-            assertNotNull(dataFetcher, "you must provide a data fetcher");
-            assertNotNull(fieldName, "you must tell us what field");
+            assertNotNull(dataFetcher, () -> "you must provide a data fetcher");
+            assertNotNull(fieldName, () -> "you must tell us what field");
             fieldDataFetchers.put(fieldName, dataFetcher);
             return this;
         }
@@ -116,7 +116,7 @@ public class TypeRuntimeWiring {
          * @return the current type wiring
          */
         public Builder dataFetchers(Map<String, DataFetcher> dataFetchersMap) {
-            assertNotNull(dataFetchersMap, "you must provide a data fetchers map");
+            assertNotNull(dataFetchersMap, () -> "you must provide a data fetchers map");
             fieldDataFetchers.putAll(dataFetchersMap);
             return this;
         }
@@ -144,13 +144,13 @@ public class TypeRuntimeWiring {
          * @return the current type wiring
          */
         public Builder typeResolver(TypeResolver typeResolver) {
-            assertNotNull(typeResolver, "you must provide a type resolver");
+            assertNotNull(typeResolver, () -> "you must provide a type resolver");
             this.typeResolver = typeResolver;
             return this;
         }
 
         public Builder enumValues(EnumValuesProvider enumValuesProvider) {
-            assertNotNull(enumValuesProvider, "you must provide a type resolver");
+            assertNotNull(enumValuesProvider, () -> "you must provide a type resolver");
             this.enumValuesProvider = enumValuesProvider;
             return this;
         }
@@ -159,7 +159,7 @@ public class TypeRuntimeWiring {
          * @return the built type wiring
          */
         public TypeRuntimeWiring build() {
-            assertNotNull(typeName, "you must provide a type name");
+            assertNotNull(typeName, () -> "you must provide a type name");
             return new TypeRuntimeWiring(typeName, defaultDataFetcher, fieldDataFetchers, typeResolver, enumValuesProvider);
         }
     }

--- a/src/main/java/graphql/schema/validation/SchemaValidationError.java
+++ b/src/main/java/graphql/schema/validation/SchemaValidationError.java
@@ -8,8 +8,8 @@ public class SchemaValidationError {
     private final String description;
 
     public SchemaValidationError(SchemaValidationErrorType errorType, String description) {
-        assertNotNull(errorType, "error type can not be null");
-        assertNotNull(description, "error description can not be null");
+        assertNotNull(errorType, () -> "error type can not be null");
+        assertNotNull(description, () -> "error description can not be null");
         this.errorType = errorType;
         this.description = description;
     }

--- a/src/main/java/graphql/util/DefaultTraverserContext.java
+++ b/src/main/java/graphql/util/DefaultTraverserContext.java
@@ -72,7 +72,7 @@ public class DefaultTraverserContext<T> implements TraverserContext<T> {
 
     @Override
     public T thisNode() {
-        assertFalse(this.nodeDeleted, "node is deleted");
+        assertFalse(this.nodeDeleted, () -> "node is deleted");
         if (newNode != null) {
             return newNode;
         }
@@ -87,15 +87,15 @@ public class DefaultTraverserContext<T> implements TraverserContext<T> {
     @Override
     public void changeNode(T newNode) {
         assertNotNull(newNode);
-        assertFalse(this.nodeDeleted, "node is deleted");
+        assertFalse(this.nodeDeleted, () -> "node is deleted");
         this.newNode = newNode;
     }
 
 
     @Override
     public void deleteNode() {
-        assertNull(this.newNode, "node is already changed");
-        assertFalse(this.nodeDeleted, "node is already deleted");
+        assertNull(this.newNode, () -> "node is already changed");
+        assertFalse(this.nodeDeleted, () -> "node is already deleted");
         this.nodeDeleted = true;
     }
 
@@ -221,14 +221,14 @@ public class DefaultTraverserContext<T> implements TraverserContext<T> {
      * PRIVATE: Used by {@link Traverser}
      */
     void setChildrenContexts(Map<String, List<TraverserContext<T>>> children) {
-        assertTrue(this.children == null, "children already set");
+        assertTrue(this.children == null, () -> "children already set");
         this.children = children;
     }
 
 
     @Override
     public Map<String, List<TraverserContext<T>>> getChildrenContexts() {
-        assertNotNull(children, "children not available");
+        assertNotNull(children, () -> "children not available");
         return children;
     }
 

--- a/src/main/java/graphql/util/NodeMultiZipper.java
+++ b/src/main/java/graphql/util/NodeMultiZipper.java
@@ -71,7 +71,7 @@ public class NodeMultiZipper<T> {
             curZippers.removeAll(deepestZippers);
             curZippers.addAll(newZippers);
         }
-        assertTrue(curZippers.size() == 1, "unexpected state: all zippers must share the same root node");
+        assertTrue(curZippers.size() == 1, () -> "unexpected state: all zippers must share the same root node");
         return curZippers.iterator().next().toRoot();
     }
 
@@ -104,7 +104,7 @@ public class NodeMultiZipper<T> {
 
     public NodeMultiZipper<T> withReplacedZipper(NodeZipper<T> oldZipper, NodeZipper<T> newZipper) {
         int index = zippers.indexOf(oldZipper);
-        assertTrue(index >= 0, "oldZipper not found");
+        assertTrue(index >= 0, () -> "oldZipper not found");
         List<NodeZipper<T>> newZippers = new ArrayList<>(zippers);
         newZippers.set(index, newZipper);
         return new NodeMultiZipper<>(commonRoot, newZippers, this.nodeAdapter);
@@ -112,7 +112,7 @@ public class NodeMultiZipper<T> {
 
     public NodeMultiZipper<T> withReplacedZipperForNode(T currentNode, T newNode) {
         int index = FpKit.findIndex(zippers, zipper -> zipper.getCurNode() == currentNode);
-        assertTrue(index >= 0, "No current zipper found for provided node");
+        assertTrue(index >= 0, () -> "No current zipper found for provided node");
         NodeZipper<T> newZipper = zippers.get(index).withNewNode(newNode);
         List<NodeZipper<T>> newZippers = new ArrayList<>(zippers);
         newZippers.set(index, newZipper);
@@ -128,7 +128,7 @@ public class NodeMultiZipper<T> {
     }
 
     private NodeZipper<T> moveUp(T parent, List<NodeZipper<T>> sameParent) {
-        assertNotEmpty(sameParent, "expected at least one zipper");
+        assertNotEmpty(sameParent, () -> "expected at least one zipper");
 
         Map<String, List<T>> childrenMap = new HashMap<>(nodeAdapter.getNamedChildren(parent));
         Map<String, Integer> indexCorrection = new HashMap<>();

--- a/src/main/java/graphql/util/Traverser.java
+++ b/src/main/java/graphql/util/Traverser.java
@@ -112,8 +112,8 @@ public class Traverser<T> {
                 currentContext.setPhase(TraverserContext.Phase.LEAVE);
                 TraversalControl traversalControl = visitor.leave(currentContext);
                 currentAccValue = currentContext.getNewAccumulate();
-                assertNotNull(traversalControl, "result of leave must not be null");
-                assertTrue(CONTINUE_OR_QUIT.contains(traversalControl), "result can only return CONTINUE or QUIT");
+                assertNotNull(traversalControl, () -> "result of leave must not be null");
+                assertTrue(CONTINUE_OR_QUIT.contains(traversalControl), () -> "result can only return CONTINUE or QUIT");
 
                 switch (traversalControl) {
                     case QUIT:
@@ -132,8 +132,8 @@ public class Traverser<T> {
                 currentContext.setPhase(TraverserContext.Phase.BACKREF);
                 TraversalControl traversalControl = visitor.backRef(currentContext);
                 currentAccValue = currentContext.getNewAccumulate();
-                assertNotNull(traversalControl, "result of backRef must not be null");
-                assertTrue(CONTINUE_OR_QUIT.contains(traversalControl), "backRef can only return CONTINUE or QUIT");
+                assertNotNull(traversalControl, () -> "result of backRef must not be null");
+                assertTrue(CONTINUE_OR_QUIT.contains(traversalControl), () -> "backRef can only return CONTINUE or QUIT");
                 if (traversalControl == QUIT) {
                     break traverseLoop;
                 }
@@ -143,7 +143,7 @@ public class Traverser<T> {
                 currentContext.setPhase(TraverserContext.Phase.ENTER);
                 TraversalControl traversalControl = visitor.enter(currentContext);
                 currentAccValue = currentContext.getNewAccumulate();
-                assertNotNull(traversalControl, "result of enter must not be null");
+                assertNotNull(traversalControl, () -> "result of enter must not be null");
                 this.traverserState.addVisited((T) nodeBeforeEnter);
                 switch (traversalControl) {
                     case QUIT:

--- a/src/main/java/graphql/util/TraverserState.java
+++ b/src/main/java/graphql/util/TraverserState.java
@@ -44,7 +44,7 @@ public abstract class TraverserState<T> {
                 childrenMap.keySet().forEach(key -> {
                     List<U> children = childrenMap.get(key);
                     for (int i = children.size() - 1; i >= 0; i--) {
-                        U child = assertNotNull(children.get(i), "null child for key " + key);
+                        U child = assertNotNull(children.get(i), () -> "null child for key " + key);
                         NodeLocation nodeLocation = new NodeLocation(key, i);
                         DefaultTraverserContext<U> context = super.newContext(child, traverserContext, nodeLocation);
                         super.state.push(context);
@@ -72,7 +72,7 @@ public abstract class TraverserState<T> {
                 childrenMap.keySet().forEach(key -> {
                     List<U> children = childrenMap.get(key);
                     for (int i = 0; i < children.size(); i++) {
-                        U child = assertNotNull(children.get(i), "null child for key " + key);
+                        U child = assertNotNull(children.get(i), () -> "null child for key " + key);
                         NodeLocation nodeLocation = new NodeLocation(key, i);
                         DefaultTraverserContext<U> context = super.newContext(child, traverserContext, nodeLocation);
                         childrenContextMap.computeIfAbsent(key, notUsed -> new ArrayList<>());

--- a/src/main/java/graphql/util/TreeParallelTransformer.java
+++ b/src/main/java/graphql/util/TreeParallelTransformer.java
@@ -101,8 +101,8 @@ public class TreeParallelTransformer<T> {
             currentContext.setPhase(TraverserContext.Phase.ENTER);
             currentContext.setVar(List.class, myZippers);
             TraversalControl traversalControl = visitor.enter(currentContext);
-            assertNotNull(traversalControl, "result of enter must not be null");
-            assertTrue(QUIT != traversalControl, "can't return QUIT for parallel traversing");
+            assertNotNull(traversalControl, () -> "result of enter must not be null");
+            assertTrue(QUIT != traversalControl, () -> "can't return QUIT for parallel traversing");
             if (traversalControl == ABORT) {
                 this.children = Collections.emptyList();
                 tryComplete();
@@ -151,7 +151,7 @@ public class TreeParallelTransformer<T> {
         }
 
         private NodeZipper<T> moveUp(T parent, List<NodeZipper<T>> sameParent) {
-            assertNotEmpty(sameParent, "expected at least one zipper");
+            assertNotEmpty(sameParent, () -> "expected at least one zipper");
 
             Map<String, List<T>> childrenMap = new HashMap<>(nodeAdapter.getNamedChildren(parent));
             Map<String, Integer> indexCorrection = new HashMap<>();
@@ -223,7 +223,7 @@ public class TreeParallelTransformer<T> {
             childrenMap.keySet().forEach(key -> {
                 List<T> children = childrenMap.get(key);
                 for (int i = children.size() - 1; i >= 0; i--) {
-                    T child = assertNotNull(children.get(i), "null child for key %s", key);
+                    T child = assertNotNull(children.get(i), () -> String.format("null child for key %s", key));
                     NodeLocation nodeLocation = new NodeLocation(key, i);
                     DefaultTraverserContext<T> context = newContext(child, traverserContext, nodeLocation);
                     contexts.push(context);

--- a/src/main/java/graphql/util/TreeParallelTraverser.java
+++ b/src/main/java/graphql/util/TreeParallelTraverser.java
@@ -131,8 +131,8 @@ public class TreeParallelTraverser<T> {
         public void compute() {
             currentContext.setPhase(TraverserContext.Phase.ENTER);
             TraversalControl traversalControl = visitor.enter(currentContext);
-            assertNotNull(traversalControl, "result of enter must not be null");
-            assertTrue(QUIT != traversalControl, "can't return QUIT for parallel traversing");
+            assertNotNull(traversalControl, () -> "result of enter must not be null");
+            assertTrue(QUIT != traversalControl, () -> "can't return QUIT for parallel traversing");
             if (traversalControl == ABORT) {
                 tryComplete();
                 return;
@@ -162,7 +162,7 @@ public class TreeParallelTraverser<T> {
             childrenMap.keySet().forEach(key -> {
                 List<T> children = childrenMap.get(key);
                 for (int i = children.size() - 1; i >= 0; i--) {
-                    T child = assertNotNull(children.get(i), "null child for key %s", key);
+                    T child = assertNotNull(children.get(i), () -> String.format("null child for key %s", key));
                     NodeLocation nodeLocation = new NodeLocation(key, i);
                     DefaultTraverserContext<T> context = newContext(child, traverserContext, nodeLocation);
                     contexts.push(context);

--- a/src/main/java/graphql/util/TreeTransformerUtil.java
+++ b/src/main/java/graphql/util/TreeTransformerUtil.java
@@ -50,7 +50,7 @@ public class TreeTransformerUtil {
 
     private static <T> void replaceZipperForNode(List<NodeZipper<T>> zippers, T currentNode, T newNode) {
         int index = FpKit.findIndex(zippers, zipper -> zipper.getCurNode() == currentNode);
-        assertTrue(index >= 0, "No current zipper found for provided node");
+        assertTrue(index >= 0, () -> "No current zipper found for provided node");
         NodeZipper<T> newZipper = zippers.get(index).withNewNode(newNode);
         zippers.set(index, newZipper);
     }

--- a/src/test/groovy/graphql/AssertTest.groovy
+++ b/src/test/groovy/graphql/AssertTest.groovy
@@ -2,8 +2,6 @@ package graphql
 
 import spock.lang.Specification
 
-import java.util.function.Supplier
-
 class AssertTest extends Specification {
     def "assertNull should not throw on none null value"() {
         when:
@@ -23,7 +21,7 @@ class AssertTest extends Specification {
 
     def "assertNull with error message should not throw on none null value"() {
         when:
-        Assert.assertNotNull("some object", "error message")
+        Assert.assertNotNull("some object", { -> "error message"})
 
         then:
         noExceptionThrown()
@@ -31,7 +29,7 @@ class AssertTest extends Specification {
 
     def "assertNull with error message should throw on null value with formatted message"() {
         when:
-        Assert.assertNotNull(value, format, arg)
+        Assert.assertNotNull(value, { -> String.format(format, arg) })
 
         then:
         def error = thrown(AssertException)
@@ -79,7 +77,7 @@ class AssertTest extends Specification {
 
     def "assertNotEmpty collection should throw on null or empty"() {
         when:
-        Assert.assertNotEmpty(value, format, arg)
+        Assert.assertNotEmpty(value, { -> String.format(format, arg) })
 
         then:
         def error = thrown(AssertException)
@@ -93,7 +91,7 @@ class AssertTest extends Specification {
 
     def "assertNotEmpty should not throw on none empty collection"() {
         when:
-        Assert.assertNotEmpty(["some object"], "error message")
+        Assert.assertNotEmpty(["some object"], { -> "error message"})
 
         then:
         noExceptionThrown()
@@ -101,7 +99,7 @@ class AssertTest extends Specification {
 
     def "assertTrue should not throw on true value"() {
         when:
-        Assert.assertTrue(true, "error message")
+        Assert.assertTrue(true, { ->"error message"})
 
         then:
         noExceptionThrown()
@@ -109,30 +107,7 @@ class AssertTest extends Specification {
 
     def "assertTrue with error message should throw on false value with formatted message"() {
         when:
-        Assert.assertTrue(false, format, arg)
-
-        then:
-        def error = thrown(AssertException)
-        error.message == expectedMessage
-
-        where:
-        format     | arg   || expectedMessage
-        "error %s" | "msg" || "error msg"
-        "code %d"  | 1     || "code 1"
-        "code"     | null  || "code"
-    }
-
-    def "assertTrueLazily should not throw on true value"() {
-        when:
-        Assert.assertTrueLazily(true, "error message")
-
-        then:
-        noExceptionThrown()
-    }
-
-    def "assertTrueLazily with error message should throw on false value with formatted message"() {
-        when:
-        Assert.assertTrueLazily(false, format, { _ -> arg} as Supplier)
+        Assert.assertTrue(false, { -> String.format(format, arg) })
 
         then:
         def error = thrown(AssertException)
@@ -172,7 +147,7 @@ class AssertTest extends Specification {
         where:
         name   | _
         "0abc" | _
-        "едц"  | _
+        "пїЅпїЅпїЅ"  | _
         "_()"  | _
     }
 }

--- a/src/test/groovy/graphql/Issue1847.groovy
+++ b/src/test/groovy/graphql/Issue1847.groovy
@@ -1,0 +1,42 @@
+package graphql
+
+import spock.lang.Specification
+
+class Issue1847 extends Specification {
+    def schema = TestUtil.schema('''
+                type Query {
+                    listWithCircularReference(filter : TypeWithCircularReference) : String 
+                    list(filter : Type) : String 
+                }
+                input TypeWithCircularReference {
+                    circularField : TypeWithCircularReference
+                }
+                input Type {
+                    field: String
+                }
+            ''')
+
+    def "#1847 when there is a circular reference between Input Type and Input Field - not StackOverflowError"() {
+        when:
+        def type = schema.getType("TypeWithCircularReference")
+
+        def string = type.toString()
+
+        println(string)
+
+        then:
+        string.contains("[GraphQLInputObjectType]")
+    }
+
+    def "#1847 when there is no circular reference between Input Type and Input Field - toString returns all data"() {
+        when:
+        def type = schema.getType("Type")
+
+        def string = type.toString()
+        println(string)
+
+        then:
+        !string.contains("[GraphQLInputObjectType]")
+        string.contains("GraphQLScalarType")
+    }
+}


### PR DESCRIPTION
This means all asserts will be encouraged to be efficient by default.

It not longer possible to write an accidental slow one even if you do

```
assertTrue(b, String.format("%s", someExpensiveMethod())
````

because it wont compile.

it must now be

```
assertTrue(b, () -> String.format("%s", someExpensiveMethod())
````


I have commented on the actually changed files that matter.

This is technically not a breaking API change because it was marked as @Internal.  However its likely people have used it - well that's what @Internal is there to warn people about.  Soz but we reserve the right with a reason nad this is one of those reasons.


See #1876 for the original problem - this takes it much further