### PR TITLE
Reverting DataLoader to 2.x version for graphql-java 17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,7 +89,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:20.1.0'
     implementation 'org.antlr:antlr4-runtime:' + antlrVersion
     implementation 'org.slf4j:slf4j-api:' + slf4jVersion
-    api 'com.graphql-java:java-dataloader:3.0.1'
+    api 'com.graphql-java:java-dataloader:2.2.3'
     api 'org.reactivestreams:reactive-streams:' + reactiveStreamsVersion
     antlr 'org.antlr:antlr4:' + antlrVersion
     implementation 'com.google.guava:guava:30.0-jre'


### PR DESCRIPTION
Dataloader 3.x introduced a new "async `ValueCache`" which, while powerful, is causing problems and need revision

As such, with graphql-java 17.0 imminent, we have decided to revert back to the battle tested 2.2.3 version and we will revisit the dataloader code in another version