### PR TITLE
Add getter for AsyncDataFetcher

### DIFF
--- a/src/main/java/graphql/schema/AsyncDataFetcher.java
+++ b/src/main/java/graphql/schema/AsyncDataFetcher.java
@@ -53,6 +53,15 @@ public class AsyncDataFetcher<T> implements DataFetcher<CompletableFuture<T>> {
     private final DataFetcher<T> wrappedDataFetcher;
     private final Executor executor;
 
+
+    public DataFetcher<T> getWrappedDataFetcher() {
+        return wrappedDataFetcher;
+    }
+
+    public Executor getExecutor() {
+        return executor;
+    }
+
     public AsyncDataFetcher(DataFetcher<T> wrappedDataFetcher) {
         this(wrappedDataFetcher, ForkJoinPool.commonPool());
     }


### PR DESCRIPTION
In some case, Instrumentation#instrumentDataFetcher need to know the information about the wrapped DF and Executor. such as whether DF is trivial, and which Executor the DF use.