### PR TITLE
Fix ClassCastException in TypeAndFieldRule

### DIFF
--- a/src/main/java/graphql/schema/validation/InvalidSchemaException.java
+++ b/src/main/java/graphql/schema/validation/InvalidSchemaException.java
@@ -2,14 +2,23 @@ package graphql.schema.validation;
 
 import graphql.GraphQLException;
 import graphql.Internal;
+import graphql.VisibleForTesting;
 
 import java.util.Collection;
 
 @Internal
 public class InvalidSchemaException extends GraphQLException {
 
+    private final Collection<SchemaValidationError> errors;
+
     public InvalidSchemaException(Collection<SchemaValidationError> errors) {
         super(buildErrorMsg(errors));
+        this.errors = errors;
+    }
+
+    @VisibleForTesting
+    Collection<SchemaValidationError> getErrors() {
+        return errors;
     }
 
     private static String buildErrorMsg(Collection<SchemaValidationError> errors) {

--- a/src/main/java/graphql/schema/validation/TypeAndFieldRule.java
+++ b/src/main/java/graphql/schema/validation/TypeAndFieldRule.java
@@ -1,6 +1,5 @@
 package graphql.schema.validation;
 
-import graphql.language.TypeName;
 import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLEnumValueDefinition;
@@ -130,12 +129,12 @@ public class TypeAndFieldRule implements SchemaValidationRule {
             GraphQLNamedType graphQLNamedType = schemaTypeHolder.get(typeName);
             if (!(graphQLNamedType instanceof GraphQLObjectType)) {
                 SchemaValidationError validationError =
-                        new SchemaValidationError(SchemaValidationErrorType.InvalidUnionMemberTypeError, String.format("The member types of a Union type must all be Object base types. member type \"%s\" in Union \"%s\" is invalid.", ((TypeName) memberType).getName(), type.getName()));
+                        new SchemaValidationError(SchemaValidationErrorType.InvalidUnionMemberTypeError, String.format("The member types of a Union type must all be Object base types. member type \"%s\" in Union \"%s\" is invalid.", memberType.getName(), type.getName()));
                 errorCollector.addError(validationError);
             }
             if (typeNames.contains(typeName)) {
                 SchemaValidationError validationError =
-                        new SchemaValidationError(SchemaValidationErrorType.RepetitiveElementError, String.format("The member types of a Union type must be unique. member type \"%s\" in Union \"%s\" is not unique.", ((TypeName) memberType).getName(), type.getName()));
+                        new SchemaValidationError(SchemaValidationErrorType.RepetitiveElementError, String.format("The member types of a Union type must be unique. member type \"%s\" in Union \"%s\" is not unique.", memberType.getName(), type.getName()));
                 errorCollector.addError(validationError);
             }
             typeNames.add(typeName);


### PR DESCRIPTION
### Description 
This PR fixes two instances of ClassCastException in `TypeAndFieldRule` when the following conditions are met:
- union member types are not object types
- union member types are repeated.

### Testing
It was quite hard to add a unit test since it looks like these two rules are already present in the [UnionTypesChecker](https://github.com/graphql-java/graphql-java/blob/7a8e9038df64ddba27a8aa4040ecdeb60fe387e5/src/main/java/graphql/schema/idl/UnionTypesChecker.java#L69).

Should we remove these two altogether?