### PR TITLE
pre-sizing internal data structures

### DIFF
--- a/src/main/java/graphql/ExceptionWhileDataFetching.java
+++ b/src/main/java/graphql/ExceptionWhileDataFetching.java
@@ -46,8 +46,7 @@ public class ExceptionWhileDataFetching implements GraphQLError {
         if (exception instanceof GraphQLError) {
             Map<String, Object> map = ((GraphQLError) exception).getExtensions();
             if (map != null) {
-                extensions = new LinkedHashMap<>();
-                extensions.putAll(map);
+                extensions = new LinkedHashMap<>(map);
             }
         }
         return extensions;

--- a/src/main/java/graphql/execution/AbstractAsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AbstractAsyncExecutionStrategy.java
@@ -32,7 +32,7 @@ public abstract class AbstractAsyncExecutionStrategy extends ExecutionStrategy {
                 handleNonNullException(executionContext, overallResult, exception);
                 return;
             }
-            Map<String, Object> resolvedValuesByField = new LinkedHashMap<>();
+            Map<String, Object> resolvedValuesByField = new LinkedHashMap<>(fieldNames.size());
             int ix = 0;
             for (ExecutionResult executionResult : results) {
 

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -516,7 +516,7 @@ public abstract class ExecutionStrategy {
                 instrumentationParams
         );
 
-        List<FieldValueInfo> fieldValueInfos = new ArrayList<>();
+        List<FieldValueInfo> fieldValueInfos = new ArrayList<>(values.size());
         int index = 0;
         for (Object item : values) {
             ResultPath indexedPath = parameters.getPath().segment(index);
@@ -552,7 +552,7 @@ public abstract class ExecutionStrategy {
                 completeListCtx.onCompleted(executionResult, exception);
                 return;
             }
-            List<Object> completedResults = new ArrayList<>();
+            List<Object> completedResults = new ArrayList<>(results.size());
             for (ExecutionResult completedValue : results) {
                 completedResults.add(completedValue.getData());
             }

--- a/src/main/java/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentation.java
@@ -163,8 +163,7 @@ public class DataLoaderDispatcherInstrumentation extends SimpleInstrumentation {
         }
         DataLoaderDispatcherInstrumentationState state = parameters.getInstrumentationState();
         Map<Object, Object> currentExt = executionResult.getExtensions();
-        Map<Object, Object> statsMap = new LinkedHashMap<>();
-        statsMap.putAll(currentExt == null ? Collections.emptyMap() : currentExt);
+        Map<Object, Object> statsMap = new LinkedHashMap<>(currentExt == null ? Collections.emptyMap() : currentExt);
         Map<Object, Object> dataLoaderStats = buildStatsMap(state);
         statsMap.put("dataloader", dataLoaderStats);
 

--- a/src/main/java/graphql/execution/instrumentation/tracing/TracingInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/tracing/TracingInstrumentation.java
@@ -77,8 +77,7 @@ public class TracingInstrumentation extends SimpleInstrumentation {
         Map<Object, Object> currentExt = executionResult.getExtensions();
 
         TracingSupport tracingSupport = parameters.getInstrumentationState();
-        Map<Object, Object> tracingMap = new LinkedHashMap<>();
-        tracingMap.putAll(currentExt == null ? Collections.emptyMap() : currentExt);
+        Map<Object, Object> tracingMap = new LinkedHashMap<>(currentExt == null ? Collections.emptyMap() : currentExt);
         tracingMap.put("tracing", tracingSupport.snapshotTracingData());
 
         return CompletableFuture.completedFuture(new ExecutionResultImpl(executionResult.getData(), executionResult.getErrors(), tracingMap));

--- a/src/main/java/graphql/execution/instrumentation/tracing/TracingSupport.java
+++ b/src/main/java/graphql/execution/instrumentation/tracing/TracingSupport.java
@@ -140,10 +140,7 @@ public class TracingSupport implements InstrumentationState {
     }
 
     private Object copyMap(Map<String, Object> map) {
-        Map<String, Object> mapCopy = new LinkedHashMap<>();
-        mapCopy.putAll(map);
-        return mapCopy;
-
+        return new LinkedHashMap<>(map);
     }
 
     private Map<String, Object> executionData() {

--- a/src/main/java/graphql/language/EnumValueDefinition.java
+++ b/src/main/java/graphql/language/EnumValueDefinition.java
@@ -66,9 +66,7 @@ public class EnumValueDefinition extends AbstractDescribedNode<EnumValueDefiniti
 
     @Override
     public List<Node> getChildren() {
-        List<Node> result = new ArrayList<>();
-        result.addAll(directives);
-        return result;
+        return new ArrayList<>(directives);
     }
 
     @Override

--- a/src/main/java/graphql/language/FragmentSpread.java
+++ b/src/main/java/graphql/language/FragmentSpread.java
@@ -67,9 +67,7 @@ public class FragmentSpread extends AbstractNode<FragmentSpread> implements Sele
 
     @Override
     public List<Node> getChildren() {
-        List<Node> result = new ArrayList<>();
-        result.addAll(directives);
-        return result;
+        return new ArrayList<>(directives);
     }
 
     @Override
@@ -173,7 +171,6 @@ public class FragmentSpread extends AbstractNode<FragmentSpread> implements Sele
             this.additionalData.put(key, value);
             return this;
         }
-
 
         public FragmentSpread build() {
             return new FragmentSpread(name, directives, sourceLocation, comments, ignoredChars, additionalData);

--- a/src/main/java/graphql/language/ObjectValue.java
+++ b/src/main/java/graphql/language/ObjectValue.java
@@ -44,9 +44,7 @@ public class ObjectValue extends AbstractNode<ObjectValue> implements Value<Obje
 
     @Override
     public List<Node> getChildren() {
-        List<Node> result = new ArrayList<>();
-        result.addAll(objectFields);
-        return result;
+        return new ArrayList<>(objectFields);
     }
 
     @Override


### PR DESCRIPTION
Helps to reduce garbage collector pressure and memory usage in general by avoiding some re-allocations of j.u.ArrayList and j.u.LinkedHashMap.

Following discussion in https://spectrum.chat/graphql-java/general/does-there-exist-a-more-efficient-implemantion-of-asyncexecutionstrategy~93dad126-8b9f-45fc-aaec-9dc04ddae4bc looks like most of our results are between 1 and 6 fields. By default LinkedHashMap is allocating 16 elements. With this change I would like to cut some memory waste and reallocations.
