### PR TITLE
SPIKE - WIP - Another PR that shows how we could transition to the new idea of state per instrumentation method call

### DIFF
--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -204,7 +204,7 @@ public abstract class ExecutionStrategy {
 
         Instrumentation instrumentation = executionContext.getInstrumentation();
         InstrumentationContext<ExecutionResult> fieldCtx = instrumentation.beginField(
-                new InstrumentationFieldParameters(executionContext, executionStepInfo)
+                new InstrumentationFieldParameters(executionContext, executionStepInfo), executionContext.getInstrumentationState()
         );
 
         CompletableFuture<FetchedValue> fetchFieldFuture = fetchField(executionContext, parameters);
@@ -270,7 +270,7 @@ public abstract class ExecutionStrategy {
         Instrumentation instrumentation = executionContext.getInstrumentation();
 
         InstrumentationFieldFetchParameters instrumentationFieldFetchParams = new InstrumentationFieldFetchParameters(executionContext, environment, parameters, dataFetcher instanceof TrivialDataFetcher);
-        InstrumentationContext<Object> fetchCtx = instrumentation.beginFieldFetch(instrumentationFieldFetchParams);
+        InstrumentationContext<Object> fetchCtx = instrumentation.beginFieldFetch(instrumentationFieldFetchParams, executionContext.getInstrumentationState());
 
         CompletableFuture<Object> fetchedValue;
         dataFetcher = instrumentation.instrumentDataFetcher(dataFetcher, instrumentationFieldFetchParams);
@@ -354,9 +354,9 @@ public abstract class ExecutionStrategy {
 
     private <T> CompletableFuture<T> asyncHandleException(DataFetcherExceptionHandler handler, DataFetcherExceptionHandlerParameters handlerParameters, ExecutionContext executionContext) {
         //noinspection unchecked
-        return  handler.handleException(handlerParameters)
-            .thenApply(handlerResult -> (T) DataFetcherResult.<FetchedValue>newResult().errors(handlerResult.getErrors()).build()
-            );
+        return handler.handleException(handlerParameters)
+                .thenApply(handlerResult -> (T) DataFetcherResult.<FetchedValue>newResult().errors(handlerResult.getErrors()).build()
+                );
     }
 
     /**
@@ -385,7 +385,7 @@ public abstract class ExecutionStrategy {
         Instrumentation instrumentation = executionContext.getInstrumentation();
         InstrumentationFieldCompleteParameters instrumentationParams = new InstrumentationFieldCompleteParameters(executionContext, parameters, () -> executionStepInfo, fetchedValue);
         InstrumentationContext<ExecutionResult> ctxCompleteField = instrumentation.beginFieldComplete(
-                instrumentationParams
+                instrumentationParams, executionContext.getInstrumentationState()
         );
 
         NonNullableFieldValidator nonNullableFieldValidator = new NonNullableFieldValidator(executionContext, executionStepInfo);
@@ -519,7 +519,7 @@ public abstract class ExecutionStrategy {
         Instrumentation instrumentation = executionContext.getInstrumentation();
 
         InstrumentationContext<ExecutionResult> completeListCtx = instrumentation.beginFieldListComplete(
-                instrumentationParams
+                instrumentationParams, executionContext.getInstrumentationState()
         );
 
         List<FieldValueInfo> fieldValueInfos = new ArrayList<>(size.orElse(1));

--- a/src/main/java/graphql/execution/SubscriptionExecutionStrategy.java
+++ b/src/main/java/graphql/execution/SubscriptionExecutionStrategy.java
@@ -123,7 +123,9 @@ public class SubscriptionExecutionStrategy extends ExecutionStrategy {
         ExecutionStepInfo subscribedFieldStepInfo = createSubscribedFieldStepInfo(executionContext, newParameters);
 
         InstrumentationFieldParameters i13nFieldParameters = new InstrumentationFieldParameters(executionContext, () -> subscribedFieldStepInfo);
-        InstrumentationContext<ExecutionResult> subscribedFieldCtx = instrumentation.beginSubscribedFieldEvent(i13nFieldParameters);
+        InstrumentationContext<ExecutionResult> subscribedFieldCtx = instrumentation.beginSubscribedFieldEvent(
+                i13nFieldParameters, executionContext.getInstrumentationState()
+        );
 
         FetchedValue fetchedValue = unboxPossibleDataFetcherResult(newExecutionContext, parameters, eventPayload);
         FieldValueInfo fieldValueInfo = completeField(newExecutionContext, newParameters, fetchedValue);

--- a/src/main/java/graphql/execution/instrumentation/ChainedInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/ChainedInstrumentation.java
@@ -120,7 +120,7 @@ public class ChainedInstrumentation implements Instrumentation {
 
     @Override
     public InstrumentationContext<ExecutionResult> beginSubscribedFieldEvent(InstrumentationFieldParameters parameters, InstrumentationState state) {
-        return new ChainedInstrumentationContext<>(map(instrumentations, it -> it.beginSubscribedFieldEvent(parameters, state)));
+        return new ChainedInstrumentationContext<>(map(instrumentations, it -> it.beginSubscribedFieldEvent(parameters, getState(it, state))));
     }
 
     @Override
@@ -133,7 +133,7 @@ public class ChainedInstrumentation implements Instrumentation {
 
     @Override
     public InstrumentationContext<ExecutionResult> beginField(InstrumentationFieldParameters parameters, InstrumentationState state) {
-        return new ChainedInstrumentationContext<>(map(instrumentations, it -> it.beginField(parameters, state)));
+        return new ChainedInstrumentationContext<>(map(instrumentations, it -> it.beginField(parameters, getState(it, state))));
     }
 
     @Override

--- a/src/main/java/graphql/execution/instrumentation/ChainedInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/ChainedInstrumentation.java
@@ -119,11 +119,21 @@ public class ChainedInstrumentation implements Instrumentation {
     }
 
     @Override
+    public InstrumentationContext<ExecutionResult> beginSubscribedFieldEvent(InstrumentationFieldParameters parameters, InstrumentationState state) {
+        return new ChainedInstrumentationContext<>(map(instrumentations, it -> it.beginSubscribedFieldEvent(parameters, state)));
+    }
+
+    @Override
     public InstrumentationContext<ExecutionResult> beginField(InstrumentationFieldParameters parameters) {
         return new ChainedInstrumentationContext<>(map(instrumentations, instrumentation -> {
             InstrumentationState state = getState(instrumentation, parameters.getInstrumentationState());
             return instrumentation.beginField(parameters.withNewState(state));
         }));
+    }
+
+    @Override
+    public InstrumentationContext<ExecutionResult> beginField(InstrumentationFieldParameters parameters, InstrumentationState state) {
+        return new ChainedInstrumentationContext<>(map(instrumentations, it -> it.beginField(parameters, state)));
     }
 
     @Override
@@ -135,6 +145,11 @@ public class ChainedInstrumentation implements Instrumentation {
     }
 
     @Override
+    public InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters, InstrumentationState state) {
+        return new ChainedInstrumentationContext<>(map(instrumentations, it -> it.beginFieldFetch(parameters, getState(it, state))));
+    }
+
+    @Override
     public InstrumentationContext<ExecutionResult> beginFieldComplete(InstrumentationFieldCompleteParameters parameters) {
         return new ChainedInstrumentationContext<>(map(instrumentations, instrumentation -> {
             InstrumentationState state = getState(instrumentation, parameters.getInstrumentationState());
@@ -143,11 +158,21 @@ public class ChainedInstrumentation implements Instrumentation {
     }
 
     @Override
+    public InstrumentationContext<ExecutionResult> beginFieldComplete(InstrumentationFieldCompleteParameters parameters, InstrumentationState state) {
+        return new ChainedInstrumentationContext<>(map(instrumentations, it -> it.beginFieldComplete(parameters, getState(it, state))));
+    }
+
+    @Override
     public InstrumentationContext<ExecutionResult> beginFieldListComplete(InstrumentationFieldCompleteParameters parameters) {
         return new ChainedInstrumentationContext<>(map(instrumentations, instrumentation -> {
             InstrumentationState state = getState(instrumentation, parameters.getInstrumentationState());
             return instrumentation.beginFieldListComplete(parameters.withNewState(state));
         }));
+    }
+
+    @Override
+    public InstrumentationContext<ExecutionResult> beginFieldListComplete(InstrumentationFieldCompleteParameters parameters, InstrumentationState state) {
+        return new ChainedInstrumentationContext<>(map(instrumentations, it -> it.beginFieldListComplete(parameters, getState(it, state))));
     }
 
     @Override

--- a/src/main/java/graphql/execution/instrumentation/Instrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/Instrumentation.java
@@ -114,8 +114,13 @@ public interface Instrumentation {
      *
      * @return a non null {@link InstrumentationContext} object that will be called back when the step ends
      */
+    @Deprecated
     default InstrumentationContext<ExecutionResult> beginSubscribedFieldEvent(InstrumentationFieldParameters parameters) {
         return noOp();
+    }
+
+    default InstrumentationContext<ExecutionResult> beginSubscribedFieldEvent(InstrumentationFieldParameters parameters, InstrumentationState state) {
+        return beginSubscribedFieldEvent(parameters.withNewState(state));
     }
 
     /**
@@ -125,7 +130,12 @@ public interface Instrumentation {
      *
      * @return a non null {@link InstrumentationContext} object that will be called back when the step ends
      */
+    @Deprecated
     InstrumentationContext<ExecutionResult> beginField(InstrumentationFieldParameters parameters);
+
+    default InstrumentationContext<ExecutionResult> beginField(InstrumentationFieldParameters parameters, InstrumentationState state) {
+        return beginField(parameters.withNewState(state));
+    }
 
     /**
      * This is called just before a field {@link DataFetcher} is invoked.
@@ -134,7 +144,12 @@ public interface Instrumentation {
      *
      * @return a non null {@link InstrumentationContext} object that will be called back when the step ends
      */
+    @Deprecated
     InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters);
+
+    default InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters, InstrumentationState state) {
+        return beginFieldFetch(parameters.withNewState(state));
+    }
 
 
     /**
@@ -144,8 +159,13 @@ public interface Instrumentation {
      *
      * @return a non null {@link InstrumentationContext} object that will be called back when the step ends
      */
+    @Deprecated
     default InstrumentationContext<ExecutionResult> beginFieldComplete(InstrumentationFieldCompleteParameters parameters) {
         return noOp();
+    }
+
+    default InstrumentationContext<ExecutionResult> beginFieldComplete(InstrumentationFieldCompleteParameters parameters, InstrumentationState state) {
+        return beginFieldComplete(parameters.withNewState(state));
     }
 
     /**
@@ -155,8 +175,13 @@ public interface Instrumentation {
      *
      * @return a non null {@link InstrumentationContext} object that will be called back when the step ends
      */
+    @Deprecated
     default InstrumentationContext<ExecutionResult> beginFieldListComplete(InstrumentationFieldCompleteParameters parameters) {
         return noOp();
+    }
+
+    default InstrumentationContext<ExecutionResult> beginFieldListComplete(InstrumentationFieldCompleteParameters parameters, InstrumentationState state) {
+        return beginFieldListComplete(parameters.withNewState(state));
     }
 
     /**


### PR DESCRIPTION
 I wanted to spike whether we can transition to passing "state" to each instrumentation method call rather than creating an object.

I think this works really well and is NON API breaking.  

If we did this I think we would

* deprecated the old methods that only take a "parameter with state" object
* deprecater the `getState` on the parameter objects
* create side line default methods for each instrumentation method so it takes state but it calls back like these do
* go through the provided graphql-java instrumentations and make them only use the new methods

