### PR TITLE
Allow QueryTraverser and QueryTransformer to complete without required variables

### DIFF
--- a/src/main/java/graphql/analysis/NodeVisitorWithTypeTracking.java
+++ b/src/main/java/graphql/analysis/NodeVisitorWithTypeTracking.java
@@ -61,6 +61,15 @@ public class NodeVisitorWithTypeTracking extends NodeVisitorStub {
         this.fragmentsByName = fragmentsByName;
     }
 
+    public NodeVisitorWithTypeTracking(QueryVisitor preOrderCallback, QueryVisitor postOrderCallback, Map<String, Object> variables, GraphQLSchema schema, Map<String, FragmentDefinition> fragmentsByName, boolean allowMissingVariables) {
+        this.preOrderCallback = preOrderCallback;
+        this.postOrderCallback = postOrderCallback;
+        this.variables = variables;
+        this.schema = schema;
+        this.fragmentsByName = fragmentsByName;
+        this.valuesResolver.allowMissingVariables(allowMissingVariables);
+    }
+
     @Override
     public TraversalControl visitDirective(Directive node, TraverserContext<Node> context) {
         // to avoid visiting arguments for directives we abort the traversal here

--- a/src/main/java/graphql/analysis/NodeVisitorWithTypeTracking.java
+++ b/src/main/java/graphql/analysis/NodeVisitorWithTypeTracking.java
@@ -61,13 +61,9 @@ public class NodeVisitorWithTypeTracking extends NodeVisitorStub {
         this.fragmentsByName = fragmentsByName;
     }
 
-    public NodeVisitorWithTypeTracking(QueryVisitor preOrderCallback, QueryVisitor postOrderCallback, Map<String, Object> variables, GraphQLSchema schema, Map<String, FragmentDefinition> fragmentsByName, boolean allowMissingVariables) {
-        this.preOrderCallback = preOrderCallback;
-        this.postOrderCallback = postOrderCallback;
-        this.variables = variables;
-        this.schema = schema;
-        this.fragmentsByName = fragmentsByName;
-        this.valuesResolver.allowMissingVariables(allowMissingVariables);
+    public void allowMissingVariables(boolean allow) {
+        this.valuesResolver.allowMissingVariables(allow);
+        this.conditionalNodes.allowMissingVariables(allow);
     }
 
     @Override

--- a/src/main/java/graphql/analysis/QueryTraverser.java
+++ b/src/main/java/graphql/analysis/QueryTraverser.java
@@ -80,7 +80,7 @@ public class QueryTraverser {
                            boolean allowMissingVariables) {
         this.schema = assertNotNull(schema, () -> "schema can't be null");
         this.allowMissingVariables = allowMissingVariables;
-        if (allowMissingVariables) {
+        if (allowMissingVariables && variables == null) {
             this.variables = new HashMap<>();
         } else {
             this.variables = assertNotNull(variables, () -> "variables can't be null");

--- a/src/main/java/graphql/analysis/QueryTraverser.java
+++ b/src/main/java/graphql/analysis/QueryTraverser.java
@@ -61,8 +61,8 @@ public class QueryTraverser {
         this.roots = singletonList(getOperationResult.operationDefinition);
         this.rootParentType = getRootTypeFromOperation(getOperationResult.operationDefinition);
         this.allowMissingVariables = allowMissingVariables;
-        if (allowMissingVariables && variables == null) {
-            this.variables = new HashMap<>();
+        if (allowMissingVariables) {
+            this.variables = variables == null ? new HashMap<>() : variables;
         } else {
             this.variables = coerceVariables(assertNotNull(variables, () -> "variables can't be null"), variableDefinitions);
         }
@@ -80,8 +80,8 @@ public class QueryTraverser {
                            boolean allowMissingVariables) {
         this.schema = assertNotNull(schema, () -> "schema can't be null");
         this.allowMissingVariables = allowMissingVariables;
-        if (allowMissingVariables && variables == null) {
-            this.variables = new HashMap<>();
+        if (allowMissingVariables) {
+            this.variables = variables == null ? new HashMap<>() : variables;
         } else {
             this.variables = assertNotNull(variables, () -> "variables can't be null");
         }

--- a/src/main/java/graphql/analysis/QueryTraverser.java
+++ b/src/main/java/graphql/analysis/QueryTraverser.java
@@ -195,7 +195,8 @@ public class QueryTraverser {
         }
 
         NodeTraverser nodeTraverser = new NodeTraverser(rootVars, this::childrenOf);
-        NodeVisitorWithTypeTracking nodeVisitorWithTypeTracking = new NodeVisitorWithTypeTracking(preOrderCallback, postOrderCallback, variables, schema, fragmentsByName, allowMissingVariables);
+        NodeVisitorWithTypeTracking nodeVisitorWithTypeTracking = new NodeVisitorWithTypeTracking(preOrderCallback, postOrderCallback, variables, schema, fragmentsByName);
+        nodeVisitorWithTypeTracking.allowMissingVariables(allowMissingVariables);
         return nodeTraverser.depthFirst(nodeVisitorWithTypeTracking, roots);
     }
 

--- a/src/main/java/graphql/execution/ConditionalNodes.java
+++ b/src/main/java/graphql/execution/ConditionalNodes.java
@@ -18,6 +18,13 @@ public class ConditionalNodes {
     @VisibleForTesting
     ValuesResolver valuesResolver = new ValuesResolver();
 
+    private boolean allowMissingVariables = false;
+
+    public void allowMissingVariables(boolean allow) {
+        this.allowMissingVariables = allow;
+        valuesResolver.allowMissingVariables(allow);
+    }
+
     public boolean shouldInclude(Map<String, Object> variables, List<Directive> directives) {
         boolean skip = getDirectiveResult(variables, directives, SkipDirective.getName(), false);
         if (skip) {
@@ -32,8 +39,17 @@ public class ConditionalNodes {
         if (foundDirective != null) {
             Map<String, Object> argumentValues = valuesResolver.getArgumentValues(SkipDirective.getArguments(), foundDirective.getArguments(), variables);
             Object flag = argumentValues.get("if");
-            Assert.assertTrue(flag instanceof Boolean, () -> String.format("The '%s' directive MUST have a value for the 'if' argument", directiveName));
-            return (Boolean) flag;
+            //Always return default for null if we allow missing variables
+            if (allowMissingVariables) {
+                if (flag instanceof Boolean) {
+                    return (Boolean) flag;
+                } else {
+                    return defaultValue;
+                }
+            } else {
+                Assert.assertTrue(flag instanceof Boolean, () -> String.format("The '%s' directive MUST have a value for the 'if' argument", directiveName));
+                return (Boolean) flag;
+            }
         }
         return defaultValue;
     }

--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -75,6 +75,12 @@ public class ValuesResolver {
         NORMALIZED
     }
 
+    private boolean allowMissingVariables = false;
+
+    public void allowMissingVariables(boolean allow) {
+        this.allowMissingVariables = allow;
+    }
+
     /**
      * This method coerces the "raw" variables values provided to the engine. The coerced values will be used to
      * provide arguments to {@link graphql.schema.DataFetchingEnvironment}
@@ -459,7 +465,7 @@ public class ValuesResolver {
                         defaultValue,
                         argumentType);
                 coercedValues.put(argumentName, coercedDefaultValue);
-            } else if (isNonNull(argumentType) && (!hasValue || isNullValue(value))) {
+            } else if (isNonNull(argumentType) && (!hasValue || isNullValue(value)) && !allowMissingVariables) {
                 throw new NonNullableValueCoercedAsNullException(argumentDefinition);
             } else if (hasValue) {
                 if (isNullValue(value)) {

--- a/src/test/groovy/graphql/analysis/QueryTransformerTest.groovy
+++ b/src/test/groovy/graphql/analysis/QueryTransformerTest.groovy
@@ -544,17 +544,17 @@ class QueryTransformerTest extends Specification {
         def newDocument = queryTransformer.transform(visitor)
 
         then:
-        printAstCompact(newDocument) == expected
+        printAstCompact(newDocument) == "query MyQuery(\$includeA:Boolean,\$skipB:Boolean) {...TestRootA@include(if:\$includeA) ...TestRootB@skip(if:\$skipB)} fragment TestRootA on Query {root {fooA-modified}} fragment TestRootB on Query {root {fooB-modified}}"
 
         where:
-        includeA   | skipB      | expected
-        true       | false      | "query MyQuery(\$includeA:Boolean,\$skipB:Boolean) {...TestRootA@include(if:\$includeA) ...TestRootB@skip(if:\$skipB)} fragment TestRootA on Query {root {fooA-modified}} fragment TestRootB on Query {root {fooB-modified}}"
-        false      | false      | "query MyQuery(\$includeA:Boolean,\$skipB:Boolean) {...TestRootA@include(if:\$includeA) ...TestRootB@skip(if:\$skipB)} fragment TestRootA on Query {root {fooA-modified}} fragment TestRootB on Query {root {fooB-modified}}"
-        null       | false      | "query MyQuery(\$includeA:Boolean,\$skipB:Boolean) {...TestRootA@include(if:\$includeA) ...TestRootB@skip(if:\$skipB)} fragment TestRootA on Query {root {fooA-modified}} fragment TestRootB on Query {root {fooB-modified}}"
-        true       | true       | "query MyQuery(\$includeA:Boolean,\$skipB:Boolean) {...TestRootA@include(if:\$includeA) ...TestRootB@skip(if:\$skipB)} fragment TestRootA on Query {root {fooA-modified}} fragment TestRootB on Query {root {fooB-modified}}"
-        false      | true       | "query MyQuery(\$includeA:Boolean,\$skipB:Boolean) {...TestRootA@include(if:\$includeA) ...TestRootB@skip(if:\$skipB)} fragment TestRootA on Query {root {fooA-modified}} fragment TestRootB on Query {root {fooB-modified}}"
-        null       | true       | "query MyQuery(\$includeA:Boolean,\$skipB:Boolean) {...TestRootA@include(if:\$includeA) ...TestRootB@skip(if:\$skipB)} fragment TestRootA on Query {root {fooA-modified}} fragment TestRootB on Query {root {fooB-modified}}"
-        null       | false      | "query MyQuery(\$includeA:Boolean,\$skipB:Boolean) {...TestRootA@include(if:\$includeA) ...TestRootB@skip(if:\$skipB)} fragment TestRootA on Query {root {fooA-modified}} fragment TestRootB on Query {root {fooB-modified}}"
-        null       | null       | "query MyQuery(\$includeA:Boolean,\$skipB:Boolean) {...TestRootA@include(if:\$includeA) ...TestRootB@skip(if:\$skipB)} fragment TestRootA on Query {root {fooA-modified}} fragment TestRootB on Query {root {fooB-modified}}"
+        includeA   | skipB
+        true       | false
+        false      | false
+        null       | false
+        true       | true
+        false      | true
+        null       | true
+        null       | false
+        null       | null
     }
 }

--- a/src/test/groovy/graphql/analysis/QueryTraverserTest.groovy
+++ b/src/test/groovy/graphql/analysis/QueryTraverserTest.groovy
@@ -21,6 +21,7 @@ import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLSchema
 import graphql.schema.GraphQLUnionType
 import graphql.util.TraversalControl
+import spock.lang.Rollup
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -1901,6 +1902,7 @@ class QueryTraverserTest extends Specification {
         false       | ["bar", "foo", "subFoo", "otherString"]
     }
 
+    @Rollup
     def "always include conditional fragments and fields if allowMissingVariables is true"() {
         given:
         def schema = TestUtil.schema("""

--- a/src/test/groovy/graphql/analysis/QueryTraverserTest.groovy
+++ b/src/test/groovy/graphql/analysis/QueryTraverserTest.groovy
@@ -1844,6 +1844,7 @@ class QueryTraverserTest extends Specification {
         fields == ["foo", "bar", "subFoo"].toSet()
     }
 
+    @Rollup
     def "properly use given variables while allowing other missing required variables"() {
         given:
         def schema = TestUtil.schema("""

--- a/src/test/groovy/graphql/execution/ConditionalNodesTest.groovy
+++ b/src/test/groovy/graphql/execution/ConditionalNodesTest.groovy
@@ -1,5 +1,6 @@
 package graphql.execution
 
+import graphql.AssertException
 import graphql.Directives
 import graphql.language.Argument
 import graphql.language.BooleanValue
@@ -32,5 +33,51 @@ class ConditionalNodesTest extends Specification {
         expect:
         conditionalNodes.shouldInclude(variables, [])
 
+    }
+
+    def "throws if no variable present for condition"() {
+        given:
+        def variables = new LinkedHashMap<String, Object>()
+        ConditionalNodes conditionalNodes = new ConditionalNodes()
+        conditionalNodes.valuesResolver = Mock(ValuesResolver)
+
+        def argument = Argument.newArgument("if", new BooleanValue(true)).build()
+        def directives = [Directive.newDirective().name("skip").arguments([argument]).build()]
+
+        conditionalNodes.valuesResolver.getArgumentValues(Directives.SkipDirective.getArguments(), [argument], variables) >> [:]
+
+        when:
+        conditionalNodes.shouldInclude(variables, directives)
+
+        then:
+        thrown AssertException
+    }
+
+    def "returns default value for condition if allowMissingVariables is true and variable missing"() {
+        given:
+        def variables = new LinkedHashMap<String, Object>()
+        ConditionalNodes conditionalNodes = new ConditionalNodes()
+        conditionalNodes.allowMissingVariables(true)
+        conditionalNodes.valuesResolver = Mock(ValuesResolver)
+
+        def argument = Argument.newArgument("if", new BooleanValue(true)).build()
+        def directives = [Directive.newDirective().name(directiveName).arguments([argument]).build()]
+
+        conditionalNodes.valuesResolver.getArgumentValues(Directives.SkipDirective.getArguments(), [argument], variables) >> condition
+
+        when:
+        def shouldInclude = conditionalNodes.shouldInclude(variables, directives)
+
+        then:
+        shouldInclude == expected
+
+        where:
+        directiveName | condition     | expected
+        "include"     | ["if": false] | false
+        "include"     | ["if": true]  | true
+        "include"     | [:]           | true
+        "skip"        | ["if": false] | true
+        "skip"        | ["if": true]  | false
+        "skip"        | [:]           | true
     }
 }

--- a/src/test/groovy/graphql/execution/ConditionalNodesTest.groovy
+++ b/src/test/groovy/graphql/execution/ConditionalNodesTest.groovy
@@ -5,6 +5,7 @@ import graphql.Directives
 import graphql.language.Argument
 import graphql.language.BooleanValue
 import graphql.language.Directive
+import spock.lang.Rollup
 import spock.lang.Specification
 
 class ConditionalNodesTest extends Specification {
@@ -53,6 +54,7 @@ class ConditionalNodesTest extends Specification {
         thrown AssertException
     }
 
+    @Rollup
     def "returns default value for condition if allowMissingVariables is true and variable missing"() {
         given:
         def variables = new LinkedHashMap<String, Object>()


### PR DESCRIPTION
Hello from Twitter!

### What
This PR adds a new method to `QueryTraverser.Builder`, `allowMissingVariables(boolean allow)` to relax the requirement during traversal that all required variables are present for the traversal to complete. The implication is this state variable needs to eventually be passed down into the execution package `ValuesResolver` class. The intent of this change is to simply relax the requirement for all required variables be present during traversal, and that's it. If there's a better way to implement this functionality, I'm open to any suggestions.

### Why
Our workflow includes other teams uploading queries as strings to be stored in a database. At the time the query is uploaded, we perform static analysis on the query to determine certain statistics of execution based on some directives we add to various fields in the schema. This means that at the time the query document string is uploaded, we do not have the required non-null variables for the query.

Digging into the `QueryTraverser`, we noticed that the `NodeVisitorWithTypeTracking` creates its own `ValuesResolver` instance which expects a fully validated query (otherwise we get the `NonNullableValueCoercedAsNullException`), which isn't necessarily what we care about when we're traversing for static analysis.

Additionally, `NodeVisitorWithTypeTracking` is also used by `QueryTransformer`, and this functionality also seems to make sense to enable there, if you want to transform a query without necessarily having all the variables. In this case, `QueryTransformer` will always traverse into all parts of the query regardless of variables and conditions.

If you have thoughts on a better way of doing this kind of analysis, please let us know. Thanks!