### PR TITLE
New validation rule: providing the explicit value 'null' to non-null argument is invalid

### DIFF
--- a/src/main/java/graphql/validation/ValidationErrorType.java
+++ b/src/main/java/graphql/validation/ValidationErrorType.java
@@ -33,5 +33,6 @@ public enum ValidationErrorType {
     DuplicateFragmentName,
     DuplicateDirectiveName,
     DuplicateArgumentNames,
-    DuplicateVariableName
+    DuplicateVariableName,
+    NullValueForNonNullArgument
 }

--- a/src/main/java/graphql/validation/rules/ProvidedNonNullArguments.java
+++ b/src/main/java/graphql/validation/rules/ProvidedNonNullArguments.java
@@ -6,6 +6,8 @@ import graphql.language.Argument;
 import graphql.language.Directive;
 import graphql.language.Field;
 import graphql.language.Node;
+import graphql.language.NullValue;
+import graphql.language.Value;
 import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLFieldDefinition;
@@ -40,6 +42,14 @@ public class ProvidedNonNullArguments extends AbstractRule {
             if (argument == null && nonNullType && noDefaultValue) {
                 String message = String.format("Missing field argument %s", graphQLArgument.getName());
                 addError(ValidationErrorType.MissingFieldArgument, field.getSourceLocation(), message);
+            }
+
+            if(argument!=null) {
+                Value value = argument.getValue();
+                if ((value == null || value instanceof NullValue) && nonNullType && noDefaultValue) {
+                    String message = String.format("null value for non-null field argument %s", graphQLArgument.getName());
+                    addError(ValidationErrorType.NullValueForNonNullArgument, field.getSourceLocation(), message);
+                }
             }
         }
     }


### PR DESCRIPTION
[required Arguments rule](https://spec.graphql.org/draft/#sel-HALTHHFTCAACCnCjmR)
>Providing the explicit value null is also not valid since required arguments always have a non‐null type.

[demo](https://spec.graphql.org/draft/#example-0bc81):
```sql
fragment missingRequiredArg on Arguments {
  nonNullBooleanArgField(nonNullBooleanArg: null)
}
```