### PR TITLE
fix #2131: single instance for noOp()

### DIFF
--- a/src/main/java/graphql/execution/instrumentation/SimpleInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/SimpleInstrumentation.java
@@ -26,9 +26,6 @@ public class SimpleInstrumentation implements Instrumentation {
      */
     public static final SimpleInstrumentation INSTANCE = new SimpleInstrumentation();
 
-    public SimpleInstrumentation() {
-    }
-
     @Override
     public InstrumentationContext<ExecutionResult> beginExecution(InstrumentationExecutionParameters parameters) {
         return SimpleInstrumentationContext.noOp();

--- a/src/main/java/graphql/execution/instrumentation/SimpleInstrumentationContext.java
+++ b/src/main/java/graphql/execution/instrumentation/SimpleInstrumentationContext.java
@@ -12,6 +12,8 @@ import java.util.function.Consumer;
 @PublicApi
 public class SimpleInstrumentationContext<T> implements InstrumentationContext<T> {
 
+    private static final InstrumentationContext<Object> NO_OP = new SimpleInstrumentationContext<>();
+
     /**
      * A context that does nothing
      *
@@ -19,8 +21,9 @@ public class SimpleInstrumentationContext<T> implements InstrumentationContext<T
      *
      * @return a context that does nothing
      */
+    @SuppressWarnings("unchecked")
     public static <T> InstrumentationContext<T> noOp() {
-        return new SimpleInstrumentationContext<>();
+        return (InstrumentationContext<T>) NO_OP;
     }
 
     private final BiConsumer<T, Throwable> codeToRunOnComplete;


### PR DESCRIPTION
Previous fix was incomplete (33cd6e60df47bb1f6d407d3ff32804a05b335ae0): SimpleInstrumentationContext.noOp() should avoid allocations too.