### PR TITLE
add description to schema itself

### DIFF
--- a/src/main/antlr/GraphqlSDL.g4
+++ b/src/main/antlr/GraphqlSDL.g4
@@ -1,7 +1,7 @@
 grammar GraphqlSDL;
 import GraphqlCommon;
 
-typeSystemDefinition: description?
+typeSystemDefinition:
 schemaDefinition |
 typeDefinition |
 directiveDefinition

--- a/src/main/java/graphql/introspection/Introspection.java
+++ b/src/main/java/graphql/introspection/Introspection.java
@@ -475,6 +475,9 @@ public class Introspection {
                     " of a GraphQL server. It exposes all available types and directives on " +
                     "the server, the entry points for query, mutation, and subscription operations.")
             .field(newFieldDefinition()
+                    .name("description")
+                    .type(GraphQLString))
+            .field(newFieldDefinition()
                     .name("types")
                     .description("A list of all types supported by this server.")
                     .type(nonNull(list(nonNull(__Type)))))
@@ -497,6 +500,9 @@ public class Introspection {
             .build();
 
     static {
+        register(__Schema, "description", environment -> {
+            return environment.getGraphQLSchema().getDescription();
+        });
         register(__Schema, "types", environment -> {
             GraphQLSchema schema = environment.getSource();
             return schema.getAllTypesAsList();
@@ -564,6 +570,7 @@ public class Introspection {
      * @param schema     the schema to use
      * @param parentType the type of the parent object
      * @param fieldName  the field to look up
+     *
      * @return a field definition otherwise throws an assertion exception if its null
      */
     public static GraphQLFieldDefinition getFieldDef(GraphQLSchema schema, GraphQLCompositeType parentType, String fieldName) {

--- a/src/main/java/graphql/language/SchemaDefinition.java
+++ b/src/main/java/graphql/language/SchemaDefinition.java
@@ -17,7 +17,7 @@ import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 import static graphql.language.NodeUtil.directivesByName;
 
 @PublicApi
-public class SchemaDefinition extends AbstractNode<SchemaDefinition> implements SDLDefinition<SchemaDefinition> {
+public class SchemaDefinition extends AbstractDescribedNode<SchemaDefinition> implements SDLDefinition<SchemaDefinition> {
 
     private final List<Directive> directives;
     private final List<OperationTypeDefinition> operationTypeDefinitions;
@@ -25,14 +25,16 @@ public class SchemaDefinition extends AbstractNode<SchemaDefinition> implements 
     public static final String CHILD_DIRECTIVES = "directives";
     public static final String CHILD_OPERATION_TYPE_DEFINITIONS = "operationTypeDefinitions";
 
+
     @Internal
     protected SchemaDefinition(List<Directive> directives,
                                List<OperationTypeDefinition> operationTypeDefinitions,
                                SourceLocation sourceLocation,
                                List<Comment> comments,
                                IgnoredChars ignoredChars,
-                               Map<String, String> additionalData) {
-        super(sourceLocation, comments, ignoredChars, additionalData);
+                               Map<String, String> additionalData,
+                               Description description) {
+        super(sourceLocation, comments, ignoredChars, additionalData, description);
         this.directives = directives;
         this.operationTypeDefinitions = operationTypeDefinitions;
     }
@@ -52,6 +54,10 @@ public class SchemaDefinition extends AbstractNode<SchemaDefinition> implements 
 
     public List<OperationTypeDefinition> getOperationTypeDefinitions() {
         return new ArrayList<>(operationTypeDefinitions);
+    }
+
+    public Description getDescription() {
+        return description;
     }
 
     @Override
@@ -92,7 +98,7 @@ public class SchemaDefinition extends AbstractNode<SchemaDefinition> implements 
     @Override
     public SchemaDefinition deepCopy() {
         return new SchemaDefinition(deepCopy(directives), deepCopy(operationTypeDefinitions), getSourceLocation(), getComments(),
-                getIgnoredChars(), getAdditionalData());
+                getIgnoredChars(), getAdditionalData(), description);
     }
 
     @Override
@@ -125,6 +131,8 @@ public class SchemaDefinition extends AbstractNode<SchemaDefinition> implements 
         private List<OperationTypeDefinition> operationTypeDefinitions = new ArrayList<>();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
+        private Description description;
+
 
         protected Builder() {
         }
@@ -136,8 +144,13 @@ public class SchemaDefinition extends AbstractNode<SchemaDefinition> implements 
             this.operationTypeDefinitions = existing.getOperationTypeDefinitions();
             this.ignoredChars = existing.getIgnoredChars();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
+            this.description = existing.getDescription();
         }
 
+        public Builder description(Description description) {
+            this.description = description;
+            return this;
+        }
 
         public Builder sourceLocation(SourceLocation sourceLocation) {
             this.sourceLocation = sourceLocation;
@@ -190,7 +203,8 @@ public class SchemaDefinition extends AbstractNode<SchemaDefinition> implements 
                     sourceLocation,
                     comments,
                     ignoredChars,
-                    additionalData);
+                    additionalData,
+                    description);
         }
     }
 }

--- a/src/main/java/graphql/language/SchemaExtensionDefinition.java
+++ b/src/main/java/graphql/language/SchemaExtensionDefinition.java
@@ -13,8 +13,13 @@ import static graphql.Assert.assertNotNull;
 @PublicApi
 public class SchemaExtensionDefinition extends SchemaDefinition {
 
-    protected SchemaExtensionDefinition(List<Directive> directives, List<OperationTypeDefinition> operationTypeDefinitions, SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars, Map<String, String> additionalData) {
-        super(directives, operationTypeDefinitions, sourceLocation, comments, ignoredChars, additionalData);
+    protected SchemaExtensionDefinition(List<Directive> directives,
+                                        List<OperationTypeDefinition> operationTypeDefinitions,
+                                        SourceLocation sourceLocation,
+                                        List<Comment> comments,
+                                        IgnoredChars ignoredChars,
+                                        Map<String, String> additionalData) {
+        super(directives, operationTypeDefinitions, sourceLocation, comments, ignoredChars, additionalData, null);
     }
 
     @Override

--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -378,6 +378,7 @@ public class GraphqlAntlrToLanguage {
         SchemaDefinition.Builder def = SchemaDefinition.newSchemaDefinition();
         addCommonData(def, ctx);
         def.directives(createDirectives(ctx.directives()));
+        def.description(newDescription(ctx.description()));
         def.operationTypeDefinitions(ctx.operationTypeDefinition().stream()
                 .map(this::createOperationTypeDefinition).collect(toList()));
         return def.build();

--- a/src/main/java/graphql/schema/GraphQLSchema.java
+++ b/src/main/java/graphql/schema/GraphQLSchema.java
@@ -54,8 +54,11 @@ public class GraphQLSchema {
     private final Map<String, GraphQLNamedType> typeMap;
     private final Map<String, List<GraphQLObjectType>> byInterface;
 
+    private final String description;
+
     /**
      * @param queryType the query type
+     *
      * @deprecated use the {@link #newSchema()} builder pattern instead, as this constructor will be made private in a future version.
      */
     @Internal
@@ -68,6 +71,7 @@ public class GraphQLSchema {
      * @param queryType       the query type
      * @param mutationType    the mutation type
      * @param additionalTypes additional types
+     *
      * @deprecated use the {@link #newSchema()} builder pattern instead, as this constructor will be made private in a future version.
      */
     @Internal
@@ -81,6 +85,7 @@ public class GraphQLSchema {
      * @param mutationType     the mutation type
      * @param subscriptionType the subscription type
      * @param additionalTypes  additional types
+     *
      * @deprecated use the {@link #newSchema()} builder pattern instead, as this constructor will be made private in a future version.
      */
     @Internal
@@ -110,6 +115,7 @@ public class GraphQLSchema {
         SchemaUtil schemaUtil = new SchemaUtil();
         this.typeMap = new TreeMap<>(schemaUtil.allTypes(this, additionalTypes, afterTransform));
         this.byInterface = new TreeMap<>(schemaUtil.groupImplementations(this));
+        this.description = builder.description;
     }
 
     // This can be removed once we no longer extract legacy code from types such as data fetchers but for now
@@ -128,6 +134,7 @@ public class GraphQLSchema {
 
         this.typeMap = otherSchema.typeMap;
         this.byInterface = otherSchema.byInterface;
+        this.description = otherSchema.description;
     }
 
 
@@ -147,7 +154,9 @@ public class GraphQLSchema {
      * Called to return a named {@link graphql.schema.GraphQLObjectType} from the schema
      *
      * @param typeName the name of the type
+     *
      * @return a graphql object type or null if there is one
+     *
      * @throws graphql.GraphQLException if the type is NOT a object type
      */
     public GraphQLObjectType getObjectType(String typeName) {
@@ -172,6 +181,7 @@ public class GraphQLSchema {
      * interface type.
      *
      * @param type interface type to obtain implementations of.
+     *
      * @return list of types implementing provided interface
      */
     public List<GraphQLObjectType> getImplementations(GraphQLInterfaceType type) {
@@ -189,6 +199,7 @@ public class GraphQLSchema {
      *
      * @param abstractType abstract type either interface or union
      * @param concreteType concrete type
+     *
      * @return true if possible type, false otherwise.
      */
     public boolean isPossibleType(GraphQLNamedType abstractType, GraphQLObjectType concreteType) {
@@ -219,6 +230,7 @@ public class GraphQLSchema {
 
     /**
      * @return the field visibility
+     *
      * @deprecated use {@link GraphQLCodeRegistry#getFieldVisibility()} instead
      */
     @Deprecated
@@ -307,11 +319,16 @@ public class GraphQLSchema {
         return subscriptionType != null;
     }
 
+    public String getDescription() {
+        return description;
+    }
+
     /**
      * This helps you transform the current GraphQLSchema object into another one by starting a builder with all
      * the current values and allows you to transform it how you want.
      *
      * @param builderConsumer the consumer code that will be given a builder to transform
+     *
      * @return a new GraphQLSchema object based on calling build on that builder
      */
     public GraphQLSchema transform(Consumer<Builder> builderConsumer) {
@@ -332,6 +349,7 @@ public class GraphQLSchema {
      * schema and then allows you to replace them.
      *
      * @param existingSchema the existing schema
+     *
      * @return a new schema builder
      */
     public static Builder newSchema(GraphQLSchema existingSchema) {
@@ -345,7 +363,8 @@ public class GraphQLSchema {
                 .additionalDirectives(existingSchema.directives)
                 .clearSchemaDirectives()
                 .withSchemaDirectives(schemaDirectivesArray(existingSchema))
-                .additionalTypes(existingSchema.additionalTypes);
+                .additionalTypes(existingSchema.additionalTypes)
+                .description(existingSchema.getDescription());
     }
 
     private static GraphQLDirective[] schemaDirectivesArray(GraphQLSchema existingSchema) {
@@ -361,6 +380,7 @@ public class GraphQLSchema {
         private Set<GraphQLType> additionalTypes = new LinkedHashSet<>();
         private SchemaDefinition definition;
         private List<SchemaExtensionDefinition> extensionDefinitions;
+        private String description;
 
         // we default these in
         private Set<GraphQLDirective> additionalDirectives = new LinkedHashSet<>(
@@ -399,7 +419,9 @@ public class GraphQLSchema {
 
         /**
          * @param fieldVisibility the field visibility
+         *
          * @return this builder
+         *
          * @deprecated use {@link graphql.schema.GraphQLCodeRegistry.Builder#fieldVisibility(graphql.schema.visibility.GraphqlFieldVisibility)} instead
          */
         @Deprecated
@@ -481,11 +503,18 @@ public class GraphQLSchema {
             return this;
         }
 
+        public Builder description(String description) {
+            this.description = description;
+            return this;
+        }
+
         /**
          * Builds the schema
          *
          * @param additionalTypes - please dont use this any more
+         *
          * @return the built schema
+         *
          * @deprecated - Use the {@link #additionalType(GraphQLType)} methods
          */
         @Deprecated
@@ -498,7 +527,9 @@ public class GraphQLSchema {
          *
          * @param additionalTypes      - please don't use this any more
          * @param additionalDirectives - please don't use this any more
+         *
          * @return the built schema
+         *
          * @deprecated - Use the {@link #additionalType(GraphQLType)} and {@link #additionalDirective(GraphQLDirective)} methods
          */
         @Deprecated

--- a/src/main/java/graphql/schema/idl/SchemaGenerator.java
+++ b/src/main/java/graphql/schema/idl/SchemaGenerator.java
@@ -218,7 +218,9 @@ public class SchemaGenerator {
      *
      * @param typeRegistry this can be obtained via {@link SchemaParser#parse(String)}
      * @param wiring       this can be built using {@link RuntimeWiring#newRuntimeWiring()}
+     *
      * @return an executable schema
+     *
      * @throws SchemaProblem if there are problems in assembling a schema such as missing type resolvers or no operations defined
      */
     public GraphQLSchema makeExecutableSchema(TypeDefinitionRegistry typeRegistry, RuntimeWiring wiring) throws SchemaProblem {
@@ -232,7 +234,9 @@ public class SchemaGenerator {
      * @param options      the controlling options
      * @param typeRegistry this can be obtained via {@link SchemaParser#parse(String)}
      * @param wiring       this can be built using {@link RuntimeWiring#newRuntimeWiring()}
+     *
      * @return an executable schema
+     *
      * @throws SchemaProblem if there are problems in assembling a schema such as missing type resolvers or no operations defined
      */
     public GraphQLSchema makeExecutableSchema(Options options, TypeDefinitionRegistry typeRegistry, RuntimeWiring wiring) throws SchemaProblem {
@@ -273,6 +277,9 @@ public class SchemaGenerator {
         GraphQLCodeRegistry codeRegistry = buildCtx.getCodeRegistry().build();
         schemaBuilder.codeRegistry(codeRegistry);
 
+        buildCtx.typeRegistry.schemaDefinition().ifPresent(schemaDefinition -> {
+            schemaBuilder.description(schemaGeneratorHelper.buildDescription(schemaDefinition, schemaDefinition.getDescription()));
+        });
         GraphQLSchema graphQLSchema = schemaBuilder.build();
 
         Collection<SchemaGeneratorPostProcessing> schemaTransformers = buildCtx.getWiring().getSchemaGeneratorPostProcessings();
@@ -356,6 +363,7 @@ public class SchemaGenerator {
      * but then we build the rest of the types specified and put them in as additional types
      *
      * @param buildCtx the context we need to work out what we are doing
+     *
      * @return the additional types not referenced from the top level operations
      */
     private Set<GraphQLType> buildAdditionalTypes(BuildContext buildCtx) {
@@ -400,6 +408,7 @@ public class SchemaGenerator {
      *
      * @param buildCtx the context we need to work out what we are doing
      * @param rawType  the type to be built
+     *
      * @return an output type
      */
     @SuppressWarnings({"unchecked", "TypeParameterUnusedInFormals"})

--- a/src/test/groovy/graphql/introspection/IntrospectionTest.groovy
+++ b/src/test/groovy/graphql/introspection/IntrospectionTest.groovy
@@ -57,4 +57,28 @@ class IntrospectionTest extends Specification {
                 ]
         ]
     }
+
+    def "schema description can be defined in SDL and queried via introspection"() {
+        given:
+        def sdl = ''' 
+        """
+        This is my schema
+        """
+        schema {
+            query: Foo
+        }
+        
+        type Foo {
+            foo: String
+        }
+        
+        '''
+        def graphql = TestUtil.graphQL(sdl).build()
+        when:
+        def data = graphql.execute("{__schema { description }}").getData()
+
+        then:
+        data == [__schema: [description: "This is my schema"]]
+
+    }
 }


### PR DESCRIPTION
The spec allows description to be placed on a the schema itself inside the SDL and to be queried.

This adds support for it.