### PR TITLE
Fix AstTransformer extension being converted to base type when changing child node

### DIFF
--- a/src/main/java/graphql/analysis/QueryTraverser.java
+++ b/src/main/java/graphql/analysis/QueryTraverser.java
@@ -35,7 +35,7 @@ import static java.util.Collections.singletonList;
  * visitField calls.
  */
 @PublicApi
-public class    QueryTraverser {
+public class QueryTraverser {
 
     private final Collection<? extends Node> roots;
     private final GraphQLSchema schema;

--- a/src/main/java/graphql/language/AstPrinter.java
+++ b/src/main/java/graphql/language/AstPrinter.java
@@ -65,6 +65,7 @@ public class AstPrinter {
         printers.put(ScalarTypeDefinition.class, scalarTypeDefinition());
         printers.put(ScalarTypeExtensionDefinition.class, scalarTypeExtensionDefinition());
         printers.put(SchemaDefinition.class, schemaDefinition());
+        printers.put(SchemaExtensionDefinition.class, schemaExtensionDefinition());
         printers.put(SelectionSet.class, selectionSet());
         printers.put(StringValue.class, value());
         printers.put(TypeName.class, type());
@@ -382,6 +383,10 @@ public class AstPrinter {
 
     private NodePrinter<InputObjectTypeExtensionDefinition> inputObjectTypeExtensionDefinition() {
         return (out, node) -> out.printf("extend %s", node(node, InputObjectTypeDefinition.class));
+    }
+
+    private NodePrinter<SchemaExtensionDefinition> schemaExtensionDefinition() {
+        return (out, node) -> out.printf("extend %s", node(node, SchemaDefinition.class));
     }
 
     private NodePrinter<UnionTypeDefinition> unionTypeDefinition() {

--- a/src/main/java/graphql/language/EnumTypeExtensionDefinition.java
+++ b/src/main/java/graphql/language/EnumTypeExtensionDefinition.java
@@ -51,6 +51,14 @@ public class EnumTypeExtensionDefinition extends EnumTypeDefinition {
         return new Builder();
     }
 
+    @Override
+    public EnumTypeExtensionDefinition withNewChildren(NodeChildrenContainer newChildren) {
+        return transformExtension(builder -> builder
+                .enumValueDefinitions(newChildren.getChildren(CHILD_ENUM_VALUE_DEFINITIONS))
+                .directives(newChildren.getChildren(CHILD_DIRECTIVES))
+        );
+    }
+
     public EnumTypeExtensionDefinition transformExtension(Consumer<Builder> builderConsumer) {
         Builder builder = new Builder(this);
         builderConsumer.accept(builder);

--- a/src/main/java/graphql/language/InputObjectTypeExtensionDefinition.java
+++ b/src/main/java/graphql/language/InputObjectTypeExtensionDefinition.java
@@ -51,6 +51,13 @@ public class InputObjectTypeExtensionDefinition extends InputObjectTypeDefinitio
         return new Builder();
     }
 
+    @Override
+    public InputObjectTypeExtensionDefinition withNewChildren(NodeChildrenContainer newChildren) {
+        return transformExtension(builder -> builder
+                .directives(newChildren.getChildren(CHILD_DIRECTIVES))
+                .inputValueDefinitions(newChildren.getChildren(CHILD_INPUT_VALUES_DEFINITIONS))
+        );
+    }
 
     public InputObjectTypeExtensionDefinition transformExtension(Consumer<Builder> builderConsumer) {
         Builder builder = new Builder(this);

--- a/src/main/java/graphql/language/InterfaceTypeExtensionDefinition.java
+++ b/src/main/java/graphql/language/InterfaceTypeExtensionDefinition.java
@@ -54,6 +54,14 @@ public class InterfaceTypeExtensionDefinition extends InterfaceTypeDefinition {
         return new Builder();
     }
 
+    @Override
+    public InterfaceTypeExtensionDefinition withNewChildren(NodeChildrenContainer newChildren) {
+        return transformExtension(builder -> builder
+                .definitions(newChildren.getChildren(CHILD_DEFINITIONS))
+                .directives(newChildren.getChildren(CHILD_DIRECTIVES))
+        );
+    }
+
     public InterfaceTypeExtensionDefinition transformExtension(Consumer<Builder> builderConsumer) {
         Builder builder = new Builder(this);
         builderConsumer.accept(builder);

--- a/src/main/java/graphql/language/ObjectTypeExtensionDefinition.java
+++ b/src/main/java/graphql/language/ObjectTypeExtensionDefinition.java
@@ -52,6 +52,12 @@ public class ObjectTypeExtensionDefinition extends ObjectTypeDefinition {
                 getAdditionalData());
     }
 
+    @Override
+    public ObjectTypeExtensionDefinition withNewChildren(NodeChildrenContainer newChildren) {
+        return transformExtension(builder -> builder.implementz(newChildren.getChildren(CHILD_IMPLEMENTZ))
+                .directives(newChildren.getChildren(CHILD_DIRECTIVES))
+                .fieldDefinitions(newChildren.getChildren(CHILD_FIELD_DEFINITIONS)));
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/graphql/language/ScalarTypeExtensionDefinition.java
+++ b/src/main/java/graphql/language/ScalarTypeExtensionDefinition.java
@@ -42,6 +42,13 @@ public class ScalarTypeExtensionDefinition extends ScalarTypeDefinition {
         return new Builder();
     }
 
+    @Override
+    public ScalarTypeExtensionDefinition withNewChildren(NodeChildrenContainer newChildren) {
+        return transformExtension(builder -> builder
+                .directives(newChildren.getChildren(CHILD_DIRECTIVES))
+        );
+    }
+
     public ScalarTypeExtensionDefinition transformExtension(Consumer<Builder> builderConsumer) {
         Builder builder = new Builder(this);
         builderConsumer.accept(builder);

--- a/src/main/java/graphql/language/UnionTypeExtensionDefinition.java
+++ b/src/main/java/graphql/language/UnionTypeExtensionDefinition.java
@@ -57,6 +57,14 @@ public class UnionTypeExtensionDefinition extends UnionTypeDefinition {
         return new Builder();
     }
 
+    @Override
+    public UnionTypeExtensionDefinition withNewChildren(NodeChildrenContainer newChildren) {
+        return transformExtension(builder -> builder
+                .directives(newChildren.getChildren(CHILD_DIRECTIVES))
+                .memberTypes(newChildren.getChildren(CHILD_MEMBER_TYPES))
+        );
+    }
+
     public UnionTypeExtensionDefinition transformExtension(Consumer<Builder> builderConsumer) {
         Builder builder = new Builder(this);
         builderConsumer.accept(builder);

--- a/src/test/groovy/graphql/language/AstPrinterTest.groovy
+++ b/src/test/groovy/graphql/language/AstPrinterTest.groovy
@@ -454,6 +454,10 @@ type Query {
 
     def "print type extensions"() {
         def query = '''
+    extend schema {
+        query: Query
+    }
+    
     extend type Object @directive {
         objectField : String
     }    
@@ -479,7 +483,11 @@ type Query {
         String output = printAst(document)
 
         expect:
-        output == '''extend type Object @directive {
+        output == '''extend schema {
+  query: Query
+}
+
+extend type Object @directive {
   objectField: String
 }
 


### PR DESCRIPTION
### Description
When using the `AstTransformer`, and working on extensions, I noticed in some cases when changing a child node on an extension, the resulting node would wrongly be converted to its base type. 

Here is an **example**, given: 
```graphql
extend type MyType {
  login: String
}
```
and changing the field `login` to say `signin` using the `AstTransformer` will have the effect of changing `MyType` extension object type to an object type. 
Resulting document would be:
```graphql
type MyType {
  signin: String
}
```

## Fix 
This bug happens because the `AstTransformer` uses the `withNewChildren()` method on each definition to reattach the children and this method being missing in extensions would defer to using `withNewChildren()` on the base definition returning a new instance of the base instead of the extensions.

Adding the appropriate override in each extension definition solves the issue.

I also noticed while writing the test, the `AstPrinter` was missing knowledge on how to print schema extensions.

## Testing
Unit test in `AstTransformerTest` covers all types of extensions.
Unit test in `AstPrinterTest` covers the missed schema extension printing.

(I can backport on 14.x once it merges)