### PR TITLE
Fix gh-2702 and add `Introspection.__DirectiveLocation` regression tests

### DIFF
--- a/src/main/java/graphql/introspection/Introspection.java
+++ b/src/main/java/graphql/introspection/Introspection.java
@@ -431,7 +431,7 @@ public class Introspection {
             .value("FRAGMENT_DEFINITION", DirectiveLocation.FRAGMENT_DEFINITION, "Indicates the directive is valid on fragment definitions.")
             .value("FRAGMENT_SPREAD", DirectiveLocation.FRAGMENT_SPREAD, "Indicates the directive is valid on fragment spreads.")
             .value("INLINE_FRAGMENT", DirectiveLocation.INLINE_FRAGMENT, "Indicates the directive is valid on inline fragments.")
-            .value("VARIABLE_DEFINITION", DirectiveLocation.INPUT_FIELD_DEFINITION, "Indicates the directive is valid on variable definitions.")
+            .value("VARIABLE_DEFINITION", DirectiveLocation.VARIABLE_DEFINITION, "Indicates the directive is valid on variable definitions.")
             //
             // from schema SDL PR  https://github.com/facebook/graphql/pull/90
             //

--- a/src/test/groovy/graphql/introspection/IntrospectionTest.groovy
+++ b/src/test/groovy/graphql/introspection/IntrospectionTest.groovy
@@ -83,10 +83,11 @@ class IntrospectionTest extends Specification {
     def "Introspection#__DirectiveLocation(GraphQLEnumType) should have 19 distinct values"() {
         given:
         def directiveLocationValues = Introspection.__DirectiveLocation.values
+        def numValues = 19
 
         expect:
-        directiveLocationValues.size() == 19
-        directiveLocationValues.unique(false).size() == 19
+        directiveLocationValues.size() == numValues
+        directiveLocationValues.unique(false).size() == numValues
     }
 
     def "Introspection#__DirectiveLocation(GraphQLEnumType) should contain all Introspection.DirectiveLocation"() {

--- a/src/test/groovy/graphql/introspection/IntrospectionTest.groovy
+++ b/src/test/groovy/graphql/introspection/IntrospectionTest.groovy
@@ -6,6 +6,8 @@ import graphql.schema.FieldCoordinates
 import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLFieldsContainer
 import graphql.schema.GraphQLNamedType
+import spock.lang.Issue
+import spock.lang.See
 import spock.lang.Specification
 
 import static graphql.GraphQL.newGraphQL
@@ -62,6 +64,42 @@ class IntrospectionTest extends Specification {
                         ]
                 ]
         ]
+    }
+
+    @Issue("https://github.com/graphql-java/graphql-java/issues/2702")
+    def "Introspection#__DirectiveLocation(GraphQLEnumType) `name` should match `value`'s DirectiveLocation#name() #2702"() {
+        given:
+        def directiveLocationValues = Introspection.__DirectiveLocation.values
+
+        expect:
+        directiveLocationValues.each {
+            def value = it.value
+            assert value instanceof Introspection.DirectiveLocation
+            assert it.name == (value as Introspection.DirectiveLocation).name()
+        }
+    }
+
+    @See("https://spec.graphql.org/October2021/#sec-Schema-Introspection.Schema-Introspection-Schema")
+    def "Introspection#__DirectiveLocation(GraphQLEnumType) should have 19 distinct values"() {
+        given:
+        def directiveLocationValues = Introspection.__DirectiveLocation.values
+
+        expect:
+        directiveLocationValues.size() == 19
+        directiveLocationValues.unique(false).size() == 19
+    }
+
+    def "Introspection#__DirectiveLocation(GraphQLEnumType) should contain all Introspection.DirectiveLocation"() {
+        given:
+        def directiveLocationValues = new ArrayList<>(Introspection.__DirectiveLocation.values)
+        def possibleLocations = new ArrayList<>(Introspection.DirectiveLocation.values().toList()).iterator()
+
+        expect:
+        while (possibleLocations.hasNext()) {
+            def nextPossibleLocation = possibleLocations.next()
+            assert directiveLocationValues.retainAll { (it.value != nextPossibleLocation) }
+        }
+        assert directiveLocationValues.isEmpty()
     }
 
     def "schema description can be defined in SDL and queried via introspection"() {


### PR DESCRIPTION
The `GraphQLEnumValueDefinition.value` of `VARIABLE_DEFINITION` was `DirectiveLocation.INPUT_VALUE_DEFINITION` instead of `DirectiveLocation.VARIABLE_DEFINITION`.

Closes graphql-java/graphql-java#2702