### PR TITLE
Improve ExecutableNormalizedField.isConditional for interface fields and fix a bug regarding covariant fields

### DIFF
--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -30,6 +30,7 @@ import static graphql.Assert.assertShouldNeverHappen;
 import static graphql.execution.ExecutionContextBuilder.newExecutionContextBuilder;
 import static graphql.execution.ExecutionStepInfo.newExecutionStepInfo;
 import static graphql.execution.ExecutionStrategyParameters.newParameters;
+import static graphql.execution.nextgen.Common.getOperationRootType;
 import static graphql.language.OperationDefinition.Operation.MUTATION;
 import static graphql.language.OperationDefinition.Operation.QUERY;
 import static graphql.language.OperationDefinition.Operation.SUBSCRIPTION;
@@ -174,31 +175,5 @@ public class Execution {
         result = result.whenComplete(executeOperationCtx::onCompleted);
 
         return result;
-    }
-
-
-    private GraphQLObjectType getOperationRootType(GraphQLSchema graphQLSchema, OperationDefinition operationDefinition) {
-        OperationDefinition.Operation operation = operationDefinition.getOperation();
-        if (operation == MUTATION) {
-            GraphQLObjectType mutationType = graphQLSchema.getMutationType();
-            if (mutationType == null) {
-                throw new MissingRootTypeException("Schema is not configured for mutations.", operationDefinition.getSourceLocation());
-            }
-            return mutationType;
-        } else if (operation == QUERY) {
-            GraphQLObjectType queryType = graphQLSchema.getQueryType();
-            if (queryType == null) {
-                throw new MissingRootTypeException("Schema does not define the required query root type.", operationDefinition.getSourceLocation());
-            }
-            return queryType;
-        } else if (operation == SUBSCRIPTION) {
-            GraphQLObjectType subscriptionType = graphQLSchema.getSubscriptionType();
-            if (subscriptionType == null) {
-                throw new MissingRootTypeException("Schema is not configured for subscriptions.", operationDefinition.getSourceLocation());
-            }
-            return subscriptionType;
-        } else {
-            return assertShouldNeverHappen("Unhandled case.  An extra operation enum has been added without code support");
-        }
     }
 }

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -176,4 +176,30 @@ public class Execution {
 
         return result;
     }
+
+
+    private GraphQLObjectType getOperationRootType(GraphQLSchema graphQLSchema, OperationDefinition operationDefinition) {
+        OperationDefinition.Operation operation = operationDefinition.getOperation();
+        if (operation == MUTATION) {
+            GraphQLObjectType mutationType = graphQLSchema.getMutationType();
+            if (mutationType == null) {
+                throw new MissingRootTypeException("Schema is not configured for mutations.", operationDefinition.getSourceLocation());
+            }
+            return mutationType;
+        } else if (operation == QUERY) {
+            GraphQLObjectType queryType = graphQLSchema.getQueryType();
+            if (queryType == null) {
+                throw new MissingRootTypeException("Schema does not define the required query root type.", operationDefinition.getSourceLocation());
+            }
+            return queryType;
+        } else if (operation == SUBSCRIPTION) {
+            GraphQLObjectType subscriptionType = graphQLSchema.getSubscriptionType();
+            if (subscriptionType == null) {
+                throw new MissingRootTypeException("Schema is not configured for subscriptions.", operationDefinition.getSourceLocation());
+            }
+            return subscriptionType;
+        } else {
+            return assertShouldNeverHappen("Unhandled case.  An extra operation enum has been added without code support");
+        }
+    }
 }

--- a/src/main/java/graphql/execution/nextgen/Common.java
+++ b/src/main/java/graphql/execution/nextgen/Common.java
@@ -3,8 +3,11 @@ package graphql.execution.nextgen;
 import graphql.Internal;
 import graphql.execution.MissingRootTypeException;
 import graphql.language.OperationDefinition;
+import graphql.language.SourceLocation;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
 
@@ -19,21 +22,30 @@ import static graphql.language.OperationDefinition.Operation.SUBSCRIPTION;
 @Deprecated
 @Internal
 public class Common {
-
     public static GraphQLObjectType getOperationRootType(GraphQLSchema graphQLSchema, OperationDefinition operationDefinition) {
-        OperationDefinition.Operation operation = operationDefinition.getOperation();
+        return getOperationRootType(graphQLSchema, operationDefinition.getOperation(), operationDefinition.getSourceLocation());
+    }
+
+    public static GraphQLObjectType getOperationRootType(@NotNull GraphQLSchema graphQLSchema,
+                                                         @NotNull OperationDefinition.Operation operation) {
+        return getOperationRootType(graphQLSchema, operation, null);
+    }
+
+    public static GraphQLObjectType getOperationRootType(@NotNull GraphQLSchema graphQLSchema,
+                                                         @NotNull OperationDefinition.Operation operation,
+                                                         @Nullable SourceLocation sourceLocation) {
         if (operation == MUTATION) {
             GraphQLObjectType mutationType = graphQLSchema.getMutationType();
             return Optional.ofNullable(mutationType)
-                    .orElseThrow(() -> new MissingRootTypeException("Schema is not configured for mutations.", operationDefinition.getSourceLocation()));
+                    .orElseThrow(() -> new MissingRootTypeException("Schema is not configured for mutations.", sourceLocation));
         } else if (operation == QUERY) {
             GraphQLObjectType queryType = graphQLSchema.getQueryType();
             return Optional.ofNullable(queryType)
-                    .orElseThrow(() -> new MissingRootTypeException("Schema does not define the required query root type.", operationDefinition.getSourceLocation()));
+                    .orElseThrow(() -> new MissingRootTypeException("Schema does not define the required query root type.", sourceLocation));
         } else if (operation == SUBSCRIPTION) {
             GraphQLObjectType subscriptionType = graphQLSchema.getSubscriptionType();
             return Optional.ofNullable(subscriptionType)
-                    .orElseThrow(() -> new MissingRootTypeException("Schema is not configured for subscriptions.", operationDefinition.getSourceLocation()));
+                    .orElseThrow(() -> new MissingRootTypeException("Schema is not configured for subscriptions.", sourceLocation));
         } else {
             return assertShouldNeverHappen("Unhandled case.  An extra operation enum has been added without code support");
         }

--- a/src/main/java/graphql/execution/nextgen/Common.java
+++ b/src/main/java/graphql/execution/nextgen/Common.java
@@ -3,11 +3,8 @@ package graphql.execution.nextgen;
 import graphql.Internal;
 import graphql.execution.MissingRootTypeException;
 import graphql.language.OperationDefinition;
-import graphql.language.SourceLocation;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
 
@@ -22,30 +19,21 @@ import static graphql.language.OperationDefinition.Operation.SUBSCRIPTION;
 @Deprecated
 @Internal
 public class Common {
+
     public static GraphQLObjectType getOperationRootType(GraphQLSchema graphQLSchema, OperationDefinition operationDefinition) {
-        return getOperationRootType(graphQLSchema, operationDefinition.getOperation(), operationDefinition.getSourceLocation());
-    }
-
-    public static GraphQLObjectType getOperationRootType(@NotNull GraphQLSchema graphQLSchema,
-                                                         @NotNull OperationDefinition.Operation operation) {
-        return getOperationRootType(graphQLSchema, operation, null);
-    }
-
-    public static GraphQLObjectType getOperationRootType(@NotNull GraphQLSchema graphQLSchema,
-                                                         @NotNull OperationDefinition.Operation operation,
-                                                         @Nullable SourceLocation sourceLocation) {
+        OperationDefinition.Operation operation = operationDefinition.getOperation();
         if (operation == MUTATION) {
             GraphQLObjectType mutationType = graphQLSchema.getMutationType();
             return Optional.ofNullable(mutationType)
-                    .orElseThrow(() -> new MissingRootTypeException("Schema is not configured for mutations.", sourceLocation));
+                    .orElseThrow(() -> new MissingRootTypeException("Schema is not configured for mutations.", operationDefinition.getSourceLocation()));
         } else if (operation == QUERY) {
             GraphQLObjectType queryType = graphQLSchema.getQueryType();
             return Optional.ofNullable(queryType)
-                    .orElseThrow(() -> new MissingRootTypeException("Schema does not define the required query root type.", sourceLocation));
+                    .orElseThrow(() -> new MissingRootTypeException("Schema does not define the required query root type.", operationDefinition.getSourceLocation()));
         } else if (operation == SUBSCRIPTION) {
             GraphQLObjectType subscriptionType = graphQLSchema.getSubscriptionType();
             return Optional.ofNullable(subscriptionType)
-                    .orElseThrow(() -> new MissingRootTypeException("Schema is not configured for subscriptions.", sourceLocation));
+                    .orElseThrow(() -> new MissingRootTypeException("Schema is not configured for subscriptions.", operationDefinition.getSourceLocation()));
         } else {
             return assertShouldNeverHappen("Unhandled case.  An extra operation enum has been added without code support");
         }

--- a/src/main/java/graphql/normalized/ExecutableNormalizedField.java
+++ b/src/main/java/graphql/normalized/ExecutableNormalizedField.java
@@ -5,11 +5,15 @@ import com.google.common.collect.ImmutableMap;
 import graphql.Internal;
 import graphql.Mutable;
 import graphql.collect.ImmutableKit;
+import graphql.introspection.Introspection;
 import graphql.language.Argument;
 import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLInterfaceType;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLOutputType;
 import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLType;
+import graphql.schema.GraphQLUnionType;
 import graphql.util.FpKit;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -61,6 +65,7 @@ public class ExecutableNormalizedField {
         this.parent = builder.parent;
     }
 
+    @Deprecated // doesn't really work
     public boolean isConditional(GraphQLSchema schema) {
         if (parent == null) {
             return false;
@@ -68,13 +73,100 @@ public class ExecutableNormalizedField {
         return objectTypeNames.size() > 1 || unwrapAll(parent.getType(schema)) != getOneObjectType(schema);
     }
 
+    /**
+     * Determines whether this NF needs a fragment to select the field. However, it considers the parent
+     * output type when determining whether it needs a fragment.
+     * <p>
+     * Consider the following schema
+     *
+     * <pre>
+     * interface Animal {
+     *     name: String
+     *     parent: Animal
+     * }
+     * type Cat implements Animal {
+     *     name: String
+     *     parent: Cat
+     * }
+     * type Dog implements Animal {
+     *     name: String
+     *     parent: Dog
+     *     isGoodBoy: Boolean
+     * }
+     * type Query {
+     *     animal: Animal
+     * }
+     * </pre>
+     * <p>
+     * and the following query
+     *
+     * <pre>
+     * {
+     *     animal {
+     *         parent {
+     *             name
+     *         }
+     *     }
+     * }
+     * </pre>
+     * <p>
+     * Then we would get the following normalized operation tree
+     *
+     * <pre>
+     * -Query.animal: Animal
+     * --[Cat, Dog].parent: Cat, Dog
+     * ---[Cat, Dog].name: String
+     * </pre>
+     * <p>
+     * If we simply checked the {@link #parent}'s {@link #getFieldDefinitions(GraphQLSchema)} that would
+     * point us to {@code Cat.parent} and {@code Dog.parent} whose output types would incorrectly answer
+     * our question whether this is conditional?
+     * <p>
+     * We MUST consider that the output type of the {@code parent} field is {@code Animal} and
+     * NOT {@code Cat} or {@code Dog} as their respective impls would say.
+     */
+    public boolean isConditional(GraphQLSchema schema, @Nullable String parentOutputTypeName) {
+        if (parent == null || parentOutputTypeName == null) {
+            return false;
+        }
+
+        GraphQLType parentOutputType = schema.getType(parentOutputTypeName);
+
+        // Is not conditional if field exists in interface type, and we have specified all impls
+        if (parentOutputType instanceof GraphQLInterfaceType) {
+            GraphQLInterfaceType parentOutputTypeAsInterface = (GraphQLInterfaceType) parentOutputType;
+            List<GraphQLObjectType> interfaceImpls = schema.getImplementations(parentOutputTypeAsInterface);
+            if (interfaceImpls.size() == objectTypeNames.size()) {
+                return parentOutputTypeAsInterface.getField(this.fieldName) == null
+                        && !this.fieldName.equals(Introspection.TypeNameMetaFieldDef.getName());
+            } else {
+                return true;
+            }
+        } else if (parentOutputType instanceof GraphQLUnionType) {
+            GraphQLUnionType parentOutputTypeAsUnion = (GraphQLUnionType) parentOutputType;
+            if (objectTypeNames.size() == parentOutputTypeAsUnion.getTypes().size()) {
+                return !this.fieldName.equals(Introspection.TypeNameMetaFieldDef.getName());
+            } else {
+                return true;
+            }
+        }
+
+        if (objectTypeNames.size() > 1) {
+            return true;
+        }
+
+        return parentOutputType != getOneObjectType(schema);
+    }
+
+    @Deprecated // using this is ALMOST always wrong
     public GraphQLOutputType getType(GraphQLSchema schema) {
         return getOneFieldDefinition(schema).getType();
     }
 
+    @Deprecated // using this is ALMOST always wrong
     public GraphQLFieldDefinition getOneFieldDefinition(GraphQLSchema schema) {
         GraphQLFieldDefinition fieldDefinition;
-        GraphQLFieldDefinition introspectionField = resolveIntrospectionField(fieldName, schema);
+        GraphQLFieldDefinition introspectionField = resolveIntrospectionField(schema, objectTypeNames, fieldName);
         if (introspectionField != null) {
             return introspectionField;
         }
@@ -84,7 +176,7 @@ public class ExecutableNormalizedField {
     }
 
     public List<GraphQLFieldDefinition> getFieldDefinitions(GraphQLSchema schema) {
-        GraphQLFieldDefinition fieldDefinition = resolveIntrospectionField(fieldName, schema);
+        GraphQLFieldDefinition fieldDefinition = resolveIntrospectionField(schema, objectTypeNames, fieldName);
         if (fieldDefinition != null) {
             return ImmutableList.of(fieldDefinition);
         }
@@ -96,10 +188,10 @@ public class ExecutableNormalizedField {
         return builder.build();
     }
 
-    private static GraphQLFieldDefinition resolveIntrospectionField(String fieldName, GraphQLSchema schema) {
+    private static GraphQLFieldDefinition resolveIntrospectionField(GraphQLSchema schema, Set<String> objectTypeNames, String fieldName) {
         if (fieldName.equals(schema.getIntrospectionTypenameFieldDefinition().getName())) {
             return schema.getIntrospectionTypenameFieldDefinition();
-        } else {
+        } else if (objectTypeNames.size() == 1 && objectTypeNames.iterator().next().equals(schema.getQueryType().getName())) {
             if (fieldName.equals(schema.getIntrospectionSchemaFieldDefinition().getName())) {
                 return schema.getIntrospectionSchemaFieldDefinition();
             } else if (fieldName.equals(schema.getIntrospectionTypeFieldDefinition().getName())) {
@@ -199,13 +291,12 @@ public class ExecutableNormalizedField {
         return objectTypeNames.iterator().next();
     }
 
+    @Deprecated // using this is ALMOST always wrong
     public GraphQLObjectType getOneObjectType(GraphQLSchema schema) {
         return (GraphQLObjectType) schema.getType(objectTypeNames.iterator().next());
     }
 
-
     public String printDetails() {
-
         StringBuilder result = new StringBuilder();
         if (getAlias() != null) {
             result.append(getAlias()).append(": ");
@@ -303,7 +394,6 @@ public class ExecutableNormalizedField {
         private ImmutableList<Argument> astArguments = ImmutableKit.emptyList();
 
         private Builder() {
-
         }
 
         private Builder(ExecutableNormalizedField existing) {
@@ -374,8 +464,5 @@ public class ExecutableNormalizedField {
         public ExecutableNormalizedField build() {
             return new ExecutableNormalizedField(this);
         }
-
-
     }
-
 }

--- a/src/main/java/graphql/normalized/ExecutableNormalizedOperationFactory.java
+++ b/src/main/java/graphql/normalized/ExecutableNormalizedOperationFactory.java
@@ -158,7 +158,6 @@ public class ExecutableNormalizedOperationFactory {
         CollectNFResult nextLevel = collectFromMergedField(fieldCollectorNormalizedQueryParams, field, mergedField, curLevel + 1);
 
         for (ExecutableNormalizedField child : nextLevel.children) {
-
             field.addChild(child);
             ImmutableList<FieldAndAstParent> mergedFieldForChild = nextLevel.normalizedFieldToAstFields.get(child);
             normalizedFieldToMergedField.put(child, newMergedField(map(mergedFieldForChild, fieldAndAstParent -> fieldAndAstParent.field)).build());
@@ -172,8 +171,6 @@ public class ExecutableNormalizedOperationFactory {
                     normalizedFieldToMergedField,
                     coordinatesToNormalizedFields,
                     curLevel + 1);
-
-
         }
     }
 
@@ -218,13 +215,11 @@ public class ExecutableNormalizedOperationFactory {
                                                   ExecutableNormalizedField executableNormalizedField,
                                                   ImmutableList<FieldAndAstParent> mergedField,
                                                   int level) {
-        GraphQLUnmodifiedType fieldType = unwrapAll(executableNormalizedField.getType(parameters.getGraphQLSchema()));
-        // if not composite we don't have any selectionSet because it is a Scalar or enum
-        if (!(fieldType instanceof GraphQLCompositeType)) {
+        List<GraphQLFieldDefinition> fieldDefs = executableNormalizedField.getFieldDefinitions(parameters.getGraphQLSchema());
+        Set<GraphQLObjectType> possibleObjects = resolvePossibleObjects(fieldDefs, parameters.getGraphQLSchema());
+        if (possibleObjects.isEmpty()) {
             return new CollectNFResult(Collections.emptyList(), ImmutableListMultimap.of());
         }
-
-        Set<GraphQLObjectType> possibleObjects = resolvePossibleObjects((GraphQLCompositeType) fieldType, parameters.getGraphQLSchema());
 
         List<CollectedField> collectedFields = new ArrayList<>();
         for (FieldAndAstParent fieldAndAstParent : mergedField) {
@@ -255,8 +250,6 @@ public class ExecutableNormalizedOperationFactory {
     public CollectNFResult collectFromOperation(FieldCollectorNormalizedQueryParams parameters,
                                                 OperationDefinition operationDefinition,
                                                 GraphQLObjectType rootType) {
-
-
         Set<GraphQLObjectType> possibleObjects = new LinkedHashSet<>();
         possibleObjects.add(rootType);
         List<CollectedField> collectedFields = new ArrayList<>();
@@ -363,7 +356,6 @@ public class ExecutableNormalizedOperationFactory {
                                          GraphQLCompositeType astTypeCondition,
                                          Set<GraphQLObjectType> possibleObjects
     ) {
-
         for (Selection<?> selection : selectionSet.getSelections()) {
             if (selection instanceof Field) {
                 collectField(parameters, result, (Field) selection, possibleObjects, astTypeCondition);
@@ -445,22 +437,34 @@ public class ExecutableNormalizedOperationFactory {
             return;
         }
         // this means there is actually no possible type for this field and we are done
-        if (possibleObjectTypes.size() == 0) {
+        if (possibleObjectTypes.isEmpty()) {
             return;
         }
         result.add(new CollectedField(field, possibleObjectTypes, astTypeCondition));
     }
-
 
     private Set<GraphQLObjectType> narrowDownPossibleObjects(Set<GraphQLObjectType> currentOnes,
                                                              GraphQLCompositeType typeCondition,
                                                              GraphQLSchema graphQLSchema) {
 
         ImmutableSet<GraphQLObjectType> resolvedTypeCondition = resolvePossibleObjects(typeCondition, graphQLSchema);
-        if (currentOnes.size() == 0) {
+        if (currentOnes.isEmpty()) {
             return resolvedTypeCondition;
         }
         return Sets.intersection(currentOnes, resolvedTypeCondition);
+    }
+
+    private ImmutableSet<GraphQLObjectType> resolvePossibleObjects(List<GraphQLFieldDefinition> defs, GraphQLSchema graphQLSchema) {
+        ImmutableSet.Builder<GraphQLObjectType> builder = ImmutableSet.builder();
+
+        for (GraphQLFieldDefinition def : defs) {
+            GraphQLUnmodifiedType outputType = unwrapAll(def.getType());
+            if (outputType instanceof GraphQLCompositeType) {
+                builder.addAll(resolvePossibleObjects((GraphQLCompositeType) outputType, graphQLSchema));
+            }
+        }
+
+        return builder.build();
     }
 
     private ImmutableSet<GraphQLObjectType> resolvePossibleObjects(GraphQLCompositeType type, GraphQLSchema graphQLSchema) {
@@ -470,11 +474,9 @@ public class ExecutableNormalizedOperationFactory {
             return ImmutableSet.copyOf(graphQLSchema.getImplementations((GraphQLInterfaceType) type));
         } else if (type instanceof GraphQLUnionType) {
             List types = ((GraphQLUnionType) type).getTypes();
-            return ImmutableSet.copyOf((types));
+            return ImmutableSet.copyOf(types);
         } else {
             return assertShouldNeverHappen();
         }
-
     }
-
 }

--- a/src/main/java/graphql/normalized/ExecutableNormalizedOperationToAstCompiler.java
+++ b/src/main/java/graphql/normalized/ExecutableNormalizedOperationToAstCompiler.java
@@ -2,6 +2,7 @@ package graphql.normalized;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import graphql.Assert;
 import graphql.Internal;
 import graphql.language.Argument;
 import graphql.language.ArrayValue;
@@ -16,7 +17,10 @@ import graphql.language.Selection;
 import graphql.language.SelectionSet;
 import graphql.language.TypeName;
 import graphql.language.Value;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLUnmodifiedType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -25,12 +29,16 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import static graphql.Assert.assertNotNull;
 import static graphql.collect.ImmutableKit.map;
 import static graphql.language.Argument.newArgument;
 import static graphql.language.Field.newField;
 import static graphql.language.InlineFragment.newInlineFragment;
 import static graphql.language.SelectionSet.newSelectionSet;
 import static graphql.language.TypeName.newTypeName;
+import static graphql.schema.FieldCoordinates.coordinates;
+import static graphql.schema.GraphQLTypeUtil.unwrapAll;
+import static java.util.Collections.emptyList;
 
 @Internal
 public class ExecutableNormalizedOperationToAstCompiler {
@@ -53,17 +61,17 @@ public class ExecutableNormalizedOperationToAstCompiler {
         }
     }
 
-    public static CompilerResult compileToDocument(
-            GraphQLSchema schema,
-            OperationDefinition.Operation operationKind,
-            String operationName,
-            List<ExecutableNormalizedField> topLevelFields,
-            VariablePredicate variablePredicate
-    ) {
-        VariableAccumulator variableAccumulator = new VariableAccumulator(variablePredicate);
-        List<Selection<?>> selections = selectionsForNormalizedFields(schema, topLevelFields, variableAccumulator);
-        SelectionSet selectionSet = new SelectionSet(selections);
+    public static CompilerResult compileToDocument(@NotNull GraphQLSchema schema,
+                                                   @NotNull OperationDefinition.Operation operationKind,
+                                                   @Nullable String operationName,
+                                                   @NotNull List<ExecutableNormalizedField> topLevelFields,
+                                                   @Nullable VariablePredicate variablePredicate) {
+        GraphQLObjectType operationType = assertNotNull(getOperationType(schema, operationKind),
+                () -> "Schema does not support " + operationKind.name().toLowerCase() + " operations");
 
+        VariableAccumulator variableAccumulator = new VariableAccumulator(variablePredicate);
+        List<Selection<?>> selections = subselectionsForNormalizedField(schema, operationType.getName(), topLevelFields, variableAccumulator);
+        SelectionSet selectionSet = new SelectionSet(selections);
 
         OperationDefinition.Builder definitionBuilder = OperationDefinition.newOperationDefinition()
                 .name(operationName)
@@ -80,34 +88,32 @@ public class ExecutableNormalizedOperationToAstCompiler {
         );
     }
 
-    private static List<Selection<?>> selectionsForNormalizedFields(
-            GraphQLSchema schema,
-            List<ExecutableNormalizedField> executableNormalizedFields,
-            VariableAccumulator variableAccumulator
-    ) {
+    private static List<Selection<?>> subselectionsForNormalizedField(GraphQLSchema schema,
+                                                                      @Nullable String parentOutputType,
+                                                                      List<ExecutableNormalizedField> executableNormalizedFields,
+                                                                      VariableAccumulator variableAccumulator) {
         ImmutableList.Builder<Selection<?>> selections = ImmutableList.builder();
 
-        // All conditional fields go here instead of directly to selections so they can be grouped together
-        // in the same inline fragement in the output
-        Map<String, List<Field>> conditionalFieldsByObjectTypeName = new LinkedHashMap<>();
+        // All conditional fields go here instead of directly to selections, so they can be grouped together
+        // in the same inline fragment in the output
+        Map<String, List<Field>> fieldsByTypeCondition = new LinkedHashMap<>();
 
         for (ExecutableNormalizedField nf : executableNormalizedFields) {
-            Map<String, List<Field>> groupFieldsForChild = selectionForNormalizedField(schema, nf, variableAccumulator);
-            if (nf.isConditional(schema)) {
-                groupFieldsForChild.forEach((objectTypeName, fields) -> {
-                    List<Field> fieldList = conditionalFieldsByObjectTypeName.computeIfAbsent(objectTypeName, ignored -> new ArrayList<>());
-                    fieldList.addAll(fields);
-                });
+            if (nf.isConditional(schema, parentOutputType)) {
+                selectionForNormalizedField(schema, nf, variableAccumulator)
+                        .forEach((objectTypeName, field) ->
+                                fieldsByTypeCondition
+                                        .computeIfAbsent(objectTypeName, ignored -> new ArrayList<>())
+                                        .add(field));
             } else {
-                List<Field> fields = groupFieldsForChild.values().iterator().next();
-                selections.addAll(fields);
+                selections.add(selectionForNormalizedField(schema, parentOutputType, nf, variableAccumulator));
             }
         }
 
-        conditionalFieldsByObjectTypeName.forEach((objectTypeName, fields) -> {
+        fieldsByTypeCondition.forEach((objectTypeName, fields) -> {
             TypeName typeName = newTypeName(objectTypeName).build();
-            InlineFragment inlineFragment = newInlineFragment().
-                    typeCondition(typeName)
+            InlineFragment inlineFragment = newInlineFragment()
+                    .typeCondition(typeName)
                     .selectionSet(selectionSet(fields))
                     .build();
             selections.add(inlineFragment);
@@ -116,38 +122,66 @@ public class ExecutableNormalizedOperationToAstCompiler {
         return selections.build();
     }
 
-    private static Map<String, List<Field>> selectionForNormalizedField(
-            GraphQLSchema schema,
-            ExecutableNormalizedField executableNormalizedField,
-            VariableAccumulator variableAccumulator
-    ) {
-        Map<String, List<Field>> groupedFields = new LinkedHashMap<>();
-        for (String objectTypeName : executableNormalizedField.getObjectTypeNames()) {
-            List<Selection<?>> subSelections = selectionsForNormalizedFields(schema, executableNormalizedField.getChildren(), variableAccumulator);
-            SelectionSet selectionSet = null;
-            if (subSelections.size() > 0) {
-                selectionSet = newSelectionSet()
-                        .selections(subSelections)
-                        .build();
-            }
-            List<Argument> arguments = createArguments(executableNormalizedField, variableAccumulator);
-            Field field = newField()
-                    .name(executableNormalizedField.getFieldName())
-                    .alias(executableNormalizedField.getAlias())
-                    .selectionSet(selectionSet)
-                    .arguments(arguments)
-                    .build();
+    /**
+     * @return Map of object type names to list of fields
+     */
+    private static Map<String, Field> selectionForNormalizedField(GraphQLSchema schema,
+                                                                  ExecutableNormalizedField executableNormalizedField,
+                                                                  VariableAccumulator variableAccumulator) {
+        Map<String, Field> groupedFields = new LinkedHashMap<>();
 
-            groupedFields.computeIfAbsent(objectTypeName, ignored -> new ArrayList<>()).add(field);
+        for (String objectTypeName : executableNormalizedField.getObjectTypeNames()) {
+            groupedFields.put(objectTypeName, selectionForNormalizedField(schema, objectTypeName, executableNormalizedField, variableAccumulator));
         }
+
         return groupedFields;
+    }
+
+    /**
+     * @return Map of object type names to list of fields
+     */
+    private static Field selectionForNormalizedField(GraphQLSchema schema,
+                                                     String objectTypeName,
+                                                     ExecutableNormalizedField executableNormalizedField,
+                                                     VariableAccumulator variableAccumulator) {
+        final List<Selection<?>> subSelections;
+        if (executableNormalizedField.getChildren().isEmpty()) {
+            subSelections = emptyList();
+        } else {
+            GraphQLFieldDefinition fieldDefinition = getFieldDefinition(schema, objectTypeName, executableNormalizedField);
+            assertNotNull(fieldDefinition, () -> String.format("Field at %s.%s does not exist", objectTypeName, executableNormalizedField.getName()));
+            GraphQLUnmodifiedType fieldOutputType = unwrapAll(fieldDefinition.getType());
+
+            subSelections = subselectionsForNormalizedField(
+                    schema,
+                    fieldOutputType.getName(),
+                    executableNormalizedField.getChildren(),
+                    variableAccumulator
+            );
+        }
+
+        SelectionSet selectionSet = selectionSetOrNullIfEmpty(subSelections);
+        List<Argument> arguments = createArguments(executableNormalizedField, variableAccumulator);
+
+        return newField()
+                .name(executableNormalizedField.getFieldName())
+                .alias(executableNormalizedField.getAlias())
+                .selectionSet(selectionSet)
+                .arguments(arguments)
+                .build();
+    }
+
+    @Nullable
+    private static SelectionSet selectionSetOrNullIfEmpty(List<Selection<?>> selections) {
+        return selections.isEmpty() ? null : newSelectionSet().selections(selections).build();
     }
 
     private static SelectionSet selectionSet(List<Field> fields) {
         return newSelectionSet().selections(fields).build();
     }
 
-    private static List<Argument> createArguments(ExecutableNormalizedField executableNormalizedField, VariableAccumulator variableAccumulator) {
+    private static List<Argument> createArguments(ExecutableNormalizedField executableNormalizedField,
+                                                  VariableAccumulator variableAccumulator) {
         ImmutableList.Builder<Argument> result = ImmutableList.builder();
         ImmutableMap<String, NormalizedInputValue> normalizedArguments = executableNormalizedField.getNormalizedArguments();
         for (String argName : normalizedArguments.keySet()) {
@@ -163,7 +197,10 @@ public class ExecutableNormalizedOperationToAstCompiler {
     }
 
     @SuppressWarnings("unchecked")
-    private static Value<?> argValue(ExecutableNormalizedField executableNormalizedField, String argName, @Nullable Object value, VariableAccumulator variableAccumulator) {
+    private static Value<?> argValue(ExecutableNormalizedField executableNormalizedField,
+                                     String argName,
+                                     @Nullable Object value,
+                                     VariableAccumulator variableAccumulator) {
         if (value instanceof List) {
             ArrayValue.Builder arrayValue = ArrayValue.newArrayValue();
             arrayValue.values(map((List<Object>) value, val -> argValue(executableNormalizedField, argName, val, variableAccumulator)));
@@ -185,12 +222,37 @@ public class ExecutableNormalizedOperationToAstCompiler {
     }
 
     @NotNull
-    private static Value<?> argValue(ExecutableNormalizedField executableNormalizedField, String argName, NormalizedInputValue normalizedInputValue, VariableAccumulator variableAccumulator) {
+    private static Value<?> argValue(ExecutableNormalizedField executableNormalizedField,
+                                     String argName,
+                                     NormalizedInputValue normalizedInputValue,
+                                     VariableAccumulator variableAccumulator) {
         if (variableAccumulator.shouldMakeVariable(executableNormalizedField, argName, normalizedInputValue)) {
             VariableValueWithDefinition variableWithDefinition = variableAccumulator.accumulateVariable(normalizedInputValue);
             return variableWithDefinition.getVariableReference();
         } else {
             return argValue(executableNormalizedField, argName, normalizedInputValue.getValue(), variableAccumulator);
         }
+    }
+
+    @Nullable
+    private static GraphQLFieldDefinition getFieldDefinition(GraphQLSchema schema,
+                                                             String parentType,
+                                                             ExecutableNormalizedField nf) {
+        return schema.getFieldDefinition(coordinates(parentType, nf.getName()));
+    }
+
+    @Nullable
+    private static GraphQLObjectType getOperationType(@NotNull GraphQLSchema schema,
+                                                      @NotNull OperationDefinition.Operation operationKind) {
+        switch (operationKind) {
+            case QUERY:
+                return schema.getQueryType();
+            case MUTATION:
+                return schema.getMutationType();
+            case SUBSCRIPTION:
+                return schema.getSubscriptionType();
+        }
+
+        return Assert.assertShouldNeverHappen("Unknown operation kind " + operationKind);
     }
 }

--- a/src/main/java/graphql/normalized/VariableAccumulator.java
+++ b/src/main/java/graphql/normalized/VariableAccumulator.java
@@ -2,6 +2,7 @@ package graphql.normalized;
 
 import graphql.Internal;
 import graphql.language.VariableDefinition;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,15 +19,16 @@ import static graphql.normalized.ValueToVariableValueCompiler.normalizedInputVal
 public class VariableAccumulator {
 
     private final List<VariableValueWithDefinition> valueWithDefinitions;
+    @Nullable
     private final VariablePredicate variablePredicate;
 
-    public VariableAccumulator(VariablePredicate variablePredicate) {
+    public VariableAccumulator(@Nullable VariablePredicate variablePredicate) {
         this.variablePredicate = variablePredicate;
         valueWithDefinitions = new ArrayList<>();
     }
 
     public boolean shouldMakeVariable(ExecutableNormalizedField executableNormalizedField, String argName, NormalizedInputValue normalizedInputValue) {
-        return variablePredicate.shouldMakeVariable(executableNormalizedField, argName, normalizedInputValue);
+        return variablePredicate != null && variablePredicate.shouldMakeVariable(executableNormalizedField, argName, normalizedInputValue);
     }
 
     public VariableValueWithDefinition accumulateVariable(NormalizedInputValue normalizedInputValue) {

--- a/src/test/groovy/graphql/normalized/ExecutableNormalizedOperationFactoryTest.groovy
+++ b/src/test/groovy/graphql/normalized/ExecutableNormalizedOperationFactoryTest.groovy
@@ -22,7 +22,6 @@ import static graphql.schema.FieldCoordinates.coordinates
 
 class ExecutableNormalizedOperationFactoryTest extends Specification {
 
-
     def "test"() {
         String schema = """
 type Query{ 
@@ -708,7 +707,7 @@ type Dog implements Animal{
     }
 
     def "query with interface in between"() {
-        def graphQLSchema = TestUtil.schema("""
+        def graphQLSchema = schema("""
         type Query {
             pets: [Pet]
         }
@@ -745,36 +744,87 @@ type Dog implements Animal{
                         'Human.name']
     }
 
+    def "test interface fields with different output types on the implementations"() {
+        def graphQLSchema = schema("""
+        interface Animal {
+            parent: Animal
+            name: String
+        }
+        type Cat implements Animal {
+            name: String
+            parent: Cat
+        }
+        type Dog implements Animal {
+            name: String
+            parent: Dog
+            isGoodBoy: Boolean
+        }
+        type Query {
+            animal: Animal
+        }
+        """)
+
+        def query = """
+        {
+            animal {
+                parent {
+                    name
+                }
+            }
+        }
+        """
+
+        assertValidQuery(graphQLSchema, query)
+
+        Document document = TestUtil.parseQuery(query)
+
+        def dependencyGraph = new ExecutableNormalizedOperationFactory()
+        def tree = dependencyGraph.createExecutableNormalizedOperation(graphQLSchema, document, null, [:])
+        def printedTree = printTreeWithLevelInfo(tree, graphQLSchema)
+
+        expect:
+        printedTree == [
+                "-Query.animal: Animal",
+                "--[Cat, Dog].parent: Cat, Dog",
+                "---[Cat, Dog].name: String",
+        ]
+    }
 
     List<String> printTree(ExecutableNormalizedOperation queryExecutionTree) {
         def result = []
-        Traverser<ExecutableNormalizedField> traverser = Traverser.depthFirst({ it.getChildren() });
+        Traverser<ExecutableNormalizedField> traverser = Traverser.depthFirst({ it.getChildren() })
         traverser.traverse(queryExecutionTree.getTopLevelFields(), new TraverserVisitorStub<ExecutableNormalizedField>() {
             @Override
             TraversalControl enter(TraverserContext<ExecutableNormalizedField> context) {
-                ExecutableNormalizedField queryExecutionField = context.thisNode();
+                ExecutableNormalizedField queryExecutionField = context.thisNode()
                 result << queryExecutionField.printDetails()
-                return TraversalControl.CONTINUE;
+                return TraversalControl.CONTINUE
             }
-        });
+        })
         result
     }
 
-    List<String> printTreeWithLevelInfo(ExecutableNormalizedOperation queryExecutionTree, GraphQLSchema schema) {
+    static List<String> printTreeWithLevelInfo(ExecutableNormalizedOperation queryExecutionTree, GraphQLSchema schema) {
         def result = []
-        Traverser<ExecutableNormalizedField> traverser = Traverser.depthFirst({ it.getChildren() });
+        Traverser<ExecutableNormalizedField> traverser = Traverser.depthFirst({ it.getChildren() })
         traverser.traverse(queryExecutionTree.getTopLevelFields(), new TraverserVisitorStub<ExecutableNormalizedField>() {
             @Override
             TraversalControl enter(TraverserContext<ExecutableNormalizedField> context) {
-                ExecutableNormalizedField queryExecutionField = context.thisNode();
+                ExecutableNormalizedField queryExecutionField = context.thisNode()
                 String prefix = ""
                 for (int i = 1; i <= queryExecutionField.getLevel(); i++) {
                     prefix += "-"
                 }
-                result << (prefix + queryExecutionField.printDetails() + ": " + GraphQLTypeUtil.simplePrint(queryExecutionField.getType(schema)))
-                return TraversalControl.CONTINUE;
+
+                def possibleOutputTypes = new LinkedHashSet<String>()
+                for (fieldDef in queryExecutionField.getFieldDefinitions(schema)) {
+                    possibleOutputTypes.add(GraphQLTypeUtil.simplePrint(fieldDef.type))
+                }
+
+                result << (prefix + queryExecutionField.printDetails() + ": " + possibleOutputTypes.join(", "))
+                return TraversalControl.CONTINUE
             }
-        });
+        })
         result
     }
 

--- a/src/test/groovy/graphql/normalized/ExecutableNormalizedOperationToAstCompilerTest.groovy
+++ b/src/test/groovy/graphql/normalized/ExecutableNormalizedOperationToAstCompilerTest.groovy
@@ -1,6 +1,5 @@
 package graphql.normalized
 
-
 import graphql.GraphQL
 import graphql.TestUtil
 import graphql.language.AstPrinter
@@ -838,13 +837,13 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         when:
         def result = compileToDocument(schema, QUERY, null, fields, noVariables)
         then:
-        AstPrinter.printAst(result.document) == '''query {
+        AstPrinter.printAst(new AstSorter().sort(result.document)) == '''query {
   foo(arg: {arg1 : "fooArg"}) {
     bar(arg: {arg1 : "barArg"}) {
       baz {
         ... on ABaz {
-          boo
           a
+          boo
         }
       }
     }
@@ -870,7 +869,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         when:
         def result = compileToDocument(schema, QUERY, null, fields, noVariables)
         then:
-        AstPrinter.printAst(result.document) == '''query {
+        AstPrinter.printAst(new AstSorter().sort(result.document)) == '''query {
   foo1(arg: "hello")
   foo2(a: 123, b: true, c: 123.45)
 }
@@ -894,7 +893,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         when:
         def result = compileToDocument(schema, QUERY, "My_Op23", fields, noVariables)
         then:
-        AstPrinter.printAst(result.document) == '''query My_Op23 {
+        AstPrinter.printAst(new AstSorter().sort(result.document)) == '''query My_Op23 {
   foo1(arg: "hello")
   foo2(a: 123, b: true, c: 123.45)
 }
@@ -937,7 +936,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         when:
         def result = compileToDocument(schema, QUERY, null, fields, noVariables)
         then:
-        AstPrinter.printAst(result.document) == '''query {
+        AstPrinter.printAst(new AstSorter().sort(result.document)) == '''query {
   foo1(arg: {arg1 : "Hello", arg2 : 123, arg3 : "IDID", arg4 : false, arg5 : 123.123, nested : {arg1 : "Hello2", arg2 : 1234, arg3 : "IDID1", arg4 : null, arg5 : null}})
 }
 '''
@@ -966,7 +965,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         when:
         def result = compileToDocument(schema, MUTATION, null, fields, noVariables)
         then:
-        AstPrinter.printAst(result.document) == '''mutation {
+        AstPrinter.printAst(new AstSorter().sort(result.document)) == '''mutation {
   foo1(arg: {arg1 : "Mutation"})
 }
 '''
@@ -995,7 +994,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         when:
         def result = compileToDocument(schema, SUBSCRIPTION, null, fields, noVariables)
         then:
-        AstPrinter.printAst(result.document) == '''subscription {
+        AstPrinter.printAst(new AstSorter().sort(result.document)) == '''subscription {
   foo1(arg: {arg1 : "Subscription"})
 }
 '''
@@ -1033,7 +1032,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         when:
         def result = compileToDocument(schema, MUTATION, null, fields, noVariables)
         then:
-        AstPrinter.printAst(result.document) == '''mutation {
+        AstPrinter.printAst(new AstSorter().sort(result.document)) == '''mutation {
   foo1(arg: {arg1 : "Mutation"}) {
     test
   }
@@ -1076,7 +1075,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         when:
         def result = compileToDocument(schema, QUERY, null, fields, noVariables)
         then:
-        AstPrinter.printAst(result.document) == '''query {
+        AstPrinter.printAst(new AstSorter().sort(result.document)) == '''query {
   foo1(arg: {arg1 : "Query"}) {
     test
   }
@@ -1263,7 +1262,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
 
         then:
         result.variables == [v0: ["48x48": "hello"]]
-        AstPrinter.printAst(result.document) == '''mutation ($v0: JSON!) {
+        AstPrinter.printAst(new AstSorter().sort(result.document)) == '''mutation ($v0: JSON!) {
   foo1(arg: $v0)
 }
 '''
@@ -1293,7 +1292,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         def result = compileToDocument(schema, MUTATION, null, fields, jsonVariables)
         then:
         result.variables == [v0: "hello there"]
-        AstPrinter.printAst(result.document) == '''mutation ($v0: JSON!) {
+        AstPrinter.printAst(new AstSorter().sort(result.document)) == '''mutation ($v0: JSON!) {
   foo1(arg: $v0)
 }
 '''
@@ -1324,7 +1323,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
 
         then:
         result.variables == [v0: 1]
-        AstPrinter.printAst(result.document) == '''mutation ($v0: JSON!) {
+        AstPrinter.printAst(new AstSorter().sort(result.document)) == '''mutation ($v0: JSON!) {
   foo1(arg: $v0)
 }
 '''
@@ -1352,7 +1351,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         def result = compileToDocument(schema, MUTATION, null, fields, noVariables)
         then:
         result.variables == [:]
-        AstPrinter.printAst(result.document) == '''mutation {
+        AstPrinter.printAst(new AstSorter().sort(result.document)) == '''mutation {
   foo1
 }
 '''
@@ -1380,7 +1379,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         def result = compileToDocument(schema, MUTATION, null, fields, noVariables)
         then:
         result.variables == [:]
-        AstPrinter.printAst(result.document) == '''mutation {
+        AstPrinter.printAst(new AstSorter().sort(result.document)) == '''mutation {
   foo1(arg: null)
 }
 '''
@@ -1408,7 +1407,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         def result = compileToDocument(schema, MUTATION, null, fields, jsonVariables)
         then:
         result.variables == [v0: [one: "two", three: ["four", "five"]]]
-        AstPrinter.printAst(result.document) == '''mutation ($v0: JSON!) {
+        AstPrinter.printAst(new AstSorter().sort(result.document)) == '''mutation ($v0: JSON!) {
   foo1(arg: $v0)
 }
 '''
@@ -1438,7 +1437,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         result.variables.size() == 2
         result.variables['v0'] == [one: "two", three: ["four", "five"]]
         result.variables['v1'] == [[one: "two", three: ["four", "five"]]]
-        AstPrinter.printAst(result.document) == '''mutation ($v0: JSON!, $v1: [JSON!]) {
+        AstPrinter.printAst(new AstSorter().sort(result.document)) == '''mutation ($v0: JSON!, $v1: [JSON!]) {
   foo1(arg1: $v0, arg2: $v1)
 }
 '''
@@ -1473,7 +1472,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         then:
         vars.size() == 1
         vars['v0'] == [lastName: "Ibrahimoviç", name: "Zlatan", clubs: ["MU", "Barsa", "Inter", "Milan"]]
-        AstPrinter.printAst(result.document) == '''mutation ($v0: JSON) {
+        AstPrinter.printAst(new AstSorter().sort(result.document)) == '''mutation ($v0: JSON) {
   foo1(arg: {id : "ID-00", json : $v0})
 }
 '''
@@ -1506,7 +1505,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         def result = compileToDocument(schema, MUTATION, null, fields, noVariables)
         then:
         result.variables == [:]
-        AstPrinter.printAst(result.document) == '''mutation {
+        AstPrinter.printAst(new AstSorter().sort(result.document)) == '''mutation {
   foo1(arg: {id : "ID-00", json : null})
 }
 '''
@@ -1539,7 +1538,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         def result = compileToDocument(schema, MUTATION, null, fields, noVariables)
         then:
         result.variables == [:]
-        AstPrinter.printAst(result.document) == '''mutation {
+        AstPrinter.printAst(new AstSorter().sort(result.document)) == '''mutation {
   foo1(arg: {id : "ID-00"})
 }
 '''
@@ -1586,7 +1585,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
                                     "48x48" : "Zlatan_48x48.jpg",
                                     "96x96" : null
                                    ]]
-        AstPrinter.printAst(result.document) == '''mutation ($v0: [JSON!]) {
+        AstPrinter.printAst(new AstSorter().sort(result.document)) == '''mutation ($v0: [JSON!]) {
   foo1(arg: {id : "ID-00", json : $v0})
 }
 '''
@@ -1651,23 +1650,23 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         def result = compileToDocument(schema, QUERY, "named", fields, allVariables)
         def document = result.document
         def vars = result.variables
-        def ast = AstPrinter.printAst(document)
+        def ast = AstPrinter.printAst(new AstSorter().sort(document))
         then:
 
         ast == '''query named($v0: [Int], $v1: [I], $v2: [I!]!, $v3: I, $v4: I, $v5: I) {
-  listField1(arg: $v0)
-  listField2(arg: $v1)
-  fooNonNull(arg: $v2)
   foo(arg: $v5) {
     bar(arg: $v4) {
       baz {
         ... on ABaz {
-          boo(arg: $v3)
           a
+          boo(arg: $v3)
         }
       }
     }
   }
+  fooNonNull(arg: $v2)
+  listField1(arg: $v0)
+  listField2(arg: $v1)
 }
 '''
 


### PR DESCRIPTION
Not done, need to review the logic, clean it up and add tests etc. Just putting up for early review.

This heavily compresses some queries described in GQLGW-1181.

It got the query I had down from 4k lines to 800