### PR TITLE
#1914 Use default values for fields of input types when default argument value is provided

### DIFF
--- a/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
+++ b/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
@@ -24,6 +24,7 @@ import graphql.language.Node;
 import graphql.language.NullValue;
 import graphql.language.ObjectTypeDefinition;
 import graphql.language.ObjectTypeExtensionDefinition;
+import graphql.language.ObjectField;
 import graphql.language.ObjectValue;
 import graphql.language.OperationTypeDefinition;
 import graphql.language.ScalarTypeDefinition;
@@ -292,8 +293,13 @@ public class SchemaGeneratorHelper {
 
     Object buildObjectValue(ObjectValue defaultValue, GraphQLInputObjectType objectType) {
         Map<String, Object> map = new LinkedHashMap<>();
-        defaultValue.getObjectFields().forEach(of -> map.put(of.getName(),
-                buildValue(of.getValue(), objectType.getField(of.getName()).getType())));
+        objectType.getFieldDefinitions().forEach(
+                f -> {
+                    final Value<?> fieldValueFromDefaultObjectValue = defaultValue.getObjectFields().stream()
+                            .filter(dvf -> dvf.getName().equals(f.getName())).map(ObjectField::getValue).findFirst().orElse(null);
+                    map.put(f.getName(), fieldValueFromDefaultObjectValue != null ? buildValue(fieldValueFromDefaultObjectValue, f.getType()): f.getDefaultValue());
+                }
+        );
         return map;
     }
 

--- a/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
+++ b/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
@@ -295,12 +295,20 @@ public class SchemaGeneratorHelper {
         Map<String, Object> map = new LinkedHashMap<>();
         objectType.getFieldDefinitions().forEach(
                 f -> {
-                    final Value<?> fieldValueFromDefaultObjectValue = defaultValue.getObjectFields().stream()
-                            .filter(dvf -> dvf.getName().equals(f.getName())).map(ObjectField::getValue).findFirst().orElse(null);
-                    map.put(f.getName(), fieldValueFromDefaultObjectValue != null ? buildValue(fieldValueFromDefaultObjectValue, f.getType()): f.getDefaultValue());
+                    final Value<?> fieldValueFromDefaultObjectValue = getFieldValueFromObjectValue(defaultValue, f.getName());
+                    map.put(f.getName(), fieldValueFromDefaultObjectValue != null ? buildValue(fieldValueFromDefaultObjectValue, f.getType()) : f.getDefaultValue());
                 }
         );
         return map;
+    }
+
+    Value<?> getFieldValueFromObjectValue(final ObjectValue objectValue, final String fieldName) {
+        return objectValue.getObjectFields()
+                .stream()
+                .filter(dvf -> dvf.getName().equals(fieldName))
+                .map(ObjectField::getValue)
+                .findFirst()
+                .orElse(null);
     }
 
     String buildDescription(Node<?> node, Description description) {

--- a/src/test/groovy/graphql/Issue1914.groovy
+++ b/src/test/groovy/graphql/Issue1914.groovy
@@ -1,0 +1,81 @@
+package graphql
+
+import graphql.schema.DataFetcher
+import spock.lang.Specification
+
+class Issue1914 extends Specification {
+
+    def "default values in input objects are respected when variable is not provided"() {
+        given:
+        def spec = """type Query {
+            sayHello(arg: Arg! = {}): String
+        }
+        input Arg {
+            foo: String = "bar"
+        }
+        """
+        DataFetcher df = { dfe ->
+            Map arg = dfe.getArgument("arg")
+            return arg.get("foo")
+        } as DataFetcher
+        def graphQL = TestUtil.graphQL(spec, ["Query": ["sayHello": df]]).build()
+
+        when:
+        def result = graphQL.execute('{sayHello}')
+
+        then:
+        result.errors.isEmpty()
+        result.data == [sayHello: "bar"]
+
+    }
+
+    def "default values in input objects are overridden when variable is provided"() {
+        given:
+        def spec = """type Query {
+            sayHello(arg: Arg! = {foo: "brewery"}): String
+        }
+        input Arg {
+            foo: String = "bar"
+        }
+        """
+        DataFetcher df = { dfe ->
+            Map arg = dfe.getArgument("arg")
+            return arg.get("foo")
+        } as DataFetcher
+        def graphQL = TestUtil.graphQL(spec, ["Query": ["sayHello": df]]).build()
+
+        when:
+        def result = graphQL.execute('{sayHello}')
+
+        then:
+        result.errors.isEmpty()
+        result.data == [sayHello: "brewery"]
+
+    }
+
+    def "default values in input objects are overridden when variable is provided and otherwise default values in input objects are respected"() {
+        given:
+        def spec = """type Query {
+            sayHello(arg: Arg! = {field1: "F1ValOverride"}): String
+        }
+        input Arg {
+            field1: String = "F1V"
+            field2: String = "F2V"
+        }
+        """
+        DataFetcher df = { dfe ->
+            Map arg = dfe.getArgument("arg")
+            return arg.get("field1") + " & " + arg.get("field2")
+        } as DataFetcher
+        def graphQL = TestUtil.graphQL(spec, ["Query": ["sayHello": df]]).build()
+
+        when:
+        def result = graphQL.execute('{sayHello}')
+
+        then:
+        result.errors.isEmpty()
+        result.data == [sayHello: "F1ValOverride & F2V"]
+
+    }
+}
+

--- a/src/test/groovy/graphql/Issue1914.groovy
+++ b/src/test/groovy/graphql/Issue1914.groovy
@@ -53,7 +53,7 @@ class Issue1914 extends Specification {
 
     }
 
-    def "default values in input objects are overridden when variable is provided and otherwise default values in input objects are respected"() {
+    def "default values in input objects are overridden when variable is provided and otherwise are respected"() {
         given:
         def spec = """type Query {
             sayHello(arg: Arg! = {field1: "F1ValOverride"}): String

--- a/src/test/groovy/graphql/Issue1914.groovy
+++ b/src/test/groovy/graphql/Issue1914.groovy
@@ -53,6 +53,30 @@ class Issue1914 extends Specification {
 
     }
 
+    def "default values in input objects are overridden when null value is provided in input"() {
+        given:
+        def spec = """type Query {
+            sayHello(arg: Arg! = {foo: null}): String
+        }
+        input Arg {
+            foo: String = "bar"
+        }
+        """
+        DataFetcher df = { dfe ->
+            Map arg = dfe.getArgument("arg")
+            return arg.get("foo")
+        } as DataFetcher
+        def graphQL = TestUtil.graphQL(spec, ["Query": ["sayHello": df]]).build()
+
+        when:
+        def result = graphQL.execute('{sayHello}')
+
+        then:
+        result.errors.isEmpty()
+        result.data == [sayHello: null]
+
+    }
+
     def "default values in input objects are overridden when variable is provided and otherwise are respected"() {
         given:
         def spec = """type Query {

--- a/src/test/groovy/graphql/Issue1914.groovy
+++ b/src/test/groovy/graphql/Issue1914.groovy
@@ -105,17 +105,19 @@ class Issue1914 extends Specification {
     def "default values (including null) in input objects are overridden when variable is provided and otherwise are respected"() {
         given:
         def spec = """type Query {
-            sayHello(arg: Arg! = {field1: "F1ValOverride"}): String
+            sayHello(arg: Arg! = {field1: "F1ValOverride", field5: "F5Val"}): String
         }
         input Arg {
             field1: String = "F1V"
             field2: String = "F2V"
-            field3: String
+            field3: String = null
+            field4: String
+            field5: String
         }
         """
         DataFetcher df = { dfe ->
             Map arg = dfe.getArgument("arg")
-            return arg.get("field1") + " & " + arg.get("field2") + " & " + arg.get("field3")
+            return arg.get("field1") + " & " + arg.get("field2") + " & " + arg.get("field3") + " & " + arg.get("field4") + " & " + arg.get("field5")
         } as DataFetcher
         def graphQL = TestUtil.graphQL(spec, ["Query": ["sayHello": df]]).build()
 
@@ -124,7 +126,7 @@ class Issue1914 extends Specification {
 
         then:
         result.errors.isEmpty()
-        result.data == [sayHello: "F1ValOverride & F2V & null"]
+        result.data == [sayHello: "F1ValOverride & F2V & null & null & F5Val"]
 
     }
 }

--- a/src/test/groovy/graphql/introspection/IntrospectionResultToSchemaTest.groovy
+++ b/src/test/groovy/graphql/introspection/IntrospectionResultToSchemaTest.groovy
@@ -590,7 +590,7 @@ input CharacterInput {
 }
 
 type Query {
-  outputField(inputArg: InputType = {age : 666, name : "nameViaArg"}, inputBoolean: Boolean = true, inputInt: Int = 1, inputString: String = "viaArgString"): OutputType
+  outputField(inputArg: InputType = {age : 666, complex : {boolean : true, int : 666, string : "string"}, name : "nameViaArg", rocks : true}, inputBoolean: Boolean = true, inputInt: Int = 1, inputString: String = "viaArgString"): OutputType
 }
 
 input ComplexType {


### PR DESCRIPTION
Adds support for honoring the default values declared in input type definition ([Issue](https://github.com/graphql-java/graphql-java/issues/1914))

### Example 1
Schema:
```
type Query {
    sayHello(arg: Arg! = {}): String
}

input Arg {
    foo: String = "Bar"
}
```
Query:
```
query {
    sayHello
}
```
arg value before change:
`{}`

arg value after change:
`{foo: "Bar"}`

### Example 2
Schema:
```
type Query {
    sayHello(arg: Arg! = {field1: "F1ValOverride"}): String
}

input Arg {
    field1: String = "F1V"
    field2: String = "F2V"
}
```
Query:
```
query {
    sayHello
}
```
arg value before change:
`{field1: "F1ValOverride"}`

arg value after change:
`{field1: "F1ValOverride", field2: "F2V"}`
