### PR TITLE
Small tweak in a hot spot method that pre-allocates the array list

### DIFF
--- a/src/main/java/graphql/execution/Async.java
+++ b/src/main/java/graphql/execution/Async.java
@@ -26,15 +26,17 @@ public class Async {
     public static <U> CompletableFuture<List<U>> each(List<CompletableFuture<U>> futures) {
         CompletableFuture<List<U>> overallResult = new CompletableFuture<>();
 
+        @SuppressWarnings("unchecked")
+        CompletableFuture<U>[] arrayOfFutures = futures.toArray(new CompletableFuture[0]);
         CompletableFuture
-                .allOf(futures.toArray(new CompletableFuture[0]))
-                .whenComplete((noUsed, exception) -> {
+                .allOf(arrayOfFutures)
+                .whenComplete((ignored, exception) -> {
                     if (exception != null) {
                         overallResult.completeExceptionally(exception);
                         return;
                     }
-                    List<U> results = new ArrayList<>();
-                    for (CompletableFuture<U> future : futures) {
+                    List<U> results = new ArrayList<>(arrayOfFutures.length);
+                    for (CompletableFuture<U> future : arrayOfFutures) {
                         results.add(future.join());
                     }
                     overallResult.complete(results);


### PR DESCRIPTION
Looking at Flight Recorder allocation I noticed that Asyc.each is a hot spot method and hence this pre-allocates the result array and iterate the array we have