### PR TITLE
Replace wrong constructor call to BigInteger in tests

### DIFF
--- a/src/test/groovy/graphql/ScalarsFloatTest.groovy
+++ b/src/test/groovy/graphql/ScalarsFloatTest.groovy
@@ -54,8 +54,9 @@ class ScalarsFloatTest extends Specification {
         42.0000d              | 42
         new Integer(42)       | 42
         "-1"                  | -1
-        new BigInteger(42)    | 42
+        new BigInteger("42")  | 42
         new BigDecimal("42")  | 42
+        new BigDecimal("4.2") | 4.2d
         42.3f                 | 42.3d
         42.0d                 | 42d
         new Byte("42")        | 42

--- a/src/test/groovy/graphql/ScalarsIntTest.groovy
+++ b/src/test/groovy/graphql/ScalarsIntTest.groovy
@@ -58,7 +58,7 @@ class ScalarsIntTest extends Specification {
         42.0000d              | 42
         new Integer(42)       | 42
         "-1"                  | -1
-        new BigInteger(42)    | 42
+        new BigInteger("42")  | 42
         new BigDecimal("42")  | 42
         42.0f                 | 42
         42.0d                 | 42


### PR DESCRIPTION
ScalarFloatTest and ScalarIntTest used the wrong constructor. This caused failing tests when compiling past JDK 8.

Also adds a ScalarFloatTest testcase for `new BigDecimal("4.2") -> 4.2d`

Part of my CI effort (#2676 )