### PR TITLE
Adding support for making the exception handlers async

### DIFF
--- a/src/main/java/graphql/ExecutionResultImpl.java
+++ b/src/main/java/graphql/ExecutionResultImpl.java
@@ -45,7 +45,7 @@ public class ExecutionResultImpl implements ExecutionResult {
         this.dataPresent = dataPresent;
         this.data = data;
 
-        if (errors != null && !errors.isEmpty()) {
+        if (errors != null) {
             this.errors = ImmutableList.copyOf(errors);
         } else {
             this.errors = ImmutableKit.emptyList();

--- a/src/main/java/graphql/collect/ImmutableKit.java
+++ b/src/main/java/graphql/collect/ImmutableKit.java
@@ -2,6 +2,7 @@ package graphql.collect;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import graphql.Internal;
 
 import java.util.Collection;
@@ -94,7 +95,7 @@ public final class ImmutableKit {
      * @param extraValues more values to add
      * @param <T>         for two
      *
-     * @return an Immutable list with the extra effort.
+     * @return an Immutable list with the extra items.
      */
     public static <T> ImmutableList<T> addToList(Collection<? extends T> existing, T newValue, T... extraValues) {
         assertNotNull(existing);
@@ -107,6 +108,29 @@ public final class ImmutableKit {
             newList.add(extraValue);
         }
         return newList.build();
+    }
+
+    /**
+     * This constructs a new Immutable set from an existing collection and adds a new element to it.
+     *
+     * @param existing    the existing collection
+     * @param newValue    the new value to add
+     * @param extraValues more values to add
+     * @param <T>         for two
+     *
+     * @return an Immutable Set with the extra itens.
+     */
+    public static <T> ImmutableSet<T> addToSet(Collection<? extends T> existing, T newValue, T... extraValues) {
+        assertNotNull(existing);
+        assertNotNull(newValue);
+        int expectedSize = existing.size() + 1 + extraValues.length;
+        ImmutableSet.Builder<T> newSet = ImmutableSet.builderWithExpectedSize(expectedSize);
+        newSet.addAll(existing);
+        newSet.add(newValue);
+        for (T extraValue : extraValues) {
+            newSet.add(extraValue);
+        }
+        return newSet.build();
     }
 
 }

--- a/src/main/java/graphql/execution/DataFetcherExceptionHandler.java
+++ b/src/main/java/graphql/execution/DataFetcherExceptionHandler.java
@@ -38,7 +38,7 @@ public interface DataFetcherExceptionHandler {
      *
      * @return a result that can contain custom formatted {@link graphql.GraphQLError}s
      */
-    default CompletionStage<DataFetcherExceptionHandlerResult> handleException(DataFetcherExceptionHandlerParameters handlerParameters) {
+    default CompletableFuture<DataFetcherExceptionHandlerResult> handleException(DataFetcherExceptionHandlerParameters handlerParameters) {
         DataFetcherExceptionHandlerResult result = onException(handlerParameters);
         return CompletableFuture.completedFuture(result);
     }

--- a/src/main/java/graphql/execution/DataFetcherExceptionHandler.java
+++ b/src/main/java/graphql/execution/DataFetcherExceptionHandler.java
@@ -1,8 +1,12 @@
 package graphql.execution;
 
+import graphql.ExecutionResult;
 import graphql.PublicSpi;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * This is called when an exception is thrown during {@link graphql.schema.DataFetcher#get(DataFetchingEnvironment)} execution
@@ -11,12 +15,31 @@ import graphql.schema.DataFetchingEnvironment;
 public interface DataFetcherExceptionHandler {
 
     /**
-     * When an exception during a call to a {@link DataFetcher} then this handler
-     * is called back to shape the error that should be placed in the list of errors
+     * When an exception occurs during a call to a {@link DataFetcher} then this handler
+     * is called to shape the errors that should be placed in the {@link ExecutionResult#getErrors()}
+     * list of errors.
+     *
+     * @param handlerParameters the parameters to this callback
+     *
+     * @return a result that can contain custom formatted {@link graphql.GraphQLError}s
+     *
+     * @deprecated use {@link #handleException(DataFetcherExceptionHandlerParameters)} instead which as an asynchronous
+     * version
+     */
+    @Deprecated
+    DataFetcherExceptionHandlerResult onException(DataFetcherExceptionHandlerParameters handlerParameters);
+
+    /**
+     * When an exception occurs during a call to a {@link DataFetcher} then this handler
+     * is called to shape the errors that should be placed in the {@link ExecutionResult#getErrors()}
+     * list of errors.
      *
      * @param handlerParameters the parameters to this callback
      *
      * @return a result that can contain custom formatted {@link graphql.GraphQLError}s
      */
-    DataFetcherExceptionHandlerResult onException(DataFetcherExceptionHandlerParameters handlerParameters);
+    default CompletionStage<DataFetcherExceptionHandlerResult> handleException(DataFetcherExceptionHandlerParameters handlerParameters) {
+        DataFetcherExceptionHandlerResult result = onException(handlerParameters);
+        return CompletableFuture.completedFuture(result);
+    }
 }

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -355,7 +355,7 @@ public abstract class ExecutionStrategy {
     }
 
     private <T> CompletableFuture<T> asyncHandleException(DataFetcherExceptionHandler handler, DataFetcherExceptionHandlerParameters handlerParameters, ExecutionContext executionContext) {
-        CompletionStage<T> cs = handler.handleException(handlerParameters)
+        return handler.handleException(handlerParameters)
                 .thenApply(handlerResult -> {
                             // the side effect is that we added the returned errors to the execution context
                             // here
@@ -364,7 +364,6 @@ public abstract class ExecutionStrategy {
                             return null;
                         }
                 );
-        return cs.toCompletableFuture();
     }
 
     /**

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -48,7 +48,6 @@ import java.util.Map;
 import java.util.OptionalInt;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -311,9 +310,8 @@ public abstract class ExecutionStrategy {
                                                           Object result) {
 
         if (result instanceof DataFetcherResult) {
-            //noinspection unchecked
-            DataFetcherResult<?> dataFetcherResult = (DataFetcherResult) result;
-            dataFetcherResult.getErrors().forEach(executionContext::addError);
+            DataFetcherResult<?> dataFetcherResult = (DataFetcherResult<?>) result;
+            executionContext.addErrors(dataFetcherResult.getErrors());
 
             Object localContext = dataFetcherResult.getLocalContext();
             if (localContext == null) {
@@ -359,7 +357,7 @@ public abstract class ExecutionStrategy {
                 .thenApply(handlerResult -> {
                             // the side effect is that we added the returned errors to the execution context
                             // here
-                            handlerResult.getErrors().forEach(executionContext::addError);
+                            executionContext.addErrors(handlerResult.getErrors());
                             // and we return null because there is no data for the executed field
                             return null;
                         }
@@ -717,7 +715,6 @@ public abstract class ExecutionStrategy {
         TypeMismatchError error = new TypeMismatchError(parameters.getPath(), parameters.getExecutionStepInfo().getUnwrappedNonNullType());
         logNotSafe.warn("{} got {}", error.getMessage(), result.getClass());
         context.addError(error);
-
     }
 
 

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -49,6 +49,7 @@ import java.util.OptionalInt;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static graphql.execution.Async.exceptionallyCompletedFuture;
@@ -296,7 +297,7 @@ public abstract class ExecutionStrategy {
                         return CompletableFuture.completedFuture(result);
                     }
                 })
-                .thenCompose(errorOrValue -> errorOrValue)
+                .thenCompose(Function.identity())
                 .thenApply(result -> unboxPossibleDataFetcherResult(executionContext, parameters, result));
     }
 

--- a/src/test/groovy/graphql/collect/ImmutableKitTest.groovy
+++ b/src/test/groovy/graphql/collect/ImmutableKitTest.groovy
@@ -42,4 +42,23 @@ class ImmutableKitTest extends Specification {
         then:
         list == ["a", "b", "c", "d", "e"]
     }
+
+    def "can add to sets"() {
+        def set = new HashSet(["a"])
+
+        when:
+        set = ImmutableKit.addToSet(set, "b")
+        then:
+        set == ["a", "b"] as Set
+
+        when:
+        set = ImmutableKit.addToSet(set, "c", "d", "e")
+        then:
+        set == ["a", "b", "c", "d", "e"] as Set
+
+        when:
+        set = ImmutableKit.addToSet(set, "c", "d", "e", "f")
+        then:
+        set == ["a", "b", "c", "d", "e", "f"] as Set
+    }
 }

--- a/src/test/groovy/graphql/execution/DataFetcherExceptionHandlerTest.groovy
+++ b/src/test/groovy/graphql/execution/DataFetcherExceptionHandlerTest.groovy
@@ -1,12 +1,17 @@
 package graphql.execution
 
 import graphql.ErrorType
-import graphql.ExecutionInput
+import graphql.GraphQL
 import graphql.GraphQLError
 import graphql.TestUtil
 import graphql.language.SourceLocation
 import graphql.schema.DataFetcher
 import spock.lang.Specification
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+
+import static graphql.ExecutionInput.newExecutionInput
 
 class DataFetcherExceptionHandlerTest extends Specification {
 
@@ -35,11 +40,7 @@ class DataFetcherExceptionHandlerTest extends Specification {
         }
     }
 
-    def "integration test to prove custom error handle can be made"() {
-        DataFetcherExceptionHandler handler = {
-            params -> DataFetcherExceptionHandlerResult.newResult().error(new CustomError("The thing went " + params.getException().getMessage(), params.getSourceLocation())).build()
-        }
-
+    private static GraphQL mkTestingGraphQL(DataFetcherExceptionHandler handler) {
         def dataFetchers = [
                 Query: [field: { env -> throw new RuntimeException("BANG") } as DataFetcher]
         ]
@@ -51,33 +52,115 @@ class DataFetcherExceptionHandlerTest extends Specification {
         ''', dataFetchers)
                 .queryExecutionStrategy(new AsyncExecutionStrategy(handler))
                 .build()
+        graphQL
+    }
+
+    def "integration test to prove custom error handle can be made"() {
+        DataFetcherExceptionHandler handler = new DataFetcherExceptionHandler() {
+            @Override
+            DataFetcherExceptionHandlerResult onException(DataFetcherExceptionHandlerParameters handlerParameters) {
+                def msg = "The thing went " + handlerParameters.getException().getMessage()
+                return DataFetcherExceptionHandlerResult.newResult().error(new CustomError(msg, handlerParameters.getSourceLocation())).build()
+            }
+        }
+
+        GraphQL graphQL = mkTestingGraphQL(handler)
         when:
-        def result = graphQL.execute(ExecutionInput.newExecutionInput().query(' { field }'))
+        def result = graphQL.execute(newExecutionInput().query(' { field }'))
+        then:
+        !result.errors.isEmpty()
+        result.errors[0].message == "The thing went BANG"
+    }
+
+
+    def "integration test to prove an async custom error handle can be made"() {
+        DataFetcherExceptionHandler handler = new DataFetcherExceptionHandler() {
+            @Override
+            DataFetcherExceptionHandlerResult onException(DataFetcherExceptionHandlerParameters handlerParameters) {
+                return null
+            }
+
+            @Override
+            CompletionStage<DataFetcherExceptionHandlerResult> handleException(DataFetcherExceptionHandlerParameters params) {
+                def msg = "The thing went " + params.getException().getMessage()
+                def result = DataFetcherExceptionHandlerResult.newResult().error(new CustomError(msg, params.getSourceLocation())).build()
+                return CompletableFuture.supplyAsync({ -> result })
+            }
+        }
+
+        GraphQL graphQL = mkTestingGraphQL(handler)
+
+        when:
+        def result = graphQL.execute(newExecutionInput().query(' { field }'))
         then:
         !result.errors.isEmpty()
         result.errors[0].message == "The thing went BANG"
     }
 
     def "if an exception handler itself throws an exception than that is handled"() {
-        DataFetcherExceptionHandler handler = {
-            throw new RuntimeException("The handler itself went BANG!")
+        DataFetcherExceptionHandler handler = new DataFetcherExceptionHandler() {
+            @Override
+            DataFetcherExceptionHandlerResult onException(DataFetcherExceptionHandlerParameters handlerParameters) {
+                throw new RuntimeException("The handler itself went BANG!")
+            }
         }
 
-        def dataFetchers = [
-                Query: [field: { env -> throw new RuntimeException("BANG") } as DataFetcher]
-        ]
+        GraphQL graphQL = mkTestingGraphQL(handler)
 
-        def graphQL = TestUtil.graphQL('''
-            type Query {
-                field : String
-            }
-        ''', dataFetchers)
-                .queryExecutionStrategy(new AsyncExecutionStrategy(handler))
-                .build()
         when:
-        def result = graphQL.execute(ExecutionInput.newExecutionInput().query(' { field }'))
+        def result = graphQL.execute(newExecutionInput().query(' { field }'))
         then:
         !result.errors.isEmpty()
         result.errors[0].message.contains("The handler itself went BANG!")
+    }
+
+    def "if an async exception handler itself throws an exception than that is handled"() {
+        DataFetcherExceptionHandler handler = new DataFetcherExceptionHandler() {
+            @Override
+            DataFetcherExceptionHandlerResult onException(DataFetcherExceptionHandlerParameters handlerParameters) {
+                return null
+            }
+
+            @Override
+            CompletionStage<DataFetcherExceptionHandlerResult> handleException(DataFetcherExceptionHandlerParameters handlerParameters) {
+                throw new RuntimeException("The handler itself went BANG!")
+            }
+        }
+
+        GraphQL graphQL = mkTestingGraphQL(handler)
+
+        when:
+        def result = graphQL.execute(newExecutionInput().query(' { field }'))
+        then:
+        !result.errors.isEmpty()
+        result.errors[0].message.contains("The handler itself went BANG!")
+    }
+
+
+    def "multiple errors can be returned in a handler"() {
+        DataFetcherExceptionHandler handler = new DataFetcherExceptionHandler() {
+            @Override
+            DataFetcherExceptionHandlerResult onException(DataFetcherExceptionHandlerParameters handlerParameters) {
+                return null
+            }
+
+            @Override
+            CompletionStage<DataFetcherExceptionHandlerResult> handleException(DataFetcherExceptionHandlerParameters params) {
+                def result = DataFetcherExceptionHandlerResult.newResult()
+                for (int i = 0; i < 5; i++) {
+                    def msg = "$i The thing went " + params.getException().getMessage()
+                    result.error(new CustomError(msg, params.getSourceLocation()))
+                }
+                return CompletableFuture.supplyAsync({ -> result.build() })
+            }
+        }
+
+        GraphQL graphQL = mkTestingGraphQL(handler)
+
+        when:
+        def result = graphQL.execute(newExecutionInput().query(' { field }'))
+
+        then:
+        result.errors.size() == 5
     }
 }

--- a/src/test/groovy/graphql/execution/DataFetcherExceptionHandlerTest.groovy
+++ b/src/test/groovy/graphql/execution/DataFetcherExceptionHandlerTest.groovy
@@ -9,7 +9,6 @@ import graphql.schema.DataFetcher
 import spock.lang.Specification
 
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.CompletionStage
 
 import static graphql.ExecutionInput.newExecutionInput
 

--- a/src/test/groovy/graphql/execution/DataFetcherExceptionHandlerTest.groovy
+++ b/src/test/groovy/graphql/execution/DataFetcherExceptionHandlerTest.groovy
@@ -81,7 +81,7 @@ class DataFetcherExceptionHandlerTest extends Specification {
             }
 
             @Override
-            CompletionStage<DataFetcherExceptionHandlerResult> handleException(DataFetcherExceptionHandlerParameters params) {
+            CompletableFuture<DataFetcherExceptionHandlerResult> handleException(DataFetcherExceptionHandlerParameters params) {
                 def msg = "The thing went " + params.getException().getMessage()
                 def result = DataFetcherExceptionHandlerResult.newResult().error(new CustomError(msg, params.getSourceLocation())).build()
                 return CompletableFuture.supplyAsync({ -> result })
@@ -122,7 +122,7 @@ class DataFetcherExceptionHandlerTest extends Specification {
             }
 
             @Override
-            CompletionStage<DataFetcherExceptionHandlerResult> handleException(DataFetcherExceptionHandlerParameters handlerParameters) {
+            CompletableFuture<DataFetcherExceptionHandlerResult> handleException(DataFetcherExceptionHandlerParameters handlerParameters) {
                 throw new RuntimeException("The handler itself went BANG!")
             }
         }
@@ -145,7 +145,7 @@ class DataFetcherExceptionHandlerTest extends Specification {
             }
 
             @Override
-            CompletionStage<DataFetcherExceptionHandlerResult> handleException(DataFetcherExceptionHandlerParameters params) {
+            CompletableFuture<DataFetcherExceptionHandlerResult> handleException(DataFetcherExceptionHandlerParameters params) {
                 def result = DataFetcherExceptionHandlerResult.newResult()
                 for (int i = 0; i < 5; i++) {
                     def msg = "$i The thing went " + params.getException().getMessage()


### PR DESCRIPTION
This makes the data fetching exception handlers async.

The old method is left in place for backwards compatibiility reasons but the new async version is the one called.

It will delegate back to the old sync method.

New implementations can use proper async processing in making fetching errros