### PR TITLE
Fix for coerceVariableValues

### DIFF
--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -68,21 +68,12 @@ public class ValuesResolver {
                 }
             } else {
                 Object value = variableValues.get(variableName);
-                Object coercedValue = getVariableValue(fieldVisibility, variableDefinition, variableType, value);
+                Object coercedValue = coerceValue(fieldVisibility, variableDefinition, variableDefinition.getName(), variableType, value);
                 coercedValues.put(variableName, coercedValue);
             }
         }
 
         return coercedValues;
-    }
-
-    private Object getVariableValue(GraphqlFieldVisibility fieldVisibility, VariableDefinition variableDefinition, GraphQLType variableType, Object value) {
-
-        if (value == null && variableDefinition.getDefaultValue() != null) {
-            return coerceValueAst(fieldVisibility, variableType, variableDefinition.getDefaultValue(), null);
-        }
-
-        return coerceValue(fieldVisibility, variableDefinition, variableDefinition.getName(), variableType, value);
     }
 
     public Map<String, Object> getArgumentValues(List<GraphQLArgument> argumentTypes, List<Argument> arguments, Map<String, Object> variables) {


### PR DESCRIPTION
Fix for [coerceVariableValues](https://github.com/graphql-java/graphql-java/blob/0de364ae0fdc75126b0217ba6ad61253ec4007c0/src/main/java/graphql/execution/ValuesResolver.java#L54) to ensure that:
1. use null when variable defined in variableValuesMap is null;
2. if variableType is a Non‐Nullable type and value is null, throw a query error.

Linkage to [algorithm defined in spec](https://spec.graphql.org/draft/#sec-Coercing-Variable-Values)