### PR TITLE
Fix TypesImplementInterfaces.check() for interfaces implementing interface #2072 

### DIFF
--- a/src/main/java/graphql/schema/validation/TypesImplementInterfaces.java
+++ b/src/main/java/graphql/schema/validation/TypesImplementInterfaces.java
@@ -174,6 +174,8 @@ public class TypesImplementInterfaces implements SchemaValidationRule {
             return objectIsMemberOfUnion((GraphQLUnionType) constraintType, objectType);
         } else if (constraintType instanceof GraphQLInterfaceType && objectType instanceof GraphQLObjectType) {
             return objectImplementsInterface((GraphQLInterfaceType) constraintType, (GraphQLObjectType) objectType);
+        } else if (constraintType instanceof GraphQLInterfaceType && objectType instanceof GraphQLInterfaceType) {
+            return interfaceImplementsInterface((GraphQLInterfaceType) constraintType, (GraphQLInterfaceType) objectType);
         } else if (isList(constraintType) && isList(objectType)) {
             GraphQLOutputType wrappedConstraintType = (GraphQLOutputType) unwrapOne(constraintType);
             GraphQLOutputType wrappedObjectType = (GraphQLOutputType) unwrapOne(objectType);
@@ -200,6 +202,10 @@ public class TypesImplementInterfaces implements SchemaValidationRule {
 
     boolean objectImplementsInterface(GraphQLInterfaceType interfaceType, GraphQLObjectType objectType) {
         return objectType.getInterfaces().contains(interfaceType);
+    }
+
+    boolean interfaceImplementsInterface(GraphQLInterfaceType interfaceType, GraphQLInterfaceType implementingType) {
+        return implementingType.getInterfaces().contains(interfaceType);
     }
 
     boolean objectIsMemberOfUnion(GraphQLUnionType unionType, GraphQLOutputType objectType) {

--- a/src/test/groovy/graphql/schema/validation/TypesImplementInterfacesTest.groovy
+++ b/src/test/groovy/graphql/schema/validation/TypesImplementInterfacesTest.groovy
@@ -195,6 +195,55 @@ class TypesImplementInterfacesTest extends Specification {
         !badErrorCollector.getErrors().isEmpty()
     }
 
+    def "field is list of interfaces implementing interface" () {
+        given:
+        def person = newInterface()
+                .name("Person")
+                .field(newFieldDefinition().name("name").type(GraphQLString).build())
+                .typeResolver({})
+                .build()
+
+        def actor = newInterface()
+                .name("Actor")
+                .field(newFieldDefinition().name("name").type(GraphQLString).build())
+                .withInterface(person)
+                .build()
+
+        def prop = newObject()
+                .name("Prop")
+                .field(newFieldDefinition().name("name").type(GraphQLString).build())
+                .build()
+
+        GraphQLInterfaceType interfaceType = newInterface()
+                .name("TestInterface")
+                .field(newFieldDefinition().name("field").type(list(person)).build())
+                .typeResolver({})
+                .build()
+
+        GraphQLObjectType goodImpl = newObject()
+                .name("GoodImpl")
+                .field(newFieldDefinition().name("field").type(list(actor)).build())
+                .withInterface(interfaceType)
+                .build()
+
+        GraphQLObjectType badImpl = newObject()
+                .name("BadImpl")
+                .field(newFieldDefinition().name("field").type(list(prop)).build())
+                .withInterface(interfaceType)
+                .build()
+
+        SchemaValidationErrorCollector goodErrorCollector = new SchemaValidationErrorCollector()
+        SchemaValidationErrorCollector badErrorCollector = new SchemaValidationErrorCollector()
+
+        when:
+        new TypesImplementInterfaces().check(goodImpl, goodErrorCollector)
+        new TypesImplementInterfaces().check(badImpl, badErrorCollector)
+
+        then:
+        goodErrorCollector.getErrors().isEmpty()
+        !badErrorCollector.getErrors().isEmpty()
+    }
+
     def "field is member of union"() {
         given:
         def actor = newObject()


### PR DESCRIPTION
This is a fix for #2072.
It adds another check for the case where both types are of `GraphQLInterfaceType` and then checks if the implementing type actually has the correct interface, similar to how `objectImplementsInterface` works. It also includes a test for the case mentioned in the issue.