### PR TITLE
Support for thread switching in a cross cutting way

### DIFF
--- a/src/main/java/graphql/execution/instrumentation/threadpools/ExecutorInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/threadpools/ExecutorInstrumentation.java
@@ -1,6 +1,8 @@
 package graphql.execution.instrumentation.threadpools;
 
+import com.google.common.annotations.Beta;
 import graphql.Assert;
+import graphql.Internal;
 import graphql.TrivialDataFetcher;
 import graphql.execution.Async;
 import graphql.execution.instrumentation.SimpleInstrumentation;
@@ -35,6 +37,8 @@ import static graphql.execution.instrumentation.threadpools.ExecutorInstrumentat
  * This code uses {@link CompletableFuture#supplyAsync(Supplier, Executor)} and {@link CompletableFuture#thenApplyAsync(Function, Executor)} to transfer
  * control between thread pools.
  */
+@Internal
+@Beta
 public class ExecutorInstrumentation extends SimpleInstrumentation {
 
     private static final Consumer<Action> NOOP = a -> {

--- a/src/main/java/graphql/execution/instrumentation/threadpools/ExecutorInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/threadpools/ExecutorInstrumentation.java
@@ -1,0 +1,160 @@
+package graphql.execution.instrumentation.threadpools;
+
+import graphql.Assert;
+import graphql.TrivialDataFetcher;
+import graphql.execution.Async;
+import graphql.execution.instrumentation.SimpleInstrumentation;
+import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static graphql.execution.instrumentation.threadpools.ExecutorInstrumentation.Action.FETCHING;
+import static graphql.execution.instrumentation.threadpools.ExecutorInstrumentation.Action.PROCESSING;
+
+/**
+ * This instrumentation can be used to control on what thread calls to {@link DataFetcher}s happen on.
+ * <p>
+ * If your data fetching is inherently IO bound then you could use a IO oriented thread pool for your fetches and transfer control
+ * back to a CPU oriented thread pool and allow graphql-java code to run the post processing of results there.
+ * <p>
+ * An IO oriented thread pool is typically a multiple of {@link Runtime#availableProcessors()} while a CPU oriented thread pool
+ * is typically no more than {@link Runtime#availableProcessors()}.
+ * <p>
+ * The instrumentation will use the {@link graphql.execution.instrumentation.Instrumentation#instrumentDataFetcher(DataFetcher, InstrumentationFieldFetchParameters)}
+ * method to change your data fetchers so they are executed on a thread pool dedicated to fetching (if you provide one).
+ * <p>
+ * Once the data fetcher value is returns it will transfer control back to a processing thread pool (if you provide one).
+ * <p>
+ * This code uses {@link CompletableFuture#supplyAsync(Supplier, Executor)} and {@link CompletableFuture#thenApplyAsync(Function, Executor)} to transfer
+ * control between thread pools.
+ */
+public class ExecutorInstrumentation extends SimpleInstrumentation {
+
+    private static final Consumer<Action> NOOP = a -> {
+    };
+
+    /**
+     * This describes what action is currently being done.  This is mostly intended for testing.
+     */
+    enum Action {FETCHING, PROCESSING}
+
+    private final Executor fetchExecutor;
+    private final Executor processingExecutor;
+    private final Consumer<Action> actionObserver;
+
+    private ExecutorInstrumentation(Executor fetchExecutor, Executor processingExecutor, Consumer<Action> actionObserver) {
+        this.fetchExecutor = fetchExecutor;
+        this.processingExecutor = processingExecutor;
+        this.actionObserver = actionObserver;
+    }
+
+    public Executor getFetchExecutor() {
+        return fetchExecutor;
+    }
+
+    public Executor getProcessingExecutor() {
+        return processingExecutor;
+    }
+
+    public static Builder newThreadPoolExecutionInstrumentation() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        Executor fetchExecutor;
+        Executor processingExecutor;
+        private Consumer<Action> actionObserver;
+
+        public Builder fetchExecutor(Executor fetchExecutor) {
+            this.fetchExecutor = fetchExecutor;
+            return this;
+        }
+
+        public Builder processingExecutor(Executor processingExecutor) {
+            this.processingExecutor = processingExecutor;
+            return this;
+        }
+
+        /**
+         * This is really intended for testing but this consumer will be called during
+         * stages to indicate what is happening.
+         *
+         * @param actionObserver the observer code
+         *
+         * @return this builder
+         */
+        public Builder actionObserver(Consumer<Action> actionObserver) {
+            this.actionObserver = Assert.assertNotNull(actionObserver);
+            return this;
+        }
+
+        public ExecutorInstrumentation build() {
+            return new ExecutorInstrumentation(fetchExecutor, processingExecutor, actionObserver != null ? actionObserver : NOOP);
+        }
+
+    }
+
+    @Override
+    public DataFetcher<?> instrumentDataFetcher(DataFetcher<?> originalDataFetcher, InstrumentationFieldFetchParameters parameters) {
+        if (originalDataFetcher instanceof TrivialDataFetcher) {
+            return originalDataFetcher;
+        }
+        return environment -> {
+            CompletableFuture<CompletionStage<?>> invokedCF;
+            if (fetchExecutor != null) {
+                // run the fetch asynchronously via the fetch executor
+                // the CF will be left running on that fetch executors thread
+                invokedCF = CompletableFuture.supplyAsync(invokedAsync(originalDataFetcher, environment), fetchExecutor);
+            } else {
+                invokedCF = invokedSynch(originalDataFetcher, environment);
+            }
+            if (processingExecutor != null) {
+                invokedCF = invokedCF.thenApplyAsync(processingControl(), processingExecutor);
+            } else {
+                invokedCF = invokedCF.thenApply(processingControl());
+            }
+            return invokedCF.thenCompose(cs -> cs);
+        };
+    }
+
+
+    private Supplier<CompletionStage<?>> invokedAsync(DataFetcher<?> originalDataFetcher, DataFetchingEnvironment environment) {
+        return () -> {
+            actionObserver.accept(FETCHING);
+            return invokeOriginalDF(originalDataFetcher, environment);
+        };
+    }
+
+    private CompletableFuture<CompletionStage<?>> invokedSynch(DataFetcher<?> originalDataFetcher, DataFetchingEnvironment environment) {
+        actionObserver.accept(FETCHING);
+        return CompletableFuture.completedFuture(invokeOriginalDF(originalDataFetcher, environment));
+    }
+
+    private Function<CompletionStage<?>, CompletionStage<?>> processingControl() {
+        return completionStage -> {
+            actionObserver.accept(PROCESSING);
+            return completionStage;
+        };
+    }
+
+    private CompletionStage<?> invokeOriginalDF(DataFetcher<?> originalDataFetcher, DataFetchingEnvironment environment) {
+        Object value;
+        try {
+            value = originalDataFetcher.get(environment);
+        } catch (Exception e) {
+            return Async.exceptionallyCompletedFuture(e);
+        }
+        if (value instanceof CompletionStage) {
+            return ((CompletionStage<?>) value);
+        } else {
+            return CompletableFuture.completedFuture(value);
+        }
+    }
+}

--- a/src/test/groovy/graphql/execution/instrumentation/threadpools/ExecutorInstrumentationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/threadpools/ExecutorInstrumentationTest.groovy
@@ -148,6 +148,7 @@ class ExecutorInstrumentationTest extends Specification {
     def "will fetch on current thread if the executor is null but transfer control back"() {
 
         when:
+        def currentThreadName = currentThread().getName()
         instrumentation = build(null, ProcessingExecutor, observer)
 
         DataFetcher df = { env -> currentThread().getName() }
@@ -161,8 +162,8 @@ class ExecutorInstrumentationTest extends Specification {
         def value = asCF(returnedValue).join()
 
         then:
-        value == "main"
-        observer.actions == ["FETCHING on main", "PROCESSING on ProcessingThread"]
+        value == "${currentThreadName}"
+        observer.actions == ["FETCHING on ${currentThreadName}", "PROCESSING on ProcessingThread"]
     }
 
     def "a data fetcher can return a CF and that is handled"() {

--- a/src/test/groovy/graphql/execution/instrumentation/threadpools/ExecutorInstrumentationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/threadpools/ExecutorInstrumentationTest.groovy
@@ -1,0 +1,210 @@
+package graphql.execution.instrumentation.threadpools
+
+
+import graphql.TestUtil
+import graphql.schema.DataFetcher
+import graphql.schema.DataFetchingEnvironment
+import graphql.schema.DataFetchingEnvironmentImpl
+import graphql.schema.PropertyDataFetcher
+import spock.lang.Specification
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
+import java.util.concurrent.ThreadFactory
+import java.util.function.Consumer
+
+import static ExecutorInstrumentation.Action
+import static java.lang.Thread.currentThread
+
+class ExecutorInstrumentationTest extends Specification {
+
+    private static ThreadFactory threadFactory(String name) {
+        new ThreadFactory() {
+            @Override
+            Thread newThread(Runnable r) {
+                return new Thread(r, name)
+            }
+        }
+    }
+
+    static class TestingObserver implements Consumer<Action> {
+        def actions = []
+
+        @Override
+        void accept(Action action) {
+            actions.add(action.toString() + " on " + currentThread().getName())
+        }
+    }
+
+    def FetchExecutor = Executors.newSingleThreadExecutor(threadFactory("FetchThread"))
+    def ProcessingExecutor = Executors.newSingleThreadExecutor(threadFactory("ProcessingThread"))
+
+    ExecutorInstrumentation instrumentation
+    def observer = new TestingObserver()
+
+
+    ExecutorInstrumentation build(Executor fetchExecutor, Executor processingExecutor, Consumer<Action> observer) {
+        def builder = ExecutorInstrumentation.newThreadPoolExecutionInstrumentation()
+        if (fetchExecutor != null) {
+            builder.fetchExecutor(fetchExecutor)
+        }
+        if (processingExecutor != null) {
+            builder.processingExecutor(processingExecutor)
+        }
+        builder.actionObserver(observer).build()
+    }
+
+    DataFetchingEnvironment dfEnv(Object s) {
+        DataFetchingEnvironmentImpl.newDataFetchingEnvironment().source(s).build()
+    }
+
+    CompletableFuture asCF(returnedValue) {
+        (CompletableFuture) returnedValue
+    }
+
+    void setup() {
+        observer = new TestingObserver()
+        instrumentation = build(FetchExecutor, ProcessingExecutor, observer)
+    }
+
+    def "basic building works"() {
+        expect:
+        instrumentation.getFetchExecutor() == FetchExecutor
+        instrumentation.getProcessingExecutor() == ProcessingExecutor
+    }
+
+    def "can handle a data fetcher that throws exceptions"() {
+        when:
+        DataFetcher df = { env -> throw new RuntimeException("BANG") }
+        def modifiedDataFetcher = instrumentation.instrumentDataFetcher(df, null)
+        def returnedValue = modifiedDataFetcher.get(null)
+
+        then:
+        returnedValue instanceof CompletableFuture
+
+        when:
+        asCF(returnedValue).join()
+
+        then:
+        def e = thrown(RuntimeException)
+        e.getMessage().contains("BANG")
+    }
+
+
+    def "will leave trivial data fetchers as is"() {
+
+        when:
+        DataFetcher df = PropertyDataFetcher.fetching({ o -> "trivial" })
+        def modifiedDataFetcher = instrumentation.instrumentDataFetcher(df, null)
+        def returnedValue = modifiedDataFetcher.get(dfEnv("source"))
+
+        then:
+        modifiedDataFetcher == df
+        returnedValue == "trivial"
+    }
+
+
+    def "will execute on another thread and transfer execution back to the processing thread"() {
+
+        when:
+        instrumentation = build(FetchExecutor, ProcessingExecutor, observer)
+
+        DataFetcher df = { env -> currentThread().getName() }
+        def modifiedDataFetcher = instrumentation.instrumentDataFetcher(df, null)
+        def returnedValue = modifiedDataFetcher.get(null)
+
+        then:
+        returnedValue instanceof CompletableFuture
+
+        when:
+        def value = asCF(returnedValue).join()
+
+        then:
+        value == "FetchThread"
+        observer.actions == ["FETCHING on FetchThread", "PROCESSING on ProcessingThread"]
+    }
+
+    def "will execute on another thread and stay there without a processing executor"() {
+
+        when:
+        instrumentation = build(FetchExecutor, null, observer)
+
+        DataFetcher df = { env -> currentThread().getName() }
+        def modifiedDataFetcher = instrumentation.instrumentDataFetcher(df, null)
+        def returnedValue = modifiedDataFetcher.get(null)
+
+        then:
+        returnedValue instanceof CompletableFuture
+
+        when:
+        def value = asCF(returnedValue).join()
+
+        then:
+        value == "FetchThread"
+        observer.actions == ["FETCHING on FetchThread", "PROCESSING on FetchThread"]
+    }
+
+    def "will fetch on current thread if the executor is null but transfer control back"() {
+
+        when:
+        instrumentation = build(null, ProcessingExecutor, observer)
+
+        DataFetcher df = { env -> currentThread().getName() }
+        def modifiedDataFetcher = instrumentation.instrumentDataFetcher(df, null)
+        def returnedValue = modifiedDataFetcher.get(null)
+
+        then:
+        returnedValue instanceof CompletableFuture
+
+        when:
+        def value = asCF(returnedValue).join()
+
+        then:
+        value == "main"
+        observer.actions == ["FETCHING on main", "PROCESSING on ProcessingThread"]
+    }
+
+    def "a data fetcher can return a CF and that is handled"() {
+        when:
+        instrumentation = build(FetchExecutor, ProcessingExecutor, observer)
+
+        DataFetcher df = { env -> CompletableFuture.completedFuture(currentThread().getName()) }
+        def modifiedDataFetcher = instrumentation.instrumentDataFetcher(df, null)
+        def returnedValue = modifiedDataFetcher.get(null)
+
+        then:
+        returnedValue instanceof CompletableFuture
+
+        when:
+        def value = asCF(returnedValue).join()
+
+        then:
+        value == "FetchThread"
+        observer.actions == ["FETCHING on FetchThread", "PROCESSING on ProcessingThread"]
+    }
+
+    def "can work in a full schema"() {
+        def sdl = """
+            type Query { 
+                field1 : String 
+                field2 : String 
+            }
+        """
+        DataFetcher df1 = { env -> CompletableFuture.completedFuture("f1" + currentThread().getName()) }
+        DataFetcher df2 = { env -> "f2" + currentThread().getName() }
+
+        def graphQL = TestUtil.graphQL(sdl, [Query: [field1: df1, field2: df2]]).instrumentation(instrumentation).build()
+
+        when:
+        def er = graphQL.execute("{field1, field2}")
+        then:
+        er.errors.isEmpty()
+        er.data["field1"] == "f1FetchThread"
+        er.data["field2"] == "f2FetchThread"
+        observer.actions.sort() == [
+                "FETCHING on FetchThread", "FETCHING on FetchThread",
+                "PROCESSING on ProcessingThread", "PROCESSING on ProcessingThread"
+        ]
+    }
+}


### PR DESCRIPTION
This will allow ANY data fetcher to be automatically executed on a a fetch thread pool and then control passed back to a processing thread pool