### PR TITLE
Change ExecutionContext.errors from CopyOnWriteArrayList to Collections.synchronizedList(new ArrayList<>())

### DIFF
--- a/src/main/java/graphql/execution/ExecutionContext.java
+++ b/src/main/java/graphql/execution/ExecutionContext.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.ArrayList;
 import java.util.function.Consumer;
 
 @SuppressWarnings("TypeParameterUnusedInFormals")
@@ -40,7 +40,7 @@ public class ExecutionContext {
     private final Object context;
     private final Object localContext;
     private final Instrumentation instrumentation;
-    private final List<GraphQLError> errors = new CopyOnWriteArrayList<>();
+    private final List<GraphQLError> errors = Collections.synchronizedList(new ArrayList<>());
     private final Set<ResultPath> errorPaths = new HashSet<>();
     private final DataLoaderRegistry dataLoaderRegistry;
     private final CacheControl cacheControl;


### PR DESCRIPTION
We have been experiencing poor performance with our graphql-java application under heavy load during scale testing.  During these tests, several other backends have also struggled which results in timeout or circuit breaker exceptions being thrown and mapped to GraphQL errors added to the response.  We started profiling with Java Flight Recorder and reviewing the results in Mission Control.  One finding is that there is significant blocking on the ExecutionContext.addErrors() method, which is backed by a CopyOnWriteArrayList.  Researching CopyOnWriteArrayList vs. other options, CopyOnWriteArrayList blocks on write operations and is expensive because it has to create a new copy of the array on every write.  It is ideal for situations with limited concurrent writes and many concurrent reads.  For how the list is being used in this context, I would expect many concurrent writes and single threaded reads.  This PR updates the ExecutionContext.error field to use Collections.synchronizedList(new ArrayList()), which is more performant way to support a synchronized list with concurrent writes.  We ran a perf test with this change off of a local build and Mission Control was no longer reporting blocking in ExecutionContext.addErrors().

Sources: 
- "This is ordinarily too costly, but may be more efficient than alternatives when traversal operations vastly outnumber mutations" https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/CopyOnWriteArrayList.html
- https://www.geeksforgeeks.org/java-collection-difference-between-synchronized-arraylist-and-copyonwritearraylist/
