### PR TITLE
Prevent an illegal argument exception in the case where breadcrumbs a…

### DIFF
--- a/src/main/java/graphql/schema/SchemaTransformer.java
+++ b/src/main/java/graphql/schema/SchemaTransformer.java
@@ -360,7 +360,13 @@ public class SchemaTransformer {
         }
 
         GraphQLSchemaElement newNode = SCHEMA_ELEMENT_ADAPTER.withNewChildren(parent, childrenMap);
-        List<Breadcrumb<GraphQLSchemaElement>> newBreadcrumbs = sameParent.get(0).getBreadcrumbs().subList(1, sameParent.get(0).getBreadcrumbs().size());
+        final List<Breadcrumb<GraphQLSchemaElement>> oldBreadcrumbs = sameParent.get(0).getBreadcrumbs();
+        List<Breadcrumb<GraphQLSchemaElement>> newBreadcrumbs;
+        if (oldBreadcrumbs.size() > 1) {
+            newBreadcrumbs = oldBreadcrumbs.subList(1, oldBreadcrumbs.size());
+        } else {
+            newBreadcrumbs = Collections.emptyList();
+        }
         return new NodeZipper<>(newNode, newBreadcrumbs, SCHEMA_ELEMENT_ADAPTER);
     }
 


### PR DESCRIPTION
…re empty

Encountered the following stack trace (sadly it was in JSON format)
```
"java.lang.IllegalArgumentException","message":"fromIndex(1) > toIndex(0)","frames":[{"class":"java.util.ArrayList","method":"subListRangeCheck","line":1014},{"class":"java.util.ArrayList","method":"subList","line":1004},{"class":"java.util.Collections$UnmodifiableRandomAccessList","method":"subList","line":1402},{"class":"graphql.schema.SchemaTransformer","method":"moveUp","line":363},{"class":"graphql.schema.SchemaTransformer","method":"toRootNode","line":217},{"class":"graphql.schema.SchemaTransformer","method":"transform","line":176},{"class":"graphql.schema.SchemaTransformer","method":"transformSchema","line":112},
```
This seems the likely fix