### PR TITLE
This provides @deprecated on input fields and arguments

### DIFF
--- a/src/main/java/graphql/Directives.java
+++ b/src/main/java/graphql/Directives.java
@@ -8,11 +8,13 @@ import graphql.schema.GraphQLDirective;
 
 import static graphql.Scalars.GraphQLBoolean;
 import static graphql.Scalars.GraphQLString;
+import static graphql.introspection.Introspection.DirectiveLocation.ARGUMENT_DEFINITION;
 import static graphql.introspection.Introspection.DirectiveLocation.ENUM_VALUE;
 import static graphql.introspection.Introspection.DirectiveLocation.FIELD;
 import static graphql.introspection.Introspection.DirectiveLocation.FIELD_DEFINITION;
 import static graphql.introspection.Introspection.DirectiveLocation.FRAGMENT_SPREAD;
 import static graphql.introspection.Introspection.DirectiveLocation.INLINE_FRAGMENT;
+import static graphql.introspection.Introspection.DirectiveLocation.INPUT_FIELD_DEFINITION;
 import static graphql.introspection.Introspection.DirectiveLocation.SCALAR;
 import static graphql.language.DirectiveLocation.newDirectiveLocation;
 import static graphql.language.InputValueDefinition.newInputValueDefinition;
@@ -40,6 +42,8 @@ public class Directives {
                 .name(DEPRECATED)
                 .directiveLocation(newDirectiveLocation().name(FIELD_DEFINITION.name()).build())
                 .directiveLocation(newDirectiveLocation().name(ENUM_VALUE.name()).build())
+                .directiveLocation(newDirectiveLocation().name(ARGUMENT_DEFINITION.name()).build())
+                .directiveLocation(newDirectiveLocation().name(INPUT_FIELD_DEFINITION.name()).build())
                 .description(createDescription("Marks the field or enum value as deprecated"))
                 .inputValueDefinition(
                         newInputValueDefinition()
@@ -91,13 +95,13 @@ public class Directives {
      */
     public static final GraphQLDirective DeprecatedDirective = GraphQLDirective.newDirective()
             .name(DEPRECATED)
-            .description("Marks the field or enum value as deprecated")
+            .description("Marks the field, argument, input field or enum value as deprecated")
             .argument(newArgument()
                     .name("reason")
                     .type(GraphQLString)
                     .defaultValue(NO_LONGER_SUPPORTED)
                     .description("The reason for the deprecation"))
-            .validLocations(FIELD_DEFINITION, ENUM_VALUE)
+            .validLocations(FIELD_DEFINITION, ENUM_VALUE, ARGUMENT_DEFINITION, INPUT_FIELD_DEFINITION)
             .definition(DEPRECATED_DIRECTIVE_DEFINITION)
             .build();
 

--- a/src/main/java/graphql/introspection/IntrospectionQuery.java
+++ b/src/main/java/graphql/introspection/IntrospectionQuery.java
@@ -42,7 +42,7 @@ public interface IntrospectionQuery {
             "      isDeprecated\n" +
             "      deprecationReason\n" +
             "    }\n" +
-            "    inputFields {\n" +
+            "    inputFields(includeDeprecated: true) {\n" +
             "      ...InputValue\n" +
             "    }\n" +
             "    interfaces {\n" +
@@ -64,6 +64,8 @@ public interface IntrospectionQuery {
             "    description\n" +
             "    type { ...TypeRef }\n" +
             "    defaultValue\n" +
+            "    isDeprecated\n" +
+            "    deprecationReason\n" +
             "  }\n" +
             "\n" +
             //

--- a/src/main/java/graphql/schema/GraphQLArgument.java
+++ b/src/main/java/graphql/schema/GraphQLArgument.java
@@ -41,6 +41,7 @@ public class GraphQLArgument implements GraphQLNamedSchemaElement, GraphQLInputV
 
     private final String name;
     private final String description;
+    private final String deprecationReason;
     private final GraphQLInputType originalType;
     private final Object value;
     private final Object defaultValue;
@@ -91,10 +92,10 @@ public class GraphQLArgument implements GraphQLNamedSchemaElement, GraphQLInputV
      * @deprecated use the {@link #newArgument()} builder pattern instead, as this constructor will be made private in a future version.
      */
     public GraphQLArgument(String name, String description, GraphQLInputType type, Object defaultValue, InputValueDefinition definition) {
-        this(name, description, type, defaultValue, null, definition, Collections.emptyList());
+        this(name, description, type, defaultValue, null, definition, Collections.emptyList(), null);
     }
 
-    private GraphQLArgument(String name, String description, GraphQLInputType type, Object defaultValue, Object value, InputValueDefinition definition, List<GraphQLDirective> directives) {
+    private GraphQLArgument(String name, String description, GraphQLInputType type, Object defaultValue, Object value, InputValueDefinition definition, List<GraphQLDirective> directives, String deprecationReason) {
         assertValidName(name);
         assertNotNull(type, () -> "type can't be null");
         this.name = name;
@@ -103,6 +104,7 @@ public class GraphQLArgument implements GraphQLNamedSchemaElement, GraphQLInputV
         this.defaultValue = defaultValue;
         this.value = value;
         this.definition = definition;
+        this.deprecationReason = deprecationReason;
         this.directives = new DirectivesUtil.DirectivesHolder(directives);
     }
 
@@ -147,6 +149,14 @@ public class GraphQLArgument implements GraphQLNamedSchemaElement, GraphQLInputV
 
     public String getDescription() {
         return description;
+    }
+
+    public String getDeprecationReason() {
+        return deprecationReason;
+    }
+
+    public boolean isDeprecated() {
+        return deprecationReason != null;
     }
 
     public InputValueDefinition getDefinition() {
@@ -256,6 +266,7 @@ public class GraphQLArgument implements GraphQLNamedSchemaElement, GraphQLInputV
         private GraphQLInputType type;
         private Object defaultValue = DEFAULT_VALUE_SENTINEL;
         private Object value;
+        private String deprecationReason;
         private InputValueDefinition definition;
         private final List<GraphQLDirective> directives = new ArrayList<>();
 
@@ -269,6 +280,7 @@ public class GraphQLArgument implements GraphQLNamedSchemaElement, GraphQLInputV
             this.defaultValue = existing.defaultValue;
             this.description = existing.getDescription();
             this.definition = existing.getDefinition();
+            this.deprecationReason = existing.deprecationReason;
             DirectivesUtil.enforceAddAll(this.directives, existing.getDirectives());
         }
 
@@ -295,6 +307,10 @@ public class GraphQLArgument implements GraphQLNamedSchemaElement, GraphQLInputV
             return this;
         }
 
+        public Builder deprecate(String deprecationReason) {
+            this.deprecationReason = deprecationReason;
+            return this;
+        }
 
         public Builder type(GraphQLInputType type) {
             this.type = type;
@@ -356,7 +372,8 @@ public class GraphQLArgument implements GraphQLNamedSchemaElement, GraphQLInputV
                     defaultValue,
                     value,
                     definition,
-                    sort(directives, GraphQLArgument.class, GraphQLDirective.class)
+                    sort(directives, GraphQLArgument.class, GraphQLDirective.class),
+                    deprecationReason
             );
         }
     }

--- a/src/main/java/graphql/schema/GraphQLInputObjectField.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectField.java
@@ -1,7 +1,6 @@
 package graphql.schema;
 
 
-import com.google.common.collect.ImmutableList;
 import graphql.DirectivesUtil;
 import graphql.Internal;
 import graphql.PublicApi;
@@ -10,14 +9,12 @@ import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
-import static graphql.util.FpKit.getByName;
 import static java.util.Collections.emptyList;
 
 /**
@@ -35,6 +32,7 @@ public class GraphQLInputObjectField implements GraphQLNamedSchemaElement, Graph
     private final String description;
     private final GraphQLInputType originalType;
     private final Object defaultValue;
+    private final String deprecationReason;
     private final InputValueDefinition definition;
     private final DirectivesUtil.DirectivesHolder directives;
 
@@ -82,6 +80,10 @@ public class GraphQLInputObjectField implements GraphQLNamedSchemaElement, Graph
     @Internal
     @Deprecated
     public GraphQLInputObjectField(String name, String description, GraphQLInputType type, Object defaultValue, List<GraphQLDirective> directives, InputValueDefinition definition) {
+        this(name, description, type, defaultValue, directives, definition, null);
+    }
+
+    private GraphQLInputObjectField(String name, String description, GraphQLInputType type, Object defaultValue, List<GraphQLDirective> directives, InputValueDefinition definition, String deprecationReason) {
         assertValidName(name);
         assertNotNull(type, () -> "type can't be null");
         assertNotNull(directives, () -> "directives cannot be null");
@@ -92,6 +94,7 @@ public class GraphQLInputObjectField implements GraphQLNamedSchemaElement, Graph
         this.description = description;
         this.directives = new DirectivesUtil.DirectivesHolder(directives);
         this.definition = definition;
+        this.deprecationReason = deprecationReason;
     }
 
     void replaceType(GraphQLInputType type) {
@@ -113,6 +116,14 @@ public class GraphQLInputObjectField implements GraphQLNamedSchemaElement, Graph
 
     public String getDescription() {
         return description;
+    }
+
+    public String getDeprecationReason() {
+        return deprecationReason;
+    }
+
+    public boolean isDeprecated() {
+        return deprecationReason != null;
     }
 
     public InputValueDefinition getDefinition() {
@@ -233,6 +244,7 @@ public class GraphQLInputObjectField implements GraphQLNamedSchemaElement, Graph
         private GraphQLInputType type;
         private InputValueDefinition definition;
         private final List<GraphQLDirective> directives = new ArrayList<>();
+        private String deprecationReason;
 
         public Builder() {
         }
@@ -243,7 +255,8 @@ public class GraphQLInputObjectField implements GraphQLNamedSchemaElement, Graph
             this.defaultValue = existing.getDefaultValue();
             this.type = existing.originalType;
             this.definition = existing.getDefinition();
-            DirectivesUtil.enforceAddAll(this.directives,existing.getDirectives());
+            this.deprecationReason = existing.deprecationReason;
+            DirectivesUtil.enforceAddAll(this.directives, existing.getDirectives());
         }
 
         @Override
@@ -266,6 +279,11 @@ public class GraphQLInputObjectField implements GraphQLNamedSchemaElement, Graph
 
         public Builder definition(InputValueDefinition definition) {
             this.definition = definition;
+            return this;
+        }
+
+        public Builder deprecate(String deprecationReason) {
+            this.deprecationReason = deprecationReason;
             return this;
         }
 
@@ -327,7 +345,8 @@ public class GraphQLInputObjectField implements GraphQLNamedSchemaElement, Graph
                     type,
                     defaultValue,
                     sort(directives, GraphQLInputObjectField.class, GraphQLDirective.class),
-                    definition);
+                    definition,
+                    deprecationReason);
         }
     }
 }

--- a/src/main/java/graphql/schema/idl/SchemaPrinter.java
+++ b/src/main/java/graphql/schema/idl/SchemaPrinter.java
@@ -53,8 +53,10 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static graphql.Directives.DeprecatedDirective;
+import static graphql.introspection.Introspection.DirectiveLocation.ARGUMENT_DEFINITION;
 import static graphql.introspection.Introspection.DirectiveLocation.ENUM_VALUE;
 import static graphql.introspection.Introspection.DirectiveLocation.FIELD_DEFINITION;
+import static graphql.introspection.Introspection.DirectiveLocation.INPUT_FIELD_DEFINITION;
 import static graphql.schema.visibility.DefaultGraphqlFieldVisibility.DEFAULT_FIELD_VISIBILITY;
 import static graphql.util.EscapeUtil.escapeJsonString;
 import static java.util.Optional.ofNullable;
@@ -72,7 +74,7 @@ public class SchemaPrinter {
     //
     private static final GraphQLDirective DeprecatedDirective4Printing = GraphQLDirective.newDirective()
             .name("deprecated")
-            .validLocations(FIELD_DEFINITION, ENUM_VALUE)
+            .validLocations(FIELD_DEFINITION, ENUM_VALUE, ARGUMENT_DEFINITION, INPUT_FIELD_DEFINITION)
             .build();
 
     /**

--- a/src/test/groovy/graphql/Issue2141.groovy
+++ b/src/test/groovy/graphql/Issue2141.groovy
@@ -40,7 +40,7 @@ directive @auth(roles: [String!]) on FIELD_DEFINITION
 directive @deprecated(
     "The reason for the deprecation"
     reason: String = "No longer supported"
-  ) on FIELD_DEFINITION | ENUM_VALUE
+  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
 
 "Exposes a URL that specifies the behaviour of this scalar."
 directive @specifiedBy(

--- a/src/test/groovy/graphql/introspection/IntrospectionTest.groovy
+++ b/src/test/groovy/graphql/introspection/IntrospectionTest.groovy
@@ -106,6 +106,7 @@ class IntrospectionTest extends Specification {
         def spec = '''
             type Query {
                namedField(arg : InputType @deprecated ) : Enum @deprecated
+               notDeprecated(arg : InputType) : Enum
             }
             enum Enum {
                 RED @deprecated
@@ -125,9 +126,12 @@ class IntrospectionTest extends Specification {
 
         def types = executionResult.data['__schema']['types'] as List
         def queryType = types.find { it['name'] == 'Query' }
-        def namedField = (queryType['fields'] as List)[0]
+        def namedField = (queryType['fields'] as List).find({ it["name"] == "namedField"})
         namedField["isDeprecated"]
-        namedField["deprecationReason"] == "No longer supported"
+
+        def notDeprecatedField = (queryType['fields'] as List).find({ it["name"] == "notDeprecated"})
+        !notDeprecatedField["isDeprecated"]
+        notDeprecatedField["deprecationReason"] == null
 
         def enumType = types.find { it['name'] == 'Enum' }
         def red = enumType["enumValues"].find({ it["name"] == "RED" })
@@ -139,8 +143,12 @@ class IntrospectionTest extends Specification {
         inputField["isDeprecated"]
         inputField["deprecationReason"] == "No longer supported"
 
-        def argument = (namedField["args"] as List)[0]
+        def argument = (namedField["args"] as List).find({ it["name"] == "arg"})
         argument["isDeprecated"]
         argument["deprecationReason"] == "No longer supported"
+
+        def argument2 = (notDeprecatedField["args"] as List).find({ it["name"] == "arg"})
+        !argument2["isDeprecated"]
+        argument2["deprecationReason"] == null
     }
 }

--- a/src/test/groovy/graphql/introspection/IntrospectionTest.groovy
+++ b/src/test/groovy/graphql/introspection/IntrospectionTest.groovy
@@ -1,13 +1,7 @@
 package graphql.introspection
 
-
 import graphql.TestUtil
 import spock.lang.Specification
-
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
-import java.util.concurrent.ThreadFactory
 
 class IntrospectionTest extends Specification {
 
@@ -136,12 +130,12 @@ class IntrospectionTest extends Specification {
         namedField["deprecationReason"] == "No longer supported"
 
         def enumType = types.find { it['name'] == 'Enum' }
-        def red = enumType["enumValues"].find({ it["name"] == "RED"})
+        def red = enumType["enumValues"].find({ it["name"] == "RED" })
         red["isDeprecated"]
         red["deprecationReason"] == "No longer supported"
 
         def inputType = types.find { it['name'] == 'InputType' }
-        def inputField = inputType["inputFields"].find({ it["name"] == "inputField"})
+        def inputField = inputType["inputFields"].find({ it["name"] == "inputField" })
         inputField["isDeprecated"]
         inputField["deprecationReason"] == "No longer supported"
 

--- a/src/test/groovy/graphql/schema/GraphQLArgumentTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLArgumentTest.groovy
@@ -13,6 +13,7 @@ class GraphQLArgumentTest extends Specification {
         def startingArgument = GraphQLArgument.newArgument().name("A1")
                 .description("A1_description")
                 .type(GraphQLInt)
+                .deprecate("custom reason")
                 .withDirective(newDirective().name("directive1"))
                 .build()
         when:
@@ -23,6 +24,7 @@ class GraphQLArgumentTest extends Specification {
                     .type(GraphQLString)
                     .withDirective(newDirective().name("directive3"))
                     .value("VALUE")
+                    .deprecate(null)
                     .defaultValue("DEFAULT")
         })
 
@@ -31,6 +33,8 @@ class GraphQLArgumentTest extends Specification {
         startingArgument.description == "A1_description"
         startingArgument.type == GraphQLInt
         startingArgument.defaultValue == null
+        startingArgument.deprecationReason == "custom reason"
+        startingArgument.isDeprecated()
         startingArgument.getDirectives().size() == 1
         startingArgument.getDirective("directive1") != null
 
@@ -39,6 +43,8 @@ class GraphQLArgumentTest extends Specification {
         transformedArgument.type == GraphQLString
         transformedArgument.value == "VALUE"
         transformedArgument.defaultValue == "DEFAULT"
+        transformedArgument.deprecationReason == null
+        !transformedArgument.isDeprecated()
         transformedArgument.getDirectives().size() == 2
         transformedArgument.getDirective("directive1") != null
         transformedArgument.getDirective("directive3") != null

--- a/src/test/groovy/graphql/schema/GraphQLInputObjectFieldTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLInputObjectFieldTest.groovy
@@ -17,12 +17,14 @@ class GraphQLInputObjectFieldTest extends Specification {
                 .description("F1_description")
                 .withDirective(newDirective().name("directive1"))
                 .withDirective(newDirective().name("directive2"))
+                .deprecate("No longer useful")
                 .build()
 
         when:
         def transformedField = startingField.transform({ builder ->
             builder.name("F2")
                     .type(GraphQLInt)
+                    .deprecate(null)
                     .withDirective(newDirective().name("directive3"))
 
         })
@@ -33,6 +35,8 @@ class GraphQLInputObjectFieldTest extends Specification {
         startingField.name == "F1"
         startingField.type == GraphQLFloat
         startingField.description == "F1_description"
+        startingField.isDeprecated()
+        startingField.getDeprecationReason() == "No longer useful"
 
         startingField.getDirectives().size() == 2
         startingField.getDirective("directive1") != null
@@ -41,6 +45,9 @@ class GraphQLInputObjectFieldTest extends Specification {
         transformedField.name == "F2"
         transformedField.type == GraphQLInt
         transformedField.description == "F1_description" // left alone
+
+        ! transformedField.isDeprecated()
+        transformedField.getDeprecationReason() == null
 
         transformedField.getDirectives().size() == 3
         transformedField.getDirective("directive1") != null

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -10,8 +10,8 @@ import graphql.schema.Coercing
 import graphql.schema.GraphQLArgument
 import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLEnumType
-import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLEnumValueDefinition
+import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLInputObjectField
 import graphql.schema.GraphQLInputObjectType
 import graphql.schema.GraphQLInputType
@@ -991,7 +991,7 @@ directive @repeatableDirective repeatable on SCALAR
 directive @deprecated(
     "The reason for the deprecation"
     reason: String = "No longer supported"
-  ) on FIELD_DEFINITION | ENUM_VALUE
+  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
 
 "Exposes a URL that specifies the behaviour of this scalar."
 directive @specifiedBy(
@@ -1084,6 +1084,8 @@ input SomeInput {
               active : Enum
               deprecated : Enum @deprecated
               deprecatedWithReason : Enum @deprecated(reason : "Custom reason 1")
+              deprecatedFieldArgument( arg1 : String, arg2 : Int @deprecated) : Enum
+              deprecatedFieldArgumentWithReason( arg1 : String, arg2 : Int @deprecated(reason : "Custom arg reason 1")) : Enum
             }
             
             type Query {
@@ -1095,6 +1097,12 @@ input SomeInput {
               DEPRECATED @deprecated
               DEPRECATED_WITH_REASON @deprecated(reason : "Custom reason 2")
             }
+            
+            input Input {
+              active : Enum
+              deprecated : Enum @deprecated
+              deprecatedWithReason : Enum @deprecated(reason : "Custom reason 3")
+          }
         """
         def registry = new SchemaParser().parse(idl)
         def runtimeWiring = newRuntimeWiring().build()
@@ -1122,7 +1130,7 @@ directive @skip(
 directive @deprecated(
     "The reason for the deprecation"
     reason: String = "No longer supported"
-  ) on FIELD_DEFINITION | ENUM_VALUE
+  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
 
 "Exposes a URL that specifies the behaviour of this scalar."
 directive @specifiedBy(
@@ -1133,6 +1141,8 @@ directive @specifiedBy(
 type Field {
   active: Enum
   deprecated: Enum @deprecated(reason : "No longer supported")
+  deprecatedFieldArgument(arg1: String, arg2: Int @deprecated(reason : "No longer supported")): Enum
+  deprecatedFieldArgumentWithReason(arg1: String, arg2: Int @deprecated(reason : "Custom arg reason 1")): Enum
   deprecatedWithReason: Enum @deprecated(reason : "Custom reason 1")
 }
 
@@ -1144,6 +1154,12 @@ enum Enum {
   ACTIVE
   DEPRECATED @deprecated(reason : "No longer supported")
   DEPRECATED_WITH_REASON @deprecated(reason : "Custom reason 2")
+}
+
+input Input {
+  active: Enum
+  deprecated: Enum @deprecated(reason : "No longer supported")
+  deprecatedWithReason: Enum @deprecated(reason : "Custom reason 3")
 }
 '''
     }
@@ -1211,7 +1227,7 @@ directive @moreComplex(arg1: String = "default", arg2: Int) on FIELD_DEFINITION 
 directive @deprecated(
     "The reason for the deprecation"
     reason: String = "No longer supported"
-  ) on FIELD_DEFINITION | ENUM_VALUE
+  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
 
 "Exposes a URL that specifies the behaviour of this scalar."
 directive @specifiedBy(
@@ -1276,7 +1292,7 @@ directive @moreComplex(arg1: String = "default", arg2: Int) on FIELD_DEFINITION 
 directive @deprecated(
     "The reason for the deprecation"
     reason: String = "No longer supported"
-  ) on FIELD_DEFINITION | ENUM_VALUE
+  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
 
 "Exposes a URL that specifies the behaviour of this scalar."
 directive @specifiedBy(
@@ -1408,7 +1424,7 @@ directive @directive1 on SCALAR
 directive @deprecated(
     "The reason for the deprecation"
     reason: String = "No longer supported"
-  ) on FIELD_DEFINITION | ENUM_VALUE
+  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
 
 "Exposes a URL that specifies the behaviour of this scalar."
 directive @specifiedBy(
@@ -1519,6 +1535,10 @@ extend type Query {
             enum Enum {
               enumVal @deprecated
             }
+            
+            input Input {
+                deprecated : String @deprecated(reason : "custom reason")
+            }
         """
         def registry = new SchemaParser().parse(idl)
         def runtimeWiring = newRuntimeWiring().build()
@@ -1539,6 +1559,10 @@ type Query {
 
 enum Enum {
   enumVal @deprecated(reason : "No longer supported")
+}
+
+input Input {
+  deprecated: String @deprecated(reason : "custom reason")
 }
 '''
     }


### PR DESCRIPTION
See #1770 


See also https://github.com/smitt04/graphql/blob/ac15638ac02ac88013d838785d907c24bbaeff6b/spec/Section%204%20--%20Introspection.md

This now allows @deprecated to be on input fields and arguments.

```
type Query {
    someField(someArg : Int @deprecated) : String
}

input InputType {
    someInputField : String @deprecated
}    
```
    