### PR TITLE
Override ImmutableMapWithNullValues.toString() (#2568)

### DIFF
--- a/src/main/java/graphql/collect/ImmutableMapWithNullValues.java
+++ b/src/main/java/graphql/collect/ImmutableMapWithNullValues.java
@@ -192,4 +192,9 @@ public final class ImmutableMapWithNullValues<K, V> implements Map<K, V> {
     public V merge(K key, V value, BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public String toString() {
+        return delegate.toString();
+    }
 }


### PR DESCRIPTION
Fix #2568