### PR TITLE
Fix generics on JDK 9+

### DIFF
--- a/src/main/java/graphql/schema/idl/ImplementingTypesChecker.java
+++ b/src/main/java/graphql/schema/idl/ImplementingTypesChecker.java
@@ -66,8 +66,7 @@ class ImplementingTypesChecker {
         List<InterfaceTypeDefinition> interfaces = typeRegistry.getTypes(InterfaceTypeDefinition.class);
         List<ObjectTypeDefinition> objects = typeRegistry.getTypes(ObjectTypeDefinition.class);
 
-        Stream.of(interfaces.stream(), objects.stream())
-                .flatMap(Function.identity())
+        Stream.<ImplementingTypeDefinition<?>>concat(interfaces.stream(), objects.stream())
                 .forEach(type -> checkImplementingType(errors, typeRegistry, type));
     }
 

--- a/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
+++ b/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
@@ -1191,10 +1191,11 @@ public class SchemaGeneratorHelper {
         return new PropertyDataFetcher(fieldName);
     }
 
-    private List<Directive> directivesOf(List<? extends TypeDefinition> typeDefinitions) {
+    private List<Directive> directivesOf(List<? extends TypeDefinition<?>> typeDefinitions) {
         return typeDefinitions.stream()
-                .map(TypeDefinition::getDirectives).filter(Objects::nonNull)
-                .<Directive>flatMap(List::stream).collect(Collectors.toList());
+                .map(TypeDefinition::getDirectives)
+                .filter(Objects::nonNull)
+                .flatMap(List::stream).collect(Collectors.toList());
     }
 
     private <T extends GraphQLDirectiveContainer> T directivesObserve(BuildContext buildCtx, T directiveContainer) {

--- a/src/main/java/graphql/schema/idl/UnionTypesChecker.java
+++ b/src/main/java/graphql/schema/idl/UnionTypesChecker.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static java.lang.String.format;
@@ -46,8 +45,7 @@ class UnionTypesChecker {
         List<UnionTypeDefinition> unionTypes = typeRegistry.getTypes(UnionTypeDefinition.class);
         List<UnionTypeExtensionDefinition> unionTypeExtensions = typeRegistry.getTypes(UnionTypeExtensionDefinition.class);
 
-        Stream.of(unionTypes.stream(), unionTypeExtensions.stream())
-                .flatMap(Function.identity())
+        Stream.concat(unionTypes.stream(), unionTypeExtensions.stream())
                 .forEach(type -> checkUnionType(typeRegistry, type, errors));
     }
 


### PR DESCRIPTION
Compilation of these specific methods fails on JDK 9+. IntelliJ does not produce IDE warnings/errors.

Probably related to JEP 215 "Tiered Attribution for javac"

See: https://openjdk.java.net/jeps/215

Part of my CI effort (#2676 )