### PR TITLE
Adding GraphQlContext in preference to the legacy context

### DIFF
--- a/src/main/java/graphql/ExecutionInput.java
+++ b/src/main/java/graphql/ExecutionInput.java
@@ -329,7 +329,7 @@ public class ExecutionInput {
         }
 
         /**
-         * This will put all the valuyes from the map into the underlying {@link GraphQLContext} of this execution input
+         * This will put all the values from the map into the underlying {@link GraphQLContext} of this execution input
          *
          * @param mapOfContext a map of values to put in the context
          *

--- a/src/main/java/graphql/ExecutionInput.java
+++ b/src/main/java/graphql/ExecutionInput.java
@@ -205,8 +205,8 @@ public class ExecutionInput {
 
         private String query;
         private String operationName;
-        private Object context = GraphQLContext.newContext().build();
         private GraphQLContext graphQLContext = GraphQLContext.newContext().build();
+        private Object context = graphQLContext; // we make these the same object on purpose - legacy code will get the same object if this change nothing
         private Object localContext;
         private Object root;
         private Map<String, Object> variables = Collections.emptyMap();
@@ -274,11 +274,17 @@ public class ExecutionInput {
          *
          * @return this builder
          *
-         * @deprecated - use {@link #graphQLContext(GraphQLContext)} instead
+         * @deprecated - the {@link ExecutionInput#getGraphQLContext()} is a fixed mutable instance now
          */
         @Deprecated
         public Builder context(Object context) {
             this.context = context;
+            return this;
+        }
+
+        // hidden on purpose
+        private Builder graphQLContext(GraphQLContext graphQLContext) {
+            this.graphQLContext = graphQLContext;
             return this;
         }
 
@@ -289,7 +295,7 @@ public class ExecutionInput {
          *
          * @return this builder
          *
-         * @deprecated - use {@link #graphQLContext(GraphQLContext.Builder)} instead
+         * @deprecated - the {@link ExecutionInput#getGraphQLContext()} is a fixed mutable instance now
          */
         @Deprecated
         public Builder context(GraphQLContext.Builder contextBuilder) {
@@ -304,49 +310,13 @@ public class ExecutionInput {
          *
          * @return this builder
          *
-         * @deprecated - use {@link #graphQLContext(UnaryOperator)} instead
+         * @deprecated - the {@link ExecutionInput#getGraphQLContext()} is a fixed mutable instance now
          */
         @Deprecated
         public Builder context(UnaryOperator<GraphQLContext.Builder> contextBuilderFunction) {
             GraphQLContext.Builder builder = GraphQLContext.newContext();
             builder = contextBuilderFunction.apply(builder);
             return context(builder.build());
-        }
-
-        /**
-         * This allows you to set up your own context object that will be passed to all data fetchers during execution
-         *
-         * @param context the context object to use
-         *
-         * @return this builder
-         */
-        public Builder graphQLContext(GraphQLContext context) {
-            this.graphQLContext = assertNotNull(context, () -> "you MUST provide a non null GraphqlContext");
-            return this;
-        }
-
-        /**
-         * This allows you to set up your own context object that will be passed to all data fetchers during execution
-         *
-         * @param contextBuilder the {@link GraphQLContext.Builder} object to use
-         *
-         * @return this builder
-         */
-        public Builder graphQLContext(GraphQLContext.Builder contextBuilder) {
-            return graphQLContext(contextBuilder.build());
-        }
-
-        /**
-         * This allows you to set up your own context object that will be passed to all data fetchers during execution
-         *
-         * @param contextBuilderFunction as callback give a {@link GraphQLContext.Builder} object to use
-         *
-         * @return this builder
-         */
-        public Builder graphQLContext(UnaryOperator<GraphQLContext.Builder> contextBuilderFunction) {
-            GraphQLContext.Builder builder = GraphQLContext.newContext();
-            builder = contextBuilderFunction.apply(builder);
-            return graphQLContext(builder.build());
         }
 
         public Builder root(Object root) {

--- a/src/main/java/graphql/ExecutionInput.java
+++ b/src/main/java/graphql/ExecutionInput.java
@@ -153,7 +153,7 @@ public class ExecutionInput {
                 .query(this.query)
                 .operationName(this.operationName)
                 .context(this.context)
-                .graphQLContext(this.graphQLContext)
+                .transfer(this.graphQLContext)
                 .localContext(this.localContext)
                 .root(this.root)
                 .dataLoaderRegistry(this.dataLoaderRegistry)
@@ -282,12 +282,6 @@ public class ExecutionInput {
             return this;
         }
 
-        // hidden on purpose
-        private Builder graphQLContext(GraphQLContext graphQLContext) {
-            this.graphQLContext = graphQLContext;
-            return this;
-        }
-
         /**
          * The legacy context object
          *
@@ -317,6 +311,39 @@ public class ExecutionInput {
             GraphQLContext.Builder builder = GraphQLContext.newContext();
             builder = contextBuilderFunction.apply(builder);
             return context(builder.build());
+        }
+
+        /**
+         * This will give you a builder of {@link GraphQLContext} and any values you set will be copied
+         * into the underlying {@link GraphQLContext} of this execution input
+         *
+         * @param builderFunction a builder function you can use to put values into the context
+         *
+         * @return this builder
+         */
+        public Builder graphQLContext(Consumer<GraphQLContext.Builder> builderFunction) {
+            GraphQLContext.Builder builder = GraphQLContext.newContext();
+            builderFunction.accept(builder);
+            this.graphQLContext.putAll(builder);
+            return this;
+        }
+
+        /**
+         * This will put all the valuyes from the map into the underlying {@link GraphQLContext} of this execution input
+         *
+         * @param mapOfContext a map of values to put in the context
+         *
+         * @return this builder
+         */
+        public Builder graphQLContext(Map<?, Object> mapOfContext) {
+            this.graphQLContext.putAll(mapOfContext);
+            return this;
+        }
+
+        // hidden on purpose
+        private Builder transfer(GraphQLContext graphQLContext) {
+            this.graphQLContext = Assert.assertNotNull(graphQLContext);
+            return this;
         }
 
         public Builder root(Object root) {

--- a/src/main/java/graphql/ExecutionInput.java
+++ b/src/main/java/graphql/ExecutionInput.java
@@ -21,6 +21,7 @@ public class ExecutionInput {
     private final String query;
     private final String operationName;
     private final Object context;
+    private final GraphQLContext graphQLContext;
     private final Object localContext;
     private final Object root;
     private final Map<String, Object> variables;
@@ -36,6 +37,7 @@ public class ExecutionInput {
         this.query = assertNotNull(builder.query, () -> "query can't be null");
         this.operationName = builder.operationName;
         this.context = builder.context;
+        this.graphQLContext = assertNotNull(builder.graphQLContext);
         this.root = builder.root;
         this.variables = builder.variables;
         this.dataLoaderRegistry = builder.dataLoaderRegistry;
@@ -61,10 +63,23 @@ public class ExecutionInput {
     }
 
     /**
+     * The legacy context object has been deprecated in favour of the more shareable
+     * {@link #getGraphQLContext()}
+     *
      * @return the context object to pass to all data fetchers
+     *
+     * @deprecated - use {@link #getGraphQLContext()}
      */
+    @Deprecated
     public Object getContext() {
         return context;
+    }
+
+    /**
+     * @return the shared {@link GraphQLContext} object to pass to all data fetchers
+     */
+    public GraphQLContext getGraphQLContext() {
+        return graphQLContext;
     }
 
     /**
@@ -130,6 +145,7 @@ public class ExecutionInput {
      * the current values and allows you to transform it how you want.
      *
      * @param builderConsumer the consumer code that will be given a builder to transform
+     *
      * @return a new ExecutionInput object based on calling build on that builder
      */
     public ExecutionInput transform(Consumer<Builder> builderConsumer) {
@@ -137,6 +153,7 @@ public class ExecutionInput {
                 .query(this.query)
                 .operationName(this.operationName)
                 .context(this.context)
+                .graphQLContext(this.graphQLContext)
                 .localContext(this.localContext)
                 .root(this.root)
                 .dataLoaderRegistry(this.dataLoaderRegistry)
@@ -157,6 +174,7 @@ public class ExecutionInput {
                 "query='" + query + '\'' +
                 ", operationName='" + operationName + '\'' +
                 ", context=" + context +
+                ", graphQLContext=" + graphQLContext +
                 ", root=" + root +
                 ", variables=" + variables +
                 ", dataLoaderRegistry=" + dataLoaderRegistry +
@@ -176,6 +194,7 @@ public class ExecutionInput {
      * Creates a new builder of ExecutionInput objects with the given query
      *
      * @param query the query to execute
+     *
      * @return a new builder of ExecutionInput objects
      */
     public static Builder newExecutionInput(String query) {
@@ -187,6 +206,7 @@ public class ExecutionInput {
         private String query;
         private String operationName;
         private Object context = GraphQLContext.newContext().build();
+        private GraphQLContext graphQLContext = GraphQLContext.newContext().build();
         private Object localContext;
         private Object root;
         private Map<String, Object> variables = Collections.emptyMap();
@@ -214,6 +234,7 @@ public class ExecutionInput {
          * A default one will be assigned, but you can set your own.
          *
          * @param executionId an execution id object
+         *
          * @return this builder
          */
         public Builder executionId(ExecutionId executionId) {
@@ -226,6 +247,7 @@ public class ExecutionInput {
          * Sets the locale to use for this operation
          *
          * @param locale the locale to use
+         *
          * @return this builder
          */
         public Builder locale(Locale locale) {
@@ -237,6 +259,7 @@ public class ExecutionInput {
          * Sets initial localContext in root data fetchers
          *
          * @param localContext the local context to use
+         *
          * @return this builder
          */
         public Builder localContext(Object localContext) {
@@ -245,25 +268,85 @@ public class ExecutionInput {
         }
 
         /**
-         * By default you will get a {@link GraphQLContext} object but you can set your own.
+         * The legacy context object
          *
          * @param context the context object to use
+         *
          * @return this builder
+         *
+         * @deprecated - use {@link #graphQLContext(GraphQLContext)} instead
          */
+        @Deprecated
         public Builder context(Object context) {
             this.context = context;
             return this;
         }
 
+        /**
+         * The legacy context object
+         *
+         * @param contextBuilder the context builder object to use
+         *
+         * @return this builder
+         *
+         * @deprecated - use {@link #graphQLContext(GraphQLContext.Builder)} instead
+         */
+        @Deprecated
         public Builder context(GraphQLContext.Builder contextBuilder) {
             this.context = contextBuilder.build();
             return this;
         }
 
+        /**
+         * The legacy context object
+         *
+         * @param contextBuilderFunction the context builder function to use
+         *
+         * @return this builder
+         *
+         * @deprecated - use {@link #graphQLContext(UnaryOperator)} instead
+         */
+        @Deprecated
         public Builder context(UnaryOperator<GraphQLContext.Builder> contextBuilderFunction) {
             GraphQLContext.Builder builder = GraphQLContext.newContext();
             builder = contextBuilderFunction.apply(builder);
             return context(builder.build());
+        }
+
+        /**
+         * This allows you to set up your own context object that will be passed to all data fetchers during execution
+         *
+         * @param context the context object to use
+         *
+         * @return this builder
+         */
+        public Builder graphQLContext(GraphQLContext context) {
+            this.graphQLContext = assertNotNull(context, () -> "you MUST provide a non null GraphqlContext");
+            return this;
+        }
+
+        /**
+         * This allows you to set up your own context object that will be passed to all data fetchers during execution
+         *
+         * @param contextBuilder the {@link GraphQLContext.Builder} object to use
+         *
+         * @return this builder
+         */
+        public Builder graphQLContext(GraphQLContext.Builder contextBuilder) {
+            return graphQLContext(contextBuilder.build());
+        }
+
+        /**
+         * This allows you to set up your own context object that will be passed to all data fetchers during execution
+         *
+         * @param contextBuilderFunction as callback give a {@link GraphQLContext.Builder} object to use
+         *
+         * @return this builder
+         */
+        public Builder graphQLContext(UnaryOperator<GraphQLContext.Builder> contextBuilderFunction) {
+            GraphQLContext.Builder builder = GraphQLContext.newContext();
+            builder = contextBuilderFunction.apply(builder);
+            return graphQLContext(builder.build());
         }
 
         public Builder root(Object root) {
@@ -287,6 +370,7 @@ public class ExecutionInput {
          * instances as this will create unexpected results.
          *
          * @param dataLoaderRegistry a registry of {@link org.dataloader.DataLoader}s
+         *
          * @return this builder
          */
         public Builder dataLoaderRegistry(DataLoaderRegistry dataLoaderRegistry) {

--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -462,7 +462,7 @@ public class GraphQL {
         }
         String queryString = executionInput.getQuery();
         String operationName = executionInput.getOperationName();
-        Object context = executionInput.getContext();
+        Object context = executionInput.getGraphQLContext();
         return executionInput.transform(builder -> builder.executionId(idProvider.provide(queryString, operationName, context)));
     }
 

--- a/src/main/java/graphql/GraphQLContext.java
+++ b/src/main/java/graphql/GraphQLContext.java
@@ -236,6 +236,14 @@ public class GraphQLContext {
     public static class Builder {
         private final ConcurrentMap<Object, Object> map = new ConcurrentHashMap<>();
 
+        public Builder put(
+                Object key1, Object value1
+        ) {
+            return putImpl(
+                    key1, value1
+            );
+        }
+
         public Builder of(
                 Object key1, Object value1
         ) {
@@ -309,6 +317,17 @@ public class GraphQLContext {
                 map.put(assertNotNull(entry.getKey()), assertNotNull(entry.getValue()));
             }
             return this;
+        }
+
+        /**
+         * Adds all of the values in the map into the context builder.  All keys and values MUST be non null
+         *
+         * @param mapOfContext the map to put into context
+         *
+         * @return this builder
+         */
+        public Builder putAll(Map<?, Object> mapOfContext) {
+            return of(mapOfContext);
         }
 
         /**

--- a/src/main/java/graphql/GraphQLContext.java
+++ b/src/main/java/graphql/GraphQLContext.java
@@ -1,6 +1,7 @@
 package graphql;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -17,7 +18,7 @@ import static graphql.Assert.assertNotNull;
  * {@code
  *     DataFetcher df = new DataFetcher() {
  *        public Object get(DataFetchingEnvironment env) {
- *            GraphQLContext ctx = env.getContext()
+ *            GraphQLContext ctx = env.getGraphqlContext()
  *            User currentUser = ctx.getOrDefault("userKey",new AnonymousUser())
  *            ...
  *        }
@@ -25,7 +26,11 @@ import static graphql.Assert.assertNotNull;
  * }
  * </pre>
  *
- * You can set this up via {@link ExecutionInput.Builder#context(graphql.GraphQLContext.Builder)}
+ * You can set this up via {@link ExecutionInput.Builder#graphQLContext(GraphQLContext)}}
+ *
+ * All keys and values in the context MUST be non null.
+ *
+ * The class is mutable via a thread safe implementation but it is recommended to try to use this class in an immutable way if you can.
  */
 @PublicApi
 @ThreadSafe
@@ -38,42 +43,140 @@ public class GraphQLContext {
         this.map = map;
     }
 
-    public void delete(Object key) {
+    /**
+     * Deletes a key in the context
+     *
+     * @param key the key to delete
+     *
+     * @return this GraphQLContext object
+     */
+    public GraphQLContext delete(Object key) {
         map.remove(assertNotNull(key));
+        return this;
     }
 
+    /**
+     * Returns a value in the context by key
+     *
+     * @param key the key to look up
+     * @param <T> for two
+     *
+     * @return a value or null
+     */
     public <T> T get(Object key) {
         return (T) map.get(assertNotNull(key));
     }
 
+    /**
+     * Returns a value in the context by key
+     *
+     * @param key          the key to look up
+     * @param defaultValue the default value to use if these is no key entry
+     * @param <T>          for two
+     *
+     * @return a value or default value
+     */
     public <T> T getOrDefault(Object key, T defaultValue) {
         return (T) map.getOrDefault(assertNotNull(key), defaultValue);
     }
 
+    /**
+     * Returns a {@link Optional} value in the context by key
+     *
+     * @param key the key to look up
+     * @param <T> for two
+     *
+     * @return a value or an empty optional value
+     */
     public <T> Optional<T> getOrEmpty(Object key) {
         T t = (T) map.get(assertNotNull(key));
         return Optional.ofNullable(t);
     }
 
+    /**
+     * Returns true if the context contains a value for that key
+     *
+     * @param key the key to lookup
+     *
+     * @return true if there is a value for that key
+     */
     public boolean hasKey(Object key) {
         return map.containsKey(assertNotNull(key));
     }
 
-    public void put(Object key, Object value) {
+    /**
+     * Puts a value into the context
+     *
+     * @param key   the key to set
+     * @param value the new value (which not must be null)
+     *
+     * @return this {@link GraphQLContext} object
+     */
+    public GraphQLContext put(Object key, Object value) {
         map.put(assertNotNull(key), assertNotNull(value));
+        return this;
     }
 
-    public void putAll(GraphQLContext context) {
+    /**
+     * Puts all of the values into the context
+     *
+     * @param context the other context to use
+     *
+     * @return this {@link GraphQLContext} object
+     */
+    public GraphQLContext putAll(GraphQLContext context) {
         assertNotNull(context);
         for (Map.Entry<Object, Object> entry : context.map.entrySet()) {
             put(entry.getKey(), entry.getValue());
         }
+        return this;
     }
 
+    /**
+     * @return a stream of entries in the context
+     */
     public Stream<Map.Entry<Object, Object>> stream() {
         return map.entrySet().stream();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        GraphQLContext that = (GraphQLContext) o;
+        return map.equals(that.map);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(map);
+    }
+
+    @Override
+    public String toString() {
+        return map.toString();
+    }
+
+    /**
+     * Creates a new GraphqlContext with the map of context added to it
+     *
+     * @param mapOfContext the map of context value to use
+     *
+     * @return the new GraphqlContext
+     */
+    public static GraphQLContext of(Map<?, Object> mapOfContext) {
+        return new Builder().of(mapOfContext).build();
+    }
+
+    /**
+     * Creates a new GraphqlContext builder
+     *
+     * @return the new builder
+     */
     public static Builder newContext() {
         return new Builder();
     }
@@ -139,6 +242,21 @@ public class GraphQLContext {
                     key4, value4,
                     key5, value5
             );
+        }
+
+        /**
+         * Adds all of the values in the map into the context builder.  All keys and values MUSt be non null
+         *
+         * @param mapOfContext the map to put into context
+         *
+         * @return this builder
+         */
+        public Builder of(Map<?, Object> mapOfContext) {
+            assertNotNull(mapOfContext);
+            for (Map.Entry<?, Object> entry : mapOfContext.entrySet()) {
+                map.put(assertNotNull(entry.getKey()), assertNotNull(entry.getValue()));
+            }
+            return this;
         }
 
         private Builder putImpl(Object... kvs) {

--- a/src/main/java/graphql/GraphQLContext.java
+++ b/src/main/java/graphql/GraphQLContext.java
@@ -38,9 +38,9 @@ import static graphql.Assert.assertNotNull;
 @SuppressWarnings("unchecked")
 public class GraphQLContext {
 
-    protected final ConcurrentMap<Object, Object> map;
+    private final ConcurrentMap<Object, Object> map;
 
-    protected GraphQLContext(ConcurrentMap<Object, Object> map) {
+    private GraphQLContext(ConcurrentMap<Object, Object> map) {
         this.map = map;
     }
 

--- a/src/main/java/graphql/GraphQLContext.java
+++ b/src/main/java/graphql/GraphQLContext.java
@@ -38,9 +38,9 @@ import static graphql.Assert.assertNotNull;
 @SuppressWarnings("unchecked")
 public class GraphQLContext {
 
-    private final ConcurrentMap<Object, Object> map;
+    protected final ConcurrentMap<Object, Object> map;
 
-    private GraphQLContext(ConcurrentMap<Object, Object> map) {
+    protected GraphQLContext(ConcurrentMap<Object, Object> map) {
         this.map = map;
     }
 

--- a/src/main/java/graphql/cachecontrol/CacheControl.java
+++ b/src/main/java/graphql/cachecontrol/CacheControl.java
@@ -1,5 +1,6 @@
 package graphql.cachecontrol;
 
+import graphql.ExecutionInput;
 import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.PublicApi;
@@ -21,7 +22,7 @@ import static graphql.collect.ImmutableKit.map;
  * To best use this class you need to pass a CacheControl object to each {@link graphql.schema.DataFetcher} and have them decide on
  * the caching hint values.
  * <p>
- * The easiest way to do this is create a CacheControl object at query start and pass it in as a "context" object via {@link graphql.ExecutionInput#getContext()} and then have
+ * The easiest way to do this is create a CacheControl object at query start and pass it in as a "context" object via {@link ExecutionInput#getGraphQLContext()} and then have
  * each {@link graphql.schema.DataFetcher} that wants to make cache control hints use that.
  * <p>
  * Then at the end of the query you would call {@link #addTo(graphql.ExecutionResult)} to record the cache control hints into the {@link graphql.ExecutionResult}

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -83,6 +83,7 @@ public class Execution {
                 .mutationStrategy(mutationStrategy)
                 .subscriptionStrategy(subscriptionStrategy)
                 .context(executionInput.getContext())
+                .graphQLContext(executionInput.getGraphQLContext())
                 .localContext(executionInput.getLocalContext())
                 .root(executionInput.getRoot())
                 .fragmentsByName(fragmentsByName)

--- a/src/main/java/graphql/execution/ExecutionContext.java
+++ b/src/main/java/graphql/execution/ExecutionContext.java
@@ -4,6 +4,7 @@ package graphql.execution;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import graphql.ExecutionInput;
+import graphql.GraphQLContext;
 import graphql.GraphQLError;
 import graphql.PublicApi;
 import graphql.cachecontrol.CacheControl;
@@ -45,6 +46,7 @@ public class ExecutionContext {
     private final ImmutableMapWithNullValues<String, Object> variables;
     private final Object root;
     private final Object context;
+    private final GraphQLContext graphQLContext;
     private final Object localContext;
     private final Instrumentation instrumentation;
     private final List<GraphQLError> errors = Collections.synchronizedList(new ArrayList<>());
@@ -68,6 +70,7 @@ public class ExecutionContext {
         this.document = builder.document;
         this.operationDefinition = builder.operationDefinition;
         this.context = builder.context;
+        this.graphQLContext = builder.graphQLContext;
         this.root = builder.root;
         this.instrumentation = builder.instrumentation;
         this.dataLoaderRegistry = builder.dataLoaderRegistry;
@@ -117,9 +120,19 @@ public class ExecutionContext {
         return variables;
     }
 
-    @SuppressWarnings("unchecked")
+    /**
+     * @return the legacy context
+     *
+     * @deprecated use {@link #getGraphQLContext()} instead
+     */
+    @Deprecated
+    @SuppressWarnings({"unchecked", "TypeParameterUnusedInFormals"})
     public <T> T getContext() {
         return (T) context;
+    }
+
+    public GraphQLContext getGraphQLContext() {
+        return graphQLContext;
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/graphql/execution/ExecutionContextBuilder.java
+++ b/src/main/java/graphql/execution/ExecutionContextBuilder.java
@@ -3,6 +3,7 @@ package graphql.execution;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import graphql.ExecutionInput;
+import graphql.GraphQLContext;
 import graphql.GraphQLError;
 import graphql.Internal;
 import graphql.PublicApi;
@@ -34,6 +35,7 @@ public class ExecutionContextBuilder {
     ExecutionStrategy mutationStrategy;
     ExecutionStrategy subscriptionStrategy;
     Object context;
+    GraphQLContext graphQLContext;
     Object root;
     Document document;
     OperationDefinition operationDefinition;
@@ -79,6 +81,7 @@ public class ExecutionContextBuilder {
         mutationStrategy = other.getMutationStrategy();
         subscriptionStrategy = other.getSubscriptionStrategy();
         context = other.getContext();
+        graphQLContext = other.getGraphQLContext();
         localContext = other.getLocalContext();
         root = other.getRoot();
         document = other.getDocument();
@@ -130,6 +133,11 @@ public class ExecutionContextBuilder {
 
     public ExecutionContextBuilder context(Object context) {
         this.context = context;
+        return this;
+    }
+
+    public ExecutionContextBuilder graphQLContext(GraphQLContext context) {
+        this.graphQLContext = context;
         return this;
     }
 

--- a/src/main/java/graphql/execution/ResolveType.java
+++ b/src/main/java/graphql/execution/ResolveType.java
@@ -23,6 +23,7 @@ public class ResolveType {
                     .value(source)
                     .argumentValues(arguments)
                     .context(executionContext.getContext())
+                    .graphQLContext(executionContext.getGraphQLContext())
                     .schema(executionContext.getGraphQLSchema()).build();
             resolvedType = resolveTypeForInterface(resolutionParams);
 
@@ -33,6 +34,7 @@ public class ResolveType {
                     .value(source)
                     .argumentValues(arguments)
                     .context(executionContext.getContext())
+                    .graphQLContext(executionContext.getGraphQLContext())
                     .schema(executionContext.getGraphQLSchema()).build();
             resolvedType = resolveTypeForUnion(resolutionParams);
         } else {

--- a/src/main/java/graphql/execution/TypeResolutionParameters.java
+++ b/src/main/java/graphql/execution/TypeResolutionParameters.java
@@ -1,5 +1,6 @@
 package graphql.execution;
 
+import graphql.GraphQLContext;
 import graphql.PublicApi;
 import graphql.collect.ImmutableMapWithNullValues;
 import graphql.schema.GraphQLInterfaceType;
@@ -18,16 +19,17 @@ public class TypeResolutionParameters {
     private final ImmutableMapWithNullValues<String, Object> argumentValues;
     private final GraphQLSchema schema;
     private final Object context;
+    private final GraphQLContext graphQLContext;
 
-    private TypeResolutionParameters(GraphQLInterfaceType graphQLInterfaceType, GraphQLUnionType graphQLUnionType,
-                                     MergedField field, Object value, ImmutableMapWithNullValues<String, Object> argumentValues, GraphQLSchema schema, final Object context) {
-        this.graphQLInterfaceType = graphQLInterfaceType;
-        this.graphQLUnionType = graphQLUnionType;
-        this.field = field;
-        this.value = value;
-        this.argumentValues = argumentValues;
-        this.schema = schema;
-        this.context = context;
+    private TypeResolutionParameters(Builder builder) {
+        this.graphQLInterfaceType = builder.graphQLInterfaceType;
+        this.graphQLUnionType = builder.graphQLUnionType;
+        this.field = builder.field;
+        this.value = builder.value;
+        this.argumentValues = builder.argumentValues;
+        this.schema = builder.schema;
+        this.context = builder.context;
+        this.graphQLContext = builder.graphQLContext;
     }
 
     public GraphQLInterfaceType getGraphQLInterfaceType() {
@@ -58,8 +60,18 @@ public class TypeResolutionParameters {
         return new Builder();
     }
 
+    /**
+     * @return the legacy context object
+     *
+     * @deprecated use {@link #getGraphQLContext()} instead
+     */
+    @Deprecated
     public Object getContext() {
         return context;
+    }
+
+    public GraphQLContext getGraphQLContext() {
+        return graphQLContext;
     }
 
     public static class Builder {
@@ -71,6 +83,7 @@ public class TypeResolutionParameters {
         private ImmutableMapWithNullValues<String, Object> argumentValues;
         private GraphQLSchema schema;
         private Object context;
+        private GraphQLContext graphQLContext;
 
         public Builder field(MergedField field) {
             this.field = field;
@@ -102,13 +115,19 @@ public class TypeResolutionParameters {
             return this;
         }
 
+        @Deprecated
         public Builder context(Object context) {
             this.context = context;
             return this;
         }
 
+        public Builder graphQLContext(GraphQLContext context) {
+            this.graphQLContext = context;
+            return this;
+        }
+
         public TypeResolutionParameters build() {
-            return new TypeResolutionParameters(graphQLInterfaceType, graphQLUnionType, field, value, argumentValues, schema, context);
+            return new TypeResolutionParameters(this);
         }
     }
 }

--- a/src/main/java/graphql/execution/instrumentation/nextgen/InstrumentationExecutionParameters.java
+++ b/src/main/java/graphql/execution/instrumentation/nextgen/InstrumentationExecutionParameters.java
@@ -1,6 +1,7 @@
 package graphql.execution.instrumentation.nextgen;
 
 import graphql.ExecutionInput;
+import graphql.GraphQLContext;
 import graphql.Internal;
 import graphql.execution.instrumentation.InstrumentationState;
 import graphql.schema.GraphQLSchema;
@@ -17,6 +18,7 @@ public class InstrumentationExecutionParameters {
     private final String query;
     private final String operation;
     private final Object context;
+    private final GraphQLContext graphQLContext;
     private final Map<String, Object> variables;
     private final InstrumentationState instrumentationState;
     private final GraphQLSchema schema;
@@ -26,6 +28,7 @@ public class InstrumentationExecutionParameters {
         this.query = executionInput.getQuery();
         this.operation = executionInput.getOperationName();
         this.context = executionInput.getContext();
+        this.graphQLContext = executionInput.getGraphQLContext();
         this.variables = executionInput.getVariables() != null ? executionInput.getVariables() : Collections.emptyMap();
         this.instrumentationState = instrumentationState;
         this.schema = schema;
@@ -54,9 +57,19 @@ public class InstrumentationExecutionParameters {
         return operation;
     }
 
+    /**
+     * @return the legacy context
+     *
+     * @deprecated use {@link #getGraphQLContext()} instead
+     */
+    @Deprecated
     @SuppressWarnings({"unchecked", "TypeParameterUnusedInFormals"})
     public <T> T getContext() {
         return (T) context;
+    }
+
+    public GraphQLContext getGraphQLContext() {
+        return graphQLContext;
     }
 
     public Map<String, Object> getVariables() {

--- a/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationExecutionParameters.java
+++ b/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationExecutionParameters.java
@@ -1,6 +1,7 @@
 package graphql.execution.instrumentation.parameters;
 
 import graphql.ExecutionInput;
+import graphql.GraphQLContext;
 import graphql.PublicApi;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationState;
@@ -18,6 +19,7 @@ public class InstrumentationExecutionParameters {
     private final String query;
     private final String operation;
     private final Object context;
+    private final GraphQLContext graphQLContext;
     private final Map<String, Object> variables;
     private final InstrumentationState instrumentationState;
     private final GraphQLSchema schema;
@@ -27,6 +29,7 @@ public class InstrumentationExecutionParameters {
         this.query = executionInput.getQuery();
         this.operation = executionInput.getOperationName();
         this.context = executionInput.getContext();
+        this.graphQLContext = executionInput.getGraphQLContext();
         this.variables = executionInput.getVariables() != null ? executionInput.getVariables() : Collections.emptyMap();
         this.instrumentationState = instrumentationState;
         this.schema = schema;
@@ -55,9 +58,19 @@ public class InstrumentationExecutionParameters {
         return operation;
     }
 
+    /**
+     * @return the legacy context
+     *
+     * @deprecated use {@link #getGraphQLContext()} instead
+     */
+    @Deprecated
     @SuppressWarnings({"unchecked", "TypeParameterUnusedInFormals"})
     public <T> T getContext() {
         return (T) context;
+    }
+
+    public GraphQLContext getGraphQLContext() {
+        return graphQLContext;
     }
 
     public Map<String, Object> getVariables() {

--- a/src/main/java/graphql/execution/nextgen/ExecutionHelper.java
+++ b/src/main/java/graphql/execution/nextgen/ExecutionHelper.java
@@ -56,6 +56,7 @@ public class ExecutionHelper {
                 .instrumentationState(instrumentationState)
                 .graphQLSchema(graphQLSchema)
                 .context(executionInput.getContext())
+                .graphQLContext(executionInput.getGraphQLContext())
                 .root(executionInput.getRoot())
                 .fragmentsByName(fragmentsByName)
                 .variables(coercedVariables)

--- a/src/main/java/graphql/nextgen/GraphQL.java
+++ b/src/main/java/graphql/nextgen/GraphQL.java
@@ -256,7 +256,7 @@ public class GraphQL {
     private CompletableFuture<ExecutionResult> execute(ExecutionInput executionInput, Document document, GraphQLSchema graphQLSchema, InstrumentationState instrumentationState) {
         String query = executionInput.getQuery();
         String operationName = executionInput.getOperationName();
-        Object context = executionInput.getContext();
+        Object context = executionInput.getGraphQLContext();
 
         Execution execution = new Execution();
         ExecutionId executionId = idProvider.provide(query, operationName, context);

--- a/src/main/java/graphql/schema/DataFetchingEnvironment.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironment.java
@@ -1,5 +1,6 @@
 package graphql.schema;
 
+import graphql.GraphQLContext;
 import graphql.PublicApi;
 import graphql.cachecontrol.CacheControl;
 import graphql.execution.ExecutionId;
@@ -34,6 +35,7 @@ public interface DataFetchingEnvironment extends IntrospectionDataFetchingEnviro
      * For the root query, it is equal to {{@link DataFetchingEnvironment#getRoot}
      *
      * @param <T> you decide what type it is
+     *
      * @return can be null for the root query, otherwise it is never null
      */
     <T> T getSource();
@@ -47,6 +49,7 @@ public interface DataFetchingEnvironment extends IntrospectionDataFetchingEnviro
      * Returns true of the named argument is present
      *
      * @param name the name of the argument
+     *
      * @return true of the named argument is present
      */
     boolean containsArgument(String name);
@@ -56,6 +59,7 @@ public interface DataFetchingEnvironment extends IntrospectionDataFetchingEnviro
      *
      * @param name the name of the argument
      * @param <T>  you decide what type it is
+     *
      * @return the named argument or null if its not present
      */
     <T> T getArgument(String name);
@@ -66,20 +70,35 @@ public interface DataFetchingEnvironment extends IntrospectionDataFetchingEnviro
      * @param name         the name of the argument
      * @param defaultValue the default value if the argument is not present
      * @param <T>          you decide what type it is
+     *
      * @return the named argument or the default if its not present
      */
     <T> T getArgumentOrDefault(String name, T defaultValue);
 
     /**
-     * Returns a context argument that is set up when the {@link graphql.GraphQL#execute(graphql.ExecutionInput)} )} method
+     * Returns a legacy context argument that is set up when the {@link graphql.GraphQL#execute(graphql.ExecutionInput)} )} method
      * is invoked.
      * <p>
      * This is a info object which is provided to all DataFetchers, but never used by graphql-java itself.
      *
      * @param <T> you decide what type it is
+     *
      * @return can be null
+     *
+     * @deprecated - use {@link #getGraphQlContext()} instead
      */
+    @Deprecated
     <T> T getContext();
+
+    /**
+     * Returns a shared context argument that is set up when the {@link graphql.GraphQL#execute(graphql.ExecutionInput)} )} method
+     * is invoked.
+     * <p>
+     * This is a info object which is provided to all DataFetchers.
+     *
+     * @return can NOT be null
+     */
+    GraphQLContext getGraphQlContext();
 
     /**
      * This returns a context object that parent fields may have returned returned
@@ -93,6 +112,7 @@ public interface DataFetchingEnvironment extends IntrospectionDataFetchingEnviro
      * fields execute.
      *
      * @param <T> you decide what type it is
+     *
      * @return can be null if no field context objects are passed back by previous parent fields
      */
     <T> T getLocalContext();
@@ -101,6 +121,7 @@ public interface DataFetchingEnvironment extends IntrospectionDataFetchingEnviro
      * This is the source object for the root query.
      *
      * @param <T> you decide what type it is
+     *
      * @return can be null
      */
     <T> T getRoot();
@@ -113,6 +134,7 @@ public interface DataFetchingEnvironment extends IntrospectionDataFetchingEnviro
 
     /**
      * @return the list of fields
+     *
      * @deprecated Use {@link #getMergedField()}.
      */
     @Deprecated
@@ -191,6 +213,7 @@ public interface DataFetchingEnvironment extends IntrospectionDataFetchingEnviro
      * This gives you access to the directives related to this field
      *
      * @return the {@link graphql.execution.directives.QueryDirectives} for the currently executing field
+     *
      * @see graphql.execution.directives.QueryDirectives for more information
      */
     QueryDirectives getQueryDirectives();
@@ -201,7 +224,9 @@ public interface DataFetchingEnvironment extends IntrospectionDataFetchingEnviro
      * @param dataLoaderName the name of the data loader to fetch
      * @param <K>            the key type
      * @param <V>            the value type
+     *
      * @return the named data loader or null
+     *
      * @see org.dataloader.DataLoaderRegistry#getDataLoader(String)
      */
     <K, V> DataLoader<K, V> getDataLoader(String dataLoaderName);

--- a/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
@@ -2,6 +2,7 @@ package graphql.schema;
 
 
 import com.google.common.collect.ImmutableMap;
+import graphql.GraphQLContext;
 import graphql.Internal;
 import graphql.cachecontrol.CacheControl;
 import graphql.collect.ImmutableKit;
@@ -30,6 +31,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
     private final Object source;
     private final Supplier<Map<String, Object>> arguments;
     private final Object context;
+    private final GraphQLContext graphQLContext;
     private final Object localContext;
     private final Object root;
     private final GraphQLFieldDefinition fieldDefinition;
@@ -53,6 +55,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
         this.source = builder.source;
         this.arguments = builder.arguments == null ? Collections::emptyMap : builder.arguments;
         this.context = builder.context;
+        this.graphQLContext = builder.graphQLContext;
         this.localContext = builder.localContext;
         this.root = builder.root;
         this.fieldDefinition = builder.fieldDefinition;
@@ -87,6 +90,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
     public static Builder newDataFetchingEnvironment(ExecutionContext executionContext) {
         return new Builder()
                 .context(executionContext.getContext())
+                .graphQLContext(executionContext.getGraphQLContext())
                 .root(executionContext.getRoot())
                 .graphQLSchema(executionContext.getGraphQLSchema())
                 .fragmentsByName(executionContext.getFragmentsByName())
@@ -127,6 +131,11 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
     @Override
     public <T> T getContext() {
         return (T) context;
+    }
+
+    @Override
+    public GraphQLContext getGraphQlContext() {
+        return graphQLContext;
     }
 
     @Override
@@ -245,6 +254,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
 
         private Object source;
         private Object context;
+        private GraphQLContext graphQLContext;
         private Object localContext;
         private Object root;
         private GraphQLFieldDefinition fieldDefinition;
@@ -269,6 +279,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
             this.source = env.source;
             this.arguments = env.arguments;
             this.context = env.context;
+            this.graphQLContext = env.graphQLContext;
             this.localContext = env.localContext;
             this.root = env.root;
             this.fieldDefinition = env.fieldDefinition;
@@ -306,8 +317,14 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
             return this;
         }
 
+        @Deprecated
         public Builder context(Object context) {
             this.context = context;
+            return this;
+        }
+
+        public Builder graphQLContext(GraphQLContext context) {
+            this.graphQLContext = context;
             return this;
         }
 

--- a/src/main/java/graphql/schema/DelegatingDataFetchingEnvironment.java
+++ b/src/main/java/graphql/schema/DelegatingDataFetchingEnvironment.java
@@ -1,5 +1,6 @@
 package graphql.schema;
 
+import graphql.GraphQLContext;
 import graphql.PublicApi;
 import graphql.cachecontrol.CacheControl;
 import graphql.execution.ExecutionId;
@@ -60,6 +61,11 @@ public class DelegatingDataFetchingEnvironment implements DataFetchingEnvironmen
 
     public <T> T getContext() {
         return delegateEnvironment.getContext();
+    }
+
+    @Override
+    public GraphQLContext getGraphQlContext() {
+        return delegateEnvironment.getGraphQlContext();
     }
 
     public <T> T getLocalContext() {

--- a/src/test/groovy/example/http/HttpMain.java
+++ b/src/test/groovy/example/http/HttpMain.java
@@ -3,7 +3,6 @@ package example.http;
 import graphql.ExecutionInput;
 import graphql.ExecutionResult;
 import graphql.GraphQL;
-import graphql.GraphQLContext;
 import graphql.StarWarsData;
 import graphql.execution.instrumentation.ChainedInstrumentation;
 import graphql.execution.instrumentation.Instrumentation;
@@ -113,11 +112,12 @@ public class HttpMain extends AbstractHandler {
         DataLoaderRegistry dataLoaderRegistry = buildDataLoaderRegistry();
 
 
-        ExecutionInput.Builder executionInput = newExecutionInput()
+        ExecutionInput executionInput = newExecutionInput()
                 .query(parameters.getQuery())
                 .operationName(parameters.getOperationName())
                 .variables(parameters.getVariables())
-                .dataLoaderRegistry(dataLoaderRegistry);
+                .dataLoaderRegistry(dataLoaderRegistry)
+                .build();
 
 
         //
@@ -134,7 +134,7 @@ public class HttpMain extends AbstractHandler {
         Map<String, Object> context = new HashMap<>();
         context.put("YouAppSecurityClearanceLevel", "CodeRed");
         context.put("YouAppExecutingUser", "Dr Nefarious");
-        executionInput.graphQLContext(GraphQLContext.of(context));
+        executionInput.getGraphQLContext().putAll(context);
 
         //
         // you need a schema in order to execute queries
@@ -153,7 +153,7 @@ public class HttpMain extends AbstractHandler {
                 // instrumentation is pluggable
                 .instrumentation(instrumentation)
                 .build();
-        ExecutionResult executionResult = graphQL.execute(executionInput.build());
+        ExecutionResult executionResult = graphQL.execute(executionInput);
 
         returnAsJson(httpResponse, executionResult);
     }

--- a/src/test/groovy/example/http/HttpMain.java
+++ b/src/test/groovy/example/http/HttpMain.java
@@ -3,6 +3,7 @@ package example.http;
 import graphql.ExecutionInput;
 import graphql.ExecutionResult;
 import graphql.GraphQL;
+import graphql.GraphQLContext;
 import graphql.StarWarsData;
 import graphql.execution.instrumentation.ChainedInstrumentation;
 import graphql.execution.instrumentation.Instrumentation;
@@ -133,7 +134,7 @@ public class HttpMain extends AbstractHandler {
         Map<String, Object> context = new HashMap<>();
         context.put("YouAppSecurityClearanceLevel", "CodeRed");
         context.put("YouAppExecutingUser", "Dr Nefarious");
-        executionInput.context(context);
+        executionInput.graphQLContext(GraphQLContext.of(context));
 
         //
         // you need a schema in order to execute queries

--- a/src/test/groovy/example/http/HttpMain.java
+++ b/src/test/groovy/example/http/HttpMain.java
@@ -112,12 +112,11 @@ public class HttpMain extends AbstractHandler {
         DataLoaderRegistry dataLoaderRegistry = buildDataLoaderRegistry();
 
 
-        ExecutionInput executionInput = newExecutionInput()
+        ExecutionInput.Builder executionInput = newExecutionInput()
                 .query(parameters.getQuery())
                 .operationName(parameters.getOperationName())
                 .variables(parameters.getVariables())
-                .dataLoaderRegistry(dataLoaderRegistry)
-                .build();
+                .dataLoaderRegistry(dataLoaderRegistry);
 
 
         //
@@ -134,7 +133,7 @@ public class HttpMain extends AbstractHandler {
         Map<String, Object> context = new HashMap<>();
         context.put("YouAppSecurityClearanceLevel", "CodeRed");
         context.put("YouAppExecutingUser", "Dr Nefarious");
-        executionInput.getGraphQLContext().putAll(context);
+        executionInput.graphQLContext(context);
 
         //
         // you need a schema in order to execute queries

--- a/src/test/groovy/graphql/ExecutionInputTest.groovy
+++ b/src/test/groovy/graphql/ExecutionInputTest.groovy
@@ -26,12 +26,13 @@ class ExecutionInputTest extends Specification {
                 .variables(variables)
                 .root(root)
                 .context(context)
+                .graphQLContext({ it.of(["a": "b"]) })
                 .locale(Locale.GERMAN)
                 .extensions([some: "map"])
                 .build()
         then:
         executionInput.context == context
-        executionInput.graphQLContext != null
+        executionInput.graphQLContext.get("a") == "b"
         executionInput.root == root
         executionInput.variables == variables
         executionInput.dataLoaderRegistry == registry
@@ -39,6 +40,15 @@ class ExecutionInputTest extends Specification {
         executionInput.query == query
         executionInput.locale == Locale.GERMAN
         executionInput.extensions == [some: "map"]
+    }
+
+    def "map context build works"() {
+        when:
+        def executionInput = ExecutionInput.newExecutionInput().query(query)
+                .graphQLContext([a: "b"])
+                .build()
+        then:
+        executionInput.graphQLContext.get("a") == "b"
     }
 
     def "legacy context methods work"() {
@@ -83,6 +93,7 @@ class ExecutionInputTest extends Specification {
                 .extensions([some: "map"])
                 .root(root)
                 .context(context)
+                .graphQLContext({ it.of(["a": "b"]) })
                 .locale(Locale.GERMAN)
                 .build()
         def graphQLContext = executionInputOld.getGraphQLContext()

--- a/src/test/groovy/graphql/ExecutionInputTest.groovy
+++ b/src/test/groovy/graphql/ExecutionInputTest.groovy
@@ -3,6 +3,7 @@ package graphql
 import graphql.cachecontrol.CacheControl
 import graphql.execution.ExecutionId
 import graphql.schema.DataFetcher
+import graphql.schema.DataFetchingEnvironment
 import org.dataloader.DataLoaderRegistry
 import spock.lang.Specification
 
@@ -15,6 +16,7 @@ class ExecutionInputTest extends Specification {
     def cacheControl = CacheControl.newCacheControl()
     def root = "root"
     def context = "context"
+    def graphQLContext = GraphQLContext.newContext().build()
     def variables = [key: "value"]
 
     def "build works"() {
@@ -25,11 +27,13 @@ class ExecutionInputTest extends Specification {
                 .variables(variables)
                 .root(root)
                 .context(context)
+                .graphQLContext(graphQLContext)
                 .locale(Locale.GERMAN)
                 .extensions([some: "map"])
                 .build()
         then:
         executionInput.context == context
+        executionInput.graphQLContext == graphQLContext
         executionInput.root == root
         executionInput.variables == variables
         executionInput.dataLoaderRegistry == registry
@@ -39,7 +43,7 @@ class ExecutionInputTest extends Specification {
         executionInput.extensions == [some: "map"]
     }
 
-    def "context methods work"() {
+    def "legacy context methods work"() {
         when:
         def executionInput = ExecutionInput.newExecutionInput().query(query)
                 .context({ builder -> builder.of("k1", "v1") } as UnaryOperator)
@@ -55,12 +59,45 @@ class ExecutionInputTest extends Specification {
         (executionInput.context as GraphQLContext).get("k2") == "v2"
     }
 
-    def "context is defaulted"() {
+    def "graphql context methods work"() {
+        when:
+        def executionInput = ExecutionInput.newExecutionInput().query(query)
+                .graphQLContext({ builder -> builder.of("k1", "v1") } as UnaryOperator)
+                .build()
+        then:
+        executionInput.graphQLContext.get("k1") == "v1"
+
+        when:
+        executionInput = ExecutionInput.newExecutionInput().query(query)
+                .graphQLContext(GraphQLContext.newContext().of("k2", "v2"))
+                .build()
+        then:
+        executionInput.graphQLContext.get("k2") == "v2"
+    }
+
+    def "legacy context is defaulted"() {
         when:
         def executionInput = ExecutionInput.newExecutionInput().query(query)
                 .build()
         then:
         executionInput.context instanceof GraphQLContext
+    }
+
+    def "graphql context is defaulted"() {
+        when:
+        def executionInput = ExecutionInput.newExecutionInput().query(query)
+                .build()
+        then:
+        executionInput.graphQLContext instanceof GraphQLContext
+    }
+
+    def "graphql context is not allowed to be null"() {
+        when:
+        ExecutionInput.newExecutionInput()
+                .graphQLContext(null as GraphQLContext)
+                .build()
+        then:
+        thrown(AssertException)
     }
 
     def "transform works and copies values"() {
@@ -72,12 +109,14 @@ class ExecutionInputTest extends Specification {
                 .extensions([some: "map"])
                 .root(root)
                 .context(context)
+                .graphQLContext(graphQLContext)
                 .locale(Locale.GERMAN)
                 .build()
         def executionInput = executionInputOld.transform({ bldg -> bldg.query("new query") })
 
         then:
         executionInput.context == context
+        executionInput.graphQLContext == graphQLContext
         executionInput.root == root
         executionInput.variables == variables
         executionInput.dataLoaderRegistry == registry
@@ -105,28 +144,32 @@ class ExecutionInputTest extends Specification {
                 fetch : String
             }
         '''
-        DataFetcher df = { env ->
+        DataFetcher df = { DataFetchingEnvironment env ->
             return [
-                    "locale"      : env.getLocale().getDisplayName(),
-                    "cacheControl": env.getCacheControl() == cacheControl,
-                    "executionId" : env.getExecutionId().toString()
+                    "locale"        : env.getLocale().getDisplayName(),
+                    "cacheControl"  : env.getCacheControl() == cacheControl,
+                    "executionId"   : env.getExecutionId().toString(),
+                    "graphqlContext": env.getGraphQlContext().get("a")
 
             ]
         }
         def schema = TestUtil.schema(sdl, ["Query": ["fetch": df]])
         def graphQL = GraphQL.newGraphQL(schema).build()
 
+        def graphqlContext = GraphQLContext.newContext().of("a", "b").build()
+
         when:
         ExecutionInput executionInput = ExecutionInput.newExecutionInput()
                 .query("{ fetch }")
                 .locale(Locale.GERMAN)
                 .cacheControl(cacheControl)
+                .graphQLContext(graphqlContext)
                 .executionId(ExecutionId.from("ID123"))
                 .build()
         def er = graphQL.execute(executionInput)
 
         then:
         er.errors.isEmpty()
-        er.data["fetch"] == "{locale=German, cacheControl=true, executionId=ID123}"
+        er.data["fetch"] == "{locale=German, cacheControl=true, executionId=ID123, graphqlContext=b}"
     }
 }

--- a/src/test/groovy/graphql/GraphQLTest.groovy
+++ b/src/test/groovy/graphql/GraphQLTest.groovy
@@ -244,7 +244,7 @@ class GraphQLTest extends Specification {
         def expected = [field2: 'value2']
 
         when:
-        def executionInput = newExecutionInput().query(query).operationName('Query2').context(null).variables([:])
+        def executionInput = newExecutionInput().query(query).operationName('Query2').variables([:])
         def result = GraphQL.newGraphQL(schema).build().execute(executionInput)
 
         then:

--- a/src/test/groovy/graphql/NullValueSupportTest.groovy
+++ b/src/test/groovy/graphql/NullValueSupportTest.groovy
@@ -70,7 +70,7 @@ class NullValueSupportTest extends Specification {
         when:
 
         def executionInput = newExecutionInput().query(queryStr)
-                .operationName("mutate").context("ctx").variables(variables)
+                .operationName("mutate").variables(variables)
                 .build()
         def result = graphQL.execute(executionInput)
 
@@ -174,7 +174,7 @@ class NullValueSupportTest extends Specification {
         ExecutionResult result = null
         try {
             def executionInput = newExecutionInput().query(queryStr)
-                    .operationName("mutate").context("ctx").variables(variables)
+                    .operationName("mutate").variables(variables)
                     .build()
             result = graphQL.execute(executionInput)
         } catch (GraphQLException e) {
@@ -218,7 +218,7 @@ class NullValueSupportTest extends Specification {
 
         when:
         def executionInput = newExecutionInput().query(queryStr)
-                .operationName("mutate").context("ctx").variables(variables)
+                .operationName("mutate").variables(variables)
                 .build()
         def executionResult = graphQL.execute(executionInput)
 
@@ -308,7 +308,7 @@ class NullValueSupportTest extends Specification {
 
         when:
         def executionInput = newExecutionInput().query(queryStr)
-                .operationName(null).context("ctx").variables([:])
+                .operationName(null).variables([:])
                 .build()
         def result = graphQL.execute(executionInput)
         assert result.errors.isEmpty(): "Unexpected query errors : ${result.errors}"

--- a/src/test/groovy/graphql/cachecontrol/CacheControlTest.groovy
+++ b/src/test/groovy/graphql/cachecontrol/CacheControlTest.groovy
@@ -97,8 +97,9 @@ class CacheControlTest extends Specification {
 
         def cacheControl = CacheControl.newCacheControl()
         when:
-        ExecutionInput ei = ExecutionInput.newExecutionInput(' { levelA { levelB { levelC } } }').build()
-        ei.getGraphQLContext().putAll(["cacheControl": cacheControl])
+        ExecutionInput ei = ExecutionInput.newExecutionInput(' { levelA { levelB { levelC } } }')
+                .graphQLContext(["cacheControl": cacheControl])
+                .build()
         def er = graphQL.execute(ei)
         er = cacheControl.addTo(er)
         then:

--- a/src/test/groovy/graphql/cachecontrol/CacheControlTest.groovy
+++ b/src/test/groovy/graphql/cachecontrol/CacheControlTest.groovy
@@ -2,6 +2,7 @@ package graphql.cachecontrol
 
 
 import graphql.ExecutionResultImpl
+import graphql.GraphQLContext
 import graphql.TestUtil
 import graphql.execution.ResultPath
 import graphql.schema.DataFetcher
@@ -76,16 +77,16 @@ class CacheControlTest extends Specification {
         '''
 
         DataFetcher dfA = { env ->
-            CacheControl cc = env.getContext()
+            CacheControl cc = env.getGraphQlContext().get("cacheControl")
             cc.hint(env, 100)
         } as DataFetcher
         DataFetcher dfB = { env ->
-            CacheControl cc = env.getContext()
+            CacheControl cc = env.getGraphQlContext().get("cacheControl")
             cc.hint(env, 999)
         } as DataFetcher
 
         DataFetcher dfC = { env ->
-            CacheControl cc = env.getContext()
+            CacheControl cc = env.getGraphQlContext().get("cacheControl")
             cc.hint(env, CacheControl.Scope.PRIVATE)
         } as DataFetcher
 
@@ -98,7 +99,7 @@ class CacheControlTest extends Specification {
         def cacheControl = CacheControl.newCacheControl()
         when:
         def er = graphQL.execute({ input ->
-            input.context(cacheControl)
+            input.graphQLContext(GraphQLContext.of(["cacheControl" : cacheControl]))
                     .query(' { levelA { levelB { levelC } } }')
         })
         er = cacheControl.addTo(er)

--- a/src/test/groovy/graphql/cachecontrol/CacheControlTest.groovy
+++ b/src/test/groovy/graphql/cachecontrol/CacheControlTest.groovy
@@ -1,8 +1,7 @@
 package graphql.cachecontrol
 
-
+import graphql.ExecutionInput
 import graphql.ExecutionResultImpl
-import graphql.GraphQLContext
 import graphql.TestUtil
 import graphql.execution.ResultPath
 import graphql.schema.DataFetcher
@@ -98,10 +97,9 @@ class CacheControlTest extends Specification {
 
         def cacheControl = CacheControl.newCacheControl()
         when:
-        def er = graphQL.execute({ input ->
-            input.graphQLContext(GraphQLContext.of(["cacheControl" : cacheControl]))
-                    .query(' { levelA { levelB { levelC } } }')
-        })
+        ExecutionInput ei = ExecutionInput.newExecutionInput(' { levelA { levelB { levelC } } }').build()
+        ei.getGraphQLContext().putAll(["cacheControl": cacheControl])
+        def er = graphQL.execute(ei)
         er = cacheControl.addTo(er)
         then:
         er.errors.isEmpty()

--- a/src/test/groovy/graphql/execution/ExecutionContextBuilderTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionContextBuilderTest.groovy
@@ -1,5 +1,6 @@
 package graphql.execution
 
+import graphql.GraphQLContext
 import graphql.cachecontrol.CacheControl
 import graphql.execution.instrumentation.Instrumentation
 import graphql.language.Document
@@ -38,6 +39,9 @@ class ExecutionContextBuilderTest extends Specification {
         def context = "context"
         executionContextBuilder.context(context)
 
+        def graphQLContext = GraphQLContext.newContext().build()
+        executionContextBuilder.graphQLContext(graphQLContext)
+
         def root = "root"
         executionContextBuilder.root(root)
 
@@ -71,6 +75,7 @@ class ExecutionContextBuilderTest extends Specification {
         executionContext.subscriptionStrategy == subscriptionStrategy
         executionContext.root == root
         executionContext.context == context
+        executionContext.graphQLContext == graphQLContext
         executionContext.variables == [var: 'value']
         executionContext.getFragmentsByName() == [MyFragment: fragment]
         executionContext.operationDefinition == operation

--- a/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
@@ -3,6 +3,7 @@ package graphql.execution
 import graphql.Assert
 import graphql.ExceptionWhileDataFetching
 import graphql.ExecutionResult
+import graphql.GraphQLContext
 import graphql.GraphqlErrorBuilder
 import graphql.Scalars
 import graphql.SerializationError
@@ -70,6 +71,7 @@ class ExecutionStrategyTest extends Specification {
                 .subscriptionStrategy(executionStrategy)
                 .variables(variables)
                 .context("context")
+                .graphQLContext(GraphQLContext.newContext().of("key","context").build())
                 .root("root")
                 .dataLoaderRegistry(new DataLoaderRegistry())
                 .locale(Locale.getDefault())
@@ -516,6 +518,7 @@ class ExecutionStrategyTest extends Specification {
         environment.fieldDefinition == fieldDefinition
         environment.graphQLSchema == schema
         environment.context == "context"
+        environment.graphQlContext.get("key") == "context"
         environment.source == "source"
         environment.fields == [field]
         environment.root == "root"

--- a/src/test/groovy/graphql/schema/DataFetchingEnvironmentImplTest.groovy
+++ b/src/test/groovy/graphql/schema/DataFetchingEnvironmentImplTest.groovy
@@ -1,5 +1,6 @@
 package graphql.schema
 
+import graphql.GraphQLContext
 import graphql.cachecontrol.CacheControl
 import graphql.execution.ExecutionId
 import graphql.execution.ExecutionStepInfo
@@ -34,6 +35,7 @@ class DataFetchingEnvironmentImplTest extends Specification {
     def executionContext = newExecutionContextBuilder()
             .root("root")
             .context("context")
+            .graphQLContext(GraphQLContext.of(["key":"context"]))
             .executionId(executionId)
             .operationDefinition(operationDefinition)
             .document(document)
@@ -67,6 +69,7 @@ class DataFetchingEnvironmentImplTest extends Specification {
         then:
         dfe.getRoot() == "root"
         dfe.getContext() == "context"
+        dfe.getGraphQlContext().get("key") == "context"
         dfe.getGraphQLSchema() == starWarsSchema
         dfe.getDocument() == document
         dfe.getVariables() == variables
@@ -78,6 +81,7 @@ class DataFetchingEnvironmentImplTest extends Specification {
     def "create environment from existing one will copy everything to new instance"() {
         def dfe = newDataFetchingEnvironment()
                 .context("Test Context")
+                .graphQLContext(GraphQLContext.of(["key": "context"]))
                 .source("Test Source")
                 .root("Test Root")
                 .fieldDefinition(Mock(GraphQLFieldDefinition))
@@ -103,6 +107,7 @@ class DataFetchingEnvironmentImplTest extends Specification {
         then:
         dfe != dfeCopy
         dfe.getContext() == dfeCopy.getContext()
+        dfe.getGraphQlContext() == dfeCopy.getGraphQlContext()
         dfe.getSource() == dfeCopy.getSource()
         dfe.getRoot() == dfeCopy.getRoot()
         dfe.getFieldDefinition() == dfeCopy.getFieldDefinition()

--- a/src/test/groovy/graphql/schema/DelegatingDataFetchingEnvironmentTest.groovy
+++ b/src/test/groovy/graphql/schema/DelegatingDataFetchingEnvironmentTest.groovy
@@ -1,5 +1,6 @@
 package graphql.schema
 
+import graphql.GraphQLContext
 import spock.lang.Specification
 
 class DelegatingDataFetchingEnvironmentTest extends Specification {
@@ -15,12 +16,17 @@ class DelegatingDataFetchingEnvironmentTest extends Specification {
                 .source(source)
                 .arguments(args)
                 .root(root)
-                .context("context")
+                .graphQLContext(GraphQLContext.of(["key": "context"]))
                 .variables(variables)
                 .build()
 
         when:
         def delegatingDFE = new DelegatingDataFetchingEnvironment(dfe) {
+            @Override
+            GraphQLContext getGraphQlContext() {
+                return GraphQLContext.of(["key": "overriddenContext"])
+            }
+
             @Override
             def getContext() {
                 return "overriddenContext"
@@ -30,6 +36,7 @@ class DelegatingDataFetchingEnvironmentTest extends Specification {
         delegatingDFE.getSource() == source
         delegatingDFE.getRoot() == root
         delegatingDFE.getContext() == "overriddenContext"
+        delegatingDFE.getGraphQlContext().get("key") == "overriddenContext"
         delegatingDFE.getVariables() == variables
         delegatingDFE.getArguments() == args
         delegatingDFE.getArgumentOrDefault("arg1", "x") == "val1"

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorDirectiveHelperTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorDirectiveHelperTest.groovy
@@ -537,9 +537,9 @@ class SchemaGeneratorDirectiveHelperTest extends Specification {
         def executionInput = ExecutionInput.newExecutionInput()
                 .root(root)
                 .query(query)
+                .graphQLContext([protectSecrets: true])
                 .build()
 
-        executionInput.getGraphQLContext().putAll([protectSecrets: true])
         def er = graphQL.execute(executionInput)
 
         then:
@@ -553,8 +553,8 @@ class SchemaGeneratorDirectiveHelperTest extends Specification {
         executionInput = ExecutionInput.newExecutionInput()
                 .root(root)
                 .query(query)
+                .graphQLContext([protectSecrets: false])
                 .build()
-        executionInput.getGraphQLContext().putAll([protectSecrets: false])
 
         er = graphQL.execute(executionInput)
 

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorDirectiveHelperTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorDirectiveHelperTest.groovy
@@ -2,7 +2,6 @@ package graphql.schema.idl
 
 import graphql.ExecutionInput
 import graphql.GraphQL
-import graphql.GraphQLContext
 import graphql.execution.ValuesResolver
 import graphql.schema.Coercing
 import graphql.schema.CoercingParseLiteralException
@@ -538,9 +537,9 @@ class SchemaGeneratorDirectiveHelperTest extends Specification {
         def executionInput = ExecutionInput.newExecutionInput()
                 .root(root)
                 .query(query)
-                .graphQLContext(GraphQLContext.of([protectSecrets: true]))
                 .build()
 
+        executionInput.getGraphQLContext().putAll([protectSecrets: true])
         def er = graphQL.execute(executionInput)
 
         then:
@@ -554,8 +553,8 @@ class SchemaGeneratorDirectiveHelperTest extends Specification {
         executionInput = ExecutionInput.newExecutionInput()
                 .root(root)
                 .query(query)
-                .graphQLContext(GraphQLContext.of([protectSecrets: false]))
                 .build()
+        executionInput.getGraphQLContext().putAll([protectSecrets: false])
 
         er = graphQL.execute(executionInput)
 

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorDirectiveHelperTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorDirectiveHelperTest.groovy
@@ -2,6 +2,7 @@ package graphql.schema.idl
 
 import graphql.ExecutionInput
 import graphql.GraphQL
+import graphql.GraphQLContext
 import graphql.execution.ValuesResolver
 import graphql.schema.Coercing
 import graphql.schema.CoercingParseLiteralException
@@ -495,8 +496,8 @@ class SchemaGeneratorDirectiveHelperTest extends Specification {
                 }
                 contextMap.put(key, true)
 
-                DataFetcher wrapper = { dfEnv ->
-                    def flag = dfEnv.getContext()['protectSecrets']
+                DataFetcher wrapper = { DataFetchingEnvironment dfEnv ->
+                    def flag = dfEnv.getGraphQlContext().get('protectSecrets')
                     if (flag == null || flag == false) {
                         return originalFetcher.get(dfEnv)
                     }
@@ -537,7 +538,7 @@ class SchemaGeneratorDirectiveHelperTest extends Specification {
         def executionInput = ExecutionInput.newExecutionInput()
                 .root(root)
                 .query(query)
-                .context([protectSecrets: true])
+                .graphQLContext(GraphQLContext.of([protectSecrets: true]))
                 .build()
 
         def er = graphQL.execute(executionInput)
@@ -553,7 +554,7 @@ class SchemaGeneratorDirectiveHelperTest extends Specification {
         executionInput = ExecutionInput.newExecutionInput()
                 .root(root)
                 .query(query)
-                .context([protectSecrets: false])
+                .graphQLContext(GraphQLContext.of([protectSecrets: false]))
                 .build()
 
         er = graphQL.execute(executionInput)

--- a/src/test/groovy/readme/ConcernsExamples.java
+++ b/src/test/groovy/readme/ConcernsExamples.java
@@ -3,9 +3,12 @@ package readme;
 import graphql.ExecutionInput;
 import graphql.ExecutionResult;
 import graphql.GraphQL;
+import graphql.GraphQLContext;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.GraphQLSchema;
+
+import java.util.concurrent.ConcurrentMap;
 
 import static graphql.StarWarsSchema.queryType;
 

--- a/src/test/groovy/readme/ConcernsExamples.java
+++ b/src/test/groovy/readme/ConcernsExamples.java
@@ -56,8 +56,9 @@ public class ConcernsExamples {
         //
         UserContext contextForUser = YourGraphqlContextBuilder.getContextForUser(getCurrentUser());
 
-        ExecutionInput executionInput = ExecutionInput.newExecutionInput().build();
-        executionInput.getGraphQLContext().putAll(context -> context.of("userContext", contextForUser));
+        ExecutionInput executionInput = ExecutionInput.newExecutionInput()
+                .graphQLContext(context -> context.put("userContext", contextForUser))
+                .build();
 
         ExecutionResult executionResult = graphQL.execute(executionInput);
 

--- a/src/test/groovy/readme/ConcernsExamples.java
+++ b/src/test/groovy/readme/ConcernsExamples.java
@@ -57,7 +57,7 @@ public class ConcernsExamples {
         UserContext contextForUser = YourGraphqlContextBuilder.getContextForUser(getCurrentUser());
 
         ExecutionInput executionInput = ExecutionInput.newExecutionInput()
-                .context(contextForUser)
+                .graphQLContext(builder -> builder.of("userContext", contextForUser))
                 .build();
 
         ExecutionResult executionResult = graphQL.execute(executionInput);
@@ -70,7 +70,7 @@ public class ConcernsExamples {
         DataFetcher dataFetcher = new DataFetcher() {
             @Override
             public Object get(DataFetchingEnvironment environment) {
-                UserContext userCtx = environment.getContext();
+                UserContext userCtx = environment.getGraphQlContext().get("userContext");
                 Long businessObjId = environment.getArgument("businessObjId");
 
                 return invokeBusinessLayerMethod(userCtx, businessObjId);

--- a/src/test/groovy/readme/ConcernsExamples.java
+++ b/src/test/groovy/readme/ConcernsExamples.java
@@ -56,9 +56,8 @@ public class ConcernsExamples {
         //
         UserContext contextForUser = YourGraphqlContextBuilder.getContextForUser(getCurrentUser());
 
-        ExecutionInput executionInput = ExecutionInput.newExecutionInput()
-                .graphQLContext(builder -> builder.of("userContext", contextForUser))
-                .build();
+        ExecutionInput executionInput = ExecutionInput.newExecutionInput().build();
+        executionInput.getGraphQLContext().putAll(context -> context.of("userContext", contextForUser));
 
         ExecutionResult executionResult = graphQL.execute(executionInput);
 

--- a/src/test/groovy/readme/DirectivesExamples.java
+++ b/src/test/groovy/readme/DirectivesExamples.java
@@ -83,8 +83,8 @@ public class DirectivesExamples {
 
         ExecutionInput executionInput = ExecutionInput.newExecutionInput()
                 .query(query)
-                .graphQLContext(builder -> builder.of("authCtx", authCtx))
                 .build();
+        executionInput.getGraphQLContext().putAll(builder -> builder.of("authCtx", authCtx));
     }
 
 

--- a/src/test/groovy/readme/DirectivesExamples.java
+++ b/src/test/groovy/readme/DirectivesExamples.java
@@ -83,7 +83,7 @@ public class DirectivesExamples {
 
         ExecutionInput executionInput = ExecutionInput.newExecutionInput()
                 .query(query)
-                .context(authCtx)
+                .graphQLContext(builder -> builder.of("authCtx", authCtx))
                 .build();
     }
 

--- a/src/test/groovy/readme/DirectivesExamples.java
+++ b/src/test/groovy/readme/DirectivesExamples.java
@@ -83,8 +83,8 @@ public class DirectivesExamples {
 
         ExecutionInput executionInput = ExecutionInput.newExecutionInput()
                 .query(query)
+                .graphQLContext(builder -> builder.put("authCtx", authCtx))
                 .build();
-        executionInput.getGraphQLContext().putAll(builder -> builder.of("authCtx", authCtx));
     }
 
 


### PR DESCRIPTION
The original graphql-java code copied the graphql-js pattern of having a opaque context object

Since everything in JS is untyped and mutable this works because one can just "wack" another property into the context

However we have learnt over time that since the context is sa shared place (for both frameworks and user code to use) we need to have a more formal mechanism that just a `Object getContext()` pattern.

So we have made the `GraphqlContext getGraphqlContext()` the preferred context mechanism and deprecated the older `Object getContext` methods.

At some point the legacy `getContext` will disappear but since this is a WIDELY used mechanism that will not be any time soon.