### PR TITLE
Add schema validator to check if object type is not empty

### DIFF
--- a/src/main/java/graphql/schema/validation/ObjectTypeWithNoField.java
+++ b/src/main/java/graphql/schema/validation/ObjectTypeWithNoField.java
@@ -1,0 +1,34 @@
+package graphql.schema.validation;
+
+import graphql.Internal;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLType;
+
+import static graphql.schema.validation.SchemaValidationErrorType.ObjectDoesNotContainsAnyField;
+
+/**
+ * Schema validation rule ensuring an object type has defined any field.
+ */
+@Internal
+public class ObjectTypeWithNoField implements SchemaValidationRule {
+    @Override
+    public void check(GraphQLFieldDefinition fieldDef, SchemaValidationErrorCollector validationErrorCollector) {
+
+    }
+
+    @Override
+    public void check(GraphQLType type, SchemaValidationErrorCollector validationErrorCollector) {
+        if (type instanceof GraphQLObjectType) {
+            check((GraphQLObjectType) type, validationErrorCollector);
+        }
+    }
+
+    public void check(GraphQLObjectType type, SchemaValidationErrorCollector validationErrorCollector) {
+        if (type.getFieldDefinitions().isEmpty()) {
+            String msg = String.format("%s type does not contains any fields", type.getName());
+            SchemaValidationError error = new SchemaValidationError(ObjectDoesNotContainsAnyField, msg);
+            validationErrorCollector.addError(error);
+        }
+    }
+}

--- a/src/main/java/graphql/schema/validation/SchemaValidationErrorType.java
+++ b/src/main/java/graphql/schema/validation/SchemaValidationErrorType.java
@@ -6,5 +6,6 @@ import graphql.Internal;
 public enum SchemaValidationErrorType {
 
     UnbrokenInputCycle,
-    ObjectDoesNotImplementItsInterfaces
+    ObjectDoesNotImplementItsInterfaces,
+    ObjectDoesNotContainsAnyField
 }

--- a/src/main/java/graphql/schema/validation/SchemaValidator.java
+++ b/src/main/java/graphql/schema/validation/SchemaValidator.java
@@ -22,6 +22,7 @@ public class SchemaValidator {
     public SchemaValidator() {
         rules.add(new NoUnbrokenInputCycles());
         rules.add(new TypesImplementInterfaces());
+        rules.add(new ObjectTypeWithNoField());
     }
 
     SchemaValidator(List<SchemaValidationRule> rules) {

--- a/src/test/groovy/graphql/schema/validation/ObjectTypeWithNoFieldTest.groovy
+++ b/src/test/groovy/graphql/schema/validation/ObjectTypeWithNoFieldTest.groovy
@@ -1,0 +1,50 @@
+package graphql.schema.validation
+
+import graphql.schema.GraphQLObjectType
+import spock.lang.Specification
+
+import static SchemaValidationErrorType.ObjectDoesNotContainsAnyField
+import static graphql.Scalars.GraphQLString
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
+
+class ObjectTypeWithNoFieldTest extends Specification {
+
+    def "object type with no fields"() {
+        given: "type with no fields"
+        GraphQLObjectType noFieldObjType = GraphQLObjectType.newObject()
+                .name("obj")
+                .build()
+
+        and: "a errorCollector"
+        SchemaValidationErrorCollector errorCollector = new SchemaValidationErrorCollector()
+
+        when: "a check if the type is valid"
+        new ObjectTypeWithNoField().check(noFieldObjType, errorCollector)
+
+        then: "errorCollector contains ObjectDoesNotContainsAnyField error"
+        errorCollector.containsValidationError(ObjectDoesNotContainsAnyField)
+        errorCollector.getErrors() == [
+                new SchemaValidationError(ObjectDoesNotContainsAnyField,
+                        "obj type does not contains any fields")
+        ]
+    }
+
+    def "object type with a field"() {
+        given: "type with one field"
+        GraphQLObjectType noFieldObjType = GraphQLObjectType.newObject()
+                .name("obj")
+                .field(newFieldDefinition().name("name").type(GraphQLString))
+                .build()
+
+        and: "a errorCollector"
+        SchemaValidationErrorCollector errorCollector = new SchemaValidationErrorCollector()
+
+        when: "a check if the type is valid"
+        new ObjectTypeWithNoField().check(noFieldObjType, errorCollector)
+
+        then: "errorCollector dosen't contains any error"
+        !errorCollector.containsValidationError(ObjectDoesNotContainsAnyField)
+        errorCollector.getErrors().isEmpty()
+    }
+
+}


### PR DESCRIPTION
Documentation of graphql doesn't allow to define object with no fields : http://spec.graphql.org/draft/#sel-HAHZhCFBABABuBq9O