### PR TITLE
The Scalar code is now broken down into their own implementations

### DIFF
--- a/src/main/java/graphql/Scalars.java
+++ b/src/main/java/graphql/Scalars.java
@@ -64,18 +64,27 @@ public class Scalars {
 
     /**
      * This represents the "Long" type which is a representation of java.lang.Long
+     *
+     * @deprecated The is a non standard scalar and is difficult for clients (such as browser and mobile code) to cope with
+     * the exact semantics.  These will be removed in the future version and moved to another library.
      */
     public static final GraphQLScalarType GraphQLLong = GraphQLScalarType.newScalar()
             .name("Long").description("Long type").coercing(new GraphqlLongCoercing()).build();
 
     /**
      * This represents the "Short" type which is a representation of java.lang.Short
+     *
+     * @deprecated The is a non standard scalar and is difficult for clients (such as browser and mobile code) to cope with
+     * the exact semantics.  These will be removed in the future version and moved to another library.
      */
     public static final GraphQLScalarType GraphQLShort = GraphQLScalarType.newScalar()
             .name("Short").description("Built-in Short as Int").coercing(new GraphqlShortCoercing()).build();
 
     /**
      * This represents the "Byte" type which is a representation of java.lang.Byte
+     *
+     * @deprecated The is a non standard scalar and is difficult for clients (such as browser and mobile code) to cope with
+     * the exact semantics.  These will be removed in the future version and moved to another library.
      */
     public static final GraphQLScalarType GraphQLByte = GraphQLScalarType.newScalar()
             .name("Byte").description("Built-in Byte as Int").coercing(new GraphqlByteCoercing()).build();
@@ -83,12 +92,18 @@ public class Scalars {
 
     /**
      * This represents the "BigInteger" type which is a representation of java.math.BigInteger
+     *
+     * @deprecated The is a non standard scalar and is difficult for clients (such as browser and mobile code) to cope with
+     * the exact semantics.  These will be removed in the future version and moved to another library.
      */
     public static final GraphQLScalarType GraphQLBigInteger = GraphQLScalarType.newScalar()
             .name("BigInteger").description("Built-in java.math.BigInteger").coercing(new GraphqlBigIntegerCoercing()).build();
 
     /**
      * This represents the "BigDecimal" type which is a representation of java.math.BigDecimal
+     *
+     * @deprecated The is a non standard scalar and is difficult for clients (such as browser and mobile code) to cope with
+     * the exact semantics.  These will be removed in the future version and moved to another library.
      */
     public static final GraphQLScalarType GraphQLBigDecimal = GraphQLScalarType.newScalar()
             .name("BigDecimal").description("Built-in java.math.BigDecimal").coercing(new GraphqlBigDecimalCoercing()).build();
@@ -96,6 +111,9 @@ public class Scalars {
 
     /**
      * This represents the "Char" type which is a representation of java.lang.Character
+     *
+     * @deprecated The is a non standard scalar and is difficult for clients (such as browser and mobile code) to cope with
+     * the exact semantics.  These will be removed in the future version and moved to another library.
      */
     public static final GraphQLScalarType GraphQLChar = GraphQLScalarType.newScalar()
             .name("Char").description("Built-in Char as Character").coercing(new GraphqlCharCoercing()).build();

--- a/src/main/java/graphql/Scalars.java
+++ b/src/main/java/graphql/Scalars.java
@@ -1,716 +1,103 @@
 package graphql;
 
 
-import graphql.language.BooleanValue;
-import graphql.language.FloatValue;
-import graphql.language.IntValue;
-import graphql.language.StringValue;
-import graphql.schema.Coercing;
-import graphql.schema.CoercingParseLiteralException;
-import graphql.schema.CoercingParseValueException;
-import graphql.schema.CoercingSerializeException;
+import graphql.scalar.GraphqlBigDecimalCoercing;
+import graphql.scalar.GraphqlBigIntegerCoercing;
+import graphql.scalar.GraphqlBooleanCoercing;
+import graphql.scalar.GraphqlByteCoercing;
+import graphql.scalar.GraphqlCharCoercing;
+import graphql.scalar.GraphqlFloatCoercing;
+import graphql.scalar.GraphqlIDCoercing;
+import graphql.scalar.GraphqlIntCoercing;
+import graphql.scalar.GraphqlLongCoercing;
+import graphql.scalar.GraphqlShortCoercing;
+import graphql.scalar.GraphqlStringCoercing;
 import graphql.schema.GraphQLScalarType;
-
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.util.UUID;
-
-import static graphql.Assert.assertShouldNeverHappen;
 
 /**
  * This contains the implementations of the Scalar types that ship with graphql-java.  Some are proscribed
  * by the graphql specification (Int, Float, String, Boolean and ID) while others are offer because they are common on
  * Java platforms.
- *
+ * <p>
  * For more info see http://graphql.org/learn/schema/#scalar-types and more specifically http://facebook.github.io/graphql/#sec-Scalars
  */
 @PublicApi
 public class Scalars {
 
-    private static final BigInteger LONG_MAX = BigInteger.valueOf(Long.MAX_VALUE);
-    private static final BigInteger LONG_MIN = BigInteger.valueOf(Long.MIN_VALUE);
-    private static final BigInteger INT_MAX = BigInteger.valueOf(Integer.MAX_VALUE);
-    private static final BigInteger INT_MIN = BigInteger.valueOf(Integer.MIN_VALUE);
-    private static final BigInteger BYTE_MAX = BigInteger.valueOf(Byte.MAX_VALUE);
-    private static final BigInteger BYTE_MIN = BigInteger.valueOf(Byte.MIN_VALUE);
-    private static final BigInteger SHORT_MAX = BigInteger.valueOf(Short.MAX_VALUE);
-    private static final BigInteger SHORT_MIN = BigInteger.valueOf(Short.MIN_VALUE);
-
-
-    private static boolean isNumberIsh(Object input) {
-        return input instanceof Number || input instanceof String;
-    }
-
-    private static String typeName(Object input) {
-        if (input == null) {
-            return "null";
-        }
-
-        return input.getClass().getSimpleName();
-    }
-
     /**
      * This represents the "Int" type as defined in the graphql specification : http://facebook.github.io/graphql/#sec-Int
-     *
+     * <p>
      * The Int scalar type represents a signed 32‐bit numeric non‐fractional value.
      */
-    public static final GraphQLScalarType GraphQLInt = new GraphQLScalarType("Int", "Built-in Int", new Coercing<Integer, Integer>() {
-
-        private Integer convertImpl(Object input) {
-            if (input instanceof Integer) {
-                return (Integer) input;
-            } else if (isNumberIsh(input)) {
-                BigDecimal value;
-                try {
-                    value = new BigDecimal(input.toString());
-                } catch (NumberFormatException e) {
-                    return null;
-                }
-                try {
-                    return value.intValueExact();
-                } catch (ArithmeticException e) {
-                    return null;
-                }
-            } else {
-                return null;
-            }
-        }
-
-        @Override
-        public Integer serialize(Object input) {
-            Integer result = convertImpl(input);
-            if (result == null) {
-                throw new CoercingSerializeException(
-                        "Expected type 'Int' but was '" + typeName(input) + "'."
-                );
-            }
-            return result;
-        }
-
-        @Override
-        public Integer parseValue(Object input) {
-            Integer result = convertImpl(input);
-            if (result == null) {
-                throw new CoercingParseValueException(
-                        "Expected type 'Int' but was '" + typeName(input) + "'."
-                );
-            }
-            return result;
-        }
-
-        @Override
-        public Integer parseLiteral(Object input) {
-            if (!(input instanceof IntValue)) {
-                throw new CoercingParseLiteralException(
-                        "Expected AST type 'IntValue' but was '" + typeName(input) + "'."
-                );
-            }
-            BigInteger value = ((IntValue) input).getValue();
-            if (value.compareTo(INT_MIN) < 0 || value.compareTo(INT_MAX) > 0) {
-                throw new CoercingParseLiteralException(
-                        "Expected value to be in the Integer range but it was '" + value.toString() + "'"
-                );
-            }
-            return value.intValue();
-        }
-    });
+    public static final GraphQLScalarType GraphQLInt = GraphQLScalarType.newScalar()
+            .name("Int").description("Built-in Int").coercing(new GraphqlIntCoercing()).build();
 
     /**
      * This represents the "Float" type as defined in the graphql specification : http://facebook.github.io/graphql/#sec-Float
-     *
+     * <p>
      * Note: The Float type in GraphQL is equivalent to Double in Java. (double precision IEEE 754)
      */
-    public static final GraphQLScalarType GraphQLFloat = new GraphQLScalarType("Float", "Built-in Float", new Coercing<Double, Double>() {
-
-        private Double convertImpl(Object input) {
-            if (isNumberIsh(input)) {
-                BigDecimal value;
-                try {
-                    value = new BigDecimal(input.toString());
-                } catch (NumberFormatException e) {
-                    return null;
-                }
-                return value.doubleValue();
-            } else {
-                return null;
-            }
-
-        }
-
-        @Override
-        public Double serialize(Object input) {
-            Double result = convertImpl(input);
-            if (result == null) {
-                throw new CoercingSerializeException(
-                        "Expected type 'Float' but was '" + typeName(input) + "'."
-                );
-            }
-            return result;
-
-        }
-
-        @Override
-        public Double parseValue(Object input) {
-            Double result = convertImpl(input);
-            if (result == null) {
-                throw new CoercingParseValueException(
-                        "Expected type 'Float' but was '" + typeName(input) + "'."
-                );
-            }
-            return result;
-        }
-
-        @Override
-        public Double parseLiteral(Object input) {
-            if (input instanceof IntValue) {
-                return ((IntValue) input).getValue().doubleValue();
-            } else if (input instanceof FloatValue) {
-                return ((FloatValue) input).getValue().doubleValue();
-            } else {
-                throw new CoercingParseLiteralException(
-                        "Expected AST type 'IntValue' or 'FloatValue' but was '" + typeName(input) + "'."
-                );
-            }
-        }
-    });
+    public static final GraphQLScalarType GraphQLFloat = GraphQLScalarType.newScalar()
+            .name("Float").description("Built-in Float").coercing(new GraphqlFloatCoercing()).build();
 
     /**
      * This represents the "String" type as defined in the graphql specification : http://facebook.github.io/graphql/#sec-String
      */
-    public static final GraphQLScalarType GraphQLString = new GraphQLScalarType("String", "Built-in String", new Coercing<String, String>() {
-        @Override
-        public String serialize(Object input) {
-            return input.toString();
-        }
-
-        @Override
-        public String parseValue(Object input) {
-            return serialize(input);
-        }
-
-        @Override
-        public String parseLiteral(Object input) {
-            if (!(input instanceof StringValue)) {
-                throw new CoercingParseLiteralException(
-                        "Expected AST type 'StringValue' but was '" + typeName(input) + "'."
-                );
-            }
-            return ((StringValue) input).getValue();
-        }
-    });
+    public static final GraphQLScalarType GraphQLString = GraphQLScalarType.newScalar()
+            .name("String").description("Built-in String").coercing(new GraphqlStringCoercing()).build();
 
     /**
      * This represents the "Boolean" type as defined in the graphql specification : http://facebook.github.io/graphql/#sec-Boolean
      */
-    public static final GraphQLScalarType GraphQLBoolean = new GraphQLScalarType("Boolean", "Built-in Boolean", new Coercing<Boolean, Boolean>() {
-
-        private Boolean convertImpl(Object input) {
-            if (input instanceof Boolean) {
-                return (Boolean) input;
-            } else if (input instanceof String) {
-                return Boolean.parseBoolean((String) input);
-            } else if (isNumberIsh(input)) {
-                BigDecimal value;
-                try {
-                    value = new BigDecimal(input.toString());
-                } catch (NumberFormatException e) {
-                    // this should never happen because String is handled above
-                    return assertShouldNeverHappen();
-                }
-                return value.compareTo(BigDecimal.ZERO) != 0;
-            } else {
-                return null;
-            }
-
-        }
-
-        @Override
-        public Boolean serialize(Object input) {
-            Boolean result = convertImpl(input);
-            if (result == null) {
-                throw new CoercingSerializeException(
-                        "Expected type 'Boolean' but was '" + typeName(input) + "'."
-                );
-            }
-            return result;
-        }
-
-        @Override
-        public Boolean parseValue(Object input) {
-            Boolean result = convertImpl(input);
-            if (result == null) {
-                throw new CoercingParseValueException(
-                        "Expected type 'Boolean' but was '" + typeName(input) + "'."
-                );
-            }
-            return result;
-        }
-
-        @Override
-        public Boolean parseLiteral(Object input) {
-            if (!(input instanceof BooleanValue)) {
-                throw new CoercingParseLiteralException(
-                        "Expected AST type 'BooleanValue' but was '" + typeName(input) + "'."
-                );
-            }
-            return ((BooleanValue) input).isValue();
-        }
-    });
+    public static final GraphQLScalarType GraphQLBoolean = GraphQLScalarType.newScalar()
+            .name("Boolean").description("Built-in Boolean").coercing(new GraphqlBooleanCoercing()).build();
 
     /**
      * This represents the "ID" type as defined in the graphql specification : http://facebook.github.io/graphql/#sec-ID
-     *
+     * <p>
      * The ID scalar type represents a unique identifier, often used to re-fetch an object or as the key for a cache. The
      * ID type is serialized in the same way as a String; however, it is not intended to be human‐readable. While it is
      * often numeric, it should always serialize as a String.
      */
-    public static final GraphQLScalarType GraphQLID = new GraphQLScalarType("ID", "Built-in ID", new Coercing<Object, Object>() {
-
-        private String convertImpl(Object input) {
-            if (input instanceof String) {
-                return (String) input;
-            }
-            if (input instanceof Integer) {
-                return String.valueOf(input);
-            }
-            if (input instanceof Long) {
-                return String.valueOf(input);
-            }
-            if (input instanceof UUID) {
-                return String.valueOf(input);
-            }
-            if (input instanceof BigInteger) {
-                return String.valueOf(input);
-            }
-            return String.valueOf(input);
-
-        }
-
-        @Override
-        public String serialize(Object input) {
-            String result = String.valueOf(input);
-            if (result == null) {
-                throw new CoercingSerializeException(
-                        "Expected type 'ID' but was '" + typeName(input) + "'."
-                );
-            }
-            return result;
-        }
-
-        @Override
-        public String parseValue(Object input) {
-            String result = convertImpl(input);
-            if (result == null) {
-                throw new CoercingParseValueException(
-                        "Expected type 'ID' but was '" + typeName(input) + "'."
-                );
-            }
-            return result;
-        }
-
-        @Override
-        public String parseLiteral(Object input) {
-            if (input instanceof StringValue) {
-                return ((StringValue) input).getValue();
-            }
-            if (input instanceof IntValue) {
-                return ((IntValue) input).getValue().toString();
-            }
-            throw new CoercingParseLiteralException(
-                    "Expected AST type 'IntValue' or 'StringValue' but was '" + typeName(input) + "'."
-            );
-        }
-    });
+    public static final GraphQLScalarType GraphQLID = GraphQLScalarType.newScalar()
+            .name("ID").description("Built-in ID").coercing(new GraphqlIDCoercing()).build();
 
     /**
      * This represents the "Long" type which is a representation of java.lang.Long
      */
-    public static final GraphQLScalarType GraphQLLong = new GraphQLScalarType("Long", "Long type", new Coercing<Long, Long>() {
-
-        private Long convertImpl(Object input) {
-            if (input instanceof Long) {
-                return (Long) input;
-            } else if (isNumberIsh(input)) {
-                BigDecimal value;
-                try {
-                    value = new BigDecimal(input.toString());
-                } catch (NumberFormatException e) {
-                    return null;
-                }
-                try {
-                    return value.longValueExact();
-                } catch (ArithmeticException e) {
-                    return null;
-                }
-            } else {
-                return null;
-            }
-
-        }
-
-        @Override
-        public Long serialize(Object input) {
-            Long result = convertImpl(input);
-            if (result == null) {
-                throw new CoercingSerializeException(
-                        "Expected type 'Long' but was '" + typeName(input) + "'."
-                );
-            }
-            return result;
-        }
-
-        @Override
-        public Long parseValue(Object input) {
-            Long result = convertImpl(input);
-            if (result == null) {
-                throw new CoercingParseValueException(
-                        "Expected type 'Long' but was '" + typeName(input) + "'."
-                );
-            }
-            return result;
-        }
-
-        @Override
-        public Long parseLiteral(Object input) {
-            if (input instanceof StringValue) {
-                try {
-                    return Long.parseLong(((StringValue) input).getValue());
-                } catch (NumberFormatException e) {
-                    throw new CoercingParseLiteralException(
-                            "Expected value to be a Long but it was '" + String.valueOf(input) + "'"
-                    );
-                }
-            } else if (input instanceof IntValue) {
-                BigInteger value = ((IntValue) input).getValue();
-                if (value.compareTo(LONG_MIN) < 0 || value.compareTo(LONG_MAX) > 0) {
-                    throw new CoercingParseLiteralException(
-                            "Expected value to be in the Long range but it was '" + value.toString() + "'"
-                    );
-                }
-                return value.longValue();
-            }
-            throw new CoercingParseLiteralException(
-                    "Expected AST type 'IntValue' or 'StringValue' but was '" + typeName(input) + "'."
-            );
-        }
-    });
+    public static final GraphQLScalarType GraphQLLong = GraphQLScalarType.newScalar()
+            .name("Long").description("Long type").coercing(new GraphqlLongCoercing()).build();
 
     /**
      * This represents the "Short" type which is a representation of java.lang.Short
      */
-    public static final GraphQLScalarType GraphQLShort = new GraphQLScalarType("Short", "Built-in Short as Int", new Coercing<Short, Short>() {
-
-        private Short convertImpl(Object input) {
-            if (input instanceof Short) {
-                return (Short) input;
-            } else if (isNumberIsh(input)) {
-                BigDecimal value;
-                try {
-                    value = new BigDecimal(input.toString());
-                } catch (NumberFormatException e) {
-                    return null;
-                }
-                try {
-                    return value.shortValueExact();
-                } catch (ArithmeticException e) {
-                    return null;
-                }
-            } else {
-                return null;
-            }
-
-        }
-
-        @Override
-        public Short serialize(Object input) {
-            Short result = convertImpl(input);
-            if (result == null) {
-                throw new CoercingSerializeException(
-                        "Expected type 'Short' but was '" + typeName(input) + "'."
-                );
-            }
-            return result;
-        }
-
-        @Override
-        public Short parseValue(Object input) {
-            Short result = convertImpl(input);
-            if (result == null) {
-                throw new CoercingParseValueException(
-                        "Expected type 'Short' but was '" + typeName(input) + "'."
-                );
-            }
-            return result;
-        }
-
-        @Override
-        public Short parseLiteral(Object input) {
-            if (!(input instanceof IntValue)) {
-                throw new CoercingParseLiteralException(
-                        "Expected AST type 'IntValue' but was '" + typeName(input) + "'."
-                );
-            }
-            BigInteger value = ((IntValue) input).getValue();
-            if (value.compareTo(SHORT_MIN) < 0 || value.compareTo(SHORT_MAX) > 0) {
-                throw new CoercingParseLiteralException(
-                        "Expected value to be in the Short range but it was '" + value.toString() + "'"
-                );
-            }
-            return value.shortValue();
-        }
-    });
+    public static final GraphQLScalarType GraphQLShort = GraphQLScalarType.newScalar()
+            .name("Short").description("Built-in Short as Int").coercing(new GraphqlShortCoercing()).build();
 
     /**
      * This represents the "Byte" type which is a representation of java.lang.Byte
      */
-    public static final GraphQLScalarType GraphQLByte = new GraphQLScalarType("Byte", "Built-in Byte as Int", new Coercing<Byte, Byte>() {
-
-        private Byte convertImpl(Object input) {
-            if (input instanceof Byte) {
-                return (Byte) input;
-            } else if (isNumberIsh(input)) {
-                BigDecimal value;
-                try {
-                    value = new BigDecimal(input.toString());
-                } catch (NumberFormatException e) {
-                    return null;
-                }
-                try {
-                    return value.byteValueExact();
-                } catch (ArithmeticException e) {
-                    return null;
-                }
-            } else {
-                return null;
-            }
-
-        }
-
-        @Override
-        public Byte serialize(Object input) {
-            Byte result = convertImpl(input);
-            if (result == null) {
-                throw new CoercingSerializeException(
-                        "Expected type 'Byte' but was '" + typeName(input) + "'."
-                );
-            }
-            return result;
-        }
-
-        @Override
-        public Byte parseValue(Object input) {
-            Byte result = convertImpl(input);
-            if (result == null) {
-                throw new CoercingParseValueException(
-                        "Expected type 'Byte' but was '" + typeName(input) + "'."
-                );
-            }
-            return result;
-        }
-
-        @Override
-        public Byte parseLiteral(Object input) {
-            if (!(input instanceof IntValue)) {
-                throw new CoercingParseLiteralException(
-                        "Expected AST type 'IntValue' but was '" + typeName(input) + "'."
-                );
-            }
-            BigInteger value = ((IntValue) input).getValue();
-            if (value.compareTo(BYTE_MIN) < 0 || value.compareTo(BYTE_MAX) > 0) {
-                throw new CoercingParseLiteralException(
-                        "Expected value to be in the Byte range but it was '" + value.toString() + "'"
-                );
-            }
-            return value.byteValue();
-        }
-    });
+    public static final GraphQLScalarType GraphQLByte = GraphQLScalarType.newScalar()
+            .name("Byte").description("Built-in Byte as Int").coercing(new GraphqlByteCoercing()).build();
 
 
     /**
      * This represents the "BigInteger" type which is a representation of java.math.BigInteger
      */
-    public static final GraphQLScalarType GraphQLBigInteger = new GraphQLScalarType("BigInteger", "Built-in java.math.BigInteger", new Coercing<BigInteger, BigInteger>() {
-
-        private BigInteger convertImpl(Object input) {
-            if (isNumberIsh(input)) {
-                BigDecimal value;
-                try {
-                    value = new BigDecimal(input.toString());
-                } catch (NumberFormatException e) {
-                    return null;
-                }
-                try {
-                    return value.toBigIntegerExact();
-                } catch (ArithmeticException e) {
-                    return null;
-                }
-            }
-            return null;
-
-        }
-
-        @Override
-        public BigInteger serialize(Object input) {
-            BigInteger result = convertImpl(input);
-            if (result == null) {
-                throw new CoercingSerializeException(
-                        "Expected type 'BigInteger' but was '" + typeName(input) + "'."
-                );
-            }
-            return result;
-        }
-
-        @Override
-        public BigInteger parseValue(Object input) {
-            BigInteger result = convertImpl(input);
-            if (result == null) {
-                throw new CoercingParseValueException(
-                        "Expected type 'BigInteger' but was '" + typeName(input) + "'."
-                );
-            }
-            return result;
-        }
-
-        @Override
-        public BigInteger parseLiteral(Object input) {
-            if (input instanceof StringValue) {
-                try {
-                    return new BigDecimal(((StringValue) input).getValue()).toBigIntegerExact();
-                } catch (NumberFormatException | ArithmeticException e) {
-                    throw new CoercingParseLiteralException(
-                            "Unable to turn AST input into a 'BigInteger' : '" + String.valueOf(input) + "'"
-                    );
-                }
-            } else if (input instanceof IntValue) {
-                return ((IntValue) input).getValue();
-            } else if (input instanceof FloatValue) {
-                try {
-                    return ((FloatValue) input).getValue().toBigIntegerExact();
-                } catch (ArithmeticException e) {
-                    throw new CoercingParseLiteralException(
-                            "Unable to turn AST input into a 'BigInteger' : '" + String.valueOf(input) + "'"
-                    );
-                }
-            }
-            throw new CoercingParseLiteralException(
-                    "Expected AST type 'IntValue', 'StringValue' or 'FloatValue' but was '" + typeName(input) + "'."
-            );
-        }
-    });
+    public static final GraphQLScalarType GraphQLBigInteger = GraphQLScalarType.newScalar()
+            .name("BigInteger").description("Built-in java.math.BigInteger").coercing(new GraphqlBigIntegerCoercing()).build();
 
     /**
      * This represents the "BigDecimal" type which is a representation of java.math.BigDecimal
      */
-    public static final GraphQLScalarType GraphQLBigDecimal = new GraphQLScalarType("BigDecimal", "Built-in java.math.BigDecimal", new Coercing<BigDecimal, BigDecimal>() {
-
-        private BigDecimal convertImpl(Object input) {
-            if (isNumberIsh(input)) {
-                try {
-                    return new BigDecimal(input.toString());
-                } catch (NumberFormatException e) {
-                    return null;
-                }
-            }
-            return null;
-
-        }
-
-        @Override
-        public BigDecimal serialize(Object input) {
-            BigDecimal result = convertImpl(input);
-            if (result == null) {
-                throw new CoercingSerializeException(
-                        "Expected type 'BigDecimal' but was '" + typeName(input) + "'."
-                );
-            }
-            return result;
-        }
-
-        @Override
-        public BigDecimal parseValue(Object input) {
-            BigDecimal result = convertImpl(input);
-            if (result == null) {
-                throw new CoercingParseValueException(
-                        "Expected type 'BigDecimal' but was '" + typeName(input) + "'."
-                );
-            }
-            return result;
-        }
-
-        @Override
-        public BigDecimal parseLiteral(Object input) {
-            if (input instanceof StringValue) {
-                try {
-                    return new BigDecimal(((StringValue) input).getValue());
-                } catch (NumberFormatException e) {
-                    throw new CoercingParseLiteralException(
-                            "Unable to turn AST input into a 'BigDecimal' : '" + String.valueOf(input) + "'"
-                    );
-                }
-            } else if (input instanceof IntValue) {
-                return new BigDecimal(((IntValue) input).getValue());
-            } else if (input instanceof FloatValue) {
-                return ((FloatValue) input).getValue();
-            }
-            throw new CoercingParseLiteralException(
-                    "Expected AST type 'IntValue', 'StringValue' or 'FloatValue' but was '" + typeName(input) + "'."
-            );
-        }
-    });
+    public static final GraphQLScalarType GraphQLBigDecimal = GraphQLScalarType.newScalar()
+            .name("BigDecimal").description("Built-in java.math.BigDecimal").coercing(new GraphqlBigDecimalCoercing()).build();
 
 
     /**
      * This represents the "Char" type which is a representation of java.lang.Character
      */
-    public static final GraphQLScalarType GraphQLChar = new GraphQLScalarType("Char", "Built-in Char as Character", new Coercing<Character, Character>() {
+    public static final GraphQLScalarType GraphQLChar = GraphQLScalarType.newScalar()
+            .name("Char").description("Built-in Char as Character").coercing(new GraphqlCharCoercing()).build();
 
-        private Character convertImpl(Object input) {
-            if (input instanceof String && ((String) input).length() == 1) {
-                return ((String) input).charAt(0);
-            } else if (input instanceof Character) {
-                return (Character) input;
-            } else {
-                return null;
-            }
-
-        }
-
-        @Override
-        public Character serialize(Object input) {
-            Character result = convertImpl(input);
-            if (result == null) {
-                throw new CoercingSerializeException(
-                        "Expected type 'Char' but was '" + typeName(input) + "'."
-                );
-            }
-            return result;
-        }
-
-        @Override
-        public Character parseValue(Object input) {
-            Character result = convertImpl(input);
-            if (result == null) {
-                throw new CoercingParseValueException(
-                        "Expected type 'Char' but was '" + typeName(input) + "'."
-                );
-            }
-            return result;
-        }
-
-        @Override
-        public Character parseLiteral(Object input) {
-            if (!(input instanceof StringValue)) {
-                throw new CoercingParseLiteralException(
-                        "Expected AST type 'StringValue' but was '" + typeName(input) + "'."
-                );
-            }
-            String value = ((StringValue) input).getValue();
-            if (value.length() != 1) {
-                throw new CoercingParseLiteralException(
-                        "Empty 'StringValue' provided."
-                );
-            }
-            return value.charAt(0);
-        }
-    });
 }

--- a/src/main/java/graphql/scalar/CoercingUtil.java
+++ b/src/main/java/graphql/scalar/CoercingUtil.java
@@ -1,0 +1,18 @@
+package graphql.scalar;
+
+import graphql.Internal;
+
+@Internal
+class CoercingUtil {
+    static boolean isNumberIsh(Object input) {
+        return input instanceof Number || input instanceof String;
+    }
+
+    static String typeName(Object input) {
+        if (input == null) {
+            return "null";
+        }
+
+        return input.getClass().getSimpleName();
+    }
+}

--- a/src/main/java/graphql/scalar/GraphqlBigDecimalCoercing.java
+++ b/src/main/java/graphql/scalar/GraphqlBigDecimalCoercing.java
@@ -1,0 +1,73 @@
+package graphql.scalar;
+
+import graphql.Internal;
+import graphql.language.FloatValue;
+import graphql.language.IntValue;
+import graphql.language.StringValue;
+import graphql.schema.Coercing;
+import graphql.schema.CoercingParseLiteralException;
+import graphql.schema.CoercingParseValueException;
+import graphql.schema.CoercingSerializeException;
+
+import java.math.BigDecimal;
+
+import static graphql.scalar.CoercingUtil.isNumberIsh;
+import static graphql.scalar.CoercingUtil.typeName;
+
+@Internal
+public class GraphqlBigDecimalCoercing implements Coercing<BigDecimal, BigDecimal> {
+
+    private BigDecimal convertImpl(Object input) {
+        if (isNumberIsh(input)) {
+            try {
+                return new BigDecimal(input.toString());
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+        return null;
+
+    }
+
+    @Override
+    public BigDecimal serialize(Object input) {
+        BigDecimal result = convertImpl(input);
+        if (result == null) {
+            throw new CoercingSerializeException(
+                    "Expected type 'BigDecimal' but was '" + typeName(input) + "'."
+            );
+        }
+        return result;
+    }
+
+    @Override
+    public BigDecimal parseValue(Object input) {
+        BigDecimal result = convertImpl(input);
+        if (result == null) {
+            throw new CoercingParseValueException(
+                    "Expected type 'BigDecimal' but was '" + typeName(input) + "'."
+            );
+        }
+        return result;
+    }
+
+    @Override
+    public BigDecimal parseLiteral(Object input) {
+        if (input instanceof StringValue) {
+            try {
+                return new BigDecimal(((StringValue) input).getValue());
+            } catch (NumberFormatException e) {
+                throw new CoercingParseLiteralException(
+                        "Unable to turn AST input into a 'BigDecimal' : '" + input + "'"
+                );
+            }
+        } else if (input instanceof IntValue) {
+            return new BigDecimal(((IntValue) input).getValue());
+        } else if (input instanceof FloatValue) {
+            return ((FloatValue) input).getValue();
+        }
+        throw new CoercingParseLiteralException(
+                "Expected AST type 'IntValue', 'StringValue' or 'FloatValue' but was '" + typeName(input) + "'."
+        );
+    }
+}

--- a/src/main/java/graphql/scalar/GraphqlBigIntegerCoercing.java
+++ b/src/main/java/graphql/scalar/GraphqlBigIntegerCoercing.java
@@ -1,0 +1,86 @@
+package graphql.scalar;
+
+import graphql.Internal;
+import graphql.language.FloatValue;
+import graphql.language.IntValue;
+import graphql.language.StringValue;
+import graphql.schema.Coercing;
+import graphql.schema.CoercingParseLiteralException;
+import graphql.schema.CoercingParseValueException;
+import graphql.schema.CoercingSerializeException;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import static graphql.scalar.CoercingUtil.isNumberIsh;
+import static graphql.scalar.CoercingUtil.typeName;
+
+@Internal
+public class GraphqlBigIntegerCoercing implements Coercing<BigInteger, BigInteger> {
+
+    private BigInteger convertImpl(Object input) {
+        if (isNumberIsh(input)) {
+            BigDecimal value;
+            try {
+                value = new BigDecimal(input.toString());
+            } catch (NumberFormatException e) {
+                return null;
+            }
+            try {
+                return value.toBigIntegerExact();
+            } catch (ArithmeticException e) {
+                return null;
+            }
+        }
+        return null;
+
+    }
+
+    @Override
+    public BigInteger serialize(Object input) {
+        BigInteger result = convertImpl(input);
+        if (result == null) {
+            throw new CoercingSerializeException(
+                    "Expected type 'BigInteger' but was '" + typeName(input) + "'."
+            );
+        }
+        return result;
+    }
+
+    @Override
+    public BigInteger parseValue(Object input) {
+        BigInteger result = convertImpl(input);
+        if (result == null) {
+            throw new CoercingParseValueException(
+                    "Expected type 'BigInteger' but was '" + typeName(input) + "'."
+            );
+        }
+        return result;
+    }
+
+    @Override
+    public BigInteger parseLiteral(Object input) {
+        if (input instanceof StringValue) {
+            try {
+                return new BigDecimal(((StringValue) input).getValue()).toBigIntegerExact();
+            } catch (NumberFormatException | ArithmeticException e) {
+                throw new CoercingParseLiteralException(
+                        "Unable to turn AST input into a 'BigInteger' : '" + input + "'"
+                );
+            }
+        } else if (input instanceof IntValue) {
+            return ((IntValue) input).getValue();
+        } else if (input instanceof FloatValue) {
+            try {
+                return ((FloatValue) input).getValue().toBigIntegerExact();
+            } catch (ArithmeticException e) {
+                throw new CoercingParseLiteralException(
+                        "Unable to turn AST input into a 'BigInteger' : '" + input + "'"
+                );
+            }
+        }
+        throw new CoercingParseLiteralException(
+                "Expected AST type 'IntValue', 'StringValue' or 'FloatValue' but was '" + typeName(input) + "'."
+        );
+    }
+}

--- a/src/main/java/graphql/scalar/GraphqlBooleanCoercing.java
+++ b/src/main/java/graphql/scalar/GraphqlBooleanCoercing.java
@@ -1,0 +1,70 @@
+package graphql.scalar;
+
+import graphql.Internal;
+import graphql.language.BooleanValue;
+import graphql.schema.Coercing;
+import graphql.schema.CoercingParseLiteralException;
+import graphql.schema.CoercingParseValueException;
+import graphql.schema.CoercingSerializeException;
+
+import java.math.BigDecimal;
+
+import static graphql.Assert.assertShouldNeverHappen;
+import static graphql.scalar.CoercingUtil.isNumberIsh;
+import static graphql.scalar.CoercingUtil.typeName;
+
+@Internal
+public class GraphqlBooleanCoercing implements Coercing<Boolean, Boolean> {
+
+    private Boolean convertImpl(Object input) {
+        if (input instanceof Boolean) {
+            return (Boolean) input;
+        } else if (input instanceof String) {
+            return Boolean.parseBoolean((String) input);
+        } else if (isNumberIsh(input)) {
+            BigDecimal value;
+            try {
+                value = new BigDecimal(input.toString());
+            } catch (NumberFormatException e) {
+                // this should never happen because String is handled above
+                return assertShouldNeverHappen();
+            }
+            return value.compareTo(BigDecimal.ZERO) != 0;
+        } else {
+            return null;
+        }
+
+    }
+
+    @Override
+    public Boolean serialize(Object input) {
+        Boolean result = convertImpl(input);
+        if (result == null) {
+            throw new CoercingSerializeException(
+                    "Expected type 'Boolean' but was '" + typeName(input) + "'."
+            );
+        }
+        return result;
+    }
+
+    @Override
+    public Boolean parseValue(Object input) {
+        Boolean result = convertImpl(input);
+        if (result == null) {
+            throw new CoercingParseValueException(
+                    "Expected type 'Boolean' but was '" + typeName(input) + "'."
+            );
+        }
+        return result;
+    }
+
+    @Override
+    public Boolean parseLiteral(Object input) {
+        if (!(input instanceof BooleanValue)) {
+            throw new CoercingParseLiteralException(
+                    "Expected AST type 'BooleanValue' but was '" + typeName(input) + "'."
+            );
+        }
+        return ((BooleanValue) input).isValue();
+    }
+}

--- a/src/main/java/graphql/scalar/GraphqlByteCoercing.java
+++ b/src/main/java/graphql/scalar/GraphqlByteCoercing.java
@@ -1,0 +1,80 @@
+package graphql.scalar;
+
+import graphql.Internal;
+import graphql.language.IntValue;
+import graphql.schema.Coercing;
+import graphql.schema.CoercingParseLiteralException;
+import graphql.schema.CoercingParseValueException;
+import graphql.schema.CoercingSerializeException;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import static graphql.scalar.CoercingUtil.isNumberIsh;
+import static graphql.scalar.CoercingUtil.typeName;
+
+@Internal
+public class GraphqlByteCoercing implements Coercing<Byte, Byte> {
+
+    private static final BigInteger BYTE_MAX = BigInteger.valueOf(Byte.MAX_VALUE);
+    private static final BigInteger BYTE_MIN = BigInteger.valueOf(Byte.MIN_VALUE);
+
+    private Byte convertImpl(Object input) {
+        if (input instanceof Byte) {
+            return (Byte) input;
+        } else if (isNumberIsh(input)) {
+            BigDecimal value;
+            try {
+                value = new BigDecimal(input.toString());
+            } catch (NumberFormatException e) {
+                return null;
+            }
+            try {
+                return value.byteValueExact();
+            } catch (ArithmeticException e) {
+                return null;
+            }
+        } else {
+            return null;
+        }
+
+    }
+
+    @Override
+    public Byte serialize(Object input) {
+        Byte result = convertImpl(input);
+        if (result == null) {
+            throw new CoercingSerializeException(
+                    "Expected type 'Byte' but was '" + typeName(input) + "'."
+            );
+        }
+        return result;
+    }
+
+    @Override
+    public Byte parseValue(Object input) {
+        Byte result = convertImpl(input);
+        if (result == null) {
+            throw new CoercingParseValueException(
+                    "Expected type 'Byte' but was '" + typeName(input) + "'."
+            );
+        }
+        return result;
+    }
+
+    @Override
+    public Byte parseLiteral(Object input) {
+        if (!(input instanceof IntValue)) {
+            throw new CoercingParseLiteralException(
+                    "Expected AST type 'IntValue' but was '" + typeName(input) + "'."
+            );
+        }
+        BigInteger value = ((IntValue) input).getValue();
+        if (value.compareTo(BYTE_MIN) < 0 || value.compareTo(BYTE_MAX) > 0) {
+            throw new CoercingParseLiteralException(
+                    "Expected value to be in the Byte range but it was '" + value.toString() + "'"
+            );
+        }
+        return value.byteValue();
+    }
+}

--- a/src/main/java/graphql/scalar/GraphqlCharCoercing.java
+++ b/src/main/java/graphql/scalar/GraphqlCharCoercing.java
@@ -1,0 +1,63 @@
+package graphql.scalar;
+
+import graphql.Internal;
+import graphql.language.StringValue;
+import graphql.schema.Coercing;
+import graphql.schema.CoercingParseLiteralException;
+import graphql.schema.CoercingParseValueException;
+import graphql.schema.CoercingSerializeException;
+
+import static graphql.scalar.CoercingUtil.typeName;
+
+@Internal
+public class GraphqlCharCoercing implements Coercing<Character, Character> {
+
+    private Character convertImpl(Object input) {
+        if (input instanceof String && ((String) input).length() == 1) {
+            return ((String) input).charAt(0);
+        } else if (input instanceof Character) {
+            return (Character) input;
+        } else {
+            return null;
+        }
+
+    }
+
+    @Override
+    public Character serialize(Object input) {
+        Character result = convertImpl(input);
+        if (result == null) {
+            throw new CoercingSerializeException(
+                    "Expected type 'Char' but was '" + typeName(input) + "'."
+            );
+        }
+        return result;
+    }
+
+    @Override
+    public Character parseValue(Object input) {
+        Character result = convertImpl(input);
+        if (result == null) {
+            throw new CoercingParseValueException(
+                    "Expected type 'Char' but was '" + typeName(input) + "'."
+            );
+        }
+        return result;
+    }
+
+    @Override
+    public Character parseLiteral(Object input) {
+        if (!(input instanceof StringValue)) {
+            throw new CoercingParseLiteralException(
+                    "Expected AST type 'StringValue' but was '" + typeName(input) + "'."
+            );
+        }
+        String value = ((StringValue) input).getValue();
+        if (value.length() != 1) {
+            throw new CoercingParseLiteralException(
+                    "Empty 'StringValue' provided."
+            );
+        }
+        return value.charAt(0);
+    }
+}

--- a/src/main/java/graphql/scalar/GraphqlFloatCoercing.java
+++ b/src/main/java/graphql/scalar/GraphqlFloatCoercing.java
@@ -1,0 +1,70 @@
+package graphql.scalar;
+
+import graphql.Internal;
+import graphql.language.FloatValue;
+import graphql.language.IntValue;
+import graphql.schema.Coercing;
+import graphql.schema.CoercingParseLiteralException;
+import graphql.schema.CoercingParseValueException;
+import graphql.schema.CoercingSerializeException;
+
+import java.math.BigDecimal;
+
+import static graphql.scalar.CoercingUtil.isNumberIsh;
+import static graphql.scalar.CoercingUtil.typeName;
+
+@Internal
+public class GraphqlFloatCoercing implements Coercing<Double, Double> {
+
+    private Double convertImpl(Object input) {
+        if (isNumberIsh(input)) {
+            BigDecimal value;
+            try {
+                value = new BigDecimal(input.toString());
+            } catch (NumberFormatException e) {
+                return null;
+            }
+            return value.doubleValue();
+        } else {
+            return null;
+        }
+
+    }
+
+    @Override
+    public Double serialize(Object input) {
+        Double result = convertImpl(input);
+        if (result == null) {
+            throw new CoercingSerializeException(
+                    "Expected type 'Float' but was '" + typeName(input) + "'."
+            );
+        }
+        return result;
+
+    }
+
+    @Override
+    public Double parseValue(Object input) {
+        Double result = convertImpl(input);
+        if (result == null) {
+            throw new CoercingParseValueException(
+                    "Expected type 'Float' but was '" + typeName(input) + "'."
+            );
+        }
+        return result;
+    }
+
+    @Override
+    public Double parseLiteral(Object input) {
+        if (input instanceof IntValue) {
+            return ((IntValue) input).getValue().doubleValue();
+        } else if (input instanceof FloatValue) {
+            return ((FloatValue) input).getValue().doubleValue();
+        } else {
+            throw new CoercingParseLiteralException(
+                    "Expected AST type 'IntValue' or 'FloatValue' but was '" + typeName(input) + "'."
+            );
+        }
+    }
+}
+

--- a/src/main/java/graphql/scalar/GraphqlIDCoercing.java
+++ b/src/main/java/graphql/scalar/GraphqlIDCoercing.java
@@ -1,0 +1,73 @@
+package graphql.scalar;
+
+import graphql.Internal;
+import graphql.language.IntValue;
+import graphql.language.StringValue;
+import graphql.schema.Coercing;
+import graphql.schema.CoercingParseLiteralException;
+import graphql.schema.CoercingParseValueException;
+import graphql.schema.CoercingSerializeException;
+
+import java.math.BigInteger;
+import java.util.UUID;
+
+import static graphql.scalar.CoercingUtil.typeName;
+
+@Internal
+public class GraphqlIDCoercing implements Coercing<Object, Object> {
+
+    private String convertImpl(Object input) {
+        if (input instanceof String) {
+            return (String) input;
+        }
+        if (input instanceof Integer) {
+            return String.valueOf(input);
+        }
+        if (input instanceof Long) {
+            return String.valueOf(input);
+        }
+        if (input instanceof UUID) {
+            return String.valueOf(input);
+        }
+        if (input instanceof BigInteger) {
+            return String.valueOf(input);
+        }
+        return String.valueOf(input);
+
+    }
+
+    @Override
+    public String serialize(Object input) {
+        String result = String.valueOf(input);
+        if (result == null) {
+            throw new CoercingSerializeException(
+                    "Expected type 'ID' but was '" + typeName(input) + "'."
+            );
+        }
+        return result;
+    }
+
+    @Override
+    public String parseValue(Object input) {
+        String result = convertImpl(input);
+        if (result == null) {
+            throw new CoercingParseValueException(
+                    "Expected type 'ID' but was '" + typeName(input) + "'."
+            );
+        }
+        return result;
+    }
+
+    @Override
+    public String parseLiteral(Object input) {
+        if (input instanceof StringValue) {
+            return ((StringValue) input).getValue();
+        }
+        if (input instanceof IntValue) {
+            return ((IntValue) input).getValue().toString();
+        }
+        throw new CoercingParseLiteralException(
+                "Expected AST type 'IntValue' or 'StringValue' but was '" + typeName(input) + "'."
+        );
+    }
+}

--- a/src/main/java/graphql/scalar/GraphqlIntCoercing.java
+++ b/src/main/java/graphql/scalar/GraphqlIntCoercing.java
@@ -1,0 +1,79 @@
+package graphql.scalar;
+
+import graphql.Internal;
+import graphql.language.IntValue;
+import graphql.schema.Coercing;
+import graphql.schema.CoercingParseLiteralException;
+import graphql.schema.CoercingParseValueException;
+import graphql.schema.CoercingSerializeException;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import static graphql.scalar.CoercingUtil.isNumberIsh;
+import static graphql.scalar.CoercingUtil.typeName;
+
+@Internal
+public class GraphqlIntCoercing implements Coercing<Integer, Integer> {
+
+    private static final BigInteger INT_MAX = BigInteger.valueOf(Integer.MAX_VALUE);
+    private static final BigInteger INT_MIN = BigInteger.valueOf(Integer.MIN_VALUE);
+
+    private Integer convertImpl(Object input) {
+        if (input instanceof Integer) {
+            return (Integer) input;
+        } else if (isNumberIsh(input)) {
+            BigDecimal value;
+            try {
+                value = new BigDecimal(input.toString());
+            } catch (NumberFormatException e) {
+                return null;
+            }
+            try {
+                return value.intValueExact();
+            } catch (ArithmeticException e) {
+                return null;
+            }
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public Integer serialize(Object input) {
+        Integer result = convertImpl(input);
+        if (result == null) {
+            throw new CoercingSerializeException(
+                    "Expected type 'Int' but was '" + typeName(input) + "'."
+            );
+        }
+        return result;
+    }
+
+    @Override
+    public Integer parseValue(Object input) {
+        Integer result = convertImpl(input);
+        if (result == null) {
+            throw new CoercingParseValueException(
+                    "Expected type 'Int' but was '" + typeName(input) + "'."
+            );
+        }
+        return result;
+    }
+
+    @Override
+    public Integer parseLiteral(Object input) {
+        if (!(input instanceof IntValue)) {
+            throw new CoercingParseLiteralException(
+                    "Expected AST type 'IntValue' but was '" + typeName(input) + "'."
+            );
+        }
+        BigInteger value = ((IntValue) input).getValue();
+        if (value.compareTo(INT_MIN) < 0 || value.compareTo(INT_MAX) > 0) {
+            throw new CoercingParseLiteralException(
+                    "Expected value to be in the Integer range but it was '" + value.toString() + "'"
+            );
+        }
+        return value.intValue();
+    }
+}

--- a/src/main/java/graphql/scalar/GraphqlLongCoercing.java
+++ b/src/main/java/graphql/scalar/GraphqlLongCoercing.java
@@ -1,0 +1,89 @@
+package graphql.scalar;
+
+import graphql.Internal;
+import graphql.language.IntValue;
+import graphql.language.StringValue;
+import graphql.schema.Coercing;
+import graphql.schema.CoercingParseLiteralException;
+import graphql.schema.CoercingParseValueException;
+import graphql.schema.CoercingSerializeException;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import static graphql.scalar.CoercingUtil.isNumberIsh;
+import static graphql.scalar.CoercingUtil.typeName;
+
+@Internal
+public class GraphqlLongCoercing implements Coercing<Long, Long> {
+
+    private static final BigInteger LONG_MAX = BigInteger.valueOf(Long.MAX_VALUE);
+    private static final BigInteger LONG_MIN = BigInteger.valueOf(Long.MIN_VALUE);
+
+    private Long convertImpl(Object input) {
+        if (input instanceof Long) {
+            return (Long) input;
+        } else if (isNumberIsh(input)) {
+            BigDecimal value;
+            try {
+                value = new BigDecimal(input.toString());
+            } catch (NumberFormatException e) {
+                return null;
+            }
+            try {
+                return value.longValueExact();
+            } catch (ArithmeticException e) {
+                return null;
+            }
+        } else {
+            return null;
+        }
+
+    }
+
+    @Override
+    public Long serialize(Object input) {
+        Long result = convertImpl(input);
+        if (result == null) {
+            throw new CoercingSerializeException(
+                    "Expected type 'Long' but was '" + typeName(input) + "'."
+            );
+        }
+        return result;
+    }
+
+    @Override
+    public Long parseValue(Object input) {
+        Long result = convertImpl(input);
+        if (result == null) {
+            throw new CoercingParseValueException(
+                    "Expected type 'Long' but was '" + typeName(input) + "'."
+            );
+        }
+        return result;
+    }
+
+    @Override
+    public Long parseLiteral(Object input) {
+        if (input instanceof StringValue) {
+            try {
+                return Long.parseLong(((StringValue) input).getValue());
+            } catch (NumberFormatException e) {
+                throw new CoercingParseLiteralException(
+                        "Expected value to be a Long but it was '" + input + "'"
+                );
+            }
+        } else if (input instanceof IntValue) {
+            BigInteger value = ((IntValue) input).getValue();
+            if (value.compareTo(LONG_MIN) < 0 || value.compareTo(LONG_MAX) > 0) {
+                throw new CoercingParseLiteralException(
+                        "Expected value to be in the Long range but it was '" + value.toString() + "'"
+                );
+            }
+            return value.longValue();
+        }
+        throw new CoercingParseLiteralException(
+                "Expected AST type 'IntValue' or 'StringValue' but was '" + typeName(input) + "'."
+        );
+    }
+}

--- a/src/main/java/graphql/scalar/GraphqlShortCoercing.java
+++ b/src/main/java/graphql/scalar/GraphqlShortCoercing.java
@@ -1,0 +1,80 @@
+package graphql.scalar;
+
+import graphql.Internal;
+import graphql.language.IntValue;
+import graphql.schema.Coercing;
+import graphql.schema.CoercingParseLiteralException;
+import graphql.schema.CoercingParseValueException;
+import graphql.schema.CoercingSerializeException;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import static graphql.scalar.CoercingUtil.isNumberIsh;
+import static graphql.scalar.CoercingUtil.typeName;
+
+@Internal
+public class GraphqlShortCoercing implements Coercing<Short, Short> {
+
+    private static final BigInteger SHORT_MAX = BigInteger.valueOf(Short.MAX_VALUE);
+    private static final BigInteger SHORT_MIN = BigInteger.valueOf(Short.MIN_VALUE);
+
+    private Short convertImpl(Object input) {
+        if (input instanceof Short) {
+            return (Short) input;
+        } else if (isNumberIsh(input)) {
+            BigDecimal value;
+            try {
+                value = new BigDecimal(input.toString());
+            } catch (NumberFormatException e) {
+                return null;
+            }
+            try {
+                return value.shortValueExact();
+            } catch (ArithmeticException e) {
+                return null;
+            }
+        } else {
+            return null;
+        }
+
+    }
+
+    @Override
+    public Short serialize(Object input) {
+        Short result = convertImpl(input);
+        if (result == null) {
+            throw new CoercingSerializeException(
+                    "Expected type 'Short' but was '" + typeName(input) + "'."
+            );
+        }
+        return result;
+    }
+
+    @Override
+    public Short parseValue(Object input) {
+        Short result = convertImpl(input);
+        if (result == null) {
+            throw new CoercingParseValueException(
+                    "Expected type 'Short' but was '" + typeName(input) + "'."
+            );
+        }
+        return result;
+    }
+
+    @Override
+    public Short parseLiteral(Object input) {
+        if (!(input instanceof IntValue)) {
+            throw new CoercingParseLiteralException(
+                    "Expected AST type 'IntValue' but was '" + typeName(input) + "'."
+            );
+        }
+        BigInteger value = ((IntValue) input).getValue();
+        if (value.compareTo(SHORT_MIN) < 0 || value.compareTo(SHORT_MAX) > 0) {
+            throw new CoercingParseLiteralException(
+                    "Expected value to be in the Short range but it was '" + value.toString() + "'"
+            );
+        }
+        return value.shortValue();
+    }
+}

--- a/src/main/java/graphql/scalar/GraphqlStringCoercing.java
+++ b/src/main/java/graphql/scalar/GraphqlStringCoercing.java
@@ -1,0 +1,31 @@
+package graphql.scalar;
+
+import graphql.Internal;
+import graphql.language.StringValue;
+import graphql.schema.Coercing;
+import graphql.schema.CoercingParseLiteralException;
+
+import static graphql.scalar.CoercingUtil.typeName;
+
+@Internal
+public class GraphqlStringCoercing implements Coercing<String, String> {
+    @Override
+    public String serialize(Object input) {
+        return input.toString();
+    }
+
+    @Override
+    public String parseValue(Object input) {
+        return serialize(input);
+    }
+
+    @Override
+    public String parseLiteral(Object input) {
+        if (!(input instanceof StringValue)) {
+            throw new CoercingParseLiteralException(
+                    "Expected AST type 'StringValue' but was '" + typeName(input) + "'."
+            );
+        }
+        return ((StringValue) input).getValue();
+    }
+}


### PR DESCRIPTION
This breaks down the monolithic Scalar class into a series of specific classes for each coercing.

This will make it easier to maintain and understand