### PR TITLE
Coercion exception catching tests for MaxComplexityInstrumentation

### DIFF
--- a/src/test/groovy/graphql/NullVariableCoercionTest.groovy
+++ b/src/test/groovy/graphql/NullVariableCoercionTest.groovy
@@ -1,5 +1,6 @@
 package graphql
 
+import graphql.analysis.MaxQueryComplexityInstrumentation
 import graphql.language.SourceLocation
 import graphql.schema.GraphQLObjectType
 import graphql.schema.idl.RuntimeWiring
@@ -68,6 +69,74 @@ class NullVariableCoercionTest extends Specification {
         varResult.errors[0].errorType == ErrorType.ValidationError
         varResult.errors[0].message == "Field 'baz' of variable 'input' has coerced Null value for NonNull type 'String!'"
         varResult.errors[0].locations == [new SourceLocation(1, 11)]
+    }
+
+    def "null coercion errors with Max Query Complexity Instrumentation have source locations"() {
+
+        when:
+
+        RuntimeWiring runtimeWiring = RuntimeWiring.newRuntimeWiring()
+          .type(newTypeWiring("Query")
+                  .dataFetcher("bar",
+                               { env ->
+                                 Map<String, Object> map = new HashMap<>()
+                                 map.put("id", "def")
+                                 return map
+                               })
+        )
+          .type(newTypeWiring("Node")
+                  .typeResolver({ env -> (GraphQLObjectType) env.getSchema().getType("Foo") }))
+          .build()
+
+        def graphQL = TestUtil.graphQL("""
+                schema {
+                  query: Query
+                }
+
+                type Query {
+                  bar(input: BarInput!): String
+                }
+
+                input BarInput {
+                  baz: String!
+                }
+            """, runtimeWiring)
+          .instrumentation(new MaxQueryComplexityInstrumentation(100))
+          .build()
+
+        def variables = ["input": ["baz": null]]
+
+        ExecutionInput varInput = ExecutionInput.newExecutionInput()
+            .query('query Bar($input: BarInput!) {bar(input: $input)}')
+            .variables(variables)
+            .build()
+
+        ExecutionInput varInput2 = ExecutionInput.newExecutionInput()
+                                                .query('query Bar($foo: String!) {bar(input: {baz: $foo})}')
+                                                .variables(variables)
+                                                .build()
+
+        ExecutionResult varResult = graphQL
+            .executeAsync(varInput)
+            .join()
+
+        ExecutionResult varResult2 = graphQL
+          .executeAsync(varInput2)
+          .join()
+
+      then:
+
+        varResult.data == null
+        varResult.errors.size() == 1
+        varResult.errors[0].errorType == ErrorType.ValidationError
+        varResult.errors[0].message == "Field 'baz' of variable 'input' has coerced Null value for NonNull type 'String!'"
+        varResult.errors[0].locations == [new SourceLocation(1, 11)]
+
+        varResult2.data == null
+        varResult2.errors.size() == 1
+        varResult2.errors[0].errorType == ErrorType.ValidationError
+        varResult2.errors[0].message == "Field 'baz' of variable 'input' has coerced Null value for NonNull type 'String!'"
+        varResult2.errors[0].locations == [new SourceLocation(1, 11)]
     }
 }
 

--- a/src/test/groovy/graphql/NullVariableCoercionTest.groovy
+++ b/src/test/groovy/graphql/NullVariableCoercionTest.groovy
@@ -71,7 +71,7 @@ class NullVariableCoercionTest extends Specification {
         varResult.errors[0].locations == [new SourceLocation(1, 11)]
     }
 
-    def "null coercion errors with Max Query Complexity Instrumentation have source locations"() {
+    def "null coercion errors with MaxQueryComplexityInstrumentation return an error"() {
 
         when:
 

--- a/src/test/groovy/graphql/ScalarCoercionTest.groovy
+++ b/src/test/groovy/graphql/ScalarCoercionTest.groovy
@@ -1,0 +1,171 @@
+package graphql
+
+import graphql.analysis.MaxQueryComplexityInstrumentation
+import graphql.language.SourceLocation
+import graphql.language.StringValue
+import graphql.schema.*
+import graphql.schema.idl.RuntimeWiring
+import spock.lang.Specification
+
+import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring
+
+class ScalarCoercionTest extends Specification {
+
+    def "scalar coercion errors have source locations"() {
+        when:
+
+        GraphQLScalarType customValueScalar = GraphQLScalarType.newScalar()
+                                                               .name("CustomValue")
+                                                               .description("A custom scalar that handles values")
+                                                               .coercing(new CustomValueScalar())
+                                                               .build()
+
+        RuntimeWiring runtimeWiring = RuntimeWiring.newRuntimeWiring()
+          .type(newTypeWiring("Query")
+                  .dataFetcher("bar",
+                               { env ->
+                                 Map<String, Object> map = new HashMap<>()
+                                 map.put("id", "def")
+                                 return map
+                               })
+        )
+          .scalar(customValueScalar)
+          .build()
+
+        def graphQL = TestUtil.graphQL("""
+                schema {
+                  query: Query
+                }
+
+                type Query {
+                  bar(input: BarInput!): String
+                }
+
+                input BarInput {
+                  baz: CustomValue
+                }
+
+                scalar CustomValue
+            """, runtimeWiring).build()
+
+        def variables = ["input": ["baz": "x"]]
+
+        ExecutionInput varInput = ExecutionInput.newExecutionInput()
+            .query('query Bar($input: BarInput!) {bar(input: $input)}')
+            .variables(variables)
+            .build()
+
+        ExecutionResult varResult = graphQL
+            .executeAsync(varInput)
+            .join()
+
+        then:
+
+        varResult.data == null
+        varResult.errors.size() == 1
+        varResult.errors[0].errorType == ErrorType.ValidationError
+        varResult.errors[0].message == "Variable 'baz' has an invalid value : Unable to parse variable value x as a custom value"
+        varResult.errors[0].locations == [new SourceLocation(1, 11)]
+    }
+
+    def "scalar coercion errors with MaxQueryComplexityInstrumentation return an error"() {
+        when:
+        
+        GraphQLScalarType customValueScalar = GraphQLScalarType.newScalar()
+                                                               .name("CustomValue")
+                                                               .description("A custom scalar that handles values")
+                                                               .coercing(new CustomValueScalar())
+                                                               .build()
+
+        RuntimeWiring runtimeWiring = RuntimeWiring.newRuntimeWiring()
+          .type(newTypeWiring("Query")
+                  .dataFetcher("bar",
+                               { env ->
+                                 Map<String, Object> map = new HashMap<>()
+                                 map.put("id", "def")
+                                 return map
+                               })
+        )
+          .scalar(customValueScalar)
+          .build()
+
+        def graphQL = TestUtil.graphQL("""
+                schema {
+                  query: Query
+                }
+
+                type Query {
+                  bar(input: BarInput!): String
+                }
+
+                input BarInput {
+                  baz: CustomValue
+                }
+
+                scalar CustomValue
+            """, runtimeWiring)
+          .instrumentation(new MaxQueryComplexityInstrumentation(100))
+          .build()
+
+        def variables = ["input": ["baz": "x"]]
+
+        ExecutionInput varInput = ExecutionInput.newExecutionInput()
+            .query('query Bar($input: BarInput!) {bar(input: $input)}')
+            .variables(variables)
+            .build()
+
+        ExecutionResult varResult = graphQL
+            .executeAsync(varInput)
+            .join()
+
+        then:
+
+        varResult.data == null
+        varResult.errors.size() == 1
+        varResult.errors[0].errorType == ErrorType.ValidationError
+        varResult.errors[0].message == "Variable 'baz' has an invalid value : Unable to parse variable value x as a custom value"
+        varResult.errors[0].locations == [new SourceLocation(1, 11)]
+    }
+
+    private static class CustomValueScalar implements Coercing<String, String> {
+
+        @Override
+        String serialize(Object dataFetcherResult) {
+            String value = String.valueOf(dataFetcherResult)
+            if (isValid(value)) {
+              return value
+            } else {
+              throw new CoercingSerializeException("Unable to serialize " + value + " as a custom value")
+            }
+        }
+
+        @Override
+        String parseValue(Object input) {
+            if (input instanceof String) {
+              String value = input.toString()
+              if (isValid(value)) {
+                return value
+              }
+            }
+            throw new CoercingParseValueException("Unable to parse variable value " + input + " as a custom value")
+        }
+
+        @Override
+        String parseLiteral(Object input) {
+            if (input instanceof StringValue) {
+              String value = ((StringValue) input).getValue()
+              if (isValid(value)) {
+                return value
+              }
+            }
+            throw new CoercingParseLiteralException(
+              "Value is not a custom value: '" + String.valueOf(input) + "'"
+            )
+        }
+
+        private static boolean isValid(String value) {
+            return value.startsWith("custom_")
+        }
+    }
+}
+


### PR DESCRIPTION
This PR includes two tests which reproduce the issue described in issue #1896 with the MaxQueryComplexityInstrumentation. 

Between versions 14.1 and 16.2 it seems and additional regression was introduced which caused this for non-nested inputs as well. Between these two versions it also started to become a problem for scalar coercion as well.