### PR TITLE
Support Max validation errors being produced

### DIFF
--- a/src/main/java/graphql/validation/ValidationErrorCollector.java
+++ b/src/main/java/graphql/validation/ValidationErrorCollector.java
@@ -6,6 +6,8 @@ import graphql.Internal;
 import java.util.ArrayList;
 import java.util.List;
 
+import static graphql.validation.ValidationErrorType.MaxValidationErrorsReached;
+
 @Internal
 public class ValidationErrorCollector {
 
@@ -20,8 +22,8 @@ public class ValidationErrorCollector {
         this.maxErrors = maxErrors;
     }
 
-    public boolean atMaxErrors() {
-        return errors.size() >= maxErrors;
+    private boolean atMaxErrors() {
+        return errors.size() >= maxErrors - 1;
     }
 
     /**
@@ -35,6 +37,13 @@ public class ValidationErrorCollector {
         if (!atMaxErrors()) {
             this.errors.add(validationError);
         } else {
+            this.errors.add(ValidationError.newValidationError()
+                    .validationErrorType(MaxValidationErrorsReached)
+                    .description(
+                            String.format("The maximum number of validation errors has been reached. (%d)", maxErrors)
+                    )
+                    .build());
+
             throw new MaxValidationErrorsReached();
         }
     }

--- a/src/main/java/graphql/validation/ValidationErrorCollector.java
+++ b/src/main/java/graphql/validation/ValidationErrorCollector.java
@@ -10,9 +10,33 @@ import java.util.List;
 public class ValidationErrorCollector {
 
     private final List<ValidationError> errors = new ArrayList<>();
+    private final int maxErrors;
 
-    public void addError(ValidationError validationError) {
-        this.errors.add(validationError);
+    public ValidationErrorCollector() {
+        this(Validator.MAX_VALIDATION_ERRORS);
+    }
+
+    public ValidationErrorCollector(int maxErrors) {
+        this.maxErrors = maxErrors;
+    }
+
+    public boolean atMaxErrors() {
+        return errors.size() >= maxErrors;
+    }
+
+    /**
+     * This will throw {@link MaxValidationErrorsReached} if too many validation errors are added
+     *
+     * @param validationError the error to add
+     *
+     * @throws MaxValidationErrorsReached if too many errors have been generated
+     */
+    public void addError(ValidationError validationError) throws MaxValidationErrorsReached {
+        if (!atMaxErrors()) {
+            this.errors.add(validationError);
+        } else {
+            throw new MaxValidationErrorsReached();
+        }
     }
 
     public List<ValidationError> getErrors() {
@@ -38,4 +62,17 @@ public class ValidationErrorCollector {
                 "errors=" + errors +
                 '}';
     }
+
+    /**
+     * Indicates that that maximum number of validation errors has been reached
+     */
+    @Internal
+    static class MaxValidationErrorsReached extends RuntimeException {
+
+        @Override
+        public synchronized Throwable fillInStackTrace() {
+            return this;
+        }
+    }
+
 }

--- a/src/main/java/graphql/validation/ValidationErrorType.java
+++ b/src/main/java/graphql/validation/ValidationErrorType.java
@@ -3,6 +3,7 @@ package graphql.validation;
 
 public enum ValidationErrorType {
 
+    MaxValidationErrorsReached,
     DefaultForNonNullArgument,
     WrongType,
     UnknownType,

--- a/src/main/java/graphql/validation/Validator.java
+++ b/src/main/java/graphql/validation/Validator.java
@@ -36,14 +36,14 @@ import java.util.List;
 @Internal
 public class Validator {
 
-    static int MAX_VALIDATION_ERRORS = 500;
+    static int MAX_VALIDATION_ERRORS = 100;
 
     /**
      * `graphql-java` will stop validation after a maximum number of validation messages has been reached.  Attackers
      * can send pathologically invalid queries to induce a Denial of Service attack and fill memory with 10000s of errors
      * and burn CPU in process.
      *
-     * You can set a new JVM wide value as the maximum allow validation errors.  By default this is set to 500 errors.
+     * By default, this is set to 100 errors.  You can set a new JVM wide value as the maximum allowed validation errors.
      *
      * @param maxValidationErrors the maximum validation errors allow JVM wide
      */

--- a/src/test/groovy/graphql/validation/MaxValidationErrorsTest.groovy
+++ b/src/test/groovy/graphql/validation/MaxValidationErrorsTest.groovy
@@ -13,7 +13,7 @@ class MaxValidationErrorsTest extends SpecValidationBase {
         def validationErrors = validate(query)
 
         then:
-        validationErrors.size() == 500
+        validationErrors.size() == 100
 
         when: "we can set a new maximum"
         Validator.setMaxValidationErrors(10)

--- a/src/test/groovy/graphql/validation/MaxValidationErrorsTest.groovy
+++ b/src/test/groovy/graphql/validation/MaxValidationErrorsTest.groovy
@@ -1,0 +1,25 @@
+package graphql.validation
+
+class MaxValidationErrorsTest extends SpecValidationBase {
+
+    def "The maximum number of validation messages is respected"() {
+        def directives = "@lol" * 10000
+        def query = """
+            query lotsOfErrors {
+              f $directives        
+            }
+        """
+        when:
+        def validationErrors = validate(query)
+
+        then:
+        validationErrors.size() == 500
+
+        when: "we can set a new maximum"
+        Validator.setMaxValidationErrors(10)
+        validationErrors = validate(query)
+
+        then:
+        validationErrors.size() == 10
+    }
+}

--- a/src/test/java/benchmark/TypeDefinitionParserVersusSerializeBenchMark.java
+++ b/src/test/java/benchmark/TypeDefinitionParserVersusSerializeBenchMark.java
@@ -2,7 +2,6 @@ package benchmark;
 
 import graphql.schema.idl.SchemaParser;
 import graphql.schema.idl.TypeDefinitionRegistry;
-import org.jetbrains.annotations.NotNull;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Measurement;
@@ -62,7 +61,6 @@ public class TypeDefinitionParserVersusSerializeBenchMark {
         });
     }
 
-    @NotNull
     private static ByteArrayOutputStream serialisedRegistryStream(TypeDefinitionRegistry registryOut) {
         return asRTE(() -> {
             ByteArrayOutputStream baOS = new ByteArrayOutputStream();


### PR DESCRIPTION
Its not useful to have 10,000 validation errors in a response

However an attack can use this to DOS the engine and force it to produce lots of validation errors at the expense of CPU nd memory.

This introduces a maximum number of validation errors messages.