### PR TITLE
Simple builder for graphql schema

### DIFF
--- a/src/main/java/graphql/schema/GraphQLSchema.java
+++ b/src/main/java/graphql/schema/GraphQLSchema.java
@@ -137,7 +137,7 @@ public class GraphQLSchema {
      * a constructor aimed at the simple builder - the type tree can be taken as is!
      */
     @Internal
-    public GraphQLSchema(SimpleBuilder builder) {
+    public GraphQLSchema(BuilderWithoutTypes builder) {
         assertNotNull(builder.codeRegistry, () -> "codeRegistry can't be null");
 
         GraphQLSchema existingSchema = builder.existingSchema;
@@ -504,15 +504,15 @@ public class GraphQLSchema {
     }
 
     /**
-     * This helps you transform the current GraphQLSchema object into another one by starting a simple builder that only allows you to change
+     * This helps you transform the current GraphQLSchema object into another one by using a builder that only allows you to change
      * simple values and does not involve changing the complex schema type graph.
      *
-     * @param builderConsumer the consumer code that will be given a simple builder to transform
+     * @param builderConsumer the consumer code that will be given a builder to transform
      *
-     * @return a new GraphQLSchema object based on calling built on that simple builder
+     * @return a new GraphQLSchema object based on calling built on that builder
      */
-    public GraphQLSchema simpleTransform(Consumer<SimpleBuilder> builderConsumer) {
-        SimpleBuilder builder = new SimpleBuilder(this);
+    public GraphQLSchema transformWithoutTypes(Consumer<BuilderWithoutTypes> builderConsumer) {
+        BuilderWithoutTypes builder = new BuilderWithoutTypes(this);
         builderConsumer.accept(builder);
         return builder.build();
     }
@@ -548,27 +548,27 @@ public class GraphQLSchema {
                 .description(existingSchema.getDescription());
     }
 
-    public static class SimpleBuilder {
+    public static class BuilderWithoutTypes {
         private GraphQLCodeRegistry codeRegistry;
         private String description;
         private final GraphQLSchema existingSchema;
 
-        private SimpleBuilder(GraphQLSchema existingSchema) {
+        private BuilderWithoutTypes(GraphQLSchema existingSchema) {
             this.existingSchema = existingSchema;
             this.codeRegistry = existingSchema.codeRegistry;
             this.description = existingSchema.description;
         }
 
-        public SimpleBuilder codeRegistry(GraphQLCodeRegistry codeRegistry) {
+        public BuilderWithoutTypes codeRegistry(GraphQLCodeRegistry codeRegistry) {
             this.codeRegistry = Assert.assertNotNull(codeRegistry);
             return this;
         }
 
-        public SimpleBuilder codeRegistry(GraphQLCodeRegistry.Builder codeRegistryBuilder) {
+        public BuilderWithoutTypes codeRegistry(GraphQLCodeRegistry.Builder codeRegistryBuilder) {
             return codeRegistry(codeRegistryBuilder.build());
         }
 
-        public SimpleBuilder description(String description) {
+        public BuilderWithoutTypes description(String description) {
             this.description = description;
             return this;
         }

--- a/src/test/groovy/graphql/schema/GraphQLSchemaTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLSchemaTest.groovy
@@ -84,7 +84,7 @@ class GraphQLSchemaTest extends Specification {
         assert 0 == runQuery(schema).getErrors().size()
     }
 
-    def runQuery(GraphQLSchema schema) {
+    static def runQuery(GraphQLSchema schema) {
         GraphQL graphQL = GraphQL.newGraphQL(schema)
                 .build()
 
@@ -97,7 +97,7 @@ class GraphQLSchemaTest extends Specification {
                 .join()
     }
 
-    def basicSchemaBuilder() {
+    static def basicSchemaBuilder() {
         GraphQLSchema.newSchema()
                 .query(newObject()
                         .name("QueryType")
@@ -143,7 +143,7 @@ class GraphQLSchemaTest extends Specification {
         schema.directives.size() == 3
 
         when: "the schema is transformed, things are copied"
-        schema = schema.transform({ bldr -> bldr.additionalDirective(Directives.IncludeDirective) })
+        schema = schema.transform({ builder -> builder.additionalDirective(Directives.IncludeDirective) })
         then:
         schema.directives.size() == 4
     }
@@ -168,7 +168,7 @@ class GraphQLSchemaTest extends Specification {
         schema.additionalTypes.size() == 1
 
         when: "the schema is transformed, things are copied"
-        schema = schema.transform({ bldr -> bldr.additionalType(additionalType2) })
+        schema = schema.transform({ builder -> builder.additionalType(additionalType2) })
         then:
         schema.additionalTypes.size() == 2
     }
@@ -212,5 +212,64 @@ class GraphQLSchemaTest extends Specification {
 
         GraphQLObjectType dogType = schema.getTypeAs("Dog")
         dogType.getName() == "Dog"
+    }
+
+    def "cheap simple builder transformation works"() {
+
+        def sdl = '''
+        "a schema involving pets"
+        schema {
+            query : Query
+        }
+        type Query {
+            field1 : Dog
+            field2 : Cat
+        }
+        
+        type Dog {
+            name : String
+        }
+
+        type Cat {
+            name : String
+        }
+            
+        '''
+
+
+        when:
+        DataFetcher nameDF = { env -> "name" }
+        def originalSchema = TestUtil.schema(sdl, ["Dog": ["name": nameDF]])
+        def originalCodeRegistry = originalSchema.getCodeRegistry()
+
+        then:
+        originalSchema.getDescription() == "a schema involving pets"
+        originalSchema.containsType("Dog")
+        !originalSchema.containsType("Elephant")
+
+        originalCodeRegistry.getDataFetcher(originalSchema.getObjectType("Dog"), originalSchema.getObjectType("Dog").getField("name")) === nameDF
+
+        when:
+        def newRegistry = originalCodeRegistry.transform({ bld -> bld.clearDataFetchers() })
+        def newSchema = originalSchema.simpleTransform({
+            it.description("A new home for pets").codeRegistry(newRegistry)
+        })
+
+        then:
+
+        newSchema.getDescription() == "A new home for pets"
+        newSchema.containsType("Dog")
+        !newSchema.containsType("Elephant")
+
+        def dogType = newSchema.getObjectType("Dog")
+        dogType === originalSchema.getObjectType("Dog") // schema type graph is the same
+
+        newRegistry == newSchema.getCodeRegistry()
+        newRegistry != originalCodeRegistry
+
+
+        def newDF = newRegistry.getDataFetcher(dogType, dogType.getField("name"))
+        newDF !== nameDF
+        newDF instanceof PropertyDataFetcher // defaulted in
     }
 }

--- a/src/test/groovy/graphql/schema/GraphQLSchemaTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLSchemaTest.groovy
@@ -214,7 +214,7 @@ class GraphQLSchemaTest extends Specification {
         dogType.getName() == "Dog"
     }
 
-    def "cheap simple builder transformation works"() {
+    def "cheap transform without types transformation works"() {
 
         def sdl = '''
         "a schema involving pets"
@@ -251,7 +251,7 @@ class GraphQLSchemaTest extends Specification {
 
         when:
         def newRegistry = originalCodeRegistry.transform({ bld -> bld.clearDataFetchers() })
-        def newSchema = originalSchema.simpleTransform({
+        def newSchema = originalSchema.transformWithoutTypes({
             it.description("A new home for pets").codeRegistry(newRegistry)
         })
 


### PR DESCRIPTION
This creates a fast path way to change schema properties that are not related to the complex rule driven type graph

This is simple object re-allocation - no traversals and zippers etc...