### PR TITLE
Makes a default data fetcher exception handler possible

### DIFF
--- a/src/main/java/graphql/execution/ValueUnboxer.java
+++ b/src/main/java/graphql/execution/ValueUnboxer.java
@@ -2,9 +2,17 @@ package graphql.execution;
 
 import graphql.PublicSpi;
 
+/**
+ * A value unboxer takes values that are wrapped in classes like {@link java.util.Optional} / {@link java.util.OptionalInt} etc..
+ * and returns value from them.  You can provide your own implementation if you have your own specific
+ * holder classes.
+ */
 @PublicSpi
 public interface ValueUnboxer {
 
+    /**
+     * The default value unboxer handles JDK classes such as {@link java.util.Optional} and {@link java.util.OptionalInt} etc..
+     */
     ValueUnboxer DEFAULT = new DefaultValueUnboxer();
 
     /**
@@ -13,7 +21,6 @@ public interface ValueUnboxer {
      * unmodified
      *
      * @param object to unbox
-     *
      * @return unboxed object, or original if cannot unbox
      */
     Object unbox(final Object object);


### PR DESCRIPTION
This allows consumers to put ina  default data fetching exception handler more easily and after 2 years as deprecated we have removed the direct constructors on the `GraphQL` object