### PR TITLE
Propagate errors to individual Subscription events

### DIFF
--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -458,7 +458,7 @@ public abstract class ExecutionStrategy {
             // and validate the field is nullable, if non-nullable throw exception
             parameters.getNonNullFieldValidator().validate(parameters.getPath(), null);
             // complete the field as null
-            fieldValue = completedFuture(new ExecutionResultImpl(null, null));
+            fieldValue = completedFuture(new ExecutionResultImpl(null, executionContext.getErrors()));
         }
         return FieldValueInfo.newFieldValueInfo(OBJECT).fieldValue(fieldValue).build();
     }
@@ -473,7 +473,7 @@ public abstract class ExecutionStrategy {
     protected CompletableFuture<ExecutionResult> completeValueForNull(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
         return Async.tryCatch(() -> {
             Object nullValue = parameters.getNonNullFieldValidator().validate(parameters.getPath(), null);
-            return completedFuture(new ExecutionResultImpl(nullValue, null));
+            return completedFuture(new ExecutionResultImpl(nullValue, executionContext.getErrors()));
         });
     }
 
@@ -562,7 +562,7 @@ public abstract class ExecutionStrategy {
             for (ExecutionResult completedValue : results) {
                 completedResults.add(completedValue.getData());
             }
-            ExecutionResultImpl executionResult = new ExecutionResultImpl(completedResults, null);
+            ExecutionResultImpl executionResult = new ExecutionResultImpl(completedResults, executionContext.getErrors());
             overallResult.complete(executionResult);
         });
         overallResult.whenComplete(completeListCtx::onCompleted);
@@ -602,7 +602,7 @@ public abstract class ExecutionStrategy {
         } catch (NonNullableFieldWasNullException e) {
             return exceptionallyCompletedFuture(e);
         }
-        return completedFuture(new ExecutionResultImpl(serialized, null));
+        return completedFuture(new ExecutionResultImpl(serialized, executionContext.getErrors()));
     }
 
     /**
@@ -627,7 +627,7 @@ public abstract class ExecutionStrategy {
         } catch (NonNullableFieldWasNullException e) {
             return exceptionallyCompletedFuture(e);
         }
-        return completedFuture(new ExecutionResultImpl(serialized, null));
+        return completedFuture(new ExecutionResultImpl(serialized, executionContext.getErrors()));
     }
 
     /**

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -495,7 +495,7 @@ public abstract class ExecutionStrategy {
             return FieldValueInfo.newFieldValueInfo(LIST).fieldValue(exceptionallyCompletedFuture(e)).build();
         }
         if (resultIterable == null) {
-            return FieldValueInfo.newFieldValueInfo(LIST).fieldValue(completedFuture(new ExecutionResultImpl(null, null))).build();
+            return FieldValueInfo.newFieldValueInfo(LIST).fieldValue(completedFuture(new ExecutionResultImpl(null, executionContext.getErrors()))).build();
         }
         return completeValueForList(executionContext, parameters, resultIterable);
     }

--- a/src/test/groovy/graphql/execution/SubscriptionExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/SubscriptionExecutionStrategyTest.groovy
@@ -7,6 +7,7 @@ import graphql.GraphQL
 import graphql.GraphQLError
 import graphql.GraphqlErrorBuilder
 import graphql.TestUtil
+import graphql.TypeMismatchError
 import graphql.execution.instrumentation.TestingInstrumentation
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters
 import graphql.execution.pubsub.CapturingSubscriber
@@ -43,6 +44,7 @@ class SubscriptionExecutionStrategyTest extends Specification {
             
             type Subscription {
                 newMessage(roomId:Int) : Message
+                newListOfMessages(roomId:Int): [Message]
             }
         """
 
@@ -50,13 +52,29 @@ class SubscriptionExecutionStrategyTest extends Specification {
         buildSubscriptionQL(newMessageDF, PropertyDataFetcher.fetching("sender"), PropertyDataFetcher.fetching("text"))
     }
 
-    GraphQL buildSubscriptionQL(DataFetcher newMessageDF, DataFetcher senderDF, DataFetcher textDF) {
-        RuntimeWiring runtimeWiring = RuntimeWiring.newRuntimeWiring()
-                .type(newTypeWiring("Subscription").dataFetcher("newMessage", newMessageDF).build())
+    RuntimeWiring.Builder buildBaseSubscriptionWiring(DataFetcher senderDF, DataFetcher textDF) {
+        return RuntimeWiring.newRuntimeWiring()
                 .type(newTypeWiring("Message")
                         .dataFetcher("sender", senderDF)
                         .dataFetcher("text", textDF)
                         .build())
+    }
+
+    GraphQL buildSubscriptionListQL(DataFetcher newListOfMessagesDF) {
+        return buildSubscriptionListQL(newListOfMessagesDF, PropertyDataFetcher.fetching("sender"), PropertyDataFetcher.fetching("text"))
+    }
+
+    GraphQL buildSubscriptionListQL(DataFetcher newListOfMessagesDF, DataFetcher senderDF, DataFetcher textDF) {
+        RuntimeWiring runtimeWiring = buildBaseSubscriptionWiring(senderDF, textDF)
+                .type(newTypeWiring("Subscription").dataFetcher("newListOfMessages", newListOfMessagesDF).build())
+                .build()
+
+        return TestUtil.graphQL(idl, runtimeWiring).subscriptionExecutionStrategy(new SubscriptionExecutionStrategy()).build()
+    }
+
+    GraphQL buildSubscriptionQL(DataFetcher newMessageDF, DataFetcher senderDF, DataFetcher textDF) {
+        RuntimeWiring runtimeWiring = buildBaseSubscriptionWiring(senderDF, textDF)
+                .type(newTypeWiring("Subscription").dataFetcher("newMessage", newMessageDF).build())
                 .build()
 
         return TestUtil.graphQL(idl, runtimeWiring).subscriptionExecutionStrategy(new SubscriptionExecutionStrategy()).build()
@@ -66,6 +84,54 @@ class SubscriptionExecutionStrategyTest extends Specification {
         GraphqlErrorBuilder.newError().message(message).build()
     }
 
+    @Unroll
+    def "#2609 when a GraphQLList is expected and a non iterable or non array is passed then it should yield a TypeMismatch error (spec October2021/6.2.3.2.ExecuteSubscriptionEvent(...).5)"() {
+        given:
+        DataFetcher newListOfMessagesDF = new DataFetcher() {
+            @Override
+            Object get(DataFetchingEnvironment environment) {
+                return new ReactiveStreamsMessagePublisher(5) {
+                    @Override
+                    protected Message examineMessage(Message message, Integer at) {
+                        // Should actually be list of messages ([Message])
+                        return new Message("aSender_" + at, "someText" + at)
+                    }
+                }
+            }
+        }
+
+        GraphQL graphQL = buildSubscriptionListQL(newListOfMessagesDF)
+
+        def executionInput = ExecutionInput.newExecutionInput().query("""
+            subscription NewListOfMessages {
+              newListOfMessages(roomId: 123) {
+                sender
+                text
+              }
+            }
+        """).build()
+
+        when:
+        def executionResult = graphQL.execute(executionInput)
+
+        Publisher<ExecutionResult> msgStream = executionResult.getData()
+
+        def capturingSubscriber = new CapturingSubscriber<ExecutionResult>()
+        msgStream.subscribe(capturingSubscriber)
+
+        then:
+        Awaitility.await().untilTrue(capturingSubscriber.isDone())
+
+        def messages = capturingSubscriber.events
+        messages.size() == 5
+        for (int i = 0; i < messages.size(); i++) {
+            def message = messages[i]
+            assert message.errors.size() == 1
+            assert message.errors[0] instanceof TypeMismatchError
+            assert message.errors[0].message.contains("/newListOfMessages")
+            assert message.errors[0].message.contains("LIST")
+        }
+    }
 
     @Unroll
     def "subscription query sends out a stream of events using the '#why' implementation"() {
@@ -547,10 +613,10 @@ class SubscriptionExecutionStrategyTest extends Specification {
 
         def subscribedFieldCalls = instrumentation.executionList.findAll { s -> s.contains(":subscribed-field-event") }
         subscribedFieldCalls.size() == 20 // start and end calls
-        subscribedFieldCalls.findAll { s -> s.contains("newMessage")}.size() == 20 // all for our subscribed field
+        subscribedFieldCalls.findAll { s -> s.contains("newMessage") }.size() == 20 // all for our subscribed field
 
         // this works because our calls are serial - if we truly had async values then the order would not work
-        subscribedFieldCalls.withIndex().collect({s,index ->
+        subscribedFieldCalls.withIndex().collect({ s, index ->
             if (index % 2 == 0) {
                 assert s.startsWith("start:"), "expected start: on even indexes"
             } else {
@@ -560,4 +626,5 @@ class SubscriptionExecutionStrategyTest extends Specification {
 
         instrumentResultCalls.size() == 11 // one for the initial execution and then one for each stream event
     }
+
 }


### PR DESCRIPTION
This is my first PR on this project, glad to be able to finally contribute! Please let me know if I should change anything.

This PR fixes #2609.

~~The same issue may also emerge at line [461](https://github.com/graphql-java/graphql-java/commit/0d52319db6d0b02bf9126297dcee6aad304b5bdc#diff-2ece51452808f5a3fd08db50de534a12806aa6cd4e236c549dff9759884e43ffR461) and [476](https://github.com/graphql-java/graphql-java/commit/0d52319db6d0b02bf9126297dcee6aad304b5bdc#diff-2ece51452808f5a3fd08db50de534a12806aa6cd4e236c549dff9759884e43ffR476) (I wouldn't know in which situations though). LMK if I should apply the same change there.~~

The PR fixes compliance with the GraphQL (October 2021) spec [section 6.2.3.2 ("Response Stream") under ExecuteSubscriptionEvent point 5. ](https://spec.graphql.org/October2021/#sel-IANNJdHCJCAACEsBlmF)