### PR TITLE
CodeRegistry can be used to provide the default data fetcher as intended

### DIFF
--- a/src/main/java/graphql/schema/DataFetcherFactoryEnvironment.java
+++ b/src/main/java/graphql/schema/DataFetcherFactoryEnvironment.java
@@ -25,7 +25,7 @@ public class DataFetcherFactoryEnvironment {
         return new Builder();
     }
 
-    static class Builder {
+    public static class Builder {
         GraphQLFieldDefinition fieldDefinition;
 
         public Builder fieldDefinition(GraphQLFieldDefinition fieldDefinition) {

--- a/src/main/java/graphql/schema/GraphQLCodeRegistry.java
+++ b/src/main/java/graphql/schema/GraphQLCodeRegistry.java
@@ -227,6 +227,13 @@ public class GraphQLCodeRegistry {
         }
 
         /**
+         * @return the default data fetcher facttory associated with this code registry
+         */
+        public DataFetcherFactory<?> getDefaultDataFetcherFactory() {
+            return defaultDataFetcherFactory;
+        }
+
+        /**
          * Returns true if the code registry contained a data fetcher at the specified co-ordinates
          *
          * @param coordinates the field coordinates

--- a/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
+++ b/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
@@ -915,22 +915,23 @@ public class SchemaGeneratorHelper {
         // if they have already wired in a fetcher - then leave it alone
         FieldCoordinates coordinates = FieldCoordinates.coordinates(parentType.getName(), fieldDefinition.getName());
         if (!buildCtx.getCodeRegistry().hasDataFetcher(coordinates)) {
-            DataFetcherFactory dataFetcherFactory = buildDataFetcherFactory(buildCtx, parentType, fieldDef, fieldType, Arrays.asList(directives));
+            DataFetcherFactory<?> dataFetcherFactory = buildDataFetcherFactory(buildCtx, parentType, fieldDef, fieldType, Arrays.asList(directives));
             buildCtx.getCodeRegistry().dataFetcher(coordinates, dataFetcherFactory);
         }
         return fieldDefinition;
     }
 
-    private DataFetcherFactory buildDataFetcherFactory(BuildContext buildCtx,
-                                                       TypeDefinition parentType,
-                                                       FieldDefinition fieldDef,
-                                                       GraphQLOutputType fieldType,
-                                                       List<GraphQLDirective> directives) {
+    private DataFetcherFactory<?> buildDataFetcherFactory(BuildContext buildCtx,
+                                                          TypeDefinition<?> parentType,
+                                                          FieldDefinition fieldDef,
+                                                          GraphQLOutputType fieldType,
+                                                          List<GraphQLDirective> directives) {
         String fieldName = fieldDef.getName();
         String parentTypeName = parentType.getName();
         TypeDefinitionRegistry typeRegistry = buildCtx.getTypeRegistry();
         RuntimeWiring runtimeWiring = buildCtx.getWiring();
         WiringFactory wiringFactory = runtimeWiring.getWiringFactory();
+        GraphQLCodeRegistry.Builder codeRegistry = buildCtx.getCodeRegistry();
 
         FieldWiringEnvironment wiringEnvironment = new FieldWiringEnvironment(typeRegistry, parentType, fieldDef, fieldType, directives);
 
@@ -952,6 +953,10 @@ public class SchemaGeneratorHelper {
                     if (dataFetcher == null) {
                         dataFetcher = wiringFactory.getDefaultDataFetcher(wiringEnvironment);
                         if (dataFetcher == null) {
+                            DataFetcherFactory<?> codeRegistryDDF = codeRegistry.getDefaultDataFetcherFactory();
+                            if (codeRegistryDDF != null) {
+                                return codeRegistryDDF;
+                            }
                             dataFetcher = dataFetcherOfLastResort(wiringEnvironment);
                         }
                     }

--- a/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
+++ b/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
@@ -953,9 +953,9 @@ public class SchemaGeneratorHelper {
                     if (dataFetcher == null) {
                         dataFetcher = wiringFactory.getDefaultDataFetcher(wiringEnvironment);
                         if (dataFetcher == null) {
-                            DataFetcherFactory<?> codeRegistryDDF = codeRegistry.getDefaultDataFetcherFactory();
-                            if (codeRegistryDDF != null) {
-                                return codeRegistryDDF;
+                            DataFetcherFactory<?> codeRegistryDFF = codeRegistry.getDefaultDataFetcherFactory();
+                            if (codeRegistryDFF != null) {
+                                return codeRegistryDFF;
                             }
                             dataFetcher = dataFetcherOfLastResort(wiringEnvironment);
                         }


### PR DESCRIPTION
The code registry was always meant to be a place of data fetching defaults but this was missed in schema generation

See https://github.com/graphql-java/graphql-java/issues/2282