### PR TITLE
Added support for a context object to the AstTransformer

### DIFF
--- a/src/main/java/graphql/language/AstTransformer.java
+++ b/src/main/java/graphql/language/AstTransformer.java
@@ -21,7 +21,12 @@ import static graphql.language.AstNodeAdapter.AST_NODE_ADAPTER;
 @PublicApi
 public class AstTransformer {
 
-
+    /**
+     * Transforms the input tree using the Visitor Pattern.
+     * @param root the root node of the input tree.
+     * @param nodeVisitor the visitor which will transform the input tree.
+     * @return the transformed tree.
+     */
     public Node transform(Node root, NodeVisitor nodeVisitor) {
         assertNotNull(root);
         assertNotNull(nodeVisitor);
@@ -31,6 +36,16 @@ public class AstTransformer {
         return treeTransformer.transform(root, traverserVisitor);
     }
 
+    /**
+     * Transforms the input tree using the Visitor Pattern.
+     * @param root the root node of the input tree.
+     * @param nodeVisitor the visitor which will transform the input tree.
+     * @param rootVars a context argument to pass information into the nodeVisitor. Pass a contextual
+     *                 object to your visitor by adding it to this map such that such that the key
+     *                 is the class of the object, and the value is the object itself. The object
+     *                 can be retrieved within the visitor by calling context.getVarFromParents().
+     * @return the transformed tree.
+     */
     public Node transform(Node root, NodeVisitor nodeVisitor, Map<Class<?>, Object> rootVars) {
         assertNotNull(root);
         assertNotNull(nodeVisitor);
@@ -61,8 +76,6 @@ public class AstTransformer {
     }
 
     private TraverserVisitor<Node> getNodeTraverserVisitor(NodeVisitor nodeVisitor) {
-
-
         return new TraverserVisitor<Node>() {
             @Override
             public TraversalControl enter(TraverserContext<Node> context) {

--- a/src/main/java/graphql/language/AstTransformer.java
+++ b/src/main/java/graphql/language/AstTransformer.java
@@ -8,6 +8,7 @@ import graphql.util.TraverserVisitorStub;
 import graphql.util.TreeParallelTransformer;
 import graphql.util.TreeTransformer;
 
+import java.util.Map;
 import java.util.concurrent.ForkJoinPool;
 
 import static graphql.Assert.assertNotNull;
@@ -25,20 +26,18 @@ public class AstTransformer {
         assertNotNull(root);
         assertNotNull(nodeVisitor);
 
-        TraverserVisitor<Node> traverserVisitor = new TraverserVisitor<Node>() {
-            @Override
-            public TraversalControl enter(TraverserContext<Node> context) {
-                return context.thisNode().accept(context, nodeVisitor);
-            }
-
-            @Override
-            public TraversalControl leave(TraverserContext<Node> context) {
-                return TraversalControl.CONTINUE;
-            }
-        };
-
+        TraverserVisitor<Node> traverserVisitor = getNodeTraverserVisitor(nodeVisitor);
         TreeTransformer<Node> treeTransformer = new TreeTransformer<>(AST_NODE_ADAPTER);
         return treeTransformer.transform(root, traverserVisitor);
+    }
+
+    public Node transform(Node root, NodeVisitor nodeVisitor, Map<Class<?>, Object> rootVars) {
+        assertNotNull(root);
+        assertNotNull(nodeVisitor);
+
+        TraverserVisitor<Node> traverserVisitor = getNodeTraverserVisitor(nodeVisitor);
+        TreeTransformer<Node> treeTransformer = new TreeTransformer<>(AST_NODE_ADAPTER);
+        return treeTransformer.transform(root, traverserVisitor, rootVars);
     }
 
     public Node transformParallel(Node root, NodeVisitor nodeVisitor) {
@@ -61,4 +60,19 @@ public class AstTransformer {
         return treeParallelTransformer.transform(root, traverserVisitor);
     }
 
+    private TraverserVisitor<Node> getNodeTraverserVisitor(NodeVisitor nodeVisitor) {
+
+
+        return new TraverserVisitor<Node>() {
+            @Override
+            public TraversalControl enter(TraverserContext<Node> context) {
+                return context.thisNode().accept(context, nodeVisitor);
+            }
+
+            @Override
+            public TraversalControl leave(TraverserContext<Node> context) {
+                return TraversalControl.CONTINUE;
+            }
+        };
+    }
 }


### PR DESCRIPTION
Hello from Twitter!

### About
I'm working on a task for my overlord @jbellenger to prune unused fragments from a `Document`. To accomplish this, I'm hoping to pass a context argument into the `AstTransfromer` which will provide the names of the nodes to prune. This seems like functionality other users may want from `AstTransfromer` so I'm raising a pull request to add it. 

### What Changed
I overloaded the `.transform()` method of `AstTransformer` so that it accepts a "rootVars" object, and passes it to the `TreeTransformer`. 

This is my first time contributing to graphql-java, or any open source project, so please let me know if I should add other details before raising a PR in the future. Looking forwards to working with y'all.