### PR TITLE
fix npe in query traverser when default variable value is a list

### DIFF
--- a/src/main/java/graphql/analysis/NodeVisitorWithTypeTracking.java
+++ b/src/main/java/graphql/analysis/NodeVisitorWithTypeTracking.java
@@ -233,9 +233,19 @@ public class NodeVisitorWithTypeTracking extends NodeVisitorStub {
         return TraversalControl.CONTINUE;
     }
 
+    private static boolean isChildOfVariableDefinition(TraverserContext<Node> context) {
+        if (context == null) {
+            return false;
+        }
+        if (context.getParentNode() instanceof VariableDefinition) {
+            return true;
+        }
+        return isChildOfVariableDefinition(context.getParentContext());
+    }
+
     @Override
     protected TraversalControl visitValue(Value<?> value, TraverserContext<Node> context) {
-        if (context.getParentNode() instanceof VariableDefinition) {
+        if (isChildOfVariableDefinition(context)) {
             return TraversalControl.CONTINUE;
         }
 

--- a/src/main/java/graphql/analysis/NodeVisitorWithTypeTracking.java
+++ b/src/main/java/graphql/analysis/NodeVisitorWithTypeTracking.java
@@ -236,6 +236,7 @@ public class NodeVisitorWithTypeTracking extends NodeVisitorStub {
     @Override
     protected TraversalControl visitValue(Value<?> value, TraverserContext<Node> context) {
         if (context.getParentNode() instanceof VariableDefinition) {
+            visitVariableDefinition(((VariableDefinition) context.getParentNode()), context);
             return TraversalControl.ABORT;
         }
 

--- a/src/main/java/graphql/analysis/NodeVisitorWithTypeTracking.java
+++ b/src/main/java/graphql/analysis/NodeVisitorWithTypeTracking.java
@@ -233,20 +233,10 @@ public class NodeVisitorWithTypeTracking extends NodeVisitorStub {
         return TraversalControl.CONTINUE;
     }
 
-    private static boolean isChildOfVariableDefinition(TraverserContext<Node> context) {
-        if (context == null) {
-            return false;
-        }
-        if (context.getParentNode() instanceof VariableDefinition) {
-            return true;
-        }
-        return isChildOfVariableDefinition(context.getParentContext());
-    }
-
     @Override
     protected TraversalControl visitValue(Value<?> value, TraverserContext<Node> context) {
-        if (isChildOfVariableDefinition(context)) {
-            return TraversalControl.CONTINUE;
+        if (context.getParentNode() instanceof VariableDefinition) {
+            return TraversalControl.ABORT;
         }
 
         QueryVisitorFieldArgumentEnvironment fieldArgEnv = context.getVarFromParents(QueryVisitorFieldArgumentEnvironment.class);


### PR DESCRIPTION
inside of `visitValue` method we check whether a parent of a node is a var reference
```java
if (context.getParentNode() instanceof VariableDefinition) {
    return TraversalControl.CONTINUE;
}
```

But if a grandparent of a node is a var reference we won't exit the method. The method fails with NPE