### PR TITLE
This allows system data fetchers to be replaced

### DIFF
--- a/src/main/java/graphql/introspection/Introspection.java
+++ b/src/main/java/graphql/introspection/Introspection.java
@@ -64,11 +64,11 @@ public class Introspection {
     @Internal
     public static void addCodeForIntrospectionTypes(GraphQLCodeRegistry.Builder codeRegistry) {
         // place the system __ fields into the mix.  They have no parent types
-        codeRegistry.systemDataFetcher(systemCoordinates(SchemaMetaFieldDef.getName()), SchemaMetaFieldDefDataFetcher);
-        codeRegistry.systemDataFetcher(systemCoordinates(TypeNameMetaFieldDef.getName()), TypeNameMetaFieldDefDataFetcher);
-        codeRegistry.systemDataFetcher(systemCoordinates(TypeMetaFieldDef.getName()), TypeMetaFieldDefDataFetcher);
+        codeRegistry.dataFetcherIfAbsent(systemCoordinates(SchemaMetaFieldDef.getName()), SchemaMetaFieldDefDataFetcher);
+        codeRegistry.dataFetcherIfAbsent(systemCoordinates(TypeNameMetaFieldDef.getName()), TypeNameMetaFieldDefDataFetcher);
+        codeRegistry.dataFetcherIfAbsent(systemCoordinates(TypeMetaFieldDef.getName()), TypeMetaFieldDefDataFetcher);
 
-        introspectionDataFetchers.forEach((coordinates, idf) -> codeRegistry.dataFetcher(coordinates, idf));
+        introspectionDataFetchers.forEach(codeRegistry::dataFetcherIfAbsent);
     }
 
     public enum TypeKind {

--- a/src/main/java/graphql/introspection/IntrospectionWithDirectivesSupport.java
+++ b/src/main/java/graphql/introspection/IntrospectionWithDirectivesSupport.java
@@ -13,6 +13,7 @@ import graphql.schema.GraphQLDirectiveContainer;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLSchemaElement;
+import graphql.schema.GraphQLType;
 import graphql.schema.GraphQLTypeVisitorStub;
 import graphql.schema.SchemaTransformer;
 import graphql.util.TraversalControl;
@@ -21,6 +22,7 @@ import graphql.util.TraverserContext;
 import java.util.List;
 import java.util.Set;
 
+import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertShouldNeverHappen;
 import static graphql.Scalars.GraphQLString;
 import static graphql.introspection.Introspection.__EnumValue;
@@ -53,15 +55,15 @@ import static java.util.stream.Collectors.toList;
  *      type __Field {
  *          name: String!
  *          // other fields ...
- *          appliedDirectives: [__AppliedDirective!]!   // NEW FIELD
+ *          appliedDirectives: [_AppliedDirective!]!   // NEW FIELD
  *      }
  *
- *     type __AppliedDirective {                        // NEW INTROSPECTION TYPE
+ *     type _AppliedDirective {                        // NEW INTROSPECTION TYPE
  *          name: String!
- *          args: [__DirectiveArgument!]!
+ *          args: [_DirectiveArgument!]!
  *      }
  *
- *      type __DirectiveArgument {                      // NEW INTROSPECTION TYPE
+ *      type _DirectiveArgument {                      // NEW INTROSPECTION TYPE
  *          name: String!
  *          value: String!
  *      }
@@ -71,32 +73,12 @@ import static java.util.stream.Collectors.toList;
 public class IntrospectionWithDirectivesSupport {
 
     private final DirectivePredicate directivePredicate;
+    private final String typePrefix;
 
     private final Set<String> INTROSPECTION_ELEMENTS = ImmutableSet.of(
             __Schema.getName(), __Type.getName(), __Field.getName(), __EnumValue.getName(), __InputValue.getName()
     );
 
-    private final GraphQLObjectType __DirectiveArgument = newObject().name("__DirectiveArgument")
-            .description("Directive arguments can have names and values.  The values are in graphql SDL syntax printed as a string." +
-                    " This type is NOT specified by the graphql specification presently.")
-            .field(fld -> fld
-                    .name("name")
-                    .type(nonNull(GraphQLString)))
-            .field(fld -> fld
-                    .name("value")
-                    .type(nonNull(GraphQLString)))
-            .build();
-
-    private final GraphQLObjectType __AppliedDirective = newObject().name("__AppliedDirective")
-            .description("An Applied Directive is an instances of a directive as applied to a schema element." +
-                    " This type is NOT specified by the graphql specification presently.")
-            .field(fld -> fld
-                    .name("name")
-                    .type(nonNull(GraphQLString)))
-            .field(fld -> fld
-                    .name("args")
-                    .type(nonNull(list(nonNull(__DirectiveArgument)))))
-            .build();
 
     /**
      * This version lists all directives on a schema element
@@ -111,7 +93,23 @@ public class IntrospectionWithDirectivesSupport {
      * @param directivePredicate the filtering predicate to decide what directives are shown
      */
     public IntrospectionWithDirectivesSupport(DirectivePredicate directivePredicate) {
-        this.directivePredicate = directivePredicate;
+        this(directivePredicate, "_");
+    }
+
+    /**
+     * This version allows you to filter what directives are listed via the provided predicate
+     *
+     * Some graphql systems (graphql-js in 2021) cannot cope with extra types starting with `__`
+     * so we use a `_` as a prefx by default.   You can supply your own prefix via this constructor.
+     *
+     * See: https://github.com/graphql-java/graphql-java/pull/2221 for more details
+     *
+     * @param directivePredicate the filtering predicate to decide what directives are shown
+     * @param typePrefix         the prefix to put on the new `AppliedDirectives` type
+     */
+    public IntrospectionWithDirectivesSupport(DirectivePredicate directivePredicate, String typePrefix) {
+        this.directivePredicate = assertNotNull(directivePredicate);
+        this.typePrefix = assertNotNull(typePrefix);
     }
 
     /**
@@ -122,13 +120,15 @@ public class IntrospectionWithDirectivesSupport {
      * @return the transformed schema with new extension types and fields in it for Introspection
      */
     public GraphQLSchema apply(GraphQLSchema schema) {
+        GraphQLObjectType directiveArgumentType = mkDirectiveArgumentType(typePrefix + "DirectiveArgument");
+        GraphQLObjectType appliedDirectiveType = mkAppliedDirectiveType(typePrefix + "AppliedDirective", directiveArgumentType);
         GraphQLTypeVisitorStub visitor = new GraphQLTypeVisitorStub() {
             @Override
             public TraversalControl visitGraphQLObjectType(GraphQLObjectType objectType, TraverserContext<GraphQLSchemaElement> context) {
                 GraphQLCodeRegistry.Builder codeRegistry = context.getVarFromParents(GraphQLCodeRegistry.Builder.class);
                 // we need to change __XXX introspection types to have directive extensions
                 if (INTROSPECTION_ELEMENTS.contains(objectType.getName())) {
-                    GraphQLObjectType newObjectType = addAppliedDirectives(objectType, codeRegistry);
+                    GraphQLObjectType newObjectType = addAppliedDirectives(objectType, codeRegistry, appliedDirectiveType, directiveArgumentType);
                     return changeNode(context, newObjectType);
                 }
                 return CONTINUE;
@@ -138,19 +138,44 @@ public class IntrospectionWithDirectivesSupport {
         return addDirectiveDefinitionFilter(schema);
     }
 
+    private GraphQLObjectType mkDirectiveArgumentType(String name) {
+        return newObject().name(name)
+                .description("Directive arguments can have names and values.  The values are in graphql SDL syntax printed as a string." +
+                        " This type is NOT specified by the graphql specification presently.")
+                .field(fld -> fld
+                        .name("name")
+                        .type(nonNull(GraphQLString)))
+                .field(fld -> fld
+                        .name("value")
+                        .type(nonNull(GraphQLString)))
+                .build();
+    }
+
+    private GraphQLObjectType mkAppliedDirectiveType(String name, GraphQLType directiveArgumentType) {
+        return newObject().name(name)
+                .description("An Applied Directive is an instances of a directive as applied to a schema element." +
+                        " This type is NOT specified by the graphql specification presently.")
+                .field(fld -> fld
+                        .name("name")
+                        .type(nonNull(GraphQLString)))
+                .field(fld -> fld
+                        .name("args")
+                        .type(nonNull(list(nonNull(directiveArgumentType)))))
+                .build();
+    }
+
     private GraphQLSchema addDirectiveDefinitionFilter(GraphQLSchema schema) {
         DataFetcher<?> df = env -> {
             List<GraphQLDirective> definedDirectives = env.getGraphQLSchema().getDirectives();
             return filterDirectives(true, null, definedDirectives);
         };
-        GraphQLCodeRegistry codeRegistry = schema.getCodeRegistry().transform(builder -> {
-            builder.dataFetcher(coordinates(__Schema, "directives"), df);
-        });
-        return schema.transform(schemaBuilder -> schemaBuilder.codeRegistry(codeRegistry));
+        GraphQLCodeRegistry codeRegistry = schema.getCodeRegistry().transform(bld ->
+                bld.dataFetcher(coordinates(__Schema, "directives"), df));
+        return schema.transform(bld -> bld.codeRegistry(codeRegistry));
     }
 
-    private GraphQLObjectType addAppliedDirectives(GraphQLObjectType originalType, GraphQLCodeRegistry.Builder codeRegistry) {
-        GraphQLObjectType objectType = originalType.transform(bld -> bld.field(fld -> fld.name("appliedDirectives").type(nonNull(list(nonNull(__AppliedDirective))))));
+    private GraphQLObjectType addAppliedDirectives(GraphQLObjectType originalType, GraphQLCodeRegistry.Builder codeRegistry, GraphQLObjectType appliedDirectiveType, GraphQLObjectType directiveArgumentType) {
+        GraphQLObjectType objectType = originalType.transform(bld -> bld.field(fld -> fld.name("appliedDirectives").type(nonNull(list(nonNull(appliedDirectiveType))))));
         DataFetcher<?> df = env -> {
             Object source = env.getSource();
             if (source instanceof GraphQLDirectiveContainer) {
@@ -173,8 +198,8 @@ public class IntrospectionWithDirectivesSupport {
             return AstPrinter.printAst(AstValueHelper.astFromValue(value, argument.getType()));
         };
         codeRegistry.dataFetcher(coordinates(objectType, "appliedDirectives"), df);
-        codeRegistry.dataFetcher(coordinates(__AppliedDirective, "args"), argsDF);
-        codeRegistry.dataFetcher(coordinates(__DirectiveArgument, "value"), argValueDF);
+        codeRegistry.dataFetcher(coordinates(appliedDirectiveType, "args"), argsDF);
+        codeRegistry.dataFetcher(coordinates(directiveArgumentType, "value"), argValueDF);
         return objectType;
     }
 

--- a/src/main/java/graphql/schema/FieldCoordinates.java
+++ b/src/main/java/graphql/schema/FieldCoordinates.java
@@ -33,6 +33,9 @@ public class FieldCoordinates {
         return fieldName;
     }
 
+    public boolean isSystemCoordinates() {
+        return systemCoordinates;
+    }
 
     /**
      * Checks the validity of the field coordinate names.  The validity checks vary by coordinate type.  Standard

--- a/src/main/java/graphql/schema/GraphQLCodeRegistry.java
+++ b/src/main/java/graphql/schema/GraphQLCodeRegistry.java
@@ -53,6 +53,7 @@ public class GraphQLCodeRegistry {
      *
      * @param parentType      the container type
      * @param fieldDefinition the field definition
+     *
      * @return the DataFetcher associated with this field.  All fields have data fetchers
      */
     public DataFetcher<?> getDataFetcher(GraphQLFieldsContainer parentType, GraphQLFieldDefinition fieldDefinition) {
@@ -64,10 +65,22 @@ public class GraphQLCodeRegistry {
      *
      * @param coordinates     the field coordinates
      * @param fieldDefinition the field definition
+     *
      * @return the DataFetcher associated with this field.  All fields have data fetchers
      */
     public DataFetcher<?> getDataFetcher(FieldCoordinates coordinates, GraphQLFieldDefinition fieldDefinition) {
         return getDataFetcherImpl(coordinates, fieldDefinition, dataFetcherMap, systemDataFetcherMap, defaultDataFetcherFactory);
+    }
+
+    /**
+     * Returns true if the code registry contained a data fetcher at the specified co-ordinates
+     *
+     * @param coordinates the field coordinates
+     *
+     * @return the true if there is a data fetcher at those co-ordinates
+     */
+    public boolean hasDataFetcher(FieldCoordinates coordinates) {
+        return hasDataFetcherImpl(coordinates, dataFetcherMap, systemDataFetcherMap);
     }
 
     private static DataFetcher<?> getDataFetcherImpl(FieldCoordinates coordinates, GraphQLFieldDefinition fieldDefinition, Map<FieldCoordinates, DataFetcherFactory<?>> dataFetcherMap, Map<String, DataFetcherFactory<?>> systemDataFetcherMap, DataFetcherFactory<?> defaultDataFetcherFactory) {
@@ -101,6 +114,7 @@ public class GraphQLCodeRegistry {
      * Returns the type resolver associated with this interface type
      *
      * @param interfaceType the interface type
+     *
      * @return a non null {@link graphql.schema.TypeResolver}
      */
     public TypeResolver getTypeResolver(GraphQLInterfaceType interfaceType) {
@@ -111,6 +125,7 @@ public class GraphQLCodeRegistry {
      * Returns the type resolver associated with this union type
      *
      * @param unionType the union type
+     *
      * @return a non null {@link graphql.schema.TypeResolver}
      */
 
@@ -141,6 +156,7 @@ public class GraphQLCodeRegistry {
      * the current values and allows you to transform it how you want.
      *
      * @param builderConsumer the consumer code that will be given a builder to transform
+     *
      * @return a new GraphQLCodeRegistry object based on calling build on that builder
      */
     public GraphQLCodeRegistry transform(Consumer<Builder> builderConsumer) {
@@ -160,6 +176,7 @@ public class GraphQLCodeRegistry {
      * Returns a new builder of {@link graphql.schema.GraphQLCodeRegistry} objects based on the existing one
      *
      * @param existingCodeRegistry the existing code registry to use
+     *
      * @return a new builder of {@link graphql.schema.GraphQLCodeRegistry} objects
      */
     public static Builder newCodeRegistry(GraphQLCodeRegistry existingCodeRegistry) {
@@ -178,6 +195,7 @@ public class GraphQLCodeRegistry {
         }
 
         private Builder(GraphQLCodeRegistry codeRegistry) {
+            this.systemDataFetcherMap.putAll(codeRegistry.systemDataFetcherMap);
             this.dataFetcherMap.putAll(codeRegistry.dataFetcherMap);
             this.typeResolverMap.putAll(codeRegistry.typeResolverMap);
             this.fieldVisibility = codeRegistry.fieldVisibility;
@@ -189,6 +207,7 @@ public class GraphQLCodeRegistry {
          *
          * @param parentType      the container type
          * @param fieldDefinition the field definition
+         *
          * @return the DataFetcher associated with this field.  All fields have data fetchers
          */
         public DataFetcher<?> getDataFetcher(GraphQLFieldsContainer parentType, GraphQLFieldDefinition fieldDefinition) {
@@ -200,6 +219,7 @@ public class GraphQLCodeRegistry {
          *
          * @param coordinates     the field coordinates
          * @param fieldDefinition the field definition
+         *
          * @return the DataFetcher associated with this field.  All fields have data fetchers
          */
         public DataFetcher<?> getDataFetcher(FieldCoordinates coordinates, GraphQLFieldDefinition fieldDefinition) {
@@ -207,10 +227,11 @@ public class GraphQLCodeRegistry {
         }
 
         /**
-         * Returns a data fetcher associated with a field within a container type
+         * Returns true if the code registry contained a data fetcher at the specified co-ordinates
          *
          * @param coordinates the field coordinates
-         * @return the true if there is a data fetcher already for this field
+         *
+         * @return the true if there is a data fetcher at those co-ordinates
          */
         public boolean hasDataFetcher(FieldCoordinates coordinates) {
             return hasDataFetcherImpl(coordinates, dataFetcherMap, systemDataFetcherMap);
@@ -220,6 +241,7 @@ public class GraphQLCodeRegistry {
          * Returns the type resolver associated with this interface type
          *
          * @param interfaceType the interface type
+         *
          * @return a non null {@link graphql.schema.TypeResolver}
          */
         public TypeResolver getTypeResolver(GraphQLInterfaceType interfaceType) {
@@ -230,6 +252,7 @@ public class GraphQLCodeRegistry {
          * Returns true of a type resolver has been registered for this type name
          *
          * @param typeName the name to check
+         *
          * @return true if there is already a type resolver
          */
         public boolean hasTypeResolver(String typeName) {
@@ -240,6 +263,7 @@ public class GraphQLCodeRegistry {
          * Returns the type resolver associated with this union type
          *
          * @param unionType the union type
+         *
          * @return a non null {@link graphql.schema.TypeResolver}
          */
         public TypeResolver getTypeResolver(GraphQLUnionType unionType) {
@@ -251,6 +275,7 @@ public class GraphQLCodeRegistry {
          *
          * @param coordinates the field coordinates
          * @param dataFetcher the data fetcher code for that field
+         *
          * @return this builder
          */
         public Builder dataFetcher(FieldCoordinates coordinates, DataFetcher<?> dataFetcher) {
@@ -264,6 +289,7 @@ public class GraphQLCodeRegistry {
          * @param parentType      the container type
          * @param fieldDefinition the field definition
          * @param dataFetcher     the data fetcher code for that field
+         *
          * @return this builder
          */
         public Builder dataFetcher(GraphQLFieldsContainer parentType, GraphQLFieldDefinition fieldDefinition, DataFetcher<?> dataFetcher) {
@@ -275,6 +301,7 @@ public class GraphQLCodeRegistry {
          *
          * @param coordinates the field coordinates
          * @param dataFetcher the data fetcher code for that field
+         *
          * @return this builder
          */
         public Builder systemDataFetcher(FieldCoordinates coordinates, DataFetcher<?> dataFetcher) {
@@ -290,13 +317,18 @@ public class GraphQLCodeRegistry {
          *
          * @param coordinates        the field coordinates
          * @param dataFetcherFactory the data fetcher factory code for that field
+         *
          * @return this builder
          */
         public Builder dataFetcher(FieldCoordinates coordinates, DataFetcherFactory<?> dataFetcherFactory) {
             assertNotNull(dataFetcherFactory);
             assertNotNull(coordinates);
             coordinates.assertValidNames();
-            dataFetcherMap.put(coordinates, dataFetcherFactory);
+            if (coordinates.isSystemCoordinates()) {
+                systemDataFetcherMap.put(coordinates.getFieldName(), dataFetcherFactory);
+            } else {
+                dataFetcherMap.put(coordinates, dataFetcherFactory);
+            }
             return this;
         }
 
@@ -305,10 +337,17 @@ public class GraphQLCodeRegistry {
          *
          * @param coordinates the field coordinates
          * @param dataFetcher the data fetcher code for that field
+         *
          * @return this builder
          */
         public Builder dataFetcherIfAbsent(FieldCoordinates coordinates, DataFetcher<?> dataFetcher) {
-            dataFetcherMap.putIfAbsent(assertNotNull(coordinates), DataFetcherFactories.useDataFetcher(dataFetcher));
+            if (!hasDataFetcher(coordinates)) {
+                if (coordinates.isSystemCoordinates()) {
+                    systemDataFetcher(coordinates, dataFetcher);
+                } else {
+                    dataFetcher(coordinates, dataFetcher);
+                }
+            }
             return this;
         }
 
@@ -317,6 +356,7 @@ public class GraphQLCodeRegistry {
          *
          * @param parentTypeName    the parent container type
          * @param fieldDataFetchers the map of field names to data fetchers
+         *
          * @return this builder
          */
         public Builder dataFetchers(String parentTypeName, Map<String, DataFetcher<?>> fieldDataFetchers) {
@@ -330,6 +370,7 @@ public class GraphQLCodeRegistry {
          * {@link graphql.schema.PropertyDataFetcher} is used but you can have your own default via this method.
          *
          * @param defaultDataFetcherFactory the default data fetcher factory used
+         *
          * @return this builder
          */
         public Builder defaultDataFetcher(DataFetcherFactory<?> defaultDataFetcherFactory) {

--- a/src/main/java/graphql/schema/GraphQLSchema.java
+++ b/src/main/java/graphql/schema/GraphQLSchema.java
@@ -260,7 +260,7 @@ public class GraphQLSchema {
      * Warning - your are inviting class cast errors if you the types are not what you expect.
      *
      * @param typeName the name of the type to retrieve
-     * @param <T> for two
+     * @param <T>      for two
      *
      * @return the type cast to the target type.
      */

--- a/src/test/java/graphql/introspection/IntrospectionWithDirectivesSupportTest.groovy
+++ b/src/test/java/graphql/introspection/IntrospectionWithDirectivesSupportTest.groovy
@@ -12,6 +12,7 @@ class IntrospectionWithDirectivesSupportTest extends Specification {
     def "can find directives in introspection"() {
         def sdl = '''
             directive @example( argName : String = "default") on OBJECT | FIELD_DEFINITION | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
+            directive @secret( argName : String = "secret") on OBJECT
             
             schema @example(argName : "onSchema") {
                 query : Query
@@ -40,6 +41,9 @@ class IntrospectionWithDirectivesSupportTest extends Specification {
         def query = '''
         {
             __schema {
+                directives {
+                    name
+                }
                 appliedDirectives {
                     name
                     args {
@@ -89,6 +93,9 @@ class IntrospectionWithDirectivesSupportTest extends Specification {
         println TestUtil.prettyPrint(er)
 
         def schemaType = er.data["__schema"]
+
+        schemaType["directives"] == [[name: "include"], [name: "skip"], [name: "example"], [name: "secret"], [name: "deprecated"], [name: "specifiedBy"]]
+
         schemaType["appliedDirectives"] == [[name: "example", args: [[name: "argName", value: '"onSchema"']]]]
 
         def queryType = er.data["__schema"]["types"].find({ type -> (type["name"] == "Query") })
@@ -134,6 +141,9 @@ class IntrospectionWithDirectivesSupportTest extends Specification {
         def query = '''
         {
             __schema {
+                directives {
+                    name
+                }
                 types {
                     name
                     appliedDirectives {
@@ -156,5 +166,10 @@ class IntrospectionWithDirectivesSupportTest extends Specification {
 
         def helloType = er.data["__schema"]["types"].find({ type -> (type["name"] == "Hello") })
         helloType["appliedDirectives"] == [[name: "example", args: [[name: "argName", value: '"default"']]]]
+
+        def definedDirectives = er.data["__schema"]["directives"]
+        // secret is filter out
+        definedDirectives == [[name: "include"], [name: "skip"], [name: "example"], [name: "deprecated"], [name: "specifiedBy"]]
+
     }
 }


### PR DESCRIPTION
Previously the Introspection data fetchers were placed into the code registry ALWAYS and replaced any from before

Now we do a replace if absent and hence allow people to replace the default Introspection data fetchers.

(They will of course want to keep the fetching contract in place otherwise they will shoot themselves in the foot)

