### PR TITLE
use default df from GraphQLCodeRegistry

### DIFF
--- a/src/main/java/graphql/schema/CodeRegistryVisitor.java
+++ b/src/main/java/graphql/schema/CodeRegistryVisitor.java
@@ -22,12 +22,12 @@ class CodeRegistryVisitor extends GraphQLTypeVisitorStub {
     @Override
     public TraversalControl visitGraphQLFieldDefinition(GraphQLFieldDefinition node, TraverserContext<GraphQLSchemaElement> context) {
         GraphQLFieldsContainer parentContainerType = (GraphQLFieldsContainer) context.getParentContext().thisNode();
-        DataFetcher dataFetcher = node.getDataFetcher();
-        if (dataFetcher == null) {
-            dataFetcher = new PropertyDataFetcher<>(node.getName());
+        DataFetcher<?> dataFetcher = node.getDataFetcher();
+        if (dataFetcher != null) {
+            FieldCoordinates coordinates = coordinates(parentContainerType, node);
+            codeRegistry.dataFetcherIfAbsent(coordinates, dataFetcher);
         }
-        FieldCoordinates coordinates = coordinates(parentContainerType, node);
-        codeRegistry.dataFetcherIfAbsent(coordinates, dataFetcher);
+        
         return CONTINUE;
     }
 

--- a/src/main/java/graphql/schema/GraphQLFieldDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLFieldDefinition.java
@@ -83,7 +83,6 @@ public class GraphQLFieldDefinition implements GraphQLNamedSchemaElement, GraphQ
     @Deprecated
     public GraphQLFieldDefinition(String name, String description, GraphQLOutputType type, DataFetcherFactory dataFetcherFactory, List<GraphQLArgument> arguments, String deprecationReason, List<GraphQLDirective> directives, FieldDefinition definition) {
         assertValidName(name);
-        assertNotNull(dataFetcherFactory, () -> "you have to provide a DataFetcher (or DataFetcherFactory)");
         assertNotNull(type, () -> "type can't be null");
         assertNotNull(arguments, () -> "arguments can't be null");
         this.name = name;
@@ -112,6 +111,9 @@ public class GraphQLFieldDefinition implements GraphQLNamedSchemaElement, GraphQ
 
     // to be removed in a future version when all code is in the code registry
     DataFetcher<?> getDataFetcher() {
+        if (dataFetcherFactory == null) {
+            return null;
+        }
         return dataFetcherFactory.get(newDataFetchingFactoryEnvironment()
                 .fieldDefinition(this)
                 .build());
@@ -492,9 +494,6 @@ public class GraphQLFieldDefinition implements GraphQLNamedSchemaElement, GraphQ
         }
 
         public GraphQLFieldDefinition build() {
-            if (dataFetcherFactory == null) {
-                dataFetcherFactory = DataFetcherFactories.useDataFetcher(new PropertyDataFetcher<>(name));
-            }
             return new GraphQLFieldDefinition(
                     name,
                     description,

--- a/src/test/groovy/graphql/schema/GraphQLCodeRegistryTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLCodeRegistryTest.groovy
@@ -197,6 +197,28 @@ class GraphQLCodeRegistryTest extends Specification {
         dataFetcher.get(null) == "hi"
     }
 
+    def "default DF is used when no data fetcher is specified"() {
+
+        def queryType = newObject().name("Query")
+                .field(newFieldDefinition().name("test").type(Scalars.GraphQLString))
+                .build()
+
+        DataFetcher customDF = { env -> "hi" }
+        DataFetcherFactory customDataFetcherFactory = { env -> customDF }
+
+        def codeRegistry = GraphQLCodeRegistry.newCodeRegistry().defaultDataFetcher(customDataFetcherFactory).build()
+
+        def schema = GraphQLSchema.newSchema().query(queryType).codeRegistry(codeRegistry).build()
+        def graphQL = GraphQL.newGraphQL(schema).build()
+
+        when:
+        def er = graphQL.execute(ExecutionInput.newExecutionInput().query('''query { test }''').build())
+
+        then:
+        er.errors.isEmpty()
+        er.data == [test: "hi"]
+    }
+
     def "integration test that code registry gets asked for data fetchers"() {
 
         def queryType = newObject().name("Query")

--- a/src/test/groovy/graphql/schema/idl/WiringFactoryTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/WiringFactoryTest.groovy
@@ -335,7 +335,7 @@ class WiringFactoryTest extends Specification {
         //
         // no directive - plain name
         //
-        def fetcher2 = type.getFieldDefinition("name").getDataFetcher()
+        def fetcher2 = schema.getCodeRegistry().getDataFetcher(type, type.getFieldDefinition("name"))
         fetcher2 instanceof PropertyDataFetcher
 
         PropertyDataFetcher propertyDataFetcher2 = fetcher2 as PropertyDataFetcher


### PR DESCRIPTION
This PR removes hardcoding the `PropertyDataFetcher` if no data fetcher is specified inside a `GraphQLFieldDefinition`. Instead, the default data fetcher defined in the `GraphQLCodeRegistry` is used now if a `GraphQLFieldDefinition` does not specify a custom data fetcher.

fixes #2145