### PR TITLE
AstPrinter performance improvements

### DIFF
--- a/src/main/java/graphql/language/AstPrinter.java
+++ b/src/main/java/graphql/language/AstPrinter.java
@@ -575,7 +575,7 @@ public class AstPrinter {
             }
             return "";
         }
-        return start + maybeString + (!isEmpty(end) ? end : "");
+        return new StringBuilder().append(start).append(maybeString).append(!isEmpty(end) ? end : "").toString();
     }
 
     private <T extends Node> String block(List<T> nodes) {
@@ -583,20 +583,20 @@ public class AstPrinter {
             return "{}";
         }
         if (compactMode) {
-            return "{"
-                    + join(nodes, " ")
-                    + "}";
+            return new StringBuilder().append("{").append(join(nodes, " ")).append("}").toString();
         }
-        return indent("{\n"
-                + join(nodes, "\n"))
+        return indent(new StringBuilder().append("{\n").append(join(nodes, "\n")))
                 + "\n}";
     }
 
-    private String indent(String maybeString) {
-        if (isEmpty(maybeString)) {
-            return "";
+    private StringBuilder indent(StringBuilder maybeString) {
+        for (int i = 0; i < maybeString.length(); i++) {
+            char c = maybeString.charAt(i);
+            if (c == '\n') {
+                maybeString.replace(i,i+1,"\n  ");
+                i+=3;
+            }
         }
-        maybeString = maybeString.replaceAll("\\n", "\n  ");
         return maybeString;
     }
 
@@ -605,13 +605,14 @@ public class AstPrinter {
         if (maybeNode == null) {
             return "";
         }
-        return start + node(maybeNode) + (isEmpty(end) ? "" : end);
+        return new StringBuilder().append(start).append(node(maybeNode)).append(isEmpty(end) ? "" : end).toString();
     }
 
     /**
      * This will pretty print the AST node in graphql language format
      *
      * @param node the AST node to print
+     *
      * @return the printed node in graphql language format
      */
     public static String printAst(Node node) {
@@ -637,6 +638,7 @@ public class AstPrinter {
      * and comments stripped out of the text.
      *
      * @param node the AST node to print
+     *
      * @return the printed node in a compact graphql language format
      */
     public static String printAstCompact(Node node) {

--- a/src/test/java/benchmark/AstPrinterBenchmark.java
+++ b/src/test/java/benchmark/AstPrinterBenchmark.java
@@ -233,4 +233,22 @@ public class AstPrinterBenchmark {
     public static void printAst(Blackhole blackhole) {
         blackhole.consume(AstPrinter.printAst(document));
     }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public void benchMarkAstPrinterCompactThroughput(Blackhole blackhole) {
+        printAstCompact(blackhole);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public void benchMarkAstPrinterCompactAvgTime(Blackhole blackhole) {
+        printAstCompact(blackhole);
+    }
+
+    public static void printAstCompact(Blackhole blackhole) {
+        blackhole.consume(AstPrinter.printAstCompact(document));
+    }
 }


### PR DESCRIPTION
```
Benchmark                                           Mode  Cnt     Score     Error  Units
AstPrinterBenchmark.benchMarkAstPrinterThroughput  thrpt   15  3715.744 ± 102.575  ops/s
AstPrinterBenchmark.benchMarkAstPrinterAvgTime      avgt   15     0.282 ±   0.022  ms/op


Benchmark                                           Mode  Cnt     Score     Error  Units
AstPrinterBenchmark.benchMarkAstPrinterThroughput  thrpt   15  4468.229 ± 153.149  ops/s
AstPrinterBenchmark.benchMarkAstPrinterAvgTime      avgt   15     0.220 ±   0.015  ms/op

```

ps - this is the benchmarks but with printCompact - its still MUCH faster

```
Benchmark                                                  Mode  Cnt     Score     Error  Units
AstPrinterBenchmark.benchMarkAstPrinterCompactThroughput  thrpt   15  8555.174 ± 298.140  ops/s
AstPrinterBenchmark.benchMarkAstPrinterThroughput         thrpt   15  4734.532 ± 213.044  ops/s
AstPrinterBenchmark.benchMarkAstPrinterAvgTime             avgt   15     0.208 ±   0.011  ms/op
AstPrinterBenchmark.benchMarkAstPrinterCompactAvgTime      avgt   15     0.119 ±   0.004  ms/op
```
