### PR TITLE
 Add directive validation rules defined in spec

### DIFF
--- a/src/main/java/graphql/schema/idl/SchemaTypeDirectivesChecker.java
+++ b/src/main/java/graphql/schema/idl/SchemaTypeDirectivesChecker.java
@@ -18,12 +18,20 @@ import graphql.language.NonNullType;
 import graphql.language.ObjectTypeDefinition;
 import graphql.language.SchemaDefinition;
 import graphql.language.TypeDefinition;
+import graphql.language.ScalarTypeDefinition;
+import graphql.language.NamedNode;
+import graphql.language.TypeName;
 import graphql.language.UnionTypeDefinition;
 import graphql.schema.idl.errors.DirectiveIllegalLocationError;
 import graphql.schema.idl.errors.DirectiveMissingNonNullArgumentError;
 import graphql.schema.idl.errors.DirectiveUndeclaredError;
 import graphql.schema.idl.errors.DirectiveUnknownArgumentError;
+import graphql.schema.idl.errors.MissingTypeError;
+import graphql.schema.idl.errors.NotAnInputTypeError;
+import graphql.schema.idl.errors.IllegalNameError;
+import graphql.schema.idl.errors.DirectiveIllegalReferenceError;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -91,6 +99,9 @@ class SchemaTypeDirectivesChecker {
         // we need to have a Node for error reporting so we make one in case there is not one
         SchemaDefinition schemaDefinition = typeRegistry.schemaDefinition().orElse(SchemaDefinition.newSchemaDefinition().build());
         checkDirectives(DirectiveLocation.SCHEMA, errors, typeRegistry, schemaDefinition, "schema", schemaDirectives);
+
+        Collection<DirectiveDefinition> directiveDefinitions = typeRegistry.getDirectiveDefinitions().values();
+        commonCheck(directiveDefinitions, errors);
     }
 
 
@@ -174,5 +185,45 @@ class SchemaTypeDirectivesChecker {
 
     private boolean isNoNullArgWithoutDefaultValue(InputValueDefinition definitionArgument) {
         return definitionArgument.getType() instanceof NonNullType && definitionArgument.getDefaultValue() == null;
+    }
+
+    private void commonCheck(Collection<DirectiveDefinition> directiveDefinitions, List<GraphQLError> errors) {
+        directiveDefinitions.forEach(directiveDefinition -> {
+            assertTypeName(directiveDefinition, errors);
+            directiveDefinition.getInputValueDefinitions().forEach(inputValueDefinition -> {
+                assertTypeName(inputValueDefinition, errors);
+                assertExistAndIsInputType(inputValueDefinition, errors);
+                if (inputValueDefinition.getDirective(directiveDefinition.getName()) != null) {
+                    errors.add(new DirectiveIllegalReferenceError(directiveDefinition, inputValueDefinition));
+                }
+            });
+        });
+    }
+
+    private void assertTypeName(NamedNode node, List<GraphQLError> errors) {
+        if (node.getName().length() >= 2 && node.getName().startsWith("__")) {
+            errors.add((new IllegalNameError(node)));
+        }
+    }
+
+    public void assertExistAndIsInputType(InputValueDefinition definition, List<GraphQLError> errors) {
+        TypeName namedType = TypeUtil.unwrapAll(definition.getType());
+
+        TypeDefinition unwrappedType = findTypeDefFromRegistry(namedType.getName(), typeRegistry);
+
+        if (unwrappedType == null) {
+            errors.add(new MissingTypeError(namedType.getName(), definition, definition.getName()));
+            return;
+        }
+
+        if (!(unwrappedType instanceof InputObjectTypeDefinition)
+                && !(unwrappedType instanceof EnumTypeDefinition)
+                && !(unwrappedType instanceof ScalarTypeDefinition)) {
+            errors.add(new NotAnInputTypeError(namedType, unwrappedType));
+        }
+    }
+
+    private TypeDefinition findTypeDefFromRegistry(String typeName, TypeDefinitionRegistry typeRegistry) {
+        return typeRegistry.getType(typeName).orElseGet(() -> typeRegistry.scalars().get(typeName));
     }
 }

--- a/src/main/java/graphql/schema/idl/TypeUtil.java
+++ b/src/main/java/graphql/schema/idl/TypeUtil.java
@@ -1,0 +1,105 @@
+package graphql.schema.idl;
+
+import graphql.language.Type;
+import graphql.language.TypeName;
+import graphql.language.ListType;
+import graphql.language.NonNullType;
+
+/**
+ * This class consists of {@code static} utility methods for operating on {@link graphql.language.Type}.
+ */
+public class TypeUtil {
+
+    /**
+     * This will return the type in graphql SDL format, eg [typeName!]!
+     *
+     * @param type the type in play
+     * @return the type in graphql SDL format, eg [typeName!]!
+     */
+    public static String simplePrint(Type type) {
+        StringBuilder sb = new StringBuilder();
+        if (isNonNull(type)) {
+            sb.append(simplePrint(unwrapOne(type)));
+            sb.append("!");
+        } else if (isList(type)) {
+            sb.append("[");
+            sb.append(simplePrint(unwrapOne(type)));
+            sb.append("]");
+        } else {
+            sb.append(((TypeName) type).getName());
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Unwraps all layers of the type or just returns the type again if its not a wrapped type
+     *
+     * @param type the type to be unwrapped
+     *
+     * @return the unwrapped type or the same type again if its not wrapped
+     */
+    public static TypeName unwrapAll(Type type) {
+        if (isList(type)) {
+            return unwrapAll(((ListType) type).getType());
+        } else if (type instanceof NonNullType) {
+            return unwrapAll(((NonNullType) type).getType());
+        }
+        return (TypeName) type;
+    }
+
+    /**
+     * Unwraps one layer of the type or just returns the type again if its not a wrapped type
+     *
+     * @param type the type to be unwrapped
+     *
+     * @return the unwrapped type or the same type again if its not wrapped
+     */
+    public static Type unwrapOne(Type type) {
+        if (isNonNull(type)) {
+            return ((NonNullType) type).getType();
+        } else if (isList(type)) {
+            return ((ListType) type).getType();
+        }
+        return type;
+    }
+
+    /**
+     * Returns {@code true} if the provided type is a non null type,
+     * otherwise returns {@code false}.
+     *
+     * @param type the type to check
+     *
+     * @return {@code true} if the provided type is a non null type
+     * otherwise {@code false}
+     */
+    public static boolean isNonNull(Type type) {
+        return type instanceof NonNullType;
+    }
+
+    /**
+     * Returns {@code true} if the provided type is a list type,
+     * otherwise returns {@code false}.
+     *
+     * @param type the type to check
+     *
+     * @return {@code true} if the provided type is a list typ,
+     * otherwise {@code false}
+     */
+    public static boolean isList(Type type) {
+        return type instanceof ListType;
+    }
+
+    /**
+     * Returns {@code true} if the given type is a non null or list type,
+     * that is a wrapped type, otherwise returns {@code false}.
+     *
+     * @param type the type to check
+     *
+     * @return {@code true} if the given type is a non null or list type,
+     * otherwise {@code false}
+     */
+    public static boolean isWrapped(Type type) {
+        return isList(type) || isNonNull(type);
+    }
+
+}

--- a/src/main/java/graphql/schema/idl/errors/DirectiveIllegalReferenceError.java
+++ b/src/main/java/graphql/schema/idl/errors/DirectiveIllegalReferenceError.java
@@ -1,0 +1,15 @@
+package graphql.schema.idl.errors;
+
+import graphql.Internal;
+import graphql.language.DirectiveDefinition;
+import graphql.language.NamedNode;
+
+@Internal
+public class DirectiveIllegalReferenceError extends BaseError {
+    public DirectiveIllegalReferenceError(DirectiveDefinition directive, NamedNode location) {
+        super(directive,
+                String.format("'%s' must not reference itself on '%s''%s'",
+                        directive.getName(), location.getName(), lineCol(location)
+                ));
+    }
+}

--- a/src/main/java/graphql/schema/idl/errors/IllegalNameError.java
+++ b/src/main/java/graphql/schema/idl/errors/IllegalNameError.java
@@ -1,0 +1,14 @@
+package graphql.schema.idl.errors;
+
+import graphql.Internal;
+import graphql.language.NamedNode;
+
+@Internal
+public class IllegalNameError extends BaseError {
+    public IllegalNameError(NamedNode directiveDefinition) {
+        super(directiveDefinition,
+                String.format("'%s''%s' must not begin with '__', which is reserved by GraphQL introspection.",
+                        directiveDefinition.getName(), lineCol(directiveDefinition)
+                ));
+    }
+}

--- a/src/main/java/graphql/schema/idl/errors/MissingTypeError.java
+++ b/src/main/java/graphql/schema/idl/errors/MissingTypeError.java
@@ -19,4 +19,9 @@ public class MissingTypeError extends BaseError {
         super(node, format("The %s type '%s' is not present when resolving type '%s' %s",
                 typeOfType, typeName.getName(), name, lineCol(node)));
     }
+
+    public MissingTypeError(String typeOfType, Node node,String name) {
+        super(node, format("The %s type is not present when resolving type '%s' %s",
+                typeOfType, name, lineCol(node)));
+    }
 }


### PR DESCRIPTION
[Details in spec](https://spec.graphql.org/draft/#sec-Type-System.Directives.Validation):
1. A directive definition must not contain the use of a directive which references itself indirectly;
2. The directive must not have a name which begins with the characters "__" (two underscores).
3. For each argument of the directive:
    - The argument must not have a name which begins with the characters "__" (two underscores);
    -  _The type of argument must exist;_
    - The argument must accept a type where IsInputType(argumentType) returns true.

others: