### PR TITLE
Backport of fix #1785: Make PropertyDataFetcherHelpder#mkKey rely on Class#getName instead of Class#getCanonicalName

### DIFF
--- a/src/main/java/graphql/schema/PropertyDataFetcherHelper.java
+++ b/src/main/java/graphql/schema/PropertyDataFetcherHelper.java
@@ -252,7 +252,7 @@ public class PropertyDataFetcherHelper {
     }
 
     private static String mkKey(Class<?> clazz, String propertyName) {
-        return clazz.getCanonicalName() + "__" + propertyName;
+        return clazz.getName() + "__" + propertyName;
     }
 
     // by not filling out the stack trace, we gain speed when using the exception as flow control


### PR DESCRIPTION
…f Class#getCanonicalName

(cherry picked from commit a2dbaef973c7aaf51974306d76f2110bfc6bfba8)