### PR TITLE
Support for tracking the parse order

### DIFF
--- a/src/main/java/graphql/schema/GraphQLSchema.java
+++ b/src/main/java/graphql/schema/GraphQLSchema.java
@@ -293,6 +293,14 @@ public class GraphQLSchema {
         return (GraphQLObjectType) graphQLType;
     }
 
+    /**
+     * Returns a {@link GraphQLFieldDefinition} as the specified co-ordinates or null
+     * if it does not exist
+     *
+     * @param fieldCoordinates the field co-ordinates
+     *
+     * @return the field or null if it does not exist
+     */
     public GraphQLFieldDefinition getFieldDefinition(FieldCoordinates fieldCoordinates) {
         String fieldName = fieldCoordinates.getFieldName();
         if (fieldCoordinates.isSystemCoordinates()) {
@@ -317,12 +325,33 @@ public class GraphQLSchema {
         return null;
     }
 
+    /**
+     * @return all the named types in the scheme as a map from name to named type
+     */
     public Map<String, GraphQLNamedType> getTypeMap() {
         return typeMap;
     }
 
+    /**
+     * This returns all the {@link GraphQLNamedType} named types in th schema
+     *
+     * @return all the {@link GraphQLNamedType} types in the schema
+     */
     public List<GraphQLNamedType> getAllTypesAsList() {
         return getAllTypesAsList(typeMap);
+    }
+
+    /**
+     * This returns all the top level {@link GraphQLNamedSchemaElement} named types and directives
+     * in the schema
+     *
+     * @return all the top level {@link GraphQLNamedSchemaElement} types and directives in the schema
+     */
+    public List<GraphQLNamedSchemaElement> getAllElementsAsList() {
+        List<GraphQLNamedSchemaElement> list = new ArrayList<>();
+        list.addAll(getDirectives());
+        list.addAll(getAllTypesAsList());
+        return list;
     }
 
     /**
@@ -358,14 +387,23 @@ public class GraphQLSchema {
         return assertShouldNeverHappen("Unsupported abstract type %s. Abstract types supported are Union and Interface.", abstractType.getName());
     }
 
+    /**
+     * @return the Query type of the schema
+     */
     public GraphQLObjectType getQueryType() {
         return queryType;
     }
 
+    /**
+     * @return the Mutation type of the schema of null if there is not one
+     */
     public GraphQLObjectType getMutationType() {
         return mutationType;
     }
 
+    /**
+     * @return the Subscription type of the schema of null if there is not one
+     */
     public GraphQLObjectType getSubscriptionType() {
         return subscriptionType;
     }

--- a/src/main/java/graphql/schema/GraphQLTypeUtil.java
+++ b/src/main/java/graphql/schema/GraphQLTypeUtil.java
@@ -2,8 +2,12 @@ package graphql.schema;
 
 import graphql.Assert;
 import graphql.PublicApi;
+import graphql.introspection.Introspection;
+import graphql.schema.idl.DirectiveInfo;
+import graphql.schema.idl.ScalarInfo;
 
 import java.util.Stack;
+import java.util.function.Predicate;
 
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertShouldNeverHappen;
@@ -175,7 +179,7 @@ public class GraphQLTypeUtil {
      * and then cast to the target type.
      *
      * @param type the type to unwrapOne
-     * @param <T> for two
+     * @param <T>  for two
      *
      * @return the unwrapped type or the same type again if its not wrapped
      */
@@ -205,7 +209,7 @@ public class GraphQLTypeUtil {
      * and then cast to the target type.
      *
      * @param type the type to unwrapOne
-     * @param <T> for two
+     * @param <T>  for two
      *
      * @return the underlying type
      */
@@ -234,7 +238,7 @@ public class GraphQLTypeUtil {
      * and then cast to the target type.
      *
      * @param type the type to unwrap
-     * @param <T> for two
+     * @param <T>  for two
      *
      * @return the underlying type that is not {@link GraphQLNonNull}
      */
@@ -253,7 +257,7 @@ public class GraphQLTypeUtil {
      * @return a stack of the type wrapping which will be at least 1 later deep
      */
     public static Stack<GraphQLType> unwrapType(GraphQLType type) {
-        type = assertNotNull(type);
+        assertNotNull(type);
         Stack<GraphQLType> decoration = new Stack<>();
         while (true) {
             decoration.push(type);
@@ -274,4 +278,24 @@ public class GraphQLTypeUtil {
     }
 
 
+    /**
+     * This predicate returns true if the schema element is an inbuilt schema element
+     * such as the system scalars and directives or introspection types
+     *
+     * @return true if its a system schema element
+     */
+    public static Predicate<GraphQLNamedSchemaElement> isSystemElement() {
+        return schemaElement -> {
+            if (schemaElement instanceof GraphQLScalarType) {
+                return ScalarInfo.isGraphqlSpecifiedScalar((GraphQLScalarType) schemaElement);
+            }
+            if (schemaElement instanceof GraphQLDirective) {
+                return DirectiveInfo.isGraphqlSpecifiedDirective((GraphQLDirective) schemaElement);
+            }
+            if (schemaElement instanceof GraphQLNamedType) {
+                return Introspection.isIntrospectionTypes((GraphQLNamedType) schemaElement);
+            }
+            return false;
+        };
+    }
 }

--- a/src/main/java/graphql/schema/idl/SchemaParseOrder.java
+++ b/src/main/java/graphql/schema/idl/SchemaParseOrder.java
@@ -10,6 +10,7 @@ import graphql.schema.GraphQLInputObjectField;
 import graphql.schema.GraphQLNamedSchemaElement;
 import graphql.schema.GraphQLSchemaElement;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -25,7 +26,7 @@ import static java.util.Optional.ofNullable;
  * This class will track what order {@link SDLDefinition} were parsed in
  * via {@link SchemaParser} and {@link TypeDefinitionRegistry}
  */
-public class SchemaParseOrder {
+public class SchemaParseOrder implements Serializable {
 
     private final Map<String, List<SDLDefinition<?>>> definitionOrder = new LinkedHashMap<>();
 

--- a/src/main/java/graphql/schema/idl/SchemaParseOrder.java
+++ b/src/main/java/graphql/schema/idl/SchemaParseOrder.java
@@ -1,0 +1,148 @@
+package graphql.schema.idl;
+
+import com.google.common.collect.ImmutableMap;
+import graphql.language.SDLDefinition;
+import graphql.language.SDLNamedDefinition;
+import graphql.language.SourceLocation;
+import graphql.schema.GraphQLEnumValueDefinition;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLInputObjectField;
+import graphql.schema.GraphQLNamedSchemaElement;
+import graphql.schema.GraphQLSchemaElement;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
+
+import static java.util.Optional.ofNullable;
+
+/**
+ * This class will track what order {@link SDLDefinition} were parsed in
+ * via {@link SchemaParser} and {@link TypeDefinitionRegistry}
+ */
+public class SchemaParseOrder {
+
+    private final Map<String, List<SDLDefinition<?>>> definitionOrder = new LinkedHashMap<>();
+
+
+    /**
+     * This map is the order in which {@link SDLDefinition}s were parsed per unique {@link SourceLocation#getSourceName()}.  If there
+     * is no source then the empty string "" is used.
+     *
+     * @return a map of source names to definitions in parsed order
+     */
+    public Map<String, List<SDLDefinition<?>>> getInOrder() {
+        return ImmutableMap.copyOf(definitionOrder);
+    }
+
+    /**
+     * This map is the order in which {@link SDLDefinition}s were parsed per unique {@link SourceLocation#getSourceName()} and it
+     * only contains {@link SDLNamedDefinition}s.  If there is no source then the empty string "" is used.
+     *
+     * @return a map of source names to definitions in parsed order
+     */
+    public Map<String, List<SDLNamedDefinition<?>>> getInNameOrder() {
+        Map<String, List<SDLNamedDefinition<?>>> named = new LinkedHashMap<>();
+        definitionOrder.forEach((location, def) -> {
+            List<SDLNamedDefinition<?>> namedDefs = def.stream()
+                    .filter(d -> d instanceof SDLNamedDefinition)
+                    .map(d -> (SDLNamedDefinition<?>) d)
+                    .collect(Collectors.toList());
+            named.put(location, namedDefs);
+        });
+        return named;
+    }
+
+    /**
+     * This comparator will sort according to the original parsed order
+     *
+     * @param <T> is a {@link GraphQLSchemaElement}
+     *
+     * @return a comparator that sorts schema elements in parsed order
+     */
+    public <T extends GraphQLSchemaElement> Comparator<? super T> getElementComparator() {
+        // relies in the fact that names in graphql schema are unique across ALL elements
+        Map<String, Integer> namedSortValues = buildNameIndex(getInNameOrder());
+        return (e1, e2) -> {
+            if (e1 instanceof GraphQLFieldDefinition || e1 instanceof GraphQLInputObjectField || e1 instanceof GraphQLEnumValueDefinition) {
+                return 0; // as is
+            }
+            if (e1 instanceof GraphQLNamedSchemaElement && e2 instanceof GraphQLNamedSchemaElement) {
+                int sortVal1 = sortVale((GraphQLNamedSchemaElement) e1, namedSortValues);
+                int sortVal2 = sortVale((GraphQLNamedSchemaElement) e2, namedSortValues);
+                return Integer.compare(sortVal1, sortVal2);
+            }
+            return -1; // sort to the top
+        };
+    }
+
+    private Integer sortVale(GraphQLNamedSchemaElement e1, Map<String, Integer> namedSortValues) {
+        return namedSortValues.getOrDefault(e1.getName(), -1);
+    }
+
+    private Map<String, Integer> buildNameIndex(Map<String, List<SDLNamedDefinition<?>>> inNameOrder) {
+        Map<String, Integer> nameIndex = new HashMap<>();
+        int sourceIndex = 0;
+        for (Map.Entry<String, List<SDLNamedDefinition<?>>> entry : inNameOrder.entrySet()) {
+            List<SDLNamedDefinition<?>> namedDefs = entry.getValue();
+            for (int i = 0; i < namedDefs.size(); i++) {
+                SDLNamedDefinition<?> namedDefinition = namedDefs.get(i);
+                // we will put it in parsed order AND with first sources first
+                int index = i + (sourceIndex * 100_000_000);
+                nameIndex.put(namedDefinition.getName(), index);
+            }
+            sourceIndex++;
+        }
+        return nameIndex;
+    }
+
+    /**
+     * This adds a new {@link SDLDefinition} to the order
+     *
+     * @param sdlDefinition the SDL definition to add
+     * @param <T>           for two
+     *
+     * @return this {@link SchemaParseOrder} for fluent building
+     */
+    public <T extends SDLDefinition<?>> SchemaParseOrder addDefinition(T sdlDefinition) {
+        if (sdlDefinition != null) {
+            definitionList(sdlDefinition).add(sdlDefinition);
+        }
+        return this;
+    }
+
+    /**
+     * This removes a {@link SDLDefinition} from the order
+     *
+     * @param sdlDefinition the SDL definition to remove
+     * @param <T>           for two
+     *
+     * @return this {@link SchemaParseOrder} for fluent building
+     */
+    public <T extends SDLDefinition<?>> SchemaParseOrder removedDefinition(T sdlDefinition) {
+        definitionList(sdlDefinition).remove(sdlDefinition);
+        return this;
+    }
+
+    private <T extends SDLDefinition<?>> List<SDLDefinition<?>> definitionList(T sdlDefinition) {
+        String location = ofNullable(sdlDefinition.getSourceLocation())
+                .map(SourceLocation::getSourceName).orElse("");
+        return computeIfAbsent(location);
+    }
+
+    private List<SDLDefinition<?>> computeIfAbsent(String location) {
+        return definitionOrder.computeIfAbsent(location, k -> new ArrayList<>());
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", SchemaParseOrder.class.getSimpleName() + "[", "]")
+                .add("definitionOrder=" + definitionOrder)
+                .toString();
+    }
+}

--- a/src/main/java/graphql/schema/idl/SchemaParser.java
+++ b/src/main/java/graphql/schema/idl/SchemaParser.java
@@ -11,10 +11,10 @@ import graphql.parser.Parser;
 import graphql.schema.idl.errors.NonSDLDefinitionError;
 import graphql.schema.idl.errors.SchemaProblem;
 
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
 import java.nio.file.Files;

--- a/src/main/java/graphql/schema/idl/SchemaPrinter.java
+++ b/src/main/java/graphql/schema/idl/SchemaPrinter.java
@@ -945,6 +945,22 @@ public class SchemaPrinter {
         return sw.toString();
     }
 
+    public String print(List<GraphQLSchemaElement> elements) {
+        StringWriter sw = new StringWriter();
+        PrintWriter out = new PrintWriter(sw);
+
+        for (GraphQLSchemaElement element : elements) {
+            if (element instanceof GraphQLDirective) {
+                out.print(print(((GraphQLDirective) element)));
+            } else if (element instanceof GraphQLType) {
+                printType(out, (GraphQLType) element, DEFAULT_FIELD_VISIBILITY);
+            } else {
+                Assert.assertShouldNeverHappen("How did we miss a %s", element.getClass());
+            }
+        }
+        return sw.toString();
+    }
+
     public String print(GraphQLDirective graphQLDirective) {
         return directiveDefinition(graphQLDirective);
     }

--- a/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java
+++ b/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java
@@ -262,7 +262,7 @@ public class TypeDefinitionRegistry implements Serializable {
      */
     public void remove(SDLDefinition definition) {
         assertNotNull(definition, () -> "definition to remove can't be null");
-        schemaParseOrder.removedDefinition(definition);
+        schemaParseOrder.removeDefinition(definition);
         if (definition instanceof ObjectTypeExtensionDefinition) {
             removeFromList(objectTypeExtensions, (TypeDefinition) definition);
         } else if (definition instanceof InterfaceTypeExtensionDefinition) {
@@ -310,7 +310,7 @@ public class TypeDefinitionRegistry implements Serializable {
     public void remove(String key, SDLDefinition definition) {
         assertNotNull(definition, () -> "definition to remove can't be null");
         assertNotNull(key, () -> "key to remove can't be null");
-        schemaParseOrder.removedDefinition(definition);
+        schemaParseOrder.removeDefinition(definition);
         if (definition instanceof ObjectTypeExtensionDefinition) {
             removeFromMap(objectTypeExtensions, key);
         } else if (definition instanceof InterfaceTypeExtensionDefinition) {


### PR DESCRIPTION
This provides a tracker class that remembers the order of elements
as they were parsed.

This could then be used by a print a schema in parse order say