### PR TITLE
Bug fix and improvements to KnownDirectives

### DIFF
--- a/src/main/java/graphql/validation/rules/KnownDirectives.java
+++ b/src/main/java/graphql/validation/rules/KnownDirectives.java
@@ -19,6 +19,7 @@ import graphql.validation.ValidationErrorCollector;
 import graphql.validation.ValidationErrorType;
 
 import java.util.List;
+import java.util.EnumSet;
 
 @Internal
 public class KnownDirectives extends AbstractRule {
@@ -46,21 +47,26 @@ public class KnownDirectives extends AbstractRule {
 
     @SuppressWarnings("deprecation") // the suppression stands because its deprecated but still in graphql spec
     private boolean hasInvalidLocation(GraphQLDirective directive, Node ancestor) {
+        EnumSet<DirectiveLocation> validLocations = directive.validLocations();
         if (ancestor instanceof OperationDefinition) {
             Operation operation = ((OperationDefinition) ancestor).getOperation();
-            return Operation.QUERY.equals(operation) ?
-                    !(directive.validLocations().contains(DirectiveLocation.QUERY)) :
-                    !(directive.validLocations().contains(DirectiveLocation.MUTATION));
+            if (Operation.QUERY.equals(operation)) {
+                return !validLocations.contains(DirectiveLocation.QUERY);
+            } else if (Operation.MUTATION.equals(operation)) {
+                return !validLocations.contains(DirectiveLocation.MUTATION);
+            } else if (Operation.SUBSCRIPTION.equals(operation)) {
+                return !validLocations.contains(DirectiveLocation.SUBSCRIPTION);
+            }
         } else if (ancestor instanceof Field) {
-            return !(directive.validLocations().contains(DirectiveLocation.FIELD));
+            return !(validLocations.contains(DirectiveLocation.FIELD));
         } else if (ancestor instanceof FragmentSpread) {
-            return !(directive.validLocations().contains(DirectiveLocation.FRAGMENT_SPREAD));
+            return !(validLocations.contains(DirectiveLocation.FRAGMENT_SPREAD));
         } else if (ancestor instanceof FragmentDefinition) {
-            return !(directive.validLocations().contains(DirectiveLocation.FRAGMENT_DEFINITION));
+            return !(validLocations.contains(DirectiveLocation.FRAGMENT_DEFINITION));
         } else if (ancestor instanceof InlineFragment) {
-            return !(directive.validLocations().contains(DirectiveLocation.INLINE_FRAGMENT));
+            return !(validLocations.contains(DirectiveLocation.INLINE_FRAGMENT));
         } else if (ancestor instanceof VariableDefinition) {
-            return !(directive.validLocations().contains(DirectiveLocation.VARIABLE_DEFINITION));
+            return !(validLocations.contains(DirectiveLocation.VARIABLE_DEFINITION));
         }
         return true;
     }

--- a/src/test/groovy/graphql/validation/rules/KnownDirectivesTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/KnownDirectivesTest.groovy
@@ -1,6 +1,7 @@
 package graphql.validation.rules
 
 import graphql.StarWarsSchema
+import graphql.TestUtil
 import graphql.language.Document
 import graphql.parser.Parser
 import graphql.validation.LanguageTraversal
@@ -9,6 +10,7 @@ import graphql.validation.TraversalContext
 import graphql.validation.ValidationContext
 import graphql.validation.ValidationErrorCollector
 import graphql.validation.ValidationErrorType
+import graphql.validation.Validator
 import spock.lang.Specification
 
 class KnownDirectivesTest extends Specification {
@@ -234,5 +236,52 @@ class KnownDirectivesTest extends Specification {
 
     }
 
+    def sdl = '''
+        
+        directive @queryDirective on QUERY 
+        
+        directive @subDirective on SUBSCRIPTION
+ 
+        type Query {
+            field: String
+        }
+        
+    '''
+
+    def schema = TestUtil.schema(sdl)
+
+
+    def "invalid  directive on SUBSCRIPTION"() {
+        def spec = '''
+            subscription sub @queryDirective{
+                field 
+            }
+        '''
+
+        when:
+        def document = TestUtil.parseQuery(spec)
+        def validator = new Validator();
+        def validationErrors = validator.validateDocument(schema, document);
+
+        then:
+        validationErrors.size() == 1
+        validationErrors.get(0).message == "Validation error of type MisplacedDirective: Directive queryDirective not allowed here"
+    }
+
+    def "valid  directive on SUBSCRIPTION"() {
+        def spec = '''
+            subscription sub @subDirective{
+                field 
+            }
+        '''
+
+        when:
+        def document = TestUtil.parseQuery(spec)
+        def validator = new Validator();
+        def validationErrors = validator.validateDocument(schema, document);
+
+        then:
+        validationErrors.size() == 0
+    }
 
 }


### PR DESCRIPTION
The test below will fail:
```
   def sdl = '''
        
        directive @subDirective on SUBSCRIPTION
 
        type Query {
            field: String
        }
        
    '''

    def schema = TestUtil.schema(sdl)


    def "valid  directive on SUBSCRIPTION"() {
        def spec = '''
            subscription sub @subDirective{
                field 
            }
        '''

        when:
        def document = TestUtil.parseQuery(spec)
        def validator = new Validator();
        def validationErrors = validator.validateDocument(schema, document);

        then:
        validationErrors.size() == 0
    }
```
Error message:
```
    Condition not satisfied:

    validationErrors.size() == 0
    |                |      |
    |                1      false
    [ValidationError{validationErrorType=MisplacedDirective, queryPath=null, message=Validation error of type MisplacedDirective: Directive subDirective not allowed here, locations=[SourceLocation{line=2, column=30}], description='Directive subDirective not allowed here'}]

    Condition not satisfied:

    validationErrors.size() == 0
    |                |      |
    |                1      false
    [ValidationError{validationErrorType=MisplacedDirective, queryPath=null, message=Validation error of type MisplacedDirective: Directive subDirective not allowed here, locations=[SourceLocation{line=2, column=30}], description='Directive subDirective not allowed here'}]

    at graphql.validation.rules.KnownDirectivesTest.valid  directive on SUBSCRIPTION(KnownDirectivesTest.groovy:265)
```

There are two main change to `KnownDirectives.hasInvalidLocation` in this PR:
1. Determain whether directive's ancestor is `SUBSCRIPTION`, and then determain whether definitionLocations contain `SUBSCRIPTION`;
2. Invoking `directive.validLocations()` ahead, and then determain whether definitionLocations contain usageLocation. since `directive.validLocations()` will do copy operation, details in #2023 .