### PR TITLE
fix #2131: less allocations in SimpleInstrumentation

### DIFF
--- a/src/main/java/graphql/execution/instrumentation/SimpleInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/SimpleInstrumentation.java
@@ -31,17 +31,17 @@ public class SimpleInstrumentation implements Instrumentation {
 
     @Override
     public InstrumentationContext<ExecutionResult> beginExecution(InstrumentationExecutionParameters parameters) {
-        return new SimpleInstrumentationContext<>();
+        return SimpleInstrumentationContext.noOp();
     }
 
     @Override
     public InstrumentationContext<Document> beginParse(InstrumentationExecutionParameters parameters) {
-        return new SimpleInstrumentationContext<>();
+        return SimpleInstrumentationContext.noOp();
     }
 
     @Override
     public InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters) {
-        return new SimpleInstrumentationContext<>();
+        return SimpleInstrumentationContext.noOp();
     }
 
     @Override
@@ -61,16 +61,16 @@ public class SimpleInstrumentation implements Instrumentation {
 
     @Override
     public InstrumentationContext<ExecutionResult> beginExecuteOperation(InstrumentationExecuteOperationParameters parameters) {
-        return new SimpleInstrumentationContext<>();
+        return SimpleInstrumentationContext.noOp();
     }
 
     @Override
     public InstrumentationContext<ExecutionResult> beginField(InstrumentationFieldParameters parameters) {
-        return new SimpleInstrumentationContext<>();
+        return SimpleInstrumentationContext.noOp();
     }
 
     @Override
     public InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters) {
-        return new SimpleInstrumentationContext<>();
+        return SimpleInstrumentationContext.noOp();
     }
 }


### PR DESCRIPTION
Since SimpleInstrumentation is often used as base class, it would be
possible to skip some allocations in case the method is not overridden.
