### PR TITLE
Allow certain query validation rules to be skipped

### DIFF
--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -40,6 +40,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 
 import static graphql.Assert.assertNotNull;
@@ -170,6 +171,7 @@ public class GraphQL {
      * Helps you build a GraphQL object ready to execute queries
      *
      * @param graphQLSchema the schema to use
+     *
      * @return a builder of GraphQL objects
      */
     public static Builder newGraphQL(GraphQLSchema graphQLSchema) {
@@ -181,6 +183,7 @@ public class GraphQL {
      * the current values and allows you to transform it how you want.
      *
      * @param builderConsumer the consumer code that will be given a builder to transform
+     *
      * @return a new GraphQL object based on calling build on that builder
      */
     public GraphQL transform(Consumer<GraphQL.Builder> builderConsumer) {
@@ -241,6 +244,7 @@ public class GraphQL {
          * in {@link graphql.schema.DataFetcher} invocations.
          *
          * @param dataFetcherExceptionHandler the default handler for data fetching exception
+         *
          * @return this builder
          */
         public Builder defaultDataFetcherExceptionHandler(DataFetcherExceptionHandler dataFetcherExceptionHandler) {
@@ -306,6 +310,7 @@ public class GraphQL {
      * Executes the specified graphql query/mutation/subscription
      *
      * @param query the query/mutation/subscription
+     *
      * @return an {@link ExecutionResult} which can include errors
      */
     public ExecutionResult execute(String query) {
@@ -320,7 +325,9 @@ public class GraphQL {
      *
      * @param query   the query/mutation/subscription
      * @param context custom object provided to each {@link graphql.schema.DataFetcher}
+     *
      * @return an {@link ExecutionResult} which can include errors
+     *
      * @deprecated Use {@link #execute(ExecutionInput)}
      */
     @Deprecated
@@ -339,7 +346,9 @@ public class GraphQL {
      * @param query         the query/mutation/subscription
      * @param operationName the name of the operation to execute
      * @param context       custom object provided to each {@link graphql.schema.DataFetcher}
+     *
      * @return an {@link ExecutionResult} which can include errors
+     *
      * @deprecated Use {@link #execute(ExecutionInput)}
      */
     @Deprecated
@@ -359,7 +368,9 @@ public class GraphQL {
      * @param query     the query/mutation/subscription
      * @param context   custom object provided to each {@link graphql.schema.DataFetcher}
      * @param variables variable values uses as argument
+     *
      * @return an {@link ExecutionResult} which can include errors
+     *
      * @deprecated Use {@link #execute(ExecutionInput)}
      */
     @Deprecated
@@ -380,7 +391,9 @@ public class GraphQL {
      * @param operationName name of the operation to execute
      * @param context       custom object provided to each {@link graphql.schema.DataFetcher}
      * @param variables     variable values uses as argument
+     *
      * @return an {@link ExecutionResult} which can include errors
+     *
      * @deprecated Use {@link #execute(ExecutionInput)}
      */
     @Deprecated
@@ -399,6 +412,7 @@ public class GraphQL {
      * Executes the graphql query using the provided input object builder
      *
      * @param executionInputBuilder {@link ExecutionInput.Builder}
+     *
      * @return an {@link ExecutionResult} which can include errors
      */
     public ExecutionResult execute(ExecutionInput.Builder executionInputBuilder) {
@@ -416,6 +430,7 @@ public class GraphQL {
      * </pre>
      *
      * @param builderFunction a function that is given a {@link ExecutionInput.Builder}
+     *
      * @return an {@link ExecutionResult} which can include errors
      */
     public ExecutionResult execute(UnaryOperator<ExecutionInput.Builder> builderFunction) {
@@ -426,6 +441,7 @@ public class GraphQL {
      * Executes the graphql query using the provided input object
      *
      * @param executionInput {@link ExecutionInput}
+     *
      * @return an {@link ExecutionResult} which can include errors
      */
     public ExecutionResult execute(ExecutionInput executionInput) {
@@ -447,6 +463,7 @@ public class GraphQL {
      * which is the result of executing the provided query.
      *
      * @param executionInputBuilder {@link ExecutionInput.Builder}
+     *
      * @return a promise to an {@link ExecutionResult} which can include errors
      */
     public CompletableFuture<ExecutionResult> executeAsync(ExecutionInput.Builder executionInputBuilder) {
@@ -467,6 +484,7 @@ public class GraphQL {
      * </pre>
      *
      * @param builderFunction a function that is given a {@link ExecutionInput.Builder}
+     *
      * @return a promise to an {@link ExecutionResult} which can include errors
      */
     public CompletableFuture<ExecutionResult> executeAsync(UnaryOperator<ExecutionInput.Builder> builderFunction) {
@@ -480,6 +498,7 @@ public class GraphQL {
      * which is the result of executing the provided query.
      *
      * @param executionInput {@link ExecutionInput}
+     *
      * @return a promise to an {@link ExecutionResult} which can include errors
      */
     public CompletableFuture<ExecutionResult> executeAsync(ExecutionInput executionInput) {
@@ -595,7 +614,8 @@ public class GraphQL {
         CompletableFuture<List<ValidationError>> cf = new CompletableFuture<>();
         validationCtx.onDispatched(cf);
 
-        List<ValidationError> validationErrors = ParseAndValidate.validate(graphQLSchema, document);
+        Predicate<Class<?>> validationRulePredicate = executionInput.getGraphQLContext().getOrDefault(ParseAndValidate.VALIDATION_PREDICATE_HINT, r -> true);
+        List<ValidationError> validationErrors = ParseAndValidate.validate(graphQLSchema, document, validationRulePredicate);
 
         validationCtx.onCompleted(validationErrors, null);
         cf.complete(validationErrors);

--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -614,7 +614,7 @@ public class GraphQL {
         CompletableFuture<List<ValidationError>> cf = new CompletableFuture<>();
         validationCtx.onDispatched(cf);
 
-        Predicate<Class<?>> validationRulePredicate = executionInput.getGraphQLContext().getOrDefault(ParseAndValidate.VALIDATION_PREDICATE_HINT, r -> true);
+        Predicate<Class<?>> validationRulePredicate = executionInput.getGraphQLContext().getOrDefault(ParseAndValidate.INTERNAL_VALIDATION_PREDICATE_HINT, r -> true);
         List<ValidationError> validationErrors = ParseAndValidate.validate(graphQLSchema, document, validationRulePredicate);
 
         validationCtx.onCompleted(validationErrors, null);

--- a/src/main/java/graphql/ParseAndValidate.java
+++ b/src/main/java/graphql/ParseAndValidate.java
@@ -9,6 +9,7 @@ import graphql.validation.ValidationError;
 import graphql.validation.Validator;
 
 import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * This class allows you to parse and validate a graphql query without executing it.  It will tell you
@@ -17,6 +18,11 @@ import java.util.List;
  */
 @PublicApi
 public class ParseAndValidate {
+
+    /**
+     * This {@link GraphQLContext} hint can be used to supply a Predicate to the Validator so that certain rules can be skipped.
+     */
+    public static final String VALIDATION_PREDICATE_HINT = "graphql.ParseAndValidate.Predicate";
 
     /**
      * This can be called to parse and validate a graphql query against a schema, which is useful if you want to know if it would be acceptable
@@ -65,7 +71,20 @@ public class ParseAndValidate {
      * @return a result object that indicates how this operation went
      */
     public static List<ValidationError> validate(GraphQLSchema graphQLSchema, Document parsedDocument) {
+        return validate(graphQLSchema, parsedDocument, ruleClass -> true);
+    }
+
+    /**
+     * This can be called to validate a parsed graphql query.
+     *
+     * @param graphQLSchema  the graphql schema to validate against
+     * @param parsedDocument the previously parsed document
+     * @param rulePredicate  this predicate is used to decide what validation rules will be applied
+     *
+     * @return a result object that indicates how this operation went
+     */
+    public static List<ValidationError> validate(GraphQLSchema graphQLSchema, Document parsedDocument, Predicate<Class<?>> rulePredicate) {
         Validator validator = new Validator();
-        return validator.validateDocument(graphQLSchema, parsedDocument);
+        return validator.validateDocument(graphQLSchema, parsedDocument, rulePredicate);
     }
 }

--- a/src/main/java/graphql/ParseAndValidate.java
+++ b/src/main/java/graphql/ParseAndValidate.java
@@ -21,8 +21,12 @@ public class ParseAndValidate {
 
     /**
      * This {@link GraphQLContext} hint can be used to supply a Predicate to the Validator so that certain rules can be skipped.
+     *
+     * This is an internal capability that you should use at your own risk.  While we intend for this to be present for some time, the validation
+     * rule class names may change, as may this mechanism.
      */
-    public static final String VALIDATION_PREDICATE_HINT = "graphql.ParseAndValidate.Predicate";
+    @Internal
+    public static final String INTERNAL_VALIDATION_PREDICATE_HINT = "graphql.ParseAndValidate.Predicate";
 
     /**
      * This can be called to parse and validate a graphql query against a schema, which is useful if you want to know if it would be acceptable

--- a/src/main/java/graphql/nextgen/GraphQL.java
+++ b/src/main/java/graphql/nextgen/GraphQL.java
@@ -34,6 +34,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 
 import static graphql.Assert.assertNotNull;
@@ -65,6 +66,7 @@ public class GraphQL {
      * which is the result of executing the provided query.
      *
      * @param executionInputBuilder {@link ExecutionInput.Builder}
+     *
      * @return an {@link ExecutionResult} which can include errors
      */
     public ExecutionResult execute(ExecutionInput.Builder executionInputBuilder) {
@@ -85,6 +87,7 @@ public class GraphQL {
      * </pre>
      *
      * @param builderFunction a function that is given a {@link ExecutionInput.Builder}
+     *
      * @return a promise to an {@link ExecutionResult} which can include errors
      */
     public CompletableFuture<ExecutionResult> execute(UnaryOperator<ExecutionInput.Builder> builderFunction) {
@@ -98,6 +101,7 @@ public class GraphQL {
      * which is the result of executing the provided query.
      *
      * @param executionInput {@link ExecutionInput}
+     *
      * @return a promise to an {@link ExecutionResult} which can include errors
      */
     public ExecutionResult execute(ExecutionInput executionInput) {
@@ -111,6 +115,7 @@ public class GraphQL {
      * which is the result of executing the provided query.
      *
      * @param executionInputBuilder {@link ExecutionInput.Builder}
+     *
      * @return a promise to an {@link ExecutionResult} which can include errors
      */
     public CompletableFuture<ExecutionResult> executeAsync(ExecutionInput.Builder executionInputBuilder) {
@@ -131,6 +136,7 @@ public class GraphQL {
      * </pre>
      *
      * @param builderFunction a function that is given a {@link ExecutionInput.Builder}
+     *
      * @return a promise to an {@link ExecutionResult} which can include errors
      */
     public CompletableFuture<ExecutionResult> executeAsync(UnaryOperator<ExecutionInput.Builder> builderFunction) {
@@ -144,6 +150,7 @@ public class GraphQL {
      * which is the result of executing the provided query.
      *
      * @param executionInput {@link ExecutionInput}
+     *
      * @return a promise to an {@link ExecutionResult} which can include errors
      */
     public CompletableFuture<ExecutionResult> executeAsync(ExecutionInput executionInput) {
@@ -246,7 +253,8 @@ public class GraphQL {
         CompletableFuture<List<ValidationError>> cf = new CompletableFuture<>();
         validationCtx.onDispatched(cf);
 
-        List<ValidationError> validationErrors = ParseAndValidate.validate(graphQLSchema, document);
+        Predicate<Class<?>> validationRulePredicate = executionInput.getGraphQLContext().getOrDefault(ParseAndValidate.VALIDATION_PREDICATE_HINT, r -> true);
+        List<ValidationError> validationErrors = ParseAndValidate.validate(graphQLSchema, document, validationRulePredicate);
 
         validationCtx.onCompleted(validationErrors, null);
         cf.complete(validationErrors);
@@ -286,6 +294,7 @@ public class GraphQL {
      * Helps you build a GraphQL object ready to execute queries
      *
      * @param graphQLSchema the schema to use
+     *
      * @return a builder of GraphQL objects
      */
     public static Builder newGraphQL(GraphQLSchema graphQLSchema) {
@@ -297,6 +306,7 @@ public class GraphQL {
      * the current values and allows you to transform it how you want.
      *
      * @param builderConsumer the consumer code that will be given a builder to transform
+     *
      * @return a new GraphQL object based on calling build on that builder
      */
     public GraphQL transform(Consumer<Builder> builderConsumer) {

--- a/src/main/java/graphql/nextgen/GraphQL.java
+++ b/src/main/java/graphql/nextgen/GraphQL.java
@@ -253,7 +253,7 @@ public class GraphQL {
         CompletableFuture<List<ValidationError>> cf = new CompletableFuture<>();
         validationCtx.onDispatched(cf);
 
-        Predicate<Class<?>> validationRulePredicate = executionInput.getGraphQLContext().getOrDefault(ParseAndValidate.VALIDATION_PREDICATE_HINT, r -> true);
+        Predicate<Class<?>> validationRulePredicate = executionInput.getGraphQLContext().getOrDefault(ParseAndValidate.INTERNAL_VALIDATION_PREDICATE_HINT, r -> true);
         List<ValidationError> validationErrors = ParseAndValidate.validate(graphQLSchema, document, validationRulePredicate);
 
         validationCtx.onCompleted(validationErrors, null);

--- a/src/test/groovy/graphql/ParseAndValidateTest.groovy
+++ b/src/test/groovy/graphql/ParseAndValidateTest.groovy
@@ -3,7 +3,10 @@ package graphql
 import graphql.parser.InvalidSyntaxException
 import graphql.validation.ValidationError
 import graphql.validation.ValidationErrorType
+import graphql.validation.rules.NoUnusedFragments
 import spock.lang.Specification
+
+import java.util.function.Predicate
 
 /**
  * We trust that other unit tests of the parser and validation catch ALL of the combinations.  These tests
@@ -108,5 +111,49 @@ class ParseAndValidateTest extends Specification {
         result.syntaxException != null
 
         (result.errors[0] as InvalidSyntaxError).message.contains("Invalid Syntax")
+    }
+
+    def "can use the graphql context to stop certain validation rules"() {
+
+        def sdl = '''type Query { foo : ID } '''
+        def graphQL = TestUtil.graphQL(sdl).build()
+
+        Predicate<Class<?>> predicate = new Predicate<Class<?>>() {
+            @Override
+            boolean test(Class<?> aClass) {
+                if (aClass == NoUnusedFragments.class) {
+                    return false
+                }
+                return true
+            }
+        }
+
+        def query = '''
+            query { foo }
+            
+            fragment UnusedFrag on Query {
+                foo
+            }
+        '''
+
+        def map = ["graphql.ParseAndValidate.Predicate": predicate]
+        when:
+        def ei = ExecutionInput.newExecutionInput(query)
+                .graphQLContext(map)
+                .build()
+        def rs = graphQL.execute(ei)
+
+        then:
+        rs.errors.isEmpty() // we skipped a rule
+
+        when:
+        predicate = { it -> true }
+        ei = ExecutionInput.newExecutionInput(query)
+                .graphQLContext(["graphql.ParseAndValidate.Predicate": predicate])
+                .build()
+        rs = graphQL.execute(ei)
+
+        then:
+        !rs.errors.isEmpty() // all rules apply - we have errors
     }
 }

--- a/src/test/groovy/graphql/ParseAndValidateTest.groovy
+++ b/src/test/groovy/graphql/ParseAndValidateTest.groovy
@@ -136,10 +136,9 @@ class ParseAndValidateTest extends Specification {
             }
         '''
 
-        def map = ["graphql.ParseAndValidate.Predicate": predicate]
         when:
         def ei = ExecutionInput.newExecutionInput(query)
-                .graphQLContext(map)
+                .graphQLContext(["graphql.ParseAndValidate.Predicate": predicate])
                 .build()
         def rs = graphQL.execute(ei)
 


### PR DESCRIPTION
This used a `GraphqlContext` hint to pass in the predicate needed to skip certain rules