### PR TITLE
Sort schema directives in `SchemaPrinter`.

### DIFF
--- a/src/main/java/graphql/schema/idl/SchemaPrinter.java
+++ b/src/main/java/graphql/schema/idl/SchemaPrinter.java
@@ -875,10 +875,19 @@ public class SchemaPrinter {
 
     private String directiveDefinitions(List<GraphQLDirective> directives) {
         StringBuilder sb = new StringBuilder();
-        directives.stream().filter(options.getIncludeSchemaElement()).forEach(directive -> {
-            sb.append(directiveDefinition(directive));
-            sb.append("\n\n");
-        });
+        GraphqlTypeComparatorEnvironment environment = GraphqlTypeComparatorEnvironment.newEnvironment()
+            .parentType(GraphQLSchemaElement.class)
+            .elementType(GraphQLDirective.class)
+            .build();
+        Comparator<? super GraphQLSchemaElement> comparator = options.comparatorRegistry.getComparator(environment);
+        directives
+            .stream()
+            .sorted(comparator)
+            .filter(options.getIncludeSchemaElement())
+            .forEach(directive -> {
+                sb.append(directiveDefinition(directive));
+                sb.append("\n\n");
+            });
         return sb.toString();
     }
 

--- a/src/test/groovy/graphql/Issue2141.groovy
+++ b/src/test/groovy/graphql/Issue2141.groovy
@@ -22,7 +22,15 @@ class Issue2141 extends Specification {
         def schemaStr = new SchemaPrinter().print(schema)
 
         then:
-        schemaStr == """"Directs the executor to include this field or fragment only when the `if` argument is true"
+        schemaStr == """directive @auth(roles: [String!]) on FIELD_DEFINITION
+
+"Marks the field, argument, input field or enum value as deprecated"
+directive @deprecated(
+    "The reason for the deprecation"
+    reason: String = "No longer supported"
+  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+
+"Directs the executor to include this field or fragment only when the `if` argument is true"
 directive @include(
     "Included when true."
     if: Boolean!
@@ -33,14 +41,6 @@ directive @skip(
     "Skipped when true."
     if: Boolean!
   ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
-
-directive @auth(roles: [String!]) on FIELD_DEFINITION
-
-"Marks the field, argument, input field or enum value as deprecated"
-directive @deprecated(
-    "The reason for the deprecation"
-    reason: String = "No longer supported"
-  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
 
 "Exposes a URL that specifies the behaviour of this scalar."
 directive @specifiedBy(

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -892,53 +892,7 @@ type Query {
 
         then:
         // args and directives are sorted like the rest of the schema printer
-        result == '''"Directs the executor to include this field or fragment only when the `if` argument is true"
-directive @include(
-    "Included when true."
-    if: Boolean!
-  ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
-
-"Directs the executor to skip this field or fragment when the `if`'argument is true."
-directive @skip(
-    "Skipped when true."
-    if: Boolean!
-  ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
-
-directive @interfaceFieldDirective on FIELD_DEFINITION
-
-directive @unionTypeDirective on UNION
-
-directive @query1 repeatable on OBJECT
-
-directive @query2(arg1: String) on OBJECT
-
-directive @fieldDirective1 on FIELD_DEFINITION
-
-directive @fieldDirective2(argBool: Boolean, argFloat: Float, argInt: Int, argStr: String) on FIELD_DEFINITION
-
-directive @argDirective on ARGUMENT_DEFINITION
-
-directive @interfaceImplementingTypeDirective on OBJECT
-
-directive @enumTypeDirective on ENUM
-
-directive @single on OBJECT
-
-directive @singleField on FIELD_DEFINITION
-
-directive @interfaceImplementingFieldDirective on FIELD_DEFINITION
-
-directive @enumValueDirective on ENUM_VALUE
-
-directive @inputTypeDirective on INPUT_OBJECT
-
-directive @inputFieldDirective on INPUT_FIELD_DEFINITION
-
-directive @interfaceTypeDirective on INTERFACE
-
-directive @scalarDirective on SCALAR
-
-directive @repeatableDirective repeatable on SCALAR
+        result == '''directive @argDirective on ARGUMENT_DEFINITION
 
 "Marks the field, argument, input field or enum value as deprecated"
 directive @deprecated(
@@ -946,11 +900,57 @@ directive @deprecated(
     reason: String = "No longer supported"
   ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
 
+directive @enumTypeDirective on ENUM
+
+directive @enumValueDirective on ENUM_VALUE
+
+directive @fieldDirective1 on FIELD_DEFINITION
+
+directive @fieldDirective2(argBool: Boolean, argFloat: Float, argInt: Int, argStr: String) on FIELD_DEFINITION
+
+"Directs the executor to include this field or fragment only when the `if` argument is true"
+directive @include(
+    "Included when true."
+    if: Boolean!
+  ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+directive @inputFieldDirective on INPUT_FIELD_DEFINITION
+
+directive @inputTypeDirective on INPUT_OBJECT
+
+directive @interfaceFieldDirective on FIELD_DEFINITION
+
+directive @interfaceImplementingFieldDirective on FIELD_DEFINITION
+
+directive @interfaceImplementingTypeDirective on OBJECT
+
+directive @interfaceTypeDirective on INTERFACE
+
+directive @query1 repeatable on OBJECT
+
+directive @query2(arg1: String) on OBJECT
+
+directive @repeatableDirective repeatable on SCALAR
+
+directive @scalarDirective on SCALAR
+
+directive @single on OBJECT
+
+directive @singleField on FIELD_DEFINITION
+
+"Directs the executor to skip this field or fragment when the `if`'argument is true."
+directive @skip(
+    "Skipped when true."
+    if: Boolean!
+  ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
 "Exposes a URL that specifies the behaviour of this scalar."
 directive @specifiedBy(
     "The URL that specifies the behaviour of this scalar."
     url: String!
   ) on SCALAR
+
+directive @unionTypeDirective on UNION
 
 interface SomeInterface @interfaceTypeDirective {
   fieldA: String @interfaceFieldDirective
@@ -1067,7 +1067,13 @@ input SomeInput {
 
         then:
         // args and directives are sorted like the rest of the schema printer
-        result == '''"Directs the executor to include this field or fragment only when the `if` argument is true"
+        result == '''"Marks the field, argument, input field or enum value as deprecated"
+directive @deprecated(
+    "The reason for the deprecation"
+    reason: String = "No longer supported"
+  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+
+"Directs the executor to include this field or fragment only when the `if` argument is true"
 directive @include(
     "Included when true."
     if: Boolean!
@@ -1078,12 +1084,6 @@ directive @skip(
     "Skipped when true."
     if: Boolean!
   ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
-
-"Marks the field, argument, input field or enum value as deprecated"
-directive @deprecated(
-    "The reason for the deprecation"
-    reason: String = "No longer supported"
-  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
 
 "Exposes a URL that specifies the behaviour of this scalar."
 directive @specifiedBy(
@@ -1160,27 +1160,27 @@ type Query {
         def resultWithDirectives = new SchemaPrinter(defaultOptions().includeDirectives(true)).print(schema)
 
         then:
-        resultWithDirectives == '''"Directs the executor to include this field or fragment only when the `if` argument is true"
+        resultWithDirectives == '''"Marks the field, argument, input field or enum value as deprecated"
+directive @deprecated(
+    "The reason for the deprecation"
+    reason: String = "No longer supported"
+  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+
+directive @example on FIELD_DEFINITION
+
+"Directs the executor to include this field or fragment only when the `if` argument is true"
 directive @include(
     "Included when true."
     if: Boolean!
   ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+directive @moreComplex(arg1: String = "default", arg2: Int) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 "Directs the executor to skip this field or fragment when the `if`'argument is true."
 directive @skip(
     "Skipped when true."
     if: Boolean!
   ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
-
-directive @example on FIELD_DEFINITION
-
-directive @moreComplex(arg1: String = "default", arg2: Int) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
-
-"Marks the field, argument, input field or enum value as deprecated"
-directive @deprecated(
-    "The reason for the deprecation"
-    reason: String = "No longer supported"
-  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
 
 "Exposes a URL that specifies the behaviour of this scalar."
 directive @specifiedBy(
@@ -1225,27 +1225,27 @@ type Query {
         def resultWithDirectiveDefinitions = new SchemaPrinter(defaultOptions().includeDirectiveDefinitions(true)).print(schema)
 
         then:
-        resultWithDirectiveDefinitions == '''"Directs the executor to include this field or fragment only when the `if` argument is true"
+        resultWithDirectiveDefinitions == '''"Marks the field, argument, input field or enum value as deprecated"
+directive @deprecated(
+    "The reason for the deprecation"
+    reason: String = "No longer supported"
+  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+
+directive @example on FIELD_DEFINITION
+
+"Directs the executor to include this field or fragment only when the `if` argument is true"
 directive @include(
     "Included when true."
     if: Boolean!
   ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+directive @moreComplex(arg1: String = "default", arg2: Int) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 "Directs the executor to skip this field or fragment when the `if`'argument is true."
 directive @skip(
     "Skipped when true."
     if: Boolean!
   ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
-
-directive @example on FIELD_DEFINITION
-
-directive @moreComplex(arg1: String = "default", arg2: Int) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
-
-"Marks the field, argument, input field or enum value as deprecated"
-directive @deprecated(
-    "The reason for the deprecation"
-    reason: String = "No longer supported"
-  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
 
 "Exposes a URL that specifies the behaviour of this scalar."
 directive @specifiedBy(
@@ -1359,7 +1359,15 @@ type Query {
         def result = new SchemaPrinter(printOptions).print(schema)
 
         then:
-        result == '''"Directs the executor to include this field or fragment only when the `if` argument is true"
+        result == '''"Marks the field, argument, input field or enum value as deprecated"
+directive @deprecated(
+    "The reason for the deprecation"
+    reason: String = "No longer supported"
+  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+
+directive @directive1 on SCALAR
+
+"Directs the executor to include this field or fragment only when the `if` argument is true"
 directive @include(
     "Included when true."
     if: Boolean!
@@ -1370,14 +1378,6 @@ directive @skip(
     "Skipped when true."
     if: Boolean!
   ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
-
-directive @directive1 on SCALAR
-
-"Marks the field, argument, input field or enum value as deprecated"
-directive @deprecated(
-    "The reason for the deprecation"
-    reason: String = "No longer supported"
-  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
 
 "Exposes a URL that specifies the behaviour of this scalar."
 directive @specifiedBy(
@@ -1862,6 +1862,14 @@ type PrintMeType {
   query: MyQuery
 }
 
+"Marks the field, argument, input field or enum value as deprecated"
+directive @deprecated(
+    "The reason for the deprecation"
+    reason: String = "No longer supported"
+  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+
+directive @foo on SCHEMA
+
 "Directs the executor to include this field or fragment only when the `if` argument is true"
 directive @include(
     "Included when true."
@@ -1873,14 +1881,6 @@ directive @skip(
     "Skipped when true."
     if: Boolean!
   ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
-
-directive @foo on SCHEMA
-
-"Marks the field, argument, input field or enum value as deprecated"
-directive @deprecated(
-    "The reason for the deprecation"
-    reason: String = "No longer supported"
-  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
 
 "Exposes a URL that specifies the behaviour of this scalar."
 directive @specifiedBy(


### PR DESCRIPTION
Hello from Twitter!

We have a system that stores the gold schema file, which is generated by the `SchemaPrinter`. To avoid having to detect sweeping changes in the schema, we rely on stable alphabetical sorting for all the schema elements – types, fields inside of objects, arms inside of enums, directives, scalars, etc. We've noticed that graphql-java does not sort directive definitions. This patch fixes that.