### PR TITLE
Initial work on Traversal Improvements in GraphqlSchema builds

### DIFF
--- a/src/main/java/graphql/schema/CodeRegistryVisitor.java
+++ b/src/main/java/graphql/schema/CodeRegistryVisitor.java
@@ -1,6 +1,17 @@
 package graphql.schema;
 
 import graphql.Internal;
+import graphql.introspection.Introspection;
+import graphql.schema.DataFetcher;
+import graphql.schema.FieldCoordinates;
+import graphql.schema.GraphQLCodeRegistry;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLFieldsContainer;
+import graphql.schema.GraphQLInterfaceType;
+import graphql.schema.GraphQLSchemaElement;
+import graphql.schema.GraphQLTypeVisitorStub;
+import graphql.schema.GraphQLUnionType;
+import graphql.schema.TypeResolver;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
@@ -12,11 +23,12 @@ import static graphql.util.TraversalControl.CONTINUE;
  * This ensure that all fields have data fetchers and that unions and interfaces have type resolvers
  */
 @Internal
-class CodeRegistryVisitor extends GraphQLTypeVisitorStub {
+public class CodeRegistryVisitor extends GraphQLTypeVisitorStub {
     private final GraphQLCodeRegistry.Builder codeRegistry;
 
-    CodeRegistryVisitor(GraphQLCodeRegistry.Builder codeRegistry) {
+    public CodeRegistryVisitor(GraphQLCodeRegistry.Builder codeRegistry) {
         this.codeRegistry = codeRegistry;
+        Introspection.addCodeForIntrospectionTypes(codeRegistry);
     }
 
     @Override
@@ -27,7 +39,7 @@ class CodeRegistryVisitor extends GraphQLTypeVisitorStub {
             FieldCoordinates coordinates = coordinates(parentContainerType, node);
             codeRegistry.dataFetcherIfAbsent(coordinates, dataFetcher);
         }
-        
+
         return CONTINUE;
     }
 
@@ -38,7 +50,7 @@ class CodeRegistryVisitor extends GraphQLTypeVisitorStub {
             codeRegistry.typeResolverIfAbsent(node, typeResolver);
         }
         assertTrue(codeRegistry.getTypeResolver(node) != null,
-                () -> String.format("You MUST provide a type resolver for the interface type '%s'",node.getName()));
+                () -> String.format("You MUST provide a type resolver for the interface type '%s'", node.getName()));
         return CONTINUE;
     }
 

--- a/src/main/java/graphql/schema/SchemaTransformer.java
+++ b/src/main/java/graphql/schema/SchemaTransformer.java
@@ -26,7 +26,7 @@ import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertShouldNeverHappen;
 import static graphql.schema.GraphQLSchemaElementAdapter.SCHEMA_ELEMENT_ADAPTER;
 import static graphql.schema.SchemaElementChildrenContainer.newSchemaElementChildrenContainer;
-import static graphql.schema.StronglyConnectedComponentsTopologicallySorted.getStronglyConnectedComponentsTopologicallySorted;
+import static graphql.schema.impl.StronglyConnectedComponentsTopologicallySorted.getStronglyConnectedComponentsTopologicallySorted;
 import static graphql.util.NodeZipper.ModificationType.REPLACE;
 import static graphql.util.TraversalControl.CONTINUE;
 import static java.lang.String.format;

--- a/src/main/java/graphql/schema/SchemaTransformer.java
+++ b/src/main/java/graphql/schema/SchemaTransformer.java
@@ -26,7 +26,6 @@ import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertShouldNeverHappen;
 import static graphql.schema.GraphQLSchemaElementAdapter.SCHEMA_ELEMENT_ADAPTER;
 import static graphql.schema.SchemaElementChildrenContainer.newSchemaElementChildrenContainer;
-import static graphql.schema.StronglyConnectedComponentsTopologicallySorted.getStronglyConnectedComponentsTopologicallySorted;
 import static graphql.util.NodeZipper.ModificationType.DELETE;
 import static graphql.schema.impl.StronglyConnectedComponentsTopologicallySorted.getStronglyConnectedComponentsTopologicallySorted;
 import static graphql.util.NodeZipper.ModificationType.REPLACE;
@@ -545,7 +544,7 @@ public class SchemaTransformer {
                     .withSchemaDirectives(this.schemaDirectives)
                     .codeRegistry(codeRegistry.build())
                     .description(schema.getDescription())
-                    .buildImpl(true);
+                    .build();
         }
     }
 }

--- a/src/main/java/graphql/schema/impl/GraphQLTypeCollectingVisitor.java
+++ b/src/main/java/graphql/schema/impl/GraphQLTypeCollectingVisitor.java
@@ -1,12 +1,26 @@
-package graphql.schema;
+package graphql.schema.impl;
 
+import com.google.common.collect.ImmutableMap;
 import graphql.AssertException;
 import graphql.Internal;
+import graphql.schema.GraphQLEnumType;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLInputObjectType;
+import graphql.schema.GraphQLInterfaceType;
+import graphql.schema.GraphQLNamedType;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLScalarType;
+import graphql.schema.GraphQLSchemaElement;
+import graphql.schema.GraphQLType;
+import graphql.schema.GraphQLTypeReference;
+import graphql.schema.GraphQLTypeVisitorStub;
+import graphql.schema.GraphQLUnionType;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 import static java.lang.String.format;
 
@@ -109,7 +123,7 @@ public class GraphQLTypeCollectingVisitor extends GraphQLTypeVisitorStub {
         }
     }
 
-    public Map<String, GraphQLNamedType> getResult() {
-        return result;
+    public ImmutableMap<String, GraphQLNamedType> getResult() {
+        return ImmutableMap.copyOf(new TreeMap<>(result));
     }
 }

--- a/src/main/java/graphql/schema/impl/MultiReadOnlyGraphQLTypeVisitor.java
+++ b/src/main/java/graphql/schema/impl/MultiReadOnlyGraphQLTypeVisitor.java
@@ -1,6 +1,7 @@
 package graphql.schema.impl;
 
 import graphql.Assert;
+import graphql.Internal;
 import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLCompositeType;
 import graphql.schema.GraphQLDirective;
@@ -31,6 +32,11 @@ import graphql.util.TraverserContext;
 
 import java.util.List;
 
+/**
+ * A delegating type visitor that allows you to call N visitors in a list
+ * and always continues via {@link TraversalControl#CONTINUE}
+ */
+@Internal
 public class MultiReadOnlyGraphQLTypeVisitor implements GraphQLTypeVisitor {
 
     private final List<GraphQLTypeVisitor> visitors;

--- a/src/main/java/graphql/schema/impl/MultiReadOnlyGraphQLTypeVisitor.java
+++ b/src/main/java/graphql/schema/impl/MultiReadOnlyGraphQLTypeVisitor.java
@@ -1,0 +1,205 @@
+package graphql.schema.impl;
+
+import graphql.Assert;
+import graphql.schema.GraphQLArgument;
+import graphql.schema.GraphQLCompositeType;
+import graphql.schema.GraphQLDirective;
+import graphql.schema.GraphQLDirectiveContainer;
+import graphql.schema.GraphQLEnumType;
+import graphql.schema.GraphQLEnumValueDefinition;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLFieldsContainer;
+import graphql.schema.GraphQLInputFieldsContainer;
+import graphql.schema.GraphQLInputObjectField;
+import graphql.schema.GraphQLInputObjectType;
+import graphql.schema.GraphQLInputType;
+import graphql.schema.GraphQLInterfaceType;
+import graphql.schema.GraphQLList;
+import graphql.schema.GraphQLModifiedType;
+import graphql.schema.GraphQLNonNull;
+import graphql.schema.GraphQLNullableType;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLOutputType;
+import graphql.schema.GraphQLScalarType;
+import graphql.schema.GraphQLSchemaElement;
+import graphql.schema.GraphQLTypeReference;
+import graphql.schema.GraphQLTypeVisitor;
+import graphql.schema.GraphQLUnionType;
+import graphql.schema.GraphQLUnmodifiedType;
+import graphql.util.TraversalControl;
+import graphql.util.TraverserContext;
+
+import java.util.List;
+
+public class MultiReadOnlyGraphQLTypeVisitor implements GraphQLTypeVisitor {
+
+    private final List<GraphQLTypeVisitor> visitors;
+
+    public MultiReadOnlyGraphQLTypeVisitor(List<GraphQLTypeVisitor> visitors) {
+        this.visitors = visitors;
+    }
+
+    @Override
+    public TraversalControl visitGraphQLArgument(GraphQLArgument node, TraverserContext<GraphQLSchemaElement> context) {
+        visitors.forEach(v -> v.visitGraphQLArgument(node, context));
+        return TraversalControl.CONTINUE;
+    }
+
+    @Override
+    public TraversalControl visitGraphQLInterfaceType(GraphQLInterfaceType node, TraverserContext<GraphQLSchemaElement> context) {
+        visitors.forEach(v -> v.visitGraphQLInterfaceType(node, context));
+        return TraversalControl.CONTINUE;
+    }
+
+    @Override
+    public TraversalControl visitGraphQLEnumType(GraphQLEnumType node, TraverserContext<GraphQLSchemaElement> context) {
+        visitors.forEach(v -> v.visitGraphQLEnumType(node, context));
+        return TraversalControl.CONTINUE;
+    }
+
+    @Override
+    public TraversalControl visitGraphQLEnumValueDefinition(GraphQLEnumValueDefinition node, TraverserContext<GraphQLSchemaElement> context) {
+        visitors.forEach(v -> v.visitGraphQLEnumValueDefinition(node, context));
+        return TraversalControl.CONTINUE;
+    }
+
+    @Override
+    public TraversalControl visitGraphQLFieldDefinition(GraphQLFieldDefinition node, TraverserContext<GraphQLSchemaElement> context) {
+        visitors.forEach(v -> v.visitGraphQLFieldDefinition(node, context));
+        return TraversalControl.CONTINUE;
+    }
+
+    @Override
+    public TraversalControl visitGraphQLDirective(GraphQLDirective node, TraverserContext<GraphQLSchemaElement> context) {
+        visitors.forEach(v -> v.visitGraphQLDirective(node, context));
+        return TraversalControl.CONTINUE;
+    }
+
+    @Override
+    public TraversalControl visitGraphQLInputObjectField(GraphQLInputObjectField node, TraverserContext<GraphQLSchemaElement> context) {
+        visitors.forEach(v -> v.visitGraphQLInputObjectField(node, context));
+        return TraversalControl.CONTINUE;
+    }
+
+    @Override
+    public TraversalControl visitGraphQLInputObjectType(GraphQLInputObjectType node, TraverserContext<GraphQLSchemaElement> context) {
+        visitors.forEach(v -> v.visitGraphQLInputObjectType(node, context));
+        return TraversalControl.CONTINUE;
+    }
+
+    @Override
+    public TraversalControl visitGraphQLList(GraphQLList node, TraverserContext<GraphQLSchemaElement> context) {
+        visitors.forEach(v -> v.visitGraphQLList(node, context));
+        return TraversalControl.CONTINUE;
+    }
+
+    @Override
+    public TraversalControl visitGraphQLNonNull(GraphQLNonNull node, TraverserContext<GraphQLSchemaElement> context) {
+        visitors.forEach(v -> v.visitGraphQLNonNull(node, context));
+        return TraversalControl.CONTINUE;
+    }
+
+    @Override
+    public TraversalControl visitGraphQLObjectType(GraphQLObjectType node, TraverserContext<GraphQLSchemaElement> context) {
+        visitors.forEach(v -> v.visitGraphQLObjectType(node, context));
+        return TraversalControl.CONTINUE;
+    }
+
+    @Override
+    public TraversalControl visitGraphQLScalarType(GraphQLScalarType node, TraverserContext<GraphQLSchemaElement> context) {
+        visitors.forEach(v -> v.visitGraphQLScalarType(node, context));
+        return TraversalControl.CONTINUE;
+    }
+
+    @Override
+    public TraversalControl visitGraphQLTypeReference(GraphQLTypeReference node, TraverserContext<GraphQLSchemaElement> context) {
+        visitors.forEach(v -> v.visitGraphQLTypeReference(node, context));
+        return TraversalControl.CONTINUE;
+    }
+
+    @Override
+    public TraversalControl visitGraphQLUnionType(GraphQLUnionType node, TraverserContext<GraphQLSchemaElement> context) {
+        visitors.forEach(v -> v.visitGraphQLUnionType(node, context));
+        return TraversalControl.CONTINUE;
+    }
+
+    @Override
+    public TraversalControl visitBackRef(TraverserContext<GraphQLSchemaElement> context) {
+        visitors.forEach(v -> v.visitBackRef(context));
+        return TraversalControl.CONTINUE;
+    }
+
+    @Override
+    public TraversalControl visitGraphQLModifiedType(GraphQLModifiedType node, TraverserContext<GraphQLSchemaElement> context) {
+        visitors.forEach(v -> v.visitGraphQLModifiedType(node, context));
+        return TraversalControl.CONTINUE;
+    }
+
+    @Override
+    public TraversalControl visitGraphQLCompositeType(GraphQLCompositeType node, TraverserContext<GraphQLSchemaElement> context) {
+        visitors.forEach(v -> v.visitGraphQLCompositeType(node, context));
+        return TraversalControl.CONTINUE;
+    }
+
+    @Override
+    public TraversalControl visitGraphQLDirectiveContainer(GraphQLDirectiveContainer node, TraverserContext<GraphQLSchemaElement> context) {
+        visitors.forEach(v -> v.visitGraphQLDirectiveContainer(node, context));
+        return TraversalControl.CONTINUE;
+    }
+
+    @Override
+    public TraversalControl visitGraphQLFieldsContainer(GraphQLFieldsContainer node, TraverserContext<GraphQLSchemaElement> context) {
+        visitors.forEach(v -> v.visitGraphQLFieldsContainer(node, context));
+        return TraversalControl.CONTINUE;
+    }
+
+    @Override
+    public TraversalControl visitGraphQLInputFieldsContainer(GraphQLInputFieldsContainer node, TraverserContext<GraphQLSchemaElement> context) {
+        visitors.forEach(v -> v.visitGraphQLInputFieldsContainer(node, context));
+        return TraversalControl.CONTINUE;
+    }
+
+    @Override
+    public TraversalControl visitGraphQLInputType(GraphQLInputType node, TraverserContext<GraphQLSchemaElement> context) {
+        visitors.forEach(v -> v.visitGraphQLInputType(node, context));
+        return TraversalControl.CONTINUE;
+    }
+
+    @Override
+    public TraversalControl visitGraphQLNullableType(GraphQLNullableType node, TraverserContext<GraphQLSchemaElement> context) {
+        visitors.forEach(v -> v.visitGraphQLNullableType(node, context));
+        return TraversalControl.CONTINUE;
+    }
+
+    @Override
+    public TraversalControl visitGraphQLOutputType(GraphQLOutputType node, TraverserContext<GraphQLSchemaElement> context) {
+        visitors.forEach(v -> v.visitGraphQLOutputType(node, context));
+        return TraversalControl.CONTINUE;
+    }
+
+    @Override
+    public TraversalControl visitGraphQLUnmodifiedType(GraphQLUnmodifiedType node, TraverserContext<GraphQLSchemaElement> context) {
+        visitors.forEach(v -> v.visitGraphQLUnmodifiedType(node, context));
+        return TraversalControl.CONTINUE;
+    }
+
+    @Override
+    public TraversalControl changeNode(TraverserContext<GraphQLSchemaElement> context, GraphQLSchemaElement newChangedNode) {
+        return Assert.assertShouldNeverHappen("This must be a read only operation");
+    }
+
+    @Override
+    public TraversalControl deleteNode(TraverserContext<GraphQLSchemaElement> context) {
+        return Assert.assertShouldNeverHappen("This must be a read only operation");
+    }
+
+    @Override
+    public TraversalControl insertAfter(TraverserContext<GraphQLSchemaElement> context, GraphQLSchemaElement toInsertAfter) {
+        return Assert.assertShouldNeverHappen("This must be a read only operation");
+    }
+
+    @Override
+    public TraversalControl insertBefore(TraverserContext<GraphQLSchemaElement> context, GraphQLSchemaElement toInsertBefore) {
+        return Assert.assertShouldNeverHappen("This must be a read only operation");
+    }
+}

--- a/src/main/java/graphql/schema/impl/SchemaUtil.java
+++ b/src/main/java/graphql/schema/impl/SchemaUtil.java
@@ -3,10 +3,7 @@ package graphql.schema.impl;
 
 import com.google.common.collect.ImmutableMap;
 import graphql.Internal;
-import graphql.schema.CodeRegistryVisitor;
-import graphql.schema.GraphQLCodeRegistry;
 import graphql.schema.GraphQLImplementingType;
-import graphql.schema.GraphQLInterfaceType;
 import graphql.schema.GraphQLNamedOutputType;
 import graphql.schema.GraphQLNamedType;
 import graphql.schema.GraphQLObjectType;
@@ -22,13 +19,10 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeMap;
 
 @Internal
 public class SchemaUtil {
-
-    private static final SchemaTraverser TRAVERSER = new SchemaTraverser();
 
     /**
      * Called to visit a partially build schema (during {@link GraphQLSchema} build phases) with a set of visitors
@@ -67,60 +61,7 @@ public class SchemaUtil {
         traverser.depthFirst(visitor, roots);
     }
 
-    public ImmutableMap<String, GraphQLNamedType> allTypes(final GraphQLSchema schema, final Set<GraphQLType> additionalTypes, boolean afterTransform) {
-        List<GraphQLSchemaElement> roots = new ArrayList<>();
-        roots.add(schema.getQueryType());
-
-        if (schema.isSupportingMutations()) {
-            roots.add(schema.getMutationType());
-        }
-
-        if (schema.isSupportingSubscriptions()) {
-            roots.add(schema.getSubscriptionType());
-        }
-
-        if (additionalTypes != null) {
-            roots.addAll(additionalTypes);
-        }
-
-        if (schema.getDirectives() != null) {
-            roots.addAll(schema.getDirectives());
-        }
-
-        roots.add(schema.getIntrospectionSchemaType());
-
-        GraphQLTypeCollectingVisitor visitor = new GraphQLTypeCollectingVisitor();
-        SchemaTraverser traverser;
-        // when collecting all types we never want to follow type references
-        // When a schema is build first the type references are not replaced, so
-        // this is not a problem. But when a schema is transformed,
-        // the type references are actually replaced so we need to make sure we
-        // use the original type references
-        if (afterTransform) {
-            traverser = new SchemaTraverser(schemaElement -> schemaElement.getChildrenWithTypeReferences().getChildrenAsList());
-        } else {
-            traverser = new SchemaTraverser();
-        }
-        traverser.depthFirst(visitor, roots);
-        Map<String, GraphQLNamedType> result = visitor.getResult();
-        return ImmutableMap.copyOf(new TreeMap<>(result));
-    }
-
-
-    /*
-     * Indexes GraphQLObject types registered with the provided schema by implemented GraphQLInterface name
-     *
-     * This helps in accelerates/simplifies collecting types that implement a certain interface
-     *
-     * Provided to replace {@link #findImplementations(graphql.schema.GraphQLSchema, graphql.schema.GraphQLInterfaceType)}
-     *
-     */
-    public Map<String, List<GraphQLObjectType>> groupImplementations(GraphQLSchema schema) {
-        List<GraphQLNamedType> allTypesAsList = schema.getAllTypesAsList();
-        return groupInterfaceImplementationsByName(allTypesAsList);
-    }
-
-    public ImmutableMap<String, List<GraphQLObjectType>> groupInterfaceImplementationsByName(List<GraphQLNamedType> allTypesAsList) {
+    public static ImmutableMap<String, List<GraphQLObjectType>> groupInterfaceImplementationsByName(List<GraphQLNamedType> allTypesAsList) {
         Map<String, List<GraphQLObjectType>> result = new LinkedHashMap<>();
         for (GraphQLType type : allTypesAsList) {
             if (type instanceof GraphQLObjectType) {
@@ -148,54 +89,11 @@ public class SchemaUtil {
         return ImmutableMap.copyOf(new TreeMap<>(result));
     }
 
-    /**
-     * This method is deprecated due to a performance concern.
-     *
-     * The Algorithm complexity: O(n^2), where n is number of registered GraphQLTypes
-     *
-     * That indexing operation is performed twice per input document:
-     * 1. during validation
-     * 2. during execution
-     *
-     * We now indexed all types at the schema creation, which has brought complexity down to O(1)
-     *
-     * @param schema        GraphQL schema
-     * @param interfaceType an interface type to find implementations for
-     *
-     * @return List of object types implementing provided interface
-     *
-     * @deprecated use {@link graphql.schema.GraphQLSchema#getImplementations(GraphQLInterfaceType)} instead
-     */
-    @Deprecated
-    public List<GraphQLObjectType> findImplementations(GraphQLSchema schema, GraphQLInterfaceType interfaceType) {
-        List<GraphQLObjectType> result = new ArrayList<>();
-        for (GraphQLType type : schema.getAllTypesAsList()) {
-            if (!(type instanceof GraphQLObjectType)) {
-                continue;
-            }
-            GraphQLObjectType objectType = (GraphQLObjectType) type;
-            if ((objectType).getInterfaces().contains(interfaceType)) {
-                result.add(objectType);
-            }
-        }
-        return result;
-    }
-
-    // THIS WILL BE REMOVED
-    public void replaceTypeReferences(GraphQLSchema schema) {
+    public static void replaceTypeReferences(GraphQLSchema schema) {
         final Map<String, GraphQLNamedType> typeMap = schema.getTypeMap();
-        replaceTypeReferences(schema, typeMap);
-    }
-
-    public void replaceTypeReferences(GraphQLSchema schema, Map<String, GraphQLNamedType> typeMap) {
         List<GraphQLSchemaElement> roots = new ArrayList<>(typeMap.values());
         roots.addAll(schema.getDirectives());
         SchemaTraverser schemaTraverser = new SchemaTraverser(schemaElement -> schemaElement.getChildrenWithTypeReferences().getChildrenAsList());
         schemaTraverser.depthFirst(new GraphQLTypeResolvingVisitor(typeMap), roots);
-    }
-
-    // THIS WILL BE REMOVED
-    public void extractCodeFromTypes(GraphQLCodeRegistry.Builder codeRegistry, GraphQLSchema schema) {
-        TRAVERSER.depthFirst(new CodeRegistryVisitor(codeRegistry), schema.getAllTypesAsList());
     }
 }

--- a/src/main/java/graphql/schema/impl/SchemaUtil.java
+++ b/src/main/java/graphql/schema/impl/SchemaUtil.java
@@ -1,11 +1,24 @@
-package graphql.schema;
+package graphql.schema.impl;
 
 
 import com.google.common.collect.ImmutableMap;
 import graphql.Internal;
-import graphql.introspection.Introspection;
+import graphql.schema.CodeRegistryVisitor;
+import graphql.schema.GraphQLCodeRegistry;
+import graphql.schema.GraphQLImplementingType;
+import graphql.schema.GraphQLInterfaceType;
+import graphql.schema.GraphQLNamedOutputType;
+import graphql.schema.GraphQLNamedType;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLSchemaElement;
+import graphql.schema.GraphQLType;
+import graphql.schema.GraphQLTypeResolvingVisitor;
+import graphql.schema.GraphQLTypeVisitor;
+import graphql.schema.SchemaTraverser;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -17,8 +30,44 @@ public class SchemaUtil {
 
     private static final SchemaTraverser TRAVERSER = new SchemaTraverser();
 
+    /**
+     * Called to visit a partially build schema (during {@link GraphQLSchema} build phases) with a set of visitors
+     *
+     * Each visitor is expected to hold its own side effects that might be last used to construct a full schema
+     *
+     * @param partiallyBuiltSchema the partially built schema
+     * @param visitors             the visitors to call
+     */
 
-    ImmutableMap<String, GraphQLNamedType> allTypes(final GraphQLSchema schema, final Set<GraphQLType> additionalTypes, boolean afterTransform) {
+    public static void visitPartiallySchema(final GraphQLSchema partiallyBuiltSchema, GraphQLTypeVisitor... visitors) {
+        List<GraphQLSchemaElement> roots = new ArrayList<>();
+        roots.add(partiallyBuiltSchema.getQueryType());
+
+        if (partiallyBuiltSchema.isSupportingMutations()) {
+            roots.add(partiallyBuiltSchema.getMutationType());
+        }
+
+        if (partiallyBuiltSchema.isSupportingSubscriptions()) {
+            roots.add(partiallyBuiltSchema.getSubscriptionType());
+        }
+
+        if (partiallyBuiltSchema.getAdditionalTypes() != null) {
+            roots.addAll(partiallyBuiltSchema.getAdditionalTypes());
+        }
+
+        if (partiallyBuiltSchema.getDirectives() != null) {
+            roots.addAll(partiallyBuiltSchema.getDirectives());
+        }
+
+        roots.add(partiallyBuiltSchema.getIntrospectionSchemaType());
+
+        GraphQLTypeVisitor visitor = new MultiReadOnlyGraphQLTypeVisitor(Arrays.asList(visitors));
+        SchemaTraverser traverser;
+        traverser = new SchemaTraverser(schemaElement -> schemaElement.getChildrenWithTypeReferences().getChildrenAsList());
+        traverser.depthFirst(visitor, roots);
+    }
+
+    public ImmutableMap<String, GraphQLNamedType> allTypes(final GraphQLSchema schema, final Set<GraphQLType> additionalTypes, boolean afterTransform) {
         List<GraphQLSchemaElement> roots = new ArrayList<>();
         roots.add(schema.getQueryType());
 
@@ -66,9 +115,14 @@ public class SchemaUtil {
      * Provided to replace {@link #findImplementations(graphql.schema.GraphQLSchema, graphql.schema.GraphQLInterfaceType)}
      *
      */
-    Map<String, List<GraphQLObjectType>> groupImplementations(GraphQLSchema schema) {
+    public Map<String, List<GraphQLObjectType>> groupImplementations(GraphQLSchema schema) {
+        List<GraphQLNamedType> allTypesAsList = schema.getAllTypesAsList();
+        return groupInterfaceImplementationsByName(allTypesAsList);
+    }
+
+    public ImmutableMap<String, List<GraphQLObjectType>> groupInterfaceImplementationsByName(List<GraphQLNamedType> allTypesAsList) {
         Map<String, List<GraphQLObjectType>> result = new LinkedHashMap<>();
-        for (GraphQLType type : schema.getAllTypesAsList()) {
+        for (GraphQLType type : allTypesAsList) {
             if (type instanceof GraphQLObjectType) {
                 List<GraphQLNamedOutputType> interfaces = ((GraphQLObjectType) type).getInterfaces();
                 for (GraphQLNamedOutputType interfaceType : interfaces) {
@@ -127,17 +181,21 @@ public class SchemaUtil {
         return result;
     }
 
-    void replaceTypeReferences(GraphQLSchema schema) {
+    // THIS WILL BE REMOVED
+    public void replaceTypeReferences(GraphQLSchema schema) {
         final Map<String, GraphQLNamedType> typeMap = schema.getTypeMap();
+        replaceTypeReferences(schema, typeMap);
+    }
+
+    public void replaceTypeReferences(GraphQLSchema schema, Map<String, GraphQLNamedType> typeMap) {
         List<GraphQLSchemaElement> roots = new ArrayList<>(typeMap.values());
         roots.addAll(schema.getDirectives());
         SchemaTraverser schemaTraverser = new SchemaTraverser(schemaElement -> schemaElement.getChildrenWithTypeReferences().getChildrenAsList());
         schemaTraverser.depthFirst(new GraphQLTypeResolvingVisitor(typeMap), roots);
     }
 
-    void extractCodeFromTypes(GraphQLCodeRegistry.Builder codeRegistry, GraphQLSchema schema) {
-        Introspection.addCodeForIntrospectionTypes(codeRegistry);
-
+    // THIS WILL BE REMOVED
+    public void extractCodeFromTypes(GraphQLCodeRegistry.Builder codeRegistry, GraphQLSchema schema) {
         TRAVERSER.depthFirst(new CodeRegistryVisitor(codeRegistry), schema.getAllTypesAsList());
     }
 }

--- a/src/main/java/graphql/schema/impl/StronglyConnectedComponentsTopologicallySorted.java
+++ b/src/main/java/graphql/schema/impl/StronglyConnectedComponentsTopologicallySorted.java
@@ -1,7 +1,9 @@
-package graphql.schema;
+package graphql.schema.impl;
 
 import graphql.Assert;
 import graphql.Internal;
+import graphql.schema.GraphQLNamedType;
+import graphql.schema.GraphQLSchemaElement;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;

--- a/src/main/java/graphql/util/Anonymizer.java
+++ b/src/main/java/graphql/util/Anonymizer.java
@@ -66,7 +66,7 @@ import graphql.schema.GraphQLTypeVisitor;
 import graphql.schema.GraphQLTypeVisitorStub;
 import graphql.schema.GraphQLUnionType;
 import graphql.schema.SchemaTransformer;
-import graphql.schema.SchemaUtil;
+import graphql.schema.impl.SchemaUtil;
 import graphql.schema.TypeResolver;
 import graphql.schema.idl.DirectiveInfo;
 import graphql.schema.idl.ScalarInfo;

--- a/src/test/groovy/graphql/schema/impl/SchemaUtilTest.groovy
+++ b/src/test/groovy/graphql/schema/impl/SchemaUtilTest.groovy
@@ -1,9 +1,17 @@
-package graphql.schema
+package graphql.schema.impl
 
 import graphql.AssertException
 import graphql.DirectivesUtil
 import graphql.NestedInputSchema
 import graphql.introspection.Introspection
+import graphql.schema.GraphQLArgument
+import graphql.schema.GraphQLFieldDefinition
+import graphql.schema.GraphQLInputObjectType
+import graphql.schema.GraphQLObjectType
+import graphql.schema.GraphQLType
+import graphql.schema.GraphQLTypeReference
+import graphql.schema.GraphQLUnionType
+import graphql.schema.impl.SchemaUtil
 import spock.lang.Specification
 
 import static graphql.Scalars.GraphQLBoolean

--- a/src/test/groovy/graphql/schema/impl/SchemaUtilTest.groovy
+++ b/src/test/groovy/graphql/schema/impl/SchemaUtilTest.groovy
@@ -50,7 +50,9 @@ class SchemaUtilTest extends Specification {
 
     def "collectAllTypes"() {
         when:
-        Map<String, GraphQLType> types = new SchemaUtil().allTypes(starWarsSchema, Collections.emptySet(), false)
+        def collectingVisitor = new GraphQLTypeCollectingVisitor()
+        SchemaUtil.visitPartiallySchema(starWarsSchema, collectingVisitor)
+        Map<String, GraphQLType> types = collectingVisitor.getResult()
         then:
         types.size() == 17
         types == [(droidType.name)                        : droidType,
@@ -74,7 +76,9 @@ class SchemaUtilTest extends Specification {
 
     def "collectAllTypesNestedInput"() {
         when:
-        Map<String, GraphQLType> types = new SchemaUtil().allTypes(NestedInputSchema.createSchema(), Collections.emptySet(), false)
+        def collectingVisitor = new GraphQLTypeCollectingVisitor()
+        SchemaUtil.visitPartiallySchema(NestedInputSchema.createSchema(), collectingVisitor)
+        Map<String, GraphQLType> types = collectingVisitor.getResult()
         Map<String, GraphQLType> expected =
 
                 [(NestedInputSchema.rootType().name)     : NestedInputSchema.rootType(),
@@ -97,7 +101,10 @@ class SchemaUtilTest extends Specification {
 
     def "collect all types defined in directives"() {
         when:
-        Map<String, GraphQLType> types = new SchemaUtil().allTypes(SchemaWithReferences, Collections.emptySet(), false)
+        def collectingVisitor = new GraphQLTypeCollectingVisitor()
+        SchemaUtil.visitPartiallySchema(SchemaWithReferences, collectingVisitor)
+        Map<String, GraphQLType> types = collectingVisitor.getResult()
+
         then:
         types.size() == 30
         types.containsValue(UnionDirectiveInput)
@@ -114,13 +121,13 @@ class SchemaUtilTest extends Specification {
 
     def "group all types by implemented interface"() {
         when:
-        Map<String, List<GraphQLObjectType>> byInterface = new SchemaUtil().groupImplementations(starWarsSchema)
+        Map<String, List<GraphQLObjectType>> byInterface = SchemaUtil.groupInterfaceImplementationsByName(starWarsSchema.getAllTypesAsList())
 
         then:
         byInterface.size() == 1
         byInterface[characterInterface.getName()].size() == 2
         byInterface == [
-                (characterInterface.getName()): [ droidType, humanType]
+                (characterInterface.getName()): [droidType, humanType]
         ]
     }
 
@@ -129,16 +136,16 @@ class SchemaUtilTest extends Specification {
         GraphQLInputObjectType PersonInputType = newInputObject()
                 .name("Person")
                 .field(newInputObjectField()
-                .name("name")
-                .type(GraphQLString))
+                        .name("name")
+                        .type(GraphQLString))
                 .build()
 
         GraphQLFieldDefinition field = newFieldDefinition()
                 .name("find")
                 .type(typeRef("Person"))
                 .argument(newArgument()
-                .name("ssn")
-                .type(GraphQLString))
+                        .name("ssn")
+                        .type(GraphQLString))
                 .build()
 
         GraphQLObjectType PersonService = newObject()

--- a/src/test/java/benchmark/SchemaBenchMark.java
+++ b/src/test/java/benchmark/SchemaBenchMark.java
@@ -1,0 +1,72 @@
+package benchmark;
+
+import com.google.common.io.Files;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.idl.RuntimeWiring;
+import graphql.schema.idl.SchemaGenerator;
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.TypeDefinitionRegistry;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.File;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This benchmarks schema creation
+ * <p>
+ * See https://github.com/openjdk/jmh/tree/master/jmh-samples/src/main/java/org/openjdk/jmh/samples/ for more samples
+ * on what you can do with JMH
+ * <p>
+ * You MUST have the JMH plugin for IDEA in place for this to work :  https://github.com/artyushov/idea-jmh-plugin
+ * <p>
+ * Install it and then just hit "Run" on a certain benchmark method
+ */
+@Warmup(iterations = 2, time = 5, batchSize = 3)
+@Measurement(iterations = 3, time = 10, batchSize = 4)
+public class SchemaBenchMark {
+
+    static String largeSDL = createResourceSDL("large-schema-1.graphqls");
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public void benchMarkLargeSchemaCreate(Blackhole blackhole) {
+        blackhole.consume(createSchema(largeSDL));
+    }
+
+    private static GraphQLSchema createSchema(String sdl) {
+        TypeDefinitionRegistry registry = new SchemaParser().parse(sdl);
+        return new SchemaGenerator().makeExecutableSchema(registry, RuntimeWiring.MOCKED_WIRING);
+    }
+
+    private static String createResourceSDL(String name) {
+        try {
+            URL resource = SchemaBenchMark.class.getClassLoader().getResource(name);
+            File file = new File(resource.toURI());
+            return String.join("\n", Files.readLines(file, Charset.defaultCharset()));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    @SuppressWarnings("InfiniteLoopStatement")
+    public static void main(String[] args) {
+        int i = 0;
+        while (true) {
+            createSchema(largeSDL);
+            i++;
+            if (i % 100 == 0) {
+                System.out.printf("%d\n", i);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is a WORK implementation of building a GraQhlSchema object with only less traversal

At this stage I left the OLD code in there so you could see what's different

It would be cleaned up if we accepted this code.

I copied the bench mark from the previous PR and run it.

It shows that this code as is BETTER - but not ground breakingly better.


Start

```
Benchmark                                    Mode  Cnt   Score   Error  Units
SchemaBenchMark.benchMarkLargeSchemaCreate  thrpt   15  18.134 ± 1.099  ops/s
```

This work as is

```
Benchmark                                    Mode  Cnt   Score   Error  Units
SchemaBenchMark.benchMarkLargeSchemaCreate  thrpt   15  19.771 ± 0.685  ops/s
```

I then took out the validation steps just to see what would happen to the numbers.

```
Benchmark                                    Mode  Cnt   Score   Error  Units
SchemaBenchMark.benchMarkLargeSchemaCreate  thrpt   15  25.906 ± 0.370  ops/s
```


I then took out the type replacement step and validation just to see.  This is not valid of course

```
Benchmark                                    Mode  Cnt   Score   Error  Units
SchemaBenchMark.benchMarkLargeSchemaCreate  thrpt   15  30.256 ± 1.171  ops/s
```


Having the ability to skip validation would help.  Type replacements MUST happen.

If we could find a way to combine type replacement with the previous steps then it would be better.  But that might 
be impossible - we need ALL the types collected to do type ref replacements... OR do we. ???   Anyway that's for another PR based on this one

