### PR TITLE
Update antlr to 4.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     implementation 'org.slf4j:slf4j-api:' + slf4jVersion
     api 'com.graphql-java:java-dataloader:2.2.3'
     api 'org.reactivestreams:reactive-streams:' + reactiveStreamsVersion
-    antlr "org.antlr:antlr4:4.7.2"
+    antlr "org.antlr:antlr4:4.8"
     testImplementation group: 'junit', name: 'junit', version: '4.12'
     testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
     testImplementation 'org.codehaus.groovy:groovy-all:2.5.13'


### PR DESCRIPTION
I am not sure if there is a reason that antlr4-runtime and antlt4 is on different versions ? In case this is ok to make them the same, here is a PR for that.

We get 

> ANTLR Tool version 4.7.2 used for code generation does not match the current runtime version 4.8

in SmallRye (and Quarkus). I am not sure if this is related.

Thanks :)