### PR TITLE
Create directive definition when map introspectionResult to schema

### DIFF
--- a/src/main/java/graphql/DirectiveInfo.java
+++ b/src/main/java/graphql/DirectiveInfo.java
@@ -1,0 +1,52 @@
+package graphql;
+
+import graphql.schema.GraphQLDirective;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Info on all the directives provided by graphql specification
+ */
+@PublicApi
+public class DirectiveInfo {
+
+    /**
+     * A set of directives which provided by graphql specification
+     */
+    public static final Set<GraphQLDirective> GRAPHQL_SPECIFICATION_DIRECTIVES = new LinkedHashSet();
+
+    /**
+     * A map from directive name to directive which provided by specification
+     */
+    public static final Map<String, GraphQLDirective> GRAPHQL_SPECIFICATION_DIRECTIVE_MAP = new LinkedHashMap<>();
+
+    static{
+        GRAPHQL_SPECIFICATION_DIRECTIVES.add(Directives.IncludeDirective);
+        GRAPHQL_SPECIFICATION_DIRECTIVES.add(Directives.SkipDirective);
+        GRAPHQL_SPECIFICATION_DIRECTIVES.add(Directives.DeprecatedDirective);
+        GRAPHQL_SPECIFICATION_DIRECTIVES.add(Directives.SpecifiedByDirective);
+    }
+
+    static {
+        GRAPHQL_SPECIFICATION_DIRECTIVE_MAP.put(Directives.IncludeDirective.getName(), Directives.IncludeDirective);
+        GRAPHQL_SPECIFICATION_DIRECTIVE_MAP.put(Directives.SkipDirective.getName(), Directives.SkipDirective);
+        GRAPHQL_SPECIFICATION_DIRECTIVE_MAP.put(Directives.DeprecatedDirective.getName(), Directives.DeprecatedDirective);
+        GRAPHQL_SPECIFICATION_DIRECTIVE_MAP.put(Directives.SpecifiedByDirective.getName(), Directives.SpecifiedByDirective);
+    }
+
+
+    /**
+     * Returns true if a directive with provided directiveName has been defined in graphql specification
+     *
+     * @param directiveName the name of directive in question
+     *
+     * @return true if the directive provided by graphql specification, and false otherwise
+     */
+    public static boolean isGraphqlSpecifiedDirective(String directiveName) {
+        return GRAPHQL_SPECIFICATION_DIRECTIVE_MAP.containsKey(directiveName);
+    }
+
+}

--- a/src/main/java/graphql/introspection/IntrospectionResultToSchema.java
+++ b/src/main/java/graphql/introspection/IntrospectionResultToSchema.java
@@ -6,6 +6,8 @@ import graphql.language.Argument;
 import graphql.language.AstValueHelper;
 import graphql.language.Description;
 import graphql.language.Directive;
+import graphql.language.DirectiveDefinition;
+import graphql.language.DirectiveLocation;
 import graphql.language.Document;
 import graphql.language.EnumTypeDefinition;
 import graphql.language.EnumValueDefinition;
@@ -35,9 +37,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static graphql.Assert.assertNotEmpty;
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertShouldNeverHappen;
 import static graphql.Assert.assertTrue;
+import static graphql.DirectiveInfo.isGraphqlSpecifiedDirective;
 
 @SuppressWarnings("unchecked")
 @PublicApi
@@ -61,7 +65,7 @@ public class IntrospectionResultToSchema {
 
 
     /**
-     * Returns a IDL Document that reprSesents the schema as defined by the introspection result map
+     * Returns a IDL Document that represents the schema as defined by the introspection result map
      *
      * @param introspectionResult the result of an introspection query on a schema
      *
@@ -79,6 +83,7 @@ public class IntrospectionResultToSchema {
         boolean nonDefaultQueryName = !"Query".equals(query.getName());
 
         SchemaDefinition.Builder schemaDefinition = SchemaDefinition.newSchemaDefinition();
+        schemaDefinition.description(toDescription(schema));
         schemaDefinition.operationTypeDefinition(OperationTypeDefinition.newOperationTypeDefinition().name("query").typeName(query).build());
 
         Map<String, Object> mutationType = (Map<String, Object>) schema.get("mutationType");
@@ -109,7 +114,51 @@ public class IntrospectionResultToSchema {
             document.definition(typeDefinition);
         }
 
+        List<Map<String, Object>> directives = (List<Map<String, Object>>) schema.get("directives");
+        if (directives != null) {
+            for (Map<String, Object> directive : directives) {
+                DirectiveDefinition directiveDefinition = createDirective(directive);
+                if (directiveDefinition == null) {
+                    continue;
+                }
+                document.definition(directiveDefinition);
+            }
+        }
+
         return document.build();
+    }
+
+    private DirectiveDefinition createDirective(Map<String, Object> input) {
+        String directiveName = (String) input.get("name");
+        if(isGraphqlSpecifiedDirective(directiveName)){
+            return null;
+        }
+
+        DirectiveDefinition.Builder directiveDefBuilder = DirectiveDefinition.newDirectiveDefinition();
+        directiveDefBuilder
+                .name(directiveName)
+                .description(toDescription(input));
+
+        List<Object> locations = (List<Object>) input.get("locations");
+        List<DirectiveLocation> directiveLocations = createDirectiveLocations(locations);
+        directiveDefBuilder.directiveLocations(directiveLocations);
+
+
+        List<Map<String, Object>> args = (List<Map<String, Object>>) input.get("args");
+        List<InputValueDefinition> inputValueDefinitions = createInputValueDefinitions(args);
+        directiveDefBuilder.inputValueDefinitions(inputValueDefinitions);
+
+        return directiveDefBuilder.build();
+    }
+
+    private List<DirectiveLocation> createDirectiveLocations(List<Object> locations) {
+        assertNotEmpty(locations, () -> "the locations of directive should not be empty.");
+        ArrayList<DirectiveLocation> result = new ArrayList<>();
+        for (Object location : locations) {
+            DirectiveLocation directiveLocation = DirectiveLocation.newDirectiveLocation().name(location.toString()).build();
+            result.add(directiveLocation);
+        }
+        return result;
     }
 
     private TypeDefinition createTypeDefinition(Map<String, Object> type) {
@@ -139,8 +188,10 @@ public class IntrospectionResultToSchema {
         if (ScalarInfo.isGraphqlSpecifiedScalar(name)) {
             return null;
         }
-        String specifiedBy = (String) input.get("specifiedBy");
-        return ScalarTypeDefinition.newScalarTypeDefinition().name(name).build();
+        return ScalarTypeDefinition.newScalarTypeDefinition()
+                .name(name)
+                .description(toDescription(input))
+                .build();
     }
 
 

--- a/src/main/java/graphql/introspection/IntrospectionResultToSchema.java
+++ b/src/main/java/graphql/introspection/IntrospectionResultToSchema.java
@@ -41,7 +41,7 @@ import static graphql.Assert.assertNotEmpty;
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertShouldNeverHappen;
 import static graphql.Assert.assertTrue;
-import static graphql.DirectiveInfo.isGraphqlSpecifiedDirective;
+import static graphql.schema.idl.DirectiveInfo.isGraphqlSpecifiedDirective;
 
 @SuppressWarnings("unchecked")
 @PublicApi

--- a/src/main/java/graphql/language/AstPrinter.java
+++ b/src/main/java/graphql/language/AstPrinter.java
@@ -99,6 +99,7 @@ public class AstPrinter {
     private NodePrinter<DirectiveDefinition> directiveDefinition() {
         final String argSep = compactMode ? "," : ", ";
         return (out, node) -> {
+            out.printf("%s", description(node));
             String arguments = wrap("(", join(node.getInputValueDefinitions(), argSep), ")");
             String locations = join(node.getDirectiveLocations(), " | ");
             out.printf("directive @%s%s on %s", node.getName(), arguments, locations);
@@ -331,6 +332,7 @@ public class AstPrinter {
 
     private NodePrinter<SchemaDefinition> schemaDefinition() {
         return (out, node) -> {
+            out.printf("%s", description(node));
             out.printf("%s", spaced(
                     "schema",
                     directives(node.getDirectives()),

--- a/src/main/java/graphql/schema/idl/DirectiveInfo.java
+++ b/src/main/java/graphql/schema/idl/DirectiveInfo.java
@@ -1,5 +1,7 @@
-package graphql;
+package graphql.schema.idl;
 
+import graphql.Directives;
+import graphql.PublicApi;
 import graphql.schema.GraphQLDirective;
 
 import java.util.LinkedHashMap;

--- a/src/test/groovy/graphql/introspection/IntrospectionResultToSchemaTest.groovy
+++ b/src/test/groovy/graphql/introspection/IntrospectionResultToSchemaTest.groovy
@@ -673,4 +673,130 @@ input InputType {
         then:
         document == null
     }
+
+    def "create scalars"() {
+        def input = ''' {
+            "kind": "SCALAR",
+            "name": "ScalarType",
+            "description": "description of ScalarType",
+      }
+      '''
+        def parsed = slurp(input)
+
+        when:
+        def scalarTypeDefinition = introspectionResultToSchema.createScalar(parsed)
+        def result = printAst(scalarTypeDefinition)
+
+        then:
+        result == """"description of ScalarType"\nscalar ScalarType"""
+    }
+
+    def " create directives "() {
+        def input = '''
+                    {
+                       "name": "customizedDirective",
+                       "locations": [
+                            "FIELD",
+                            "FRAGMENT_SPREAD",
+                            "INLINE_FRAGMENT"
+                       ],
+                       "args": []
+                    }
+        '''
+        def parsed = slurp(input)
+
+        when:
+        def directiveDefinition = introspectionResultToSchema.createDirective(parsed)
+        def result = printAst(directiveDefinition)
+
+        then:
+        result == """directive @customizedDirective on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT"""
+    }
+
+    def "create directives with arguments and default value"() {
+        def input = '''{
+            "name": "customizedDirective",
+            "description": "customized directive",
+            "locations": [
+                "FIELD",
+                "FRAGMENT_SPREAD",
+                "INLINE_FRAGMENT"
+            ],
+            "args": [
+                  {
+                    "name": "directiveArg",
+                    "description": "directive arg",
+                    "type": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    },
+                    "isDeprecated": false,
+                    "deprecationReason": null,
+                    "defaultValue": "\\"default Value\\""
+                  }
+             ]
+        }
+      '''
+        def parsed = slurp(input)
+
+        when:
+        def directiveDefinition = introspectionResultToSchema.createDirective(parsed)
+        def result = printAst(directiveDefinition)
+
+        then:
+        result == """"customized directive"
+directive @customizedDirective("directive arg"
+directiveArg: String = "default Value") on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT"""
+    }
+
+    def "create schema with directives"() {
+        def input = """{
+          "__schema": {
+            "queryType": {
+              "name": "QueryType"
+            },
+            "types": [],
+            "directives": [
+                {
+                    "name": "customizedDirective",
+                    "description": "customized directive",
+                    "locations": [
+                        "FIELD",
+                        "FRAGMENT_SPREAD",
+                        "INLINE_FRAGMENT"
+                    ],
+                    "args": [
+                          {
+                            "name": "directiveArg",
+                            "description": "directive arg",
+                            "type": {
+                              "kind": "SCALAR",
+                              "name": "String",
+                              "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null,
+                            "defaultValue": "\\"default Value\\""
+                          }
+                     ]
+                }
+            ]
+         }"""
+        def parsed = slurp(input)
+
+        when:
+        Document document = introspectionResultToSchema.createSchemaDefinition(parsed)
+        def result = printAst(document)
+
+        then:
+        result == """schema {
+  query: QueryType
+}
+
+"customized directive"
+directive @customizedDirective("directive arg"
+directiveArg: String = "default Value") on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+"""
+    }
 }


### PR DESCRIPTION
Changes about this PR:
1. **main purpose: create directive definition when map introspectionResult to schema**;
2. add `DirectiveInfo` to hold the directive info provided by graphql specification;
3. add some test about create scalars, create directives, create directives with arguments and default value, create schema with directives;
4. add description information of `ScalarTypeDefinition ` and `SchemaDefinition ` when map introspectionResult to schema;
5. add description information of `DirectiveDefinition` and `SchemaDefinition ` in `AstPrinter`;