### PR TITLE
Make ExecutionResult implement Serializable

### DIFF
--- a/src/main/java/graphql/ExecutionResult.java
+++ b/src/main/java/graphql/ExecutionResult.java
@@ -1,6 +1,7 @@
 package graphql;
 
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
@@ -9,7 +10,7 @@ import java.util.Map;
  */
 @PublicApi
 @SuppressWarnings("TypeParameterUnusedInFormals")
-public interface ExecutionResult {
+public interface ExecutionResult extends Serializable {
 
     /**
      * @return the errors that occurred during execution or empty list if there is none

--- a/src/main/java/graphql/ExecutionResultImpl.java
+++ b/src/main/java/graphql/ExecutionResultImpl.java
@@ -12,11 +12,12 @@ import static java.util.stream.Collectors.toList;
 
 @Internal
 public class ExecutionResultImpl implements ExecutionResult {
+    private static final long serialVersionUID = 1L;
 
     private final List<GraphQLError> errors;
     private final Object data;
-    private final transient Map<Object, Object> extensions;
-    private final transient boolean dataPresent;
+    private final Map<Object, Object> extensions;
+    private final boolean dataPresent;
 
     public ExecutionResultImpl(GraphQLError error) {
         this(false, null, Collections.singletonList(error), null);

--- a/src/test/groovy/graphql/ExecutionResultImplTest.groovy
+++ b/src/test/groovy/graphql/ExecutionResultImplTest.groovy
@@ -200,5 +200,32 @@ class ExecutionResultImplTest extends Specification {
         extensions == [ext1:"here", ext2 : "aswell"]
     }
 
+    def "test result serialize"() {
+        given:
+        def result = new ExecutionResultImpl("Some Data", KNOWN_ERRORS)
+
+        when:
+        ByteArrayOutputStream bo = new ByteArrayOutputStream()
+        ObjectOutputStream oo = new ObjectOutputStream(bo)
+        oo.writeObject(result)
+        def bytes = bo.toByteArray()
+        bo.close()
+        oo.close()
+
+
+        ByteArrayInputStream bi = new ByteArrayInputStream(bytes);
+        ObjectInputStream oi = new ObjectInputStream(bi);
+        def obj = (ExecutionResultImpl)oi.readObject();
+        def specMap = obj.toSpecification()
+        bo.close()
+        oi.close()
+
+        then:
+        specMap["data"] == "Some Data"
+        print(specMap["errors"])
+        specMap["errors"] == [
+                ['message': 'Yikes', 'locations': [[line: 666, column: 664]], extensions:[classification:"InvalidSyntax"]],
+        ]
+    }
 
 }


### PR DESCRIPTION
1. make ExecutionResult implement Serializable;
2. remove `transient ` from `dataPresent`, since the `toSpecification` in `ExecutionResultImpl` normalize the `data` by dataPresent (the only implementation of ExecutionResult. remove `transient` from `extensions`.

```java
        if (dataPresent) {
            result.put("data", data);
        }
```

If you serialize the `HashMap` of `result.toSpecification()`  to bytes, then you will lost `dataPresent` when you convert `HashMap` to result.

I think it is better for ExecutionResult to support Serializable.

