### PR TITLE
extract special Introspection DF

### DIFF
--- a/src/main/java/graphql/introspection/Introspection.java
+++ b/src/main/java/graphql/introspection/Introspection.java
@@ -6,8 +6,6 @@ import graphql.Internal;
 import graphql.PublicApi;
 import graphql.language.AstPrinter;
 import graphql.language.AstValueHelper;
-import graphql.schema.DataFetcher;
-import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.FieldCoordinates;
 import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLCodeRegistry;
@@ -52,20 +50,20 @@ import static graphql.schema.GraphQLTypeUtil.simplePrint;
 
 @PublicApi
 public class Introspection {
-    private static final Map<FieldCoordinates, DataFetcher> introspectionDataFetchers = new LinkedHashMap<>();
+    private static final Map<FieldCoordinates, IntrospectionDataFetcher> introspectionDataFetchers = new LinkedHashMap<>();
 
-    private static void register(GraphQLFieldsContainer parentType, String fieldName, DataFetcher dataFetcher) {
-        introspectionDataFetchers.put(coordinates(parentType.getName(), fieldName), dataFetcher);
+    private static void register(GraphQLFieldsContainer parentType, String fieldName, IntrospectionDataFetcher introspectionDataFetcher) {
+        introspectionDataFetchers.put(coordinates(parentType.getName(), fieldName), introspectionDataFetcher);
     }
 
     @Internal
     public static void addCodeForIntrospectionTypes(GraphQLCodeRegistry.Builder codeRegistry) {
         // place the system __ fields into the mix.  They have no parent types
-        codeRegistry.systemDataFetcher(systemCoordinates(SchemaMetaFieldDef.getName()), SchemaMetaFieldDefDataFetcher);
-        codeRegistry.systemDataFetcher(systemCoordinates(TypeNameMetaFieldDef.getName()), TypeNameMetaFieldDefDataFetcher);
-        codeRegistry.systemDataFetcher(systemCoordinates(TypeMetaFieldDef.getName()), TypeMetaFieldDefDataFetcher);
+        codeRegistry.systemDataFetcher(systemCoordinates(SchemaMetaFieldDef.getName()), SchemaMetaFieldDefDataFetcher::get);
+        codeRegistry.systemDataFetcher(systemCoordinates(TypeNameMetaFieldDef.getName()), TypeNameMetaFieldDefDataFetcher::get);
+        codeRegistry.systemDataFetcher(systemCoordinates(TypeMetaFieldDef.getName()), TypeMetaFieldDefDataFetcher::get);
 
-        introspectionDataFetchers.forEach(codeRegistry::dataFetcher);
+        introspectionDataFetchers.forEach((coordinates, idf) -> codeRegistry.dataFetcher(coordinates, idf::get));
     }
 
     public enum TypeKind {
@@ -92,7 +90,7 @@ public class Introspection {
             .value("NON_NULL", TypeKind.NON_NULL, "Indicates this type is a non-null. `ofType` is a valid field.")
             .build();
 
-    private static final DataFetcher kindDataFetcher = environment -> {
+    private static final IntrospectionDataFetcher kindDataFetcher = environment -> {
         Object type = environment.getSource();
         if (type instanceof GraphQLScalarType) {
             return TypeKind.SCALAR;
@@ -114,14 +112,14 @@ public class Introspection {
             return Assert.assertShouldNeverHappen("Unknown kind of type: %s", type);
         }
     };
-    private static final DataFetcher nameDataFetcher = environment -> {
+    private static final IntrospectionDataFetcher nameDataFetcher = environment -> {
         Object type = environment.getSource();
         if (type instanceof GraphQLNamedSchemaElement) {
             return ((GraphQLNamedSchemaElement) type).getName();
         }
         return null;
     };
-    private static final DataFetcher descriptionDataFetcher = environment -> {
+    private static final IntrospectionDataFetcher descriptionDataFetcher = environment -> {
         Object type = environment.getSource();
         if (type instanceof GraphQLNamedSchemaElement) {
             return ((GraphQLNamedSchemaElement) type).getDescription();
@@ -227,7 +225,7 @@ public class Introspection {
     }
 
 
-    private static final DataFetcher fieldsFetcher = environment -> {
+    private static final IntrospectionDataFetcher fieldsFetcher = environment -> {
         Object type = environment.getSource();
         Boolean includeDeprecated = environment.getArgument("includeDeprecated");
         if (type instanceof GraphQLFieldsContainer) {
@@ -251,7 +249,7 @@ public class Introspection {
     };
 
 
-    private static final DataFetcher interfacesFetcher = environment -> {
+    private static final IntrospectionDataFetcher interfacesFetcher = environment -> {
         Object type = environment.getSource();
         if (type instanceof GraphQLObjectType) {
             return ((GraphQLObjectType) type).getInterfaces();
@@ -262,7 +260,7 @@ public class Introspection {
         return null;
     };
 
-    private static final DataFetcher possibleTypesFetcher = environment -> {
+    private static final IntrospectionDataFetcher possibleTypesFetcher = environment -> {
         Object type = environment.getSource();
         if (type instanceof GraphQLInterfaceType) {
             return environment.getGraphQLSchema().getImplementations((GraphQLInterfaceType) type);
@@ -273,7 +271,7 @@ public class Introspection {
         return null;
     };
 
-    private static final DataFetcher enumValuesTypesFetcher = environment -> {
+    private static final IntrospectionDataFetcher enumValuesTypesFetcher = environment -> {
         Object type = environment.getSource();
         Boolean includeDeprecated = environment.getArgument("includeDeprecated");
         if (type instanceof GraphQLEnumType) {
@@ -292,7 +290,7 @@ public class Introspection {
         return null;
     };
 
-    private static final DataFetcher inputFieldsFetcher = environment -> {
+    private static final IntrospectionDataFetcher inputFieldsFetcher = environment -> {
         Object type = environment.getSource();
         if (type instanceof GraphQLInputObjectType) {
             GraphqlFieldVisibility fieldVisibility = environment
@@ -303,7 +301,7 @@ public class Introspection {
         return null;
     };
 
-    private static final DataFetcher OfTypeFetcher = environment -> {
+    private static final IntrospectionDataFetcher OfTypeFetcher = environment -> {
         Object type = environment.getSource();
         if (type instanceof GraphQLModifiedType) {
             return GraphQLTypeUtil.unwrapOne((GraphQLModifiedType) type);
@@ -311,7 +309,7 @@ public class Introspection {
         return null;
     };
 
-    private static final DataFetcher specifiedByUrlDataFetcher = environment -> {
+    private static final IntrospectionDataFetcher specifiedByUrlDataFetcher = environment -> {
         Object type = environment.getSource();
         if (type instanceof GraphQLScalarType) {
             return ((GraphQLScalarType) type).getSpecifiedByUrl();
@@ -522,14 +520,14 @@ public class Introspection {
         });
     }
 
-    public static final DataFetcher<Object> SchemaMetaFieldDefDataFetcher = DataFetchingEnvironment::getGraphQLSchema;
+    public static final IntrospectionDataFetcher SchemaMetaFieldDefDataFetcher = IntrospectionDataFetchingEnvironment::getGraphQLSchema;
     public static final GraphQLFieldDefinition SchemaMetaFieldDef = newFieldDefinition()
             .name("__schema")
             .type(nonNull(__Schema))
             .description("Access the current type schema of this server.")
             .build();
 
-    public static final DataFetcher<Object> TypeMetaFieldDefDataFetcher = environment -> {
+    public static final IntrospectionDataFetcher TypeMetaFieldDefDataFetcher = environment -> {
         String name = environment.getArgument("name");
         return environment.getGraphQLSchema().getType(name);
     };
@@ -542,7 +540,7 @@ public class Introspection {
                     .type(nonNull(GraphQLString)))
             .build();
 
-    public static final DataFetcher<Object> TypeNameMetaFieldDefDataFetcher = environment -> simplePrint(environment.getParentType());
+    public static final IntrospectionDataFetcher TypeNameMetaFieldDefDataFetcher = environment -> simplePrint(environment.getParentType());
 
     public static final GraphQLFieldDefinition TypeNameMetaFieldDef = newFieldDefinition()
             .name("__typename")

--- a/src/main/java/graphql/introspection/IntrospectionDataFetcher.java
+++ b/src/main/java/graphql/introspection/IntrospectionDataFetcher.java
@@ -1,0 +1,12 @@
+package graphql.introspection;
+
+import graphql.Internal;
+
+/**
+ * Special DataFetcher which is only used inside {@link Introspection}
+ */
+@Internal
+public interface IntrospectionDataFetcher {
+
+    Object get(IntrospectionDataFetchingEnvironment env);
+}

--- a/src/main/java/graphql/introspection/IntrospectionDataFetchingEnvironment.java
+++ b/src/main/java/graphql/introspection/IntrospectionDataFetchingEnvironment.java
@@ -1,0 +1,25 @@
+package graphql.introspection;
+
+import graphql.Internal;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLType;
+
+import java.util.Map;
+
+/**
+ * Extracted from {@link graphql.schema.DataFetchingEnvironment} to only capture
+ * the data really needed for {@link Introspection}
+ */
+@Internal
+public interface IntrospectionDataFetchingEnvironment {
+
+    <T> T getSource();
+
+    Map<String, Object> getArguments();
+
+    GraphQLSchema getGraphQLSchema();
+
+    <T> T getArgument(String name);
+
+    GraphQLType getParentType();
+}

--- a/src/main/java/graphql/schema/DataFetchingEnvironment.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironment.java
@@ -6,6 +6,7 @@ import graphql.execution.ExecutionId;
 import graphql.execution.ExecutionStepInfo;
 import graphql.execution.MergedField;
 import graphql.execution.directives.QueryDirectives;
+import graphql.introspection.IntrospectionDataFetchingEnvironment;
 import graphql.language.Document;
 import graphql.language.Field;
 import graphql.language.FragmentDefinition;
@@ -24,7 +25,7 @@ import java.util.Map;
  */
 @SuppressWarnings("TypeParameterUnusedInFormals")
 @PublicApi
-public interface DataFetchingEnvironment {
+public interface DataFetchingEnvironment extends IntrospectionDataFetchingEnvironment {
 
     /**
      * This is the value of the current object to be queried.
@@ -33,6 +34,7 @@ public interface DataFetchingEnvironment {
      * For the root query, it is equal to {{@link DataFetchingEnvironment#getRoot}
      *
      * @param <T> you decide what type it is
+     *
      * @return can be null for the root query, otherwise it is never null
      */
     <T> T getSource();
@@ -46,6 +48,7 @@ public interface DataFetchingEnvironment {
      * Returns true of the named argument is present
      *
      * @param name the name of the argument
+     *
      * @return true of the named argument is present
      */
     boolean containsArgument(String name);
@@ -55,6 +58,7 @@ public interface DataFetchingEnvironment {
      *
      * @param name the name of the argument
      * @param <T>  you decide what type it is
+     *
      * @return the named argument or null if its not present
      */
     <T> T getArgument(String name);
@@ -65,6 +69,7 @@ public interface DataFetchingEnvironment {
      * @param name         the name of the argument
      * @param defaultValue the default value if the argument is not present
      * @param <T>          you decide what type it is
+     *
      * @return the named argument or the default if its not present
      */
     <T> T getArgumentOrDefault(String name, T defaultValue);
@@ -76,6 +81,7 @@ public interface DataFetchingEnvironment {
      * This is a info object which is provided to all DataFetchers, but never used by graphql-java itself.
      *
      * @param <T> you decide what type it is
+     *
      * @return can be null
      */
     <T> T getContext();
@@ -92,6 +98,7 @@ public interface DataFetchingEnvironment {
      * fields execute.
      *
      * @param <T> you decide what type it is
+     *
      * @return can be null if no field context objects are passed back by previous parent fields
      */
     <T> T getLocalContext();
@@ -100,6 +107,7 @@ public interface DataFetchingEnvironment {
      * This is the source object for the root query.
      *
      * @param <T> you decide what type it is
+     *
      * @return can be null
      */
     <T> T getRoot();
@@ -112,6 +120,7 @@ public interface DataFetchingEnvironment {
 
     /**
      * @return the list of fields
+     *
      * @deprecated Use {@link #getMergedField()}.
      */
     @Deprecated
@@ -190,6 +199,7 @@ public interface DataFetchingEnvironment {
      * This gives you access to the directives related to this field
      *
      * @return the {@link graphql.execution.directives.QueryDirectives} for the currently executing field
+     *
      * @see graphql.execution.directives.QueryDirectives for more information
      */
     QueryDirectives getQueryDirectives();
@@ -200,7 +210,9 @@ public interface DataFetchingEnvironment {
      * @param dataLoaderName the name of the data loader to fetch
      * @param <K>            the key type
      * @param <V>            the value type
+     *
      * @return the named data loader or null
+     *
      * @see org.dataloader.DataLoaderRegistry#getDataLoader(String)
      */
     <K, V> DataLoader<K, V> getDataLoader(String dataLoaderName);


### PR DESCRIPTION
This extracts a special `IntrospectionDataFetcher` which is only used inside in `Introspection`.

This is allows custom execution engines to reuse the Introspection code more easily.