### PR TITLE
This adds the AST definitions onto applied directives and applied arguments

### DIFF
--- a/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
+++ b/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
@@ -285,7 +285,9 @@ public class SchemaGeneratorHelper {
         });
         builder.repeatable(graphQLDirective.isRepeatable());
 
-        List<GraphQLArgument> appliedArguments = map(directive.getArguments(), arg -> buildAppliedDArgument(arg, graphQLDirective));
+        builder.definition(buildCtx.isCaptureAstDefinitions() ? graphQLDirective.getDefinition() : null);
+
+        List<GraphQLArgument> appliedArguments = map(directive.getArguments(), arg -> buildAppliedDArgument(buildCtx, arg, graphQLDirective));
 
         appliedArguments = transferMissingArguments(buildCtx, appliedArguments, graphQLDirective);
         appliedArguments.forEach(builder::argument);
@@ -293,12 +295,14 @@ public class SchemaGeneratorHelper {
         return builder.build();
     }
 
-    private GraphQLArgument buildAppliedDArgument(Argument arg, GraphQLDirective directiveDefinition) {
+    private GraphQLArgument buildAppliedDArgument(BuildContext buildCtx, Argument arg, GraphQLDirective directiveDefinition) {
         GraphQLArgument directiveDefArgument = directiveDefinition.getArgument(arg.getName());
         GraphQLArgument.Builder builder = GraphQLArgument.newArgument();
-        builder.name(arg.getName());
         GraphQLInputType inputType = directiveDefArgument.getType();
-        builder.type(inputType);
+        builder.name(arg.getName())
+                .type(inputType)
+                .definition(buildCtx.isCaptureAstDefinitions() ? directiveDefArgument.getDefinition() : null);
+        
         // we know it is a literal because it was created by SchemaGenerator
         if (directiveDefArgument.getArgumentDefaultValue().isSet()) {
             builder.defaultValueLiteral((Value) directiveDefArgument.getArgumentDefaultValue().getValue());

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -61,7 +61,8 @@ class SchemaGeneratorTest extends Specification {
     }
 
     static GraphQLSchema schema(String sdl, RuntimeWiring runtimeWiring) {
-        return TestUtil.schema(sdl, runtimeWiring)
+        SchemaGenerator.Options options = defaultOptions().captureAstDefinitions(true)
+        return TestUtil.schema(options, sdl, runtimeWiring)
     }
 
 
@@ -1311,8 +1312,11 @@ class SchemaGeneratorTest extends Specification {
         expect:
         type.getDirectives().size() == 4
         type.getDirectives()[0].name == "directive1"
+        type.getDirectives()[0].getDefinition() != null
         type.getDirectives()[1].name == "directive2"
+        type.getDirectives()[1].getDefinition() != null
         type.getDirectives()[2].name == "directive3"
+        type.getDirectives()[2].getDefinition() != null
 
         // test that fields can have directives as well
 


### PR DESCRIPTION
When we build the applied directives we dont put in the AST definitions if they are asked for.

This was missed