### PR TITLE
Add path to errors thrown during coercion

### DIFF
--- a/src/main/java/graphql/execution/NonNullableValueCoercedAsNullException.java
+++ b/src/main/java/graphql/execution/NonNullableValueCoercedAsNullException.java
@@ -21,6 +21,7 @@ import graphql.schema.GraphQLTypeUtil;
 @PublicApi
 public class NonNullableValueCoercedAsNullException extends GraphQLException implements GraphQLError {
     private List<SourceLocation> sourceLocations;
+    private List<Object> path;
 
     public NonNullableValueCoercedAsNullException(VariableDefinition variableDefinition, GraphQLType graphQLType) {
         super(format("Variable '%s' has coerced Null value for NonNull type '%s'",
@@ -34,6 +35,13 @@ public class NonNullableValueCoercedAsNullException extends GraphQLException imp
         this.sourceLocations = Collections.singletonList(variableDefinition.getSourceLocation());
     }
 
+    public NonNullableValueCoercedAsNullException(VariableDefinition variableDefinition, String fieldName, List<Object> path, GraphQLType graphQLType) {
+        super(format("Field '%s' of variable '%s' has coerced Null value for NonNull type '%s'",
+                fieldName, variableDefinition.getName(), GraphQLTypeUtil.simplePrint(graphQLType)));
+        this.sourceLocations = Collections.singletonList(variableDefinition.getSourceLocation());
+        this.path = path;
+    }
+
     public NonNullableValueCoercedAsNullException(GraphQLInputObjectField inputTypeField) {
         super(format("Input field '%s' has coerced Null value for NonNull type '%s'",
                 inputTypeField.getName(), GraphQLTypeUtil.simplePrint(inputTypeField.getType())));
@@ -42,6 +50,11 @@ public class NonNullableValueCoercedAsNullException extends GraphQLException imp
     @Override
     public List<SourceLocation> getLocations() {
         return sourceLocations;
+    }
+
+    @Override
+    public List<Object> getPath() {
+        return path;
     }
 
     @Override

--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -55,6 +55,7 @@ public class ValuesResolver {
         Map<String, Object> coercedValues = new LinkedHashMap<>();
         for (VariableDefinition variableDefinition : variableDefinitions) {
             String variableName = variableDefinition.getName();
+            List<Object> nameStack = new ArrayList<>();
             GraphQLType variableType = TypeFromAST.getTypeFromAST(schema, variableDefinition.getType());
 
             if (!variableValues.containsKey(variableName)) {
@@ -67,7 +68,7 @@ public class ValuesResolver {
                 }
             } else {
                 Object value = variableValues.get(variableName);
-                Object coercedValue = coerceValue(fieldVisibility, variableDefinition, variableDefinition.getName(), variableType, value);
+                Object coercedValue = coerceValue(fieldVisibility, variableDefinition, variableDefinition.getName(), variableType, value, nameStack);
                 coercedValues.put(variableName, coercedValue);
             }
         }
@@ -133,13 +134,15 @@ public class ValuesResolver {
 
 
     @SuppressWarnings("unchecked")
-    private Object coerceValue(GraphqlFieldVisibility fieldVisibility, VariableDefinition variableDefinition, String inputName, GraphQLType graphQLType, Object value) {
+    private Object coerceValue(GraphqlFieldVisibility fieldVisibility, VariableDefinition variableDefinition, String inputName, GraphQLType graphQLType, Object value, List<Object> nameStack) {
         try {
+            nameStack.add(inputName);
+
             if (isNonNull(graphQLType)) {
                 Object returnValue =
-                        coerceValue(fieldVisibility, variableDefinition, inputName, unwrapOne(graphQLType), value);
+                        coerceValue(fieldVisibility, variableDefinition, inputName, unwrapOne(graphQLType), value, nameStack);
                 if (returnValue == null) {
-                    throw new NonNullableValueCoercedAsNullException(variableDefinition, inputName, graphQLType);
+                    throw new NonNullableValueCoercedAsNullException(variableDefinition, inputName, nameStack, graphQLType);
                 }
                 return returnValue;
             }
@@ -153,14 +156,15 @@ public class ValuesResolver {
             } else if (graphQLType instanceof GraphQLEnumType) {
                 return coerceValueForEnum((GraphQLEnumType) graphQLType, value);
             } else if (graphQLType instanceof GraphQLList) {
-                return coerceValueForList(fieldVisibility, variableDefinition, inputName, (GraphQLList) graphQLType, value);
+                return coerceValueForList(fieldVisibility, variableDefinition, inputName, (GraphQLList) graphQLType, value, nameStack);
             } else if (graphQLType instanceof GraphQLInputObjectType) {
                 if (value instanceof Map) {
-                    return coerceValueForInputObjectType(fieldVisibility, variableDefinition, (GraphQLInputObjectType) graphQLType, (Map<String, Object>) value);
+                    return coerceValueForInputObjectType(fieldVisibility, variableDefinition, (GraphQLInputObjectType) graphQLType, (Map<String, Object>) value, nameStack);
                 } else {
                     throw CoercingParseValueException.newCoercingParseValueException()
                             .message("Expected type 'Map' but was '" + value.getClass().getSimpleName() +
                                     "'. Variables for input objects must be an instance of type 'Map'.")
+                            .path(nameStack)
                             .build();
                 }
             } else {
@@ -175,12 +179,13 @@ public class ValuesResolver {
                     .extensions(e.getExtensions())
                     .cause(e.getCause())
                     .sourceLocation(variableDefinition.getSourceLocation())
+                    .path(nameStack)
                     .build();
         }
 
     }
 
-    private Object coerceValueForInputObjectType(GraphqlFieldVisibility fieldVisibility, VariableDefinition variableDefinition, GraphQLInputObjectType inputObjectType, Map<String, Object> input) {
+    private Object coerceValueForInputObjectType(GraphqlFieldVisibility fieldVisibility, VariableDefinition variableDefinition, GraphQLInputObjectType inputObjectType, Map<String, Object> input, List<Object> nameStack) {
         Map<String, Object> result = new LinkedHashMap<>();
         List<GraphQLInputObjectField> fields = fieldVisibility.getFieldDefinitions(inputObjectType);
         List<String> fieldNames = map(fields, GraphQLInputObjectField::getName);
@@ -195,7 +200,8 @@ public class ValuesResolver {
                 Object value = coerceValue(fieldVisibility, variableDefinition,
                         inputField.getName(),
                         inputField.getType(),
-                        input.get(inputField.getName()));
+                        input.get(inputField.getName()),
+                        nameStack);
                 result.put(inputField.getName(), value == null ? inputField.getDefaultValue() : value);
             }
         }
@@ -215,15 +221,15 @@ public class ValuesResolver {
         return graphQLEnumType.parseValue(value);
     }
 
-    private List coerceValueForList(GraphqlFieldVisibility fieldVisibility, VariableDefinition variableDefinition, String inputName, GraphQLList graphQLList, Object value) {
+    private List coerceValueForList(GraphqlFieldVisibility fieldVisibility, VariableDefinition variableDefinition, String inputName, GraphQLList graphQLList, Object value, List<Object> nameStack) {
         if (value instanceof Iterable) {
             List<Object> result = new ArrayList<>();
             for (Object val : (Iterable) value) {
-                result.add(coerceValue(fieldVisibility, variableDefinition, inputName, graphQLList.getWrappedType(), val));
+                result.add(coerceValue(fieldVisibility, variableDefinition, inputName, graphQLList.getWrappedType(), val, nameStack));
             }
             return result;
         } else {
-            return Collections.singletonList(coerceValue(fieldVisibility, variableDefinition, inputName, graphQLList.getWrappedType(), value));
+            return Collections.singletonList(coerceValue(fieldVisibility, variableDefinition, inputName, graphQLList.getWrappedType(), value, nameStack));
         }
     }
 

--- a/src/test/groovy/graphql/execution/ValuesResolverTest.groovy
+++ b/src/test/groovy/graphql/execution/ValuesResolverTest.groovy
@@ -115,7 +115,8 @@ class ValuesResolverTest extends Specification {
         def obj = new Person('a', 123)
         resolver.coerceVariableValues(schema, [variableDefinition], [variable: obj])
         then:
-        thrown(CoercingParseValueException)
+        def e = thrown(CoercingParseValueException)
+        e.path == ["variable"]
     }
 
     def "getVariableValues: simple value gets resolved to a list when the type is a List"() {
@@ -411,7 +412,8 @@ class ValuesResolverTest extends Specification {
         resolver.coerceVariableValues(schema, [variableDefinition], [variable: inputValue])
 
         then:
-        thrown(GraphQLException)
+        def e = thrown(GraphQLException)
+        e.path== ["variable", "intKey", "requiredField", "requiredField"]
 
         where:
         inputValue                        | _


### PR DESCRIPTION
This PR adds feature requested in issue https://github.com/graphql-java/graphql-java/issues/927 -
a way to collect the path/name of the field that failed to be deserialized.