### PR TITLE
Bugfix input object default value when value is null coercion 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,18 @@ def releaseVersion = System.env.RELEASE_VERSION
 version = releaseVersion ? releaseVersion : getDevelopmentVersion()
 group = 'com.graphql-java'
 
+gradle.buildFinished { buildResult ->
+    println "*******************************"
+    println "*"
+    if (buildResult.failure != null) {
+        println "* FAILURE - ${buildResult.failure}"
+    } else {
+        println "* SUCCESS"
+    }
+    println "* Version: $version"
+    println "*"
+    println "*******************************"
+}
 
 repositories {
     mavenCentral()

--- a/src/main/java/graphql/execution/NonNullableValueCoercedAsNullException.java
+++ b/src/main/java/graphql/execution/NonNullableValueCoercedAsNullException.java
@@ -1,10 +1,5 @@
 package graphql.execution;
 
-import static java.lang.String.format;
-
-import java.util.Collections;
-import java.util.List;
-
 import graphql.ErrorType;
 import graphql.GraphQLError;
 import graphql.GraphQLException;
@@ -14,6 +9,11 @@ import graphql.language.VariableDefinition;
 import graphql.schema.GraphQLInputObjectField;
 import graphql.schema.GraphQLType;
 import graphql.schema.GraphQLTypeUtil;
+
+import java.util.Collections;
+import java.util.List;
+
+import static java.lang.String.format;
 
 /**
  * This is thrown if a non nullable value is coerced to a null value
@@ -45,6 +45,12 @@ public class NonNullableValueCoercedAsNullException extends GraphQLException imp
     public NonNullableValueCoercedAsNullException(GraphQLInputObjectField inputTypeField) {
         super(format("Input field '%s' has coerced Null value for NonNull type '%s'",
                 inputTypeField.getName(), GraphQLTypeUtil.simplePrint(inputTypeField.getType())));
+    }
+
+    public NonNullableValueCoercedAsNullException(GraphQLInputObjectField inputTypeField, List<Object> path) {
+        super(format("Input field '%s' has coerced Null value for NonNull type '%s'",
+                inputTypeField.getName(), GraphQLTypeUtil.simplePrint(inputTypeField.getType())));
+        this.path = path;
     }
 
     @Override

--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -213,19 +213,17 @@ public class ValuesResolver {
                                                  GraphQLInputObjectType inputObjectType,
                                                  Map<String, Object> inputMap,
                                                  Deque<Object> nameStack) {
-//        Map<String, Object> result = new LinkedHashMap<>();
-        List<GraphQLInputObjectField> fields = fieldVisibility.getFieldDefinitions(inputObjectType);
-        List<String> fieldNames = map(fields, GraphQLInputObjectField::getName);
-        for (String inputFieldName : inputMap.keySet()) {
-            if (!fieldNames.contains(inputFieldName)) {
-                throw new InputMapDefinesTooManyFieldsException(inputObjectType, inputFieldName);
+        List<GraphQLInputObjectField> fieldDefinitions = fieldVisibility.getFieldDefinitions(inputObjectType);
+        List<String> fieldNames = map(fieldDefinitions, GraphQLInputObjectField::getName);
+        for (String providedFieldName : inputMap.keySet()) {
+            if (!fieldNames.contains(providedFieldName)) {
+                throw new InputMapDefinesTooManyFieldsException(inputObjectType, providedFieldName);
             }
         }
 
         Map<String, Object> coercedValues = new LinkedHashMap<>();
 
-        List<GraphQLInputObjectField> inputFieldTypes = fieldVisibility.getFieldDefinitions(inputObjectType);
-        for (GraphQLInputObjectField inputFieldDefinition : inputFieldTypes) {
+        for (GraphQLInputObjectField inputFieldDefinition : fieldDefinitions) {
 
             GraphQLInputType fieldType = inputFieldDefinition.getType();
             String fieldName = inputFieldDefinition.getName();
@@ -260,22 +258,6 @@ public class ValuesResolver {
             }
         }
         return coercedValues;
-
-
-//        for (GraphQLInputObjectField inputField : fields) {
-//            if (inputMap.containsKey(inputField.getName()) || alwaysHasValue(inputField)) {
-//                // getOrDefault will return a null value if its present in the map as null
-//                // defaulting only applies if the key is missing - we want this
-//                Object inputValue = inputMap.getOrDefault(inputField.getName(), inputField.getDefaultValue());
-//                Object coerceValue = coerceValue(fieldVisibility, variableDefinition,
-//                        inputField.getName(),
-//                        inputField.getType(),
-//                        inputValue,
-//                        nameStack);
-//                result.put(inputField.getName(), coerceValue == null ? inputField.getDefaultValue() : coerceValue);
-//            }
-//        }
-//        return result;
     }
 
     private boolean alwaysHasValue(GraphQLInputObjectField inputField) {

--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -225,21 +225,21 @@ public class ValuesResolver {
         Map<String, Object> coercedValues = new LinkedHashMap<>();
 
         List<GraphQLInputObjectField> inputFieldTypes = fieldVisibility.getFieldDefinitions(inputObjectType);
-        for (GraphQLInputObjectField inputFieldType : inputFieldTypes) {
+        for (GraphQLInputObjectField inputFieldDefinition : inputFieldTypes) {
 
-            GraphQLInputType fieldType = inputFieldType.getType();
-            String fieldName = inputFieldType.getName();
-            Object defaultValue = inputFieldType.getDefaultValue();
+            GraphQLInputType fieldType = inputFieldDefinition.getType();
+            String fieldName = inputFieldDefinition.getName();
+            Object defaultValue = inputFieldDefinition.getDefaultValue();
             boolean hasValue = inputMap.containsKey(fieldName);
             Object value;
             Object fieldValue = inputMap.getOrDefault(fieldName, null);
             value = fieldValue;
-            if (!hasValue && inputFieldType.hasSetDefaultValue()) {
+            if (!hasValue && inputFieldDefinition.hasSetDefaultValue()) {
                 //TODO: default value should be coerced
                 coercedValues.put(fieldName, defaultValue);
             } else if (isNonNull(fieldType) && (!hasValue || value == null)) {
                 nameStack.addLast(fieldName);
-                throw new NonNullableValueCoercedAsNullException(inputFieldType, Arrays.asList(nameStack.toArray()));
+                throw new NonNullableValueCoercedAsNullException(variableDefinition, fieldName, Arrays.asList(nameStack.toArray()), fieldType);
             } else if (hasValue) {
                 if (value == null) {
                     coercedValues.put(fieldName, null);
@@ -248,7 +248,7 @@ public class ValuesResolver {
                 } else {
                     value = coerceValue(fieldVisibility,
                             variableDefinition,
-                            inputFieldType.getName(),
+                            inputFieldDefinition.getName(),
                             fieldType,
                             value,
                             nameStack);

--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -25,8 +25,11 @@ import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
 import graphql.schema.visibility.GraphqlFieldVisibility;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -58,7 +61,7 @@ public class ValuesResolver {
         Map<String, Object> coercedValues = new LinkedHashMap<>();
         for (VariableDefinition variableDefinition : variableDefinitions) {
             String variableName = variableDefinition.getName();
-            List<Object> nameStack = new ArrayList<>();
+            Deque<Object> nameStack = new ArrayDeque<>();
             GraphQLType variableType = TypeFromAST.getTypeFromAST(schema, variableDefinition.getType());
             Assert.assertTrue(variableType instanceof GraphQLInputType);
             // can be NullValue
@@ -153,15 +156,14 @@ public class ValuesResolver {
 
 
     @SuppressWarnings("unchecked")
-    private Object coerceValue(GraphqlFieldVisibility fieldVisibility, VariableDefinition variableDefinition, String inputName, GraphQLType graphQLType, Object value, List<Object> nameStack) {
+    private Object coerceValue(GraphqlFieldVisibility fieldVisibility, VariableDefinition variableDefinition, String inputName, GraphQLType graphQLType, Object value, Deque<Object> nameStack) {
+        nameStack.addLast(inputName);
         try {
-            nameStack.add(inputName);
-
             if (isNonNull(graphQLType)) {
                 Object returnValue =
                         coerceValue(fieldVisibility, variableDefinition, inputName, unwrapOne(graphQLType), value, nameStack);
                 if (returnValue == null) {
-                    throw new NonNullableValueCoercedAsNullException(variableDefinition, inputName, nameStack, graphQLType);
+                    throw new NonNullableValueCoercedAsNullException(variableDefinition, inputName, Arrays.asList(nameStack.toArray()), graphQLType);
                 }
                 return returnValue;
             }
@@ -183,7 +185,7 @@ public class ValuesResolver {
                     throw CoercingParseValueException.newCoercingParseValueException()
                             .message("Expected type 'Map' but was '" + value.getClass().getSimpleName() +
                                     "'. Variables for input objects must be an instance of type 'Map'.")
-                            .path(nameStack)
+                            .path(Arrays.asList(nameStack.toArray()))
                             .build();
                 }
             } else {
@@ -198,14 +200,20 @@ public class ValuesResolver {
                     .extensions(e.getExtensions())
                     .cause(e.getCause())
                     .sourceLocation(variableDefinition.getSourceLocation())
-                    .path(nameStack)
+                    .path(Arrays.asList(nameStack.toArray()))
                     .build();
+        } finally {
+            nameStack.removeLast();
         }
 
     }
 
-    private Object coerceValueForInputObjectType(GraphqlFieldVisibility fieldVisibility, VariableDefinition variableDefinition, GraphQLInputObjectType inputObjectType, Map<String, Object> inputMap, List<Object> nameStack) {
-        Map<String, Object> result = new LinkedHashMap<>();
+    private Object coerceValueForInputObjectType(GraphqlFieldVisibility fieldVisibility,
+                                                 VariableDefinition variableDefinition,
+                                                 GraphQLInputObjectType inputObjectType,
+                                                 Map<String, Object> inputMap,
+                                                 Deque<Object> nameStack) {
+//        Map<String, Object> result = new LinkedHashMap<>();
         List<GraphQLInputObjectField> fields = fieldVisibility.getFieldDefinitions(inputObjectType);
         List<String> fieldNames = map(fields, GraphQLInputObjectField::getName);
         for (String inputFieldName : inputMap.keySet()) {
@@ -214,20 +222,60 @@ public class ValuesResolver {
             }
         }
 
-        for (GraphQLInputObjectField inputField : fields) {
-            if (inputMap.containsKey(inputField.getName()) || alwaysHasValue(inputField)) {
-                // getOrDefault will return a null value if its present in the map as null
-                // defaulting only applies if the key is missing - we want this
-                Object inputValue = inputMap.getOrDefault(inputField.getName(), inputField.getDefaultValue());
-                Object coerceValue = coerceValue(fieldVisibility, variableDefinition,
-                        inputField.getName(),
-                        inputField.getType(),
-                        inputValue,
-                        nameStack);
-                result.put(inputField.getName(), coerceValue == null ? inputField.getDefaultValue() : coerceValue);
+        Map<String, Object> coercedValues = new LinkedHashMap<>();
+
+        List<GraphQLInputObjectField> inputFieldTypes = fieldVisibility.getFieldDefinitions(inputObjectType);
+        for (GraphQLInputObjectField inputFieldType : inputFieldTypes) {
+
+            GraphQLInputType fieldType = inputFieldType.getType();
+            String fieldName = inputFieldType.getName();
+            Object defaultValue = inputFieldType.getDefaultValue();
+            boolean hasValue = inputMap.containsKey(fieldName);
+            Object value;
+            Object fieldValue = inputMap.getOrDefault(fieldName, null);
+            value = fieldValue;
+            if (!hasValue && inputFieldType.hasSetDefaultValue()) {
+                //TODO: default value should be coerced
+                coercedValues.put(fieldName, defaultValue);
+            } else if (isNonNull(fieldType) && (!hasValue || value == null)) {
+                nameStack.addLast(fieldName);
+                throw new NonNullableValueCoercedAsNullException(inputFieldType, Arrays.asList(nameStack.toArray()));
+            } else if (hasValue) {
+                if (value == null) {
+                    coercedValues.put(fieldName, null);
+                } else if (fieldValue instanceof VariableReference) {
+                    coercedValues.put(fieldName, value);
+                } else {
+                    value = coerceValue(fieldVisibility,
+                            variableDefinition,
+                            inputFieldType.getName(),
+                            fieldType,
+                            value,
+                            nameStack);
+                    coercedValues.put(fieldName, value);
+                }
+            } else {
+                // nullable type && hasValue == false && hasDefaultValue == false
+                // meaning no value was provided for this field
             }
         }
-        return result;
+        return coercedValues;
+
+
+//        for (GraphQLInputObjectField inputField : fields) {
+//            if (inputMap.containsKey(inputField.getName()) || alwaysHasValue(inputField)) {
+//                // getOrDefault will return a null value if its present in the map as null
+//                // defaulting only applies if the key is missing - we want this
+//                Object inputValue = inputMap.getOrDefault(inputField.getName(), inputField.getDefaultValue());
+//                Object coerceValue = coerceValue(fieldVisibility, variableDefinition,
+//                        inputField.getName(),
+//                        inputField.getType(),
+//                        inputValue,
+//                        nameStack);
+//                result.put(inputField.getName(), coerceValue == null ? inputField.getDefaultValue() : coerceValue);
+//            }
+//        }
+//        return result;
     }
 
     private boolean alwaysHasValue(GraphQLInputObjectField inputField) {
@@ -243,7 +291,7 @@ public class ValuesResolver {
         return graphQLEnumType.parseValue(value);
     }
 
-    private List coerceValueForList(GraphqlFieldVisibility fieldVisibility, VariableDefinition variableDefinition, String inputName, GraphQLList graphQLList, Object value, List<Object> nameStack) {
+    private List coerceValueForList(GraphqlFieldVisibility fieldVisibility, VariableDefinition variableDefinition, String inputName, GraphQLList graphQLList, Object value, Deque<Object> nameStack) {
         if (value instanceof Iterable) {
             List<Object> result = new ArrayList<>();
             for (Object val : (Iterable) value) {

--- a/src/test/groovy/graphql/execution/ValuesResolverTest.groovy
+++ b/src/test/groovy/graphql/execution/ValuesResolverTest.groovy
@@ -362,17 +362,18 @@ class ValuesResolverTest extends Specification {
 
     }
 
-    def "getVariableValues: input object with non-required fields and default values"() {
+    @Unroll
+    def "getVariableValues: input object with non-required fields and default values. #inputValue -> #outputValue"() {
         given:
 
         def inputObjectType = newInputObject()
                 .name("InputObject")
                 .field(newInputObjectField()
-                .name("intKey")
-                .type(GraphQLInt))
+                        .name("intKey")
+                        .type(GraphQLInt))
                 .field(newInputObjectField()
-                .name("stringKey")
-                .type(GraphQLString)
+                        .name("stringKey")
+                        .type(GraphQLString)
                 .defaultValue("defaultString"))
                 .build()
 
@@ -388,7 +389,7 @@ class ValuesResolverTest extends Specification {
         where:
         inputValue                    || outputValue
         [intKey: 10]                  || [intKey: 10, stringKey: 'defaultString']
-        [intKey: 10, stringKey: null] || [intKey: 10, stringKey: 'defaultString']
+        [intKey: 10, stringKey: null] || [intKey: 10, stringKey: null]
 
     }
 
@@ -413,7 +414,7 @@ class ValuesResolverTest extends Specification {
 
         then:
         def e = thrown(GraphQLException)
-        e.path== ["variable", "intKey", "requiredField", "requiredField"]
+        e.path == ["variable", "requiredField"]
 
         where:
         inputValue                        | _


### PR DESCRIPTION
This refactors the input object value coercion to align with the rest of the code.

As a side effect it fixes a bug where a `null` value in the object was overwritten with a default value.