### PR TITLE
Allow leading pipe in directive SDL, and add leading union pipe tests

### DIFF
--- a/src/main/antlr/GraphqlSDL.g4
+++ b/src/main/antlr/GraphqlSDL.g4
@@ -126,6 +126,6 @@ directiveDefinition : description? DIRECTIVE '@' name argumentsDefinition? REPEA
 directiveLocation : name;
 
 directiveLocations :
-directiveLocation |
+'|'? directiveLocation |
 directiveLocations '|' directiveLocation
 ;

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -1911,6 +1911,21 @@ type MyQuery {
         result == """directive @foo on FIELD_DEFINITION"""
     }
 
+    def "directive with leading pipe gets discarded"() {
+        def sdl = """
+            directive @foo on | OBJECT | FIELD_DEFINITION
+            type Query { anything: String @foo }
+        """
+        def schema = TestUtil.schema(sdl)
+        def directive = schema.getDirective("foo");
+
+        when:
+        def result = new SchemaPrinter(defaultOptions().includeDirectives(true)).print(directive)
+
+        then:
+        result == """directive @foo on OBJECT | FIELD_DEFINITION"""
+    }
+
     def "description printing escapes triple quotes"() {
         def descriptionWithTripleQuote = 'Hello """ \n World """ """';
         def field = newFieldDefinition().name("hello").type(GraphQLString).build()


### PR DESCRIPTION
Fixes graphql-java/graphql-java#2649

Represented as |opt in the GraphQL specification

Link to union tests in graphql-js: https://github.com/graphql/graphql-js/blob/3ab82f4981970f50dd3a96e22a11839e4ec5bb7b/src/language/__tests__/schema-parser-test.ts#L892-L962

Spec blame: https://github.com/graphql/graphql-spec/blame/c18590c477d6817d73e19b6c248c9fcc62b03017/spec/Appendix%20B%20--%20Grammar%20Summary.md#L327

graphql-js does not seem to provide directive tests for this specific circumstance (I should really open a PR over there)