### PR TITLE
Add type reference support to interface builders

### DIFF
--- a/src/main/java/graphql/schema/GraphQLInterfaceType.java
+++ b/src/main/java/graphql/schema/GraphQLInterfaceType.java
@@ -200,7 +200,7 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLCompositeT
         return transform(builder ->
                 builder.replaceDirectives(newChildren.getChildren(CHILD_DIRECTIVES))
                         .replaceFields(newChildren.getChildren(CHILD_FIELD_DEFINITIONS))
-                        .replaceInterfaces(newChildren.getChildren(CHILD_INTERFACES))
+                        .replaceInterfacesOrReferences(newChildren.getChildren(CHILD_INTERFACES))
         );
     }
 
@@ -401,10 +401,14 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLCompositeT
             return this;
         }
 
-        public Builder replaceInterfaces(List<? extends GraphQLNamedOutputType> interfaces) {
-            assertNotNull(interfaces, () -> "interfaces can't be null");
+        public Builder replaceInterfaces(List<GraphQLInterfaceType> interfaces) {
+            return replaceInterfacesOrReferences(interfaces);
+        }
+
+        public Builder replaceInterfacesOrReferences(List<? extends GraphQLNamedOutputType> interfacesOrReferences) {
+            assertNotNull(interfacesOrReferences, () -> "interfaces can't be null");
             this.interfaces.clear();
-            for (GraphQLNamedOutputType schemaElement : interfaces) {
+            for (GraphQLNamedOutputType schemaElement : interfacesOrReferences) {
                 if (schemaElement instanceof GraphQLInterfaceType || schemaElement instanceof GraphQLTypeReference) {
                     this.interfaces.put(schemaElement.getName(), schemaElement);
                 } else {

--- a/src/test/groovy/graphql/schema/GraphQLInterfaceTypeTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLInterfaceTypeTest.groovy
@@ -1,12 +1,18 @@
 package graphql.schema
 
+import graphql.util.TraversalControl
+import graphql.util.TraverserContext
 import spock.lang.Specification
 
 import static graphql.Scalars.GraphQLBoolean
 import static graphql.Scalars.GraphQLInt
 import static graphql.Scalars.GraphQLString
+import static graphql.schema.GraphQLCodeRegistry.newCodeRegistry
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
 import static graphql.schema.GraphQLInterfaceType.newInterface
+import static graphql.schema.GraphQLObjectType.newObject
+import static graphql.schema.GraphQLSchema.newSchema
+import static graphql.schema.GraphQLTypeReference.typeRef
 
 class GraphQLInterfaceTypeTest extends Specification {
 
@@ -59,4 +65,46 @@ class GraphQLInterfaceTypeTest extends Specification {
         objectType2.getFieldDefinition("Str").getType() == GraphQLBoolean
     }
 
+    def "schema transformer accepts interface with type reference"() {
+        given:
+        def iFace = newInterface().name("iFace")
+                    .field(builder -> builder.type(GraphQLString).name("field"))
+                    .withInterface(typeRef("iFace2"))
+                    .build()
+
+        def iFace2 = newInterface().name("iFace2")
+                    .field(builder -> builder.type(GraphQLString).name("field"))
+                    .build()
+
+        def impl = newObject().name("impl")
+                    .field(builder -> builder.type(GraphQLString).name("field"))
+                    .withInterfaces(typeRef("iFace"))
+                    .withInterfaces(typeRef("iFace2"))
+                    .build()
+
+        def codeRegBuilder = newCodeRegistry().typeResolver(iFace, env -> impl)
+                                .typeResolver(iFace2, env -> impl)
+
+        def schema = newSchema()
+                        .codeRegistry(codeRegBuilder.build())
+                        .additionalType(iFace).additionalType(iFace2)
+                        .query(newObject()
+                                .name("test")
+                                .field(builder -> builder.name("iFaceField").type(impl))
+                        ).build()
+
+        when:
+        SchemaTransformer.transformSchema(schema, new GraphQLTypeVisitorStub() {
+            @Override
+            TraversalControl visitGraphQLFieldDefinition(GraphQLFieldDefinition node, TraverserContext<GraphQLSchemaElement> context) {
+                GraphQLFieldDefinition transform = node.transform(
+                        builder -> builder.argument(builder1 -> builder1.name("arg").type(GraphQLString)))
+                changeNode(context, transform)
+                return super.visitGraphQLFieldDefinition(node, context)
+            }
+        })
+
+        then:
+        noExceptionThrown()
+    }
 }


### PR DESCRIPTION
Fixes #2546.

An interface (or object) can contain a type reference to itself. The referenced type is replaced with the real type object when the schema is built.

This PR adds support for type references in `GraphQLInterfaceType` builders, making these equivalent to builders in `GraphQLObjectType`.