### PR TITLE
Strict boolean support for Strings in and out

### DIFF
--- a/src/main/java/graphql/scalar/GraphqlBooleanCoercing.java
+++ b/src/main/java/graphql/scalar/GraphqlBooleanCoercing.java
@@ -22,7 +22,14 @@ public class GraphqlBooleanCoercing implements Coercing<Boolean, Boolean> {
         if (input instanceof Boolean) {
             return (Boolean) input;
         } else if (input instanceof String) {
-            return Boolean.parseBoolean((String) input);
+            String lStr = ((String) input).toLowerCase();
+            if (lStr.equals("true")) {
+                return true;
+            }
+            if (lStr.equals("false")) {
+                return false;
+            }
+            return null;
         } else if (isNumberIsh(input)) {
             BigDecimal value;
             try {

--- a/src/test/groovy/graphql/ScalarsBooleanTest.groovy
+++ b/src/test/groovy/graphql/ScalarsBooleanTest.groovy
@@ -50,8 +50,6 @@ class ScalarsBooleanTest extends Specification {
         "false"                      | false
         "true"                       | true
         "True"                       | true
-        "some value not true"        | false
-        ""                           | false
         0                            | false
         1                            | true
         -1                           | true
@@ -70,8 +68,14 @@ class ScalarsBooleanTest extends Specification {
         thrown(CoercingSerializeException)
 
         where:
-        value        | _
-        new Object() | _
+        value                 | _
+        new Object()          | _
+        "some value not true" | _
+        ""                    | _
+        "T"                   | _
+        "t"                   | _
+        "F"                   | _
+        "f"                   | _
     }
 
     @Unroll


### PR DESCRIPTION
When a AST literal is coerced it must be `true` or `false` - easy because the parser enforces that

However if you use variables then

`{"someBoolVar" : "TEST"}`

will be accepted and evaluated to false.

The old code uses Boolean.parse in Java which I have argued IS idiomatic Java however it creates strangle edge cases

We could be more strict in what we accept as a boolean.

This is that PR

If we decide to go with this PR then it would break anyone how is currently sending in strings outside "true" and "false" (case insensitive) .


See 

https://github.com/graphql-java/graphql-java/issues/1103
https://github.com/graphql-java/graphql-java/issues/865
