### PR TITLE
Bugfix: caching of visited fragments in Normalized tree

### DIFF
--- a/src/main/java/graphql/normalized/FieldCollectorNormalizedQuery.java
+++ b/src/main/java/graphql/normalized/FieldCollectorNormalizedQuery.java
@@ -76,7 +76,6 @@ public class FieldCollectorNormalizedQuery {
         // result key -> ObjectType -> NormalizedField
         Map<String, Map<GraphQLObjectType, NormalizedField>> subFields = new LinkedHashMap<>();
         Map<NormalizedField, MergedField> mergedFieldByNormalizedField = new LinkedHashMap<>();
-        List<String> visitedFragments = new ArrayList<>();
         Set<GraphQLObjectType> possibleObjects
                 = new LinkedHashSet<>(resolvePossibleObjects((GraphQLCompositeType) fieldType, parameters.getGraphQLSchema()));
         for (Field field : mergedField.getFields()) {
@@ -85,7 +84,6 @@ public class FieldCollectorNormalizedQuery {
             }
             this.collectFields(parameters,
                     field.getSelectionSet(),
-                    visitedFragments,
                     subFields,
                     mergedFieldByNormalizedField,
                     possibleObjects,
@@ -101,10 +99,9 @@ public class FieldCollectorNormalizedQuery {
                                                    GraphQLObjectType rootType) {
         Map<String, Map<GraphQLObjectType, NormalizedField>> subFields = new LinkedHashMap<>();
         Map<NormalizedField, MergedField> mergedFieldByNormalizedField = new LinkedHashMap<>();
-        List<String> visitedFragments = new ArrayList<>();
         Set<GraphQLObjectType> possibleObjects = new LinkedHashSet<>();
         possibleObjects.add(rootType);
-        this.collectFields(parameters, operationDefinition.getSelectionSet(), visitedFragments, subFields, mergedFieldByNormalizedField, possibleObjects, 1, null);
+        this.collectFields(parameters, operationDefinition.getSelectionSet(), subFields, mergedFieldByNormalizedField, possibleObjects, 1, null);
         List<NormalizedField> children = subFieldsToList(subFields);
         return new CollectFieldResult(children, mergedFieldByNormalizedField);
     }
@@ -119,7 +116,6 @@ public class FieldCollectorNormalizedQuery {
 
     private void collectFields(FieldCollectorNormalizedQueryParams parameters,
                                SelectionSet selectionSet,
-                               List<String> visitedFragments,
                                Map<String, Map<GraphQLObjectType, NormalizedField>> result,
                                Map<NormalizedField, MergedField> mergedFieldByNormalizedField,
                                Set<GraphQLObjectType> possibleObjects,
@@ -130,28 +126,23 @@ public class FieldCollectorNormalizedQuery {
             if (selection instanceof Field) {
                 collectField(parameters, result, mergedFieldByNormalizedField, (Field) selection, possibleObjects, level, parent);
             } else if (selection instanceof InlineFragment) {
-                collectInlineFragment(parameters, visitedFragments, result, mergedFieldByNormalizedField, (InlineFragment) selection, possibleObjects, level, parent);
+                collectInlineFragment(parameters, result, mergedFieldByNormalizedField, (InlineFragment) selection, possibleObjects, level, parent);
             } else if (selection instanceof FragmentSpread) {
-                collectFragmentSpread(parameters, visitedFragments, result, mergedFieldByNormalizedField, (FragmentSpread) selection, possibleObjects, level, parent);
+                collectFragmentSpread(parameters, result, mergedFieldByNormalizedField, (FragmentSpread) selection, possibleObjects, level, parent);
             }
         }
     }
 
     private void collectFragmentSpread(FieldCollectorNormalizedQueryParams parameters,
-                                       List<String> visitedFragments,
                                        Map<String, Map<GraphQLObjectType, NormalizedField>> result,
                                        Map<NormalizedField, MergedField> mergedFieldByNormalizedField,
                                        FragmentSpread fragmentSpread,
                                        Set<GraphQLObjectType> possibleObjects,
                                        int level,
                                        NormalizedField parent) {
-        if (visitedFragments.contains(fragmentSpread.getName())) {
-            return;
-        }
         if (!conditionalNodes.shouldInclude(parameters.getVariables(), fragmentSpread.getDirectives())) {
             return;
         }
-        visitedFragments.add(fragmentSpread.getName());
         FragmentDefinition fragmentDefinition = assertNotNull(parameters.getFragmentsByName().get(fragmentSpread.getName()));
 
         if (!conditionalNodes.shouldInclude(parameters.getVariables(), fragmentDefinition.getDirectives())) {
@@ -159,11 +150,10 @@ public class FieldCollectorNormalizedQuery {
         }
         GraphQLCompositeType newCondition = (GraphQLCompositeType) parameters.getGraphQLSchema().getType(fragmentDefinition.getTypeCondition().getName());
         Set<GraphQLObjectType> newConditions = narrowDownPossibleObjects(possibleObjects, newCondition, parameters.getGraphQLSchema());
-        collectFields(parameters, fragmentDefinition.getSelectionSet(), visitedFragments, result, mergedFieldByNormalizedField, newConditions, level, parent);
+        collectFields(parameters, fragmentDefinition.getSelectionSet(), result, mergedFieldByNormalizedField, newConditions, level, parent);
     }
 
     private void collectInlineFragment(FieldCollectorNormalizedQueryParams parameters,
-                                       List<String> visitedFragments,
                                        Map<String, Map<GraphQLObjectType, NormalizedField>> result,
                                        Map<NormalizedField, MergedField> mergedFieldByNormalizedField,
                                        InlineFragment inlineFragment,
@@ -179,7 +169,7 @@ public class FieldCollectorNormalizedQuery {
             newPossibleObjects = narrowDownPossibleObjects(possibleObjects, newCondition, parameters.getGraphQLSchema());
 
         }
-        collectFields(parameters, inlineFragment.getSelectionSet(), visitedFragments, result, mergedFieldByNormalizedField, newPossibleObjects, level, parent);
+        collectFields(parameters, inlineFragment.getSelectionSet(), result, mergedFieldByNormalizedField, newPossibleObjects, level, parent);
     }
 
     private void collectField(FieldCollectorNormalizedQueryParams parameters,

--- a/src/test/groovy/graphql/normalized/NormalizedQueryTreeFactoryTest.groovy
+++ b/src/test/groovy/graphql/normalized/NormalizedQueryTreeFactoryTest.groovy
@@ -784,6 +784,55 @@ type Dog implements Animal{
 
     }
 
+    def "fragment is used multiple times with different parents"() {
+        String schema = """
+        type Query{ 
+            pet: Pet
+        }
+        interface Pet {
+            name: String
+        }
+        type Dog implements Pet {
+            name: String
+        }
+        type Cat implements Pet {
+            name: String
+        }
+        """
+        GraphQLSchema graphQLSchema = TestUtil.schema(schema)
+
+        String query = """
+        {
+            pet {
+                ... on Dog {
+                    ...F
+                }
+                ... on Cat {
+                    ...F
+                }
+            }
+        }
+        fragment F on Pet {
+            name
+        }
+        
+        
+        """
+        assertValidQuery(graphQLSchema, query)
+
+        Document document = TestUtil.parseQuery(query)
+
+        NormalizedQueryTreeFactory dependencyGraph = new NormalizedQueryTreeFactory();
+        def tree = dependencyGraph.createNormalizedQuery(graphQLSchema, document, null, [:])
+        def printedTree = printTree(tree)
+
+        expect:
+        printedTree == ['Query.pet: Pet (conditional: false)',
+                        'Dog.name: String (conditional: true)',
+                        'Cat.name: String (conditional: true)'];
+    }
+
+
     def "normalized field to MergedField is build"() {
         given:
         def graphQLSchema = TestUtil.schema("""


### PR DESCRIPTION
caching leads to wrong normalized trees inn some cases. Caching removed