### PR TITLE
Bugfix: spec-compliant behaviour for non-nullable types with default values.

### DIFF
--- a/src/main/java/graphql/validation/rules/VariableTypesMatchRule.java
+++ b/src/main/java/graphql/validation/rules/VariableTypesMatchRule.java
@@ -3,12 +3,15 @@ package graphql.validation.rules;
 
 import graphql.Internal;
 import graphql.execution.TypeFromAST;
+import graphql.execution.ValuesResolver;
 import graphql.language.OperationDefinition;
+import graphql.language.Value;
 import graphql.language.VariableDefinition;
 import graphql.language.VariableReference;
 import graphql.schema.GraphQLInputType;
 import graphql.schema.GraphQLType;
 import graphql.schema.GraphQLTypeUtil;
+import graphql.schema.InputValueWithState;
 import graphql.validation.AbstractRule;
 import graphql.validation.ValidationContext;
 import graphql.validation.ValidationErrorCollector;
@@ -55,11 +58,19 @@ public class VariableTypesMatchRule extends AbstractRule {
             return;
         }
         GraphQLInputType expectedType = getValidationContext().getInputType();
+        InputValueWithState schemaDefault = getValidationContext().getArgument().getArgumentDefaultValue();
+        Value schemaDefaultValue = null;
+        if (schemaDefault.isLiteral()) {
+            schemaDefaultValue = (Value) schemaDefault.getValue();
+        } else if (schemaDefault.isSet()) {
+            schemaDefaultValue = ValuesResolver.valueToLiteral(schemaDefault, expectedType);
+        }
         if (expectedType == null) {
             // we must have a unknown variable say to not have a known type
             return;
         }
-        if (!variablesTypesMatcher.doesVariableTypesMatch(variableType, variableDefinition.getDefaultValue(), expectedType)) {
+        if (!variablesTypesMatcher.doesVariableTypesMatch(variableType, variableDefinition.getDefaultValue(), expectedType) &&
+            !variablesTypesMatcher.doesVariableTypesMatch(variableType, schemaDefaultValue, expectedType)) {
             GraphQLType effectiveType = variablesTypesMatcher.effectiveType(variableType, variableDefinition.getDefaultValue());
             String message = String.format("Variable type '%s' doesn't match expected type '%s'",
                     GraphQLTypeUtil.simplePrint(effectiveType),

--- a/src/main/java/graphql/validation/rules/VariableTypesMatchRule.java
+++ b/src/main/java/graphql/validation/rules/VariableTypesMatchRule.java
@@ -19,6 +19,7 @@ import graphql.validation.ValidationErrorType;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 
 @Internal
 public class VariableTypesMatchRule extends AbstractRule {
@@ -58,12 +59,12 @@ public class VariableTypesMatchRule extends AbstractRule {
             return;
         }
         GraphQLInputType expectedType = getValidationContext().getInputType();
-        InputValueWithState schemaDefault = getValidationContext().getArgument().getArgumentDefaultValue();
+        Optional<InputValueWithState> schemaDefault = Optional.ofNullable(getValidationContext().getArgument()).map(v -> v.getArgumentDefaultValue());
         Value schemaDefaultValue = null;
-        if (schemaDefault.isLiteral()) {
-            schemaDefaultValue = (Value) schemaDefault.getValue();
-        } else if (schemaDefault.isSet()) {
-            schemaDefaultValue = ValuesResolver.valueToLiteral(schemaDefault, expectedType);
+        if (schemaDefault.isPresent() && schemaDefault.get().isLiteral()) {
+            schemaDefaultValue = (Value) schemaDefault.get().getValue();
+        } else if (schemaDefault.isPresent() && schemaDefault.get().isSet()) {
+            schemaDefaultValue = ValuesResolver.valueToLiteral(schemaDefault.get(), expectedType);
         }
         if (expectedType == null) {
             // we must have a unknown variable say to not have a known type

--- a/src/test/groovy/graphql/GraphQLTest.groovy
+++ b/src/test/groovy/graphql/GraphQLTest.groovy
@@ -1129,6 +1129,26 @@ many lines''']
 
     }
 
+    def "default value defined in the schema is used when none provided in the query"() {
+        // Spec (https://spec.graphql.org/June2018/#sec-All-Variable-Usages-are-Allowed): A notable exception to typical variable type compatibility is allowing a variable definition with a nullable type to be provided to a non‐null location as long as either that variable or that location provides a default value.
+        given:
+        def spec = """type Query {
+            sayHello(name: String! = "amigo"): String
+        }"""
+        def df = { dfe ->
+            return dfe.getArgument("name")
+        } as DataFetcher
+        def graphQL = TestUtil.graphQL(spec, ["Query": ["sayHello": df]]).build()
+
+        when:
+        def result = graphQL.execute('query($var:String){sayHello(name:$var)}');
+
+        then:
+        result.errors.isEmpty()
+        result.getData() == [sayHello: "amigo"]
+
+    }
+
     def "specified url can be defined and queried via introspection"() {
         given:
         GraphQLSchema schema = TestUtil.schema('type Query {foo: MyScalar} scalar MyScalar @specifiedBy(url:"myUrl")');

--- a/src/test/groovy/graphql/validation/rules/VariableTypesMatchRuleTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/VariableTypesMatchRuleTest.groovy
@@ -9,6 +9,7 @@ import graphql.language.StringValue
 import graphql.language.TypeName
 import graphql.language.VariableDefinition
 import graphql.language.VariableReference
+import graphql.schema.GraphQLArgument
 import graphql.schema.GraphQLList
 import graphql.schema.GraphQLNonNull
 import graphql.validation.ValidationContext
@@ -33,9 +34,11 @@ class VariableTypesMatchRuleTest extends Specification {
         def defaultValue = new StringValue("default")
         def astType = new TypeName("String")
         def expectedType = Scalars.GraphQLBoolean
+        def argument = GraphQLArgument.newArgument().name("test").type(expectedType).build();
 
         validationContext.getSchema() >> StarWarsSchema.starWarsSchema
         validationContext.getInputType() >> expectedType
+        validationContext.getArgument() >> argument
         variablesTypeMatcher.effectiveType(Scalars.GraphQLString, defaultValue) >> Scalars.GraphQLString
         variablesTypeMatcher
                 .doesVariableTypesMatch(Scalars.GraphQLString, defaultValue, expectedType) >> false
@@ -54,11 +57,13 @@ class VariableTypesMatchRuleTest extends Specification {
         def defaultValue = null
         def astType = new NonNullType(new ListType(new TypeName("String")))
         def expectedType = GraphQLList.list(GraphQLNonNull.nonNull(Scalars.GraphQLString))
+        def argument = GraphQLArgument.newArgument().name("test").type(expectedType).build();
 
         def mismatchedType = GraphQLNonNull.nonNull(GraphQLList.list(Scalars.GraphQLString))
 
         validationContext.getSchema() >> StarWarsSchema.starWarsSchema
         validationContext.getInputType() >> expectedType
+        validationContext.getArgument() >> argument
         variablesTypeMatcher.effectiveType({ mismatchedType.isEqualTo(it) }, defaultValue) >> mismatchedType
         variablesTypeMatcher
                 .doesVariableTypesMatch(expectedType, defaultValue, expectedType) >> false


### PR DESCRIPTION
Hi folks!

### Problem

Graphql-java currently fails the document validation for queries that use nullable types for non-nullable schema field arguments with default values. As per [spec](https://spec.graphql.org/June2018/#sec-All-Variable-Usages-are-Allowed):
> A notable exception to typical variable type compatibility is allowing a variable definition with a nullable type to be provided to a non‐null location as long as either that variable or that location provides a default value.

Here's a discussion from 2018 where this change to the spec was adopted: https://github.com/graphql/graphql-spec/pull/418.

#### Motivating example:

Schema:
```
type Query {
  hello(arg: Boolean! = true)
}
```

Query:
```
query Test($var: Boolean) {
  hello(arg: $var)
}
```

This is expected to pass the validation, but currently fails:
`ValidationError{validationErrorType=VariableTypeMismatch, queryPath=[hello], message=Validation error of type VariableTypeMismatch: Variable type 'Boolean' doesn't match expected type 'Boolean!' @ 'hello', locations=[SourceLocation{line=3, column=25}], description='Variable type 'Boolean' doesn't match expected type 'Boolean!''}`

### Solution

This patch fixes the issue by extracting the schema-defined default value for the argument (if present), and checks that in the `VariablesTypeMatcher` along with the original check. This also adds a regression test to exercise this fix, similar to the [test in the reference GraphQL implementation](https://github.com/graphql/graphql-js/blob/main/src/execution/__tests__/variables-test.ts#L994-L1008).