### PR TITLE
Build: Export all graphql packages in OSGi bundle.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,6 @@ jar {
     manifest {
         attributes('Automatic-Module-Name': 'com.graphql-java')
     }
-	bnd('-exportcontents': 'graphql.*')
 }
 
 dependencies {
@@ -111,6 +110,17 @@ shadowJar {
     manifest {
         attributes('Automatic-Module-Name': 'com.graphqljava')
     }
+    //Apply biz.aQute.bnd.builder plugin logic to shadowJar as in BndBuilderPlugin 
+    convention.plugins.bundle = new  aQute.bnd.gradle.BundleTaskConvention(it)
+    doLast {
+        buildBundle()
+    }
+    //Configure bnd
+    bnd('''
+-exportcontents: graphql.*
+-removeheaders: Private-Package
+Import-Package: !com.google.*,!org.checkerframework.*,!javax.annotation.*,!graphql.com.google.*,*
+''')
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -113,9 +113,17 @@ shadowJar {
     //Apply biz.aQute.bnd.builder plugin logic to shadowJar as in BndBuilderPlugin 
     convention.plugins.bundle = new  aQute.bnd.gradle.BundleTaskConvention(it)
     doLast {
+        //Call bnd after the ShadowJar was built to update the MANIFEST.MF
         buildBundle()
     }
-    //Configure bnd
+    
+    //Configure bnd for shadowJar
+    // -exportcontents: graphql.*  Adds all packages of graphql and below to the exported packages list
+    // -removeheaders:  Private-Package Removes the MANIFEST.MF header Private-Package, which contains all the internal packages and 
+    //                                  also the repackaged pckages like guava, which would be wrong after repackaging.
+    // Import-Package:  Changes the imported packages header, to exclude guava and dependencies from the import list (! excludes packages)
+    //                  Guava was repackaged and included inside the jar, so we need remove it.
+    //                  The last ,* copies all the existing imports from the other dependencies, which is required.
     bnd('''
 -exportcontents: graphql.*
 -removeheaders: Private-Package

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,7 @@ jar {
     manifest {
         attributes('Automatic-Module-Name': 'com.graphql-java')
     }
+	bnd('-exportcontents': 'graphql.*')
 }
 
 dependencies {


### PR DESCRIPTION
Fixes #2251

This also removes the Guava imports, because it is relocated inside the bundle.