### PR TITLE
Persisted query support in graphql-java

### DIFF
--- a/src/main/java/graphql/ExecutionInput.java
+++ b/src/main/java/graphql/ExecutionInput.java
@@ -24,6 +24,7 @@ public class ExecutionInput {
     private final Object localContext;
     private final Object root;
     private final Map<String, Object> variables;
+    private final Map<String, Object> extensions;
     private final DataLoaderRegistry dataLoaderRegistry;
     private final CacheControl cacheControl;
     private final ExecutionId executionId;
@@ -31,17 +32,18 @@ public class ExecutionInput {
 
 
     @Internal
-    private ExecutionInput(String query, String operationName, Object context, Object root, Map<String, Object> variables, DataLoaderRegistry dataLoaderRegistry, CacheControl cacheControl, ExecutionId executionId, Locale locale, Object localContext) {
-        this.query = assertNotNull(query, () -> "query can't be null");
-        this.operationName = operationName;
-        this.context = context;
-        this.root = root;
-        this.variables = variables;
-        this.dataLoaderRegistry = dataLoaderRegistry;
-        this.cacheControl = cacheControl;
-        this.executionId = executionId;
-        this.locale = locale;
-        this.localContext = localContext;
+    private ExecutionInput(Builder builder) {
+        this.query = assertNotNull(builder.query, () -> "query can't be null");
+        this.operationName = builder.operationName;
+        this.context = builder.context;
+        this.root = builder.root;
+        this.variables = builder.variables;
+        this.dataLoaderRegistry = builder.dataLoaderRegistry;
+        this.cacheControl = builder.cacheControl;
+        this.executionId = builder.executionId;
+        this.locale = builder.locale;
+        this.localContext = builder.localContext;
+        this.extensions = builder.extensions;
     }
 
     /**
@@ -64,6 +66,7 @@ public class ExecutionInput {
     public Object getContext() {
         return context;
     }
+
     /**
      * @return the local context object to pass to all top level (i.e. query, mutation, subscription) data fetchers
      */
@@ -116,6 +119,13 @@ public class ExecutionInput {
     }
 
     /**
+     * @return a map of extension values that can be sent in to a request
+     */
+    public Map<String, Object> getExtensions() {
+        return extensions;
+    }
+
+    /**
      * This helps you transform the current ExecutionInput object into another one by starting a builder with all
      * the current values and allows you to transform it how you want.
      *
@@ -132,6 +142,7 @@ public class ExecutionInput {
                 .dataLoaderRegistry(this.dataLoaderRegistry)
                 .cacheControl(this.cacheControl)
                 .variables(this.variables)
+                .extensions(this.extensions)
                 .executionId(this.executionId)
                 .locale(this.locale);
 
@@ -179,6 +190,7 @@ public class ExecutionInput {
         private Object localContext;
         private Object root;
         private Map<String, Object> variables = Collections.emptyMap();
+        public Map<String, Object> extensions = Collections.emptyMap();
         //
         // this is important - it allows code to later known if we never really set a dataloader and hence it can optimize
         // dataloader field tracking away.
@@ -214,7 +226,6 @@ public class ExecutionInput {
          * Sets the locale to use for this operation
          *
          * @param locale the locale to use
-         *
          * @return this builder
          */
         public Builder locale(Locale locale) {
@@ -224,6 +235,7 @@ public class ExecutionInput {
 
         /**
          * Sets initial localContext in root data fetchers
+         *
          * @return this builder
          */
         public Builder localContext(Object localContext) {
@@ -263,6 +275,11 @@ public class ExecutionInput {
             return this;
         }
 
+        public Builder extensions(Map<String, Object> extensions) {
+            this.extensions = assertNotNull(extensions, () -> "extensions map can't be null");
+            return this;
+        }
+
         /**
          * You should create new {@link org.dataloader.DataLoaderRegistry}s and new {@link org.dataloader.DataLoader}s for each execution.  Do not
          * re-use
@@ -282,7 +299,7 @@ public class ExecutionInput {
         }
 
         public ExecutionInput build() {
-            return new ExecutionInput(query, operationName, context, root, variables, dataLoaderRegistry, cacheControl, executionId, locale, localContext);
+            return new ExecutionInput(this);
         }
     }
 }

--- a/src/main/java/graphql/execution/preparsed/NoOpPreparsedDocumentProvider.java
+++ b/src/main/java/graphql/execution/preparsed/NoOpPreparsedDocumentProvider.java
@@ -11,7 +11,7 @@ public class NoOpPreparsedDocumentProvider implements PreparsedDocumentProvider 
     public static final NoOpPreparsedDocumentProvider INSTANCE = new NoOpPreparsedDocumentProvider();
 
     @Override
-    public PreparsedDocumentEntry getDocument(ExecutionInput executionInput, Function<ExecutionInput, PreparsedDocumentEntry> computeFunction) {
-        return computeFunction.apply(executionInput);
+    public PreparsedDocumentEntry getDocument(ExecutionInput executionInput, Function<ExecutionInput, PreparsedDocumentEntry> parseAndValidateFunction) {
+        return parseAndValidateFunction.apply(executionInput);
     }
 }

--- a/src/main/java/graphql/execution/preparsed/PreparsedDocumentEntry.java
+++ b/src/main/java/graphql/execution/preparsed/PreparsedDocumentEntry.java
@@ -12,7 +12,7 @@ import static java.util.Collections.singletonList;
 
 /**
  * An instance of a preparsed document entry represents the result of a query parse and validation, like
- * an either implementation it contains either the correct result in th document property or the errors.
+ * an either implementation it contains either the correct result in the document property or the errors.
  *
  * NOTE: This class implements {@link java.io.Serializable} and hence it can be serialised and placed into a distributed cache.  However we
  * are not aiming to provide long term compatibility and do not intend for you to place this serialised data into permanent storage,

--- a/src/main/java/graphql/execution/preparsed/PreparsedDocumentProvider.java
+++ b/src/main/java/graphql/execution/preparsed/PreparsedDocumentProvider.java
@@ -7,20 +7,23 @@ import graphql.PublicSpi;
 import java.util.function.Function;
 
 /**
- * Interface that allows clients to hook in Document caching and/or the whitelisting of queries
+ * Interface that allows clients to hook in Document caching and/or the whitelisting of queries.
  */
 @PublicSpi
 public interface PreparsedDocumentProvider {
     /**
-     * This is called to get a "cached" pre-parsed query and if its not present, then the computeFunction
-     * can be called to parse and validate the query
+     * This is called to get a "cached" pre-parsed query and if its not present, then the "parseAndValidateFunction"
+     * can be called to parse and validate the query.
+     * <p>
+     * Note - the "parseAndValidateFunction" MUST be called if you dont have a per parsed version of the query because it not only parses
+     * and validates the query, it invokes {@link graphql.execution.instrumentation.Instrumentation} calls as well for parsing and validation.
+     * if you dont make a call back on this then these wont happen.
      *
-     * @param executionInput  The {@link graphql.ExecutionInput} containing the query
-     * @param computeFunction If the query has not be pre-parsed, this function can be called to parse it
-     *
+     * @param executionInput           The {@link graphql.ExecutionInput} containing the query
+     * @param parseAndValidateFunction If the query has not be pre-parsed, this function MUST be called to parse and validate it
      * @return an instance of {@link PreparsedDocumentEntry}
      */
-    PreparsedDocumentEntry getDocument(ExecutionInput executionInput, Function<ExecutionInput, PreparsedDocumentEntry> computeFunction);
+    PreparsedDocumentEntry getDocument(ExecutionInput executionInput, Function<ExecutionInput, PreparsedDocumentEntry> parseAndValidateFunction);
 }
 
 

--- a/src/main/java/graphql/execution/preparsed/persisted/ApolloPersistedQuerySupport.java
+++ b/src/main/java/graphql/execution/preparsed/persisted/ApolloPersistedQuerySupport.java
@@ -1,0 +1,51 @@
+package graphql.execution.preparsed.persisted;
+
+import graphql.ExecutionInput;
+import graphql.PublicApi;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * This persisted query support class supports the Apollo scheme where the persisted
+ * query id is in {@link graphql.ExecutionInput#getExtensions()}.
+ * <p>
+ * You need to provide a {@link PersistedQueryCache} cache implementation
+ * as the backing cache.
+ * <p>
+ * See <a href="https://www.apollographql.com/docs/apollo-server/performance/apq/">Apollo Persisted Queries</a>
+ * <p>
+ * The Apollo client sends a hash of the persisted query in the input extensions in the following form
+ * <p>
+ * <pre>
+ *     {
+ *      "extensions":{
+ *       "persistedQuery":{
+ *        "version":1,
+ *        "sha256Hash":"fcf31818e50ac3e818ca4bdbc433d6ab73176f0b9d5f9d5ad17e200cdab6fba4"
+ *      }
+ *    }
+ *  }
+ * </pre>
+ *
+ * @see graphql.ExecutionInput#getExtensions()
+ */
+@PublicApi
+public class ApolloPersistedQuerySupport extends PersistedQuerySupport {
+
+    public ApolloPersistedQuerySupport(PersistedQueryCache persistedQueryCache) {
+        super(persistedQueryCache);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected Optional<Object> getPersistedQueryId(ExecutionInput executionInput) {
+        Map<String, Object> extensions = executionInput.getExtensions();
+        Map<String, Object> persistedQuery = (Map<String, Object>) extensions.get("persistedQuery");
+        if (persistedQuery != null) {
+            Object sha256Hash = persistedQuery.get("sha256Hash");
+            return Optional.ofNullable(sha256Hash);
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/graphql/execution/preparsed/persisted/InMemoryPersistedQueryCache.java
+++ b/src/main/java/graphql/execution/preparsed/persisted/InMemoryPersistedQueryCache.java
@@ -1,0 +1,59 @@
+package graphql.execution.preparsed.persisted;
+
+import graphql.Assert;
+import graphql.ExecutionInput;
+import graphql.PublicApi;
+import graphql.execution.preparsed.PreparsedDocumentEntry;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A PersistedQueryCache that is just an in memory map of known queries.
+ */
+@PublicApi
+public class InMemoryPersistedQueryCache implements PersistedQueryCache {
+
+    private final Map<Object, PreparsedDocumentEntry> cache = new ConcurrentHashMap<>();
+    private final Map<Object, String> knownQueries;
+
+    public InMemoryPersistedQueryCache(Map<Object, String> knownQueries) {
+        this.knownQueries = Assert.assertNotNull(knownQueries);
+    }
+
+    public Map<Object, String> getKnownQueries() {
+        return knownQueries;
+    }
+
+    @Override
+    public PreparsedDocumentEntry getPersistedQueryDocument(Object persistedQueryId, ExecutionInput executionInput, PersistedQueryCacheMiss onCacheMiss) throws PersistedQueryNotFound {
+        return cache.compute(persistedQueryId, (k, v) -> {
+            if (v != null) {
+                return v;
+            }
+            String queryText = knownQueries.get(persistedQueryId);
+            if (queryText == null) {
+                throw new PersistedQueryNotFound(persistedQueryId);
+            }
+            return onCacheMiss.apply(queryText);
+        });
+    }
+
+    public static Builder newInMemoryPersistedQueryCache() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private final Map<Object, String> knownQueries = new HashMap<>();
+
+        public Builder addQuery(Object key, String queryText) {
+            knownQueries.put(key, queryText);
+            return this;
+        }
+
+        public InMemoryPersistedQueryCache build() {
+            return new InMemoryPersistedQueryCache(knownQueries);
+        }
+    }
+}

--- a/src/main/java/graphql/execution/preparsed/persisted/PersistedQueryCache.java
+++ b/src/main/java/graphql/execution/preparsed/persisted/PersistedQueryCache.java
@@ -1,0 +1,31 @@
+package graphql.execution.preparsed.persisted;
+
+import graphql.ExecutionInput;
+import graphql.PublicSpi;
+import graphql.execution.preparsed.PreparsedDocumentEntry;
+
+/**
+ * This interface is used to abstract an actual cache that can cache parsed persistent queries.
+ */
+@PublicSpi
+public interface PersistedQueryCache {
+
+    /**
+     * This is called to get a persisted query from cache.
+     * <p>
+     * If its present in cache then  it must return a PreparsedDocumentEntry where {@link graphql.execution.preparsed.PreparsedDocumentEntry#getDocument()}
+     * is already parsed and validated.  This will be passed onto the graphql engine as is.
+     * <p>
+     * If its a valid query id but its no present in cache, (cache miss) then you need to call back the "onCacheMiss" function with associated query text.
+     * This will be compiled and validated by the graphql engine and the a PreparsedDocumentEntry will be passed back ready for you to cache it.
+     * <p>
+     * If its not a valid query id then throw a {@link graphql.execution.preparsed.persisted.PersistedQueryNotFound} to indicate this.
+     *
+     * @param persistedQueryId the persisted query id
+     * @param executionInput   the original execution input
+     * @param onCacheMiss      the call back should it be a valid query id but its not currently not in the cache
+     * @return a parsed and validated PreparsedDocumentEntry where {@link graphql.execution.preparsed.PreparsedDocumentEntry#getDocument()} is set
+     * @throws graphql.execution.preparsed.persisted.PersistedQueryNotFound if the query id is not know at all and you have no query text
+     */
+    PreparsedDocumentEntry getPersistedQueryDocument(Object persistedQueryId, ExecutionInput executionInput, PersistedQueryCacheMiss onCacheMiss) throws PersistedQueryNotFound;
+}

--- a/src/main/java/graphql/execution/preparsed/persisted/PersistedQueryCacheMiss.java
+++ b/src/main/java/graphql/execution/preparsed/persisted/PersistedQueryCacheMiss.java
@@ -1,0 +1,23 @@
+package graphql.execution.preparsed.persisted;
+
+import graphql.PublicApi;
+import graphql.execution.preparsed.PreparsedDocumentEntry;
+
+import java.util.function.Function;
+
+/**
+ * The call back when a valid persisted query is not in cache and it needs to be compiled and validated
+ * by the graphql engine.  If you get a cache miss in your {@link graphql.execution.preparsed.persisted.PersistedQueryCache} implementation
+ * then you are required to call back on the provided instance of this interface
+ */
+@PublicApi
+public interface PersistedQueryCacheMiss extends Function<String, PreparsedDocumentEntry> {
+    /**
+     * You give back the missing query text and graphql-java will compile and validate it.
+     *
+     * @param queryToBeParsedAndValidated the query text to be parsed and validated
+     * @return a parsed and validated query document ready for caching
+     */
+    @Override
+    PreparsedDocumentEntry apply(String queryToBeParsedAndValidated);
+}

--- a/src/main/java/graphql/execution/preparsed/persisted/PersistedQueryNotFound.java
+++ b/src/main/java/graphql/execution/preparsed/persisted/PersistedQueryNotFound.java
@@ -1,0 +1,40 @@
+package graphql.execution.preparsed.persisted;
+
+import graphql.ErrorClassification;
+import graphql.PublicApi;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * An exception that indicates the query id is not valid and can be found ever in cache
+ */
+@PublicApi
+public class PersistedQueryNotFound extends RuntimeException implements ErrorClassification {
+    private final Object persistedQueryId;
+
+    public PersistedQueryNotFound(Object persistedQueryId) {
+        this.persistedQueryId = persistedQueryId;
+    }
+
+    @Override
+    public String getMessage() {
+        return "PersistedQueryNotFound";
+    }
+
+    public Object getPersistedQueryId() {
+        return persistedQueryId;
+    }
+
+    @Override
+    public String toString() {
+        return "PersistedQueryNotFound";
+    }
+
+    public Map<String, Object> getExtensions() {
+        LinkedHashMap<String, Object> extensions = new LinkedHashMap<>();
+        extensions.put("persistedQueryId", persistedQueryId);
+        extensions.put("generatedBy", "graphql-java");
+        return extensions;
+    }
+}

--- a/src/main/java/graphql/execution/preparsed/persisted/PersistedQuerySupport.java
+++ b/src/main/java/graphql/execution/preparsed/persisted/PersistedQuerySupport.java
@@ -1,0 +1,83 @@
+package graphql.execution.preparsed.persisted;
+
+import graphql.ExecutionInput;
+import graphql.GraphQLError;
+import graphql.GraphqlErrorBuilder;
+import graphql.PublicSpi;
+import graphql.execution.preparsed.PreparsedDocumentEntry;
+import graphql.execution.preparsed.PreparsedDocumentProvider;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import static graphql.Assert.assertNotNull;
+
+/**
+ * This abstract class forms the basis for persistent query support.  Derived classes
+ * need to implement the method to work out the query id and you also need
+ * a {@link PersistedQueryCache} implementation.
+ *
+ * @see graphql.execution.preparsed.PreparsedDocumentProvider
+ * @see graphql.GraphQL.Builder#preparsedDocumentProvider(graphql.execution.preparsed.PreparsedDocumentProvider)
+ */
+@PublicSpi
+public abstract class PersistedQuerySupport implements PreparsedDocumentProvider {
+
+    /**
+     * In order for {@link graphql.ExecutionInput#getQuery()} to never be null, use this to mark
+     * them so that invariant can be satisfied while assuming that the persisted query id is elsewhere
+     */
+    public static final String PERSISTED_QUERY_MARKER = "PersistedQueryMarker";
+
+    private final PersistedQueryCache persistedQueryCache;
+
+    public PersistedQuerySupport(PersistedQueryCache persistedQueryCache) {
+        this.persistedQueryCache = assertNotNull(persistedQueryCache);
+    }
+
+    @Override
+    public PreparsedDocumentEntry getDocument(ExecutionInput executionInput, Function<ExecutionInput, PreparsedDocumentEntry> parseAndValidateFunction) {
+        Optional<Object> queryIdOption = getPersistedQueryId(executionInput);
+        assertNotNull(queryIdOption, () -> String.format("The class %s MUST return a non null optional query id", this.getClass().getName()));
+
+        try {
+            if (queryIdOption.isPresent()) {
+                Object persistedQueryId = queryIdOption.get();
+                return persistedQueryCache.getPersistedQueryDocument(persistedQueryId, executionInput, (queryText) -> {
+                    // we have a miss and they gave us nothing - bah!
+                    if (queryText == null || queryText.trim().length() == 0) {
+                        throw new PersistedQueryNotFound(persistedQueryId);
+                    }
+                    ExecutionInput newEI = executionInput.transform(builder -> builder.query(queryText));
+                    return parseAndValidateFunction.apply(newEI);
+                });
+            }
+            // ok there is no query id - we assume the query is indeed ready to go as is - ie its not a persisted query
+            return parseAndValidateFunction.apply(executionInput);
+        } catch (PersistedQueryNotFound e) {
+            return mkMissingError(e);
+        }
+    }
+
+    /**
+     * This method is required for concrete types to work out the query id (often a hash) that should be used to look
+     * up the persisted query in the cache.
+     *
+     * @param executionInput the execution input
+     * @return an optional id of the persisted query
+     */
+    abstract protected Optional<Object> getPersistedQueryId(ExecutionInput executionInput);
+
+    /**
+     * Allows you to customize the graphql error that is sent back on a missing persistend query
+     *
+     * @param persistedQueryNotFound the missing persistent query exception
+     * @return a PreparsedDocumentEntry that holds an error
+     */
+    protected PreparsedDocumentEntry mkMissingError(PersistedQueryNotFound persistedQueryNotFound) {
+        GraphQLError gqlError = GraphqlErrorBuilder.newError()
+                .errorType(persistedQueryNotFound).message(persistedQueryNotFound.getMessage())
+                .extensions(persistedQueryNotFound.getExtensions()).build();
+        return new PreparsedDocumentEntry(gqlError);
+    }
+}

--- a/src/test/groovy/graphql/ExecutionInputTest.groovy
+++ b/src/test/groovy/graphql/ExecutionInputTest.groovy
@@ -26,6 +26,7 @@ class ExecutionInputTest extends Specification {
                 .root(root)
                 .context(context)
                 .locale(Locale.GERMAN)
+                .extensions([some: "map"])
                 .build()
         then:
         executionInput.context == context
@@ -35,6 +36,7 @@ class ExecutionInputTest extends Specification {
         executionInput.cacheControl == cacheControl
         executionInput.query == query
         executionInput.locale == Locale.GERMAN
+        executionInput.extensions == [some: "map"]
     }
 
     def "context methods work"() {
@@ -67,6 +69,7 @@ class ExecutionInputTest extends Specification {
                 .dataLoaderRegistry(registry)
                 .cacheControl(cacheControl)
                 .variables(variables)
+                .extensions([some: "map"])
                 .root(root)
                 .context(context)
                 .locale(Locale.GERMAN)
@@ -80,6 +83,7 @@ class ExecutionInputTest extends Specification {
         executionInput.dataLoaderRegistry == registry
         executionInput.cacheControl == cacheControl
         executionInput.locale == Locale.GERMAN
+        executionInput.extensions == [some: "map"]
         executionInput.query == "new query"
     }
 

--- a/src/test/groovy/graphql/execution/preparsed/PreparsedDocumentProviderTest.groovy
+++ b/src/test/groovy/graphql/execution/preparsed/PreparsedDocumentProviderTest.groovy
@@ -188,13 +188,13 @@ class PreparsedDocumentProviderTest extends Specification {
         def documentProvider = new PreparsedDocumentProvider() {
 
             @Override
-            PreparsedDocumentEntry getDocument(ExecutionInput executionInput, Function<ExecutionInput, PreparsedDocumentEntry> computeFunction) {
+            PreparsedDocumentEntry getDocument(ExecutionInput executionInput, Function<ExecutionInput, PreparsedDocumentEntry> parseAndValidateFunction) {
                 if (executionInput.getQuery() == "#A") {
                     executionInput = executionInput.transform({ it.query(queryA) })
                 } else {
                     executionInput = executionInput.transform({ it.query(queryB) })
                 }
-                return computeFunction.apply(executionInput)
+                return parseAndValidateFunction.apply(executionInput)
             }
         }
 

--- a/src/test/groovy/graphql/execution/preparsed/TestingPreparsedDocumentProvider.groovy
+++ b/src/test/groovy/graphql/execution/preparsed/TestingPreparsedDocumentProvider.groovy
@@ -9,8 +9,8 @@ class TestingPreparsedDocumentProvider implements PreparsedDocumentProvider {
     private Map<String, PreparsedDocumentEntry> cache = new HashMap<>()
 
     @Override
-    PreparsedDocumentEntry getDocument(ExecutionInput executionInput, Function<ExecutionInput, PreparsedDocumentEntry> computeFunction) {
-        Function<String, PreparsedDocumentEntry> mapCompute = { key -> computeFunction.apply(executionInput) }
+    PreparsedDocumentEntry getDocument(ExecutionInput executionInput, Function<ExecutionInput, PreparsedDocumentEntry> parseAndValidateFunction) {
+        Function<String, PreparsedDocumentEntry> mapCompute = { key -> parseAndValidateFunction.apply(executionInput) }
         return cache.computeIfAbsent(executionInput.query, mapCompute)
     }
 

--- a/src/test/groovy/graphql/execution/preparsed/persisted/ApolloPersistedQuerySupportTest.groovy
+++ b/src/test/groovy/graphql/execution/preparsed/persisted/ApolloPersistedQuerySupportTest.groovy
@@ -1,0 +1,155 @@
+package graphql.execution.preparsed.persisted
+
+import graphql.ExecutionInput
+import graphql.execution.preparsed.PreparsedDocumentEntry
+import graphql.parser.Parser
+import spock.lang.Specification
+
+import java.util.function.Function
+
+import static graphql.execution.preparsed.persisted.PersistedQuerySupport.PERSISTED_QUERY_MARKER
+import static graphql.language.AstPrinter.printAstCompact
+
+class ApolloPersistedQuerySupportTest extends Specification {
+
+    def knownQueries = [
+            "hash123": "query { oneTwoThree }",
+            "hash456": "query { fourFiveSix }"
+    ]
+
+    // this cache will do a lookup, make the call back on miss and otherwise return cached values. And it
+    // tracks call counts for assertions
+    class CacheImplementation implements PersistedQueryCache {
+        def map = [:]
+        def keyCount = [:]
+        def parseCount = [:]
+
+        @Override
+        PreparsedDocumentEntry getPersistedQueryDocument(Object persistedQueryId, ExecutionInput executionInput, PersistedQueryCacheMiss onCacheMiss) throws PersistedQueryNotFound {
+            keyCount.compute(persistedQueryId, { k, v -> v == null ? 1 : v + 1 })
+            PreparsedDocumentEntry entry = map.get(persistedQueryId) as PreparsedDocumentEntry
+            if (entry != null) {
+                return entry
+            }
+            parseCount.compute(persistedQueryId, { k, v -> v == null ? 1 : v + 1 })
+
+            def queryText = knownQueries.get(persistedQueryId)
+            // if its outside our know bounds then throw because we dont have one
+            if (queryText == null) {
+                throw new PersistedQueryNotFound(persistedQueryId)
+            }
+            def newDocEntry = onCacheMiss.apply(queryText)
+            map.put(persistedQueryId, newDocEntry)
+            return newDocEntry
+        }
+    }
+
+
+    Function<ExecutionInput, PreparsedDocumentEntry> engineParser = {
+        ExecutionInput ei ->
+            def doc = new Parser().parseDocument(ei.getQuery())
+            return new PreparsedDocumentEntry(doc)
+    }
+
+
+    def mkEI(String hash, String query) {
+        ExecutionInput.newExecutionInput().query(query).extensions([persistedQuery: [sha256Hash: hash]]).build()
+    }
+
+    def "will call the callback on cache miss and then not after initial caching"() {
+
+        CacheImplementation persistedQueryCache = new CacheImplementation()
+        def apolloSupport = new ApolloPersistedQuerySupport(persistedQueryCache)
+
+        when:
+        def ei = mkEI("hash123", PERSISTED_QUERY_MARKER)
+        def documentEntry = apolloSupport.getDocument(ei, engineParser)
+        def doc = documentEntry.getDocument()
+        then:
+        printAstCompact(doc) == "query {oneTwoThree}"
+        persistedQueryCache.keyCount["hash123"] == 1
+        persistedQueryCache.parseCount["hash123"] == 1
+
+        when:
+        ei = mkEI("hash123", PERSISTED_QUERY_MARKER)
+        documentEntry = apolloSupport.getDocument(ei, engineParser)
+        doc = documentEntry.getDocument()
+
+        then:
+        printAstCompact(doc) == "query {oneTwoThree}"
+        persistedQueryCache.keyCount["hash123"] == 2
+        persistedQueryCache.parseCount["hash123"] == 1 // only compiled once cause we had it
+    }
+
+    def "will act as a normal query if there and no hash id present"() {
+
+        CacheImplementation persistedQueryCache = new CacheImplementation()
+        def apolloSupport = new ApolloPersistedQuerySupport(persistedQueryCache)
+
+        when:
+        def ei = ExecutionInput.newExecutionInput("query { normal }").build()
+        def documentEntry = apolloSupport.getDocument(ei, engineParser)
+        def doc = documentEntry.getDocument()
+        then:
+        printAstCompact(doc) == "query {normal}"
+        persistedQueryCache.keyCount.size() == 0
+        persistedQueryCache.parseCount.size() == 0
+    }
+
+    def "will use query hash in preference to query text"() {
+        CacheImplementation persistedQueryCache = new CacheImplementation()
+        def apolloSupport = new ApolloPersistedQuerySupport(persistedQueryCache)
+
+        when:
+        def ei = mkEI("hash123", "query {normal}")
+        def documentEntry = apolloSupport.getDocument(ei, engineParser)
+        def doc = documentEntry.getDocument()
+        then:
+        printAstCompact(doc) == "query {oneTwoThree}"
+        persistedQueryCache.keyCount["hash123"] == 1
+        persistedQueryCache.parseCount["hash123"] == 1
+
+    }
+
+    def "will have error if we dont return any query text on cache miss"() {
+        CacheImplementation persistedQueryCache = new CacheImplementation()
+
+        def apolloSupport = new ApolloPersistedQuerySupport(persistedQueryCache)
+
+        when:
+        def ei = mkEI("nonExistedHash", PERSISTED_QUERY_MARKER)
+        def documentEntry = apolloSupport.getDocument(ei, engineParser)
+        then:
+        documentEntry.getDocument() == null
+        def gqlError = documentEntry.getErrors()[0]
+        gqlError.getMessage() == "PersistedQueryNotFound"
+        gqlError.getErrorType().toString() == "PersistedQueryNotFound"
+        gqlError.getExtensions()["persistedQueryId"] == "nonExistedHash"
+    }
+
+    def "InMemoryPersistedQueryCache implementation works as expected with this class"() {
+
+        InMemoryPersistedQueryCache persistedQueryCache = new InMemoryPersistedQueryCache(knownQueries)
+        def apolloSupport = new ApolloPersistedQuerySupport(persistedQueryCache)
+
+        when:
+        def ei = mkEI("hash123", PERSISTED_QUERY_MARKER)
+        def documentEntry = apolloSupport.getDocument(ei, engineParser)
+        def doc = documentEntry.getDocument()
+        then:
+        printAstCompact(doc) == "query {oneTwoThree}"
+
+        when:
+        ei = mkEI("hash456", PERSISTED_QUERY_MARKER)
+        documentEntry = apolloSupport.getDocument(ei, engineParser)
+        doc = documentEntry.getDocument()
+        then:
+        printAstCompact(doc) == "query {fourFiveSix}"
+
+        when:
+        ei = mkEI("nonExistent", PERSISTED_QUERY_MARKER)
+        documentEntry = apolloSupport.getDocument(ei, engineParser)
+        then:
+        documentEntry.hasErrors()
+    }
+}

--- a/src/test/groovy/graphql/execution/preparsed/persisted/InMemoryPersistedQueryCacheTest.groovy
+++ b/src/test/groovy/graphql/execution/preparsed/persisted/InMemoryPersistedQueryCacheTest.groovy
@@ -1,0 +1,18 @@
+package graphql.execution.preparsed.persisted
+
+import spock.lang.Specification
+
+class InMemoryPersistedQueryCacheTest extends Specification {
+
+    def "can be build as expected"() {
+        def inMemoryPersistedQueryCache = InMemoryPersistedQueryCache.newInMemoryPersistedQueryCache()
+                .addQuery("hash123", "query { oneTwoThree }")
+                .addQuery("hash456", "query { fourFiveSix }")
+                .build()
+
+        when:
+        def knownQueries = inMemoryPersistedQueryCache.getKnownQueries()
+        then:
+        knownQueries == [hash123: "query { oneTwoThree }", hash456: "query { fourFiveSix }"]
+    }
+}


### PR DESCRIPTION
This adds the basis for persisted query support in graphql-java.

In short consumers need to have their own cache implementation to be truly useful.  The `InMemoryPersistedQueryCache` one is too bare bones for production use at scale, as its not memory constrained.

`ApolloPersistedQuerySupport` has been provided which can read persistent query ids from the input extensions.

See #1972 