### PR TITLE
Only print out important tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -211,7 +211,8 @@ artifacts {
 
 test {
     testLogging {
-        exceptionFormat = 'full'
+        events "FAILED", "SKIPPED"
+        exceptionFormat = "FULL"
     }
 }
 


### PR DESCRIPTION
Our test output is getting large and its HARD to find the failing tests - so lets only print out failing or skipped tests