### PR TITLE
SchemaTransformer performance improvements 

### DIFF
--- a/src/test/groovy/graphql/schema/SchemaTransformerTest.groovy
+++ b/src/test/groovy/graphql/schema/SchemaTransformerTest.groovy
@@ -594,7 +594,6 @@ type Query {
             }
         })
         then:
-        println new SchemaPrinter().print(newType)
         newType.getName() == "FOO"
         newType.getFieldDefinition("FOO") != null
         newType.getFieldDefinition("BAR") != null


### PR DESCRIPTION
curZippers was never cleaned up before, now the zippers get removed when no longer needed.

This especially affected `zipperWithSameParent` for long large schemas