### PR TITLE
Backport of fix #1832: Escape single line comments

### DIFF
--- a/src/main/java/graphql/language/AstPrinter.java
+++ b/src/main/java/graphql/language/AstPrinter.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 
 import static graphql.Assert.assertTrue;
+import static graphql.util.EscapeUtil.escapeJsonString;
 import static java.lang.String.valueOf;
 import static java.util.stream.Collectors.joining;
 
@@ -472,7 +473,7 @@ public class AstPrinter {
         } else if (value instanceof FloatValue) {
             return valueOf(((FloatValue) value).getValue());
         } else if (value instanceof StringValue) {
-            return wrap("\"", valueOf(((StringValue) value).getValue()), "\"");
+            return wrap("\"", escapeJsonString(((StringValue) value).getValue()), "\"");
         } else if (value instanceof EnumValue) {
             return valueOf(((EnumValue) value).getName());
         } else if (value instanceof BooleanValue) {

--- a/src/main/java/graphql/schema/idl/SchemaPrinter.java
+++ b/src/main/java/graphql/schema/idl/SchemaPrinter.java
@@ -39,6 +39,7 @@ import graphql.schema.GraphQLUnionType;
 import graphql.schema.GraphqlTypeComparatorEnvironment;
 import graphql.schema.GraphqlTypeComparatorRegistry;
 import graphql.schema.visibility.GraphqlFieldVisibility;
+import graphql.util.EscapeUtil;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -56,6 +57,7 @@ import static graphql.Directives.DeprecatedDirective;
 import static graphql.introspection.Introspection.DirectiveLocation.ENUM_VALUE;
 import static graphql.introspection.Introspection.DirectiveLocation.FIELD_DEFINITION;
 import static graphql.schema.visibility.DefaultGraphqlFieldVisibility.DEFAULT_FIELD_VISIBILITY;
+import static graphql.util.EscapeUtil.escapeJsonString;
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
@@ -907,7 +909,9 @@ public class SchemaPrinter {
     }
 
     private void printSingleLineDescription(PrintWriter out, String prefix, String s) {
-        out.printf("%s\"%s\"\n", prefix, s);
+        // See: https://github.com/graphql/graphql-spec/issues/148
+        String desc = escapeJsonString(s);
+        out.printf("%s\"%s\"\n", prefix, desc);
     }
 
     private boolean hasDescription(Object descriptionHolder) {

--- a/src/main/java/graphql/util/EscapeUtil.java
+++ b/src/main/java/graphql/util/EscapeUtil.java
@@ -1,0 +1,49 @@
+package graphql.util;
+
+public final class EscapeUtil {
+
+    private EscapeUtil() {
+    }
+
+    /**
+     * Encodes the value as a JSON string according to http://json.org/ rules
+     *
+     * @param stringValue the value to encode as a JSON string
+     *
+     * @return the encoded string
+     */
+    public static String escapeJsonString(String stringValue) {
+        int len = stringValue.length();
+        StringBuilder sb = new StringBuilder(len);
+        for (int i = 0; i < len; i++) {
+            char ch = stringValue.charAt(i);
+            switch (ch) {
+                case '"':
+                    sb.append("\\\"");
+                    break;
+                case '\\':
+                    sb.append("\\\\");
+                    break;
+                case '\b':
+                    sb.append("\\b");
+                    break;
+                case '\f':
+                    sb.append("\\f");
+                    break;
+                case '\n':
+                    sb.append("\\n");
+                    break;
+                case '\r':
+                    sb.append("\\r");
+                    break;
+                case '\t':
+                    sb.append("\\t");
+                    break;
+                default:
+                    sb.append(ch);
+            }
+        }
+        return sb.toString();
+    }
+
+}

--- a/src/test/groovy/graphql/language/AstPrinterTest.groovy
+++ b/src/test/groovy/graphql/language/AstPrinterTest.groovy
@@ -562,4 +562,21 @@ extend input Input @directive {
 '''
     }
 
+    def 'StringValue is converted to valid Strings'() {
+
+        AstPrinter astPrinter = new AstPrinter(true)
+
+        when:
+        def result = astPrinter.value(new StringValue(strValue))
+
+        then:
+        result == expected
+
+        where:
+        strValue                                  | expected
+        'VALUE'                                   | '"VALUE"'
+        'VA\n\t\f\n\b\\LUE'                       | '"VA\\n\\t\\f\\n\\b\\\\LUE"'
+        'VA\\L"UE'                                | '"VA\\\\L\\"UE"'
+    }
+
 }

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -1430,5 +1430,36 @@ type Query {
 '''
     }
 
+    def "single line comments are properly escaped"() {
+        given:
+        def idl = """
+            type Query {
+              "$comment"
+              fieldX : String
+            }
+        """
+        def registry = new SchemaParser().parse(idl)
+        def runtimeWiring = newRuntimeWiring().build()
+        def options = SchemaGenerator.Options.defaultOptions()
+        def schema = new SchemaGenerator().makeExecutableSchema(options, registry, runtimeWiring)
 
+        when:
+        def result = new SchemaPrinter(defaultOptions().includeDirectives(false)).print(schema)
+
+        then:
+        result == """type Query {
+  "$comment"
+  fieldX: String
+}
+"""
+
+        where:
+        _ | comment
+        _ | 'quotation-\\"'
+        _ | 'reverse-solidus-\\\\'
+        _ | 'backspace-\\b'
+        _ | 'formfeed-\\f'
+        _ | 'carriage-return-\\r'
+        _ | 'horizontal-tab-\\t'
+    }
 }

--- a/src/test/groovy/graphql/util/EscapeUtilTest.groovy
+++ b/src/test/groovy/graphql/util/EscapeUtilTest.groovy
@@ -1,0 +1,31 @@
+package graphql.util
+
+
+import spock.lang.Specification
+
+class EscapeUtilTest extends Specification {
+
+    def "1105 - encoding of json strings"() {
+        when:
+        def json = EscapeUtil.escapeJsonString(strValue)
+
+        then:
+        json == expected
+
+        where:
+        strValue                                  | expected
+        ''                                        | ''
+        'json'                                    | 'json'
+        'quotation-"'                             | 'quotation-\\"'
+        'reverse-solidus-\\'                      | 'reverse-solidus-\\\\'
+        'backspace-\b'                            | 'backspace-\\b'
+        'formfeed-\f'                             | 'formfeed-\\f'
+        'newline-\n'                              | 'newline-\\n'
+        'carriage-return-\r'                      | 'carriage-return-\\r'
+        'horizontal-tab-\t'                       | 'horizontal-tab-\\t'
+
+        // this is some AST from issue 1105
+        '''"{"operator":"eq", "operands": []}"''' | '''\\"{\\"operator\\":\\"eq\\", \\"operands\\": []}\\"'''
+    }
+
+}


### PR DESCRIPTION
Backport of fix #1832.

I couldn't do a copy carbon cherry pick of the original commit because of some whitespace changes that created merge conflicts. I had to modify it a little bit but this backport commit should be clean.