### PR TITLE
Fix wrong newline on Windows in `SchemaPrinter` (`\r\n -> \n`)

### DIFF
--- a/src/main/java/graphql/schema/idl/SchemaPrinter.java
+++ b/src/main/java/graphql/schema/idl/SchemaPrinter.java
@@ -636,7 +636,7 @@ public class SchemaPrinter {
                 out.printf("\n%s\n", AstPrinter.printAst(extension));
             }
         }
-        out.println();
+        out.print('\n');
     }
 
     private static String printAst(InputValueWithState value, GraphQLInputType type) {
@@ -901,7 +901,7 @@ public class SchemaPrinter {
             if (superClazz != Object.class) {
                 schemaElementPrinter = printer(superClazz);
             } else {
-                schemaElementPrinter = (out, type, visibility) -> out.println("Type not implemented : " + type);
+                schemaElementPrinter = (out, type, visibility) -> out.print("Type not implemented : " + type + "\n");
             }
             printers.put(clazz, schemaElementPrinter);
         }


### PR DESCRIPTION
The printer was printing `\r\n` sequences instead of `\n`, because it was using `PrintWriter#println`

Fixes the `"can print a schema as AST elements"` test in `SchemaPrinterTest.groovy` on Windows

See
https://docs.oracle.com/javase/8/docs/api/java/io/PrintWriter.html#println--

> The line separator string is defined by the system property line.separator, **and is not necessarily a single newline character ('\n')**.