### PR TITLE
More permissive fix for #1099.

### DIFF
--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -152,14 +152,7 @@ public class Execution {
 
         CompletableFuture<ExecutionResult> result;
         try {
-            ExecutionStrategy executionStrategy;
-            if (operation == OperationDefinition.Operation.MUTATION) {
-                executionStrategy = executionContext.getMutationStrategy();
-            } else if (operation == SUBSCRIPTION) {
-                executionStrategy = executionContext.getSubscriptionStrategy();
-            } else {
-                executionStrategy = executionContext.getQueryStrategy();
-            }
+            ExecutionStrategy executionStrategy = executionContext.getStrategy(operation);
             if (logNotSafe.isDebugEnabled()) {
                 logNotSafe.debug("Executing '{}' query operation: '{}' using '{}' execution strategy", executionContext.getExecutionId(), operation, executionStrategy.getClass().getName());
             }

--- a/src/main/java/graphql/execution/ExecutionContext.java
+++ b/src/main/java/graphql/execution/ExecutionContext.java
@@ -239,9 +239,7 @@ public class ExecutionContext {
         return errors.get();
     }
 
-    public ExecutionStrategy getQueryStrategy() {
-        return queryStrategy;
-    }
+    public ExecutionStrategy getQueryStrategy() { return queryStrategy; }
 
     public ExecutionStrategy getMutationStrategy() {
         return mutationStrategy;
@@ -249,6 +247,16 @@ public class ExecutionContext {
 
     public ExecutionStrategy getSubscriptionStrategy() {
         return subscriptionStrategy;
+    }
+
+    public ExecutionStrategy getStrategy(OperationDefinition.Operation operation) {
+        if (operation == OperationDefinition.Operation.MUTATION) {
+            return getMutationStrategy();
+        } else if (operation == OperationDefinition.Operation.SUBSCRIPTION) {
+            return getSubscriptionStrategy();
+        } else {
+            return getQueryStrategy();
+        }
     }
 
     public Supplier<ExecutableNormalizedOperation> getNormalizedQueryTree() {

--- a/src/main/java/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentation.java
@@ -3,6 +3,7 @@ package graphql.execution.instrumentation.dataloader;
 import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.PublicApi;
+import graphql.execution.Async;
 import graphql.execution.AsyncExecutionStrategy;
 import graphql.execution.ExecutionContext;
 import graphql.execution.ExecutionStrategy;
@@ -110,16 +111,12 @@ public class DataLoaderDispatcherInstrumentation extends SimpleInstrumentation {
 
     private boolean isDataLoaderCompatibleExecution(ExecutionContext executionContext) {
         //
-        // currently we only support Query operations and ONLY with AsyncExecutionStrategy as the query ES
-        // This may change in the future but this is the fix for now
+        // Currently we only support aggressive batching for the AsyncExecutionStrategy.
+        // This may change in the future but this is the fix for now.
         //
-        if (executionContext.getOperationDefinition().getOperation() == OperationDefinition.Operation.QUERY) {
-            ExecutionStrategy queryStrategy = executionContext.getQueryStrategy();
-            if (queryStrategy instanceof AsyncExecutionStrategy) {
-                return true;
-            }
-        }
-        return false;
+        OperationDefinition.Operation operation = executionContext.getOperationDefinition().getOperation();
+        ExecutionStrategy strategy = executionContext.getStrategy(operation);
+        return (strategy instanceof AsyncExecutionStrategy);
     }
 
     @Override


### PR DESCRIPTION
- Related to: #1099
- Related to: #1102

This pull request proposes a more permissive fix for the bug observed in #1099.

The current fix, introduced in #1102, disables data loader batching on mutations altogether. While it works great when staying within the realms of specification compliance, it seems too restrictive: if mutations are configured to use `AsyncExecutionStrategy`, then I believe it shouldn't be an issue to allow data loader batching there too–as the `bug #1099 test mutation completes as expected and does not hang - running #note` test suggests.

For context, the reason I'm opening this PR is that my mutations become far too expensive to compute when batching is disabled; and while the ideal solution would be a core fix of #1099, I would be okay with trading spec. compliance for performance in the meantime by using the `AsyncExecutionStrategy` for mutations.