### PR TITLE
DataFetchingFieldSelectionSet ignores inline fragments when parent type is interface/union

### DIFF
--- a/src/test/groovy/graphql/StarWarsData.groovy
+++ b/src/test/groovy/graphql/StarWarsData.groovy
@@ -108,9 +108,9 @@ class StarWarsData {
         GraphQLObjectType getType(TypeResolutionEnvironment env) {
             def id = env.getObject().id
             if (humanData[id] != null)
-                return StarWarsSchema.humanType
+                return env.getSchema().getType(StarWarsSchema.humanType.name)
             if (droidData[id] != null)
-                return StarWarsSchema.droidType
+                return env.getSchema().getType(StarWarsSchema.droidType.name)
             return null
         }
     }

--- a/src/test/resources/starWarsSchemaWithArguments.graphqls
+++ b/src/test/resources/starWarsSchemaWithArguments.graphqls
@@ -5,6 +5,7 @@ schema {
 type QueryType {
     hero(episode: Episode): Character
     human(id : String) : Human
+    humanCharacter(id : String) : Character
     droid(id: ID!): Droid
 }
 


### PR DESCRIPTION
[DO NOT MERGE]
### Description
This PR is more of a question than a PR, the code changes consist of a single unit test to reproduce the use case.

Say I have the following shortened SWAPI schema:
```gql
type QueryType {
    humanCharacter(id : String) : Character
}
interface Character {
    id: ID!
}
type Human implements Character {
    id: ID!
    homePlanet: String
}
```
and the following query: 
```gql
{ 
   humanCharacter(id: "1003") {    --> returns Leia who is a Human
        id
        __typename
        ... on Human {          
            homePlanet
        }
    }
}
```

The selection set returned by `environment.getSelectionSet().get().keySet()` when ran from the `Query.humanCharacter` data fetcher contains **all the fields but `homePlanet`**. That is:
```
["id",
"__typename"]
```

I would like to understand if this omission is by design or it is a defect. 

**If it is by design:**
We are returning only the fields in the selection set which we are sure are of the same type as the field output type. In our example, we would only return the fields from the selection set that are on the type `Character`.
Assuming it is by design, does it kind of defeats the purpose of looking ahead? 
If say, we were making a request to a SQL system ([as per the doc](https://github.com/graphql-java/graphql-java/blob/527c587598e66a3b0669584efe441cfd8340dfca/src/main/java/graphql/schema/DataFetchingFieldSelectionSet.java#L33)) using the `DataDetchingSelectionSet` fields as projection. Since we only get back the selected fields on `Character`, i.e `id` and `__typename`, wouldn't this create a hurdle as `homePlanet` would be missing from the SQL statement?

**If it is a defect**
I can update the PR to include fragments in the selection set.

The test added in this PR fails because it expected `homePlanet` to be included:
```
Condition not satisfied:

captureMap.keySet() == [ "id", "__typename", "friends", "friends/id", "friends/otherId", "otherId", "homePlanet" ].toSet()
|          |        |                                                                                              |
|          |        false                                                                                          [otherId, __typename, id, friends/otherId, friends/id, homePlanet, friends]
|          [otherId, __typename, id, friends/otherId, friends/id, friends]
[otherId:otherId: id, __typename:__typename, id:id, friends/otherId:otherId: id, friends/id:id, friends:friends {
  id
  otherId: id
}]
```

 