### PR TITLE
ExecutionStepInfo optimisations

### DIFF
--- a/src/main/java/graphql/execution/ExecutionStrategyParameters.java
+++ b/src/main/java/graphql/execution/ExecutionStrategyParameters.java
@@ -16,7 +16,6 @@ public class ExecutionStrategyParameters {
     private final ExecutionStepInfo executionStepInfo;
     private final Object source;
     private final Object localContext;
-    private final Map<String, Object> arguments;
     private final MergedSelectionSet fields;
     private final NonNullableFieldValidator nonNullableFieldValidator;
     private final ResultPath path;
@@ -29,7 +28,6 @@ public class ExecutionStrategyParameters {
                                         Object source,
                                         Object localContext,
                                         MergedSelectionSet fields,
-                                        Map<String, Object> arguments,
                                         NonNullableFieldValidator nonNullableFieldValidator,
                                         ResultPath path,
                                         MergedField currentField,
@@ -41,7 +39,6 @@ public class ExecutionStrategyParameters {
         this.localContext = localContext;
         this.fields = assertNotNull(fields, () -> "fields is null");
         this.source = source;
-        this.arguments = arguments;
         this.nonNullableFieldValidator = nonNullableFieldValidator;
         this.path = path;
         this.currentField = currentField;
@@ -60,10 +57,6 @@ public class ExecutionStrategyParameters {
 
     public MergedSelectionSet getFields() {
         return fields;
-    }
-
-    public Map<String, Object> getArguments() {
-        return arguments;
     }
 
     public NonNullableFieldValidator getNonNullFieldValidator() {
@@ -124,7 +117,6 @@ public class ExecutionStrategyParameters {
         Object source;
         Object localContext;
         MergedSelectionSet fields;
-        Map<String, Object> arguments;
         NonNullableFieldValidator nonNullableFieldValidator;
         ResultPath path = ResultPath.rootPath();
         MergedField currentField;
@@ -146,7 +138,6 @@ public class ExecutionStrategyParameters {
             this.source = oldParameters.source;
             this.localContext = oldParameters.localContext;
             this.fields = oldParameters.fields;
-            this.arguments = oldParameters.arguments;
             this.nonNullableFieldValidator = oldParameters.nonNullableFieldValidator;
             this.currentField = oldParameters.currentField;
             this.path = oldParameters.path;
@@ -185,11 +176,6 @@ public class ExecutionStrategyParameters {
             return this;
         }
 
-        public Builder arguments(Map<String, Object> arguments) {
-            this.arguments = arguments;
-            return this;
-        }
-
         public Builder nonNullFieldValidator(NonNullableFieldValidator nonNullableFieldValidator) {
             this.nonNullableFieldValidator = Assert.assertNotNull(nonNullableFieldValidator, () -> "requires a NonNullValidator");
             return this;
@@ -217,7 +203,7 @@ public class ExecutionStrategyParameters {
 
 
         public ExecutionStrategyParameters build() {
-            return new ExecutionStrategyParameters(executionStepInfo, source, localContext, fields, arguments, nonNullableFieldValidator, path, currentField, listSize, currentListIndex, parent);
+            return new ExecutionStrategyParameters(executionStepInfo, source, localContext, fields, nonNullableFieldValidator, path, currentField, listSize, currentListIndex, parent);
         }
     }
 }

--- a/src/main/java/graphql/execution/SubscriptionExecutionStrategy.java
+++ b/src/main/java/graphql/execution/SubscriptionExecutionStrategy.java
@@ -122,7 +122,7 @@ public class SubscriptionExecutionStrategy extends ExecutionStrategy {
         ExecutionStrategyParameters newParameters = firstFieldOfSubscriptionSelection(parameters);
         ExecutionStepInfo subscribedFieldStepInfo = createSubscribedFieldStepInfo(executionContext, newParameters);
 
-        InstrumentationFieldParameters i13nFieldParameters = new InstrumentationFieldParameters(executionContext, subscribedFieldStepInfo.getFieldDefinition(), subscribedFieldStepInfo);
+        InstrumentationFieldParameters i13nFieldParameters = new InstrumentationFieldParameters(executionContext, () -> subscribedFieldStepInfo);
         InstrumentationContext<ExecutionResult> subscribedFieldCtx = instrumentation.beginSubscribedFieldEvent(i13nFieldParameters);
 
         FetchedValue fetchedValue = unboxPossibleDataFetcherResult(newExecutionContext, parameters, eventPayload);

--- a/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
+++ b/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
@@ -214,7 +214,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
         Instrumentation instrumentation = executionContext.getInstrumentation();
         ExecutionStepInfo executionStepInfo = parameters.getExecutionStepInfo();
         InstrumentationContext<ExecutionResult> fieldCtx = instrumentation.beginField(
-                new InstrumentationFieldParameters(executionContext, fieldDef, executionStepInfo)
+                new InstrumentationFieldParameters(executionContext, () -> executionStepInfo)
         );
 
         CompletableFuture<FetchedValues> fetchedData = fetchData(executionContext, parameters, fieldName, node, fieldDef);

--- a/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationFieldCompleteParameters.java
+++ b/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationFieldCompleteParameters.java
@@ -7,27 +7,27 @@ import graphql.execution.ExecutionStrategyParameters;
 import graphql.execution.instrumentation.InstrumentationState;
 import graphql.schema.GraphQLFieldDefinition;
 
+import java.util.function.Supplier;
+
 /**
  * Parameters sent to {@link graphql.execution.instrumentation.Instrumentation} methods
  */
 @PublicApi
 public class InstrumentationFieldCompleteParameters {
     private final ExecutionContext executionContext;
-    private final GraphQLFieldDefinition fieldDef;
-    private final ExecutionStepInfo typeInfo;
+    private final Supplier<ExecutionStepInfo> executionStepInfo;
     private final Object fetchedValue;
     private final InstrumentationState instrumentationState;
     private final ExecutionStrategyParameters executionStrategyParameters;
 
-    public InstrumentationFieldCompleteParameters(ExecutionContext executionContext, ExecutionStrategyParameters executionStrategyParameters, GraphQLFieldDefinition fieldDef, ExecutionStepInfo typeInfo, Object fetchedValue) {
-        this(executionContext, executionStrategyParameters, fieldDef, typeInfo, fetchedValue, executionContext.getInstrumentationState());
+    public InstrumentationFieldCompleteParameters(ExecutionContext executionContext, ExecutionStrategyParameters executionStrategyParameters, Supplier<ExecutionStepInfo> executionStepInfo, Object fetchedValue) {
+        this(executionContext, executionStrategyParameters, executionStepInfo, fetchedValue, executionContext.getInstrumentationState());
     }
 
-    InstrumentationFieldCompleteParameters(ExecutionContext executionContext, ExecutionStrategyParameters executionStrategyParameters, GraphQLFieldDefinition fieldDef, ExecutionStepInfo typeInfo, Object fetchedValue, InstrumentationState instrumentationState) {
+    InstrumentationFieldCompleteParameters(ExecutionContext executionContext, ExecutionStrategyParameters executionStrategyParameters, Supplier<ExecutionStepInfo> executionStepInfo, Object fetchedValue, InstrumentationState instrumentationState) {
         this.executionContext = executionContext;
         this.executionStrategyParameters = executionStrategyParameters;
-        this.fieldDef = fieldDef;
-        this.typeInfo = typeInfo;
+        this.executionStepInfo = executionStepInfo;
         this.fetchedValue = fetchedValue;
         this.instrumentationState = instrumentationState;
     }
@@ -36,12 +36,11 @@ public class InstrumentationFieldCompleteParameters {
      * Returns a cloned parameters object with the new state
      *
      * @param instrumentationState the new state for this parameters object
-     *
      * @return a new parameters object with the new state
      */
     public InstrumentationFieldCompleteParameters withNewState(InstrumentationState instrumentationState) {
         return new InstrumentationFieldCompleteParameters(
-                this.executionContext, executionStrategyParameters, this.fieldDef, this.typeInfo, this.fetchedValue, instrumentationState);
+                this.executionContext, executionStrategyParameters, this.executionStepInfo, this.fetchedValue, instrumentationState);
     }
 
 
@@ -54,11 +53,16 @@ public class InstrumentationFieldCompleteParameters {
     }
 
     public GraphQLFieldDefinition getField() {
-        return fieldDef;
+        return getExecutionStepInfo().getFieldDefinition();
     }
 
+    @Deprecated
     public ExecutionStepInfo getTypeInfo() {
-        return typeInfo;
+        return getExecutionStepInfo();
+    }
+
+    public ExecutionStepInfo getExecutionStepInfo() {
+        return executionStepInfo.get();
     }
 
     public Object getFetchedValue() {

--- a/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationFieldFetchParameters.java
+++ b/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationFieldFetchParameters.java
@@ -18,14 +18,14 @@ public class InstrumentationFieldFetchParameters extends InstrumentationFieldPar
     private final boolean trivialDataFetcher;
 
     public InstrumentationFieldFetchParameters(ExecutionContext getExecutionContext, GraphQLFieldDefinition fieldDef, DataFetchingEnvironment environment, ExecutionStrategyParameters executionStrategyParameters, boolean trivialDataFetcher) {
-        super(getExecutionContext, fieldDef, environment.getExecutionStepInfo());
+        super(getExecutionContext, environment::getExecutionStepInfo);
         this.environment = environment;
         this.executionStrategyParameters = executionStrategyParameters;
         this.trivialDataFetcher = trivialDataFetcher;
     }
 
-    private InstrumentationFieldFetchParameters(ExecutionContext getExecutionContext, GraphQLFieldDefinition fieldDef, DataFetchingEnvironment environment, InstrumentationState instrumentationState, ExecutionStrategyParameters executionStrategyParameters, boolean trivialDataFetcher) {
-        super(getExecutionContext, fieldDef, environment.getExecutionStepInfo(), instrumentationState);
+    private InstrumentationFieldFetchParameters(ExecutionContext getExecutionContext, DataFetchingEnvironment environment, InstrumentationState instrumentationState, ExecutionStrategyParameters executionStrategyParameters, boolean trivialDataFetcher) {
+        super(getExecutionContext, environment::getExecutionStepInfo, instrumentationState);
         this.environment = environment;
         this.executionStrategyParameters = executionStrategyParameters;
         this.trivialDataFetcher = trivialDataFetcher;
@@ -41,7 +41,7 @@ public class InstrumentationFieldFetchParameters extends InstrumentationFieldPar
     @Override
     public InstrumentationFieldFetchParameters withNewState(InstrumentationState instrumentationState) {
         return new InstrumentationFieldFetchParameters(
-                this.getExecutionContext(), this.getField(), this.getEnvironment(),
+                this.getExecutionContext(), this.getEnvironment(),
                 instrumentationState, executionStrategyParameters, trivialDataFetcher);
     }
 

--- a/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationFieldParameters.java
+++ b/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationFieldParameters.java
@@ -7,23 +7,23 @@ import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationState;
 import graphql.schema.GraphQLFieldDefinition;
 
+import java.util.function.Supplier;
+
 /**
  * Parameters sent to {@link Instrumentation} methods
  */
 @PublicApi
 public class InstrumentationFieldParameters {
     private final ExecutionContext executionContext;
-    private final graphql.schema.GraphQLFieldDefinition fieldDef;
-    private final ExecutionStepInfo executionStepInfo;
+    private final Supplier<ExecutionStepInfo> executionStepInfo;
     private final InstrumentationState instrumentationState;
 
-    public InstrumentationFieldParameters(ExecutionContext executionContext, GraphQLFieldDefinition fieldDef, ExecutionStepInfo executionStepInfo) {
-        this(executionContext, fieldDef, executionStepInfo, executionContext.getInstrumentationState());
+    public InstrumentationFieldParameters(ExecutionContext executionContext, Supplier<ExecutionStepInfo> executionStepInfo) {
+        this(executionContext, executionStepInfo, executionContext.getInstrumentationState());
     }
 
-    InstrumentationFieldParameters(ExecutionContext executionContext, GraphQLFieldDefinition fieldDef, ExecutionStepInfo executionStepInfo, InstrumentationState instrumentationState) {
+    InstrumentationFieldParameters(ExecutionContext executionContext, Supplier<ExecutionStepInfo> executionStepInfo, InstrumentationState instrumentationState) {
         this.executionContext = executionContext;
-        this.fieldDef = fieldDef;
         this.executionStepInfo = executionStepInfo;
         this.instrumentationState = instrumentationState;
     }
@@ -32,12 +32,11 @@ public class InstrumentationFieldParameters {
      * Returns a cloned parameters object with the new state
      *
      * @param instrumentationState the new state for this parameters object
-     *
      * @return a new parameters object with the new state
      */
     public InstrumentationFieldParameters withNewState(InstrumentationState instrumentationState) {
         return new InstrumentationFieldParameters(
-                this.executionContext, this.fieldDef, this.executionStepInfo, instrumentationState);
+                this.executionContext, this.executionStepInfo, instrumentationState);
     }
 
 
@@ -46,11 +45,11 @@ public class InstrumentationFieldParameters {
     }
 
     public GraphQLFieldDefinition getField() {
-        return fieldDef;
+        return executionStepInfo.get().getFieldDefinition();
     }
 
     public ExecutionStepInfo getExecutionStepInfo() {
-        return executionStepInfo;
+        return executionStepInfo.get();
     }
 
     @SuppressWarnings("TypeParameterUnusedInFormals")


### PR DESCRIPTION
This adds lazy ExecutionStepInfo for instrumentation calls )where they MAY not ever use it) and also reduces the number of calls create them and variable resolving.

I ran this code under JProfiler and `graphql.execution.ExecutionStrategy#createExecutionStepInfo` showed up as a hotspot.  Looking into it I see it being called a lot but for low value.  I suspect some coy and paste happened here.

Anyway this is only marginally better performance

```
Baseline:
Benchmark                                    Mode  Cnt   Score   Error  Units
BenchMark.benchMarkSimpleQueriesThroughput  thrpt   15  38.663 ± 1.852  ops/s
BenchMark.benchMarkSimpleQueriesAvgTime      avgt   15  25.562 ± 1.043  ms/op

After:

Benchmark                                    Mode  Cnt   Score   Error  Units
BenchMark.benchMarkSimpleQueriesThroughput  thrpt   15  43.890 ± 2.094  ops/s
BenchMark.benchMarkSimpleQueriesAvgTime      avgt   15  23.282 ± 0.831  ms/op

```

There are NO major wins here but it doe less work AND makes the parameters lazy for instrumentation that may never use the parameters.

