### PR TITLE
Support for Streams and Iterators

### DIFF
--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -39,10 +39,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.function.Supplier;
@@ -56,7 +56,9 @@ import static graphql.execution.FieldValueInfo.CompleteValueType.NULL;
 import static graphql.execution.FieldValueInfo.CompleteValueType.OBJECT;
 import static graphql.execution.FieldValueInfo.CompleteValueType.SCALAR;
 import static graphql.schema.DataFetchingEnvironmentImpl.newDataFetchingEnvironment;
+import static graphql.schema.GraphQLTypeUtil.isEnum;
 import static graphql.schema.GraphQLTypeUtil.isList;
+import static graphql.schema.GraphQLTypeUtil.isScalar;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
 /**
@@ -421,10 +423,10 @@ public abstract class ExecutionStrategy {
             return FieldValueInfo.newFieldValueInfo(NULL).fieldValue(fieldValue).build();
         } else if (isList(fieldType)) {
             return completeValueForList(executionContext, parameters, result);
-        } else if (fieldType instanceof GraphQLScalarType) {
+        } else if (isScalar(fieldType)) {
             fieldValue = completeValueForScalar(executionContext, parameters, (GraphQLScalarType) fieldType, result);
             return FieldValueInfo.newFieldValueInfo(SCALAR).fieldValue(fieldValue).build();
-        } else if (fieldType instanceof GraphQLEnumType) {
+        } else if (isEnum(fieldType)) {
             fieldValue = completeValueForEnum(executionContext, parameters, (GraphQLEnumType) fieldType, result);
             return FieldValueInfo.newFieldValueInfo(ENUM).fieldValue(fieldValue).build();
         }
@@ -494,19 +496,19 @@ public abstract class ExecutionStrategy {
      */
     protected FieldValueInfo completeValueForList(ExecutionContext executionContext, ExecutionStrategyParameters parameters, Iterable<Object> iterableValues) {
 
-        Collection<Object> values = FpKit.toCollection(iterableValues);
+        OptionalInt size = FpKit.toSize(iterableValues);
         ExecutionStepInfo executionStepInfo = parameters.getExecutionStepInfo();
 
-        InstrumentationFieldCompleteParameters instrumentationParams = new InstrumentationFieldCompleteParameters(executionContext, parameters, () -> executionStepInfo, values);
+        InstrumentationFieldCompleteParameters instrumentationParams = new InstrumentationFieldCompleteParameters(executionContext, parameters, () -> executionStepInfo, iterableValues);
         Instrumentation instrumentation = executionContext.getInstrumentation();
 
         InstrumentationContext<ExecutionResult> completeListCtx = instrumentation.beginFieldListComplete(
                 instrumentationParams
         );
 
-        List<FieldValueInfo> fieldValueInfos = new ArrayList<>(values.size());
+        List<FieldValueInfo> fieldValueInfos = new ArrayList<>(size.orElse(1));
         int index = 0;
-        for (Object item : values) {
+        for (Object item : iterableValues) {
             ResultPath indexedPath = parameters.getPath().segment(index);
 
             ExecutionStepInfo stepInfoForListElement = executionStepInfoFactory.newExecutionStepInfoForListElement(executionStepInfo, index);
@@ -519,7 +521,7 @@ public abstract class ExecutionStrategy {
             ExecutionStrategyParameters newParameters = parameters.transform(builder ->
                     builder.executionStepInfo(stepInfoForListElement)
                             .nonNullFieldValidator(nonNullableFieldValidator)
-                            .listSize(values.size())
+                            .listSize(size.orElse(-1)) // -1 signals that we don't know the size
                             .localContext(value.getLocalContext())
                             .currentListIndex(finalIndex)
                             .path(indexedPath)
@@ -674,13 +676,14 @@ public abstract class ExecutionStrategy {
 
 
     protected Iterable<Object> toIterable(ExecutionContext context, ExecutionStrategyParameters parameters, Object result) {
-        if (result.getClass().isArray() || result instanceof Iterable) {
-            return toIterable(result);
+        if (FpKit.isIterable(result)) {
+            return FpKit.toIterable(result);
         }
 
         handleTypeMismatchProblem(context, parameters, result);
         return null;
     }
+
 
     private void handleTypeMismatchProblem(ExecutionContext context, ExecutionStrategyParameters parameters, Object result) {
         TypeMismatchError error = new TypeMismatchError(parameters.getPath(), parameters.getExecutionStepInfo().getUnwrappedNonNullType());

--- a/src/main/java/graphql/util/FpKit.java
+++ b/src/main/java/graphql/util/FpKit.java
@@ -10,7 +10,9 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
@@ -19,6 +21,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static java.util.Collections.singletonList;
 import static java.util.function.Function.identity;
@@ -31,10 +34,10 @@ public class FpKit {
     // From a list of named things, get a map of them by name, merging them according to the merge function
     public static <T> Map<String, T> getByName(List<T> namedObjects, Function<T, String> nameFn, BinaryOperator<T> mergeFunc) {
         return namedObjects.stream().collect(Collectors.toMap(
-                nameFn,
-                identity(),
-                mergeFunc,
-                LinkedHashMap::new)
+            nameFn,
+            identity(),
+            mergeFunc,
+            LinkedHashMap::new)
         );
     }
 
@@ -45,10 +48,10 @@ public class FpKit {
 
     public static <T, NewKey> Map<NewKey, T> groupingByUniqueKey(Collection<T> list, Function<T, NewKey> keyFunction) {
         return list.stream().collect(Collectors.toMap(
-                keyFunction,
-                identity(),
-                throwingMerger(),
-                LinkedHashMap::new)
+            keyFunction,
+            identity(),
+            throwingMerger(),
+            LinkedHashMap::new)
         );
     }
 
@@ -75,17 +78,15 @@ public class FpKit {
      *
      * @param iterableResult the result object
      * @param <T>            the type of thing
-     *
      * @return an Iterable from that object
-     *
      * @throws java.lang.ClassCastException if its not an Iterable
      */
     @SuppressWarnings("unchecked")
     public static <T> Collection<T> toCollection(Object iterableResult) {
         if (iterableResult.getClass().isArray()) {
             List<Object> collect = IntStream.range(0, Array.getLength(iterableResult))
-                    .mapToObj(i -> Array.get(iterableResult, i))
-                    .collect(Collectors.toList());
+                .mapToObj(i -> Array.get(iterableResult, i))
+                .collect(Collectors.toList());
             return (List<T>) collect;
         }
         if (iterableResult instanceof Collection) {
@@ -100,14 +101,79 @@ public class FpKit {
         return list;
     }
 
+    public static boolean isIterable(Object result) {
+        return result.getClass().isArray() || result instanceof Iterable || result instanceof Stream || result instanceof Iterator;
+    }
+
+
+    @SuppressWarnings("unchecked")
+    public static <T> Iterable<T> toIterable(Object iterableResult) {
+        if (iterableResult instanceof Iterable) {
+            return ((Iterable<T>) iterableResult);
+        }
+
+        if (iterableResult instanceof Stream) {
+            return ((Stream<T>) iterableResult)::iterator;
+        }
+
+        if (iterableResult instanceof Iterator) {
+            return () -> (Iterator<T>) iterableResult;
+        }
+
+        if (iterableResult.getClass().isArray()) {
+            return () -> new ArrayIterator<>(iterableResult);
+        }
+
+        throw new ClassCastException("not Iterable: " + iterableResult.getClass());
+    }
+
+    private static class ArrayIterator<T> implements Iterator<T> {
+
+        private final Object array;
+        private final int size;
+        private int i;
+
+        private ArrayIterator(Object array) {
+            this.array = array;
+            this.size = Array.getLength(array);
+            this.i = 0;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return i < size;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public T next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            return (T) Array.get(array, i++);
+        }
+
+    }
+
+    public static OptionalInt toSize(Object iterableResult) {
+        if (iterableResult instanceof Collection) {
+            return OptionalInt.of(((Collection<?>) iterableResult).size());
+        }
+
+        if (iterableResult.getClass().isArray()) {
+            return OptionalInt.of(Array.getLength(iterableResult));
+        }
+
+        return OptionalInt.empty();
+    }
+
     /**
      * Concatenates (appends) a single elements to an existing list
      *
      * @param l   the list onto which to append the element
      * @param t   the element to append
      * @param <T> the type of elements of the list
-     *
-     * @return a <strong>new</strong> list componsed of the first list elements and the new element
+     * @return a <strong>new</strong> list composed of the first list elements and the new element
      */
     public static <T> List<T> concat(List<T> l, T t) {
         return concat(l, singletonList(t));
@@ -119,7 +185,6 @@ public class FpKit {
      * @param l1  the first list to concatenate
      * @param l2  the second list to concatenate
      * @param <T> the type of element of the lists
-     *
      * @return a <strong>new</strong> list composed of the two concatenated lists elements
      */
     public static <T> List<T> concat(List<T> l1, List<T> l2) {
@@ -152,7 +217,7 @@ public class FpKit {
             for (int j = 0; j < colCount; j++) {
                 T val = matrix.get(i).get(j);
                 if (result.size() <= j) {
-                    result.add(j, new ArrayList());
+                    result.add(j, new ArrayList<>());
                 }
                 result.get(j).add(i, val);
             }
@@ -166,15 +231,15 @@ public class FpKit {
 
     public static <T> List<T> flatList(List<List<T>> listLists) {
         return listLists.stream()
-                .flatMap(List::stream)
-                .collect(Collectors.toList());
+            .flatMap(List::stream)
+            .collect(Collectors.toList());
     }
 
     public static <T> Optional<T> findOne(Collection<T> list, Predicate<T> filter) {
         return list
-                .stream()
-                .filter(filter)
-                .findFirst();
+            .stream()
+            .filter(filter)
+            .findFirst();
     }
 
     public static <T> T findOneOrNull(List<T> list, Predicate<T> filter) {


### PR DESCRIPTION
Hi @bbakerman @andimarek,

 please find my first attempt to be a bit more lazy during list processing in `completeValueForList`.

 The basic idea is to avoid to "materialize" a `Stream` (and later maybe `Iterator`) into an `ArrayList`. 

I don't like some details of this PR (notably passing -1 as `listSize`) but let's start the discussion anyway. Maybe someone have better ideas there.

