### PR TITLE
Improve non-nullable argument exception in ValuesResolver

### DIFF
--- a/src/main/java/graphql/execution/NonNullableValueCoercedAsNullException.java
+++ b/src/main/java/graphql/execution/NonNullableValueCoercedAsNullException.java
@@ -6,6 +6,7 @@ import graphql.GraphQLException;
 import graphql.PublicApi;
 import graphql.language.SourceLocation;
 import graphql.language.VariableDefinition;
+import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLInputObjectField;
 import graphql.schema.GraphQLType;
 import graphql.schema.GraphQLTypeUtil;
@@ -57,6 +58,10 @@ public class NonNullableValueCoercedAsNullException extends GraphQLException imp
         super(format("Input field '%s' has coerced Null value for NonNull type '%s'",
                 inputTypeField.getName(), GraphQLTypeUtil.simplePrint(inputTypeField.getType())));
         this.path = path;
+    }
+
+    public NonNullableValueCoercedAsNullException(GraphQLArgument graphQLArgument) {
+        super(format("Argument '%s' has coerced Null value for NonNull type '%s'", graphQLArgument.getName(), graphQLArgument.getType()));
     }
 
     @Override

--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -452,7 +452,7 @@ public class ValuesResolver {
                         argumentType);
                 coercedValues.put(argumentName, coercedDefaultValue);
             } else if (isNonNull(argumentType) && (!hasValue || isNullValue(value))) {
-                throw new RuntimeException();
+                throw new NonNullableValueCoercedAsNullException(argumentDefinition);
             } else if (hasValue) {
                 if (isNullValue(value)) {
                     coercedValues.put(argumentName, value);

--- a/src/test/groovy/graphql/execution/ValuesResolverTest.groovy
+++ b/src/test/groovy/graphql/execution/ValuesResolverTest.groovy
@@ -530,4 +530,22 @@ class ValuesResolverTest extends Specification {
         then:
         values['arg'] == null
     }
+
+    def "argument of Non-Nullable type and with null coerced value throws error"() {
+        given:
+        def inputObjectType = newInputObject()
+                .name("inputObject")
+                .build()
+
+        def fieldArgument = newArgument().name("arg").type(nonNull(inputObjectType)).build()
+        def argument = new Argument("arg", new VariableReference("var"))
+
+        when:
+        def variables = ["var": null]
+        resolver.getArgumentValues([fieldArgument], [argument], variables)
+
+        then:
+        def error = thrown(NonNullableValueCoercedAsNullException)
+        error.message == "Argument 'arg' has coerced Null value for NonNull type 'inputObject!'"
+    }
 }


### PR DESCRIPTION
Addresses #2524.

Previously, an non-nullable argument with a coerced null value raised a generic `RuntimeException`. This PR updates the exception to be more meaningful.