### PR TITLE
Make UnknownOperationException implement GraphQLError

### DIFF
--- a/src/main/java/graphql/execution/UnknownOperationException.java
+++ b/src/main/java/graphql/execution/UnknownOperationException.java
@@ -1,7 +1,13 @@
 package graphql.execution;
 
+import graphql.ErrorClassification;
+import graphql.ErrorType;
+import graphql.GraphQLError;
 import graphql.GraphQLException;
 import graphql.PublicApi;
+import graphql.language.SourceLocation;
+
+import java.util.List;
 
 /**
  * This is thrown if multiple operations are defined in the query and
@@ -9,9 +15,18 @@ import graphql.PublicApi;
  * contained in the GraphQL query.
  */
 @PublicApi
-public class UnknownOperationException extends GraphQLException {
-
+public class UnknownOperationException extends GraphQLException implements GraphQLError {
     public UnknownOperationException(String message) {
         super(message);
+    }
+
+    @Override
+    public List<SourceLocation> getLocations() {
+        return null;
+    }
+
+    @Override
+    public ErrorClassification getErrorType() {
+        return ErrorType.ValidationError;
     }
 }


### PR DESCRIPTION
Useful if we are catching `GraphQLErrors` from execution and putting them as errors in the GraphQL response. With this change in place we don't have to have custom handling.