### PR TITLE
Fix integration test using the default Locale in Locale#getDisplayName()

### DIFF
--- a/src/test/groovy/graphql/ExecutionInputTest.groovy
+++ b/src/test/groovy/graphql/ExecutionInputTest.groovy
@@ -131,7 +131,7 @@ class ExecutionInputTest extends Specification {
         '''
         DataFetcher df = { DataFetchingEnvironment env ->
             return [
-                    "locale"        : env.getLocale().getDisplayName(),
+                    "locale"        : env.getLocale().getDisplayName(Locale.ENGLISH),
                     "cacheControl"  : env.getCacheControl() == cacheControl,
                     "executionId"   : env.getExecutionId().toString(),
                     "graphqlContext": env.getGraphQlContext().get("a")


### PR DESCRIPTION
The integration test was checking if DataFetchingEnvironment#getLocale()#getDisplayName() returned "German" when the locale passed to the ExecutionInput was Locale.GERMAN.

This PR changes the call to [getDisplayName(Locale.ENGLISH)](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/Locale.html#getDisplayName(java.util.Locale)). Making sure the system locale doesn't affect the test.

My Locale is nl_NL, so the test was comparing `Duits` ("German" in Dutch) to `German` (in English of course)