### PR TITLE
Only publish with Maven POM, disable Gradle module metadata file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -299,6 +299,11 @@ tasks.withType(PublishToMavenRepository) {
     dependsOn build
 }
 
+// Only publish Maven POM, disable default Gradle modules file
+tasks.withType(GenerateModuleMetadata) {
+    enabled = false
+}
+
 test {
     useJUnitPlatform()
 }


### PR DESCRIPTION
Fixes #2540. 

Following a Gradle version upgrade #2416, Gradle publishes a module metadata file by default. By default, Gradle projects preferentially use this module metadata file rather than the Maven POM.

This project edits the Maven POM in the publish task, but the same changes are not represented in the Gradle module file. This inconsistency causes the problem described in #2540.

Let's revert to the previous behaviour, have only one source of truth, and only publish the Maven POM. This PR disables the Gradle module metadata file.

You can verify that this PR disables Gradle module metadata generation with the task
`gradle generateMetadataFileForGraphqlJavaPublication`