### PR TITLE
Apollo Persisted Query check hash & In Mem cache use Execution Input Query

### DIFF
--- a/src/main/java/graphql/execution/preparsed/persisted/ApolloPersistedQuerySupport.java
+++ b/src/main/java/graphql/execution/preparsed/persisted/ApolloPersistedQuerySupport.java
@@ -48,20 +48,14 @@ public class ApolloPersistedQuerySupport extends PersistedQuerySupport {
         Map<String, Object> extensions = executionInput.getExtensions();
         Map<String, Object> persistedQuery = (Map<String, Object>) extensions.get("persistedQuery");
         if (persistedQuery != null) {
-            String sha256Hash = persistedQuery.get("sha256Hash").toString();
-            String query = executionInput.getQuery();
-            if (query != null && (!query.isEmpty() && !query.equals(PERSISTED_QUERY_MARKER))) {
-                if (!isValidPersistedQueryId(sha256Hash, executionInput)) {
-                    throw new PersistedQueryIdInvalid(sha256Hash);
-                }
-            } else {
-                return Optional.ofNullable(sha256Hash);
-            }
+            Object sha256Hash = persistedQuery.get("sha256Hash");
+            return Optional.ofNullable(sha256Hash);
         }
         return Optional.empty();
     }
 
-    protected boolean isValidPersistedQueryId(String id, ExecutionInput executionInput) {
+    @Override
+    protected boolean persistedQueryIdIsInvalid(Object persistedQueryId, ExecutionInput executionInput) {
         String query = executionInput.getQuery();
         MessageDigest messageDigest;
         try {
@@ -72,6 +66,6 @@ public class ApolloPersistedQuerySupport extends PersistedQuerySupport {
 
         BigInteger bigInteger = new BigInteger(1, messageDigest.digest(query.getBytes(StandardCharsets.UTF_8)));
         String calculatedChecksum = String.format("%064x", bigInteger);
-        return calculatedChecksum.equalsIgnoreCase(id);
+        return !calculatedChecksum.equalsIgnoreCase(persistedQueryId.toString());
     }
 }

--- a/src/main/java/graphql/execution/preparsed/persisted/ApolloPersistedQuerySupport.java
+++ b/src/main/java/graphql/execution/preparsed/persisted/ApolloPersistedQuerySupport.java
@@ -55,8 +55,7 @@ public class ApolloPersistedQuerySupport extends PersistedQuerySupport {
     }
 
     @Override
-    protected boolean persistedQueryIdIsInvalid(Object persistedQueryId, ExecutionInput executionInput) {
-        String query = executionInput.getQuery();
+    protected boolean persistedQueryIdIsInvalid(Object persistedQueryId, String queryText) {
         MessageDigest messageDigest;
         try {
             messageDigest = MessageDigest.getInstance(CHECKSUM_TYPE);
@@ -64,7 +63,7 @@ public class ApolloPersistedQuerySupport extends PersistedQuerySupport {
             return false;
         }
 
-        BigInteger bigInteger = new BigInteger(1, messageDigest.digest(query.getBytes(StandardCharsets.UTF_8)));
+        BigInteger bigInteger = new BigInteger(1, messageDigest.digest(queryText.getBytes(StandardCharsets.UTF_8)));
         String calculatedChecksum = String.format("%064x", bigInteger);
         return !calculatedChecksum.equalsIgnoreCase(persistedQueryId.toString());
     }

--- a/src/main/java/graphql/execution/preparsed/persisted/InMemoryPersistedQueryCache.java
+++ b/src/main/java/graphql/execution/preparsed/persisted/InMemoryPersistedQueryCache.java
@@ -32,7 +32,14 @@ public class InMemoryPersistedQueryCache implements PersistedQueryCache {
             if (v != null) {
                 return v;
             }
-            String queryText = knownQueries.get(persistedQueryId);
+
+            //get the query from the execution input. Make sure it's not null, empty or the APQ marker.
+            // if it is, fallback to the known queries.
+            String queryText = executionInput.getQuery();
+            if (queryText == null || queryText.isEmpty() || queryText.equals(PersistedQuerySupport.PERSISTED_QUERY_MARKER)) {
+                queryText = knownQueries.get(persistedQueryId);
+            }
+
             if (queryText == null) {
                 throw new PersistedQueryNotFound(persistedQueryId);
             }

--- a/src/main/java/graphql/execution/preparsed/persisted/PersistedQueryError.java
+++ b/src/main/java/graphql/execution/preparsed/persisted/PersistedQueryError.java
@@ -1,0 +1,13 @@
+package graphql.execution.preparsed.persisted;
+
+import graphql.ErrorClassification;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public abstract class PersistedQueryError extends RuntimeException implements ErrorClassification {
+
+    Map<String, Object> getExtensions() {
+        return new LinkedHashMap<>();
+    }
+}

--- a/src/main/java/graphql/execution/preparsed/persisted/PersistedQueryIdInvalid.java
+++ b/src/main/java/graphql/execution/preparsed/persisted/PersistedQueryIdInvalid.java
@@ -5,20 +5,17 @@ import graphql.PublicApi;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-/**
- * An exception that indicates the query id is not valid and can be found ever in cache
- */
 @PublicApi
-public class PersistedQueryNotFound extends PersistedQueryError {
+public class PersistedQueryIdInvalid extends PersistedQueryError {
     private final Object persistedQueryId;
 
-    public PersistedQueryNotFound(Object persistedQueryId) {
+    public PersistedQueryIdInvalid(Object persistedQueryId) {
         this.persistedQueryId = persistedQueryId;
     }
 
     @Override
     public String getMessage() {
-        return "PersistedQueryNotFound";
+        return "PersistedQueryIdInvalid";
     }
 
     public Object getPersistedQueryId() {
@@ -27,14 +24,12 @@ public class PersistedQueryNotFound extends PersistedQueryError {
 
     @Override
     public String toString() {
-        return "PersistedQueryNotFound";
+        return "PersistedQueryIdInvalid";
     }
 
-    @Override
     public Map<String, Object> getExtensions() {
         LinkedHashMap<String, Object> extensions = new LinkedHashMap<>();
-        extensions.put("persistedQueryId", persistedQueryId);
-        extensions.put("generatedBy", "graphql-java");
+        extensions.put("persistedQueryId", getPersistedQueryId());
         return extensions;
     }
 }

--- a/src/main/java/graphql/execution/preparsed/persisted/PersistedQuerySupport.java
+++ b/src/main/java/graphql/execution/preparsed/persisted/PersistedQuerySupport.java
@@ -48,6 +48,10 @@ public abstract class PersistedQuerySupport implements PreparsedDocumentProvider
                     if (queryText == null || queryText.trim().length() == 0) {
                         throw new PersistedQueryNotFound(persistedQueryId);
                     }
+                    // validate the queryText hash before returning to the cache which we assume will set it
+                    if (persistedQueryIdIsInvalid(persistedQueryId, executionInput)) {
+                        throw new PersistedQueryIdInvalid(persistedQueryId);
+                    }
                     ExecutionInput newEI = executionInput.transform(builder -> builder.query(queryText));
                     return parseAndValidateFunction.apply(newEI);
                 });
@@ -64,14 +68,20 @@ public abstract class PersistedQuerySupport implements PreparsedDocumentProvider
      * up the persisted query in the cache.
      *
      * @param executionInput the execution input
+     *
      * @return an optional id of the persisted query
      */
     abstract protected Optional<Object> getPersistedQueryId(ExecutionInput executionInput);
+
+    protected boolean persistedQueryIdIsInvalid(Object persistedQueryId, ExecutionInput executionInput) {
+        return false;
+    }
 
     /**
      * Allows you to customize the graphql error that is sent back on a missing persistend query
      *
      * @param persistedQueryError the missing persistent query exception
+     *
      * @return a PreparsedDocumentEntry that holds an error
      */
     protected PreparsedDocumentEntry mkMissingError(PersistedQueryError persistedQueryError) {

--- a/src/main/java/graphql/execution/preparsed/persisted/PersistedQuerySupport.java
+++ b/src/main/java/graphql/execution/preparsed/persisted/PersistedQuerySupport.java
@@ -49,7 +49,7 @@ public abstract class PersistedQuerySupport implements PreparsedDocumentProvider
                         throw new PersistedQueryNotFound(persistedQueryId);
                     }
                     // validate the queryText hash before returning to the cache which we assume will set it
-                    if (persistedQueryIdIsInvalid(persistedQueryId, executionInput)) {
+                    if (persistedQueryIdIsInvalid(persistedQueryId, queryText)) {
                         throw new PersistedQueryIdInvalid(persistedQueryId);
                     }
                     ExecutionInput newEI = executionInput.transform(builder -> builder.query(queryText));
@@ -73,7 +73,7 @@ public abstract class PersistedQuerySupport implements PreparsedDocumentProvider
      */
     abstract protected Optional<Object> getPersistedQueryId(ExecutionInput executionInput);
 
-    protected boolean persistedQueryIdIsInvalid(Object persistedQueryId, ExecutionInput executionInput) {
+    protected boolean persistedQueryIdIsInvalid(Object persistedQueryId, String queryText) {
         return false;
     }
 

--- a/src/main/java/graphql/execution/preparsed/persisted/PersistedQuerySupport.java
+++ b/src/main/java/graphql/execution/preparsed/persisted/PersistedQuerySupport.java
@@ -54,7 +54,7 @@ public abstract class PersistedQuerySupport implements PreparsedDocumentProvider
             }
             // ok there is no query id - we assume the query is indeed ready to go as is - ie its not a persisted query
             return parseAndValidateFunction.apply(executionInput);
-        } catch (PersistedQueryNotFound e) {
+        } catch (PersistedQueryError e) {
             return mkMissingError(e);
         }
     }
@@ -71,13 +71,13 @@ public abstract class PersistedQuerySupport implements PreparsedDocumentProvider
     /**
      * Allows you to customize the graphql error that is sent back on a missing persistend query
      *
-     * @param persistedQueryNotFound the missing persistent query exception
+     * @param persistedQueryError the missing persistent query exception
      * @return a PreparsedDocumentEntry that holds an error
      */
-    protected PreparsedDocumentEntry mkMissingError(PersistedQueryNotFound persistedQueryNotFound) {
+    protected PreparsedDocumentEntry mkMissingError(PersistedQueryError persistedQueryError) {
         GraphQLError gqlError = GraphqlErrorBuilder.newError()
-                .errorType(persistedQueryNotFound).message(persistedQueryNotFound.getMessage())
-                .extensions(persistedQueryNotFound.getExtensions()).build();
+                .errorType(persistedQueryError).message(persistedQueryError.getMessage())
+                .extensions(persistedQueryError.getExtensions()).build();
         return new PreparsedDocumentEntry(gqlError);
     }
 }

--- a/src/test/groovy/graphql/execution/preparsed/persisted/InMemoryPersistedQueryCacheTest.groovy
+++ b/src/test/groovy/graphql/execution/preparsed/persisted/InMemoryPersistedQueryCacheTest.groovy
@@ -1,8 +1,23 @@
 package graphql.execution.preparsed.persisted
 
+import graphql.ExecutionInput
+import graphql.execution.preparsed.PreparsedDocumentEntry
+import graphql.parser.Parser
 import spock.lang.Specification
 
+import static graphql.language.AstPrinter.printAstCompact
+
 class InMemoryPersistedQueryCacheTest extends Specification {
+
+    def mkEI(String hash, String query) {
+        ExecutionInput.newExecutionInput().query(query).extensions([persistedQuery: [sha256Hash: hash, version: 1]]).build()
+    }
+
+    PersistedQueryCacheMiss onMiss = {
+        String query ->
+            def doc = new Parser().parseDocument(query)
+            return new PreparsedDocumentEntry(doc)
+    }
 
     def "can be build as expected"() {
         def inMemoryPersistedQueryCache = InMemoryPersistedQueryCache.newInMemoryPersistedQueryCache()
@@ -14,5 +29,30 @@ class InMemoryPersistedQueryCacheTest extends Specification {
         def knownQueries = inMemoryPersistedQueryCache.getKnownQueries()
         then:
         knownQueries == [hash123: "query { oneTwoThree }", hash456: "query { fourFiveSix }"]
+    }
+
+    def "Uses the query from the execution input if the query ID wasn't in the cache"() {
+        def inMemCache = InMemoryPersistedQueryCache.newInMemoryPersistedQueryCache().build()
+        def hash = "thisisahash"
+        def ei = mkEI(hash, "query { oneTwoThreeFour }")
+
+        when:
+        def getDoc = inMemCache.getPersistedQueryDocument(hash, ei, onMiss)
+        def doc = getDoc.document
+        then:
+        printAstCompact(doc) == "query {oneTwoThreeFour}"
+    }
+
+    def "When there's a cache miss, uses the query from known queries if the execution input's query is the APQ Marker"() {
+        def hash = "somehash"
+        def inMemCache = InMemoryPersistedQueryCache.newInMemoryPersistedQueryCache()
+                .addQuery(hash, "query {foo bar baz}")
+                .build()
+        def ei = mkEI(hash, PersistedQuerySupport.PERSISTED_QUERY_MARKER)
+        when:
+        def getDoc = inMemCache.getPersistedQueryDocument(hash, ei, onMiss)
+        def doc = getDoc.document
+        then:
+        printAstCompact(doc) == "query {foo bar baz}"
     }
 }


### PR DESCRIPTION
Hello! 👋 

This PR would address two of the proposed ideas in this issue: https://github.com/graphql-java/graphql-java/issues/2395.

There are two proposals here. 

The first adds a new Persisted Query Error: PersistedQueryIdInvalid. This error is thrown if invocation of the method `persistedQueryIdIsInvalid` returns true. To go along with this, I also added an implementation of this protected method to `ApolloPersistedQuerySupport`. That implementations check the provided query ID is equal to the sha256 checksum of the queryText to be validated.

The second proposal is to have the example implementation `InMemoryPersistedQueryCache` register query from the execution input, much like Apollo implementation does in [requestPipeline.ts](https://github.com/apollographql/apollo-server/blob/0aa0e4b20ef97576ce92733698a7842b61d8280e/packages/apollo-server-core/src/requestPipeline.ts#L384).

I'd greatly appreciate some thoughts on this if possible.

Thanks!

For posterity, this issue is related to this issue https://github.com/Netflix/dgs-framework/issues/50 in the DGS framework repo; as well as this discussion: https://github.com/Netflix/dgs-framework/discussions/412.