### PR TITLE
This moves the AST element builder to use immutable lists 

### DIFF
--- a/src/main/java/graphql/collect/ImmutableKit.java
+++ b/src/main/java/graphql/collect/ImmutableKit.java
@@ -2,13 +2,14 @@ package graphql.collect;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import graphql.Assert;
 import graphql.Internal;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+
+import static graphql.Assert.assertNotNull;
 
 @Internal
 public final class ImmutableKit {
@@ -40,7 +41,7 @@ public final class ImmutableKit {
      */
 
     public static <K, V> ImmutableMap<K, ImmutableList<V>> toImmutableMapOfLists(Map<K, List<V>> startingMap) {
-        Assert.assertNotNull(startingMap);
+        assertNotNull(startingMap);
         ImmutableMap.Builder<K, ImmutableList<V>> map = ImmutableMap.builder();
         for (Map.Entry<K, List<V>> e : startingMap.entrySet()) {
             ImmutableList<V> value = ImmutableList.copyOf(startingMap.getOrDefault(e.getKey(), emptyList()));
@@ -66,22 +67,46 @@ public final class ImmutableKit {
      * This is more efficient than `c.stream().map().collect()` because it does not create the intermediate objects needed
      * for the flexible style.  Benchmarking has shown this to outperform `stream()`.
      *
-     * @param collection the collection to map
-     * @param mapper     the mapper function
-     * @param <T>        for two
-     * @param <R>        for result
+     * @param iterable the iterable to map
+     * @param mapper   the mapper function
+     * @param <T>      for two
+     * @param <R>      for result
      *
      * @return a map immutable list of results
      */
-    public static <T, R> ImmutableList<R> map(Collection<T> collection, Function<? super T, ? extends R> mapper) {
-        Assert.assertNotNull(collection);
-        Assert.assertNotNull(mapper);
+    public static <T, R> ImmutableList<R> map(Iterable<? extends T> iterable, Function<? super T, ? extends R> mapper) {
+        assertNotNull(iterable);
+        assertNotNull(mapper);
         @SuppressWarnings("RedundantTypeArguments")
         ImmutableList.Builder<R> builder = ImmutableList.<R>builder();
-        for (T t : collection) {
+        for (T t : iterable) {
             R r = mapper.apply(t);
             builder.add(r);
         }
         return builder.build();
     }
+
+    /**
+     * This constructs a new Immutable list from an existing collection and adds a new element to it.
+     *
+     * @param existing    the existing collection
+     * @param newValue    the new value to add
+     * @param extraValues more values to add
+     * @param <T>         for two
+     *
+     * @return an Immutable list with the extra effort.
+     */
+    public static <T> ImmutableList<T> addToList(Collection<? extends T> existing, T newValue, T... extraValues) {
+        assertNotNull(existing);
+        assertNotNull(newValue);
+        int expectedSize = existing.size() + 1 + extraValues.length;
+        ImmutableList.Builder<T> newList = ImmutableList.builderWithExpectedSize(expectedSize);
+        newList.addAll(existing);
+        newList.add(newValue);
+        for (T extraValue : extraValues) {
+            newList.add(extraValue);
+        }
+        return newList.build();
+    }
+
 }

--- a/src/main/java/graphql/language/Argument.java
+++ b/src/main/java/graphql/language/Argument.java
@@ -7,7 +7,6 @@ import graphql.PublicApi;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -22,10 +21,9 @@ import static java.util.Collections.emptyMap;
 @PublicApi
 public class Argument extends AbstractNode<Argument> implements NamedNode<Argument> {
 
+    public static final String CHILD_VALUE = "value";
     private final String name;
     private final Value value;
-
-    public static final String CHILD_VALUE = "value";
 
     @Internal
     protected Argument(String name, Value value, SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars, Map<String, String> additionalData) {
@@ -42,6 +40,14 @@ public class Argument extends AbstractNode<Argument> implements NamedNode<Argume
      */
     public Argument(String name, Value value) {
         this(name, value, null, emptyList(), IgnoredChars.EMPTY, emptyMap());
+    }
+
+    public static Builder newArgument() {
+        return new Builder();
+    }
+
+    public static Builder newArgument(String name, Value value) {
+        return new Builder().name(name).value(value);
     }
 
     @Override
@@ -105,14 +111,6 @@ public class Argument extends AbstractNode<Argument> implements NamedNode<Argume
         return visitor.visitArgument(this, context);
     }
 
-    public static Builder newArgument() {
-        return new Builder();
-    }
-
-    public static Builder newArgument(String name, Value value) {
-        return new Builder().name(name).value(value);
-    }
-
     public Argument transform(Consumer<Builder> builderConsumer) {
         Builder builder = new Builder(this);
         builderConsumer.accept(builder);
@@ -121,7 +119,7 @@ public class Argument extends AbstractNode<Argument> implements NamedNode<Argume
 
     public static final class Builder implements NodeBuilder {
         private SourceLocation sourceLocation;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private String name;
         private Value value;
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
@@ -132,7 +130,7 @@ public class Argument extends AbstractNode<Argument> implements NamedNode<Argume
 
         private Builder(Argument existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.name = existing.getName();
             this.value = existing.getValue();
             this.ignoredChars = existing.getIgnoredChars();
@@ -155,7 +153,7 @@ public class Argument extends AbstractNode<Argument> implements NamedNode<Argume
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 

--- a/src/main/java/graphql/language/ArrayValue.java
+++ b/src/main/java/graphql/language/ArrayValue.java
@@ -4,10 +4,10 @@ package graphql.language;
 import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -21,9 +21,8 @@ import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 @PublicApi
 public class ArrayValue extends AbstractNode<ArrayValue> implements Value<ArrayValue> {
 
-    private final ImmutableList<Value> values;
-
     public static final String CHILD_VALUES = "values";
+    private final ImmutableList<Value> values;
 
     @Internal
     protected ArrayValue(List<Value> values, SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars, Map<String, String> additionalData) {
@@ -38,6 +37,10 @@ public class ArrayValue extends AbstractNode<ArrayValue> implements Value<ArrayV
      */
     public ArrayValue(List<Value> values) {
         this(values, null, emptyList(), IgnoredChars.EMPTY, emptyMap());
+    }
+
+    public static Builder newArrayValue() {
+        return new Builder();
     }
 
     public List<Value> getValues() {
@@ -92,10 +95,6 @@ public class ArrayValue extends AbstractNode<ArrayValue> implements Value<ArrayV
         return visitor.visitArrayValue(this, context);
     }
 
-    public static Builder newArrayValue() {
-        return new Builder();
-    }
-
     public ArrayValue transform(Consumer<Builder> builderConsumer) {
         Builder builder = new Builder(this);
         builderConsumer.accept(builder);
@@ -104,8 +103,8 @@ public class ArrayValue extends AbstractNode<ArrayValue> implements Value<ArrayV
 
     public static final class Builder implements NodeBuilder {
         private SourceLocation sourceLocation;
-        private List<Value> values = new ArrayList<>();
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Value> values = emptyList();
+        private ImmutableList<Comment> comments = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
 
@@ -114,8 +113,8 @@ public class ArrayValue extends AbstractNode<ArrayValue> implements Value<ArrayV
 
         private Builder(ArrayValue existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
-            this.values = existing.getValues();
+            this.comments = ImmutableList.copyOf(existing.getComments());
+            this.values = ImmutableList.copyOf(existing.getValues());
             this.ignoredChars = existing.getIgnoredChars();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
         }
@@ -126,17 +125,17 @@ public class ArrayValue extends AbstractNode<ArrayValue> implements Value<ArrayV
         }
 
         public Builder values(List<Value> values) {
-            this.values = values;
+            this.values = ImmutableList.copyOf(values);
             return this;
         }
 
         public Builder value(Value value) {
-            this.values.add(value);
+            this.values = ImmutableKit.addToList(this.values, value);
             return this;
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 

--- a/src/main/java/graphql/language/BooleanValue.java
+++ b/src/main/java/graphql/language/BooleanValue.java
@@ -1,12 +1,12 @@
 package graphql.language;
 
 
+import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -108,7 +108,7 @@ public class BooleanValue extends AbstractNode<BooleanValue> implements ScalarVa
     public static final class Builder implements NodeBuilder {
         private SourceLocation sourceLocation;
         private boolean value;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
 
@@ -117,7 +117,7 @@ public class BooleanValue extends AbstractNode<BooleanValue> implements ScalarVa
 
         private Builder(BooleanValue existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.value = existing.isValue();
             this.ignoredChars = existing.getIgnoredChars();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
@@ -135,7 +135,7 @@ public class BooleanValue extends AbstractNode<BooleanValue> implements ScalarVa
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 

--- a/src/main/java/graphql/language/Directive.java
+++ b/src/main/java/graphql/language/Directive.java
@@ -4,10 +4,10 @@ package graphql.language;
 import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -15,11 +15,11 @@ import java.util.Objects;
 import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
+import static graphql.collect.ImmutableKit.emptyList;
+import static graphql.collect.ImmutableKit.emptyMap;
 import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 import static graphql.language.NodeUtil.argumentsByName;
 import static graphql.language.NodeUtil.getArgumentByName;
-import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
 
 @PublicApi
 public class Directive extends AbstractNode<Directive> implements NamedNode<Directive> {
@@ -138,9 +138,9 @@ public class Directive extends AbstractNode<Directive> implements NamedNode<Dire
 
     public static final class Builder implements NodeBuilder {
         private SourceLocation sourceLocation;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private String name;
-        private List<Argument> arguments = new ArrayList<>();
+        private ImmutableList<Argument> arguments = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
 
@@ -149,9 +149,9 @@ public class Directive extends AbstractNode<Directive> implements NamedNode<Dire
 
         private Builder(Directive existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.name = existing.getName();
-            this.arguments = existing.getArguments();
+            this.arguments = ImmutableList.copyOf(existing.getArguments());
             this.ignoredChars = existing.getIgnoredChars();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
         }
@@ -163,7 +163,7 @@ public class Directive extends AbstractNode<Directive> implements NamedNode<Dire
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 
@@ -173,7 +173,12 @@ public class Directive extends AbstractNode<Directive> implements NamedNode<Dire
         }
 
         public Builder arguments(List<Argument> arguments) {
-            this.arguments = arguments;
+            this.arguments = ImmutableList.copyOf(arguments);
+            return this;
+        }
+
+        public Builder argument(Argument argument) {
+            this.arguments = ImmutableKit.addToList(arguments,argument);
             return this;
         }
 

--- a/src/main/java/graphql/language/DirectiveDefinition.java
+++ b/src/main/java/graphql/language/DirectiveDefinition.java
@@ -4,6 +4,7 @@ package graphql.language;
 import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
@@ -141,11 +142,11 @@ public class DirectiveDefinition extends AbstractDescribedNode<DirectiveDefiniti
 
     public static final class Builder implements NodeBuilder {
         private SourceLocation sourceLocation;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private String name;
         private Description description;
-        private List<InputValueDefinition> inputValueDefinitions = new ArrayList<>();
-        private List<DirectiveLocation> directiveLocations = new ArrayList<>();
+        private ImmutableList<InputValueDefinition> inputValueDefinitions = emptyList();
+        private ImmutableList<DirectiveLocation> directiveLocations = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
 
@@ -154,11 +155,11 @@ public class DirectiveDefinition extends AbstractDescribedNode<DirectiveDefiniti
 
         private Builder(DirectiveDefinition existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.name = existing.getName();
             this.description = existing.getDescription();
-            this.inputValueDefinitions = existing.getInputValueDefinitions();
-            this.directiveLocations = existing.getDirectiveLocations();
+            this.inputValueDefinitions = ImmutableList.copyOf(existing.getInputValueDefinitions());
+            this.directiveLocations = ImmutableList.copyOf(existing.getDirectiveLocations());
             this.ignoredChars = existing.getIgnoredChars();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
         }
@@ -169,7 +170,7 @@ public class DirectiveDefinition extends AbstractDescribedNode<DirectiveDefiniti
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 
@@ -184,22 +185,23 @@ public class DirectiveDefinition extends AbstractDescribedNode<DirectiveDefiniti
         }
 
         public Builder inputValueDefinitions(List<InputValueDefinition> inputValueDefinitions) {
-            this.inputValueDefinitions = inputValueDefinitions;
+            this.inputValueDefinitions = ImmutableList.copyOf(inputValueDefinitions);
             return this;
         }
 
         public Builder inputValueDefinition(InputValueDefinition inputValueDefinition) {
-            this.inputValueDefinitions.add(inputValueDefinition);
+            this.inputValueDefinitions = ImmutableKit.addToList(inputValueDefinitions, inputValueDefinition);
             return this;
         }
 
+
         public Builder directiveLocations(List<DirectiveLocation> directiveLocations) {
-            this.directiveLocations = directiveLocations;
+            this.directiveLocations = ImmutableList.copyOf(directiveLocations);
             return this;
         }
 
         public Builder directiveLocation(DirectiveLocation directiveLocation) {
-            this.directiveLocations.add(directiveLocation);
+            this.directiveLocations = ImmutableKit.addToList(directiveLocations, directiveLocation);
             return this;
         }
 

--- a/src/main/java/graphql/language/DirectiveLocation.java
+++ b/src/main/java/graphql/language/DirectiveLocation.java
@@ -1,12 +1,12 @@
 package graphql.language;
 
 
+import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -102,7 +102,7 @@ public class DirectiveLocation extends AbstractNode<DirectiveLocation> implement
 
     public static final class Builder implements NodeBuilder {
         private SourceLocation sourceLocation;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private String name;
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
@@ -112,7 +112,7 @@ public class DirectiveLocation extends AbstractNode<DirectiveLocation> implement
 
         private Builder(DirectiveLocation existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.name = existing.getName();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
         }
@@ -123,7 +123,7 @@ public class DirectiveLocation extends AbstractNode<DirectiveLocation> implement
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 

--- a/src/main/java/graphql/language/Document.java
+++ b/src/main/java/graphql/language/Document.java
@@ -4,10 +4,10 @@ package graphql.language;
 import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -118,9 +118,9 @@ public class Document extends AbstractNode<Document> {
     }
 
     public static final class Builder implements NodeBuilder {
-        private List<Definition> definitions = new ArrayList<>();
+        private ImmutableList<Definition> definitions = emptyList();
         private SourceLocation sourceLocation;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
 
@@ -129,19 +129,19 @@ public class Document extends AbstractNode<Document> {
 
         private Builder(Document existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
-            this.definitions = existing.getDefinitions();
+            this.comments = ImmutableList.copyOf(existing.getComments());
+            this.definitions = ImmutableList.copyOf(existing.getDefinitions());
             this.ignoredChars = existing.getIgnoredChars();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
         }
 
         public Builder definitions(List<Definition> definitions) {
-            this.definitions = definitions;
+            this.definitions = ImmutableList.copyOf(definitions);
             return this;
         }
 
         public Builder definition(Definition definition) {
-            this.definitions.add(definition);
+            this.definitions = ImmutableKit.addToList(definitions,definition);
             return this;
         }
 
@@ -151,7 +151,7 @@ public class Document extends AbstractNode<Document> {
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 

--- a/src/main/java/graphql/language/EnumTypeDefinition.java
+++ b/src/main/java/graphql/language/EnumTypeDefinition.java
@@ -141,11 +141,11 @@ public class EnumTypeDefinition extends AbstractDescribedNode<EnumTypeDefinition
 
     public static final class Builder implements NodeDirectivesBuilder {
         private SourceLocation sourceLocation;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private String name;
         private Description description;
-        private List<EnumValueDefinition> enumValueDefinitions = new ArrayList<>();
-        private List<Directive> directives = new ArrayList<>();
+        private ImmutableList<EnumValueDefinition> enumValueDefinitions = emptyList();
+        private ImmutableList<Directive> directives = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
 
@@ -154,11 +154,11 @@ public class EnumTypeDefinition extends AbstractDescribedNode<EnumTypeDefinition
 
         private Builder(EnumTypeDefinition existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.name = existing.getName();
             this.description = existing.getDescription();
-            this.directives = existing.getDirectives();
-            this.enumValueDefinitions = existing.getEnumValueDefinitions();
+            this.directives = ImmutableList.copyOf(existing.getDirectives());
+            this.enumValueDefinitions = ImmutableList.copyOf(existing.getEnumValueDefinitions());
             this.ignoredChars = existing.getIgnoredChars();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
         }
@@ -169,7 +169,7 @@ public class EnumTypeDefinition extends AbstractDescribedNode<EnumTypeDefinition
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 
@@ -184,23 +184,23 @@ public class EnumTypeDefinition extends AbstractDescribedNode<EnumTypeDefinition
         }
 
         public Builder enumValueDefinitions(List<EnumValueDefinition> enumValueDefinitions) {
-            this.enumValueDefinitions = enumValueDefinitions;
+            this.enumValueDefinitions = ImmutableList.copyOf(enumValueDefinitions);
             return this;
         }
 
         public Builder enumValueDefinition(EnumValueDefinition enumValueDefinition) {
-            this.enumValueDefinitions.add(enumValueDefinition);
+            this.enumValueDefinitions = ImmutableKit.addToList(enumValueDefinitions, enumValueDefinition);
             return this;
         }
 
         @Override
         public Builder directives(List<Directive> directives) {
-            this.directives = directives;
+            this.directives = ImmutableList.copyOf(directives);
             return this;
         }
 
         public Builder directive(Directive directive) {
-            this.directives.add(directive);
+            this.directives = ImmutableKit.addToList(directives, directive);
             return this;
         }
 

--- a/src/main/java/graphql/language/EnumTypeExtensionDefinition.java
+++ b/src/main/java/graphql/language/EnumTypeExtensionDefinition.java
@@ -1,15 +1,17 @@
 package graphql.language;
 
+import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
+import static graphql.collect.ImmutableKit.emptyList;
 
 @PublicApi
 public class EnumTypeExtensionDefinition extends EnumTypeDefinition {
@@ -67,11 +69,11 @@ public class EnumTypeExtensionDefinition extends EnumTypeDefinition {
 
     public static final class Builder implements NodeDirectivesBuilder {
         private SourceLocation sourceLocation;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private String name;
         private Description description;
-        private List<EnumValueDefinition> enumValueDefinitions;
-        private List<Directive> directives;
+        private ImmutableList<EnumValueDefinition> enumValueDefinitions = emptyList();
+        private ImmutableList<Directive> directives = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
 
@@ -80,11 +82,11 @@ public class EnumTypeExtensionDefinition extends EnumTypeDefinition {
 
         private Builder(EnumTypeExtensionDefinition existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.name = existing.getName();
             this.description = existing.getDescription();
-            this.directives = existing.getDirectives();
-            this.enumValueDefinitions = existing.getEnumValueDefinitions();
+            this.directives = ImmutableList.copyOf(existing.getDirectives());
+            this.enumValueDefinitions = ImmutableList.copyOf(existing.getEnumValueDefinitions());
             this.ignoredChars = existing.getIgnoredChars();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
         }
@@ -95,7 +97,7 @@ public class EnumTypeExtensionDefinition extends EnumTypeDefinition {
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 
@@ -110,13 +112,18 @@ public class EnumTypeExtensionDefinition extends EnumTypeDefinition {
         }
 
         public Builder enumValueDefinitions(List<EnumValueDefinition> enumValueDefinitions) {
-            this.enumValueDefinitions = enumValueDefinitions;
+            this.enumValueDefinitions = ImmutableList.copyOf(enumValueDefinitions);
             return this;
         }
 
         @Override
         public Builder directives(List<Directive> directives) {
-            this.directives = directives;
+            this.directives = ImmutableList.copyOf(directives);
+            return this;
+        }
+
+        public Builder directive(Directive directive) {
+            this.directives = ImmutableKit.addToList(directives, directive);
             return this;
         }
 

--- a/src/main/java/graphql/language/EnumValue.java
+++ b/src/main/java/graphql/language/EnumValue.java
@@ -1,12 +1,12 @@
 package graphql.language;
 
 
+import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -110,7 +110,7 @@ public class EnumValue extends AbstractNode<EnumValue> implements Value<EnumValu
     public static final class Builder implements NodeBuilder {
         private SourceLocation sourceLocation;
         private String name;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
 
@@ -119,7 +119,7 @@ public class EnumValue extends AbstractNode<EnumValue> implements Value<EnumValu
 
         private Builder(EnumValue existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.name = existing.getName();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
         }
@@ -136,7 +136,7 @@ public class EnumValue extends AbstractNode<EnumValue> implements Value<EnumValu
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 

--- a/src/main/java/graphql/language/EnumValueDefinition.java
+++ b/src/main/java/graphql/language/EnumValueDefinition.java
@@ -4,10 +4,10 @@ package graphql.language;
 import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -175,6 +175,11 @@ public class EnumValueDefinition extends AbstractDescribedNode<EnumValueDefiniti
         @Override
         public Builder directives(List<Directive> directives) {
             this.directives = ImmutableList.copyOf(directives);
+            return this;
+        }
+
+        public Builder directive(Directive directive) {
+            this.directives = ImmutableKit.addToList(directives, directive);
             return this;
         }
 

--- a/src/main/java/graphql/language/EnumValueDefinition.java
+++ b/src/main/java/graphql/language/EnumValueDefinition.java
@@ -132,10 +132,10 @@ public class EnumValueDefinition extends AbstractDescribedNode<EnumValueDefiniti
 
     public static final class Builder implements NodeDirectivesBuilder {
         private SourceLocation sourceLocation;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private String name;
         private Description description;
-        private List<Directive> directives;
+        private ImmutableList<Directive> directives = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
 
@@ -144,10 +144,10 @@ public class EnumValueDefinition extends AbstractDescribedNode<EnumValueDefiniti
 
         private Builder(EnumValueDefinition existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.name = existing.getName();
             this.description = existing.getDescription();
-            this.directives = existing.getDirectives();
+            this.directives = ImmutableList.copyOf(existing.getDirectives());
             this.ignoredChars = existing.getIgnoredChars();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
         }
@@ -158,7 +158,7 @@ public class EnumValueDefinition extends AbstractDescribedNode<EnumValueDefiniti
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 
@@ -174,7 +174,7 @@ public class EnumValueDefinition extends AbstractDescribedNode<EnumValueDefiniti
 
         @Override
         public Builder directives(List<Directive> directives) {
-            this.directives = directives;
+            this.directives = ImmutableList.copyOf(directives);
             return this;
         }
 

--- a/src/main/java/graphql/language/Field.java
+++ b/src/main/java/graphql/language/Field.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
@@ -267,6 +268,11 @@ public class Field extends AbstractNode<Field> implements Selection<Field>, Sele
         @Override
         public Builder directives(List<Directive> directives) {
             this.directives = ImmutableList.copyOf(directives);
+            return this;
+        }
+
+        public Builder directive(Directive directive) {
+            this.directives = ImmutableKit.addToList(directives, directive);
             return this;
         }
 

--- a/src/main/java/graphql/language/FieldDefinition.java
+++ b/src/main/java/graphql/language/FieldDefinition.java
@@ -4,6 +4,7 @@ package graphql.language;
 import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
@@ -152,11 +153,11 @@ public class FieldDefinition extends AbstractDescribedNode<FieldDefinition> impl
     public static final class Builder implements NodeDirectivesBuilder {
         private SourceLocation sourceLocation;
         private String name;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private Type type;
         private Description description;
-        private List<InputValueDefinition> inputValueDefinitions = new ArrayList<>();
-        private List<Directive> directives = new ArrayList<>();
+        private ImmutableList<InputValueDefinition> inputValueDefinitions = emptyList();
+        private ImmutableList<Directive> directives = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
 
@@ -166,11 +167,11 @@ public class FieldDefinition extends AbstractDescribedNode<FieldDefinition> impl
         private Builder(FieldDefinition existing) {
             this.sourceLocation = existing.getSourceLocation();
             this.name = existing.getName();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.type = existing.getType();
             this.description = existing.getDescription();
-            this.inputValueDefinitions = existing.getInputValueDefinitions();
-            this.directives = existing.getDirectives();
+            this.inputValueDefinitions = ImmutableList.copyOf(existing.getInputValueDefinitions());
+            this.directives = ImmutableList.copyOf(existing.getDirectives());
             this.ignoredChars = existing.getIgnoredChars();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
         }
@@ -187,7 +188,7 @@ public class FieldDefinition extends AbstractDescribedNode<FieldDefinition> impl
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 
@@ -202,23 +203,24 @@ public class FieldDefinition extends AbstractDescribedNode<FieldDefinition> impl
         }
 
         public Builder inputValueDefinitions(List<InputValueDefinition> inputValueDefinitions) {
-            this.inputValueDefinitions = inputValueDefinitions;
+            this.inputValueDefinitions = ImmutableList.copyOf(inputValueDefinitions);
             return this;
         }
 
-        public Builder inputValueDefinition(InputValueDefinition inputValueDefinitions) {
-            this.inputValueDefinitions.add(inputValueDefinitions);
+        public Builder inputValueDefinition(InputValueDefinition inputValueDefinition) {
+            this.inputValueDefinitions = ImmutableKit.addToList(inputValueDefinitions, inputValueDefinition);
             return this;
         }
+
 
         @Override
         public Builder directives(List<Directive> directives) {
-            this.directives = directives;
+            this.directives = ImmutableList.copyOf(directives);
             return this;
         }
 
         public Builder directive(Directive directive) {
-            this.directives.add(directive);
+            this.directives = ImmutableKit.addToList(directives, directive);
             return this;
         }
 

--- a/src/main/java/graphql/language/FloatValue.java
+++ b/src/main/java/graphql/language/FloatValue.java
@@ -1,13 +1,13 @@
 package graphql.language;
 
 
+import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -108,7 +108,7 @@ public class FloatValue extends AbstractNode<FloatValue> implements ScalarValue<
     public static final class Builder implements NodeBuilder {
         private SourceLocation sourceLocation;
         private BigDecimal value;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
 
@@ -117,7 +117,7 @@ public class FloatValue extends AbstractNode<FloatValue> implements ScalarValue<
 
         private Builder(FloatValue existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.value = existing.getValue();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
         }
@@ -134,7 +134,7 @@ public class FloatValue extends AbstractNode<FloatValue> implements ScalarValue<
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 

--- a/src/main/java/graphql/language/FragmentDefinition.java
+++ b/src/main/java/graphql/language/FragmentDefinition.java
@@ -4,6 +4,7 @@ package graphql.language;
 import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
@@ -15,6 +16,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
+import static graphql.collect.ImmutableKit.emptyList;
 import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 
 /**
@@ -149,10 +151,11 @@ public class FragmentDefinition extends AbstractNode<FragmentDefinition> impleme
 
     public static final class Builder implements NodeDirectivesBuilder {
         private SourceLocation sourceLocation;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
+
         private String name;
         private TypeName typeCondition;
-        private List<Directive> directives = new ArrayList<>();
+        private ImmutableList<Directive> directives = emptyList();
         private SelectionSet selectionSet;
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
@@ -162,10 +165,10 @@ public class FragmentDefinition extends AbstractNode<FragmentDefinition> impleme
 
         private Builder(FragmentDefinition existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.name = existing.getName();
             this.typeCondition = existing.getTypeCondition();
-            this.directives = existing.getDirectives();
+            this.directives = ImmutableList.copyOf(existing.getDirectives());
             this.selectionSet = existing.getSelectionSet();
             this.ignoredChars = existing.getIgnoredChars();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
@@ -178,7 +181,7 @@ public class FragmentDefinition extends AbstractNode<FragmentDefinition> impleme
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 
@@ -194,7 +197,12 @@ public class FragmentDefinition extends AbstractNode<FragmentDefinition> impleme
 
         @Override
         public Builder directives(List<Directive> directives) {
-            this.directives = directives;
+            this.directives = ImmutableList.copyOf(directives);
+            return this;
+        }
+
+        public Builder directive(Directive directive) {
+            this.directives = ImmutableKit.addToList(directives, directive);
             return this;
         }
 

--- a/src/main/java/graphql/language/FragmentSpread.java
+++ b/src/main/java/graphql/language/FragmentSpread.java
@@ -4,10 +4,10 @@ package graphql.language;
 import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -122,9 +122,9 @@ public class FragmentSpread extends AbstractNode<FragmentSpread> implements Sele
 
     public static final class Builder implements NodeDirectivesBuilder {
         private SourceLocation sourceLocation;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private String name;
-        private List<Directive> directives = new ArrayList<>();
+        private ImmutableList<Directive> directives = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
 
@@ -133,9 +133,9 @@ public class FragmentSpread extends AbstractNode<FragmentSpread> implements Sele
 
         private Builder(FragmentSpread existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.name = existing.getName();
-            this.directives = existing.getDirectives();
+            this.directives = ImmutableList.copyOf(existing.getDirectives());
             this.ignoredChars = existing.getIgnoredChars();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
         }
@@ -146,7 +146,7 @@ public class FragmentSpread extends AbstractNode<FragmentSpread> implements Sele
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 
@@ -157,9 +157,15 @@ public class FragmentSpread extends AbstractNode<FragmentSpread> implements Sele
 
         @Override
         public Builder directives(List<Directive> directives) {
-            this.directives = directives;
+            this.directives = ImmutableList.copyOf(directives);
             return this;
         }
+
+        public Builder directive(Directive directive) {
+            this.directives = ImmutableKit.addToList(directives, directive);
+            return this;
+        }
+
 
         public Builder ignoredChars(IgnoredChars ignoredChars) {
             this.ignoredChars = ignoredChars;

--- a/src/main/java/graphql/language/InlineFragment.java
+++ b/src/main/java/graphql/language/InlineFragment.java
@@ -4,6 +4,7 @@ package graphql.language;
 import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
@@ -163,9 +164,9 @@ public class InlineFragment extends AbstractNode<InlineFragment> implements Sele
 
     public static final class Builder implements NodeDirectivesBuilder {
         private SourceLocation sourceLocation;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private TypeName typeCondition;
-        private List<Directive> directives = new ArrayList<>();
+        private ImmutableList<Directive> directives = emptyList();
         private SelectionSet selectionSet;
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
@@ -176,9 +177,9 @@ public class InlineFragment extends AbstractNode<InlineFragment> implements Sele
 
         private Builder(InlineFragment existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.typeCondition = existing.getTypeCondition();
-            this.directives = existing.getDirectives();
+            this.directives = ImmutableList.copyOf(existing.getDirectives());
             this.selectionSet = existing.getSelectionSet();
             this.ignoredChars = existing.getIgnoredChars();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
@@ -191,7 +192,7 @@ public class InlineFragment extends AbstractNode<InlineFragment> implements Sele
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 
@@ -202,9 +203,15 @@ public class InlineFragment extends AbstractNode<InlineFragment> implements Sele
 
         @Override
         public Builder directives(List<Directive> directives) {
-            this.directives = directives;
+            this.directives = ImmutableList.copyOf(directives);
             return this;
         }
+
+        public Builder directive(Directive directive) {
+            this.directives = ImmutableKit.addToList(directives, directive);
+            return this;
+        }
+
 
         public Builder selectionSet(SelectionSet selectionSet) {
             this.selectionSet = selectionSet;

--- a/src/main/java/graphql/language/InputObjectTypeDefinition.java
+++ b/src/main/java/graphql/language/InputObjectTypeDefinition.java
@@ -4,6 +4,7 @@ package graphql.language;
 import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
@@ -15,6 +16,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
+import static graphql.collect.ImmutableKit.emptyList;
 import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 
 @PublicApi
@@ -133,11 +135,11 @@ public class InputObjectTypeDefinition extends AbstractDescribedNode<InputObject
 
     public static final class Builder implements NodeDirectivesBuilder {
         private SourceLocation sourceLocation;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private String name;
         private Description description;
-        private List<Directive> directives = new ArrayList<>();
-        private List<InputValueDefinition> inputValueDefinitions = new ArrayList<>();
+        private ImmutableList<Directive> directives = emptyList();
+        private ImmutableList<InputValueDefinition> inputValueDefinitions = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
 
@@ -146,11 +148,11 @@ public class InputObjectTypeDefinition extends AbstractDescribedNode<InputObject
 
         private Builder(InputObjectTypeDefinition existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.name = existing.getName();
             this.description = existing.getDescription();
-            this.directives = existing.getDirectives();
-            this.inputValueDefinitions = existing.getInputValueDefinitions();
+            this.directives = ImmutableList.copyOf(existing.getDirectives());
+            this.inputValueDefinitions = ImmutableList.copyOf(existing.getInputValueDefinitions());
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
         }
 
@@ -161,7 +163,7 @@ public class InputObjectTypeDefinition extends AbstractDescribedNode<InputObject
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 
@@ -177,22 +179,22 @@ public class InputObjectTypeDefinition extends AbstractDescribedNode<InputObject
 
         @Override
         public Builder directives(List<Directive> directives) {
-            this.directives = directives;
+            this.directives = ImmutableList.copyOf(directives);
             return this;
         }
 
         public Builder directive(Directive directive) {
-            this.directives.add(directive);
+            this.directives = ImmutableKit.addToList(directives, directive);
             return this;
         }
 
         public Builder inputValueDefinitions(List<InputValueDefinition> inputValueDefinitions) {
-            this.inputValueDefinitions = inputValueDefinitions;
+            this.inputValueDefinitions = ImmutableList.copyOf(inputValueDefinitions);
             return this;
         }
 
         public Builder inputValueDefinition(InputValueDefinition inputValueDefinition) {
-            this.inputValueDefinitions.add(inputValueDefinition);
+            this.inputValueDefinitions = ImmutableKit.addToList(inputValueDefinitions, inputValueDefinition);
             return this;
         }
 

--- a/src/main/java/graphql/language/InputObjectTypeExtensionDefinition.java
+++ b/src/main/java/graphql/language/InputObjectTypeExtensionDefinition.java
@@ -1,15 +1,17 @@
 package graphql.language;
 
+import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
+import static graphql.collect.ImmutableKit.emptyList;
 
 @PublicApi
 public class InputObjectTypeExtensionDefinition extends InputObjectTypeDefinition {
@@ -67,11 +69,11 @@ public class InputObjectTypeExtensionDefinition extends InputObjectTypeDefinitio
 
     public static final class Builder implements NodeDirectivesBuilder {
         private SourceLocation sourceLocation;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private String name;
         private Description description;
-        private List<Directive> directives = new ArrayList<>();
-        private List<InputValueDefinition> inputValueDefinitions = new ArrayList<>();
+        private ImmutableList<Directive> directives = emptyList();
+        private ImmutableList<InputValueDefinition> inputValueDefinitions = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
 
@@ -80,11 +82,11 @@ public class InputObjectTypeExtensionDefinition extends InputObjectTypeDefinitio
 
         private Builder(InputObjectTypeDefinition existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.name = existing.getName();
             this.description = existing.getDescription();
-            this.directives = existing.getDirectives();
-            this.inputValueDefinitions = existing.getInputValueDefinitions();
+            this.directives = ImmutableList.copyOf(existing.getDirectives());
+            this.inputValueDefinitions = ImmutableList.copyOf(existing.getInputValueDefinitions());
             this.ignoredChars = existing.getIgnoredChars();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
         }
@@ -96,7 +98,7 @@ public class InputObjectTypeExtensionDefinition extends InputObjectTypeDefinitio
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 
@@ -112,12 +114,23 @@ public class InputObjectTypeExtensionDefinition extends InputObjectTypeDefinitio
 
         @Override
         public Builder directives(List<Directive> directives) {
-            this.directives = directives;
+            this.directives = ImmutableList.copyOf(directives);
             return this;
         }
 
+        public Builder directive(Directive directive) {
+            this.directives = ImmutableKit.addToList(directives, directive);
+            return this;
+        }
+
+
         public Builder inputValueDefinitions(List<InputValueDefinition> inputValueDefinitions) {
-            this.inputValueDefinitions = inputValueDefinitions;
+            this.inputValueDefinitions = ImmutableList.copyOf(inputValueDefinitions);
+            return this;
+        }
+
+        public Builder inputValueDefinition(InputValueDefinition inputValueDefinition) {
+            this.inputValueDefinitions = ImmutableKit.addToList(inputValueDefinitions, inputValueDefinition);
             return this;
         }
 

--- a/src/main/java/graphql/language/InputValueDefinition.java
+++ b/src/main/java/graphql/language/InputValueDefinition.java
@@ -4,6 +4,7 @@ package graphql.language;
 import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
@@ -175,12 +176,12 @@ public class InputValueDefinition extends AbstractDescribedNode<InputValueDefini
 
     public static final class Builder implements NodeDirectivesBuilder {
         private SourceLocation sourceLocation;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private String name;
         private Type type;
         private Value defaultValue;
         private Description description;
-        private List<Directive> directives = new ArrayList<>();
+        private ImmutableList<Directive> directives = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
 
@@ -189,12 +190,12 @@ public class InputValueDefinition extends AbstractDescribedNode<InputValueDefini
 
         private Builder(InputValueDefinition existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.name = existing.getName();
             this.type = existing.getType();
             this.defaultValue = existing.getDefaultValue();
             this.description = existing.getDescription();
-            this.directives = existing.getDirectives();
+            this.directives = ImmutableList.copyOf(existing.getDirectives());
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
         }
 
@@ -205,7 +206,7 @@ public class InputValueDefinition extends AbstractDescribedNode<InputValueDefini
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 
@@ -231,12 +232,12 @@ public class InputValueDefinition extends AbstractDescribedNode<InputValueDefini
 
         @Override
         public Builder directives(List<Directive> directives) {
-            this.directives = directives;
+            this.directives = ImmutableList.copyOf(directives);
             return this;
         }
 
         public Builder directive(Directive directive) {
-            this.directives.add(directive);
+            this.directives = ImmutableKit.addToList(directives, directive);
             return this;
         }
 

--- a/src/main/java/graphql/language/IntValue.java
+++ b/src/main/java/graphql/language/IntValue.java
@@ -1,6 +1,7 @@
 package graphql.language;
 
 
+import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
 import graphql.util.TraversalControl;
@@ -108,7 +109,7 @@ public class IntValue extends AbstractNode<IntValue> implements ScalarValue<IntV
     public static final class Builder implements NodeBuilder {
         private SourceLocation sourceLocation;
         private BigInteger value;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
 
@@ -117,7 +118,7 @@ public class IntValue extends AbstractNode<IntValue> implements ScalarValue<IntV
 
         private Builder(IntValue existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.value = existing.getValue();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
         }
@@ -133,7 +134,7 @@ public class IntValue extends AbstractNode<IntValue> implements ScalarValue<IntV
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 

--- a/src/main/java/graphql/language/InterfaceTypeDefinition.java
+++ b/src/main/java/graphql/language/InterfaceTypeDefinition.java
@@ -4,6 +4,7 @@ package graphql.language;
 import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
@@ -159,12 +160,12 @@ public class InterfaceTypeDefinition extends AbstractDescribedNode<InterfaceType
 
     public static final class Builder implements NodeDirectivesBuilder {
         private SourceLocation sourceLocation;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private String name;
         private Description description;
-        private List<Type> implementz = new ArrayList<>();
-        private List<FieldDefinition> definitions = new ArrayList<>();
-        private List<Directive> directives = new ArrayList<>();
+        private ImmutableList<Type> implementz = emptyList();
+        private ImmutableList<FieldDefinition> definitions = emptyList();
+        private ImmutableList<Directive> directives = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
 
@@ -174,14 +175,14 @@ public class InterfaceTypeDefinition extends AbstractDescribedNode<InterfaceType
 
         private Builder(InterfaceTypeDefinition existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.name = existing.getName();
             this.description = existing.getDescription();
-            this.directives = existing.getDirectives();
-            this.definitions = existing.getFieldDefinitions();
+            this.directives = ImmutableList.copyOf(existing.getDirectives());
+            this.definitions = ImmutableList.copyOf(existing.getFieldDefinitions());
             this.ignoredChars = existing.getIgnoredChars();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
-            this.implementz = existing.getImplements();
+            this.implementz = ImmutableList.copyOf(existing.getImplements());
         }
 
 
@@ -191,7 +192,7 @@ public class InterfaceTypeDefinition extends AbstractDescribedNode<InterfaceType
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 
@@ -206,34 +207,34 @@ public class InterfaceTypeDefinition extends AbstractDescribedNode<InterfaceType
         }
 
         public Builder implementz(List<Type> implementz) {
-            this.implementz = implementz;
+            this.implementz = ImmutableList.copyOf(implementz);
             return this;
         }
 
         public Builder implementz(Type implement) {
-            this.implementz.add(implement);
+            this.implementz = ImmutableKit.addToList(implementz, implement);
             return this;
         }
 
 
         public Builder definitions(List<FieldDefinition> definitions) {
-            this.definitions = definitions;
+            this.definitions = ImmutableList.copyOf(definitions);
             return this;
         }
 
         public Builder definition(FieldDefinition definition) {
-            this.definitions.add(definition);
+            this.definitions = ImmutableKit.addToList(definitions, definition);
             return this;
         }
 
         @Override
         public Builder directives(List<Directive> directives) {
-            this.directives = directives;
+            this.directives = ImmutableList.copyOf(directives);
             return this;
         }
 
         public Builder directive(Directive directive) {
-            this.directives.add(directive);
+            this.directives = ImmutableKit.addToList(directives, directive);
             return this;
         }
 

--- a/src/main/java/graphql/language/InterfaceTypeExtensionDefinition.java
+++ b/src/main/java/graphql/language/InterfaceTypeExtensionDefinition.java
@@ -1,15 +1,17 @@
 package graphql.language;
 
+import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
+import static graphql.collect.ImmutableKit.emptyList;
 
 @PublicApi
 public class InterfaceTypeExtensionDefinition extends InterfaceTypeDefinition {
@@ -70,12 +72,12 @@ public class InterfaceTypeExtensionDefinition extends InterfaceTypeDefinition {
 
     public static final class Builder implements NodeDirectivesBuilder {
         private SourceLocation sourceLocation;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private String name;
         private Description description;
-        private List<Type> implementz = new ArrayList<>();
-        private List<FieldDefinition> definitions = new ArrayList<>();
-        private List<Directive> directives = new ArrayList<>();
+        private ImmutableList<Type> implementz = emptyList();
+        private ImmutableList<FieldDefinition> definitions = emptyList();
+        private ImmutableList<Directive> directives = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
 
@@ -84,12 +86,12 @@ public class InterfaceTypeExtensionDefinition extends InterfaceTypeDefinition {
 
         private Builder(InterfaceTypeExtensionDefinition existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.name = existing.getName();
             this.description = existing.getDescription();
-            this.directives = existing.getDirectives();
-            this.implementz = existing.getImplements();
-            this.definitions = existing.getFieldDefinitions();
+            this.directives = ImmutableList.copyOf(existing.getDirectives());
+            this.implementz = ImmutableList.copyOf(existing.getImplements());
+            this.definitions = ImmutableList.copyOf(existing.getFieldDefinitions());
             this.ignoredChars = existing.getIgnoredChars();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
         }
@@ -100,7 +102,7 @@ public class InterfaceTypeExtensionDefinition extends InterfaceTypeDefinition {
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 
@@ -115,23 +117,33 @@ public class InterfaceTypeExtensionDefinition extends InterfaceTypeDefinition {
         }
 
         public Builder implementz(List<Type> implementz) {
-            this.implementz = implementz;
+            this.implementz = ImmutableList.copyOf(implementz);
             return this;
         }
 
         public Builder implementz(Type implementz) {
-            this.implementz.add(implementz);
+            this.implementz = ImmutableKit.addToList(this.implementz, implementz);
             return this;
         }
 
         public Builder definitions(List<FieldDefinition> definitions) {
-            this.definitions = definitions;
+            this.definitions = ImmutableList.copyOf(definitions);
+            return this;
+        }
+
+        public Builder definition(FieldDefinition definition) {
+            this.definitions = ImmutableKit.addToList(definitions, definition);
             return this;
         }
 
         @Override
         public Builder directives(List<Directive> directives) {
-            this.directives = directives;
+            this.directives = ImmutableList.copyOf(directives);
+            return this;
+        }
+
+        public Builder directive(Directive directive) {
+            this.directives = ImmutableKit.addToList(directives, directive);
             return this;
         }
 

--- a/src/main/java/graphql/language/ListType.java
+++ b/src/main/java/graphql/language/ListType.java
@@ -7,7 +7,6 @@ import graphql.PublicApi;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -109,7 +108,7 @@ public class ListType extends AbstractNode<ListType> implements Type<ListType> {
     public static final class Builder implements NodeBuilder {
         private Type type;
         private SourceLocation sourceLocation;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
 
@@ -118,7 +117,7 @@ public class ListType extends AbstractNode<ListType> implements Type<ListType> {
 
         private Builder(ListType existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.type = existing.getType();
             this.ignoredChars = existing.getIgnoredChars();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
@@ -136,7 +135,7 @@ public class ListType extends AbstractNode<ListType> implements Type<ListType> {
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 

--- a/src/main/java/graphql/language/NodeDirectivesBuilder.java
+++ b/src/main/java/graphql/language/NodeDirectivesBuilder.java
@@ -9,4 +9,7 @@ public interface NodeDirectivesBuilder extends NodeBuilder {
 
     NodeDirectivesBuilder directives(List<Directive> directives);
 
+    NodeDirectivesBuilder directive(Directive directive);
+
+
 }

--- a/src/main/java/graphql/language/NodeParentTree.java
+++ b/src/main/java/graphql/language/NodeParentTree.java
@@ -24,7 +24,7 @@ public class NodeParentTree<T extends Node> {
 
     private final T node;
     private final NodeParentTree<T> parent;
-    private final List<String> path;
+    private final ImmutableList<String> path;
 
     @Internal
     public NodeParentTree(Deque<T> nodeStack) {
@@ -41,7 +41,7 @@ public class NodeParentTree<T extends Node> {
         }
     }
 
-    private List<String> mkPath(Deque<T> copy) {
+    private ImmutableList<String> mkPath(Deque<T> copy) {
         return copy.stream()
                 .filter(node1 -> node1 instanceof NamedNode)
                 .map(node1 -> ((NamedNode) node1).getName())

--- a/src/main/java/graphql/language/NonNullType.java
+++ b/src/main/java/graphql/language/NonNullType.java
@@ -110,7 +110,7 @@ public class NonNullType extends AbstractNode<NonNullType> implements Type<NonNu
     public static final class Builder implements NodeBuilder {
         private SourceLocation sourceLocation;
         private Type type;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
 
@@ -119,7 +119,7 @@ public class NonNullType extends AbstractNode<NonNullType> implements Type<NonNu
 
         private Builder(NonNullType existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.type = existing.getType();
             this.ignoredChars = existing.getIgnoredChars();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
@@ -150,7 +150,7 @@ public class NonNullType extends AbstractNode<NonNullType> implements Type<NonNu
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 

--- a/src/main/java/graphql/language/NullValue.java
+++ b/src/main/java/graphql/language/NullValue.java
@@ -1,12 +1,12 @@
 package graphql.language;
 
 
+import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
+import static graphql.collect.ImmutableKit.emptyList;
 import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 import static graphql.language.NodeUtil.assertNewChildrenAreEmpty;
 
@@ -83,13 +84,13 @@ public class NullValue extends AbstractNode<NullValue> implements Value<NullValu
 
     public static final class Builder implements NodeBuilder {
         private SourceLocation sourceLocation;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
 
         private Builder(NullValue existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.ignoredChars = existing.getIgnoredChars();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
         }
@@ -103,7 +104,7 @@ public class NullValue extends AbstractNode<NullValue> implements Value<NullValu
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 

--- a/src/main/java/graphql/language/ObjectField.java
+++ b/src/main/java/graphql/language/ObjectField.java
@@ -8,13 +8,13 @@ import graphql.collect.ImmutableKit;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
+import static graphql.collect.ImmutableKit.emptyList;
 import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 
 @PublicApi
@@ -39,7 +39,7 @@ public class ObjectField extends AbstractNode<ObjectField> implements NamedNode<
      * @param value of the field
      */
     public ObjectField(String name, Value value) {
-        this(name, value, null, ImmutableKit.emptyList(), IgnoredChars.EMPTY, ImmutableKit.emptyMap());
+        this(name, value, null, emptyList(), IgnoredChars.EMPTY, ImmutableKit.emptyMap());
     }
 
     @Override
@@ -116,7 +116,7 @@ public class ObjectField extends AbstractNode<ObjectField> implements NamedNode<
     public static final class Builder implements NodeBuilder {
         private SourceLocation sourceLocation;
         private String name;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private Value value;
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
@@ -127,7 +127,7 @@ public class ObjectField extends AbstractNode<ObjectField> implements NamedNode<
 
         private Builder(ObjectField existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.name = existing.getName();
             this.value = existing.getValue();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
@@ -145,7 +145,7 @@ public class ObjectField extends AbstractNode<ObjectField> implements NamedNode<
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 

--- a/src/main/java/graphql/language/ObjectTypeDefinition.java
+++ b/src/main/java/graphql/language/ObjectTypeDefinition.java
@@ -4,6 +4,7 @@ package graphql.language;
 import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
@@ -155,12 +156,12 @@ public class ObjectTypeDefinition extends AbstractDescribedNode<ObjectTypeDefini
 
     public static final class Builder implements NodeDirectivesBuilder {
         private SourceLocation sourceLocation;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private String name;
         private Description description;
-        private List<Type> implementz = new ArrayList<>();
-        private List<Directive> directives = new ArrayList<>();
-        private List<FieldDefinition> fieldDefinitions = new ArrayList<>();
+        private ImmutableList<Type> implementz = emptyList();
+        private ImmutableList<Directive> directives = emptyList();
+        private ImmutableList<FieldDefinition> fieldDefinitions = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
 
@@ -169,12 +170,12 @@ public class ObjectTypeDefinition extends AbstractDescribedNode<ObjectTypeDefini
 
         private Builder(ObjectTypeDefinition existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.name = existing.getName();
             this.description = existing.getDescription();
-            this.directives = existing.getDirectives();
-            this.implementz = existing.getImplements();
-            this.fieldDefinitions = existing.getFieldDefinitions();
+            this.directives = ImmutableList.copyOf(existing.getDirectives());
+            this.implementz = ImmutableList.copyOf(existing.getImplements());
+            this.fieldDefinitions = ImmutableList.copyOf(existing.getFieldDefinitions());
             this.ignoredChars = existing.getIgnoredChars();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
         }
@@ -185,7 +186,7 @@ public class ObjectTypeDefinition extends AbstractDescribedNode<ObjectTypeDefini
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 
@@ -200,33 +201,33 @@ public class ObjectTypeDefinition extends AbstractDescribedNode<ObjectTypeDefini
         }
 
         public Builder implementz(List<Type> implementz) {
-            this.implementz = implementz;
+            this.implementz = ImmutableList.copyOf(implementz);
             return this;
         }
 
         public Builder implementz(Type implement) {
-            this.implementz.add(implement);
+            this.implementz = ImmutableKit.addToList(implementz, implement);
             return this;
         }
 
         @Override
         public Builder directives(List<Directive> directives) {
-            this.directives = directives;
+            this.directives = ImmutableList.copyOf(directives);
             return this;
         }
 
         public Builder directive(Directive directive) {
-            this.directives.add(directive);
+            this.directives = ImmutableKit.addToList(directives, directive);
             return this;
         }
 
         public Builder fieldDefinitions(List<FieldDefinition> fieldDefinitions) {
-            this.fieldDefinitions = fieldDefinitions;
+            this.fieldDefinitions = ImmutableList.copyOf(fieldDefinitions);
             return this;
         }
 
         public Builder fieldDefinition(FieldDefinition fieldDefinition) {
-            this.fieldDefinitions.add(fieldDefinition);
+            this.fieldDefinitions = ImmutableKit.addToList(fieldDefinitions, fieldDefinition);
             return this;
         }
 

--- a/src/main/java/graphql/language/ObjectTypeExtensionDefinition.java
+++ b/src/main/java/graphql/language/ObjectTypeExtensionDefinition.java
@@ -1,8 +1,10 @@
 package graphql.language;
 
 
+import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -82,26 +84,26 @@ public class ObjectTypeExtensionDefinition extends ObjectTypeDefinition {
 
     public static final class Builder implements NodeDirectivesBuilder {
         private SourceLocation sourceLocation;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private String name;
         private Description description;
-        private List<Type> implementz = new ArrayList<>();
-        private List<Directive> directives = new ArrayList<>();
-        private List<FieldDefinition> fieldDefinitions = new ArrayList<>();
+        private ImmutableList<Type> implementz = emptyList();
+        private ImmutableList<Directive> directives = emptyList();
+        private ImmutableList<FieldDefinition> fieldDefinitions = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
 
         private Builder() {
         }
 
-        private Builder(ObjectTypeExtensionDefinition existing) {
+        private Builder(ObjectTypeDefinition existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.name = existing.getName();
             this.description = existing.getDescription();
-            this.directives = existing.getDirectives();
-            this.implementz = existing.getImplements();
-            this.fieldDefinitions = existing.getFieldDefinitions();
+            this.directives = ImmutableList.copyOf(existing.getDirectives());
+            this.implementz = ImmutableList.copyOf(existing.getImplements());
+            this.fieldDefinitions = ImmutableList.copyOf(existing.getFieldDefinitions());
             this.ignoredChars = existing.getIgnoredChars();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
         }
@@ -112,7 +114,7 @@ public class ObjectTypeExtensionDefinition extends ObjectTypeDefinition {
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 
@@ -127,33 +129,33 @@ public class ObjectTypeExtensionDefinition extends ObjectTypeDefinition {
         }
 
         public Builder implementz(List<Type> implementz) {
-            this.implementz = implementz;
+            this.implementz = ImmutableList.copyOf(implementz);
             return this;
         }
 
-        public Builder implementz(Type implementz) {
-            this.implementz.add(implementz);
+        public Builder implementz(Type implement) {
+            this.implementz = ImmutableKit.addToList(implementz, implement);
             return this;
         }
 
         @Override
         public Builder directives(List<Directive> directives) {
-            this.directives = directives;
+            this.directives = ImmutableList.copyOf(directives);
             return this;
         }
 
         public Builder directive(Directive directive) {
-            this.directives.add(directive);
+            this.directives = ImmutableKit.addToList(directives, directive);
             return this;
         }
 
         public Builder fieldDefinitions(List<FieldDefinition> fieldDefinitions) {
-            this.fieldDefinitions = fieldDefinitions;
+            this.fieldDefinitions = ImmutableList.copyOf(fieldDefinitions);
             return this;
         }
 
         public Builder fieldDefinition(FieldDefinition fieldDefinition) {
-            this.fieldDefinitions.add(fieldDefinition);
+            this.fieldDefinitions = ImmutableKit.addToList(fieldDefinitions, fieldDefinition);
             return this;
         }
 

--- a/src/main/java/graphql/language/ObjectValue.java
+++ b/src/main/java/graphql/language/ObjectValue.java
@@ -8,13 +8,13 @@ import graphql.collect.ImmutableKit;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
+import static graphql.collect.ImmutableKit.emptyList;
 import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 
 @PublicApi
@@ -36,7 +36,7 @@ public class ObjectValue extends AbstractNode<ObjectValue> implements Value<Obje
      * @param objectFields the list of field that make up this object value
      */
     public ObjectValue(List<ObjectField> objectFields) {
-        this(objectFields, null, ImmutableKit.emptyList(), IgnoredChars.EMPTY, ImmutableKit.emptyMap());
+        this(objectFields, null, emptyList(), IgnoredChars.EMPTY, ImmutableKit.emptyMap());
     }
 
     public List<ObjectField> getObjectFields() {
@@ -106,8 +106,8 @@ public class ObjectValue extends AbstractNode<ObjectValue> implements Value<Obje
 
     public static final class Builder implements NodeBuilder {
         private SourceLocation sourceLocation;
-        private List<ObjectField> objectFields = new ArrayList<>();
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<ObjectField> objectFields = emptyList();
+        private ImmutableList<Comment> comments = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
 
@@ -116,8 +116,8 @@ public class ObjectValue extends AbstractNode<ObjectValue> implements Value<Obje
 
         private Builder(ObjectValue existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
-            this.objectFields = existing.getObjectFields();
+            this.comments = ImmutableList.copyOf(existing.getComments());
+            this.objectFields = ImmutableList.copyOf(existing.getObjectFields());
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
         }
 
@@ -127,17 +127,17 @@ public class ObjectValue extends AbstractNode<ObjectValue> implements Value<Obje
         }
 
         public Builder objectFields(List<ObjectField> objectFields) {
-            this.objectFields = objectFields;
+            this.objectFields = ImmutableList.copyOf(objectFields);
             return this;
         }
 
         public Builder objectField(ObjectField objectField) {
-            this.objectFields.add(objectField);
+            this.objectFields = ImmutableKit.addToList(objectFields, objectField);
             return this;
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 

--- a/src/main/java/graphql/language/OperationDefinition.java
+++ b/src/main/java/graphql/language/OperationDefinition.java
@@ -4,6 +4,7 @@ package graphql.language;
 import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
@@ -168,11 +169,11 @@ public class OperationDefinition extends AbstractNode<OperationDefinition> imple
 
     public static final class Builder implements NodeDirectivesBuilder {
         private SourceLocation sourceLocation;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private String name;
         private Operation operation;
-        private List<VariableDefinition> variableDefinitions = new ArrayList<>();
-        private List<Directive> directives = new ArrayList<>();
+        private ImmutableList<VariableDefinition> variableDefinitions = emptyList();
+        private ImmutableList<Directive> directives = emptyList();
         private SelectionSet selectionSet;
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
@@ -182,11 +183,11 @@ public class OperationDefinition extends AbstractNode<OperationDefinition> imple
 
         private Builder(OperationDefinition existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.name = existing.getName();
             this.operation = existing.getOperation();
-            this.variableDefinitions = existing.getVariableDefinitions();
-            this.directives = existing.getDirectives();
+            this.variableDefinitions = ImmutableList.copyOf(existing.getVariableDefinitions());
+            this.directives = ImmutableList.copyOf(existing.getDirectives());
             this.selectionSet = existing.getSelectionSet();
             this.ignoredChars = existing.getIgnoredChars();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
@@ -199,7 +200,7 @@ public class OperationDefinition extends AbstractNode<OperationDefinition> imple
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 
@@ -214,16 +215,25 @@ public class OperationDefinition extends AbstractNode<OperationDefinition> imple
         }
 
         public Builder variableDefinitions(List<VariableDefinition> variableDefinitions) {
-            this.variableDefinitions = variableDefinitions;
+            this.variableDefinitions = ImmutableList.copyOf(variableDefinitions);
+            return this;
+        }
+
+        public Builder variableDefinition(VariableDefinition variableDefinition) {
+            this.variableDefinitions = ImmutableKit.addToList(variableDefinitions, variableDefinition);
             return this;
         }
 
         @Override
         public Builder directives(List<Directive> directives) {
-            this.directives = directives;
+            this.directives = ImmutableList.copyOf(directives);
             return this;
         }
 
+        public Builder directive(Directive directive) {
+            this.directives = ImmutableKit.addToList(directives, directive);
+            return this;
+        }
         public Builder selectionSet(SelectionSet selectionSet) {
             this.selectionSet = selectionSet;
             return this;

--- a/src/main/java/graphql/language/OperationTypeDefinition.java
+++ b/src/main/java/graphql/language/OperationTypeDefinition.java
@@ -1,6 +1,7 @@
 package graphql.language;
 
 
+import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
 import graphql.util.TraversalControl;
@@ -117,7 +118,7 @@ public class OperationTypeDefinition extends AbstractNode<OperationTypeDefinitio
 
     public static final class Builder implements NodeBuilder {
         private SourceLocation sourceLocation;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private String name;
         private TypeName typeName;
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
@@ -129,7 +130,7 @@ public class OperationTypeDefinition extends AbstractNode<OperationTypeDefinitio
 
         private Builder(OperationTypeDefinition existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.name = existing.getName();
             this.typeName = existing.getTypeName();
             this.ignoredChars = existing.getIgnoredChars();
@@ -143,7 +144,7 @@ public class OperationTypeDefinition extends AbstractNode<OperationTypeDefinitio
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 

--- a/src/main/java/graphql/language/ScalarTypeDefinition.java
+++ b/src/main/java/graphql/language/ScalarTypeDefinition.java
@@ -4,10 +4,10 @@ package graphql.language;
 import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -122,10 +122,10 @@ public class ScalarTypeDefinition extends AbstractDescribedNode<ScalarTypeDefini
 
     public static final class Builder implements NodeDirectivesBuilder {
         private SourceLocation sourceLocation;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private String name;
         private Description description;
-        private List<Directive> directives = new ArrayList<>();
+        private ImmutableList<Directive> directives = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
 
@@ -134,10 +134,10 @@ public class ScalarTypeDefinition extends AbstractDescribedNode<ScalarTypeDefini
 
         private Builder(ScalarTypeDefinition existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.name = existing.getName();
             this.description = existing.getDescription();
-            this.directives = existing.getDirectives();
+            this.directives = ImmutableList.copyOf(existing.getDirectives());
             this.ignoredChars = existing.getIgnoredChars();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
         }
@@ -149,7 +149,7 @@ public class ScalarTypeDefinition extends AbstractDescribedNode<ScalarTypeDefini
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 
@@ -165,12 +165,12 @@ public class ScalarTypeDefinition extends AbstractDescribedNode<ScalarTypeDefini
 
         @Override
         public Builder directives(List<Directive> directives) {
-            this.directives = directives;
+            this.directives = ImmutableList.copyOf(directives);
             return this;
         }
 
         public Builder directive(Directive directive) {
-            this.directives.add(directive);
+            this.directives = ImmutableKit.addToList(directives, directive);
             return this;
         }
 

--- a/src/main/java/graphql/language/ScalarTypeExtensionDefinition.java
+++ b/src/main/java/graphql/language/ScalarTypeExtensionDefinition.java
@@ -1,15 +1,17 @@
 package graphql.language;
 
+import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
+import static graphql.collect.ImmutableKit.emptyList;
 
 @PublicApi
 public class ScalarTypeExtensionDefinition extends ScalarTypeDefinition {
@@ -57,23 +59,22 @@ public class ScalarTypeExtensionDefinition extends ScalarTypeDefinition {
 
     public static final class Builder implements NodeDirectivesBuilder {
         private SourceLocation sourceLocation;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private String name;
         private Description description;
-        private List<Directive> directives = new ArrayList<>();
+        private ImmutableList<Directive> directives = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
 
         private Builder() {
         }
 
-
-        private Builder(ScalarTypeExtensionDefinition existing) {
+        private Builder(ScalarTypeDefinition existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.name = existing.getName();
             this.description = existing.getDescription();
-            this.directives = existing.getDirectives();
+            this.directives = ImmutableList.copyOf(existing.getDirectives());
             this.ignoredChars = existing.getIgnoredChars();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
         }
@@ -85,7 +86,7 @@ public class ScalarTypeExtensionDefinition extends ScalarTypeDefinition {
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 
@@ -101,7 +102,12 @@ public class ScalarTypeExtensionDefinition extends ScalarTypeDefinition {
 
         @Override
         public Builder directives(List<Directive> directives) {
-            this.directives = directives;
+            this.directives = ImmutableList.copyOf(directives);
+            return this;
+        }
+
+        public Builder directive(Directive directive) {
+            this.directives = ImmutableKit.addToList(directives, directive);
             return this;
         }
 
@@ -119,7 +125,6 @@ public class ScalarTypeExtensionDefinition extends ScalarTypeDefinition {
             this.additionalData.put(key, value);
             return this;
         }
-
 
         public ScalarTypeExtensionDefinition build() {
             return new ScalarTypeExtensionDefinition(name,

--- a/src/main/java/graphql/language/SchemaDefinition.java
+++ b/src/main/java/graphql/language/SchemaDefinition.java
@@ -4,6 +4,7 @@ package graphql.language;
 import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
@@ -14,6 +15,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
+import static graphql.collect.ImmutableKit.emptyList;
 import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 import static graphql.language.NodeUtil.directiveByName;
 import static graphql.language.NodeUtil.directivesByName;
@@ -128,9 +130,9 @@ public class SchemaDefinition extends AbstractDescribedNode<SchemaDefinition> im
 
     public static final class Builder implements NodeDirectivesBuilder {
         private SourceLocation sourceLocation;
-        private List<Comment> comments = new ArrayList<>();
-        private List<Directive> directives = new ArrayList<>();
-        private List<OperationTypeDefinition> operationTypeDefinitions = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
+        private ImmutableList<Directive> directives = emptyList();
+        private ImmutableList<OperationTypeDefinition> operationTypeDefinitions = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
         private Description description;
@@ -141,9 +143,9 @@ public class SchemaDefinition extends AbstractDescribedNode<SchemaDefinition> im
 
         protected Builder(SchemaDefinition existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
-            this.directives = existing.getDirectives();
-            this.operationTypeDefinitions = existing.getOperationTypeDefinitions();
+            this.comments = ImmutableList.copyOf(existing.getComments());
+            this.directives = ImmutableList.copyOf(existing.getDirectives());
+            this.operationTypeDefinitions = ImmutableList.copyOf(existing.getOperationTypeDefinitions());
             this.ignoredChars = existing.getIgnoredChars();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
             this.description = existing.getDescription();
@@ -160,28 +162,28 @@ public class SchemaDefinition extends AbstractDescribedNode<SchemaDefinition> im
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 
         @Override
         public Builder directives(List<Directive> directives) {
-            this.directives = directives;
+            this.directives = ImmutableList.copyOf(directives);
             return this;
         }
 
         public Builder directive(Directive directive) {
-            this.directives.add(directive);
+            this.directives = ImmutableKit.addToList(directives, directive);
             return this;
         }
 
         public Builder operationTypeDefinitions(List<OperationTypeDefinition> operationTypeDefinitions) {
-            this.operationTypeDefinitions = operationTypeDefinitions;
+            this.operationTypeDefinitions = ImmutableList.copyOf(operationTypeDefinitions);
             return this;
         }
 
-        public Builder operationTypeDefinition(OperationTypeDefinition operationTypeDefinitions) {
-            this.operationTypeDefinitions.add(operationTypeDefinitions);
+        public Builder operationTypeDefinition(OperationTypeDefinition operationTypeDefinition) {
+            this.operationTypeDefinitions = ImmutableKit.addToList(operationTypeDefinitions, operationTypeDefinition);
             return this;
         }
 

--- a/src/main/java/graphql/language/SchemaExtensionDefinition.java
+++ b/src/main/java/graphql/language/SchemaExtensionDefinition.java
@@ -1,6 +1,8 @@
 package graphql.language;
 
+import com.google.common.collect.ImmutableList;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -9,6 +11,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
+import static graphql.collect.ImmutableKit.emptyList;
 
 @PublicApi
 public class SchemaExtensionDefinition extends SchemaDefinition {
@@ -56,20 +59,21 @@ public class SchemaExtensionDefinition extends SchemaDefinition {
 
     public static final class Builder implements NodeDirectivesBuilder {
         private SourceLocation sourceLocation;
-        private List<Comment> comments = new ArrayList<>();
-        private List<Directive> directives = new ArrayList<>();
-        private List<OperationTypeDefinition> operationTypeDefinitions = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
+        private ImmutableList<Directive> directives = emptyList();
+        private ImmutableList<OperationTypeDefinition> operationTypeDefinitions = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
+
 
         protected Builder() {
         }
 
         protected Builder(SchemaDefinition existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
-            this.directives = existing.getDirectives();
-            this.operationTypeDefinitions = existing.getOperationTypeDefinitions();
+            this.comments = ImmutableList.copyOf(existing.getComments());
+            this.directives = ImmutableList.copyOf(existing.getDirectives());
+            this.operationTypeDefinitions = ImmutableList.copyOf(existing.getOperationTypeDefinitions());
             this.ignoredChars = existing.getIgnoredChars();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
         }
@@ -81,28 +85,28 @@ public class SchemaExtensionDefinition extends SchemaDefinition {
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 
         @Override
         public Builder directives(List<Directive> directives) {
-            this.directives = directives;
+            this.directives = ImmutableList.copyOf(directives);
             return this;
         }
 
         public Builder directive(Directive directive) {
-            this.directives.add(directive);
+            this.directives = ImmutableKit.addToList(directives, directive);
             return this;
         }
 
         public Builder operationTypeDefinitions(List<OperationTypeDefinition> operationTypeDefinitions) {
-            this.operationTypeDefinitions = operationTypeDefinitions;
+            this.operationTypeDefinitions = ImmutableList.copyOf(operationTypeDefinitions);
             return this;
         }
 
-        public Builder operationTypeDefinition(OperationTypeDefinition operationTypeDefinitions) {
-            this.operationTypeDefinitions.add(operationTypeDefinitions);
+        public Builder operationTypeDefinition(OperationTypeDefinition operationTypeDefinition) {
+            this.operationTypeDefinitions = ImmutableKit.addToList(operationTypeDefinitions, operationTypeDefinition);
             return this;
         }
 

--- a/src/main/java/graphql/language/SelectionSet.java
+++ b/src/main/java/graphql/language/SelectionSet.java
@@ -4,10 +4,10 @@ package graphql.language;
 import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -124,9 +124,9 @@ public class SelectionSet extends AbstractNode<SelectionSet> {
 
     public static final class Builder implements NodeBuilder {
 
-        private List<Selection> selections = new ArrayList<>();
+        private ImmutableList<Selection> selections = emptyList();
         private SourceLocation sourceLocation;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
 
@@ -135,19 +135,19 @@ public class SelectionSet extends AbstractNode<SelectionSet> {
 
         private Builder(SelectionSet existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
-            this.selections = new ArrayList<>(existing.getSelections());
+            this.comments = ImmutableList.copyOf(existing.getComments());
+            this.selections = ImmutableList.copyOf(existing.getSelections());
             this.ignoredChars = existing.getIgnoredChars();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
         }
 
         public Builder selections(Collection<? extends Selection> selections) {
-            this.selections = new ArrayList<>(selections);
+            this.selections = ImmutableList.copyOf(selections);
             return this;
         }
 
         public Builder selection(Selection selection) {
-            this.selections.add(selection);
+            this.selections = ImmutableKit.addToList(selections, selection);
             return this;
         }
 
@@ -157,7 +157,7 @@ public class SelectionSet extends AbstractNode<SelectionSet> {
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 

--- a/src/main/java/graphql/language/StringValue.java
+++ b/src/main/java/graphql/language/StringValue.java
@@ -1,6 +1,7 @@
 package graphql.language;
 
 
+import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
 import graphql.util.TraversalControl;
@@ -107,7 +108,7 @@ public class StringValue extends AbstractNode<StringValue> implements ScalarValu
     public static final class Builder implements NodeBuilder {
         private SourceLocation sourceLocation;
         private String value;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
 
@@ -116,7 +117,7 @@ public class StringValue extends AbstractNode<StringValue> implements ScalarValu
 
         private Builder(StringValue existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.value = existing.getValue();
             this.ignoredChars = existing.getIgnoredChars();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
@@ -134,7 +135,7 @@ public class StringValue extends AbstractNode<StringValue> implements ScalarValu
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 
@@ -155,8 +156,7 @@ public class StringValue extends AbstractNode<StringValue> implements ScalarValu
 
 
         public StringValue build() {
-            StringValue stringValue = new StringValue(value, sourceLocation, comments, ignoredChars, additionalData);
-            return stringValue;
+            return new StringValue(value, sourceLocation, comments, ignoredChars, additionalData);
         }
     }
 }

--- a/src/main/java/graphql/language/TypeName.java
+++ b/src/main/java/graphql/language/TypeName.java
@@ -1,6 +1,7 @@
 package graphql.language;
 
 
+import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
 import graphql.util.TraversalControl;
@@ -109,7 +110,7 @@ public class TypeName extends AbstractNode<TypeName> implements Type<TypeName>, 
     public static final class Builder implements NodeBuilder {
         private String name;
         private SourceLocation sourceLocation;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
 
@@ -118,7 +119,7 @@ public class TypeName extends AbstractNode<TypeName> implements Type<TypeName>, 
 
         private Builder(TypeName existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.name = existing.getName();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
         }
@@ -135,7 +136,7 @@ public class TypeName extends AbstractNode<TypeName> implements Type<TypeName>, 
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 

--- a/src/main/java/graphql/language/UnionTypeDefinition.java
+++ b/src/main/java/graphql/language/UnionTypeDefinition.java
@@ -4,6 +4,7 @@ package graphql.language;
 import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
@@ -153,11 +154,11 @@ public class UnionTypeDefinition extends AbstractDescribedNode<UnionTypeDefiniti
 
     public static final class Builder implements NodeDirectivesBuilder {
         private SourceLocation sourceLocation;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private String name;
         private Description description;
-        private List<Directive> directives = new ArrayList<>();
-        private List<Type> memberTypes = new ArrayList<>();
+        private ImmutableList<Directive> directives = emptyList();
+        private ImmutableList<Type> memberTypes = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
 
@@ -166,11 +167,11 @@ public class UnionTypeDefinition extends AbstractDescribedNode<UnionTypeDefiniti
 
         private Builder(UnionTypeDefinition existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.name = existing.getName();
             this.description = existing.getDescription();
-            this.directives = existing.getDirectives();
-            this.memberTypes = existing.getMemberTypes();
+            this.directives = ImmutableList.copyOf(existing.getDirectives());
+            this.memberTypes = ImmutableList.copyOf(existing.getMemberTypes());
             this.ignoredChars = existing.getIgnoredChars();
         }
 
@@ -180,7 +181,7 @@ public class UnionTypeDefinition extends AbstractDescribedNode<UnionTypeDefiniti
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 
@@ -196,22 +197,22 @@ public class UnionTypeDefinition extends AbstractDescribedNode<UnionTypeDefiniti
 
         @Override
         public Builder directives(List<Directive> directives) {
-            this.directives = directives;
+            this.directives = ImmutableList.copyOf(directives);
             return this;
         }
 
         public Builder directive(Directive directive) {
-            this.directives.add(directive);
+            this.directives = ImmutableKit.addToList(directives, directive);
             return this;
         }
 
         public Builder memberTypes(List<Type> memberTypes) {
-            this.memberTypes = memberTypes;
+            this.memberTypes = ImmutableList.copyOf(memberTypes);
             return this;
         }
 
         public Builder memberType(Type memberType) {
-            this.memberTypes.add(memberType);
+            this.memberTypes = ImmutableKit.addToList(memberTypes, memberType);
             return this;
         }
 

--- a/src/main/java/graphql/language/UnionTypeExtensionDefinition.java
+++ b/src/main/java/graphql/language/UnionTypeExtensionDefinition.java
@@ -1,15 +1,17 @@
 package graphql.language;
 
+import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
+import static graphql.collect.ImmutableKit.emptyList;
 
 @PublicApi
 public class UnionTypeExtensionDefinition extends UnionTypeDefinition {
@@ -73,27 +75,25 @@ public class UnionTypeExtensionDefinition extends UnionTypeDefinition {
 
     public static final class Builder implements NodeDirectivesBuilder {
         private SourceLocation sourceLocation;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private String name;
         private Description description;
-        private List<Directive> directives = new ArrayList<>();
-        private List<Type> memberTypes = new ArrayList<>();
+        private ImmutableList<Directive> directives = emptyList();
+        private ImmutableList<Type> memberTypes = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
 
         private Builder() {
         }
 
-
-        private Builder(UnionTypeExtensionDefinition existing) {
+        private Builder(UnionTypeDefinition existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.name = existing.getName();
             this.description = existing.getDescription();
-            this.directives = existing.getDirectives();
-            this.memberTypes = existing.getMemberTypes();
+            this.directives = ImmutableList.copyOf(existing.getDirectives());
+            this.memberTypes = ImmutableList.copyOf(existing.getMemberTypes());
             this.ignoredChars = existing.getIgnoredChars();
-            this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
         }
 
         public Builder sourceLocation(SourceLocation sourceLocation) {
@@ -102,7 +102,7 @@ public class UnionTypeExtensionDefinition extends UnionTypeDefinition {
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 
@@ -118,12 +118,22 @@ public class UnionTypeExtensionDefinition extends UnionTypeDefinition {
 
         @Override
         public Builder directives(List<Directive> directives) {
-            this.directives = directives;
+            this.directives = ImmutableList.copyOf(directives);
+            return this;
+        }
+
+        public Builder directive(Directive directive) {
+            this.directives = ImmutableKit.addToList(directives, directive);
             return this;
         }
 
         public Builder memberTypes(List<Type> memberTypes) {
-            this.memberTypes = memberTypes;
+            this.memberTypes = ImmutableList.copyOf(memberTypes);
+            return this;
+        }
+
+        public Builder memberType(Type memberType) {
+            this.memberTypes = ImmutableKit.addToList(memberTypes, memberType);
             return this;
         }
 

--- a/src/main/java/graphql/language/VariableDefinition.java
+++ b/src/main/java/graphql/language/VariableDefinition.java
@@ -4,6 +4,7 @@ package graphql.language;
 import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
@@ -185,10 +186,10 @@ public class VariableDefinition extends AbstractNode<VariableDefinition> impleme
     public static final class Builder implements NodeDirectivesBuilder {
         private SourceLocation sourceLocation;
         private String name;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private Type type;
         private Value defaultValue;
-        private List<Directive> directives = new ArrayList<>();
+        private ImmutableList<Directive> directives = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
 
@@ -197,11 +198,11 @@ public class VariableDefinition extends AbstractNode<VariableDefinition> impleme
 
         private Builder(VariableDefinition existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.name = existing.getName();
             this.type = existing.getType();
             this.defaultValue = existing.getDefaultValue();
-            this.directives = existing.getDirectives();
+            this.directives = ImmutableList.copyOf(existing.getDirectives());
             this.ignoredChars = existing.getIgnoredChars();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
         }
@@ -217,7 +218,7 @@ public class VariableDefinition extends AbstractNode<VariableDefinition> impleme
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 
@@ -233,12 +234,12 @@ public class VariableDefinition extends AbstractNode<VariableDefinition> impleme
 
         @Override
         public Builder directives(List<Directive> directives) {
-            this.directives = directives;
+            this.directives = ImmutableList.copyOf(directives);
             return this;
         }
 
         public Builder directive(Directive directive) {
-            this.directives.add(directive);
+            this.directives = ImmutableKit.addToList(directives, directive);
             return this;
         }
 

--- a/src/main/java/graphql/language/VariableReference.java
+++ b/src/main/java/graphql/language/VariableReference.java
@@ -1,6 +1,7 @@
 package graphql.language;
 
 
+import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
 import graphql.util.TraversalControl;
@@ -103,7 +104,7 @@ public class VariableReference extends AbstractNode<VariableReference> implement
 
     public static final class Builder implements NodeBuilder {
         private SourceLocation sourceLocation;
-        private List<Comment> comments = new ArrayList<>();
+        private ImmutableList<Comment> comments = emptyList();
         private String name;
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
@@ -113,7 +114,7 @@ public class VariableReference extends AbstractNode<VariableReference> implement
 
         private Builder(VariableReference existing) {
             this.sourceLocation = existing.getSourceLocation();
-            this.comments = existing.getComments();
+            this.comments = ImmutableList.copyOf(existing.getComments());
             this.name = existing.getName();
             this.ignoredChars = existing.getIgnoredChars();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
@@ -125,7 +126,7 @@ public class VariableReference extends AbstractNode<VariableReference> implement
         }
 
         public Builder comments(List<Comment> comments) {
-            this.comments = comments;
+            this.comments = ImmutableList.copyOf(comments);
             return this;
         }
 

--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -4,6 +4,7 @@ package graphql.parser;
 import com.google.common.collect.ImmutableList;
 import graphql.Assert;
 import graphql.Internal;
+import graphql.collect.ImmutableKit;
 import graphql.language.Argument;
 import graphql.language.ArrayValue;
 import graphql.language.BooleanValue;
@@ -852,12 +853,12 @@ public class GraphqlAntlrToLanguage {
                 return getCommentOnChannel(refChannel);
             }
         }
-        return Collections.emptyList();
+        return ImmutableKit.emptyList();
     }
 
 
     protected List<Comment> getCommentOnChannel(List<Token> refChannel) {
-        List<Comment> comments = new ArrayList<>();
+        ImmutableList.Builder<Comment> comments = ImmutableList.builder();
         for (Token refTok : refChannel) {
             String text = refTok.getText();
             // we strip the leading hash # character but we don't trim because we don't
@@ -873,7 +874,7 @@ public class GraphqlAntlrToLanguage {
             int line = sourceAndLine.getLine() + 1;
             comments.add(new Comment(text, new SourceLocation(line, column, sourceAndLine.getSourceName())));
         }
-        return ImmutableList.copyOf(comments);
+        return comments.build();
     }
 
 

--- a/src/test/groovy/graphql/collect/ImmutableKitTest.groovy
+++ b/src/test/groovy/graphql/collect/ImmutableKitTest.groovy
@@ -28,4 +28,18 @@ class ImmutableKitTest extends Specification {
         outputList == ["kciuq", "nworb", "xof"]
         outputList instanceof ImmutableList
     }
+
+    def "can add to lists"() {
+        def list = ["a"]
+
+        when:
+        list = ImmutableKit.addToList(list, "b")
+        then:
+        list == ["a", "b"]
+
+        when:
+        list = ImmutableKit.addToList(list, "c", "d", "e")
+        then:
+        list == ["a", "b", "c", "d", "e"]
+    }
 }


### PR DESCRIPTION
This make the AST elements use immutable lists inside themselves (for performance reasons since they are created on every request but we have convenience methods for the single item add methods from before.

Related to #2099 