### PR TITLE
This adds the field selection set to the type resolver

### DIFF
--- a/src/main/java/graphql/TypeResolutionEnvironment.java
+++ b/src/main/java/graphql/TypeResolutionEnvironment.java
@@ -2,6 +2,7 @@ package graphql;
 
 import graphql.collect.ImmutableMapWithNullValues;
 import graphql.execution.MergedField;
+import graphql.schema.DataFetchingFieldSelectionSet;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
 
@@ -22,18 +23,30 @@ public class TypeResolutionEnvironment {
     private final GraphQLType fieldType;
     private final GraphQLSchema schema;
     private final Object context;
+    private final GraphQLContext graphQLContext;
+    private final DataFetchingFieldSelectionSet fieldSelectionSet;
 
-    public TypeResolutionEnvironment(Object object, Map<String, Object> arguments, MergedField field, GraphQLType fieldType, GraphQLSchema schema, final Object context) {
+    public TypeResolutionEnvironment(Object object,
+                                     Map<String, Object> arguments,
+                                     MergedField field,
+                                     GraphQLType fieldType,
+                                     GraphQLSchema schema,
+                                     Object context,
+                                     GraphQLContext graphQLContext,
+                                     DataFetchingFieldSelectionSet fieldSelectionSet) {
         this.object = object;
         this.arguments = ImmutableMapWithNullValues.copyOf(arguments);
         this.field = field;
         this.fieldType = fieldType;
         this.schema = schema;
         this.context = context;
+        this.graphQLContext = graphQLContext;
+        this.fieldSelectionSet = fieldSelectionSet;
     }
 
+
     /**
-     * You will be passed the specific source object that needs to be resolve into a concrete graphql object type
+     * You will be passed the specific source object that needs to be resolved into a concrete graphql object type
      *
      * @param <T> you decide what type it is
      *
@@ -73,7 +86,31 @@ public class TypeResolutionEnvironment {
         return schema;
     }
 
+    /**
+     * Returns the context object set in via {@link ExecutionInput#getContext()}
+     *
+     * @param <T> to two
+     *
+     * @return the context object
+     *
+     * @deprecated use {@link #getGraphQLContext()} instead
+     */
+    @Deprecated
     public <T> T getContext() {
         return (T) context;
+    }
+
+    /**
+     * @return the {@link GraphQLContext} object set in via {@link ExecutionInput#getGraphQLContext()}
+     */
+    public GraphQLContext getGraphQLContext() {
+        return graphQLContext;
+    }
+
+    /**
+     * @return the {@link DataFetchingFieldSelectionSet} for the current field fetch that needs type resolution
+     */
+    public DataFetchingFieldSelectionSet getSelectionSet() {
+        return fieldSelectionSet;
     }
 }

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -692,7 +692,7 @@ public abstract class ExecutionStrategy {
     }
 
     protected GraphQLObjectType resolveType(ExecutionContext executionContext, ExecutionStrategyParameters parameters, GraphQLType fieldType) {
-        return resolvedType.resolveType(executionContext, parameters.getField(), parameters.getSource(), parameters.getExecutionStepInfo().getArguments(), fieldType);
+        return resolvedType.resolveType(executionContext, parameters.getField(), parameters.getSource(), fieldType,  parameters.getExecutionStepInfo());
     }
 
 

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -692,7 +692,7 @@ public abstract class ExecutionStrategy {
     }
 
     protected GraphQLObjectType resolveType(ExecutionContext executionContext, ExecutionStrategyParameters parameters, GraphQLType fieldType) {
-        return resolvedType.resolveType(executionContext, parameters.getField(), parameters.getSource(), fieldType,  parameters.getExecutionStepInfo());
+        return resolvedType.resolveType(executionContext, parameters.getField(), parameters.getSource(), parameters.getExecutionStepInfo(), fieldType);
     }
 
 

--- a/src/main/java/graphql/execution/ResolveType.java
+++ b/src/main/java/graphql/execution/ResolveType.java
@@ -2,37 +2,47 @@ package graphql.execution;
 
 import graphql.Internal;
 import graphql.TypeResolutionEnvironment;
+import graphql.normalized.ExecutableNormalizedField;
+import graphql.normalized.ExecutableNormalizedOperation;
+import graphql.schema.DataFetchingFieldSelectionSet;
+import graphql.schema.DataFetchingFieldSelectionSetImpl;
 import graphql.schema.GraphQLInterfaceType;
+import graphql.schema.GraphQLNamedOutputType;
 import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLOutputType;
 import graphql.schema.GraphQLType;
 import graphql.schema.GraphQLUnionType;
 import graphql.schema.TypeResolver;
 
-import java.util.Map;
+import java.util.function.Supplier;
 
 @Internal
 public class ResolveType {
 
 
-    public GraphQLObjectType resolveType(ExecutionContext executionContext, MergedField field, Object source, Map<String, Object> arguments, GraphQLType fieldType) {
+    public GraphQLObjectType resolveType(ExecutionContext executionContext, MergedField field, Object source, GraphQLType fieldType, ExecutionStepInfo executionStepInfo) {
         GraphQLObjectType resolvedType;
         if (fieldType instanceof GraphQLInterfaceType) {
+            DataFetchingFieldSelectionSet fieldSelectionSet = buildSelectionSet(executionContext, field, (GraphQLOutputType) fieldType, executionStepInfo);
             TypeResolutionParameters resolutionParams = TypeResolutionParameters.newParameters()
                     .graphQLInterfaceType((GraphQLInterfaceType) fieldType)
                     .field(field)
                     .value(source)
-                    .argumentValues(arguments)
+                    .argumentValues(executionStepInfo.getArguments())
+                    .selectionSet(fieldSelectionSet)
                     .context(executionContext.getContext())
                     .graphQLContext(executionContext.getGraphQLContext())
                     .schema(executionContext.getGraphQLSchema()).build();
             resolvedType = resolveTypeForInterface(resolutionParams);
 
         } else if (fieldType instanceof GraphQLUnionType) {
+            DataFetchingFieldSelectionSet selectionSet = buildSelectionSet(executionContext, field, (GraphQLOutputType) fieldType, executionStepInfo);
             TypeResolutionParameters resolutionParams = TypeResolutionParameters.newParameters()
                     .graphQLUnionType((GraphQLUnionType) fieldType)
                     .field(field)
                     .value(source)
-                    .argumentValues(arguments)
+                    .argumentValues(executionStepInfo.getArguments())
+                    .selectionSet(selectionSet)
                     .context(executionContext.getContext())
                     .graphQLContext(executionContext.getGraphQLContext())
                     .schema(executionContext.getGraphQLSchema()).build();
@@ -40,31 +50,32 @@ public class ResolveType {
         } else {
             resolvedType = (GraphQLObjectType) fieldType;
         }
-
         return resolvedType;
     }
 
+    private DataFetchingFieldSelectionSet buildSelectionSet(ExecutionContext executionContext, MergedField field, GraphQLOutputType fieldType, ExecutionStepInfo executionStepInfo) {
+        Supplier<ExecutableNormalizedOperation> normalizedQuery = executionContext.getNormalizedQueryTree();
+        Supplier<ExecutableNormalizedField> normalizedFieldSupplier = () -> normalizedQuery.get().getNormalizedField(field, executionStepInfo.getObjectType(), executionStepInfo.getPath());
+        return DataFetchingFieldSelectionSetImpl.newCollector(executionContext.getGraphQLSchema(), fieldType, normalizedFieldSupplier);
+    }
+
     public GraphQLObjectType resolveTypeForInterface(TypeResolutionParameters params) {
-        TypeResolutionEnvironment env = new TypeResolutionEnvironment(params.getValue(), params.getArgumentValues(), params.getField(), params.getGraphQLInterfaceType(), params.getSchema(), params.getContext());
+        TypeResolutionEnvironment env = new TypeResolutionEnvironment(params.getValue(), params.getArgumentValues(), params.getField(), params.getGraphQLInterfaceType(), params.getSchema(), params.getContext(), params.getGraphQLContext(), params.getSelectionSet());
         GraphQLInterfaceType abstractType = params.getGraphQLInterfaceType();
         TypeResolver typeResolver = params.getSchema().getCodeRegistry().getTypeResolver(abstractType);
-        GraphQLObjectType result = typeResolver.getType(env);
-        if (result == null) {
-            throw new UnresolvedTypeException(abstractType);
-        }
-
-        if (!params.getSchema().isPossibleType(abstractType, result)) {
-            throw new UnresolvedTypeException(abstractType, result);
-        }
-
-        return result;
+        return resolveAbstractType(params, env, typeResolver, abstractType);
     }
 
     public GraphQLObjectType resolveTypeForUnion(TypeResolutionParameters params) {
-        TypeResolutionEnvironment env = new TypeResolutionEnvironment(params.getValue(), params.getArgumentValues(), params.getField(), params.getGraphQLUnionType(), params.getSchema(), params.getContext());
+        TypeResolutionEnvironment env = new TypeResolutionEnvironment(params.getValue(), params.getArgumentValues(), params.getField(), params.getGraphQLUnionType(), params.getSchema(), params.getContext(), params.getGraphQLContext(), params.getSelectionSet());
         GraphQLUnionType abstractType = params.getGraphQLUnionType();
         TypeResolver typeResolver = params.getSchema().getCodeRegistry().getTypeResolver(abstractType);
+        return resolveAbstractType(params, env, typeResolver, abstractType);
+    }
+
+    private GraphQLObjectType resolveAbstractType(TypeResolutionParameters params, TypeResolutionEnvironment env, TypeResolver typeResolver, GraphQLNamedOutputType abstractType) {
         GraphQLObjectType result = typeResolver.getType(env);
+
         if (result == null) {
             throw new UnresolvedTypeException(abstractType);
         }

--- a/src/main/java/graphql/execution/ResolveType.java
+++ b/src/main/java/graphql/execution/ResolveType.java
@@ -20,7 +20,7 @@ import java.util.function.Supplier;
 public class ResolveType {
 
 
-    public GraphQLObjectType resolveType(ExecutionContext executionContext, MergedField field, Object source, GraphQLType fieldType, ExecutionStepInfo executionStepInfo) {
+    public GraphQLObjectType resolveType(ExecutionContext executionContext, MergedField field, Object source, ExecutionStepInfo executionStepInfo, GraphQLType fieldType) {
         GraphQLObjectType resolvedType;
         if (fieldType instanceof GraphQLInterfaceType) {
             DataFetchingFieldSelectionSet fieldSelectionSet = buildSelectionSet(executionContext, field, (GraphQLOutputType) fieldType, executionStepInfo);

--- a/src/main/java/graphql/execution/TypeResolutionParameters.java
+++ b/src/main/java/graphql/execution/TypeResolutionParameters.java
@@ -1,15 +1,16 @@
 package graphql.execution;
 
 import graphql.GraphQLContext;
-import graphql.PublicApi;
+import graphql.Internal;
 import graphql.collect.ImmutableMapWithNullValues;
+import graphql.schema.DataFetchingFieldSelectionSet;
 import graphql.schema.GraphQLInterfaceType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLUnionType;
 
 import java.util.Map;
 
-@PublicApi
+@Internal
 public class TypeResolutionParameters {
 
     private final GraphQLInterfaceType graphQLInterfaceType;
@@ -20,6 +21,7 @@ public class TypeResolutionParameters {
     private final GraphQLSchema schema;
     private final Object context;
     private final GraphQLContext graphQLContext;
+    private final DataFetchingFieldSelectionSet selectionSet;
 
     private TypeResolutionParameters(Builder builder) {
         this.graphQLInterfaceType = builder.graphQLInterfaceType;
@@ -30,6 +32,7 @@ public class TypeResolutionParameters {
         this.schema = builder.schema;
         this.context = builder.context;
         this.graphQLContext = builder.graphQLContext;
+        this.selectionSet = builder.selectionSet;
     }
 
     public GraphQLInterfaceType getGraphQLInterfaceType() {
@@ -54,6 +57,10 @@ public class TypeResolutionParameters {
 
     public GraphQLSchema getSchema() {
         return schema;
+    }
+
+    public DataFetchingFieldSelectionSet getSelectionSet() {
+        return selectionSet;
     }
 
     public static Builder newParameters() {
@@ -84,6 +91,7 @@ public class TypeResolutionParameters {
         private GraphQLSchema schema;
         private Object context;
         private GraphQLContext graphQLContext;
+        private DataFetchingFieldSelectionSet selectionSet;
 
         public Builder field(MergedField field) {
             this.field = field;
@@ -123,6 +131,11 @@ public class TypeResolutionParameters {
 
         public Builder graphQLContext(GraphQLContext context) {
             this.graphQLContext = context;
+            return this;
+        }
+
+        public Builder selectionSet(DataFetchingFieldSelectionSet selectionSet) {
+            this.selectionSet = selectionSet;
             return this;
         }
 

--- a/src/main/java/graphql/execution/nextgen/ExecutionStrategyUtil.java
+++ b/src/main/java/graphql/execution/nextgen/ExecutionStrategyUtil.java
@@ -73,7 +73,7 @@ public class ExecutionStrategyUtil {
         Object localContext = resolvedValue.getLocalContext();
 
         GraphQLOutputType sourceType = executionInfo.getUnwrappedNonNullType();
-        GraphQLObjectType resolvedObjectType = resolveType.resolveType(executionContext, field, source, executionInfo.getArguments(), sourceType);
+        GraphQLObjectType resolvedObjectType = resolveType.resolveType(executionContext, field, source, sourceType, executionInfo);
         FieldCollectorParameters collectorParameters = newParameters()
                 .schema(executionContext.getGraphQLSchema())
                 .objectType(resolvedObjectType)

--- a/src/main/java/graphql/execution/nextgen/ExecutionStrategyUtil.java
+++ b/src/main/java/graphql/execution/nextgen/ExecutionStrategyUtil.java
@@ -73,7 +73,7 @@ public class ExecutionStrategyUtil {
         Object localContext = resolvedValue.getLocalContext();
 
         GraphQLOutputType sourceType = executionInfo.getUnwrappedNonNullType();
-        GraphQLObjectType resolvedObjectType = resolveType.resolveType(executionContext, field, source, sourceType, executionInfo);
+        GraphQLObjectType resolvedObjectType = resolveType.resolveType(executionContext, field, source, executionInfo, sourceType);
         FieldCollectorParameters collectorParameters = newParameters()
                 .schema(executionContext.getGraphQLSchema())
                 .objectType(resolvedObjectType)

--- a/src/main/java/graphql/execution/nextgen/FetchedValueAnalyzer.java
+++ b/src/main/java/graphql/execution/nextgen/FetchedValueAnalyzer.java
@@ -69,7 +69,7 @@ public class FetchedValueAnalyzer {
                     .build();
         }
         try {
-            GraphQLObjectType resolvedObjectType = resolveType.resolveType(executionContext, field, toAnalyze,fieldType, executionInfo);
+            GraphQLObjectType resolvedObjectType = resolveType.resolveType(executionContext, field, toAnalyze, executionInfo, fieldType);
             return newFetchedValueAnalysis(OBJECT)
                     .fetchedValue(fetchedValue)
                     .executionStepInfo(executionInfo)

--- a/src/main/java/graphql/execution/nextgen/FetchedValueAnalyzer.java
+++ b/src/main/java/graphql/execution/nextgen/FetchedValueAnalyzer.java
@@ -69,7 +69,7 @@ public class FetchedValueAnalyzer {
                     .build();
         }
         try {
-            GraphQLObjectType resolvedObjectType = resolveType.resolveType(executionContext, field, toAnalyze, executionInfo.getArguments(), fieldType);
+            GraphQLObjectType resolvedObjectType = resolveType.resolveType(executionContext, field, toAnalyze,fieldType, executionInfo);
             return newFetchedValueAnalysis(OBJECT)
                     .fetchedValue(fetchedValue)
                     .executionStepInfo(executionInfo)

--- a/src/test/groovy/graphql/TypeResolutionEnvironmentTest.groovy
+++ b/src/test/groovy/graphql/TypeResolutionEnvironmentTest.groovy
@@ -36,10 +36,12 @@ class TypeResolutionEnvironmentTest extends Specification {
 
     def schema = TestUtil.schema(idl)
 
+    def graphqlContext = GraphQLContext.newContext().of("a", "b").build()
+
     def "basic operations"() {
         given:
 
-        def environment = new TypeResolutionEnvironment("source", [:], mergedField(new Field("field")), Scalars.GraphQLString, schema, "FooBar")
+        def environment = new TypeResolutionEnvironment("source", [:], mergedField(new Field("field")), Scalars.GraphQLString, schema, "FooBar", graphqlContext, null)
 
         when:
 
@@ -82,6 +84,7 @@ class TypeResolutionEnvironmentTest extends Specification {
             GraphQLObjectType getType(TypeResolutionEnvironment env) {
                 String source = env.getObject()
                 assert source == "source"
+                assert env.getGraphQLContext().get("a") == "b"
                 if ("FooBar" == env.getContext()) {
                     return schema.getObjectType("FooBar")
                 }
@@ -93,14 +96,14 @@ class TypeResolutionEnvironmentTest extends Specification {
         }
 
         when:
-        def environmentFooBar = new TypeResolutionEnvironment("source", [:], mergedField(new Field("field")), Scalars.GraphQLString, schema, "FooBar")
+        def environmentFooBar = new TypeResolutionEnvironment("source", [:], mergedField(new Field("field")), Scalars.GraphQLString, schema, "FooBar", graphqlContext, null)
         def objTypeFooBar = resolverWithContext.getType(environmentFooBar)
 
         then:
         objTypeFooBar.name == "FooBar"
 
         when:
-        def environmentFooImpl = new TypeResolutionEnvironment("source", [:], mergedField(new Field("field")), Scalars.GraphQLString, schema, "Foo")
+        def environmentFooImpl = new TypeResolutionEnvironment("source", [:], mergedField(new Field("field")), Scalars.GraphQLString, schema, "Foo", graphqlContext, null)
         def objTypeFooImpl = resolverWithContext.getType(environmentFooImpl)
 
         then:


### PR DESCRIPTION

This makes the field selection set available to the TypeResolvers

This relates to #2593 

Even if this PR is not accepted, we should take elements of it.  Namely a miss labeled API class, the missing GraphqlContext and the missing deprecation on context object