### PR TITLE
Fix interfaces implementing interfaces sub-type validation

### DIFF
--- a/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java
+++ b/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java
@@ -468,6 +468,21 @@ public class TypeDefinitionRegistry {
     }
 
     /**
+     * Returns true if the specified type exists in the registry and is an object type or interface
+     *
+     * @param type the type to check
+     * @return true if its an object type or interface
+     */
+    public boolean isObjectTypeOrInterface(Type type) {
+        Optional<TypeDefinition> typeDefinition = getType(type);
+        if (typeDefinition.isPresent()) {
+            TypeDefinition definition = typeDefinition.get();
+            return definition instanceof ObjectTypeDefinition || definition instanceof InterfaceTypeDefinition;
+        }
+        return false;
+    }
+
+    /**
      * Returns true if the specified type exists in the registry and is an object type
      *
      * @param type the type to check
@@ -543,21 +558,21 @@ public class TypeDefinitionRegistry {
     }
 
     /**
-     * Returns true of the abstract type is in implemented by the object or interface type
+     * Returns true of the abstract type is in implemented by the object type or interface
      *
-     * @param abstractType       the abstract type to check (interface or union)
-     * @param possibleObjectType the object type to check
-     * @return true if the object type implements the abstract type
+     * @param abstractType the abstract type to check (interface or union)
+     * @param possibleType the object type or interface to check
+     * @return true if the object type or interface implements the abstract type
      */
     @SuppressWarnings("ConstantConditions")
-    public boolean isPossibleType(Type abstractType, Type possibleObjectType) {
+    public boolean isPossibleType(Type abstractType, Type possibleType) {
         if (!isInterfaceOrUnion(abstractType)) {
             return false;
         }
-        if (!isObjectType(possibleObjectType)) {
+        if (!isObjectTypeOrInterface(possibleType)) {
             return false;
         }
-        ObjectTypeDefinition targetObjectTypeDef = getType(possibleObjectType, ObjectTypeDefinition.class).get();
+        TypeDefinition targetObjectTypeDef = getType(possibleType).get();
         TypeDefinition abstractTypeDef = getType(abstractType).get();
         if (abstractTypeDef instanceof UnionTypeDefinition) {
             List<Type> memberTypes = ((UnionTypeDefinition) abstractTypeDef).getMemberTypes();
@@ -572,8 +587,8 @@ public class TypeDefinitionRegistry {
             return false;
         } else {
             InterfaceTypeDefinition iFace = (InterfaceTypeDefinition) abstractTypeDef;
-            List<ImplementingTypeDefinition> objectTypeDefinitions = getAllImplementationsOf(iFace);
-            return objectTypeDefinitions.stream()
+            List<ImplementingTypeDefinition> implementingTypeDefinitions = getAllImplementationsOf(iFace);
+            return implementingTypeDefinitions.stream()
                     .anyMatch(od -> od.getName().equals(targetObjectTypeDef.getName()));
         }
     }
@@ -622,7 +637,7 @@ public class TypeDefinitionRegistry {
         // If superType type is an abstract type, maybeSubType type may be a currently
         // possible object type.
         if (isInterfaceOrUnion(superType) &&
-                isObjectType(maybeSubType) &&
+                isObjectTypeOrInterface(maybeSubType) &&
                 isPossibleType(superType, maybeSubType)) {
             return true;
         }

--- a/src/test/groovy/graphql/schema/idl/TypeDefinitionRegistryTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/TypeDefinitionRegistryTest.groovy
@@ -325,6 +325,18 @@ class TypeDefinitionRegistryTest extends Specification {
         !registry.isInterfaceOrUnion(type("Scalar"))
     }
 
+    def "test object type or interface detection"() {
+
+        when:
+        def registry = parse(commonSpec)
+
+        then:
+        registry.isObjectTypeOrInterface(type("Type"))
+        registry.isObjectTypeOrInterface(type("Interface"))
+        !registry.isObjectTypeOrInterface(type("Union"))
+        !registry.isObjectTypeOrInterface(type("Scalar"))
+    }
+
     def "test object type detection"() {
 
         when:
@@ -379,14 +391,22 @@ class TypeDefinitionRegistryTest extends Specification {
             type Type4 implements NotThatInterface {
                 name : String
             }
+
+            interface Type5 implements Interface {
+                name : String
+            }
+
+            interface Type6 implements NotThatInterface {
+                name : String
+            }
         '''
         when:
         def registry = parse(spec)
         def interfaceDef = registry.getType("Interface", InterfaceTypeDefinition.class).get()
-        def objectTypeDefinitions = registry.getAllImplementationsOf(interfaceDef)
-        def names = objectTypeDefinitions.collect { it.getName() }
+        def implementingTypeDefinitions = registry.getAllImplementationsOf(interfaceDef)
+        def names = implementingTypeDefinitions.collect { it.getName() }
         then:
-        names == ["Type1", "Type2", "Type3"]
+        names == ["Type1", "Type2", "Type3", "Type5"]
     }
 
     def animalia = '''
@@ -397,24 +417,36 @@ class TypeDefinitionRegistryTest extends Specification {
 
             interface Mammal {
               id: String!
+              mother: Mammal!
+              offspring: [Mammal!]!
             }
 
             interface Reptile {
               id: String!
             }
 
-            type Dog implements Animal & Mammal {
+            interface Canine implements Animal & Mammal {
+              id: String!
+              mother: Canine!
+              offspring: [Canine!]!
+            }
+
+            type Dog implements Animal & Mammal & Canine {
+              id: String!
+              mother: Dog!
+              offspring: [Dog!]!
+            }
+
+            type Duck implements Animal {
               id: String!
             }
 
-            type Duck implements Animal & Mammal {
-              id: String!
-            }
-            
             union Platypus = Duck | Turtle
 
             type Cat implements Animal & Mammal {
               id: String!
+              mother: Cat!
+              offspring: [Cat!]!
             }
 
             type Turtle implements Animal & Reptile {
@@ -429,6 +461,7 @@ class TypeDefinitionRegistryTest extends Specification {
         def registry = parse(animalia)
 
         then:
+        registry.isPossibleType(type("Mammal"), type("Canine"))
         registry.isPossibleType(type("Mammal"), type("Dog"))
         registry.isPossibleType(type("Mammal"), type("Cat"))
         !registry.isPossibleType(type("Mammal"), type("Turtle"))
@@ -437,6 +470,7 @@ class TypeDefinitionRegistryTest extends Specification {
         !registry.isPossibleType(type("Reptile"), type("Cat"))
         registry.isPossibleType(type("Reptile"), type("Turtle"))
 
+        registry.isPossibleType(type("Animal"), type("Canine"))
         registry.isPossibleType(type("Animal"), type("Dog"))
         registry.isPossibleType(type("Animal"), type("Cat"))
         registry.isPossibleType(type("Animal"), type("Turtle"))
@@ -455,7 +489,12 @@ class TypeDefinitionRegistryTest extends Specification {
 
         then:
         registry.isSubTypeOf(type("Mammal"), type("Mammal"))
+        registry.isSubTypeOf(type("Canine"), type("Animal"))
+        registry.isSubTypeOf(type("Canine"), type("Mammal"))
+        registry.isSubTypeOf(type("Canine"), type("Canine"))
+        registry.isSubTypeOf(type("Dog"), type("Animal"))
         registry.isSubTypeOf(type("Dog"), type("Mammal"))
+        registry.isSubTypeOf(type("Dog"), type("Canine"))
 
         registry.isSubTypeOf(type("Turtle"), type("Animal"))
         !registry.isSubTypeOf(type("Turtle"), type("Mammal"))
@@ -465,9 +504,12 @@ class TypeDefinitionRegistryTest extends Specification {
 
         registry.isSubTypeOf(listType("Mammal"), listType("Mammal"))
         !registry.isSubTypeOf(listType("Mammal"), type("Mammal")) // but not if they aren't both lists
+        registry.isSubTypeOf(listType("Canine"), listType("Mammal"))
+        registry.isSubTypeOf(listType("Canine"), listType("Animal"))
 
         // unwraps all the way down
         registry.isSubTypeOf(listType(nonNullType(listType(type("Dog")))), listType(nonNullType(listType(type("Mammal")))))
+        registry.isSubTypeOf(listType(nonNullType(listType(type("Canine")))), listType(nonNullType(listType(type("Mammal")))))
         !registry.isSubTypeOf(listType(nonNullType(listType(type("Turtle")))), listType(nonNullType(listType(type("Mammal")))))
 
     }


### PR DESCRIPTION
This commit fixes `TypeDefinitionRegistry.isPossibleType` and
`isSubType` to consider an _interface_ that implements another interface
as a sub-type of the implemented interface. Before this commit, only an
_object_ type implementing an interface was considered as a sub-type of
the implemented interface. So this small change brings the
implementation into full alignment with the below part of the spec:

```
IsValidImplementationFieldType(fieldType, implementedFieldType):
  ...
  5. If {fieldType} is an Object or Interface type and
     {implementedFieldType} is an Interface type and {fieldType}
     declares it implements {implementedFieldType} then return {true}.
  ...
```