### PR TITLE
Performance improvement - Track  whether SchemaDirectiveWiring is required

### DIFF
--- a/src/main/java/graphql/schema/idl/FetchSchemaDirectiveWiring.java
+++ b/src/main/java/graphql/schema/idl/FetchSchemaDirectiveWiring.java
@@ -16,10 +16,13 @@ import static graphql.schema.FieldCoordinates.coordinates;
 
 /**
  * This adds ' @fetch(from : "otherName") ' support so you can rename what property is read for a given field
+ *
+ * @deprecated This support introduces a non standard directive and has interfere with some implementations.  This is no longer
+ * installed default and will be removed in a future version
  */
 @Internal
+@Deprecated
 public class FetchSchemaDirectiveWiring implements SchemaDirectiveWiring {
-
     public static final String FETCH = "fetch";
 
     @Override

--- a/src/main/java/graphql/schema/idl/RuntimeWiring.java
+++ b/src/main/java/graphql/schema/idl/RuntimeWiring.java
@@ -138,8 +138,6 @@ public class RuntimeWiring {
 
         private Builder() {
             ScalarInfo.GRAPHQL_SPECIFICATION_SCALARS.forEach(this::scalar);
-            // we give this out by default
-            registeredDirectiveWiring.put(FetchSchemaDirectiveWiring.FETCH, new FetchSchemaDirectiveWiring());
         }
 
         /**

--- a/src/main/java/graphql/schema/idl/SchemaGenerator.java
+++ b/src/main/java/graphql/schema/idl/SchemaGenerator.java
@@ -115,10 +115,18 @@ public class SchemaGenerator {
         GraphQLSchema graphQLSchema = schemaBuilder.build();
 
         List<SchemaGeneratorPostProcessing> schemaTransformers = new ArrayList<>();
-        // handle directive wiring AFTER the schema has been built and hence type references are resolved at callback time
-        schemaTransformers.add(
-                new SchemaDirectiveWiringSchemaGeneratorPostProcessing(buildCtx.getTypeRegistry(), buildCtx.getWiring(), buildCtx.getCodeRegistry())
-        );
+        // we check if there are any SchemaDirectiveWiring's in play and if there are
+        // we add this to enable them.  By not adding it always, we save unnecessary
+        // schema build traversals
+        if (buildCtx.isDirectiveWiringRequired()) {
+            // handle directive wiring AFTER the schema has been built and hence type references are resolved at callback time
+            schemaTransformers.add(
+                    new SchemaDirectiveWiringSchemaGeneratorPostProcessing(
+                            buildCtx.getTypeRegistry(),
+                            buildCtx.getWiring(),
+                            buildCtx.getCodeRegistry())
+            );
+        }
         schemaTransformers.addAll(buildCtx.getWiring().getSchemaGeneratorPostProcessings());
 
         for (SchemaGeneratorPostProcessing postProcessing : schemaTransformers) {

--- a/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
+++ b/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
@@ -38,6 +38,7 @@ import graphql.schema.FieldCoordinates;
 import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLCodeRegistry;
 import graphql.schema.GraphQLDirective;
+import graphql.schema.GraphQLDirectiveContainer;
 import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLEnumValueDefinition;
 import graphql.schema.GraphQLFieldDefinition;
@@ -116,6 +117,7 @@ public class SchemaGeneratorHelper {
         private final GraphQLCodeRegistry.Builder codeRegistry;
         public final Map<String, OperationTypeDefinition> operationTypeDefs;
         public final SchemaGenerator.Options options;
+        public boolean directiveWiringRequired;
 
         BuildContext(TypeDefinitionRegistry typeRegistry, RuntimeWiring wiring, Map<String, OperationTypeDefinition> operationTypeDefinitions, SchemaGenerator.Options options) {
             this.typeRegistry = typeRegistry;
@@ -123,6 +125,11 @@ public class SchemaGeneratorHelper {
             this.codeRegistry = GraphQLCodeRegistry.newCodeRegistry(wiring.getCodeRegistry());
             this.operationTypeDefs = operationTypeDefinitions;
             this.options = options;
+            directiveWiringRequired = false;
+        }
+
+        public boolean isDirectiveWiringRequired() {
+            return directiveWiringRequired;
         }
 
         public TypeDefinitionRegistry getTypeRegistry() {
@@ -428,7 +435,7 @@ public class SchemaGeneratorHelper {
             }
         }));
 
-        return builder.build();
+        return directivesObserve(buildCtx,builder.build());
     }
 
     private GraphQLInputObjectField buildInputField(BuildContext buildCtx, InputValueDefinition fieldDef) {
@@ -457,7 +464,7 @@ public class SchemaGeneratorHelper {
                         buildCtx.getComparatorRegistry())
         );
 
-        return fieldBuilder.build();
+        return directivesObserve(buildCtx,fieldBuilder.build());
     }
 
     GraphQLEnumType buildEnumType(BuildContext buildCtx, EnumTypeDefinition typeDefinition) {
@@ -492,7 +499,7 @@ public class SchemaGeneratorHelper {
                         buildCtx.getComparatorRegistry())
         );
 
-        return builder.build();
+        return directivesObserve(buildCtx, builder.build());
     }
 
     private GraphQLEnumValueDefinition buildEnumValue(BuildContext buildCtx,
@@ -510,7 +517,7 @@ public class SchemaGeneratorHelper {
         } else {
             value = evd.getName();
         }
-        return newEnumValueDefinition()
+        GraphQLEnumValueDefinition enumValueDefinition = newEnumValueDefinition()
                 .name(evd.getName())
                 .value(value)
                 .description(description)
@@ -526,6 +533,7 @@ public class SchemaGeneratorHelper {
                                 buildCtx.getComparatorRegistry())
                 )
                 .build();
+        return directivesObserve(buildCtx,enumValueDefinition);
     }
 
     GraphQLScalarType buildScalar(BuildContext buildCtx, ScalarTypeDefinition typeDefinition) {
@@ -559,7 +567,7 @@ public class SchemaGeneratorHelper {
                             buildCtx.getComparatorRegistry())
                     ));
         }
-        return scalar;
+        return directivesObserve(buildCtx,scalar);
     }
 
     private String getScalarDesc(GraphQLScalarType scalar, ScalarTypeDefinition typeDefinition) {
@@ -726,7 +734,7 @@ public class SchemaGeneratorHelper {
             TypeResolver typeResolver = getTypeResolverForInterface(buildCtx, typeDefinition);
             buildCtx.getCodeRegistry().typeResolver(interfaceType, typeResolver);
         }
-        return interfaceType;
+        return directivesObserve(buildCtx,interfaceType);
     }
 
     GraphQLObjectType buildObjectType(BuildContext buildCtx, ObjectTypeDefinition typeDefinition) {
@@ -761,7 +769,7 @@ public class SchemaGeneratorHelper {
 
         buildObjectTypeInterfaces(buildCtx, typeDefinition, builder, extensions);
 
-        return builder.build();
+        return directivesObserve(buildCtx,builder.build());
     }
 
     private void buildObjectTypeInterfaces(BuildContext buildCtx,
@@ -837,7 +845,7 @@ public class SchemaGeneratorHelper {
             TypeResolver typeResolver = getTypeResolverForUnion(buildCtx, typeDefinition);
             buildCtx.getCodeRegistry().typeResolver(unionType, typeResolver);
         }
-        return unionType;
+        return directivesObserve(buildCtx,unionType);
     }
 
     /**
@@ -918,7 +926,7 @@ public class SchemaGeneratorHelper {
             DataFetcherFactory dataFetcherFactory = buildDataFetcherFactory(buildCtx, parentType, fieldDef, fieldType, Arrays.asList(directives));
             buildCtx.getCodeRegistry().dataFetcher(coordinates, dataFetcherFactory);
         }
-        return fieldDefinition;
+        return directivesObserve(buildCtx,fieldDefinition);
     }
 
     private DataFetcherFactory buildDataFetcherFactory(BuildContext buildCtx,
@@ -986,7 +994,7 @@ public class SchemaGeneratorHelper {
                         buildCtx.getComparatorRegistry())
         );
 
-        return builder.build();
+        return directivesObserve(buildCtx,builder.build());
     }
 
     void buildOperations(BuildContext buildCtx, GraphQLSchema.Builder schemaBuilder) {
@@ -1181,4 +1189,13 @@ public class SchemaGeneratorHelper {
                 .map(TypeDefinition::getDirectives).filter(Objects::nonNull)
                 .<Directive>flatMap(List::stream).collect(Collectors.toList());
     }
+
+    private <T extends GraphQLDirectiveContainer> T directivesObserve(BuildContext buildCtx, T directiveContainer) {
+        if (! buildCtx.directiveWiringRequired) {
+            boolean requiresWiring = SchemaGeneratorDirectiveHelper.schemaDirectiveWiringIsRequired(directiveContainer, buildCtx.getTypeRegistry(), buildCtx.getWiring());
+            buildCtx.directiveWiringRequired = buildCtx.directiveWiringRequired | requiresWiring;
+        }
+        return directiveContainer;
+    }
+
 }

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorDirectiveHelperTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorDirectiveHelperTest.groovy
@@ -50,7 +50,7 @@ class SchemaGeneratorDirectiveHelperTest extends Specification {
             return input
         }
     })
-    .build()
+            .build()
 
     def assertCallHierarchy(elementHierarchy, astHierarchy, String name, List<String> l) {
         assert elementHierarchy[name] == l, "unexpected elementHierarchy"
@@ -924,26 +924,50 @@ class SchemaGeneratorDirectiveHelperTest extends Specification {
             }
         }
 
+        def wiringFactory = new WiringFactory() {
+            @Override
+            boolean providesSchemaDirectiveWiring(SchemaDirectiveWiringEnvironment environment) {
+                true
+            }
+
+            @Override
+            SchemaDirectiveWiring getSchemaDirectiveWiring(SchemaDirectiveWiringEnvironment environment) {
+                return generalWiring
+            }
+        }
+
+        when: "Its via a hard coded wiring"
         def runtimeWiring = RuntimeWiring.newRuntimeWiring()
                 .directiveWiring(generalWiring)
                 .build()
-
-        when:
-        def schema = schema(sdl, runtimeWiring)
+        def graphqlSchema = schema(sdl, runtimeWiring)
 
         then:
+        assert directiveWiringAsserts(graphqlSchema)
+
+        when: "It via a wiring factory"
+        runtimeWiring = RuntimeWiring.newRuntimeWiring()
+                .wiringFactory(wiringFactory)
+                .build()
+        graphqlSchema = schema(sdl, runtimeWiring)
+
+        then:
+        assert directiveWiringAsserts(graphqlSchema)
+    }
+
+    static def directiveWiringAsserts(schema) {
         def queryType = schema.getObjectType("yreuQ")
-        queryType != null
+        assert queryType != null
 
         def fld = queryType.getFieldDefinition("dleif")
-        fld != null
+        assert fld != null
 
         def arg = fld.getArgument("gra")
-        arg != null
+        assert arg != null
+        true
     }
 
-    def reverse(String s) {
+    static def reverse(String s) {
         new StringBuilder(s).reverse().toString()
     }
-
 }

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -1804,7 +1804,7 @@ class SchemaGeneratorTest extends Specification {
 
     }
 
-    def "@fetch directive is respected"() {
+    def "@fetch directive is respected if added"() {
         def spec = """             
 
             directive @fetch(from : String!) on FIELD_DEFINITION
@@ -1815,7 +1815,7 @@ class SchemaGeneratorTest extends Specification {
             }
         """
 
-        def wiring = RuntimeWiring.newRuntimeWiring().build()
+        def wiring = RuntimeWiring.newRuntimeWiring().directiveWiring(new FetchSchemaDirectiveWiring()).build()
         def schema = schema(spec, wiring)
 
         GraphQLObjectType type = schema.getType("Query") as GraphQLObjectType

--- a/src/test/groovy/graphql/schema/idl/WiringFactoryTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/WiringFactoryTest.groovy
@@ -74,7 +74,7 @@ class WiringFactoryTest extends Specification {
                     throw new UnsupportedOperationException("Not implemented")
                 }
             })
-            .build()
+                    .build()
         }
 
         @Override
@@ -305,7 +305,7 @@ class WiringFactoryTest extends Specification {
         wiringFactory.fields == ["id", "homePlanet"]
     }
 
-    def "@fetch directive is respected by default data fetcher wiring"() {
+    def "@fetch directive is respected by default data fetcher wiring if added"() {
         def spec = """
 
             directive @fetch(from : String!) on FIELD_DEFINITION              
@@ -320,6 +320,7 @@ class WiringFactoryTest extends Specification {
         }
         def wiring = RuntimeWiring.newRuntimeWiring()
                 .wiringFactory(wiringFactory)
+                .directiveWiring(new FetchSchemaDirectiveWiring())
                 .build()
 
         def schema = TestUtil.schema(spec, wiring)


### PR DESCRIPTION
This tracks whether SchemaDirectiveWiring is required and hence allows us to short cut things if not

It also removes FetchSchemaDirectiveWiring.java from automatically being used - its now deprecated and will be removed at a future date

This is therefore a breaking runtime change for those who rely in `@fetch` but we don't think anyone really does