### PR TITLE
Add logic to print directives on schemas.

### DIFF
--- a/src/main/java/graphql/schema/idl/SchemaPrinter.java
+++ b/src/main/java/graphql/schema/idl/SchemaPrinter.java
@@ -642,8 +642,7 @@ public class SchemaPrinter {
 
             // when serializing a GraphQL schema using the type system language, a
             // schema definition should be omitted if only uses the default root type names.
-            boolean needsSchemaPrinted = options.isIncludeSchemaDefinition() ||
-                    (this.options.includeDirectiveDefinitions && !schemaDirectives.isEmpty());
+            boolean needsSchemaPrinted = options.isIncludeSchemaDefinition();
 
             if (!needsSchemaPrinted) {
                 if (queryType != null && !queryType.getName().equals("Query")) {

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -1862,4 +1862,55 @@ type PrintMeType {
 """
 
     }
+
+    def "schema with directive prints directive"() {
+        def sdl = """
+            directive @foo on SCHEMA
+            type Query { anything: String }
+            schema @foo {
+                query: Query
+            }
+        """
+        def schema = TestUtil.schema(sdl)
+
+        when:
+        def result = new SchemaPrinter(defaultOptions().includeDirectives(true)).print(schema)
+
+        then:
+        result == """schema @foo{
+  query: Query
+}
+
+"Directs the executor to include this field or fragment only when the `if` argument is true"
+directive @include(
+    "Included when true."
+    if: Boolean!
+  ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"Directs the executor to skip this field or fragment when the `if`'argument is true."
+directive @skip(
+    "Skipped when true."
+    if: Boolean!
+  ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+directive @foo on SCHEMA
+
+"Marks the field or enum value as deprecated"
+directive @deprecated(
+    "The reason for the deprecation"
+    reason: String = "No longer supported"
+  ) on FIELD_DEFINITION | ENUM_VALUE
+
+"Exposes a URL that specifies the behaviour of this scalar."
+directive @specifiedBy(
+    "The URL that specifies the behaviour of this scalar."
+    url: String!
+  ) on SCALAR
+
+type Query {
+  anything: String
+}
+"""
+    }
+
 }

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -1866,9 +1866,9 @@ type PrintMeType {
     def "schema with directive prints directive"() {
         def sdl = """
             directive @foo on SCHEMA
-            type Query { anything: String }
+            type MyQuery { anything: String }
             schema @foo {
-                query: Query
+                query: MyQuery
             }
         """
         def schema = TestUtil.schema(sdl)
@@ -1878,7 +1878,7 @@ type PrintMeType {
 
         then:
         result == """schema @foo{
-  query: Query
+  query: MyQuery
 }
 
 "Directs the executor to include this field or fragment only when the `if` argument is true"
@@ -1907,7 +1907,7 @@ directive @specifiedBy(
     url: String!
   ) on SCALAR
 
-type Query {
+type MyQuery {
   anything: String
 }
 """


### PR DESCRIPTION
This PR addresses issue #2158 where the schema directive would not be printed. Logic similar to the other places where directives are printed was added for schemas.