### PR TITLE
Add missing `@Deprecated` to `ExecutionStepInfo#getFieldContainer()`

### DIFF
--- a/src/main/java/graphql/execution/ExecutionStepInfo.java
+++ b/src/main/java/graphql/execution/ExecutionStepInfo.java
@@ -87,6 +87,7 @@ public class ExecutionStepInfo {
      * @deprecated use {@link #getObjectType()} instead as it is named better
      * @see ExecutionStepInfo#getObjectType()
      */
+    @Deprecated
     public GraphQLObjectType getFieldContainer() {
         return fieldContainer;
     }


### PR DESCRIPTION
This missing annotation causes compilation failures on JDK 9+ because of JEP 277 "Enhanced Deprecation"

The method is annotated in the javadoc comment, hence causing compilation failure.

See: https://openjdk.java.net/jeps/277

Part of my CI effort (#2676 )