### PR TITLE
Ensure GraphQLSchema.transform works properly

### DIFF
--- a/src/main/java/graphql/schema/GraphQLSchema.java
+++ b/src/main/java/graphql/schema/GraphQLSchema.java
@@ -404,7 +404,7 @@ public class GraphQLSchema {
     public GraphQLSchema transform(Consumer<Builder> builderConsumer) {
         Builder builder = newSchema(this);
         builderConsumer.accept(builder);
-        return builder.build();
+        return builder.buildImpl(true);
     }
 
     /**


### PR DESCRIPTION
`transform` needs to pass `true` (signifying that the schema is being transformed) to `buildImpl` so that it doesn't throw errors when it finds types in the transformed schema that were previously defined.

Without this, transforming the schema throws an error claiming that "All types within a GraphQL schema must have unique names".