### PR TITLE
avoiding array allocations in hashCode()

### DIFF
--- a/src/main/java/graphql/GraphqlErrorHelper.java
+++ b/src/main/java/graphql/GraphqlErrorHelper.java
@@ -62,10 +62,11 @@ public class GraphqlErrorHelper {
     }
 
     public static int hashCode(GraphQLError dis) {
-        int result = dis.getMessage() != null ? dis.getMessage().hashCode() : 0;
-        result = 31 * result + (dis.getLocations() != null ? dis.getLocations().hashCode() : 0);
-        result = 31 * result + (dis.getPath() != null ? dis.getPath().hashCode() : 0);
-        result = 31 * result + dis.getErrorType().hashCode();
+        int result = 1;
+        result = 31 * result + Objects.hashCode(dis.getMessage());
+        result = 31 * result + Objects.hashCode(dis.getLocations());
+        result = 31 * result + Objects.hashCode(dis.getPath());
+        result = 31 * result + Objects.hashCode(dis.getErrorType());
         return result;
     }
 

--- a/src/main/java/graphql/analysis/FieldComplexityEnvironment.java
+++ b/src/main/java/graphql/analysis/FieldComplexityEnvironment.java
@@ -47,11 +47,11 @@ public class FieldComplexityEnvironment {
     @Override
     public String toString() {
         return "FieldComplexityEnvironment{" +
-                "field=" + field +
-                ", fieldDefinition=" + fieldDefinition +
-                ", parentType=" + parentType +
-                ", arguments=" + arguments +
-                '}';
+            "field=" + field +
+            ", fieldDefinition=" + fieldDefinition +
+            ", parentType=" + parentType +
+            ", arguments=" + arguments +
+            '}';
     }
 
     @Override
@@ -60,29 +60,21 @@ public class FieldComplexityEnvironment {
         if (o == null || getClass() != o.getClass()) return false;
 
         FieldComplexityEnvironment that = (FieldComplexityEnvironment) o;
-
-        if (!Objects.equals(field, that.field)) {
-            return false;
-        }
-        if (!Objects.equals(fieldDefinition, that.fieldDefinition)) {
-            return false;
-        }
-        if (!Objects.equals(parentType, that.parentType)) {
-            return false;
-        }
-        if (!Objects.equals(parentEnvironment, that.parentEnvironment)) {
-            return false;
-        }
-        return Objects.equals(arguments, that.arguments);
+        return Objects.equals(field, that.field)
+            && Objects.equals(fieldDefinition, that.fieldDefinition)
+            && Objects.equals(parentType, that.parentType)
+            && Objects.equals(parentEnvironment, that.parentEnvironment)
+            && Objects.equals(arguments, that.arguments);
     }
 
     @Override
     public int hashCode() {
-        int result = field != null ? field.hashCode() : 0;
-        result = 31 * result + (fieldDefinition != null ? fieldDefinition.hashCode() : 0);
-        result = 31 * result + (parentType != null ? parentType.hashCode() : 0);
-        result = 31 * result + (parentEnvironment != null ? parentEnvironment.hashCode() : 0);
-        result = 31 * result + (arguments != null ? arguments.hashCode() : 0);
+        int result = 1;
+        result = 31 * result + Objects.hashCode(field);
+        result = 31 * result + Objects.hashCode(fieldDefinition);
+        result = 31 * result + Objects.hashCode(parentType);
+        result = 31 * result + Objects.hashCode(parentEnvironment);
+        result = 31 * result + Objects.hashCode(arguments);
         return result;
     }
 }

--- a/src/main/java/graphql/analysis/QueryVisitorFieldEnvironmentImpl.java
+++ b/src/main/java/graphql/analysis/QueryVisitorFieldEnvironmentImpl.java
@@ -119,8 +119,16 @@ public class QueryVisitorFieldEnvironmentImpl implements QueryVisitorFieldEnviro
 
     @Override
     public int hashCode() {
-
-        return Objects.hash(typeNameIntrospectionField, field, fieldDefinition, parentType, unmodifiedParentType, arguments, parentEnvironment, selectionSetContainer);
+        int result = 1;
+        result = 31 * result + Objects.hashCode(typeNameIntrospectionField);
+        result = 31 * result + Objects.hashCode(field);
+        result = 31 * result + Objects.hashCode(fieldDefinition);
+        result = 31 * result + Objects.hashCode(parentType);
+        result = 31 * result + Objects.hashCode(unmodifiedParentType);
+        result = 31 * result + Objects.hashCode(arguments);
+        result = 31 * result + Objects.hashCode(parentEnvironment);
+        result = 31 * result + Objects.hashCode(selectionSetContainer);
+        return result;
     }
 
     @Override

--- a/src/main/java/graphql/analysis/QueryVisitorFragmentDefinitionEnvironmentImpl.java
+++ b/src/main/java/graphql/analysis/QueryVisitorFragmentDefinitionEnvironmentImpl.java
@@ -51,7 +51,7 @@ public class QueryVisitorFragmentDefinitionEnvironmentImpl implements QueryVisit
 
     @Override
     public int hashCode() {
-        return Objects.hash(fragmentDefinition);
+        return Objects.hashCode(fragmentDefinition);
     }
 
     @Override

--- a/src/main/java/graphql/analysis/QueryVisitorFragmentSpreadEnvironmentImpl.java
+++ b/src/main/java/graphql/analysis/QueryVisitorFragmentSpreadEnvironmentImpl.java
@@ -55,7 +55,7 @@ public class QueryVisitorFragmentSpreadEnvironmentImpl implements QueryVisitorFr
 
     @Override
     public int hashCode() {
-        return Objects.hash(fragmentSpread);
+        return Objects.hashCode(fragmentSpread);
     }
 }
 

--- a/src/main/java/graphql/analysis/QueryVisitorInlineFragmentEnvironmentImpl.java
+++ b/src/main/java/graphql/analysis/QueryVisitorInlineFragmentEnvironmentImpl.java
@@ -45,8 +45,7 @@ public class QueryVisitorInlineFragmentEnvironmentImpl implements QueryVisitorIn
 
     @Override
     public int hashCode() {
-
-        return Objects.hash(inlineFragment);
+        return Objects.hashCode(inlineFragment);
     }
 
     @Override

--- a/src/main/java/graphql/execution/MergedField.java
+++ b/src/main/java/graphql/execution/MergedField.java
@@ -181,7 +181,7 @@ public class MergedField {
 
     @Override
     public int hashCode() {
-        return Objects.hash(fields);
+        return Objects.hashCode(fields);
     }
 
     @Override

--- a/src/main/java/graphql/language/IgnoredChar.java
+++ b/src/main/java/graphql/language/IgnoredChar.java
@@ -38,10 +38,10 @@ public class IgnoredChar implements Serializable {
     @Override
     public String toString() {
         return "IgnoredChar{" +
-                "value='" + value + '\'' +
-                ", kind=" + kind +
-                ", sourceLocation=" + sourceLocation +
-                '}';
+            "value='" + value + '\'' +
+            ", kind=" + kind +
+            ", sourceLocation=" + sourceLocation +
+            '}';
     }
 
     @Override
@@ -54,12 +54,16 @@ public class IgnoredChar implements Serializable {
         }
         IgnoredChar that = (IgnoredChar) o;
         return Objects.equals(value, that.value) &&
-                kind == that.kind &&
-                Objects.equals(sourceLocation, that.sourceLocation);
+            kind == that.kind &&
+            Objects.equals(sourceLocation, that.sourceLocation);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(value, kind, sourceLocation);
+        int result = 1;
+        result = 31 * result + Objects.hashCode(value);
+        result = 31 * result + Objects.hashCode(kind);
+        result = 31 * result + Objects.hashCode(sourceLocation);
+        return result;
     }
 }

--- a/src/main/java/graphql/language/NonNullType.java
+++ b/src/main/java/graphql/language/NonNullType.java
@@ -7,7 +7,6 @@ import graphql.PublicApi;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/graphql/language/SourceLocation.java
+++ b/src/main/java/graphql/language/SourceLocation.java
@@ -49,9 +49,10 @@ public class SourceLocation implements Serializable {
 
     @Override
     public int hashCode() {
-        int result = line;
-        result = 31 * result + column;
-        result = 31 * result + (sourceName != null ? sourceName.hashCode() : 0);
+        int result = 1;
+        result = 31 * result + Integer.hashCode(line);
+        result = 31 * result + Integer.hashCode(column);
+        result = 31 * result + Objects.hashCode(sourceName);
         return result;
     }
 

--- a/src/main/java/graphql/relay/DefaultConnectionCursor.java
+++ b/src/main/java/graphql/relay/DefaultConnectionCursor.java
@@ -34,7 +34,7 @@ public class DefaultConnectionCursor implements ConnectionCursor {
 
     @Override
     public int hashCode() {
-        return value != null ? value.hashCode() : 0;
+        return Objects.hashCode(value);
     }
 
     @Override

--- a/src/main/java/graphql/schema/FieldCoordinates.java
+++ b/src/main/java/graphql/schema/FieldCoordinates.java
@@ -67,7 +67,10 @@ public class FieldCoordinates {
 
     @Override
     public int hashCode() {
-        return Objects.hash(typeName, fieldName);
+        int result = 1;
+        result = 31 * result + Objects.hashCode(typeName);
+        result = 31 * result + Objects.hashCode(fieldName);
+        return result;
     }
 
     @Override

--- a/src/main/java/graphql/schema/GraphqlTypeComparatorEnvironment.java
+++ b/src/main/java/graphql/schema/GraphqlTypeComparatorEnvironment.java
@@ -63,17 +63,14 @@ public class GraphqlTypeComparatorEnvironment {
         }
 
         GraphqlTypeComparatorEnvironment that = (GraphqlTypeComparatorEnvironment) o;
-
-        if (!Objects.equals(parentType, that.parentType)) {
-            return false;
-        }
-        return elementType.equals(that.elementType);
+        return Objects.equals(parentType, that.parentType) && elementType.equals(that.elementType);
     }
 
     @Override
     public int hashCode() {
-        int result = parentType != null ? parentType.hashCode() : 0;
-        result = 31 * result + elementType.hashCode();
+        int result = 1;
+        result = 31 * result + Objects.hashCode(parentType);
+        result = 31 * result + Objects.hashCode(elementType);
         return result;
     }
 

--- a/src/main/java/graphql/schema/PropertyFetchingImpl.java
+++ b/src/main/java/graphql/schema/PropertyFetchingImpl.java
@@ -312,7 +312,11 @@ public class PropertyFetchingImpl {
 
         @Override
         public int hashCode() {
-            return Objects.hash(classLoader, className, propertyName);
+            int result = 1;
+            result = 31 * result + Objects.hashCode(classLoader);
+            result = 31 * result + Objects.hashCode(className);
+            result = 31 * result + Objects.hashCode(propertyName);
+            return result;
         }
 
         @Override

--- a/src/main/java/graphql/schema/idl/TypeInfo.java
+++ b/src/main/java/graphql/schema/idl/TypeInfo.java
@@ -152,9 +152,12 @@ public class TypeInfo {
 
     @Override
     public int hashCode() {
-        return Objects.hash(typeName.getName(), isNonNull(), isList());
+        int result = 1;
+        result = 31 * result + Objects.hashCode(typeName.getName());
+        result = 31 * result + Boolean.hashCode(isNonNull());
+        result = 31 * result + Boolean.hashCode(isList());
+        return result;
     }
-
 
     @Override
     public String toString() {

--- a/src/main/java/graphql/schema/validation/SchemaValidationError.java
+++ b/src/main/java/graphql/schema/validation/SchemaValidationError.java
@@ -2,6 +2,8 @@ package graphql.schema.validation;
 
 import graphql.Internal;
 
+import java.util.Objects;
+
 import static graphql.Assert.assertNotNull;
 
 @Internal
@@ -27,7 +29,10 @@ public class SchemaValidationError {
 
     @Override
     public int hashCode() {
-        return errorType.hashCode() ^ description.hashCode();
+        int result = 1;
+        result = 31 * result + errorType.hashCode();
+        result = 31 * result + description.hashCode();
+        return result;
     }
 
     @Override

--- a/src/main/java/graphql/util/Breadcrumb.java
+++ b/src/main/java/graphql/util/Breadcrumb.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 /**
  * A specific {@link NodeLocation} inside a node. This means  {@link #getNode()} returns a Node which has a child
  * at {@link #getLocation()}
- *
+ * <p>
  * A list of Breadcrumbs is used to identify the exact location of a specific node inside a tree.
  *
  * @param <T> the generic type of object
@@ -46,11 +46,10 @@ public class Breadcrumb<T> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(node, location);
+        int result = 1;
+        result = 31 * result +  Objects.hashCode(node);
+        result = 31 * result + Objects.hashCode(location);
+        return result;
     }
 
-    @Override
-    public String toString() {
-        return super.toString();
-    }
 }

--- a/src/main/java/graphql/util/NodeLocation.java
+++ b/src/main/java/graphql/util/NodeLocation.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 
 /**
  * General position of a Node inside a parent.
- *
+ * <p>
  * Can be an index or a name with an index.
  */
 @PublicApi
@@ -34,9 +34,9 @@ public class NodeLocation {
     @Override
     public String toString() {
         return "NodeLocation{" +
-                "name='" + name + '\'' +
-                ", index=" + index +
-                '}';
+            "name='" + name + '\'' +
+            ", index=" + index +
+            '}';
     }
 
     @Override
@@ -49,11 +49,14 @@ public class NodeLocation {
         }
         NodeLocation that = (NodeLocation) o;
         return index == that.index &&
-                Objects.equals(name, that.name);
+            Objects.equals(name, that.name);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, index);
+        int result = 1;
+        result = 31 * result + Objects.hashCode(name);
+        result = 31 * result + Integer.hashCode(index);
+        return result;
     }
 }


### PR DESCRIPTION
According to yourkit FieldCoordinates is allocating too many Object[]
and looks like to root-cause is the usage of `Objects.hash()`.

This patch is trying to standardize use of `Objects.hashCode()`
without allocating arrays.

@andimarek  @bbakerman  this is really micro optimization but please have a look anyway