### PR TITLE
Rework isConditional to work without parent type name and adopt DataFetchingSelectionSet to ENF changes

### DIFF
--- a/src/main/java/graphql/normalized/ENFMerger.java
+++ b/src/main/java/graphql/normalized/ENFMerger.java
@@ -1,6 +1,7 @@
 package graphql.normalized;
 
 import graphql.Internal;
+import graphql.introspection.Introspection;
 import graphql.language.Argument;
 import graphql.language.AstComparator;
 import graphql.schema.GraphQLInterfaceType;
@@ -27,6 +28,11 @@ public class ENFMerger {
             overPossibleGroups:
             for (Set<ExecutableNormalizedField> group : possibleGroupsToMerge) {
                 for (ExecutableNormalizedField fieldInGroup : group) {
+                    if(field.getFieldName().equals(Introspection.TypeNameMetaFieldDef.getName())) {
+                        addToGroup = true;
+                        group.add(field);
+                        continue overPossibleGroups;
+                    }
                     if (field.getFieldName().equals(fieldInGroup.getFieldName()) &&
                             sameArguments(field.getAstArguments(), fieldInGroup.getAstArguments())
                             && isFieldInSharedInterface(field, fieldInGroup, schema)
@@ -66,6 +72,7 @@ public class ENFMerger {
     }
 
     private static boolean isFieldInSharedInterface(ExecutableNormalizedField fieldOne, ExecutableNormalizedField fieldTwo, GraphQLSchema schema) {
+
         /*
          * we can get away with only checking one of the object names, because all object names in one ENF are guaranteed to be the same field.
          * This comes from how the ENFs are created in the factory before.

--- a/src/main/java/graphql/normalized/ExecutableNormalizedField.java
+++ b/src/main/java/graphql/normalized/ExecutableNormalizedField.java
@@ -143,8 +143,7 @@ public class ExecutableNormalizedField {
                 toAdd.addAll((List) ((GraphQLInterfaceType) parentType).getInterfaces());
             }
             if (interfacesImplementedByAllParents == null) {
-                interfacesImplementedByAllParents = new LinkedHashSet<>();
-                interfacesImplementedByAllParents.addAll(toAdd);
+                interfacesImplementedByAllParents = new LinkedHashSet<>(toAdd);
             } else {
                 interfacesImplementedByAllParents.retainAll(toAdd);
             }

--- a/src/main/java/graphql/normalized/ExecutableNormalizedField.java
+++ b/src/main/java/graphql/normalized/ExecutableNormalizedField.java
@@ -166,7 +166,7 @@ public class ExecutableNormalizedField {
          *__typename is the only field in a union type that CAN be NOT conditional
          */
         List<GraphQLFieldDefinition> fieldDefinitions = parent.getFieldDefinitions(schema);
-        if (fieldDefinitions.get(0).getType() instanceof GraphQLUnionType) {
+        if (unwrapAll(fieldDefinitions.get(0).getType()) instanceof GraphQLUnionType) {
             GraphQLUnionType parentOutputTypeAsUnion = (GraphQLUnionType) fieldDefinitions.get(0).getType();
             if (this.fieldName.equals(Introspection.TypeNameMetaFieldDef.getName()) && objectTypeNames.size() == parentOutputTypeAsUnion.getTypes().size()) {
                 return false; // Not conditional

--- a/src/main/java/graphql/normalized/ExecutableNormalizedField.java
+++ b/src/main/java/graphql/normalized/ExecutableNormalizedField.java
@@ -167,7 +167,7 @@ public class ExecutableNormalizedField {
          */
         List<GraphQLFieldDefinition> fieldDefinitions = parent.getFieldDefinitions(schema);
         if (unwrapAll(fieldDefinitions.get(0).getType()) instanceof GraphQLUnionType) {
-            GraphQLUnionType parentOutputTypeAsUnion = (GraphQLUnionType) fieldDefinitions.get(0).getType();
+            GraphQLUnionType parentOutputTypeAsUnion = (GraphQLUnionType) unwrapAll(fieldDefinitions.get(0).getType());
             if (this.fieldName.equals(Introspection.TypeNameMetaFieldDef.getName()) && objectTypeNames.size() == parentOutputTypeAsUnion.getTypes().size()) {
                 return false; // Not conditional
             }

--- a/src/main/java/graphql/normalized/ExecutableNormalizedOperationToAstCompiler.java
+++ b/src/main/java/graphql/normalized/ExecutableNormalizedOperationToAstCompiler.java
@@ -98,7 +98,7 @@ public class ExecutableNormalizedOperationToAstCompiler {
         Map<String, List<Field>> fieldsByTypeCondition = new LinkedHashMap<>();
 
         for (ExecutableNormalizedField nf : executableNormalizedFields) {
-            if (nf.isConditional(schema, parentOutputType)) {
+            if (nf.isConditional(schema)) {
                 selectionForNormalizedField(schema, nf, variableAccumulator)
                         .forEach((objectTypeName, field) ->
                                 fieldsByTypeCondition

--- a/src/main/java/graphql/schema/DataFetchingFieldSelectionSetImpl.java
+++ b/src/main/java/graphql/schema/DataFetchingFieldSelectionSetImpl.java
@@ -244,8 +244,7 @@ public class DataFetchingFieldSelectionSetImpl implements DataFetchingFieldSelec
             normalisedSelectionSetFields.computeIfAbsent(globQualifiedName, newList()).add(selectedField);
             normalisedSelectionSetFields.computeIfAbsent(globSimpleName, newList()).add(selectedField);
 
-            GraphQLType unwrappedType = GraphQLTypeUtil.unwrapAll(normalizedSubSelectedField.getType(schema));
-            if (!GraphQLTypeUtil.isLeaf(unwrappedType)) {
+            if (normalizedSubSelectedField.hasChildren()) {
                 traverseSubSelectedFields(normalizedSubSelectedField, immediateFieldsBuilder, globQualifiedName, globSimpleName, false);
             }
         }

--- a/src/test/groovy/graphql/normalized/ExecutableNormalizedOperationToAstCompilerTest.groovy
+++ b/src/test/groovy/graphql/normalized/ExecutableNormalizedOperationToAstCompilerTest.groovy
@@ -706,12 +706,11 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         // --Dog.isGoodBoy: Boolean
         printed == """query {
   animal {
+    __typename
     ... on Cat {
-      __typename
       name
     }
     ... on Dog {
-      __typename
       isGoodBoy
       name
     }

--- a/src/test/groovy/graphql/schema/DataFetchingFieldSelectionSetImplTest.groovy
+++ b/src/test/groovy/graphql/schema/DataFetchingFieldSelectionSetImplTest.groovy
@@ -913,9 +913,8 @@ class DataFetchingFieldSelectionSetImplTest extends Specification {
 
         selectionSet.contains("parent") // short syntax
         selectionSet.contains("parent/name") // short syntax
-        selectionSet.contains("[Cat, Dog].parent/[Cat, Dog].name")
-//        selectionSet.contains("Cat.parent/Cat.name")
-//        selectionSet.contains("Dog.parent/Dog.name")
+        selectionSet.contains("*Cat*.parent/*Cat*.name")
+        selectionSet.contains("*Dog*.parent/*Dog*.name")
 
     }
 

--- a/src/test/groovy/graphql/schema/DataFetchingFieldSelectionSetImplTest.groovy
+++ b/src/test/groovy/graphql/schema/DataFetchingFieldSelectionSetImplTest.groovy
@@ -913,9 +913,9 @@ class DataFetchingFieldSelectionSetImplTest extends Specification {
 
         selectionSet.contains("parent") // short syntax
         selectionSet.contains("parent/name") // short syntax
-        selectionSet.contains("Animal.parent")
-        selectionSet.contains("Cat.parent/Cat.name")
-        selectionSet.contains("Dog.parent/Dog.name")
+        selectionSet.contains("[Cat, Dog].parent/[Cat, Dog].name")
+//        selectionSet.contains("Cat.parent/Cat.name")
+//        selectionSet.contains("Dog.parent/Dog.name")
 
     }
 


### PR DESCRIPTION
This also includes a test for the DFSelectionSet for covariance fields.

It also fixes a bug for ENF where __typename in Unions were not merged.