### PR TITLE
Fixes #2068 - Silent thread leak on exception in completeValueForList

### DIFF
--- a/src/main/java/graphql/execution/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncExecutionStrategy.java
@@ -76,6 +76,7 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
             // if there are any issues with combining/handling the field results,
             // complete the future at all costs and bubble up any thrown exception so
             // the execution does not hang.
+            executionStrategyCtx.onFieldValuesException();
             overallResult.completeExceptionally(ex);
             return null;
         });

--- a/src/main/java/graphql/execution/instrumentation/ExecutionStrategyInstrumentationContext.java
+++ b/src/main/java/graphql/execution/instrumentation/ExecutionStrategyInstrumentationContext.java
@@ -13,4 +13,8 @@ public interface ExecutionStrategyInstrumentationContext extends Instrumentation
 
     }
 
+    default void onFieldValuesException() {
+
+    }
+
 }

--- a/src/main/java/graphql/execution/instrumentation/dataloader/FieldLevelTrackingApproach.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/FieldLevelTrackingApproach.java
@@ -156,6 +156,13 @@ public class FieldLevelTrackingApproach {
                     dispatch();
                 }
             }
+
+            @Override
+            public void onFieldValuesException() {
+                synchronized (callStack) {
+                    callStack.increaseHappenedOnFieldValueCalls(curLevel);
+                }
+            }
         };
     }
 

--- a/src/test/groovy/graphql/Issue2068.groovy
+++ b/src/test/groovy/graphql/Issue2068.groovy
@@ -23,7 +23,7 @@ import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring
 import static graphql.ExecutionInput.newExecutionInput
 
 class Issue2068 extends Specification {
-    def "deadlock attempt"() {
+    def "shouldn't hang on exception in resolveFieldWithInfo"() {
         setup:
         def sdl = """
         type Nation {
@@ -72,120 +72,15 @@ class Issue2068 extends Specification {
                 .type(newTypeWiring("Query")
                         .dataFetcher("pets", new StaticDataFetcher(['cats': cats, 'dogs': dogs])))
                 .type(newTypeWiring("Cat")
-                        .dataFetcher("toys", new StaticDataFetcher(new List<Object>() {
+                        .dataFetcher("toys", new StaticDataFetcher(new AbstractList() {
+                            @Override
+                            Object get(int i) {
+                                throw new RuntimeException("Simulated failure");
+                            }
+
                             @Override
                             int size() {
                                 return 1
-                            }
-
-                            @Override
-                            boolean isEmpty() {
-                                return false
-                            }
-
-                            @Override
-                            boolean contains(Object o) {
-                                return false
-                            }
-
-                            @Override
-                            Iterator iterator() {
-                                throw new RuntimeException()
-                            }
-
-                            @Override
-                            Object[] toArray() {
-                                return new Object[0]
-                            }
-
-                            @Override
-                            Object[] toArray(Object[] a) {
-                                return null
-                            }
-
-                            @Override
-                            boolean add(Object o) {
-                                return false
-                            }
-
-                            @Override
-                            boolean remove(Object o) {
-                                return false
-                            }
-
-                            @Override
-                            boolean containsAll(Collection c) {
-                                return false
-                            }
-
-                            @Override
-                            boolean addAll(Collection c) {
-                                return false
-                            }
-
-                            @Override
-                            boolean addAll(int index, Collection c) {
-                                return false
-                            }
-
-                            @Override
-                            boolean removeAll(Collection c) {
-                                return false
-                            }
-
-                            @Override
-                            boolean retainAll(Collection c) {
-                                return false
-                            }
-
-                            @Override
-                            void clear() {
-
-                            }
-
-                            @Override
-                            Object get(int index) {
-                                return null
-                            }
-
-                            @Override
-                            Object set(int index, Object element) {
-                                return null
-                            }
-
-                            @Override
-                            void add(int index, Object element) {
-
-                            }
-
-                            @Override
-                            Object remove(int index) {
-                                return null
-                            }
-
-                            @Override
-                            int indexOf(Object o) {
-                                return 0
-                            }
-
-                            @Override
-                            int lastIndexOf(Object o) {
-                                return 0
-                            }
-
-                            @Override
-                            ListIterator listIterator() {
-                                return null
-                            }
-
-                            @Override
-                            ListIterator listIterator(int index) {
-                                return null
-                            }
-
-                            @Override
-                            List subList(int fromIndex, int toIndex) {
-                                return null
                             }
                         })))
                 .type(newTypeWiring("Dog")

--- a/src/test/groovy/graphql/Issue2068.groovy
+++ b/src/test/groovy/graphql/Issue2068.groovy
@@ -1,0 +1,264 @@
+package graphql
+
+import graphql.execution.instrumentation.dataloader.DataLoaderDispatcherInstrumentation
+import graphql.schema.DataFetcher
+import graphql.schema.DataFetchingEnvironment
+import graphql.schema.StaticDataFetcher
+import graphql.schema.idl.RuntimeWiring
+import org.apache.commons.lang3.concurrent.BasicThreadFactory
+import org.dataloader.BatchLoader
+import org.dataloader.DataLoader
+import org.dataloader.DataLoaderOptions
+import org.dataloader.DataLoaderRegistry
+import spock.lang.Specification
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+import java.util.concurrent.SynchronousQueue
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+
+import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring
+import static graphql.ExecutionInput.newExecutionInput
+
+class Issue2068 extends Specification {
+    def "deadlock attempt"() {
+        setup:
+        def sdl = """
+        type Nation {
+            name: String
+        }
+        
+        type Toy {
+            name: String
+        }
+        
+        type Owner {
+            nation: Nation
+        }
+        
+        type Cat {
+            toys: [Toy]
+        }
+        
+        type Dog {
+            owner: Owner
+        }
+        
+        type Pets {
+            cats: [Cat]
+            dogs: [Dog]
+        }
+        
+        type Query {
+            pets: Pets
+        }
+        """
+
+        def cats = [['id': "cat-1"]]
+        def dogs = [['id': "dog-1"]]
+
+        ThreadFactory threadFactory = new BasicThreadFactory.Builder()
+                .namingPattern("resolver-chain-thread-%d").build()
+        def executor = new ThreadPoolExecutor(15, 15, 0L,
+                TimeUnit.MILLISECONDS, new SynchronousQueue<>(), threadFactory,
+                new ThreadPoolExecutor.CallerRunsPolicy())
+
+        DataFetcher nationsDf = { env -> env.getDataLoader("owner.nation").load(env) }
+        DataFetcher ownersDf = { env -> env.getDataLoader("dog.owner").load(env) }
+
+        def wiring = RuntimeWiring.newRuntimeWiring()
+                .type(newTypeWiring("Query")
+                        .dataFetcher("pets", new StaticDataFetcher(['cats': cats, 'dogs': dogs])))
+                .type(newTypeWiring("Cat")
+                        .dataFetcher("toys", new StaticDataFetcher(new List<Object>() {
+                            @Override
+                            int size() {
+                                return 1
+                            }
+
+                            @Override
+                            boolean isEmpty() {
+                                return false
+                            }
+
+                            @Override
+                            boolean contains(Object o) {
+                                return false
+                            }
+
+                            @Override
+                            Iterator iterator() {
+                                throw new RuntimeException()
+                            }
+
+                            @Override
+                            Object[] toArray() {
+                                return new Object[0]
+                            }
+
+                            @Override
+                            Object[] toArray(Object[] a) {
+                                return null
+                            }
+
+                            @Override
+                            boolean add(Object o) {
+                                return false
+                            }
+
+                            @Override
+                            boolean remove(Object o) {
+                                return false
+                            }
+
+                            @Override
+                            boolean containsAll(Collection c) {
+                                return false
+                            }
+
+                            @Override
+                            boolean addAll(Collection c) {
+                                return false
+                            }
+
+                            @Override
+                            boolean addAll(int index, Collection c) {
+                                return false
+                            }
+
+                            @Override
+                            boolean removeAll(Collection c) {
+                                return false
+                            }
+
+                            @Override
+                            boolean retainAll(Collection c) {
+                                return false
+                            }
+
+                            @Override
+                            void clear() {
+
+                            }
+
+                            @Override
+                            Object get(int index) {
+                                return null
+                            }
+
+                            @Override
+                            Object set(int index, Object element) {
+                                return null
+                            }
+
+                            @Override
+                            void add(int index, Object element) {
+
+                            }
+
+                            @Override
+                            Object remove(int index) {
+                                return null
+                            }
+
+                            @Override
+                            int indexOf(Object o) {
+                                return 0
+                            }
+
+                            @Override
+                            int lastIndexOf(Object o) {
+                                return 0
+                            }
+
+                            @Override
+                            ListIterator listIterator() {
+                                return null
+                            }
+
+                            @Override
+                            ListIterator listIterator(int index) {
+                                return null
+                            }
+
+                            @Override
+                            List subList(int fromIndex, int toIndex) {
+                                return null
+                            }
+                        })))
+                .type(newTypeWiring("Dog")
+                        .dataFetcher("owner", ownersDf))
+                .type(newTypeWiring("Owner")
+                        .dataFetcher("nation", nationsDf))
+                .build()
+
+        def schema = TestUtil.schema(sdl, wiring)
+
+        when:
+        def graphql = GraphQL.newGraphQL(schema)
+                .instrumentation(new DataLoaderDispatcherInstrumentation())
+                .build()
+        DataLoaderRegistry dataLoaderRegistry = mkNewDataLoaderRegistry(executor)
+
+        graphql.execute(newExecutionInput()
+                .dataLoaderRegistry(dataLoaderRegistry)
+                .query("""
+                query LoadPets {
+                      pets {
+                        cats {
+                          toys {
+                            name
+                          }
+                        }
+                        dogs {
+                          owner {
+                            nation {
+                              name
+                            }
+                          }
+                        }
+                      }
+                    }
+                    """)
+                .build())
+
+        then: "execution shouldn't hang"
+        // wait for each future to complete and grab the results
+        thrown(RuntimeException)
+    }
+
+    private static DataLoaderRegistry mkNewDataLoaderRegistry(executor) {
+        def dataLoaderNations = new DataLoader<Object, Object>(new BatchLoader<DataFetchingEnvironment, List<Object>>() {
+            @Override
+            CompletionStage<List<List<Object>>> load(List<DataFetchingEnvironment> keys) {
+                return CompletableFuture.supplyAsync({
+                    def nations = []
+                    for (int i = 1; i <= 1; i++) {
+                        nations.add(['id': "nation-$i", 'name': "nation-$i"])
+                    }
+                    return nations
+                }, executor) as CompletionStage<List<List<Object>>>
+            }
+        }, DataLoaderOptions.newOptions().setMaxBatchSize(5))
+
+        def dataLoaderOwners = new DataLoader<Object, Object>(new BatchLoader<DataFetchingEnvironment, List<Object>>() {
+            @Override
+            CompletionStage<List<List<Object>>> load(List<DataFetchingEnvironment> keys) {
+                return CompletableFuture.supplyAsync({
+                    def owners = []
+                    for (int i = 1; i <= 1; i++) {
+                        owners.add(['id': "owner-$i"])
+                    }
+                    return owners
+                }, executor) as CompletionStage<List<List<Object>>>
+            }
+        }, DataLoaderOptions.newOptions().setMaxBatchSize(5))
+
+        def dataLoaderRegistry = new DataLoaderRegistry()
+        dataLoaderRegistry.register("dog.owner", dataLoaderOwners)
+        dataLoaderRegistry.register("owner.nation", dataLoaderNations)
+        dataLoaderRegistry
+    }
+}


### PR DESCRIPTION
This an attempt to fix #2068 . It might be a bit too naive, but i wanted to get another set of eyes on this issue.

Here my reasoning for this fix:
As explained in the issue, the problem lies in how the dataloader determines when to dispatch different levels. When one of the `resolveFieldWithInfo` futures completes exceptionally, the `Async.each` Future also completes exceptionally and the dataloader instrumentation is not made aware of this. Since `expectedStrategyCallsPerLevel` is increased by calls to `handleOnFieldValuesInfo` by previous levels and `allOnFieldCallsHappened` is checked for the previous level when dispatching, it means that all deeper levels will never be dispatched (`expectedStrategyCallsPerLevel` is bigger than `happenedOnFieldValueCallsPerLevel`) and we leak a thread. The changes made make sure that the instrumentation is made aware of this exceptional completion and thus that deeper levels can still be dispatched. 

If you have better ideas to fix this i am open for your suggestions! Thanks!