### PR TITLE
#1855 add ExecutionStrategyParameters parameter to handleResults method

### DIFF
--- a/src/main/java/graphql/execution/AbstractAsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AbstractAsyncExecutionStrategy.java
@@ -19,6 +19,11 @@ public abstract class AbstractAsyncExecutionStrategy extends ExecutionStrategy {
         super(dataFetcherExceptionHandler);
     }
 
+    protected BiConsumer<List<ExecutionResult>, Throwable> handleResults(ExecutionContext executionContext, List<String> fieldNames, CompletableFuture<ExecutionResult> overallResult, ExecutionStrategyParameters parameters) {
+        return this.handleResults(executionContext, fieldNames, overallResult);
+    }
+
+    // This method is kept for backward compatibility. Prefer calling/overriding another handleResults method
     protected BiConsumer<List<ExecutionResult>, Throwable> handleResults(ExecutionContext executionContext, List<String> fieldNames, CompletableFuture<ExecutionResult> overallResult) {
         return (List<ExecutionResult> results, Throwable exception) -> {
             if (exception != null) {

--- a/src/main/java/graphql/execution/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncExecutionStrategy.java
@@ -79,7 +79,7 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
         executionStrategyCtx.onDispatched(overallResult);
 
         Async.each(futures).whenComplete((completeValueInfos, throwable) -> {
-            BiConsumer<List<ExecutionResult>, Throwable> handleResultsConsumer = handleResults(executionContext, resolvedFields, overallResult);
+            BiConsumer<List<ExecutionResult>, Throwable> handleResultsConsumer = handleResults(executionContext, resolvedFields, overallResult, parameters);
             if (throwable != null) {
                 handleResultsConsumer.accept(null, throwable.getCause());
                 return;

--- a/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
@@ -24,7 +24,7 @@ public class AsyncSerialExecutionStrategy extends AbstractAsyncExecutionStrategy
     }
 
     @Override
-    @SuppressWarnings({"TypeParameterUnusedInFormals","FutureReturnValueIgnored"})
+    @SuppressWarnings({"TypeParameterUnusedInFormals", "FutureReturnValueIgnored"})
     public CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) throws NonNullableFieldWasNullException {
 
         Instrumentation instrumentation = executionContext.getInstrumentation();
@@ -44,7 +44,7 @@ public class AsyncSerialExecutionStrategy extends AbstractAsyncExecutionStrategy
         CompletableFuture<ExecutionResult> overallResult = new CompletableFuture<>();
         executionStrategyCtx.onDispatched(overallResult);
 
-        resultsFuture.whenComplete(handleResults(executionContext, fieldNames, overallResult));
+        resultsFuture.whenComplete(handleResults(executionContext, fieldNames, overallResult, parameters));
         overallResult.whenComplete(executionStrategyCtx::onCompleted);
         return overallResult;
     }


### PR DESCRIPTION
I added `ExecutionStrategyParameters` parameter to `AbstractAsyncExecutionStrategy.handleResults` method. This would allow custom `handleResults` implementations to resolve information about currently mapped Type.
For backward compatibility, I kept the existing method with 3 parameters. I was thinking about marking it as `@Deprecated` but wasn't sure about it.

@andimarek what do you think about this change?

PS this PR addresses the problem in #1855 