### PR TITLE
Throw an exception when try to register or unregister data loader when no DataLoaderRegistry provided

### DIFF
--- a/src/main/java/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentationState.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentationState.java
@@ -9,6 +9,7 @@ import org.dataloader.DataLoaderRegistry;
 import org.slf4j.Logger;
 
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 
 /**
  * A base class that keeps track of whether aggressive batching can be used
@@ -18,9 +19,23 @@ public class DataLoaderDispatcherInstrumentationState implements Instrumentation
 
     @Internal
     public static final DataLoaderRegistry EMPTY_DATALOADER_REGISTRY = new DataLoaderRegistry() {
+
+        private static final String ERROR_MESSAGE = "You MUST set in your own DataLoaderRegistry to use data loader";
+
         @Override
         public DataLoaderRegistry register(String key, DataLoader<?, ?> dataLoader) {
-            return Assert.assertShouldNeverHappen("You MUST set in your own DataLoaderRegistry to use data loader");
+            return Assert.assertShouldNeverHappen(ERROR_MESSAGE);
+        }
+
+        @Override
+        public <K, V> DataLoader<K, V> computeIfAbsent(final String key,
+                                                       final Function<String, DataLoader<?, ?>> mappingFunction) {
+            return Assert.assertShouldNeverHappen(ERROR_MESSAGE);
+        }
+
+        @Override
+        public DataLoaderRegistry unregister(String key) {
+            return Assert.assertShouldNeverHappen(ERROR_MESSAGE);
         }
     };
 


### PR DESCRIPTION
Hello!

The original implementation is throwing an exception only when the `register` method was invoked but in my reality, I'm using `computeIfAbsent` method to register a new data loader (kind of lazy initialization). Without such changes, if no data loader registry was provided it will not throw any exception and hangs on waiting for the data from the data loader, which in the first place is not very intuitive behavior. I think it's better to throw an exception for all three methods `register`, `computeIfAbsent` and `unregister`, not only one `register`.