### PR TITLE
ISSUE-1974: Included implementz in constructor

### DIFF
--- a/src/main/java/graphql/language/InterfaceTypeDefinition.java
+++ b/src/main/java/graphql/language/InterfaceTypeDefinition.java
@@ -178,6 +178,7 @@ public class InterfaceTypeDefinition extends AbstractDescribedNode<InterfaceType
             this.definitions = existing.getFieldDefinitions();
             this.ignoredChars = existing.getIgnoredChars();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
+            this.implementz = existing.getImplements();
         }
 
 


### PR DESCRIPTION
Simple PR to include `implementz` in the constructor of `InterfaceTypeDefinition.Builder(InterfaceTypeDefinition)`

More details described in the [issue](https://github.com/graphql-java/graphql-java/issues/1974)