### PR TITLE
Bugfix for ExecutableNormalizedOperationFactory

### DIFF
--- a/src/main/java/graphql/Mutable.java
+++ b/src/main/java/graphql/Mutable.java
@@ -1,0 +1,15 @@
+package graphql;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+
+/**
+ * This marks a type as mutable which means after constructing it can be changed.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = {TYPE})
+public @interface Mutable {
+}

--- a/src/main/java/graphql/normalized/ENFMerger.java
+++ b/src/main/java/graphql/normalized/ENFMerger.java
@@ -1,6 +1,5 @@
 package graphql.normalized;
 
-import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.language.Argument;
 import graphql.language.AstComparator;
@@ -116,35 +115,6 @@ public class ENFMerger {
         }
         if (!sameArguments(one.getAstArguments(), two.getAstArguments())) {
             return false;
-        }
-        return true;
-    }
-
-    private static boolean compareOneWithASet(Set<ExecutableNormalizedField> fields) {
-        if (fields.size() == 1) {
-            return true;
-        }
-        ExecutableNormalizedField first = fields.iterator().next();
-        Set<String> objectTypeNames = first.getObjectTypeNames();
-        String alias = first.getAlias();
-        String fieldName = first.getFieldName();
-        ImmutableList<Argument> arguments = first.getAstArguments();
-        Iterator<ExecutableNormalizedField> iterator = fields.iterator();
-        iterator.next();
-        while (iterator.hasNext()) {
-            ExecutableNormalizedField field = iterator.next();
-            if (!field.getObjectTypeNames().equals(objectTypeNames)) {
-                return false;
-            }
-            if (!Objects.equals(alias, field.getAlias())) {
-                return false;
-            }
-            if (!Objects.equals(fieldName, field.getFieldName())) {
-                return false;
-            }
-            if (!sameArguments(arguments, field.getAstArguments())) {
-                return false;
-            }
         }
         return true;
     }

--- a/src/main/java/graphql/normalized/ENFMerger.java
+++ b/src/main/java/graphql/normalized/ENFMerger.java
@@ -1,0 +1,178 @@
+package graphql.normalized;
+
+import com.google.common.collect.ImmutableList;
+import graphql.Internal;
+import graphql.language.Argument;
+import graphql.language.AstComparator;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+@Internal
+public class ENFMerger {
+
+    public static void merge(ExecutableNormalizedField parent, List<ExecutableNormalizedField> childrenWithSameResultKey) {
+        // they have all the same result key
+        // we can only merge the fields if they have the same field name + arguments + all children are the same
+        List<Set<ExecutableNormalizedField>> possibleGroupsToMerge = new ArrayList<>();
+        for (ExecutableNormalizedField field : childrenWithSameResultKey) {
+            boolean addToGroup = false;
+            overPossibleGroups:
+            for (Set<ExecutableNormalizedField> group : possibleGroupsToMerge) {
+                for (ExecutableNormalizedField fieldInGroup : group) {
+                    if (field.getFieldName().equals(fieldInGroup.getFieldName()) && sameArguments(field.getAstArguments(), fieldInGroup.getAstArguments())) {
+                        addToGroup = true;
+                        group.add(field);
+                        continue overPossibleGroups;
+                    }
+                }
+            }
+            if (!addToGroup) {
+                LinkedHashSet<ExecutableNormalizedField> group = new LinkedHashSet<>();
+                group.add(field);
+                possibleGroupsToMerge.add(group);
+            }
+        }
+        for (Set<ExecutableNormalizedField> groupOfFields : possibleGroupsToMerge) {
+            // for each group we check if it could be merged
+            List<Set<ExecutableNormalizedField>> listOfChildrenForGroup = new ArrayList<>();
+            for (ExecutableNormalizedField fieldInGroup : groupOfFields) {
+                Set<ExecutableNormalizedField> childrenSets = new LinkedHashSet<>(fieldInGroup.getChildren());
+                listOfChildrenForGroup.add(childrenSets);
+            }
+            boolean mergeable = areFieldSetsTheSame(listOfChildrenForGroup);
+            if (mergeable) {
+                Set<String> mergedObjects = new LinkedHashSet<>();
+                groupOfFields.forEach(f -> mergedObjects.addAll(f.getObjectTypeNames()));
+                // patching the first one to contain more objects, remove all others
+                Iterator<ExecutableNormalizedField> iterator = groupOfFields.iterator();
+                ExecutableNormalizedField first = iterator.next();
+                while (iterator.hasNext()) {
+                    parent.getChildren().remove(iterator.next());
+                }
+                first.setObjectTypeNames(mergedObjects);
+            }
+        }
+    }
+
+
+    private static boolean areFieldSetsTheSame(List<Set<ExecutableNormalizedField>> listOfSets) {
+        if (listOfSets.size() == 0 || listOfSets.size() == 1) {
+            return true;
+        }
+        Set<ExecutableNormalizedField> first = listOfSets.get(0);
+        Iterator<Set<ExecutableNormalizedField>> iterator = listOfSets.iterator();
+        iterator.next();
+        while (iterator.hasNext()) {
+            Set<ExecutableNormalizedField> set = iterator.next();
+            if (!compareTwoFieldSets(first, set)) {
+                return false;
+            }
+        }
+        List<Set<ExecutableNormalizedField>> nextLevel = new ArrayList<>();
+        for (Set<ExecutableNormalizedField> set : listOfSets) {
+            for (ExecutableNormalizedField fieldInSet : set) {
+                nextLevel.add(new LinkedHashSet<>(fieldInSet.getChildren()));
+            }
+        }
+        return areFieldSetsTheSame(nextLevel);
+    }
+
+    private static boolean compareTwoFieldSets(Set<ExecutableNormalizedField> setOne, Set<ExecutableNormalizedField> setTwo) {
+        if (setOne.size() != setTwo.size()) {
+            return false;
+        }
+        for (ExecutableNormalizedField field : setOne) {
+            if (!isContained(field, setTwo)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isContained(ExecutableNormalizedField searchFor, Set<ExecutableNormalizedField> set) {
+        for (ExecutableNormalizedField field : set) {
+            if (compareWithoutChildren(searchFor, field)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean compareWithoutChildren(ExecutableNormalizedField one, ExecutableNormalizedField two) {
+
+        if (!one.getObjectTypeNames().equals(two.getObjectTypeNames())) {
+            return false;
+        }
+        if (!Objects.equals(one.getAlias(), two.getAlias())) {
+            return false;
+        }
+        if (!Objects.equals(one.getFieldName(), two.getFieldName())) {
+            return false;
+        }
+        if (!sameArguments(one.getAstArguments(), two.getAstArguments())) {
+            return false;
+        }
+        return true;
+    }
+
+    private static boolean compareOneWithASet(Set<ExecutableNormalizedField> fields) {
+        if (fields.size() == 1) {
+            return true;
+        }
+        ExecutableNormalizedField first = fields.iterator().next();
+        Set<String> objectTypeNames = first.getObjectTypeNames();
+        String alias = first.getAlias();
+        String fieldName = first.getFieldName();
+        ImmutableList<Argument> arguments = first.getAstArguments();
+        Iterator<ExecutableNormalizedField> iterator = fields.iterator();
+        iterator.next();
+        while (iterator.hasNext()) {
+            ExecutableNormalizedField field = iterator.next();
+            if (!field.getObjectTypeNames().equals(objectTypeNames)) {
+                return false;
+            }
+            if (!Objects.equals(alias, field.getAlias())) {
+                return false;
+            }
+            if (!Objects.equals(fieldName, field.getFieldName())) {
+                return false;
+            }
+            if (!sameArguments(arguments, field.getAstArguments())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // copied from graphql.validation.rules.OverlappingFieldsCanBeMerged
+    private static boolean sameArguments(List<Argument> arguments1, List<Argument> arguments2) {
+        if (arguments1.size() != arguments2.size()) {
+            return false;
+        }
+        for (Argument argument : arguments1) {
+            Argument matchedArgument = findArgumentByName(argument.getName(), arguments2);
+            if (matchedArgument == null) {
+                return false;
+            }
+            if (!AstComparator.sameValue(argument.getValue(), matchedArgument.getValue())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static Argument findArgumentByName(String name, List<Argument> arguments) {
+        for (Argument argument : arguments) {
+            if (argument.getName().equals(name)) {
+                return argument;
+            }
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/graphql/normalized/ExecutableNormalizedField.java
+++ b/src/main/java/graphql/normalized/ExecutableNormalizedField.java
@@ -195,6 +195,10 @@ public class ExecutableNormalizedField {
         return objectTypeNames;
     }
 
+    public String getSingleObjectTypeName() {
+        return objectTypeNames.iterator().next();
+    }
+
     public GraphQLObjectType getOneObjectType(GraphQLSchema schema) {
         return (GraphQLObjectType) schema.getType(objectTypeNames.iterator().next());
     }

--- a/src/main/java/graphql/normalized/ExecutableNormalizedField.java
+++ b/src/main/java/graphql/normalized/ExecutableNormalizedField.java
@@ -9,6 +9,7 @@ import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLOutputType;
 import graphql.schema.GraphQLSchema;
+import graphql.util.FpKit;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -110,13 +111,17 @@ public class ExecutableNormalizedField {
         this.objectTypeNames.addAll(objectTypeNames);
     }
 
+    public void setObjectTypeNames(Collection<String> objectTypeNames) {
+        this.objectTypeNames.clear();
+        this.objectTypeNames.addAll(objectTypeNames);
+    }
+
     public void addChild(ExecutableNormalizedField executableNormalizedField) {
         this.children.add(executableNormalizedField);
     }
 
     public void clearChildren() {
         this.children.clear();
-        ;
     }
 
     /**
@@ -222,6 +227,10 @@ public class ExecutableNormalizedField {
 
     public List<ExecutableNormalizedField> getChildren() {
         return children;
+    }
+
+    public List<ExecutableNormalizedField> getChildrenWithSameResultKey(String resultKey) {
+        return FpKit.filterList(children, child -> child.getResultKey().equals(resultKey));
     }
 
     public int getLevel() {

--- a/src/main/java/graphql/normalized/ExecutableNormalizedField.java
+++ b/src/main/java/graphql/normalized/ExecutableNormalizedField.java
@@ -3,6 +3,7 @@ package graphql.normalized;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import graphql.Internal;
+import graphql.Mutable;
 import graphql.collect.ImmutableKit;
 import graphql.language.Argument;
 import graphql.schema.GraphQLFieldDefinition;
@@ -32,6 +33,7 @@ import static graphql.schema.GraphQLTypeUtil.unwrapAll;
  * Intentionally Mutable
  */
 @Internal
+@Mutable
 public class ExecutableNormalizedField {
     private final String alias;
     private final ImmutableMap<String, NormalizedInputValue> normalizedArguments;

--- a/src/main/java/graphql/normalized/ExecutableNormalizedOperationFactory.java
+++ b/src/main/java/graphql/normalized/ExecutableNormalizedOperationFactory.java
@@ -136,7 +136,6 @@ public class ExecutableNormalizedOperationFactory {
 
         }
         for (FieldCollectorNormalizedQueryParams.PossibleMerger possibleMerger : parameters.possibleMergerList) {
-            System.out.println(possibleMerger);
             List<ExecutableNormalizedField> childrenWithSameResultKey = possibleMerger.parent.getChildrenWithSameResultKey(possibleMerger.resultKey);
             ENFMerger.merge(possibleMerger.parent, childrenWithSameResultKey);
         }

--- a/src/main/java/graphql/normalized/ExecutableNormalizedOperationFactory.java
+++ b/src/main/java/graphql/normalized/ExecutableNormalizedOperationFactory.java
@@ -4,10 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.LinkedHashMultimap;
-import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
-import graphql.Assert;
 import graphql.Internal;
 import graphql.execution.ConditionalNodes;
 import graphql.execution.MergedField;
@@ -32,6 +29,7 @@ import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLInterfaceType;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLType;
 import graphql.schema.GraphQLUnionType;
 import graphql.schema.GraphQLUnmodifiedType;
 import org.jetbrains.annotations.Nullable;
@@ -39,15 +37,22 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import static graphql.Assert.assertNotNull;
+import static graphql.Assert.assertShouldNeverHappen;
 import static graphql.collect.ImmutableKit.map;
+import static graphql.execution.MergedField.newMergedField;
+import static graphql.schema.GraphQLTypeUtil.isInterfaceOrUnion;
+import static graphql.schema.GraphQLTypeUtil.isObjectType;
 import static graphql.schema.GraphQLTypeUtil.simplePrint;
 import static graphql.schema.GraphQLTypeUtil.unwrapAll;
+import static graphql.util.FpKit.filterSet;
+import static graphql.util.FpKit.groupingBy;
 
 @Internal
 public class ExecutableNormalizedOperationFactory {
@@ -111,15 +116,15 @@ public class ExecutableNormalizedOperationFactory {
 
         GraphQLObjectType rootType = Common.getOperationRootType(graphQLSchema, operationDefinition);
 
-        CollectFieldResult collectFromOperationResult = collectFromOperation(parameters, operationDefinition, rootType);
+        CollectNFResult collectFromOperationResult = collectFromOperation(parameters, operationDefinition, rootType);
 
         ImmutableListMultimap.Builder<Field, ExecutableNormalizedField> fieldToNormalizedField = ImmutableListMultimap.builder();
         ImmutableMap.Builder<ExecutableNormalizedField, MergedField> normalizedFieldToMergedField = ImmutableMap.builder();
         ImmutableListMultimap.Builder<FieldCoordinates, ExecutableNormalizedField> coordinatesToNormalizedFields = ImmutableListMultimap.builder();
 
         for (ExecutableNormalizedField topLevel : collectFromOperationResult.children) {
-            ImmutableList<Field> mergedField = collectFromOperationResult.normalizedFieldToAstFields.get(topLevel);
-            normalizedFieldToMergedField.put(topLevel, MergedField.newMergedField(mergedField).build());
+            ImmutableList<FieldAndAstParent> mergedField = collectFromOperationResult.normalizedFieldToAstFields.get(topLevel);
+            normalizedFieldToMergedField.put(topLevel, newMergedField(map(mergedField, fieldAndAstParent -> fieldAndAstParent.field)).build());
             updateFieldToNFMap(topLevel, mergedField, fieldToNormalizedField);
             updateCoordinatedToNFMap(coordinatesToNormalizedFields, topLevel);
 
@@ -137,18 +142,19 @@ public class ExecutableNormalizedOperationFactory {
 
 
     private void buildFieldWithChildren(ExecutableNormalizedField field,
-                                        ImmutableList<Field> mergedField,
+                                        ImmutableList<FieldAndAstParent> mergedField,
                                         FieldCollectorNormalizedQueryParams fieldCollectorNormalizedQueryParams,
                                         ImmutableListMultimap.Builder<Field, ExecutableNormalizedField> fieldNormalizedField,
                                         ImmutableMap.Builder<ExecutableNormalizedField, MergedField> normalizedFieldToMergedField,
                                         ImmutableListMultimap.Builder<FieldCoordinates, ExecutableNormalizedField> coordinatesToNormalizedFields,
                                         int curLevel) {
-        CollectFieldResult nextLevel = collectFromMergedField(fieldCollectorNormalizedQueryParams, field, mergedField, curLevel + 1);
+        CollectNFResult nextLevel = collectFromMergedField(fieldCollectorNormalizedQueryParams, field, mergedField, curLevel + 1);
+
         for (ExecutableNormalizedField child : nextLevel.children) {
 
             field.addChild(child);
-            ImmutableList<Field> mergedFieldForChild = nextLevel.normalizedFieldToAstFields.get(child);
-            normalizedFieldToMergedField.put(child, MergedField.newMergedField(mergedFieldForChild).build());
+            ImmutableList<FieldAndAstParent> mergedFieldForChild = nextLevel.normalizedFieldToAstFields.get(child);
+            normalizedFieldToMergedField.put(child, newMergedField(map(mergedFieldForChild, fieldAndAstParent -> fieldAndAstParent.field)).build());
             updateFieldToNFMap(child, mergedFieldForChild, fieldNormalizedField);
             updateCoordinatedToNFMap(coordinatesToNormalizedFields, child);
 
@@ -163,10 +169,10 @@ public class ExecutableNormalizedOperationFactory {
     }
 
     private void updateFieldToNFMap(ExecutableNormalizedField executableNormalizedField,
-                                    ImmutableList<Field> mergedField,
+                                    ImmutableList<FieldAndAstParent> mergedField,
                                     ImmutableListMultimap.Builder<Field, ExecutableNormalizedField> fieldToNormalizedField) {
-        for (Field astField : mergedField) {
-            fieldToNormalizedField.put(astField, executableNormalizedField);
+        for (FieldAndAstParent astField : mergedField) {
+            fieldToNormalizedField.put(astField.field, executableNormalizedField);
         }
     }
 
@@ -177,144 +183,134 @@ public class ExecutableNormalizedOperationFactory {
         }
     }
 
+    private static class FieldAndAstParent {
+        final Field field;
+        final GraphQLCompositeType astParentType;
 
-    public static class CollectFieldResult {
+        private FieldAndAstParent(Field field, GraphQLCompositeType astParentType) {
+            this.field = field;
+            this.astParentType = astParentType;
+        }
+    }
+
+
+    public static class CollectNFResult {
         private final Collection<ExecutableNormalizedField> children;
-        private final ImmutableListMultimap<ExecutableNormalizedField, Field> normalizedFieldToAstFields;
+        private final ImmutableListMultimap<ExecutableNormalizedField, FieldAndAstParent> normalizedFieldToAstFields;
 
-        public CollectFieldResult(Collection<ExecutableNormalizedField> children, ImmutableListMultimap<ExecutableNormalizedField, Field> normalizedFieldToAstFields) {
+        public CollectNFResult(Collection<ExecutableNormalizedField> children, ImmutableListMultimap<ExecutableNormalizedField, FieldAndAstParent> normalizedFieldToAstFields) {
             this.children = children;
             this.normalizedFieldToAstFields = normalizedFieldToAstFields;
         }
     }
 
 
-    public CollectFieldResult collectFromMergedField(FieldCollectorNormalizedQueryParams parameters,
-                                                     ExecutableNormalizedField executableNormalizedField,
-                                                     ImmutableList<Field> mergedField,
-                                                     int level) {
+    public CollectNFResult collectFromMergedField(FieldCollectorNormalizedQueryParams parameters,
+                                                  ExecutableNormalizedField executableNormalizedField,
+                                                  ImmutableList<FieldAndAstParent> mergedField,
+                                                  int level) {
         GraphQLUnmodifiedType fieldType = unwrapAll(executableNormalizedField.getType(parameters.getGraphQLSchema()));
         // if not composite we don't have any selectionSet because it is a Scalar or enum
         if (!(fieldType instanceof GraphQLCompositeType)) {
-            return new CollectFieldResult(Collections.emptyList(), ImmutableListMultimap.of());
+            return new CollectNFResult(Collections.emptyList(), ImmutableListMultimap.of());
         }
 
-        Multimap<String, ExecutableNormalizedField> subFields = LinkedHashMultimap.create();
-        ImmutableListMultimap.Builder<ExecutableNormalizedField, Field> mergedFieldByNormalizedField = ImmutableListMultimap.builder();
         Set<GraphQLObjectType> possibleObjects = resolvePossibleObjects((GraphQLCompositeType) fieldType, parameters.getGraphQLSchema());
-        for (Field field : mergedField) {
-            if (field.getSelectionSet() == null) {
+
+        Map<Field, CollectedField> collectedFields = new LinkedHashMap<>();
+        for (FieldAndAstParent fieldAndAstParent : mergedField) {
+            if (fieldAndAstParent.field.getSelectionSet() == null) {
                 continue;
             }
-            this.collectFromSelectionSet(parameters,
-                    field.getSelectionSet(),
-                    subFields,
-                    mergedFieldByNormalizedField,
-                    possibleObjects,
-                    level,
-                    executableNormalizedField);
+            this.collectFromSelectionSet2(parameters,
+                    fieldAndAstParent.field.getSelectionSet(),
+                    collectedFields,
+                    fieldAndAstParent.astParentType,
+                    possibleObjects
+            );
         }
-        return new CollectFieldResult(new LinkedHashSet<>(subFields.values()), mergedFieldByNormalizedField.build());
+        Map<String, List<CollectedField>> fieldsByName = new LinkedHashMap<>();
+        for (Field field : collectedFields.keySet()) {
+            fieldsByName.computeIfAbsent(field.getResultKey(), ignored -> new ArrayList<>()).add(collectedFields.get(field));
+        }
+        List<ExecutableNormalizedField> resultNFs = new ArrayList<>();
+        ImmutableListMultimap.Builder<ExecutableNormalizedField, FieldAndAstParent> normalizedFieldToAstFields = ImmutableListMultimap.builder();
+
+        createNFs(parameters, fieldsByName, resultNFs, normalizedFieldToAstFields, level, executableNormalizedField);
+
+        return new CollectNFResult(resultNFs, normalizedFieldToAstFields.build());
     }
 
-    public CollectFieldResult collectFromOperation(FieldCollectorNormalizedQueryParams parameters,
-                                                   OperationDefinition operationDefinition,
-                                                   GraphQLObjectType rootType) {
+    public CollectNFResult collectFromOperation(FieldCollectorNormalizedQueryParams parameters,
+                                                OperationDefinition operationDefinition,
+                                                GraphQLObjectType rootType) {
 
-        Multimap<String, ExecutableNormalizedField> subFields = LinkedHashMultimap.create();
-        ImmutableListMultimap.Builder<ExecutableNormalizedField, Field> normalizedFieldToAstFields = ImmutableListMultimap.builder();
+
         Set<GraphQLObjectType> possibleObjects = new LinkedHashSet<>();
         possibleObjects.add(rootType);
-        this.collectFromSelectionSet(parameters, operationDefinition.getSelectionSet(), subFields, normalizedFieldToAstFields, possibleObjects, 1, null);
-        return new CollectFieldResult(subFields.values(), normalizedFieldToAstFields.build());
+        Map<Field, CollectedField> collectedFields = new LinkedHashMap<>();
+        collectFromSelectionSet2(parameters, operationDefinition.getSelectionSet(), collectedFields, rootType, possibleObjects);
+        // group by result key
+        Map<String, List<CollectedField>> fieldsByName = new LinkedHashMap<>();
+        for (Field field : collectedFields.keySet()) {
+            fieldsByName.computeIfAbsent(field.getResultKey(), ignored -> new ArrayList<>()).add(collectedFields.get(field));
+        }
+        List<ExecutableNormalizedField> resultNFs = new ArrayList<>();
+        ImmutableListMultimap.Builder<ExecutableNormalizedField, FieldAndAstParent> normalizedFieldToAstFields = ImmutableListMultimap.builder();
+
+        createNFs(parameters, fieldsByName, resultNFs, normalizedFieldToAstFields, 1, null);
+
+        return new CollectNFResult(resultNFs, normalizedFieldToAstFields.build());
     }
 
-
-    private void collectFromSelectionSet(FieldCollectorNormalizedQueryParams parameters,
-                                         SelectionSet selectionSet,
-                                         Multimap<String, ExecutableNormalizedField> result,
-                                         ImmutableListMultimap.Builder<ExecutableNormalizedField, Field> mergedFieldByNormalizedField,
-                                         Set<GraphQLObjectType> possibleObjects,
-                                         int level,
-                                         ExecutableNormalizedField parent) {
-
-        for (Selection<?> selection : selectionSet.getSelections()) {
-            if (selection instanceof Field) {
-                collectField(parameters, result, mergedFieldByNormalizedField, (Field) selection, possibleObjects, level, parent);
-            } else if (selection instanceof InlineFragment) {
-                collectInlineFragment(parameters, result, mergedFieldByNormalizedField, (InlineFragment) selection, possibleObjects, level, parent);
-            } else if (selection instanceof FragmentSpread) {
-                collectFragmentSpread(parameters, result, mergedFieldByNormalizedField, (FragmentSpread) selection, possibleObjects, level, parent);
+    private void createNFs(FieldCollectorNormalizedQueryParams parameters,
+                           Map<String, List<CollectedField>> fieldsByName,
+                           List<ExecutableNormalizedField> resultNFs,
+                           ImmutableListMultimap.Builder<ExecutableNormalizedField, FieldAndAstParent> normalizedFieldToAstFields,
+                           int level,
+                           ExecutableNormalizedField parent) {
+        for (String resultKey : fieldsByName.keySet()) {
+            List<CollectedField> fieldsWithSameResultKey = fieldsByName.get(resultKey);
+            List<Set<CollectedField>> commonParentsGroups = groupByCommonParents(fieldsWithSameResultKey);
+            for (Set<CollectedField> sameParents : commonParentsGroups) {
+                ExecutableNormalizedField nf = createNF(parameters, sameParents, level, parent);
+                if (nf == null) {
+                    continue;
+                }
+                for (CollectedField collectedField : sameParents) {
+                    normalizedFieldToAstFields.put(nf, new FieldAndAstParent(collectedField.field, collectedField.astTypeCondition));
+                }
+                resultNFs.add(nf);
             }
         }
     }
 
-    private void collectFragmentSpread(FieldCollectorNormalizedQueryParams parameters,
-                                       Multimap<String, ExecutableNormalizedField> result,
-                                       ImmutableListMultimap.Builder<ExecutableNormalizedField, Field> mergedFieldByNormalizedField,
-                                       FragmentSpread fragmentSpread,
-                                       Set<GraphQLObjectType> possibleObjects,
-                                       int level,
-                                       ExecutableNormalizedField parent) {
-        if (!conditionalNodes.shouldInclude(parameters.getCoercedVariableValues(), fragmentSpread.getDirectives())) {
-            return;
-        }
-        FragmentDefinition fragmentDefinition = assertNotNull(parameters.getFragmentsByName().get(fragmentSpread.getName()));
+    private ExecutableNormalizedField createNF(FieldCollectorNormalizedQueryParams parameters,
+                                               Set<CollectedField> collectedFields,
+                                               int level,
+                                               ExecutableNormalizedField parent) {
 
-        if (!conditionalNodes.shouldInclude(parameters.getCoercedVariableValues(), fragmentDefinition.getDirectives())) {
-            return;
+        Set<GraphQLObjectType> objectTypes = new LinkedHashSet<>(collectedFields.iterator().next().objectTypes);
+        for (CollectedField collectedField : collectedFields) {
+            objectTypes.retainAll(collectedField.objectTypes);
         }
-        GraphQLCompositeType newCondition = (GraphQLCompositeType) parameters.getGraphQLSchema().getType(fragmentDefinition.getTypeCondition().getName());
-        Set<GraphQLObjectType> newConditions = narrowDownPossibleObjects(possibleObjects, newCondition, parameters.getGraphQLSchema());
-        collectFromSelectionSet(parameters, fragmentDefinition.getSelectionSet(), result, mergedFieldByNormalizedField, newConditions, level, parent);
-    }
-
-    private void collectInlineFragment(FieldCollectorNormalizedQueryParams parameters,
-                                       Multimap<String, ExecutableNormalizedField> result,
-                                       ImmutableListMultimap.Builder<ExecutableNormalizedField, Field> mergedFieldByNormalizedField,
-                                       InlineFragment inlineFragment,
-                                       Set<GraphQLObjectType> possibleObjects,
-                                       int level, ExecutableNormalizedField parent) {
-        if (!conditionalNodes.shouldInclude(parameters.getCoercedVariableValues(), inlineFragment.getDirectives())) {
-            return;
-        }
-        Set<GraphQLObjectType> newPossibleObjects = possibleObjects;
-
-        if (inlineFragment.getTypeCondition() != null) {
-            GraphQLCompositeType newCondition = (GraphQLCompositeType) parameters.getGraphQLSchema().getType(inlineFragment.getTypeCondition().getName());
-            newPossibleObjects = narrowDownPossibleObjects(possibleObjects, newCondition, parameters.getGraphQLSchema());
-
-        }
-        collectFromSelectionSet(parameters, inlineFragment.getSelectionSet(), result, mergedFieldByNormalizedField, newPossibleObjects, level, parent);
-    }
-
-    private void collectField(FieldCollectorNormalizedQueryParams parameters,
-                              Multimap<String, ExecutableNormalizedField> result,
-                              ImmutableListMultimap.Builder<ExecutableNormalizedField, Field> normalizedFieldToMergedField,
-                              Field field,
-                              Set<GraphQLObjectType> objectTypes,
-                              int level,
-                              ExecutableNormalizedField parent) {
-        if (!conditionalNodes.shouldInclude(parameters.getCoercedVariableValues(), field.getDirectives())) {
-            return;
-        }
-        // this means there is actually no possible type for this field and we are done
         if (objectTypes.size() == 0) {
-            return;
+            return null;
         }
-        String resultKey = field.getResultKey();
+        Field field = collectedFields.iterator().next().field;
         String fieldName = field.getName();
         GraphQLFieldDefinition fieldDefinition = Introspection.getFieldDef(parameters.getGraphQLSchema(), objectTypes.iterator().next(), fieldName);
 
-        if (result.containsKey(resultKey)) {
-            Collection<ExecutableNormalizedField> existingNFs = result.get(resultKey);
-            ExecutableNormalizedField matchingNF = findMatchingNF(parameters.getGraphQLSchema(), existingNFs, fieldDefinition, field.getArguments());
-            if (matchingNF != null) {
-                matchingNF.addObjectTypeNames(map(objectTypes, GraphQLObjectType::getName));
-                normalizedFieldToMergedField.put(matchingNF, field);
-                return;
-            }
-        }
+//        if (result.containsKey(resultKey)) {
+//            // can we merge it actually?
+//            Collection<ExecutableNormalizedField> existingNFs = result.get(resultKey);
+//            ExecutableNormalizedField matchingNF = findMatchingNF(parameters.getGraphQLSchema(), existingNFs, fieldDefinition, field.getArguments());
+//            if (matchingNF != null) {
+//                matchingNF.addObjectTypeNames(map(objectTypes, GraphQLObjectType::getName));
+//                normalizedFieldToMergedField.put(matchingNF, field);
+//                return;
+//            }
+//        }
         // this means we have no existing NF
         Map<String, Object> argumentValues = valuesResolver.getArgumentValues(fieldDefinition.getArguments(), field.getArguments(), parameters.getCoercedVariableValues());
         Map<String, NormalizedInputValue> normalizedArgumentValues = null;
@@ -333,9 +329,221 @@ public class ExecutableNormalizedOperationFactory {
                 .parent(parent)
                 .build();
 
-        result.put(resultKey, executableNormalizedField);
-        normalizedFieldToMergedField.put(executableNormalizedField, field);
+//        result.put(resultKey, executableNormalizedField);
+        return executableNormalizedField;
+//        normalizedFieldToMergedField.put(executableNormalizedField, field);
     }
+
+    private List<Set<CollectedField>> groupByCommonParents(Collection<CollectedField> fields) {
+        Set<CollectedField> abstractTypes = filterSet(fields, fieldAndType -> isInterfaceOrUnion(fieldAndType.astTypeCondition));
+        Set<CollectedField> concreteTypes = filterSet(fields, fieldAndType -> isObjectType(fieldAndType.astTypeCondition));
+        if (concreteTypes.isEmpty()) {
+            return Collections.singletonList(abstractTypes);
+        }
+        Map<GraphQLType, ImmutableList<CollectedField>> groupsByConcreteParent = groupingBy(concreteTypes, fieldAndType -> fieldAndType.astTypeCondition);
+        List<Set<CollectedField>> result = new ArrayList<>();
+        for (ImmutableList<CollectedField> concreteGroup : groupsByConcreteParent.values()) {
+            Set<CollectedField> oneResultGroup = new LinkedHashSet<>(concreteGroup);
+            oneResultGroup.addAll(abstractTypes);
+            result.add(oneResultGroup);
+        }
+        return result;
+    }
+
+
+//    private void collectFromSelectionSet(FieldCollectorNormalizedQueryParams parameters,
+//                                         SelectionSet selectionSet,
+//                                         Multimap<String, ExecutableNormalizedField> result,
+//                                         ImmutableListMultimap.Builder<ExecutableNormalizedField, Field> mergedFieldByNormalizedField,
+//                                         Set<GraphQLObjectType> possibleObjects,
+//                                         int level,
+//                                         ExecutableNormalizedField parent) {
+//
+//        for (Selection<?> selection : selectionSet.getSelections()) {
+//            if (selection instanceof Field) {
+//                collectField(parameters, result, mergedFieldByNormalizedField, (Field) selection, possibleObjects, level, parent);
+//            } else if (selection instanceof InlineFragment) {
+//                collectInlineFragment(parameters, result, mergedFieldByNormalizedField, (InlineFragment) selection, possibleObjects, level, parent);
+//            } else if (selection instanceof FragmentSpread) {
+//                collectFragmentSpread(parameters, result, mergedFieldByNormalizedField, (FragmentSpread) selection, possibleObjects, level, parent);
+//            }
+//        }
+//    }
+
+    private void collectFromSelectionSet2(FieldCollectorNormalizedQueryParams parameters,
+                                          SelectionSet selectionSet,
+                                          Map<Field, CollectedField> result,
+                                          GraphQLCompositeType astTypeCondition,
+                                          Set<GraphQLObjectType> possibleObjects
+    ) {
+
+        for (Selection<?> selection : selectionSet.getSelections()) {
+            if (selection instanceof Field) {
+                collectField2(parameters, result, (Field) selection, possibleObjects, astTypeCondition);
+            } else if (selection instanceof InlineFragment) {
+                collectInlineFragment2(parameters, result, (InlineFragment) selection, possibleObjects, astTypeCondition);
+            } else if (selection instanceof FragmentSpread) {
+                collectFragmentSpread2(parameters, result, (FragmentSpread) selection, possibleObjects, astTypeCondition);
+            }
+        }
+    }
+
+    private static class CollectedField {
+        Field field;
+        Set<GraphQLObjectType> objectTypes;
+        GraphQLCompositeType astTypeCondition;
+
+        public CollectedField(Field field, Set<GraphQLObjectType> objectTypes, GraphQLCompositeType astTypeCondition) {
+            this.field = field;
+            this.objectTypes = objectTypes;
+            this.astTypeCondition = astTypeCondition;
+        }
+    }
+
+    private void collectFragmentSpread2(FieldCollectorNormalizedQueryParams parameters,
+                                        Map<Field, CollectedField> result,
+                                        FragmentSpread fragmentSpread,
+                                        Set<GraphQLObjectType> possibleObjects,
+                                        GraphQLCompositeType astTypeCondition
+    ) {
+        if (!conditionalNodes.shouldInclude(parameters.getCoercedVariableValues(), fragmentSpread.getDirectives())) {
+            return;
+        }
+        FragmentDefinition fragmentDefinition = assertNotNull(parameters.getFragmentsByName().get(fragmentSpread.getName()));
+
+        if (!conditionalNodes.shouldInclude(parameters.getCoercedVariableValues(), fragmentDefinition.getDirectives())) {
+            return;
+        }
+        GraphQLCompositeType newAstTypeCondition = (GraphQLCompositeType) assertNotNull(parameters.getGraphQLSchema().getType(fragmentDefinition.getTypeCondition().getName()));
+        Set<GraphQLObjectType> newPossibleObjects = narrowDownPossibleObjects(possibleObjects, newAstTypeCondition, parameters.getGraphQLSchema());
+        collectFromSelectionSet2(parameters, fragmentDefinition.getSelectionSet(), result, newAstTypeCondition, newPossibleObjects);
+    }
+
+
+    private void collectInlineFragment2(FieldCollectorNormalizedQueryParams parameters,
+                                        Map<Field, CollectedField> result,
+                                        InlineFragment inlineFragment,
+                                        Set<GraphQLObjectType> possibleObjects,
+                                        GraphQLCompositeType astTypeCondition
+    ) {
+        if (!conditionalNodes.shouldInclude(parameters.getCoercedVariableValues(), inlineFragment.getDirectives())) {
+            return;
+        }
+        Set<GraphQLObjectType> newPossibleObjects = possibleObjects;
+        GraphQLCompositeType newAstTypeCondition = astTypeCondition;
+
+        if (inlineFragment.getTypeCondition() != null) {
+            newAstTypeCondition = (GraphQLCompositeType) parameters.getGraphQLSchema().getType(inlineFragment.getTypeCondition().getName());
+            newPossibleObjects = narrowDownPossibleObjects(possibleObjects, newAstTypeCondition, parameters.getGraphQLSchema());
+
+        }
+        collectFromSelectionSet2(parameters, inlineFragment.getSelectionSet(), result, newAstTypeCondition, newPossibleObjects);
+    }
+
+    private void collectField2(FieldCollectorNormalizedQueryParams parameters,
+                               Map<Field, CollectedField> result,
+                               Field field,
+                               Set<GraphQLObjectType> possibleObjectTypes,
+                               GraphQLCompositeType astTypeCondition
+    ) {
+        if (!conditionalNodes.shouldInclude(parameters.getCoercedVariableValues(), field.getDirectives())) {
+            return;
+        }
+        // this means there is actually no possible type for this field and we are done
+        if (possibleObjectTypes.size() == 0) {
+            return;
+        }
+        result.put(field, new CollectedField(field, possibleObjectTypes, astTypeCondition));
+    }
+
+//    private void collectFragmentSpread(FieldCollectorNormalizedQueryParams parameters,
+//                                       Multimap<String, ExecutableNormalizedField> result,
+//                                       ImmutableListMultimap.Builder<ExecutableNormalizedField, Field> mergedFieldByNormalizedField,
+//                                       FragmentSpread fragmentSpread,
+//                                       Set<GraphQLObjectType> possibleObjects,
+//                                       int level,
+//                                       ExecutableNormalizedField parent) {
+//        if (!conditionalNodes.shouldInclude(parameters.getCoercedVariableValues(), fragmentSpread.getDirectives())) {
+//            return;
+//        }
+//        FragmentDefinition fragmentDefinition = assertNotNull(parameters.getFragmentsByName().get(fragmentSpread.getName()));
+//
+//        if (!conditionalNodes.shouldInclude(parameters.getCoercedVariableValues(), fragmentDefinition.getDirectives())) {
+//            return;
+//        }
+//        GraphQLCompositeType newCondition = (GraphQLCompositeType) parameters.getGraphQLSchema().getType(fragmentDefinition.getTypeCondition().getName());
+//        Set<GraphQLObjectType> newConditions = narrowDownPossibleObjects(possibleObjects, newCondition, parameters.getGraphQLSchema());
+//        collectFromSelectionSet(parameters, fragmentDefinition.getSelectionSet(), result, mergedFieldByNormalizedField, newConditions, level, parent);
+//    }
+//
+//    private void collectInlineFragment(FieldCollectorNormalizedQueryParams parameters,
+//                                       Multimap<String, ExecutableNormalizedField> result,
+//                                       ImmutableListMultimap.Builder<ExecutableNormalizedField, Field> mergedFieldByNormalizedField,
+//                                       InlineFragment inlineFragment,
+//                                       Set<GraphQLObjectType> possibleObjects,
+//                                       int level, ExecutableNormalizedField parent) {
+//        if (!conditionalNodes.shouldInclude(parameters.getCoercedVariableValues(), inlineFragment.getDirectives())) {
+//            return;
+//        }
+//        Set<GraphQLObjectType> newPossibleObjects = possibleObjects;
+//
+//        if (inlineFragment.getTypeCondition() != null) {
+//            GraphQLCompositeType newCondition = (GraphQLCompositeType) parameters.getGraphQLSchema().getType(inlineFragment.getTypeCondition().getName());
+//            newPossibleObjects = narrowDownPossibleObjects(possibleObjects, newCondition, parameters.getGraphQLSchema());
+//
+//        }
+//        collectFromSelectionSet(parameters, inlineFragment.getSelectionSet(), result, mergedFieldByNormalizedField, newPossibleObjects, level, parent);
+//    }
+//
+//    private void collectField(FieldCollectorNormalizedQueryParams parameters,
+//                              Multimap<String, ExecutableNormalizedField> result,
+//                              ImmutableListMultimap.Builder<ExecutableNormalizedField, Field> normalizedFieldToMergedField,
+//                              Field field,
+//                              Set<GraphQLObjectType> objectTypes,
+//                              int level,
+//                              ExecutableNormalizedField parent) {
+//        if (!conditionalNodes.shouldInclude(parameters.getCoercedVariableValues(), field.getDirectives())) {
+//            return;
+//        }
+//        // this means there is actually no possible type for this field and we are done
+//        if (objectTypes.size() == 0) {
+//            return;
+//        }
+//        String resultKey = field.getResultKey();
+//        String fieldName = field.getName();
+//        GraphQLFieldDefinition fieldDefinition = Introspection.getFieldDef(parameters.getGraphQLSchema(), objectTypes.iterator().next(), fieldName);
+//
+//        if (result.containsKey(resultKey)) {
+//            // can we merge it actually?
+//            Collection<ExecutableNormalizedField> existingNFs = result.get(resultKey);
+//            ExecutableNormalizedField matchingNF = findMatchingNF(parameters.getGraphQLSchema(), existingNFs, fieldDefinition, field.getArguments());
+//            if (matchingNF != null) {
+//                matchingNF.addObjectTypeNames(map(objectTypes, GraphQLObjectType::getName));
+//                normalizedFieldToMergedField.put(matchingNF, field);
+//                return;
+//            }
+//        }
+//        // this means we have no existing NF
+//        Map<String, Object> argumentValues = valuesResolver.getArgumentValues(fieldDefinition.getArguments(), field.getArguments(), parameters.getCoercedVariableValues());
+//        Map<String, NormalizedInputValue> normalizedArgumentValues = null;
+//        if (parameters.getNormalizedVariableValues() != null) {
+//            normalizedArgumentValues = valuesResolver.getNormalizedArgumentValues(fieldDefinition.getArguments(), field.getArguments(), parameters.getNormalizedVariableValues());
+//        }
+//        ImmutableList<String> objectTypeNames = map(objectTypes, GraphQLObjectType::getName);
+//        ExecutableNormalizedField executableNormalizedField = ExecutableNormalizedField.newNormalizedField()
+//                .alias(field.getAlias())
+//                .resolvedArguments(argumentValues)
+//                .normalizedArguments(normalizedArgumentValues)
+//                .astArguments(field.getArguments())
+//                .objectTypeNames(objectTypeNames)
+//                .fieldName(fieldName)
+//                .level(level)
+//                .parent(parent)
+//                .build();
+//
+//        result.put(resultKey, executableNormalizedField);
+//        normalizedFieldToMergedField.put(executableNormalizedField, field);
+//    }
 
     private ExecutableNormalizedField findMatchingNF(GraphQLSchema schema, Collection<ExecutableNormalizedField> executableNormalizedFields, GraphQLFieldDefinition fieldDefinition, List<Argument> arguments) {
         for (ExecutableNormalizedField nf : executableNormalizedFields) {
@@ -404,7 +612,7 @@ public class ExecutableNormalizedOperationFactory {
             List types = ((GraphQLUnionType) type).getTypes();
             return ImmutableSet.copyOf((types));
         } else {
-            return Assert.assertShouldNeverHappen();
+            return assertShouldNeverHappen();
         }
 
     }

--- a/src/main/java/graphql/normalized/ExecutableNormalizedOperationFactory.java
+++ b/src/main/java/graphql/normalized/ExecutableNormalizedOperationFactory.java
@@ -137,7 +137,7 @@ public class ExecutableNormalizedOperationFactory {
         }
         for (FieldCollectorNormalizedQueryParams.PossibleMerger possibleMerger : parameters.possibleMergerList) {
             List<ExecutableNormalizedField> childrenWithSameResultKey = possibleMerger.parent.getChildrenWithSameResultKey(possibleMerger.resultKey);
-            ENFMerger.merge(possibleMerger.parent, childrenWithSameResultKey);
+            ENFMerger.merge(possibleMerger.parent, childrenWithSameResultKey, graphQLSchema);
         }
         return new ExecutableNormalizedOperation(new ArrayList<>(collectFromOperationResult.children), fieldToNormalizedField.build(), normalizedFieldToMergedField.build(), coordinatesToNormalizedFields.build());
     }

--- a/src/main/java/graphql/normalized/FieldCollectorNormalizedQueryParams.java
+++ b/src/main/java/graphql/normalized/FieldCollectorNormalizedQueryParams.java
@@ -7,7 +7,9 @@ import graphql.schema.GraphQLSchema;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 @Internal
@@ -16,6 +18,22 @@ public class FieldCollectorNormalizedQueryParams {
     private final Map<String, FragmentDefinition> fragmentsByName;
     private final Map<String, Object> coercedVariableValues;
     private final Map<String, NormalizedInputValue> normalizedVariableValues;
+
+    public List<PossibleMerger> possibleMergerList = new ArrayList<>();
+
+    public static class PossibleMerger {
+        ExecutableNormalizedField parent;
+        String resultKey;
+
+        public PossibleMerger(ExecutableNormalizedField parent, String resultKey) {
+            this.parent = parent;
+            this.resultKey = resultKey;
+        }
+    }
+
+    public void addPossibleMergers(ExecutableNormalizedField parent, String resultKey) {
+        possibleMergerList.add(new PossibleMerger(parent, resultKey));
+    }
 
     public GraphQLSchema getGraphQLSchema() {
         return graphQLSchema;

--- a/src/main/java/graphql/schema/GraphQLTypeUtil.java
+++ b/src/main/java/graphql/schema/GraphQLTypeUtil.java
@@ -264,4 +264,14 @@ public class GraphQLTypeUtil {
         }
         return decoration;
     }
+
+    public static boolean isInterfaceOrUnion(GraphQLType type) {
+        return type instanceof GraphQLInterfaceType || type instanceof GraphQLUnionType;
+    }
+
+    public static boolean isObjectType(GraphQLType type) {
+        return type instanceof GraphQLObjectType;
+    }
+
+
 }

--- a/src/main/java/graphql/util/FpKit.java
+++ b/src/main/java/graphql/util/FpKit.java
@@ -278,7 +278,7 @@ public class FpKit {
                 .collect(Collectors.toList());
     }
 
-    public static <T> Set<T> filterSet(Set<T> input, Predicate<T> filter) {
+    public static <T> Set<T> filterSet(Collection<T> input, Predicate<T> filter) {
         LinkedHashSet<T> result = new LinkedHashSet<>();
         for (T t : input) {
             if (filter.test(t)) {

--- a/src/test/groovy/graphql/normalized/ExecutableNormalizedOperationFactoryTest.groovy
+++ b/src/test/groovy/graphql/normalized/ExecutableNormalizedOperationFactoryTest.groovy
@@ -109,20 +109,24 @@ type Dog implements Animal{
 
         ExecutableNormalizedOperationFactory dependencyGraph = new ExecutableNormalizedOperationFactory();
         def tree = dependencyGraph.createExecutableNormalizedOperation(graphQLSchema, document, null, [:])
-        def printedTree = printTree(tree)
+        def printedTree = printTreeWithLevelInfo(tree, graphQLSchema)
 
         expect:
-        printedTree == ['Query.animal',
-                        '[Bird, Cat, Dog].name',
-                        'otherName: [Bird, Cat, Dog].name',
-                        '[Cat, Bird].friends',
-                        'Friend.isCatOwner',
-                        'Friend.pets',
-                        'Dog.name',
-                        'Cat.breed',
-                        'Friend.isBirdOwner',
-                        'Friend.name']
-
+        printedTree == ['-Query.animal: Animal',
+                        '--[Bird, Cat, Dog].name: String',
+                        '--Cat.name: String',
+                        '--Dog.name: String',
+                        '--otherName: [Bird, Cat, Dog].name: String',
+                        '--Cat.friends: [Friend]',
+                        '---Friend.isCatOwner: Boolean',
+                        '---Friend.pets: [Pet]',
+                        '----Dog.name: String',
+                        '--Bird.friends: [Friend]',
+                        '---Friend.isBirdOwner: Boolean',
+                        '---Friend.name: String',
+                        '---Friend.pets: [Pet]',
+                        '----Cat.breed: String'
+        ]
     }
 
     def "test2"() {
@@ -193,14 +197,20 @@ type Dog implements Animal{
 
         ExecutableNormalizedOperationFactory dependencyGraph = new ExecutableNormalizedOperationFactory();
         def tree = dependencyGraph.createExecutableNormalizedOperation(graphQLSchema, document, null, [:])
-        def printedTree = printTree(tree)
+        def printedTree = printTreeWithLevelInfo(tree, graphQLSchema)
 
         expect:
-        printedTree == ['Query.a',
-                        'myAlias: [A1, A2].b',
-                        '[B1, B2].leaf',
-                        '[A1, A2].b',
-                        '[B1, B2].leaf']
+        printedTree == ['-Query.a: A',
+                        '--myAlias: [A1, A2].b: B',
+                        '---[B1, B2].leaf: String',
+                        '--A1.b: B',
+                        '---B1.leaf: String',
+                        '---B2.leaf: String',
+                        '--A2.b: B',
+                        '---B2.leaf: String'
+        ]
+
+
     }
 
     def "test3"() {
@@ -268,14 +278,16 @@ type Dog implements Animal{
 
         ExecutableNormalizedOperationFactory dependencyGraph = new ExecutableNormalizedOperationFactory();
         def tree = dependencyGraph.createExecutableNormalizedOperation(graphQLSchema, document, null, [:])
-        def printedTree = printTree(tree)
+        def printedTree = printTreeWithLevelInfo(tree, graphQLSchema)
 
         expect:
-        printedTree == ['Query.object',
-                        'Object.someValue',
-                        'Query.a',
-                        'A1.b',
-                        '[B1, B2].leaf']
+        printedTree == ['-Query.object: Object',
+                        '--Object.someValue: String',
+                        '-Query.a: [A]',
+                        '--A1.b: B',
+                        '---B1.leaf: String',
+                        '---B2.leaf: String'
+        ]
 
     }
 
@@ -474,13 +486,17 @@ type Dog implements Animal{
 
         ExecutableNormalizedOperationFactory dependencyGraph = new ExecutableNormalizedOperationFactory();
         def tree = dependencyGraph.createExecutableNormalizedOperation(graphQLSchema, document, null, [:])
-        def printedTree = printTree(tree)
+        def printedTree = printTreeWithLevelInfo(tree, graphQLSchema)
 
         expect:
-        printedTree == ['Query.a',
-                        '[A1, A2, A3].b',
-                        'A2.otherField',
-                        '[A2, A3].b']
+        printedTree == ['-Query.a: [A]',
+                        '--[A1, A2, A3].b: String',
+                        '--A1.b: String',
+                        '--A2.b: String',
+                        '--A2.otherField: A',
+                        '---A2.b: String',
+                        '---A3.b: String'
+        ]
 
     }
 
@@ -845,8 +861,8 @@ type Dog implements Animal{
         def printedTree = printTreeWithLevelInfo(tree, graphQLSchema)
 
         expect:
-        printedTree == ['Query.pet',
-                        '[Dog, Cat].name'];
+        printedTree == ['-Query.pet: Pet',
+                        '--[Dog, Cat].name: String'];
     }
 
     def "same result key but different field"() {

--- a/src/test/groovy/graphql/normalized/ExecutableNormalizedOperationToAstCompilerTest.groovy
+++ b/src/test/groovy/graphql/normalized/ExecutableNormalizedOperationToAstCompilerTest.groovy
@@ -108,17 +108,13 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         otherName: name
         friends {
           ... on Friend {
-            isCatOwner
+            isBirdOwner
+            name
             pets {
-              ... on Dog {
-                name
-              }
               ... on Cat {
                 breed
               }
             }
-            isBirdOwner
-            name
           }
         }
       }
@@ -133,12 +129,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
               ... on Dog {
                 name
               }
-              ... on Cat {
-                breed
-              }
             }
-            isBirdOwner
-            name
           }
         }
       }


### PR DESCRIPTION
This PR fixes a problem with the ENOF which could lead to wrong executable normalized operations.

Specifically it is about diverging fields, which are fields with the same result key, but they can't be merged together:

E.g.:
```graphql
       {
          pets {
            ... on Dog {
               friends { #P1
                 ... on Dog {
                    breed: dogBreed #F1
                 }
               }
            }
            ... on Cat {
             friends {  #P2
                ... on Dog {
                  breed #F2
                }
               }
            }
          }
        }
```
Here P1 and P2 need to result into two different normalized fields, because the children actually differ: F1 is different from F2.
        