### PR TITLE
Aded getField to FieldsContainers

### DIFF
--- a/src/main/java/graphql/schema/GraphQLFieldsContainer.java
+++ b/src/main/java/graphql/schema/GraphQLFieldsContainer.java
@@ -17,4 +17,12 @@ public interface GraphQLFieldsContainer extends GraphQLCompositeType {
     GraphQLFieldDefinition getFieldDefinition(String name);
 
     List<GraphQLFieldDefinition> getFieldDefinitions();
+
+    default GraphQLFieldDefinition getField(String name) {
+        return getFieldDefinition(name);
+    }
+
+    default List<GraphQLFieldDefinition> getFields() {
+        return getFieldDefinitions();
+    }
 }

--- a/src/test/groovy/graphql/schema/GraphQLObjectTypeTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLObjectTypeTest.groovy
@@ -65,5 +65,10 @@ class GraphQLObjectTypeTest extends Specification {
         objectType2.getFieldDefinition("AddedInt").getType() == GraphQLInt
         objectType2.getFieldDefinition("Int").getType() == GraphQLInt
         objectType2.getFieldDefinition("Str").getType() == GraphQLBoolean
+
+        // getFields shortcuts work
+        objectType.getField("Int").getType() == GraphQLInt
+        objectType.getField("Str").getType() == GraphQLString
+        objectType.getFields().size() == 2
     }
 }


### PR DESCRIPTION
It has annoyed me for the longest time that `objectType.getField("foo")` did not exist but `inputObject.getField("foo")` does.

getField() is the perfect name.  Short and to the point.

This adds that