### PR TITLE
Options to control whether AST definitions are captured or not

### DIFF
--- a/src/main/java/graphql/schema/idl/SchemaGenerator.java
+++ b/src/main/java/graphql/schema/idl/SchemaGenerator.java
@@ -140,21 +140,48 @@ public class SchemaGenerator {
      */
     public static class Options {
         private final boolean useCommentsAsDescription;
+        private final boolean captureAstDefinitions;
 
-        Options(boolean useCommentsAsDescription) {
+        Options(boolean useCommentsAsDescription, boolean captureAstDefinitions) {
             this.useCommentsAsDescription = useCommentsAsDescription;
+            this.captureAstDefinitions = captureAstDefinitions;
         }
 
         public boolean isUseCommentsAsDescription() {
             return useCommentsAsDescription;
         }
 
-        public static Options defaultOptions() {
-            return new Options(true);
+        public boolean isCaptureAstDefinitions() {
+            return captureAstDefinitions;
         }
 
+        public static Options defaultOptions() {
+            return new Options(true, true);
+        }
+
+        /**
+         * This controls whether # comments can be used as descriptions in the built schema.  For specification legacy reasons
+         * # comments used to be used as schema element descriptions.  The specification has since clarified this and "" quoted string
+         * descriptions are the sanctioned way to make scheme element descriptions.
+         *
+         * @param useCommentsAsDescription the flag to control whether comments can be used as schema element descriptions
+         *
+         * @return a new Options object
+         */
         public Options useCommentsAsDescriptions(boolean useCommentsAsDescription) {
-            return new Options(useCommentsAsDescription);
+            return new Options(useCommentsAsDescription, captureAstDefinitions);
+        }
+
+        /**
+         * Memory can be saved if the original AST definitions are not associated with the built runtime types.  However
+         * some tooling may require them.
+         *
+         * @param captureAstDefinitions the flag on whether to capture AST definitions
+         *
+         * @return a new Options object
+         */
+        public Options captureAstDefinitions(boolean captureAstDefinitions) {
+            return new Options(useCommentsAsDescription, captureAstDefinitions);
         }
     }
 }

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -2488,4 +2488,38 @@ class SchemaGeneratorTest extends Specification {
         schema.getQueryType().getFieldDefinition("test").getDescription() == null
         schema.getQueryType().getFieldDefinition("test2").getDescription() == "Description"
     }
+
+    def "ast definition capture can be disabled"() {
+        def sdl = '''
+        type Query {
+            test : String
+        }
+        
+        extend type Query {
+            test2 : Int
+        }
+        '''
+        when:
+        def registry = new SchemaParser().parse(sdl)
+        def options = defaultOptions().captureAstDefinitions(false)
+        def schema = new SchemaGenerator().makeExecutableSchema(options, registry, TestUtil.mockRuntimeWiring)
+
+        then:
+        schema.getQueryType().getDefinition() == null
+        schema.getQueryType().getExtensionDefinitions() == []
+        schema.getQueryType().getFieldDefinition("test").getDefinition() == null
+
+        when:
+        registry = new SchemaParser().parse(sdl)
+        options = defaultOptions() // default is to capture them
+        schema = new SchemaGenerator().makeExecutableSchema(options, registry, TestUtil.mockRuntimeWiring)
+
+        then:
+        options.isCaptureAstDefinitions()
+        schema.getQueryType().getDefinition() != null
+        schema.getQueryType().getExtensionDefinitions().size() == 1
+        schema.getQueryType().getFieldDefinition("test").getDefinition() != null
+    }
+
+
 }


### PR DESCRIPTION
This allows the schema gen to NOT contain AST type definitions and hence saves memory

The real question is - should we make this the default (save memory by default) or not.