### PR TITLE
Ensure field errors are populated in FetchedResult

### DIFF
--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -291,7 +291,8 @@ public abstract class ExecutionStrategy {
                 .handle((result, exception) -> {
                     fetchCtx.onCompleted(result, exception);
                     if (exception != null) {
-                        return handleFetchingException(executionContext, environment, exception);
+                        CompletableFuture<Object> objectCompletableFuture = handleFetchingException(executionContext, environment, exception);
+                        return objectCompletableFuture;
                     } else {
                         return CompletableFuture.completedFuture(result);
                     }
@@ -353,15 +354,10 @@ public abstract class ExecutionStrategy {
     }
 
     private <T> CompletableFuture<T> asyncHandleException(DataFetcherExceptionHandler handler, DataFetcherExceptionHandlerParameters handlerParameters, ExecutionContext executionContext) {
-        return handler.handleException(handlerParameters)
-                .thenApply(handlerResult -> {
-                            // the side effect is that we added the returned errors to the execution context
-                            // here
-                            executionContext.addErrors(handlerResult.getErrors());
-                            // and we return null because there is no data for the executed field
-                            return null;
-                        }
-                );
+        //noinspection unchecked
+        return  handler.handleException(handlerParameters)
+            .thenApply(handlerResult -> (T) DataFetcherResult.<FetchedValue>newResult().errors(handlerResult.getErrors()).build()
+            );
     }
 
     /**

--- a/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
@@ -9,7 +9,10 @@ import graphql.Scalars
 import graphql.SerializationError
 import graphql.StarWarsSchema
 import graphql.TypeMismatchError
+import graphql.execution.instrumentation.Instrumentation
+import graphql.execution.instrumentation.InstrumentationContext
 import graphql.execution.instrumentation.SimpleInstrumentation
+import graphql.execution.instrumentation.parameters.InstrumentationFieldCompleteParameters
 import graphql.language.Argument
 import graphql.language.Field
 import graphql.language.OperationDefinition
@@ -624,6 +627,47 @@ class ExecutionStrategyTest extends Specification {
         executionContext.errors.size() == 1
         def exceptionWhileDataFetching = executionContext.errors[0] as ExceptionWhileDataFetching
         exceptionWhileDataFetching.getMessage().contains('This is the exception you are looking for')
+    }
+
+    def "data fetcher errors for a given field appear in FetchedResult within instrumentation"() {
+        def expectedException = new UnsupportedOperationException("This is the exception you are looking for")
+
+        //noinspection GroovyAssignabilityCheck,GroovyUnusedAssignment
+        def (ExecutionContext executionContext, GraphQLFieldDefinition fieldDefinition, ResultPath expectedPath, ExecutionStrategyParameters params, Field field, SourceLocation sourceLocation) = exceptionSetupFixture(expectedException)
+
+        ExecutionContextBuilder executionContextBuilder = ExecutionContextBuilder.newExecutionContextBuilder(executionContext)
+        def instrumentation = new SimpleInstrumentation() {
+            Map<String, FetchedValue> fetchedValues = [:]
+
+            @Override
+            InstrumentationContext<ExecutionResult> beginFieldComplete(InstrumentationFieldCompleteParameters parameters) {
+                if (parameters.fetchedValue instanceof FetchedValue) {
+                    FetchedValue value = (FetchedValue) parameters.fetchedValue
+                    fetchedValues.put(parameters.field.name, value)
+                }
+                return super.beginFieldComplete(parameters)
+            }
+        }
+        ExecutionContext instrumentedExecutionContext = executionContextBuilder.instrumentation(instrumentation).build()
+
+        ExecutionStrategy overridingStrategy = new ExecutionStrategy() {
+            @Override
+            CompletableFuture<ExecutionResult> execute(ExecutionContext ec, ExecutionStrategyParameters p) throws NonNullableFieldWasNullException {
+                null
+            }
+        }
+
+        when:
+        overridingStrategy.resolveField(instrumentedExecutionContext, params)
+
+        then:
+        FetchedValue fetchedValue = instrumentation.fetchedValues.get("someField")
+        fetchedValue != null
+        fetchedValue.errors.size() == 1
+        def exceptionWhileDataFetching = fetchedValue.errors[0] as ExceptionWhileDataFetching
+        exceptionWhileDataFetching.getMessage().contains('This is the exception you are looking for')
+        instrumentedExecutionContext.errors.size() == 1
+        instrumentedExecutionContext.errors[0] == fetchedValue.errors[0]
     }
 
     def "#522 - single error during execution - not two errors"() {

--- a/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
@@ -628,7 +628,7 @@ class ExecutionStrategyTest extends Specification {
         exceptionWhileDataFetching.getMessage().contains('This is the exception you are looking for')
     }
 
-    def "data fetcher errors for a given field appear in FetchedResult within instrumentation"() {
+    def "#2519 data fetcher errors for a given field appear in FetchedResult within instrumentation"() {
         def expectedException = new UnsupportedOperationException("This is the exception you are looking for")
 
         //noinspection GroovyAssignabilityCheck,GroovyUnusedAssignment

--- a/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
@@ -9,7 +9,6 @@ import graphql.Scalars
 import graphql.SerializationError
 import graphql.StarWarsSchema
 import graphql.TypeMismatchError
-import graphql.execution.instrumentation.Instrumentation
 import graphql.execution.instrumentation.InstrumentationContext
 import graphql.execution.instrumentation.SimpleInstrumentation
 import graphql.execution.instrumentation.parameters.InstrumentationFieldCompleteParameters


### PR DESCRIPTION
Currently if a DataFetcher raises an exception in any way, the `FetchedValue` given in the instrumentation `beginFieldComplete` method does not contain any errors information. The only place errors are available are on the `ExecutionContext` within a list, which is not ideal to determine if the current field has an error. This change ensures that FetchedValue contains errors if any was raised during `DataFetcher.get`.

The solution simply allows the `unboxPossibleDataFetcherResult` to hit the `result instanceof DataFetcherResult` case which properly passes through errors in the ExecutionContext and in the `FetchedResult` itself. Since I'm not super familiar with the code base, this implementation has to cast to type `T`, which seems safe since the method was returning null in the first place but would defer to your suggestions to change.

Another possible solution is to expose a `containsErrorPath` method on `ExecutionContext` as the context maintains a `Set<ResultPath> errorPaths` which could be used to look up the current ResultPath in the instrumentation to see if it's an error. However, having the error directly on the `FetchedValue` _seems_ to make more sense.