### PR TITLE
OSGi: Allow Guava Library in a wider range from 30.0 up until excl. 32.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,10 @@ jar {
     manifest {
         attributes('Automatic-Module-Name': 'com.graphql-java')
     }
-	bnd('-exportcontents': 'graphql.*')
+	bnd('''
+-exportcontents: graphql.*
+Import-Package: com.google.common.collect;version="[30.0,32)",*
+''')
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,7 @@ jar {
     manifest {
         attributes('Automatic-Module-Name': 'com.graphql-java')
     }
+	bnd('-exportcontents': 'graphql.*')
 }
 
 dependencies {


### PR DESCRIPTION
This allows the usage of the currently newest Guava version 31.1 in an OSGi environment.
