### PR TITLE
avoiding allocations in FieldCollectorParameters and MergedField

### DIFF
--- a/src/main/java/graphql/execution/FieldCollectorParameters.java
+++ b/src/main/java/graphql/execution/FieldCollectorParameters.java
@@ -6,7 +6,6 @@ import graphql.language.FragmentDefinition;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -48,8 +47,8 @@ public class FieldCollectorParameters {
 
     public static class Builder {
         private GraphQLSchema graphQLSchema;
-        private final Map<String, FragmentDefinition> fragmentsByName = new LinkedHashMap<>();
-        private final Map<String, Object> variables = new LinkedHashMap<>();
+        private Map<String, FragmentDefinition> fragmentsByName;
+        private Map<String, Object> variables;
         private GraphQLObjectType objectType;
 
         /**
@@ -70,12 +69,12 @@ public class FieldCollectorParameters {
         }
 
         public Builder fragments(Map<String, FragmentDefinition> fragmentsByName) {
-            this.fragmentsByName.putAll(fragmentsByName);
+            this.fragmentsByName = fragmentsByName;
             return this;
         }
 
         public Builder variables(Map<String, Object> variables) {
-            this.variables.putAll(variables);
+            this.variables = variables;
             return this;
         }
 

--- a/src/main/java/graphql/execution/MergedField.java
+++ b/src/main/java/graphql/execution/MergedField.java
@@ -67,7 +67,7 @@ public class MergedField {
 
     private MergedField(List<Field> fields) {
         assertNotEmpty(fields);
-        this.fields = unmodifiableList(new ArrayList<>(fields));
+        this.fields = unmodifiableList(fields);
         this.singleField = fields.get(0);
         this.name = singleField.getName();
         this.resultKey = singleField.getAlias() != null ? singleField.getAlias() : name;
@@ -144,7 +144,8 @@ public class MergedField {
     }
 
     public static class Builder {
-        private List<Field> fields;
+
+        private final List<Field> fields;
 
         private Builder() {
             this.fields = new ArrayList<>();
@@ -155,7 +156,7 @@ public class MergedField {
         }
 
         public Builder fields(List<Field> fields) {
-            this.fields = fields;
+            this.fields.addAll(fields);
             return this;
         }
 
@@ -167,7 +168,6 @@ public class MergedField {
         public MergedField build() {
             return new MergedField(fields);
         }
-
 
     }
 


### PR DESCRIPTION
ExecutionContext uses immutable maps for variables and fragments, that could be shared freely.

And, since this is an internal class, we could change a bit the contract and avoid some allocations of LinkedHashMap:

                .fragments(executionContext.getFragmentsByName())
                .variables(executionContext.getVariables())

