### PR TITLE
Coerce the ConnectionCursor by using the interface

### DIFF
--- a/src/main/java/graphql/Scalars.java
+++ b/src/main/java/graphql/Scalars.java
@@ -10,6 +10,7 @@ import graphql.schema.CoercingParseLiteralException;
 import graphql.schema.CoercingParseValueException;
 import graphql.schema.CoercingSerializeException;
 import graphql.schema.GraphQLScalarType;
+import graphql.relay.ConnectionCursor;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -281,13 +282,20 @@ public class Scalars {
             if (input instanceof BigInteger) {
                 return String.valueOf(input);
             }
+            if (input instanceof ConnectionCursor) {
+                return ((ConnectionCursor) input).getValue();
+            }
             return String.valueOf(input);
-
         }
 
         @Override
         public String serialize(Object input) {
-            String result = String.valueOf(input);
+            String result;
+            if (input instanceof ConnectionCursor) {
+                result = ((ConnectionCursor) input).getValue();
+            } else {
+                result = String.valueOf(input);
+            }
             if (result == null) {
                 throw new CoercingSerializeException(
                         "Expected type 'ID' but was '" + typeName(input) + "'."

--- a/src/main/java/graphql/relay/DefaultConnectionCursor.java
+++ b/src/main/java/graphql/relay/DefaultConnectionCursor.java
@@ -39,6 +39,8 @@ public class DefaultConnectionCursor implements ConnectionCursor {
 
     @Override
     public String toString() {
-        return value;
+        return "DefaultConnection{" +
+                "value=" + value +
+                '}';
     }
 }


### PR DESCRIPTION
The DefaultConnectionCursor had a convenient toString()-method which used the value from
the getValue method in the interface ConnectionCursor. This made the ScalarsIDTest to
pass by accident. This commit will change the default toString()-method to be more aligned
with the other relay implementations and add a check for ConnectionCursor interface in the
ScalarID coercing code.

I'm not sure if this is the correct solution so a discussion is welcome.  I stumpled upon this issue #1944 