### PR TITLE
union type check

### DIFF
--- a/src/main/java/graphql/schema/idl/SchemaTypeChecker.java
+++ b/src/main/java/graphql/schema/idl/SchemaTypeChecker.java
@@ -64,8 +64,10 @@ public class SchemaTypeChecker {
         typeExtensionsChecker.checkTypeExtensions(errors, typeRegistry);
 
         ImplementingTypesChecker implementingTypesChecker = new ImplementingTypesChecker();
-
         implementingTypesChecker.checkImplementingTypes(errors, typeRegistry);
+
+        UnionTypesChecker unionTypesChecker = new UnionTypesChecker();
+        unionTypesChecker.checkUnionTypes(errors, typeRegistry);
 
         SchemaExtensionsChecker.checkSchemaInvariants(errors, typeRegistry);
 

--- a/src/main/java/graphql/schema/idl/UnionTypesChecker.java
+++ b/src/main/java/graphql/schema/idl/UnionTypesChecker.java
@@ -2,22 +2,34 @@ package graphql.schema.idl;
 
 import graphql.GraphQLError;
 import graphql.Internal;
+import graphql.language.ObjectTypeDefinition;
 import graphql.language.Type;
+import graphql.language.TypeDefinition;
+import graphql.language.TypeName;
 import graphql.language.UnionTypeDefinition;
 import graphql.language.UnionTypeExtensionDefinition;
 import graphql.schema.idl.errors.UnionTypeError;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static java.lang.String.format;
 
 /**
- * A support class to help break up the large SchemaTypeChecker class. This handles
- * the checking of {@link graphql.language.UnionTypeDefinition}s.
+ * UnionType check, details in https://spec.graphql.org/June2018/#sec-Type-System.
+ * <pre>
+ *     <ur>
+ *         <li>Union type must include one or more unique member types;</li>
+ *         <li>The member types of a Union type must all be Object base types;</li>
+ *         <li>Invalid name begin with "__" (two underscores).</li>
+ *     </ur>
+ * </pre>
  */
 @Internal
 class UnionTypesChecker {
@@ -35,16 +47,37 @@ class UnionTypesChecker {
 
         Stream.of(unionTypes.stream(), unionTypeExtensions.stream())
                 .flatMap(Function.identity())
-                .forEach(type -> checkUnionTypes(errors, typeRegistry, type));
+                .forEach(type -> checkUnionTypes(typeRegistry, type, errors));
     }
 
-    private void checkUnionTypes(List<GraphQLError> errors, TypeDefinitionRegistry typeRegistry, UnionTypeDefinition type) {
-        List<Type> memberTypes = type.getMemberTypes();
+    private void checkUnionTypes(TypeDefinitionRegistry typeRegistry, UnionTypeDefinition type, List<GraphQLError> errors) {
+        assertTypeName(type, errors);
 
+        List<Type> memberTypes = type.getMemberTypes();
         if (memberTypes == null || memberTypes.size() == 0) {
             errors.add(new UnionTypeError(type, format("Union type \"%s\" must include one or more unique member types.", type.getName())));
         }
-        System.out.println(memberTypes);
+
+        Set<String> typeNames = new HashSet<>();
+        for (Type memberType : memberTypes) {
+            String memberTypeName = ((TypeName) memberType).getName();
+            Optional<TypeDefinition> memberTypeDefinition = typeRegistry.getType(memberTypeName);
+
+            if (!memberTypeDefinition.isPresent() || !(memberTypeDefinition.get() instanceof ObjectTypeDefinition)) {
+                errors.add(new UnionTypeError(type, format("The member types of a Union type must all be Object base types. member type \"%s\" in Union \"%s\" is invalid.", ((TypeName) memberType).getName(), type.getName())));
+                continue;
+            }
+
+            if (typeNames.contains(memberTypeName)) {
+                errors.add(new UnionTypeError(type, format("The member types of a Union type must be unique. member type \"%s\" in Union \"%s\" is not unique.", ((TypeName) memberType).getName(), type.getName())));
+            }
+        }
+    }
+
+    private void assertTypeName(UnionTypeDefinition type, List<GraphQLError> errors) {
+        if (type.getName().length() >= 2 && type.getName().startsWith("__")) {
+            errors.add((new UnionTypeError(type, String.format("\"%s\" must not begin with \"__\", which is reserved by GraphQL introspection.", type.getName()))));
+        }
     }
 
 }

--- a/src/main/java/graphql/schema/idl/UnionTypesChecker.java
+++ b/src/main/java/graphql/schema/idl/UnionTypesChecker.java
@@ -1,0 +1,50 @@
+package graphql.schema.idl;
+
+import graphql.GraphQLError;
+import graphql.Internal;
+import graphql.language.Type;
+import graphql.language.UnionTypeDefinition;
+import graphql.language.UnionTypeExtensionDefinition;
+import graphql.schema.idl.errors.UnionTypeError;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static java.lang.String.format;
+
+/**
+ * A support class to help break up the large SchemaTypeChecker class. This handles
+ * the checking of {@link graphql.language.UnionTypeDefinition}s.
+ */
+@Internal
+class UnionTypesChecker {
+    private static final Map<Class<? extends UnionTypeDefinition>, String> TYPE_OF_MAP = new HashMap<>();
+
+    static {
+        TYPE_OF_MAP.put(UnionTypeDefinition.class, "union");
+        TYPE_OF_MAP.put(UnionTypeExtensionDefinition.class, "union extension");
+    }
+
+
+    void checkUnionTypes(List<GraphQLError> errors, TypeDefinitionRegistry typeRegistry) {
+        List<UnionTypeDefinition> unionTypes = typeRegistry.getTypes(UnionTypeDefinition.class);
+        List<UnionTypeExtensionDefinition> unionTypeExtensions = typeRegistry.getTypes(UnionTypeExtensionDefinition.class);
+
+        Stream.of(unionTypes.stream(), unionTypeExtensions.stream())
+                .flatMap(Function.identity())
+                .forEach(type -> checkUnionTypes(errors, typeRegistry, type));
+    }
+
+    private void checkUnionTypes(List<GraphQLError> errors, TypeDefinitionRegistry typeRegistry, UnionTypeDefinition type) {
+        List<Type> memberTypes = type.getMemberTypes();
+
+        if (memberTypes == null || memberTypes.size() == 0) {
+            errors.add(new UnionTypeError(type, format("Union type \"%s\" must include one or more unique member types.", type.getName())));
+        }
+        System.out.println(memberTypes);
+    }
+
+}

--- a/src/main/java/graphql/schema/idl/errors/UnionTypeError.java
+++ b/src/main/java/graphql/schema/idl/errors/UnionTypeError.java
@@ -1,0 +1,9 @@
+package graphql.schema.idl.errors;
+
+import graphql.language.Node;
+
+public class UnionTypeError extends BaseError {
+    public UnionTypeError(Node node, String msg) {
+        super(node, msg);
+    }
+}

--- a/src/test/groovy/graphql/schema/idl/SchemaTypeCheckerTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaTypeCheckerTest.groovy
@@ -1738,4 +1738,24 @@ class SchemaTypeCheckerTest extends Specification {
         errorContaining(result, "'Human' extension type [@n:n] tried to redefine field 'name' [@n:n]")
 
     }
+
+    def "xe redefined in extension type should cause an error"() {
+        given:
+        def sdl = """
+            type Query { hello: String }
+            
+            type A { hello: String }
+            
+            type B { hello: String }
+            
+            union UnionType 
+        """
+
+        when:
+        def result = check(sdl)
+
+        then:
+        errorContaining(result, "'Human' extension type [@n:n] tried to redefine field 'name' [@n:n]")
+    }
+
 }


### PR DESCRIPTION
UnionType check, details in https://spec.graphql.org/June2018/#sec-Type-System. 
Especially in https://spec.graphql.org/June2018/#sec-Unions
        
           
Invalid name begin with "__" (two underscores);
Union type must include one or more member types;
The member types of a Union type must all be Object base types;
The member types of a Union type must be unique.