### PR TITLE
Make TypeDefinitionRegistry serializable

### DIFF
--- a/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java
+++ b/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java
@@ -28,6 +28,7 @@ import graphql.schema.idl.errors.SchemaRedefinitionError;
 import graphql.schema.idl.errors.TypeRedefinitionError;
 import graphql.util.FpKit;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -47,7 +48,7 @@ import static java.util.Optional.ofNullable;
  * a graphql schema definition file via {@link SchemaParser#parse(String)}
  */
 @PublicApi
-public class TypeDefinitionRegistry {
+public class TypeDefinitionRegistry implements Serializable {
 
     private final Map<String, List<ObjectTypeExtensionDefinition>> objectTypeExtensions = new LinkedHashMap<>();
     private final Map<String, List<InterfaceTypeExtensionDefinition>> interfaceTypeExtensions = new LinkedHashMap<>();
@@ -418,7 +419,7 @@ public class TypeDefinitionRegistry {
         return types.containsKey(name) || ScalarInfo.GRAPHQL_SPECIFICATION_SCALARS_DEFINITIONS.containsKey(name) || scalarTypes.containsKey(name) || objectTypeExtensions.containsKey(name);
     }
 
-    public Optional<TypeDefinition> getType(Type type) {
+    public Optional<TypeDefinition>     getType(Type type) {
         String typeName = TypeInfo.typeInfo(type).getName();
         return getType(typeName);
     }

--- a/src/test/java/benchmark/BenchmarkUtils.java
+++ b/src/test/java/benchmark/BenchmarkUtils.java
@@ -1,0 +1,28 @@
+package benchmark;
+
+import com.google.common.io.Files;
+
+import java.io.File;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.util.concurrent.Callable;
+
+public class BenchmarkUtils {
+
+    static String loadResource(String name) {
+        return asRTE(() -> {
+            URL resource = BenchmarkUtils.class.getClassLoader().getResource(name);
+            return String.join("\n", Files.readLines(new File(resource.toURI()), Charset.defaultCharset()));
+
+        });
+    }
+
+    static <T> T asRTE(Callable<T> callable) {
+        try {
+            return callable.call();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/test/java/benchmark/TypeDefinitionParserVersusSerializeBenchMark.java
+++ b/src/test/java/benchmark/TypeDefinitionParserVersusSerializeBenchMark.java
@@ -1,0 +1,75 @@
+package benchmark;
+
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.TypeDefinitionRegistry;
+import org.jetbrains.annotations.NotNull;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.concurrent.TimeUnit;
+
+import static benchmark.BenchmarkUtils.asRTE;
+
+/**
+ * This benchmarks {@link graphql.schema.idl.TypeDefinitionRegistry} parsing and serialisation
+ * <p>
+ * See https://github.com/openjdk/jmh/tree/master/jmh-samples/src/main/java/org/openjdk/jmh/samples/ for more samples
+ * on what you can do with JMH
+ * <p>
+ * You MUST have the JMH plugin for IDEA in place for this to work :  https://github.com/artyushov/idea-jmh-plugin
+ * <p>
+ * Install it and then just hit "Run" on a certain benchmark method
+ */
+@Warmup(iterations = 2, time = 5, batchSize = 3)
+@Measurement(iterations = 3, time = 10, batchSize = 4)
+public class TypeDefinitionParserVersusSerializeBenchMark {
+
+    static SchemaParser schemaParser = new SchemaParser();
+    static String SDL = BenchmarkUtils.loadResource("large-schema-2.graphqls");
+    static TypeDefinitionRegistry registryOut = schemaParser.parse(SDL);
+    static ByteArrayOutputStream baOS = serialisedRegistryStream(registryOut);
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public void benchMarkParsing(Blackhole blackhole) {
+        blackhole.consume(schemaParser.parse(SDL));
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public void benchMarkSerializing(Blackhole blackhole) {
+        blackhole.consume(serialise());
+    }
+
+    static TypeDefinitionRegistry serialise() {
+        return asRTE(() -> {
+
+            ByteArrayInputStream baIS = new ByteArrayInputStream(baOS.toByteArray());
+            ObjectInputStream ois = new ObjectInputStream(baIS);
+
+            return (TypeDefinitionRegistry) ois.readObject();
+        });
+    }
+
+    @NotNull
+    private static ByteArrayOutputStream serialisedRegistryStream(TypeDefinitionRegistry registryOut) {
+        return asRTE(() -> {
+            ByteArrayOutputStream baOS = new ByteArrayOutputStream();
+            ObjectOutputStream oos = new ObjectOutputStream(baOS);
+
+            oos.writeObject(registryOut);
+            return baOS;
+        });
+    }
+}


### PR DESCRIPTION
This would allow a "parsed" SDL file to be put into an external cache say.

All of the AST nodes are serializable - why not the parsed container of them?  Hence this PR.

However in practice is not that much faster than parsing really.  So caching the SDL String and reparsing might be in the same ballpark and  a String is a simpler contsruct to cache

The benchmark shows that serialization is faster - YMMV

```
Benchmark                                                                                                    Mode  Cnt   Score   Error  Units
TypeDefinitionParserVersusSerializeBenchMark.benchMarkParsing      thrpt   15  16.590 ± 0.320  ops/s
TypeDefinitionParserVersusSerializeBenchMark.benchMarkSerializing  thrpt   15  20.066 ± 0.458  ops/s
```


In a low CPU constrained environment, like Serverless, this might be a faster way to pre-compute part of the schema build process.

See https://github.com/graphql-java/graphql-java/discussions/2452
