### PR TITLE
[NOT READY] Distinguish null default from no default in input fields

### DIFF
--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -210,7 +210,7 @@ public class ValuesResolver {
     }
 
     private boolean alwaysHasValue(GraphQLInputObjectField inputField) {
-        return inputField.getDefaultValue() != null
+        return inputField.hasSetDefaultValue()
                 || isNonNull(inputField.getType());
     }
 
@@ -312,7 +312,7 @@ public class ValuesResolver {
                 } else {
                     assertNonNullInputField(inputTypeField);
                 }
-            } else if (inputTypeField.getDefaultValue() != null) {
+            } else if (inputTypeField.hasSetDefaultValue()) {
                 result.put(inputTypeField.getName(), inputTypeField.getDefaultValue());
             } else {
                 assertNonNullInputField(inputTypeField);

--- a/src/main/java/graphql/schema/GraphQLInputObjectField.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectField.java
@@ -38,8 +38,11 @@ public class GraphQLInputObjectField implements GraphQLNamedSchemaElement, Graph
 
     private GraphQLInputType replacedType;
 
-    public static final String CHILD_TYPE = "type";
     public static final String CHILD_DIRECTIVES = "directives";
+    public static final String CHILD_TYPE = "type";
+
+    private static final Object DEFAULT_VALUE_SENTINEL = new Object() {
+    };
 
     /**
      * @param name the name
@@ -50,7 +53,7 @@ public class GraphQLInputObjectField implements GraphQLNamedSchemaElement, Graph
     @Internal
     @Deprecated
     public GraphQLInputObjectField(String name, GraphQLInputType type) {
-        this(name, null, type, null, emptyList(), null);
+        this(name, null, type, DEFAULT_VALUE_SENTINEL, emptyList(), null);
     }
 
     /**
@@ -106,7 +109,11 @@ public class GraphQLInputObjectField implements GraphQLNamedSchemaElement, Graph
     }
 
     public Object getDefaultValue() {
-        return defaultValue;
+        return defaultValue == DEFAULT_VALUE_SENTINEL ? null : defaultValue;
+    }
+
+    public boolean hasSetDefaultValue() {
+        return defaultValue != DEFAULT_VALUE_SENTINEL;
     }
 
     public String getDescription() {
@@ -195,8 +202,9 @@ public class GraphQLInputObjectField implements GraphQLNamedSchemaElement, Graph
 
     @PublicApi
     public static class Builder extends GraphqlTypeBuilder {
-        private Object defaultValue;
+
         private GraphQLInputType type;
+        private Object defaultValue = DEFAULT_VALUE_SENTINEL;
         private InputValueDefinition definition;
         private final Map<String, GraphQLDirective> directives = new LinkedHashMap<>();
 
@@ -206,7 +214,7 @@ public class GraphQLInputObjectField implements GraphQLNamedSchemaElement, Graph
         public Builder(GraphQLInputObjectField existing) {
             this.name = existing.getName();
             this.description = existing.getDescription();
-            this.defaultValue = existing.getDefaultValue();
+            this.defaultValue = existing.defaultValue;
             this.type = existing.originalType;
             this.definition = existing.getDefinition();
             this.directives.putAll(getByName(existing.getDirectives(), GraphQLDirective::getName));

--- a/src/test/groovy/graphql/schema/GraphQLInputObjectFieldTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLInputObjectFieldTest.groovy
@@ -47,5 +47,6 @@ class GraphQLInputObjectFieldTest extends Specification {
         transformedField.getDirective("directive1") != null
         transformedField.getDirective("directive2") != null
         transformedField.getDirective("directive3") != null
+        !transformedField.hasSetDefaultValue()
     }
 }


### PR DESCRIPTION
Fixes #1958

Not ready because I'm not 100% sure if there's more places in `ValuesResolver`  that need changing (although I don't think so), or whether e.g. [this line](https://github.com/graphql-java/graphql-java/blob/master/src/main/java/graphql/schema/idl/SchemaPrinter.java#L589) needs anything (again, I don't think so).