### PR TITLE
Fix for duplicate selected fields in the selection set

### DIFF
--- a/src/main/java/graphql/schema/DataFetchingFieldSelectionSet.java
+++ b/src/main/java/graphql/schema/DataFetchingFieldSelectionSet.java
@@ -148,7 +148,7 @@ public interface DataFetchingFieldSelectionSet {
      * <p>
      * The fields are guaranteed to be in pre-order as they appear in the query.
      * <p>
-     * A selected field (or its parent) may have an alias - and hence is a unique field in the returned list.  It may
+     * A selected field may have an alias - and hence is a unique field in the returned list.  It may
      * have the same field names as others in the list but when you also consider the alias then it is indeed unique
      * because it would be another entry in the graphql result.
      *
@@ -162,7 +162,7 @@ public interface DataFetchingFieldSelectionSet {
      * <p>
      * The fields are guaranteed to be in pre-order as they appear in the query.
      * <p>
-     * A selected field (or its parent) may have an alias - and hence is a unique field in the returned list.  It may
+     * A selected field may have an alias - and hence is a unique field in the returned list.  It may
      * have the same field names as others in the list but when you also consider the alias then it is indeed unique
      * because it would be another entry in the graphql result.
      *
@@ -179,7 +179,7 @@ public interface DataFetchingFieldSelectionSet {
      * <p>
      * The fields are guaranteed to be in pre-order as they appear in the query.
      * <p>
-     * A selected field (or its parent) may have an alias - and hence is a unique field in the returned list.  It may
+     * A selected field may have an alias - and hence is a unique field in the returned list.  It may
      * have the same field names as others in the list but when you also consider the alias then it is indeed unique
      * because it would be another entry in the graphql result.
      *

--- a/src/main/java/graphql/schema/DataFetchingFieldSelectionSet.java
+++ b/src/main/java/graphql/schema/DataFetchingFieldSelectionSet.java
@@ -147,6 +147,10 @@ public interface DataFetchingFieldSelectionSet {
      * This will return all selected fields.
      * <p>
      * The fields are guaranteed to be in pre-order as they appear in the query.
+     * <p>
+     * A selected field (or its parent) may have an alias - and hence is a unique field in the returned list.  It may
+     * have the same field names as others in the list but when you also consider the alias then it is indeed unique
+     * because it would be another entry in the graphql result.
      *
      * @return a list of all selected fields or empty list if none match
      */
@@ -157,6 +161,10 @@ public interface DataFetchingFieldSelectionSet {
      * of the field being fetched.
      * <p>
      * The fields are guaranteed to be in pre-order as they appear in the query.
+     * <p>
+     * A selected field (or its parent) may have an alias - and hence is a unique field in the returned list.  It may
+     * have the same field names as others in the list but when you also consider the alias then it is indeed unique
+     * because it would be another entry in the graphql result.
      *
      * @return a list of all selected immediate child fields or empty list if none match
      */
@@ -170,6 +178,10 @@ public interface DataFetchingFieldSelectionSet {
      * match an invoice field with child fields that start with 'customer'.
      * <p>
      * The fields are guaranteed to be in pre-order as they appear in the query.
+     * <p>
+     * A selected field (or its parent) may have an alias - and hence is a unique field in the returned list.  It may
+     * have the same field names as others in the list but when you also consider the alias then it is indeed unique
+     * because it would be another entry in the graphql result.
      *
      * @param fieldGlobPattern  the glob pattern to match fields against
      * @param fieldGlobPatterns optionally more glob pattern to match fields against

--- a/src/test/groovy/graphql/schema/DataFetchingFieldSelectionSetImplTest.groovy
+++ b/src/test/groovy/graphql/schema/DataFetchingFieldSelectionSetImplTest.groovy
@@ -268,7 +268,7 @@ class DataFetchingFieldSelectionSetImplTest extends Specification {
         then:
 
         allFieldsViaAsterAster.size() == 14
-        allFields.size() == 28
+        allFields.size() == 14
         def allFieldsViaAsterAsterSorted = new ArrayList<>(allFieldsViaAsterAster).sort({ sf -> sf.qualifiedName })
         def allFieldsSorted = new ArrayList<>(allFields).sort({ sf -> sf.qualifiedName })
 
@@ -288,8 +288,8 @@ class DataFetchingFieldSelectionSetImplTest extends Specification {
                 "nodes/summary",
                 "totalCount"
         ]
-        allFieldsViaAsterAsterSorted.collect({ sf -> sf.qualifiedName }).toUnique() == expectedFieldNames
-        allFieldsSorted.collect({ sf -> sf.qualifiedName }).toUnique() == expectedFieldNames
+        allFieldsViaAsterAsterSorted.collect({ sf -> sf.qualifiedName }) == expectedFieldNames
+        allFieldsSorted.collect({ sf -> sf.qualifiedName }) == expectedFieldNames
 
         when:
         def expectedFullyQualifiedFieldNames = [
@@ -309,8 +309,8 @@ class DataFetchingFieldSelectionSetImplTest extends Specification {
                 "ThingConnection.totalCount"
         ]
         then:
-        allFieldsViaAsterAsterSorted.collect({ sf -> sf.fullyQualifiedName }).toUnique() == expectedFullyQualifiedFieldNames
-        allFieldsSorted.collect({ sf -> sf.fullyQualifiedName }).toUnique() == expectedFullyQualifiedFieldNames
+        allFieldsViaAsterAsterSorted.collect({ sf -> sf.fullyQualifiedName }) == expectedFullyQualifiedFieldNames
+        allFieldsSorted.collect({ sf -> sf.fullyQualifiedName }) == expectedFullyQualifiedFieldNames
 
     }
 
@@ -344,8 +344,8 @@ class DataFetchingFieldSelectionSetImplTest extends Specification {
         ]
 
         then:
-        fieldsGlob.collect({ field -> field.qualifiedName }).toUnique() == expectedFieldName
-        fields.collect({ field -> field.qualifiedName }).toUnique() == expectedFieldName
+        fieldsGlob.collect({ field -> field.qualifiedName }) == expectedFieldName
+        fields.collect({ field -> field.qualifiedName }) == expectedFieldName
     }
 
     def petSDL = '''
@@ -555,6 +555,11 @@ class DataFetchingFieldSelectionSetImplTest extends Specification {
 
         def selectedFields = petSelectionSet.getFields("name")
         selectedFields.size() == 2
+        assertTheyAreExpected(selectedFields, ["Lead.material"])
+
+        selectedFields = petSelectionSet.getFields()
+        selectedFields.size() == 2
+        assertTheyAreExpected(selectedFields, ["Lead.material"])
 
         def byResultKey = petSelectionSet.getFieldsGroupedByResultKey()
         byResultKey.size() == 2
@@ -810,8 +815,8 @@ class DataFetchingFieldSelectionSetImplTest extends Specification {
         def selectedFields = leadSelectionSet.getFields()
 
         then:
-        selectedFields.size() == 2
-        assertTheyAreExpected(selectedFields, ["Lead.material", "Lead.material"])
+        selectedFields.size() == 1
+        assertTheyAreExpected(selectedFields, ["Lead.material"])
 
         when:
         selectedFields = leadSelectionSet.getFields("material")

--- a/src/test/groovy/graphql/schema/DataFetchingFieldSelectionSetImplTest.groovy
+++ b/src/test/groovy/graphql/schema/DataFetchingFieldSelectionSetImplTest.groovy
@@ -555,11 +555,11 @@ class DataFetchingFieldSelectionSetImplTest extends Specification {
 
         def selectedFields = petSelectionSet.getFields("name")
         selectedFields.size() == 2
-        assertTheyAreExpected(selectedFields, ["Lead.material"])
+        assertTheyAreExpected(selectedFields, ["[Bird, Cat, Dog].name", "aliasedName:Dog.name"])
 
-        selectedFields = petSelectionSet.getFields()
-        selectedFields.size() == 2
-        assertTheyAreExpected(selectedFields, ["Lead.material"])
+        def getFields = petSelectionSet.getFields()
+        getFields.size() == 2
+        assertTheyAreExpected(getFields, ["[Bird, Cat, Dog].name", "aliasedName:Dog.name"])
 
         def byResultKey = petSelectionSet.getFieldsGroupedByResultKey()
         byResultKey.size() == 2


### PR DESCRIPTION
The ExecutableNormalisedField backed selection set work made an assumption about how we have 2 ways to do glob matching, eg by name (`age`) or full field name (`Person.age`)

However this got reflected back in the API when you get the actual fields back on `getFields` calls.

This fixes it in that it provides set semantics on the returned list.  It still matches multiples ways but it considers the list of fields to be the ones that map to the same ExecutableNF.


See https://github.com/graphql-java/graphql-java/issues/2303
https://github.com/graphql-java/graphql-java/issues/2275