### PR TITLE
Adding a parser listener AND the ability to set parser options per request

### DIFF
--- a/src/main/java/graphql/ParseAndValidate.java
+++ b/src/main/java/graphql/ParseAndValidate.java
@@ -3,6 +3,7 @@ package graphql;
 import graphql.language.Document;
 import graphql.parser.InvalidSyntaxException;
 import graphql.parser.Parser;
+import graphql.parser.ParserOptions;
 import graphql.schema.GraphQLSchema;
 import graphql.validation.ValidationError;
 import graphql.validation.Validator;
@@ -23,6 +24,7 @@ public class ParseAndValidate {
      *
      * @param graphQLSchema  the schema to validate against
      * @param executionInput the execution input containing the query
+     *
      * @return a result object that indicates how this operation went
      */
     public static ParseAndValidateResult parseAndValidate(GraphQLSchema graphQLSchema, ExecutionInput executionInput) {
@@ -38,12 +40,16 @@ public class ParseAndValidate {
      * This can be called to parse (but not validate) a graphql query.
      *
      * @param executionInput the input containing the query
+     *
      * @return a result object that indicates how this operation went
      */
     public static ParseAndValidateResult parse(ExecutionInput executionInput) {
         try {
+            //
+            // we allow the caller to specify new parser options by context
+            ParserOptions parserOptions = executionInput.getGraphQLContext().get(ParserOptions.class);
             Parser parser = new Parser();
-            Document document = parser.parseDocument(executionInput.getQuery());
+            Document document = parser.parseDocument(executionInput.getQuery(), parserOptions);
             return ParseAndValidateResult.newResult().document(document).variables(executionInput.getVariables()).build();
         } catch (InvalidSyntaxException e) {
             return ParseAndValidateResult.newResult().syntaxException(e).variables(executionInput.getVariables()).build();
@@ -55,6 +61,7 @@ public class ParseAndValidate {
      *
      * @param graphQLSchema  the graphql schema to validate against
      * @param parsedDocument the previously parsed document
+     *
      * @return a result object that indicates how this operation went
      */
     public static List<ValidationError> validate(GraphQLSchema graphQLSchema, Document parsedDocument) {

--- a/src/main/java/graphql/PublicSpi.java
+++ b/src/main/java/graphql/PublicSpi.java
@@ -15,7 +15,7 @@ import static java.lang.annotation.ElementType.TYPE;
  *
  * The guarantee  is for callers of code with this annotation as well as derivations that inherit / implement this code.
  *
- * New methods will not be added (without using default methods say) that would nominally breaks SPI implementations
+ * New methods will not be added (without using default methods say) that would nominally break SPI implementations
  * within a major release.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/graphql/parser/Parser.java
+++ b/src/main/java/graphql/parser/Parser.java
@@ -147,7 +147,7 @@ public class Parser {
         return parseDocumentImpl(reader, parserOptions);
     }
 
-    private Document parseDocumentImpl(Reader reader, ParserOptions parserOptions) throws InvalidSyntaxException, ParseCancelledException {
+    private Document parseDocumentImpl(Reader reader, ParserOptions parserOptions) throws InvalidSyntaxException {
         BiFunction<GraphqlParser, GraphqlAntlrToLanguage, Object[]> nodeFunction = (parser, toLanguage) -> {
             GraphqlParser.DocumentContext documentContext = parser.document();
             Document doc = toLanguage.createDocument(documentContext);
@@ -248,21 +248,21 @@ public class Parser {
             @Override
             public void visitTerminal(TerminalNode node) {
 
-                final Token symbol = node.getSymbol();
-                parsingListener.onToken(new ParsingListener.Symbol() {
+                final Token token = node.getSymbol();
+                parsingListener.onToken(new ParsingListener.Token() {
                     @Override
                     public String getText() {
-                        return symbol == null ? null : symbol.getText();
+                        return token == null ? null : token.getText();
                     }
 
                     @Override
                     public int getLine() {
-                        return symbol == null ? -1 : symbol.getLine();
+                        return token == null ? -1 : token.getLine();
                     }
 
                     @Override
                     public int getCharPositionInLine() {
-                        return symbol == null ? -1 : symbol.getCharPositionInLine();
+                        return token == null ? -1 : token.getCharPositionInLine();
                     }
                 });
 
@@ -271,9 +271,9 @@ public class Parser {
                     String msg = String.format("More than %d parse tokens have been presented. To prevent Denial Of Service attacks, parsing has been cancelled.", maxTokens);
                     SourceLocation sourceLocation = null;
                     String offendingToken = null;
-                    if (symbol != null) {
+                    if (token != null) {
                         offendingToken = node.getText();
-                        sourceLocation = AntlrHelper.createSourceLocation(multiSourceReader, symbol.getLine(), symbol.getCharPositionInLine());
+                        sourceLocation = AntlrHelper.createSourceLocation(multiSourceReader, token.getLine(), token.getCharPositionInLine());
                     }
 
                     throw new ParseCancelledException(msg, sourceLocation, offendingToken);

--- a/src/main/java/graphql/parser/ParserOptions.java
+++ b/src/main/java/graphql/parser/ParserOptions.java
@@ -1,9 +1,10 @@
 package graphql.parser;
 
-import graphql.Assert;
 import graphql.PublicApi;
 
 import java.util.function.Consumer;
+
+import static graphql.Assert.assertNotNull;
 
 /**
  * Options that control how the {@link Parser} behaves.
@@ -60,17 +61,19 @@ public class ParserOptions {
      * @see graphql.language.SourceLocation
      */
     public static void setDefaultParserOptions(ParserOptions options) {
-        defaultJvmParserOptions = Assert.assertNotNull(options);
+        defaultJvmParserOptions = assertNotNull(options);
     }
 
     private final boolean captureIgnoredChars;
     private final boolean captureSourceLocation;
     private final int maxTokens;
+    private final ParsingListener parsingListener;
 
     private ParserOptions(Builder builder) {
         this.captureIgnoredChars = builder.captureIgnoredChars;
         this.captureSourceLocation = builder.captureSourceLocation;
         this.maxTokens = builder.maxTokens;
+        this.parsingListener = builder.parsingListener;
     }
 
     /**
@@ -97,14 +100,18 @@ public class ParserOptions {
     }
 
     /**
-     * An graphql hacking vector is to send nonsensical queries that burn lots of parsing CPU time and burn
-     * memory representing a document that wont ever execute.  To prevent this you can set a maximum number of parse
+     * A graphql hacking vector is to send nonsensical queries that burn lots of parsing CPU time and burn
+     * memory representing a document that won't ever execute.  To prevent this you can set a maximum number of parse
      * tokens that will be accepted before an exception is thrown and the parsing is stopped.
      *
      * @return the maximum number of raw tokens the parser will accept, after which an exception will be thrown.
      */
     public int getMaxTokens() {
         return maxTokens;
+    }
+
+    public ParsingListener getParsingListener() {
+        return parsingListener;
     }
 
     public ParserOptions transform(Consumer<Builder> builderConsumer) {
@@ -122,6 +129,7 @@ public class ParserOptions {
         private boolean captureIgnoredChars = false;
         private boolean captureSourceLocation = true;
         private int maxTokens = MAX_QUERY_TOKENS;
+        private ParsingListener parsingListener = ParsingListener.NOOP;
 
         Builder() {
         }
@@ -130,6 +138,7 @@ public class ParserOptions {
             this.captureIgnoredChars = parserOptions.captureIgnoredChars;
             this.captureSourceLocation = parserOptions.captureSourceLocation;
             this.maxTokens = parserOptions.maxTokens;
+            this.parsingListener = parserOptions.parsingListener;
         }
 
         public Builder captureIgnoredChars(boolean captureIgnoredChars) {
@@ -144,6 +153,11 @@ public class ParserOptions {
 
         public Builder maxTokens(int maxTokens) {
             this.maxTokens = maxTokens;
+            return this;
+        }
+
+        public Builder parsingListener(ParsingListener parsingListener) {
+            this.parsingListener = assertNotNull(parsingListener);
             return this;
         }
 

--- a/src/main/java/graphql/parser/ParsingListener.java
+++ b/src/main/java/graphql/parser/ParsingListener.java
@@ -1,0 +1,35 @@
+package graphql.parser;
+
+import graphql.PublicSpi;
+
+/**
+ * This listener interface is invoked for each token parsed by the graphql parser code.
+ */
+@PublicSpi
+public interface ParsingListener {
+
+    /**
+     * A NoOp implementation of {@link ParsingListener}
+     */
+    ParsingListener NOOP = t -> {
+    };
+
+
+    /**
+     * This represents a token symbol that has been parsed
+     */
+    interface Symbol {
+        String getText();
+
+        int getLine();
+
+        int getCharPositionInLine();
+    }
+
+    /**
+     * This is called for each token found during parsing
+     *
+     * @param symbol the symbol found
+     */
+    void onToken(Symbol symbol);
+}

--- a/src/main/java/graphql/parser/ParsingListener.java
+++ b/src/main/java/graphql/parser/ParsingListener.java
@@ -16,20 +16,29 @@ public interface ParsingListener {
 
 
     /**
-     * This represents a token symbol that has been parsed
+     * This represents a token that has been parsed
      */
-    interface Symbol {
+    interface Token {
+        /**
+         * @return the text of the parsed token
+         */
         String getText();
 
+        /**
+         * @return the line the token occurred on
+         */
         int getLine();
 
+        /**
+         * @return the position within the line the token occurred on
+         */
         int getCharPositionInLine();
     }
 
     /**
      * This is called for each token found during parsing
      *
-     * @param symbol the symbol found
+     * @param token the token found
      */
-    void onToken(Symbol symbol);
+    void onToken(Token token);
 }


### PR DESCRIPTION
This adds a parser listener interface that allows a caller to add an parse listener pew request or JVM wide

With this one could count how many tokens or keep metrics on how many tokens are being presented etc..

