### PR TITLE
allow printing of just directives

### DIFF
--- a/src/main/java/graphql/schema/idl/SchemaPrinter.java
+++ b/src/main/java/graphql/schema/idl/SchemaPrinter.java
@@ -938,6 +938,10 @@ public class SchemaPrinter {
         return sw.toString();
     }
 
+    public String print(GraphQLDirective graphQLDirective) {
+        return directiveDefinition(graphQLDirective);
+    }
+
     private void printType(PrintWriter out, List<GraphQLType> typesAsList, Class<?>
             typeClazz, GraphqlFieldVisibility visibility) {
         typesAsList.stream()

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -1892,4 +1892,19 @@ type MyQuery {
 """
     }
 
+    def "allow printing of just directives"() {
+        def sdl = """
+            directive @foo on FIELD_DEFINITION
+            type Query { anything: String @foo }
+        """
+        def schema = TestUtil.schema(sdl)
+        def directive = schema.getDirective("foo");
+
+        when:
+        def result = new SchemaPrinter(defaultOptions().includeDirectives(true)).print(directive)
+
+        then:
+        result == """directive @foo on FIELD_DEFINITION"""
+    }
+
 }


### PR DESCRIPTION
This allows for printing just a directive, which is not a `GraphQLType`

cc @skevy