### PR TITLE
avoiding allocations in ConditionalNodes

### DIFF
--- a/src/main/java/graphql/execution/ConditionalNodes.java
+++ b/src/main/java/graphql/execution/ConditionalNodes.java
@@ -4,10 +4,10 @@ import graphql.Assert;
 import graphql.Internal;
 import graphql.VisibleForTesting;
 import graphql.language.Directive;
+import graphql.language.NodeUtil;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import static graphql.Directives.IncludeDirective;
 import static graphql.Directives.SkipDirective;
@@ -25,7 +25,7 @@ public class ConditionalNodes {
     }
 
     private boolean getDirectiveResult(Map<String, Object> variables, List<Directive> directives, String directiveName, boolean defaultValue) {
-        Directive foundDirective = findDirectiveByName(directives, directiveName);
+        Directive foundDirective = NodeUtil.findNodeByName(directives, directiveName);
         if (foundDirective != null) {
             Map<String, Object> argumentValues = valuesResolver.getArgumentValues(SkipDirective.getArguments(), foundDirective.getArguments(), variables);
             Object flag = argumentValues.get("if");
@@ -33,15 +33,6 @@ public class ConditionalNodes {
             return (Boolean) flag;
         }
         return defaultValue;
-    }
-
-    private Directive findDirectiveByName(List<Directive> directives, String name) {
-        for (Directive directive : directives) {
-            if (Objects.equals(directive.getName(), name)) {
-                return directive;
-            }
-        }
-        return null;
     }
 
 }

--- a/src/main/java/graphql/language/Directive.java
+++ b/src/main/java/graphql/language/Directive.java
@@ -19,7 +19,6 @@ import static graphql.collect.ImmutableKit.emptyList;
 import static graphql.collect.ImmutableKit.emptyMap;
 import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 import static graphql.language.NodeUtil.argumentsByName;
-import static graphql.language.NodeUtil.getArgumentByName;
 
 @PublicApi
 public class Directive extends AbstractNode<Directive> implements NamedNode<Directive> {
@@ -65,7 +64,7 @@ public class Directive extends AbstractNode<Directive> implements NamedNode<Dire
     }
 
     public Argument getArgument(String argumentName) {
-        return NodeUtil.getArgumentByName(arguments, argumentName);
+        return NodeUtil.findNodeByName(arguments, argumentName);
     }
 
     @Override

--- a/src/main/java/graphql/language/NodeUtil.java
+++ b/src/main/java/graphql/language/NodeUtil.java
@@ -9,6 +9,7 @@ import graphql.util.NodeLocation;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static graphql.util.FpKit.mergeFirst;
 
@@ -29,6 +30,15 @@ public class NodeUtil {
         return true;
     }
 
+    public static <T extends NamedNode<T>> T findNodeByName(List<T> namedNodes, String name) {
+        for (T namedNode : namedNodes) {
+            if (Objects.equals(namedNode.getName(), name)) {
+                return namedNode;
+            }
+        }
+        return null;
+    }
+
     public static Map<String, ImmutableList<Directive>> allDirectivesByName(List<Directive> directives) {
         return FpKit.groupingBy(directives, Directive::getName);
     }
@@ -36,16 +46,6 @@ public class NodeUtil {
     public static Map<String, Argument> argumentsByName(List<Argument> arguments) {
         return FpKit.getByName(arguments, Argument::getName, mergeFirst());
     }
-
-    public static Argument getArgumentByName(List<Argument> arguments, String name) {
-        for (Argument argument : arguments) {
-            if (argument.getName().equals(name)) {
-                return argument;
-            }
-        }
-        return null;
-    }
-
 
     public static class GetOperationResult {
         public OperationDefinition operationDefinition;


### PR DESCRIPTION
Alternative fix for #2119 

Master:
```
Benchmark                                    Mode  Cnt   Score   Error  Units
BenchMark.benchMarkSimpleQueriesThroughput  thrpt   15  42.681 ± 1.912  ops/s
BenchMark.benchMarkSimpleQueriesAvgTime      avgt   15  23.026 ± 0.621  ms/op
```

This branch:
```
Benchmark                                    Mode  Cnt   Score   Error  Units
BenchMark.benchMarkSimpleQueriesThroughput  thrpt   15  46.075 ± 2.372  ops/s
BenchMark.benchMarkSimpleQueriesAvgTime      avgt   15  21.021 ± 0.602  ms/op
```

