### PR TITLE
minor cleanups

### DIFF
--- a/src/main/java/graphql/execution/Async.java
+++ b/src/main/java/graphql/execution/Async.java
@@ -4,6 +4,7 @@ import graphql.Assert;
 import graphql.Internal;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -44,8 +45,8 @@ public class Async {
         return overallResult;
     }
 
-    public static <T, U> CompletableFuture<List<U>> each(Iterable<T> list, BiFunction<T, Integer, CompletableFuture<U>> cfFactory) {
-        List<CompletableFuture<U>> futures = new ArrayList<>();
+    public static <T, U> CompletableFuture<List<U>> each(Collection<T> list, BiFunction<T, Integer, CompletableFuture<U>> cfFactory) {
+        List<CompletableFuture<U>> futures = new ArrayList<>(list.size());
         int index = 0;
         for (T t : list) {
             CompletableFuture<U> cf;
@@ -178,13 +179,13 @@ public class Async {
     public static <U, T> List<CompletableFuture<U>> map(List<CompletableFuture<T>> values, Function<T, U> mapper) {
         return values
                 .stream()
-                .map(cf -> cf.thenApply(mapper::apply)).collect(Collectors.toList());
+                .map(cf -> cf.thenApply(mapper)).collect(Collectors.toList());
     }
 
     public static <U, T> List<CompletableFuture<U>> mapCompose(List<CompletableFuture<T>> values, Function<T, CompletableFuture<U>> mapper) {
         return values
                 .stream()
-                .map(cf -> cf.thenCompose(mapper::apply)).collect(Collectors.toList());
+                .map(cf -> cf.thenCompose(mapper)).collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/graphql/execution/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncExecutionStrategy.java
@@ -45,8 +45,8 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
 
         MergedSelectionSet fields = parameters.getFields();
         List<String> fieldNames = new ArrayList<>(fields.keySet());
-        List<CompletableFuture<FieldValueInfo>> futures = new ArrayList<>();
-        List<String> resolvedFields = new ArrayList<>();
+        List<CompletableFuture<FieldValueInfo>> futures = new ArrayList<>(fieldNames.size());
+        List<String> resolvedFields = new ArrayList<>(fieldNames.size());
         for (String fieldName : fieldNames) {
             MergedField currentField = fields.getSubField(fieldName);
 

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -296,8 +296,7 @@ public abstract class ExecutionStrategy {
                                                 Object result) {
 
         if (result instanceof DataFetcherResult) {
-            //noinspection unchecked
-            DataFetcherResult<?> dataFetcherResult = (DataFetcherResult) result;
+            DataFetcherResult<?> dataFetcherResult = (DataFetcherResult<?>) result;
             if (dataFetcherResult.isMapRelativeErrors()) {
                 dataFetcherResult.getErrors().stream()
                         .map(relError -> new AbsoluteGraphQLError(parameters, relError))
@@ -665,7 +664,6 @@ public abstract class ExecutionStrategy {
      * @return an Iterable from that object
      * @throws java.lang.ClassCastException if its not an Iterable
      */
-    @SuppressWarnings("unchecked")
     protected Iterable<Object> toIterable(Object result) {
         return FpKit.toCollection(result);
     }

--- a/src/main/java/graphql/execution/ExecutionStrategyParameters.java
+++ b/src/main/java/graphql/execution/ExecutionStrategyParameters.java
@@ -3,7 +3,6 @@ package graphql.execution;
 import graphql.Assert;
 import graphql.PublicApi;
 
-import java.util.Map;
 import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;

--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -131,7 +131,7 @@ public class ValuesResolver {
 
 
     private Map<String, Argument> argumentMap(List<Argument> arguments) {
-        Map<String, Argument> result = new LinkedHashMap<>();
+        Map<String, Argument> result = new LinkedHashMap<>(arguments.size());
         for (Argument argument : arguments) {
             result.put(argument.getName(), argument);
         }

--- a/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
+++ b/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
@@ -263,7 +263,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
                 .queryDirectives(queryDirectives)
                 .build();
 
-        DataFetcher supplied = codeRegistry.getDataFetcher(parentType, fieldDef);
+        DataFetcher<?> supplied = codeRegistry.getDataFetcher(parentType, fieldDef);
         boolean trivialDataFetcher = supplied instanceof TrivialDataFetcher;
         BatchedDataFetcher batchedDataFetcher = batchingFactory.create(supplied);
 
@@ -350,7 +350,6 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
         }
     }
 
-    @SuppressWarnings("unchecked")
     private List<ExecutionNode> handleList(ExecutionContext executionContext, Map<String, Object> argumentValues,
                                            FetchedValues fetchedValues, String fieldName, MergedField fields,
                                            ExecutionStepInfo executionStepInfo) {
@@ -379,7 +378,6 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
         return completeValues(executionContext, flattenedFetchedValues, newExecutionStepInfo, fieldName, fields, argumentValues);
     }
 
-    @SuppressWarnings("UnnecessaryLocalVariable")
     private List<ExecutionNode> handleObject(ExecutionContext executionContext, Map<String, Object> argumentValues,
                                              FetchedValues fetchedValues, String fieldName, MergedField fields,
                                              ExecutionStepInfo executionStepInfo) {


### PR DESCRIPTION
- presizing of few internal data structures
- removing unused method in ExecutionStrategy (public api, technically a breaking change)
- removing unused methods in Async (internal api)
- removing few unnecessary annotations