### PR TITLE
Fix extend type parsing issue

### DIFF
--- a/src/main/antlr/GraphqlSDL.g4
+++ b/src/main/antlr/GraphqlSDL.g4
@@ -59,7 +59,7 @@ objectTypeExtensionDefinition :
 ;
 
 implementsInterfaces :
-    IMPLEMENTS '&'? typeName+ |
+    IMPLEMENTS '&'? typeName |
     implementsInterfaces '&' typeName ;
 
 fieldsDefinition : '{' fieldDefinition* '}';

--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -884,9 +884,8 @@ public class GraphqlAntlrToLanguage {
     private List<Type> getImplementz(GraphqlParser.ImplementsInterfacesContext implementsInterfacesContext) {
         List<Type> implementz = new ArrayList<>();
         while (implementsInterfacesContext != null) {
-            List<TypeName> typeNames = map(implementsInterfacesContext.typeName(), this::createTypeName);
-
-            implementz.addAll(0, typeNames);
+            GraphqlParser.TypeNameContext typeName = implementsInterfacesContext.typeName();
+            implementz.add(0, createTypeName(typeName));
             implementsInterfacesContext = implementsInterfacesContext.implementsInterfaces();
         }
         return implementz;

--- a/src/test/groovy/graphql/Issue2274.groovy
+++ b/src/test/groovy/graphql/Issue2274.groovy
@@ -1,11 +1,20 @@
 package graphql
 
-import graphql.schema.idl.SchemaPrinter
+import graphql.language.AstComparator
+import graphql.language.Node
+import graphql.language.ObjectTypeExtensionDefinition
+import graphql.language.TypeName
+import graphql.parser.Parser
 import spock.lang.Specification
 
 class Issue2274 extends Specification {
-    // This test happened to work previously, as there are no tokens following 'implements Thing'
-    def "extend type without text following works"() {
+    boolean isEqual(Node node1, Node node2) {
+        return new AstComparator().isEqual(node1, node2)
+    }
+
+    // This test happened to work previously, as there were no tokens following 'implements Thing'
+    def "extend type without text following works - schema build"() {
+        given:
         def spec = '''
             type Query {
                 blob : Blob
@@ -32,19 +41,20 @@ class Issue2274 extends Specification {
             }
 
             extend type Blob implements Thing
-            '''
+        '''
 
         when:
         def schema = TestUtil.schema(spec)
 
         then:
         schema != null
-
-        println new SchemaPrinter().print(schema)
     }
 
     // Placing an input immediately after extend type without braces previously failed
-    def "extend type with text following works"() {
+    // The schema could not be compiled : SchemaProblem{errors=[The interface type 'input' is not present when resolving type
+    // 'Blob' [@20:13], The interface type 'AwesomeInput' is not present when resolving type 'Blob' [@20:13]]}. Expression: false
+    def "extend type with text following works - schema build"() {
+        given:
         def spec = '''
             type Query {
                 blob : Blob
@@ -71,16 +81,30 @@ class Issue2274 extends Specification {
                 interval: Interval!
                 amount: Int!
             }
-            '''
+        '''
 
         when:
         def schema = TestUtil.schema(spec)
 
         then:
-        // The schema could not be compiled : SchemaProblem{errors=[The interface type 'input' is not present when resolving type
-        // 'Blob' [@20:13], The interface type 'AwesomeInput' is not present when resolving type 'Blob' [@20:13]]}. Expression: false
         schema != null
+    }
 
-        println new SchemaPrinter().print(schema)
+    def "extend type with text following works - parser check"() {
+        given:
+        def spec = "extend type Blob implements Thing1 & Thing2 & Thing3"
+
+        and: "expected schema"
+        def objSchema = ObjectTypeExtensionDefinition.newObjectTypeExtensionDefinition().name("Blob")
+        objSchema.implementz(new TypeName("Thing1"))
+        objSchema.implementz(new TypeName("Thing2"))
+        objSchema.implementz(new TypeName("Thing3"))
+
+        when:
+        def document = new Parser().parseDocument(spec)
+
+        then:
+        document.definitions.size() == 1
+        isEqual(document.definitions[0], objSchema.build())
     }
 }

--- a/src/test/groovy/graphql/Issue2274.groovy
+++ b/src/test/groovy/graphql/Issue2274.groovy
@@ -1,0 +1,86 @@
+package graphql
+
+import graphql.schema.idl.SchemaPrinter
+import spock.lang.Specification
+
+class Issue2274 extends Specification {
+    // This test happened to work previously, as there are no tokens following 'implements Thing'
+    def "extend type without text following works"() {
+        def spec = '''
+            type Query {
+                blob : Blob
+            }
+
+            type Blob {
+                id: ID!
+                name: String
+            }
+
+            interface Thing {
+                name: String
+            }
+
+            input Interval {
+                now : Int
+                then : Int
+            }
+
+            # random input
+            input AwesomeInput {
+                interval: Interval!
+                amount: Int!
+            }
+
+            extend type Blob implements Thing
+            '''
+
+        when:
+        def schema = TestUtil.schema(spec)
+
+        then:
+        schema != null
+
+        println new SchemaPrinter().print(schema)
+    }
+
+    // Placing an input immediately after extend type without braces previously failed
+    def "extend type with text following works"() {
+        def spec = '''
+            type Query {
+                blob : Blob
+            }
+
+            type Blob {
+                id: ID!
+                name: String
+            }
+
+            interface Thing {
+                name: String
+            }
+
+            input Interval {
+                now : Int
+                then : Int
+            }
+
+            extend type Blob implements Thing
+            
+            # random input
+            input AwesomeInput {
+                interval: Interval!
+                amount: Int!
+            }
+            '''
+
+        when:
+        def schema = TestUtil.schema(spec)
+
+        then:
+        // The schema could not be compiled : SchemaProblem{errors=[The interface type 'input' is not present when resolving type
+        // 'Blob' [@20:13], The interface type 'AwesomeInput' is not present when resolving type 'Blob' [@20:13]]}. Expression: false
+        schema != null
+
+        println new SchemaPrinter().print(schema)
+    }
+}

--- a/src/test/groovy/graphql/TypeResolutionEnvironmentTest.groovy
+++ b/src/test/groovy/graphql/TypeResolutionEnvironmentTest.groovy
@@ -24,7 +24,7 @@ class TypeResolutionEnvironmentTest extends Specification {
             bar : String
         }
         
-        type FooBar implements Foo, Bar {
+        type FooBar implements Foo & Bar {
             foo : String
             bar : String
         }

--- a/src/test/groovy/graphql/parser/SDLParserTest.groovy
+++ b/src/test/groovy/graphql/parser/SDLParserTest.groovy
@@ -177,7 +177,7 @@ TWO @second,
     def "object schema"() {
         given:
         def input = """
-type TypeName implements Impl1 Impl2 @typeDirective(a1:\$v1) {
+type TypeName implements Impl1 & Impl2 @typeDirective(a1:\$v1) {
 one: Number
 two: Number @second
 cmd(arg1:[Number]=[1] arg2:String @secondArg(cool:true)): Function
@@ -577,12 +577,6 @@ input Gun {
             bar : String
             baz : String
         }
-    
-        type Foo2 implements Bar Baz {
-            bar : String
-            baz : String
-        }
-        
 """
         when:
         def document = new Parser().parseDocument(input)
@@ -593,13 +587,6 @@ input Gun {
         typeDef.getImplements().size() == 2
         (typeDef.getImplements()[0] as TypeName).getName() == 'Bar'
         (typeDef.getImplements()[1] as TypeName).getName() == 'Baz'
-
-        then:
-        ObjectTypeDefinition typeDef2 = document.definitions[3] as ObjectTypeDefinition
-        typeDef2.getName() == 'Foo2'
-        typeDef2.getImplements().size() == 2
-        (typeDef2.getImplements()[0] as TypeName).getName() == 'Bar'
-        (typeDef2.getImplements()[1] as TypeName).getName() == 'Baz'
     }
 
     def "object type extensions"() {

--- a/src/test/groovy/graphql/schema/GraphqlTypeComparatorsTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphqlTypeComparatorsTest.groovy
@@ -38,7 +38,7 @@ class GraphqlTypeComparatorsTest extends Specification {
             
             union XUnion = Foo | Bar
             
-            type Foo implements YInterface, XInterface, ZInterface {
+            type Foo implements YInterface & XInterface & ZInterface {
                 zField : String
                 yField : String
                 xField : String

--- a/src/test/groovy/graphql/schema/idl/SchemaParserTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaParserTest.groovy
@@ -29,7 +29,7 @@ class SchemaParserTest extends Specification {
                 is_bar : Boolean
             }     
 
-            type Baz implements Foo, Goo {
+            type Baz implements Foo & Goo {
                 is_foo : Boolean
                 is_goo : Boolean
                 is_baz : Boolean

--- a/src/test/groovy/graphql/schema/idl/TypeDefinitionRegistryTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/TypeDefinitionRegistryTest.groovy
@@ -403,21 +403,21 @@ class TypeDefinitionRegistryTest extends Specification {
               id: String!
             }
 
-            type Dog implements Animal, Mammal {
+            type Dog implements Animal & Mammal {
               id: String!
             }
 
-            type Duck implements Animal, Mammal {
+            type Duck implements Animal & Mammal {
               id: String!
             }
             
             union Platypus = Duck | Turtle
 
-            type Cat implements Animal, Mammal {
+            type Cat implements Animal & Mammal {
               id: String!
             }
 
-            type Turtle implements Animal, Reptile {
+            type Turtle implements Animal & Reptile {
               id: String!
             }
 


### PR DESCRIPTION
Fixes issue #2274.

The current spec for `implementsInterfaces` expects `&` between type names, where there are at least 2 type names. This pull request fixes the parser and tests with the current spec.

Before the June 2018 spec release, interface names were delimited with a space or comma (effectively the same thing, as commas are ignored). Implementation of an old spec then caused the parsing issue raised in #2267 & #2274.

Spec link: https://spec.graphql.org/draft/#sec-Objects