### PR TITLE
Faster Property fetching with derived classes 

### DIFF
--- a/src/main/java/graphql/schema/PropertyDataFetcherHelper.java
+++ b/src/main/java/graphql/schema/PropertyDataFetcherHelper.java
@@ -29,9 +29,19 @@ import static graphql.schema.GraphQLTypeUtil.unwrapOne;
 public class PropertyDataFetcherHelper {
     private static final AtomicBoolean USE_SET_ACCESSIBLE = new AtomicBoolean(true);
     private static final AtomicBoolean USE_NEGATIVE_CACHE = new AtomicBoolean(true);
-    private static final ConcurrentMap<String, Method> METHOD_CACHE = new ConcurrentHashMap<>();
+    private static final ConcurrentMap<String, CachedMethod> METHOD_CACHE = new ConcurrentHashMap<>();
     private static final ConcurrentMap<String, Field> FIELD_CACHE = new ConcurrentHashMap<>();
     private static final ConcurrentMap<String, String> NEGATIVE_CACHE = new ConcurrentHashMap<>();
+
+    private static class CachedMethod {
+        CachedMethod(Method method) {
+            this.method = method;
+            this.takesDataFetcherEnvironmentAsOnlyArgument = takesDataFetcherEnvironmentAsOnlyArgument(method);
+        }
+
+        Method method;
+        boolean takesDataFetcherEnvironmentAsOnlyArgument;
+    }
 
     public static Object getPropertyValue(String propertyName, Object object, GraphQLType graphQLType) {
         return getPropertyValue(propertyName, object, graphQLType, null);
@@ -42,49 +52,44 @@ public class PropertyDataFetcherHelper {
             return ((Map<?, ?>) object).get(propertyName);
         }
 
-        String key = mkKey(object, propertyName);
+        String cacheKey = mkKey(object, propertyName);
         //
         // if we have tried all strategies before and they have all failed then we negatively cache
-        // the key and assume that its never going to turn up.  This shortcuts the property lookup
+        // the cacheKey and assume that its never going to turn up.  This shortcuts the property lookup
         // in systems where there was a `foo` graphql property but they never provided an POJO
         // version of `foo`.
-        if (isNegativelyCached(key)) {
+        if (isNegativelyCached(cacheKey)) {
             return null;
         }
         // lets try positive cache mechanisms next.  If we have seen the method or field before
         // then we invoke it directly without burning any cycles doing reflection.
-        Method cachedMethod = METHOD_CACHE.get(key);
+        CachedMethod cachedMethod = METHOD_CACHE.get(cacheKey);
         if (cachedMethod != null) {
-            MethodFinder methodFinder = (aClass, methodName) -> cachedMethod;
             try {
-                return getPropertyViaGetterMethod(object, propertyName, graphQLType, methodFinder, environment);
+                return invokeMethod(object, environment, cachedMethod.method, cachedMethod.takesDataFetcherEnvironmentAsOnlyArgument);
             } catch (NoSuchMethodException ignored) {
-                assertShouldNeverHappen("A method cached as '%s' is no longer available??", key);
+                assertShouldNeverHappen("A method cached as '%s' is no longer available??", cacheKey);
             }
         }
-        Field cachedField = FIELD_CACHE.get(key);
+        Field cachedField = FIELD_CACHE.get(cacheKey);
         if (cachedField != null) {
-            try {
-                return getPropertyViaFieldAccess(object, propertyName);
-            } catch (FastNoSuchMethodException ignored) {
-                assertShouldNeverHappen("A field cached as '%s' is no longer available??", key);
-            }
+            return invokeField(object, cachedField);
         }
 
         boolean dfeInUse = environment != null;
         try {
-            MethodFinder methodFinder = (root, methodName) -> findPubliclyAccessibleMethod(propertyName, root, methodName, dfeInUse);
+            MethodFinder methodFinder = (root, methodName) -> findPubliclyAccessibleMethod(cacheKey, propertyName, root, methodName, dfeInUse);
             return getPropertyViaGetterMethod(object, propertyName, graphQLType, methodFinder, environment);
         } catch (NoSuchMethodException ignored) {
             try {
-                MethodFinder methodFinder = (aClass, methodName) -> findViaSetAccessible(propertyName, aClass, methodName, dfeInUse);
+                MethodFinder methodFinder = (aClass, methodName) -> findViaSetAccessible(cacheKey, propertyName, aClass, methodName, dfeInUse);
                 return getPropertyViaGetterMethod(object, propertyName, graphQLType, methodFinder, environment);
             } catch (NoSuchMethodException ignored2) {
                 try {
-                    return getPropertyViaFieldAccess(object, propertyName);
+                    return getPropertyViaFieldAccess(cacheKey, object, propertyName);
                 } catch (FastNoSuchMethodException e) {
                     // we have nothing to ask for and we have exhausted our lookup strategies
-                    putInNegativeCache(key);
+                    putInNegativeCache(cacheKey);
                     return null;
                 }
             }
@@ -122,21 +127,9 @@ public class PropertyDataFetcherHelper {
 
     private static Object getPropertyViaGetterUsingPrefix(Object object, String propertyName, String prefix, MethodFinder methodFinder, DataFetchingEnvironment environment) throws NoSuchMethodException {
         String getterName = prefix + propertyName.substring(0, 1).toUpperCase() + propertyName.substring(1);
-        try {
-            Method method = methodFinder.apply(object.getClass(), getterName);
-            if (takesDataFetcherEnvironmentAsOnlyArgument(method)) {
-                if (environment == null) {
-                    throw new FastNoSuchMethodException(getterName);
-                }
-                return method.invoke(object, environment);
-            } else {
-                return method.invoke(object);
-            }
-        } catch (IllegalAccessException | InvocationTargetException e) {
-            throw new GraphQLException(e);
-        }
+        Method method = methodFinder.apply(object.getClass(), getterName);
+        return invokeMethod(object, environment, method, takesDataFetcherEnvironmentAsOnlyArgument(method));
     }
-
 
     /**
      * Invoking public methods on package-protected classes via reflection
@@ -146,10 +139,9 @@ public class PropertyDataFetcherHelper {
      * which have abstract public interfaces implemented by package-protected
      * (generated) subclasses.
      */
-    private static Method findPubliclyAccessibleMethod(String propertyName, Class<?> root, String methodName, boolean dfeInUse) throws NoSuchMethodException {
-        Class<?> currentClass = root;
+    private static Method findPubliclyAccessibleMethod(String cacheKey, String propertyName, Class<?> rootClass, String methodName, boolean dfeInUse) throws NoSuchMethodException {
+        Class<?> currentClass = rootClass;
         while (currentClass != null) {
-            String key = mkKey(currentClass, propertyName);
             if (Modifier.isPublic(currentClass.getModifiers())) {
                 if (dfeInUse) {
                     //
@@ -157,7 +149,7 @@ public class PropertyDataFetcherHelper {
                     try {
                         Method method = currentClass.getMethod(methodName, DataFetchingEnvironment.class);
                         if (Modifier.isPublic(method.getModifiers())) {
-                            METHOD_CACHE.putIfAbsent(key, method);
+                            METHOD_CACHE.putIfAbsent(cacheKey, new CachedMethod(method));
                             return method;
                         }
                     } catch (NoSuchMethodException e) {
@@ -166,23 +158,22 @@ public class PropertyDataFetcherHelper {
                 }
                 Method method = currentClass.getMethod(methodName);
                 if (Modifier.isPublic(method.getModifiers())) {
-                    METHOD_CACHE.putIfAbsent(key, method);
+                    METHOD_CACHE.putIfAbsent(cacheKey, new CachedMethod(method));
                     return method;
                 }
             }
             currentClass = currentClass.getSuperclass();
         }
-        return root.getMethod(methodName);
+        assert rootClass != null;
+        return rootClass.getMethod(methodName);
     }
 
-    private static Method findViaSetAccessible(String propertyName, Class<?> aClass, String methodName, boolean dfeInUse) throws NoSuchMethodException {
+    private static Method findViaSetAccessible(String cacheKey, String propertyName, Class<?> aClass, String methodName, boolean dfeInUse) throws NoSuchMethodException {
         if (!USE_SET_ACCESSIBLE.get()) {
             throw new FastNoSuchMethodException(methodName);
         }
         Class<?> currentClass = aClass;
         while (currentClass != null) {
-            String key = mkKey(currentClass, propertyName);
-
             Predicate<Method> whichMethods = mth -> {
                 if (dfeInUse) {
                     return hasZeroArgs(mth) || takesDataFetcherEnvironmentAsOnlyArgument(mth);
@@ -199,7 +190,7 @@ public class PropertyDataFetcherHelper {
                     // few JVMs actually enforce this but it might happen
                     Method method = m.get();
                     method.setAccessible(true);
-                    METHOD_CACHE.putIfAbsent(key, method);
+                    METHOD_CACHE.putIfAbsent(cacheKey, new CachedMethod(method));
                     return method;
                 } catch (SecurityException ignored) {
                 }
@@ -209,28 +200,50 @@ public class PropertyDataFetcherHelper {
         throw new FastNoSuchMethodException(methodName);
     }
 
-    private static Object getPropertyViaFieldAccess(Object object, String propertyName) throws FastNoSuchMethodException {
+    private static Object getPropertyViaFieldAccess(String cacheKey, Object object, String propertyName) throws FastNoSuchMethodException {
         Class<?> aClass = object.getClass();
-        String key = mkKey(aClass, propertyName);
         try {
             Field field = aClass.getField(propertyName);
-            FIELD_CACHE.putIfAbsent(key, field);
+            FIELD_CACHE.putIfAbsent(cacheKey, field);
             return field.get(object);
         } catch (NoSuchFieldException e) {
             if (!USE_SET_ACCESSIBLE.get()) {
-                throw new FastNoSuchMethodException(key);
+                throw new FastNoSuchMethodException(cacheKey);
             }
             // if not public fields then try via setAccessible
             try {
                 Field field = aClass.getDeclaredField(propertyName);
                 field.setAccessible(true);
-                FIELD_CACHE.putIfAbsent(key, field);
+                FIELD_CACHE.putIfAbsent(cacheKey, field);
                 return field.get(object);
             } catch (SecurityException | NoSuchFieldException ignored2) {
-                throw new FastNoSuchMethodException(key);
+                throw new FastNoSuchMethodException(cacheKey);
             } catch (IllegalAccessException e1) {
                 throw new GraphQLException(e);
             }
+        } catch (IllegalAccessException e) {
+            throw new GraphQLException(e);
+        }
+    }
+
+    private static Object invokeMethod(Object object, DataFetchingEnvironment environment, Method method, boolean takesDataFetcherEnvironmentAsOnlyArgument) throws FastNoSuchMethodException {
+        try {
+            if (takesDataFetcherEnvironmentAsOnlyArgument) {
+                if (environment == null) {
+                    throw new FastNoSuchMethodException(method.getName());
+                }
+                return method.invoke(object, environment);
+            } else {
+                return method.invoke(object);
+            }
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new GraphQLException(e);
+        }
+    }
+
+    private static Object invokeField(Object object, Field field) {
+        try {
+            return field.get(object);
         } catch (IllegalAccessException e) {
             throw new GraphQLException(e);
         }
@@ -262,10 +275,7 @@ public class PropertyDataFetcherHelper {
     }
 
     private static String mkKey(Object object, String propertyName) {
-        return mkKey(object.getClass(), propertyName);
-    }
-
-    private static String mkKey(Class<?> clazz, String propertyName) {
+        Class<?> clazz = object.getClass();
         ClassLoader classLoader = clazz.getClassLoader();
         if (classLoader != null) {
             return classLoader.hashCode() + "__" + clazz.getName() + "__" + propertyName;

--- a/src/test/groovy/graphql/schema/PropertyDataFetcherTest.groovy
+++ b/src/test/groovy/graphql/schema/PropertyDataFetcherTest.groovy
@@ -440,7 +440,7 @@ class PropertyDataFetcherTest extends Specification {
 
     private static class Bar implements Foo {
         @Override
-        public String getSomething() {
+        String getSomething() {
             return "bar";
         }
     }
@@ -455,6 +455,13 @@ class PropertyDataFetcherTest extends Specification {
         dfe.getSource() >> bar
         when:
         def result = propertyDataFetcher.get(dfe)
+
+        then:
+        result == "bar"
+
+        // repeat - should be cached
+        when:
+        result = propertyDataFetcher.get(dfe)
 
         then:
         result == "bar"

--- a/src/test/java/benchmark/PropertyFetcherBenchMark.java
+++ b/src/test/java/benchmark/PropertyFetcherBenchMark.java
@@ -1,0 +1,71 @@
+package benchmark;
+
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingEnvironmentImpl;
+import graphql.schema.PropertyDataFetcher;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This benchmarks a simple property fetch to help improve the key class PropertyDataFetcher
+ * <p>
+ * See http://hg.openjdk.java.net/code-tools/jmh/file/tip/jmh-samples/src/main/java/org/openjdk/jmh/samples/ for more samples
+ * on what you can do with JMH
+ * <p>
+ * You MUST have the JMH plugin for IDEA in place for this to work :  https://github.com/artyushov/idea-jmh-plugin
+ * <p>
+ * Install it and then just hit "Run" on a certain benchmark method
+ */
+@Warmup(iterations = 2, time = 5, batchSize = 3)
+@Measurement(iterations = 3, time = 10, batchSize = 4)
+public class PropertyFetcherBenchMark {
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public void benchMarkThroughputInDirectClassHierarchy(Blackhole blackhole) {
+        executeTest(blackhole, dfeFoo);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public void benchMarkThroughputDirectClassHierarchy(Blackhole blackhole) {
+        executeTest(blackhole, dfeBar);
+    }
+
+    static PropertyDataFetcher<Object> nameFetcher = PropertyDataFetcher.fetching("name");
+
+    static DataFetchingEnvironment dfeFoo = DataFetchingEnvironmentImpl.newDataFetchingEnvironment().source(new Foo("brad")).build();
+    static DataFetchingEnvironment dfeBar = DataFetchingEnvironmentImpl.newDataFetchingEnvironment().source(new Bar("brad")).build();
+
+    public static void executeTest(Blackhole blackhole, DataFetchingEnvironment dfe) {
+        blackhole.consume(nameFetcher.get(dfe));
+    }
+
+    static class Foo extends Bar {
+
+        Foo(String name) {
+            super(name);
+        }
+    }
+
+    static class Bar {
+        private final String name;
+
+        Bar(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+}


### PR DESCRIPTION
I found a bug on the VERY important PropertyDataFetcher where methods on derived classes are not cached properly.  

This leads to things running slower than they are intended.

We also invoke too much code when we DO have a cached method and this simplifies that, doing way less work on POJO method invocation

I created a benchmark for this - on my Mac Pro - 

```
Baseline:
Bencnchmark                                                            Mode  Cnt        Score       Error  Units
PropertyFetcherBenchMark.benchMarkThroughputDirectClassHierarchy    thrpt   15  1085518.250 ± 19039.649  ops/s
PropertyFetcherBenchMark.benchMarkThroughputInDirectClassHierarchy  thrpt   15    48904.567 ±  2916.355  ops/s

After Inprovements
Benchmark                                                            Mode  Cnt        Score       Error  Units
PropertyFetcherBenchMark.benchMarkThroughputDirectClassHierarchy    thrpt   15  1459934.015 ± 29543.790  ops/s
PropertyFetcherBenchMark.benchMarkThroughputInDirectClassHierarchy  thrpt   15  1441122.199 ± 54806.438  ops/s

```
