### PR TITLE
SchemaDiff bugfix: check types only referenced by a Union too

### DIFF
--- a/src/main/java/graphql/schema/diff/SchemaDiff.java
+++ b/src/main/java/graphql/schema/diff/SchemaDiff.java
@@ -324,6 +324,7 @@ public class SchemaDiff {
         Map<String, Type> oldMemberTypes = sortedMap(oldDef.getMemberTypes(), SchemaDiff::getTypeName);
         Map<String, Type> newMemberTypes = sortedMap(newDef.getMemberTypes(), SchemaDiff::getTypeName);
 
+
         for (Map.Entry<String, Type> entry : oldMemberTypes.entrySet()) {
             String oldMemberTypeName = entry.getKey();
             if (!newMemberTypes.containsKey(oldMemberTypeName)) {
@@ -334,6 +335,9 @@ public class SchemaDiff {
                         .components(oldMemberTypeName)
                         .reasonMsg("The new API does not contain union member type '%s'", oldMemberTypeName)
                         .build());
+            } else {
+                // check type which is in the old and the new Union def
+                checkType(ctx, entry.getValue(), newMemberTypes.get(oldMemberTypeName));
             }
         }
         for (Map.Entry<String, Type> entry : newMemberTypes.entrySet()) {

--- a/src/test/groovy/graphql/schema/diff/SchemaDiffTest.groovy
+++ b/src/test/groovy/graphql/schema/diff/SchemaDiffTest.groovy
@@ -467,20 +467,21 @@ class SchemaDiffTest extends Specification {
         reporter.dangerCount == 3
 
         reporter.dangers[0].category == DiffCategory.ADDITION
-        reporter.dangers[0].typeName == "Character"
-        reporter.dangers[0].typeKind == TypeKind.Union
-        reporter.dangers[0].components.contains("BenignFigure")
+        reporter.dangers[0].typeName == "Temperament"
+        reporter.dangers[0].typeKind == TypeKind.Enum
+        reporter.dangers[0].components.contains("Nonplussed")
 
-        reporter.dangers[1].category == DiffCategory.DIFFERENT
-        reporter.dangers[1].typeName == "Query"
-        reporter.dangers[1].typeKind == TypeKind.Object
-        reporter.dangers[1].fieldName == "being"
-        reporter.dangers[1].components.contains("type")
+        reporter.dangers[1].category == DiffCategory.ADDITION
+        reporter.dangers[1].typeName == "Character"
+        reporter.dangers[1].typeKind == TypeKind.Union
+        reporter.dangers[1].components.contains("BenignFigure")
 
-        reporter.dangers[2].category == DiffCategory.ADDITION
-        reporter.dangers[2].typeName == "Temperament"
-        reporter.dangers[2].typeKind == TypeKind.Enum
-        reporter.dangers[2].components.contains("Nonplussed")
+        reporter.dangers[2].category == DiffCategory.DIFFERENT
+        reporter.dangers[2].typeName == "Query"
+        reporter.dangers[2].typeKind == TypeKind.Object
+        reporter.dangers[2].fieldName == "being"
+        reporter.dangers[2].components.contains("type")
+
 
     }
 
@@ -514,6 +515,47 @@ class SchemaDiffTest extends Specification {
         reporter.breakages.every {
             it.getCategory() == DiffCategory.DEPRECATION_REMOVED
         }
+    }
+
+    def "union members are checked"() {
+        def oldSchema = TestUtil.schema('''
+        type Query {
+            foo: Foo
+        }
+        union Foo = A | B 
+        type A {
+            a: String
+            toRemove: String 
+        }
+        type B {
+            b: String
+        }
+       ''')
+        def newSchema = TestUtil.schema('''
+        type Query {
+            foo: Foo
+        }
+        union Foo = A | B 
+        type A {
+            a: String
+        }
+        type B {
+            b: String
+        }
+       ''')
+        def reporter = new CapturingReporter()
+        DiffSet diffSet = DiffSet.diffSet(oldSchema, newSchema)
+        def diff = new SchemaDiff()
+        when:
+        diff.diffSchema(diffSet, reporter)
+
+        then:
+        reporter.dangerCount == 0
+        reporter.breakageCount == 1
+        reporter.breakages.every {
+            it.getCategory() == DiffCategory.MISSING
+        }
+
     }
 
 }


### PR DESCRIPTION
Previously object types which were only references by a Union were not checked

cc @skevy