### PR TITLE
proposal for #2209

### DIFF
--- a/src/main/java/graphql/execution/ConditionalNodes.java
+++ b/src/main/java/graphql/execution/ConditionalNodes.java
@@ -19,9 +19,6 @@ public class ConditionalNodes {
     ValuesResolver valuesResolver = new ValuesResolver();
 
     public boolean shouldInclude(Map<String, Object> variables, List<Directive> directives) {
-        if (directives.isEmpty()) {
-            return true;
-        }
         boolean skip = getDirectiveResult(variables, directives, SkipDirective.getName(), false);
         boolean include = getDirectiveResult(variables, directives, IncludeDirective.getName(), true);
         return !skip && include;

--- a/src/main/java/graphql/execution/ConditionalNodes.java
+++ b/src/main/java/graphql/execution/ConditionalNodes.java
@@ -19,6 +19,9 @@ public class ConditionalNodes {
     ValuesResolver valuesResolver = new ValuesResolver();
 
     public boolean shouldInclude(Map<String, Object> variables, List<Directive> directives) {
+        if (directives.isEmpty()) {
+            return true;
+        }
         boolean skip = getDirectiveResult(variables, directives, SkipDirective.getName(), false);
         boolean include = getDirectiveResult(variables, directives, IncludeDirective.getName(), true);
         return !skip && include;

--- a/src/main/java/graphql/execution/FieldCollector.java
+++ b/src/main/java/graphql/execution/FieldCollector.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static graphql.execution.MergedSelectionSet.newMergedSelectionSet;
+import static graphql.execution.MergedSelectionSet.newMergedSelectionSetFast;
 import static graphql.execution.TypeFromAST.getTypeFromAST;
 
 /**
@@ -40,7 +41,7 @@ public class FieldCollector {
             }
             this.collectFields(parameters, field.getSelectionSet(), visitedFragments, subFields);
         }
-        return newMergedSelectionSet().subFields(subFields).build();
+        return newMergedSelectionSetFast(subFields);
     }
 
     /**
@@ -55,7 +56,7 @@ public class FieldCollector {
         Map<String, MergedField> subFields = new LinkedHashMap<>();
         Set<String> visitedFragments = new HashSet<>();
         this.collectFields(parameters, selectionSet, visitedFragments, subFields);
-        return newMergedSelectionSet().subFields(subFields).build();
+        return newMergedSelectionSetFast(subFields);
     }
 
     private void collectFields(FieldCollectorParameters parameters, SelectionSet selectionSet, Set<String> visitedFragments, Map<String, MergedField> fields) {

--- a/src/main/java/graphql/execution/FieldCollector.java
+++ b/src/main/java/graphql/execution/FieldCollector.java
@@ -13,8 +13,8 @@ import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLType;
 import graphql.schema.GraphQLUnionType;
 
+import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -34,7 +34,7 @@ public class FieldCollector {
     public MergedSelectionSet collectFields(FieldCollectorParameters parameters, MergedField mergedField) {
         List<Field> fields = mergedField.getFields();
         Map<String, ImmutableList.Builder<Field>> subFields = new LinkedHashMap<>(fields.size());
-        Set<String> visitedFragments = new LinkedHashSet<>(fields.size());
+        Set<String> visitedFragments = new HashSet<>(fields.size());
         for (Field field : fields) {
             if (field.getSelectionSet() == null) {
                 continue;
@@ -54,13 +54,13 @@ public class FieldCollector {
      */
     public MergedSelectionSet collectFields(FieldCollectorParameters parameters, SelectionSet selectionSet) {
         Map<String, ImmutableList.Builder<Field>> subFields = new LinkedHashMap<>();
-        Set<String> visitedFragments = new LinkedHashSet<>();
+        Set<String> visitedFragments = new HashSet<>();
         this.collectFields(parameters, selectionSet, visitedFragments, subFields);
         return newMergedSelectionSet().withSubFields(subFields).build();
     }
 
     private void collectFields(FieldCollectorParameters parameters, SelectionSet selectionSet, Set<String> visitedFragments, Map<String, ImmutableList.Builder<Field>> fields) {
-        for (Selection selection : selectionSet.getSelections()) {
+        for (Selection<?> selection : selectionSet.getSelections()) {
             if (selection instanceof Field) {
                 collectField(parameters, fields, (Field) selection);
             } else if (selection instanceof InlineFragment) {
@@ -99,7 +99,7 @@ public class FieldCollector {
     }
 
     private void collectField(FieldCollectorParameters parameters, Map<String, ImmutableList.Builder<Field>> fields, Field field) {
-        if (!conditionalNodes.shouldInclude(parameters.getVariables(), field.getDirectives())) {
+        if (!field.getDirectives().isEmpty() && !conditionalNodes.shouldInclude(parameters.getVariables(), field.getDirectives())) {
             return;
         }
         String name = field.getResultKey();

--- a/src/main/java/graphql/execution/FieldCollector.java
+++ b/src/main/java/graphql/execution/FieldCollector.java
@@ -99,7 +99,7 @@ public class FieldCollector {
     }
 
     private void collectField(FieldCollectorParameters parameters, Map<String, ImmutableList.Builder<Field>> fields, Field field) {
-        if (!field.getDirectives().isEmpty() && !conditionalNodes.shouldInclude(parameters.getVariables(), field.getDirectives())) {
+        if (!conditionalNodes.shouldInclude(parameters.getVariables(), field.getDirectives())) {
             return;
         }
         String name = field.getResultKey();

--- a/src/main/java/graphql/execution/FieldCollector.java
+++ b/src/main/java/graphql/execution/FieldCollector.java
@@ -33,8 +33,8 @@ public class FieldCollector {
 
     public MergedSelectionSet collectFields(FieldCollectorParameters parameters, MergedField mergedField) {
         List<Field> fields = mergedField.getFields();
-        Map<String, ImmutableList.Builder<Field>> subFields = new LinkedHashMap<>(fields.size());
-        Set<String> visitedFragments = new HashSet<>(fields.size());
+        Map<String, ImmutableList.Builder<Field>> subFields = new LinkedHashMap<>();
+        Set<String> visitedFragments = new HashSet<>();
         for (Field field : fields) {
             if (field.getSelectionSet() == null) {
                 continue;

--- a/src/main/java/graphql/execution/MergedField.java
+++ b/src/main/java/graphql/execution/MergedField.java
@@ -5,7 +5,6 @@ import graphql.PublicApi;
 import graphql.language.Argument;
 import graphql.language.Field;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -131,6 +130,10 @@ public class MergedField {
         return new Builder().fields(fields);
     }
 
+    public static Builder newMergedField(ImmutableList.Builder<Field> existingBuilder) {
+        return new Builder(existingBuilder);
+    }
+
     public MergedField transform(Consumer<Builder> builderConsumer) {
         Builder builder = new Builder(this);
         builderConsumer.accept(builder);
@@ -139,10 +142,15 @@ public class MergedField {
 
     public static class Builder {
 
-        private ImmutableList.Builder<Field> fields;
+        private final ImmutableList.Builder<Field> fields;
 
         private Builder() {
             this.fields = ImmutableList.builder();
+        }
+
+        // taking ownership of existing builder
+        private Builder(ImmutableList.Builder<Field> builder) {
+            this.fields = builder;
         }
 
         private Builder(MergedField existing) {

--- a/src/main/java/graphql/execution/MergedField.java
+++ b/src/main/java/graphql/execution/MergedField.java
@@ -61,12 +61,10 @@ import static graphql.Assert.assertNotEmpty;
 public class MergedField {
 
     private final ImmutableList<Field> fields;
-    private final Field singleField;
 
     private MergedField(List<Field> fields) {
         assertNotEmpty(fields);
         this.fields = ImmutableList.copyOf(fields);
-        this.singleField = fields.get(0);
     }
 
     /**
@@ -77,7 +75,7 @@ public class MergedField {
      * @return the name of of the merged fields.
      */
     public String getName() {
-        return singleField.getName();
+        return fields.get(0).getName();
     }
 
     /**
@@ -87,7 +85,7 @@ public class MergedField {
      * @return the key for this MergedField.
      */
     public String getResultKey() {
-        return singleField.getResultKey();
+        return fields.get(0).getResultKey();
     }
 
     /**
@@ -99,7 +97,7 @@ public class MergedField {
      * @return the fist of the merged Fields
      */
     public Field getSingleField() {
-        return singleField;
+        return fields.get(0);
     }
 
     /**
@@ -108,7 +106,7 @@ public class MergedField {
      * @return the list of arguments
      */
     public List<Argument> getArguments() {
-        return singleField.getArguments();
+        return fields.get(0).getArguments();
     }
 
 

--- a/src/main/java/graphql/execution/MergedField.java
+++ b/src/main/java/graphql/execution/MergedField.java
@@ -139,18 +139,23 @@ public class MergedField {
 
     public static class Builder {
 
-        private final List<Field> fields;
+        private ImmutableList.Builder<Field> fields;
 
         private Builder() {
-            this.fields = new ArrayList<>();
+            this.fields = ImmutableList.builder();
         }
 
         private Builder(MergedField existing) {
-            this.fields = new ArrayList<>(existing.getFields());
+            this.fields = ImmutableList.builder();
+            for (Field field : existing.fields) {
+                this.fields.add(field);
+            }
         }
 
         public Builder fields(List<Field> fields) {
-            this.fields.addAll(fields);
+            for (Field field : fields) {
+                this.fields.add(field);
+            }
             return this;
         }
 
@@ -160,7 +165,7 @@ public class MergedField {
         }
 
         public MergedField build() {
-            return new MergedField(fields);
+            return new MergedField(fields.build());
         }
 
     }

--- a/src/main/java/graphql/execution/MergedField.java
+++ b/src/main/java/graphql/execution/MergedField.java
@@ -99,6 +99,11 @@ public abstract class MergedField {
      */
     public abstract List<Field> getFields();
 
+
+    public static MergedField newMergedFieldFast(Field field) {
+        return new MonoMergedField(field);
+    }
+
     public static Builder newMergedField() {
         return new Builder();
     }

--- a/src/main/java/graphql/execution/MergedSelectionSet.java
+++ b/src/main/java/graphql/execution/MergedSelectionSet.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-
 @PublicApi
 public class MergedSelectionSet {
 
@@ -53,27 +52,26 @@ public class MergedSelectionSet {
     }
 
     public static class Builder {
-        private Map<String, MergedField> subFields = ImmutableMap.of();
+
+        private final ImmutableMap.Builder<String, MergedField> subFields = ImmutableMap.builder();
 
         private Builder() {
         }
 
         public Builder subFields(Map<String, MergedField> subFields) {
-            this.subFields = ImmutableMap.copyOf(subFields);
+            this.subFields.putAll(subFields);
             return this;
         }
 
         public Builder withSubFields(Map<String, ImmutableList.Builder<Field>> subFields) {
-            ImmutableMap.Builder<String, MergedField> builder = new ImmutableMap.Builder<>();
             for (Map.Entry<String, ImmutableList.Builder<Field>> entry : subFields.entrySet()) {
-                builder.put(entry.getKey(), MergedField.newMergedField(entry.getValue()).build());
+                this.subFields.put(entry.getKey(), MergedField.newMergedField(entry.getValue()).build());
             }
-            this.subFields = builder.build();
             return this;
         }
 
         public MergedSelectionSet build() {
-            return new MergedSelectionSet(subFields);
+            return new MergedSelectionSet(subFields.build());
         }
 
     }

--- a/src/main/java/graphql/execution/MergedSelectionSet.java
+++ b/src/main/java/graphql/execution/MergedSelectionSet.java
@@ -64,13 +64,6 @@ public class MergedSelectionSet {
             return this;
         }
 
-        public Builder withSubFields(Map<String, ImmutableList.Builder<Field>> subFields) {
-            for (Map.Entry<String, ImmutableList.Builder<Field>> entry : subFields.entrySet()) {
-                this.subFields.put(entry.getKey(), MergedField.newMergedField(entry.getValue()).build());
-            }
-            return this;
-        }
-
         public MergedSelectionSet build() {
             return new MergedSelectionSet(subFields.build());
         }

--- a/src/main/java/graphql/execution/MergedSelectionSet.java
+++ b/src/main/java/graphql/execution/MergedSelectionSet.java
@@ -53,9 +53,10 @@ public class MergedSelectionSet {
 
     public static class Builder {
 
-        private final ImmutableMap.Builder<String, MergedField> subFields = ImmutableMap.builder();
+        private final ImmutableMap.Builder<String, MergedField> subFields;
 
         private Builder() {
+            subFields = ImmutableMap.builder();
         }
 
         public Builder subFields(Map<String, MergedField> subFields) {

--- a/src/main/java/graphql/execution/MergedSelectionSet.java
+++ b/src/main/java/graphql/execution/MergedSelectionSet.java
@@ -47,6 +47,11 @@ public class MergedSelectionSet {
         return subFields.isEmpty();
     }
 
+    public static MergedSelectionSet newMergedSelectionSetFast(Map<String, MergedField> mergedFields) {
+        return new MergedSelectionSet(mergedFields);
+    }
+
+
     public static Builder newMergedSelectionSet() {
         return new Builder();
     }

--- a/src/main/java/graphql/execution/MergedSelectionSet.java
+++ b/src/main/java/graphql/execution/MergedSelectionSet.java
@@ -2,9 +2,9 @@ package graphql.execution;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.sun.scenario.effect.Merge;
 import graphql.Assert;
 import graphql.PublicApi;
+import graphql.language.Field;
 
 import java.util.List;
 import java.util.Map;
@@ -63,10 +63,10 @@ public class MergedSelectionSet {
             return this;
         }
 
-        public Builder withSubFields(Map<String, MergedField.Builder> subFields) {
+        public Builder withSubFields(Map<String, ImmutableList.Builder<Field>> subFields) {
             ImmutableMap.Builder<String, MergedField> builder = new ImmutableMap.Builder<>();
-            for (Map.Entry<String, MergedField.Builder> entry : subFields.entrySet()) {
-                builder.put(entry.getKey(), entry.getValue().build());
+            for (Map.Entry<String, ImmutableList.Builder<Field>> entry : subFields.entrySet()) {
+                builder.put(entry.getKey(), MergedField.newMergedField(entry.getValue()).build());
             }
             this.subFields = builder.build();
             return this;

--- a/src/main/java/graphql/execution/MergedSelectionSet.java
+++ b/src/main/java/graphql/execution/MergedSelectionSet.java
@@ -1,10 +1,11 @@
 package graphql.execution;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.sun.scenario.effect.Merge;
 import graphql.Assert;
 import graphql.PublicApi;
 
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -52,14 +53,22 @@ public class MergedSelectionSet {
     }
 
     public static class Builder {
-        private Map<String, MergedField> subFields = new LinkedHashMap<>();
+        private Map<String, MergedField> subFields = ImmutableMap.of();
 
         private Builder() {
-
         }
 
         public Builder subFields(Map<String, MergedField> subFields) {
-            this.subFields = subFields;
+            this.subFields = ImmutableMap.copyOf(subFields);
+            return this;
+        }
+
+        public Builder withSubFields(Map<String, MergedField.Builder> subFields) {
+            ImmutableMap.Builder<String, MergedField> builder = new ImmutableMap.Builder<>();
+            for (Map.Entry<String, MergedField.Builder> entry : subFields.entrySet()) {
+                builder.put(entry.getKey(), entry.getValue().build());
+            }
+            this.subFields = builder.build();
             return this;
         }
 

--- a/src/test/java/benchmark/BenchMark.java
+++ b/src/test/java/benchmark/BenchMark.java
@@ -76,7 +76,7 @@ public class BenchMark {
         GraphQLSchema graphQLSchema = new SchemaGenerator().makeExecutableSchema(definitionRegistry, runtimeWiring);
 
         return GraphQL.newGraphQL(graphQLSchema)
-                .instrumentation(new TracingInstrumentation())
+                //.instrumentation(new TracingInstrumentation())
                 .build();
     }
 

--- a/src/test/java/benchmark/BenchMark.java
+++ b/src/test/java/benchmark/BenchMark.java
@@ -76,7 +76,7 @@ public class BenchMark {
         GraphQLSchema graphQLSchema = new SchemaGenerator().makeExecutableSchema(definitionRegistry, runtimeWiring);
 
         return GraphQL.newGraphQL(graphQLSchema)
-                //.instrumentation(new TracingInstrumentation())
+                .instrumentation(new TracingInstrumentation())
                 .build();
     }
 

--- a/src/test/java/benchmark/BenchMark.java
+++ b/src/test/java/benchmark/BenchMark.java
@@ -64,7 +64,7 @@ public class BenchMark {
         InputStream sdl = BenchMark.class.getClassLoader().getResourceAsStream("starWarsSchema.graphqls");
         TypeDefinitionRegistry definitionRegistry = new SchemaParser().parse(new InputStreamReader(sdl));
 
-        DataFetcher heroDataFetcher = environment -> CharacterDTO.mkCharacter(environment, "r2d2", NUMBER_OF_FRIENDS);
+        DataFetcher<?> heroDataFetcher = environment -> CharacterDTO.mkCharacter(environment, "r2d2", NUMBER_OF_FRIENDS);
 
         RuntimeWiring runtimeWiring = RuntimeWiring.newRuntimeWiring()
                 .type(


### PR DESCRIPTION
@andimarek tentative implementation for avoiding some copies in MergedField&co

On my old macbook (2013) I get these numbers:
```
# Warmup Iteration   1: 33.139 ops/s
# Warmup Iteration   2: 69.119 ops/s
Iteration   1: 53.670 ops/s
Iteration   2: 53.648 ops/s
Iteration   3: 54.286 ops/s
```

usually I get 50 ops/s in this benchmark . Can you please double check?

/cc @bbakerman not sure if I'm following the "mutable builder"/"immutable object" pattern. For sure, the type signature are much hard to read now.... please advise :)