### PR TITLE
Avoid a binary incompatible change while retaining common code

### DIFF
--- a/src/main/java/graphql/schema/GraphQLArgument.java
+++ b/src/main/java/graphql/schema/GraphQLArgument.java
@@ -463,26 +463,6 @@ public class GraphQLArgument implements GraphQLNamedSchemaElement, GraphQLInputV
 
         // -- the following are repeated to avoid a binary incompatibility problem --
         @Override
-        public Builder replaceAppliedDirectives(List<GraphQLAppliedDirective> directives) {
-            return super.replaceAppliedDirectives(directives);
-        }
-
-        @Override
-        public Builder withAppliedDirectives(GraphQLAppliedDirective... directives) {
-            return super.withAppliedDirectives(directives);
-        }
-
-        @Override
-        public Builder withAppliedDirective(GraphQLAppliedDirective directive) {
-            return super.withAppliedDirective(directive);
-        }
-
-        @Override
-        public Builder withAppliedDirective(GraphQLAppliedDirective.Builder builder) {
-            return super.withAppliedDirective(builder);
-        }
-
-        @Override
         public Builder replaceDirectives(List<GraphQLDirective> directives) {
             return super.replaceDirectives(directives);
         }
@@ -505,11 +485,6 @@ public class GraphQLArgument implements GraphQLNamedSchemaElement, GraphQLInputV
         @Override
         public Builder clearDirectives() {
             return super.clearDirectives();
-        }
-
-        @Override
-        protected void copyExistingDirectives(GraphQLDirectiveContainer directivesContainer) {
-            super.copyExistingDirectives(directivesContainer);
         }
 
         @Override

--- a/src/main/java/graphql/schema/GraphQLArgument.java
+++ b/src/main/java/graphql/schema/GraphQLArgument.java
@@ -461,6 +461,67 @@ public class GraphQLArgument implements GraphQLNamedSchemaElement, GraphQLInputV
             return this;
         }
 
+        // -- the following are repeated to avoid a binary incompatibility problem --
+        @Override
+        public Builder replaceAppliedDirectives(List<GraphQLAppliedDirective> directives) {
+            return super.replaceAppliedDirectives(directives);
+        }
+
+        @Override
+        public Builder withAppliedDirectives(GraphQLAppliedDirective... directives) {
+            return super.withAppliedDirectives(directives);
+        }
+
+        @Override
+        public Builder withAppliedDirective(GraphQLAppliedDirective directive) {
+            return super.withAppliedDirective(directive);
+        }
+
+        @Override
+        public Builder withAppliedDirective(GraphQLAppliedDirective.Builder builder) {
+            return super.withAppliedDirective(builder);
+        }
+
+        @Override
+        public Builder replaceDirectives(List<GraphQLDirective> directives) {
+            return super.replaceDirectives(directives);
+        }
+
+        @Override
+        public Builder withDirectives(GraphQLDirective... directives) {
+            return super.withDirectives(directives);
+        }
+
+        @Override
+        public Builder withDirective(GraphQLDirective directive) {
+            return super.withDirective(directive);
+        }
+
+        @Override
+        public Builder withDirective(GraphQLDirective.Builder builder) {
+            return super.withDirective(builder);
+        }
+
+        @Override
+        public Builder clearDirectives() {
+            return super.clearDirectives();
+        }
+
+        @Override
+        protected void copyExistingDirectives(GraphQLDirectiveContainer directivesContainer) {
+            super.copyExistingDirectives(directivesContainer);
+        }
+
+        @Override
+        public Builder name(String name) {
+            return super.name(name);
+        }
+
+        @Override
+        public Builder description(String description) {
+            return super.description(description);
+        }
+
         public GraphQLArgument build() {
             assertNotNull(type, () -> "type can't be null");
 

--- a/src/main/java/graphql/schema/GraphQLDirective.java
+++ b/src/main/java/graphql/schema/GraphQLDirective.java
@@ -290,6 +290,18 @@ public class GraphQLDirective implements GraphQLNamedSchemaElement {
             return this;
         }
 
+        // -- the following are repeated to avoid a binary incompatibility problem --
+
+        @Override
+        public Builder name(String name) {
+            return super.name(name);
+        }
+
+        @Override
+        public Builder description(String description) {
+            return super.description(description);
+        }
+
         public GraphQLDirective build() {
             return new GraphQLDirective(
                     name,

--- a/src/main/java/graphql/schema/GraphQLEnumType.java
+++ b/src/main/java/graphql/schema/GraphQLEnumType.java
@@ -381,26 +381,6 @@ public class GraphQLEnumType implements GraphQLNamedInputType, GraphQLNamedOutpu
         // -- the following are repeated to avoid a binary incompatibility problem --
 
         @Override
-        public Builder replaceAppliedDirectives(List<GraphQLAppliedDirective> directives) {
-            return super.replaceAppliedDirectives(directives);
-        }
-
-        @Override
-        public Builder withAppliedDirectives(GraphQLAppliedDirective... directives) {
-            return super.withAppliedDirectives(directives);
-        }
-
-        @Override
-        public Builder withAppliedDirective(GraphQLAppliedDirective directive) {
-            return super.withAppliedDirective(directive);
-        }
-
-        @Override
-        public Builder withAppliedDirective(GraphQLAppliedDirective.Builder builder) {
-            return super.withAppliedDirective(builder);
-        }
-
-        @Override
         public Builder replaceDirectives(List<GraphQLDirective> directives) {
             return super.replaceDirectives(directives);
         }
@@ -423,11 +403,6 @@ public class GraphQLEnumType implements GraphQLNamedInputType, GraphQLNamedOutpu
         @Override
         public Builder clearDirectives() {
             return super.clearDirectives();
-        }
-
-        @Override
-        protected void copyExistingDirectives(GraphQLDirectiveContainer directivesContainer) {
-            super.copyExistingDirectives(directivesContainer);
         }
 
         @Override

--- a/src/main/java/graphql/schema/GraphQLEnumType.java
+++ b/src/main/java/graphql/schema/GraphQLEnumType.java
@@ -378,6 +378,67 @@ public class GraphQLEnumType implements GraphQLNamedInputType, GraphQLNamedOutpu
             return this;
         }
 
+        // -- the following are repeated to avoid a binary incompatibility problem --
+
+        @Override
+        public Builder replaceAppliedDirectives(List<GraphQLAppliedDirective> directives) {
+            return super.replaceAppliedDirectives(directives);
+        }
+
+        @Override
+        public Builder withAppliedDirectives(GraphQLAppliedDirective... directives) {
+            return super.withAppliedDirectives(directives);
+        }
+
+        @Override
+        public Builder withAppliedDirective(GraphQLAppliedDirective directive) {
+            return super.withAppliedDirective(directive);
+        }
+
+        @Override
+        public Builder withAppliedDirective(GraphQLAppliedDirective.Builder builder) {
+            return super.withAppliedDirective(builder);
+        }
+
+        @Override
+        public Builder replaceDirectives(List<GraphQLDirective> directives) {
+            return super.replaceDirectives(directives);
+        }
+
+        @Override
+        public Builder withDirectives(GraphQLDirective... directives) {
+            return super.withDirectives(directives);
+        }
+
+        @Override
+        public Builder withDirective(GraphQLDirective directive) {
+            return super.withDirective(directive);
+        }
+
+        @Override
+        public Builder withDirective(GraphQLDirective.Builder builder) {
+            return super.withDirective(builder);
+        }
+
+        @Override
+        public Builder clearDirectives() {
+            return super.clearDirectives();
+        }
+
+        @Override
+        protected void copyExistingDirectives(GraphQLDirectiveContainer directivesContainer) {
+            super.copyExistingDirectives(directivesContainer);
+        }
+
+        @Override
+        public Builder name(String name) {
+            return super.name(name);
+        }
+
+        @Override
+        public Builder description(String description) {
+            return super.description(description);
+        }
 
         public GraphQLEnumType build() {
             return new GraphQLEnumType(

--- a/src/main/java/graphql/schema/GraphQLEnumValueDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLEnumValueDefinition.java
@@ -227,26 +227,6 @@ public class GraphQLEnumValueDefinition implements GraphQLNamedSchemaElement, Gr
         // -- the following are repeated to avoid a binary incompatibility problem --
 
         @Override
-        public Builder replaceAppliedDirectives(List<GraphQLAppliedDirective> directives) {
-            return super.replaceAppliedDirectives(directives);
-        }
-
-        @Override
-        public Builder withAppliedDirectives(GraphQLAppliedDirective... directives) {
-            return super.withAppliedDirectives(directives);
-        }
-
-        @Override
-        public Builder withAppliedDirective(GraphQLAppliedDirective directive) {
-            return super.withAppliedDirective(directive);
-        }
-
-        @Override
-        public Builder withAppliedDirective(GraphQLAppliedDirective.Builder builder) {
-            return super.withAppliedDirective(builder);
-        }
-
-        @Override
         public Builder replaceDirectives(List<GraphQLDirective> directives) {
             return super.replaceDirectives(directives);
         }
@@ -269,11 +249,6 @@ public class GraphQLEnumValueDefinition implements GraphQLNamedSchemaElement, Gr
         @Override
         public Builder clearDirectives() {
             return super.clearDirectives();
-        }
-
-        @Override
-        protected void copyExistingDirectives(GraphQLDirectiveContainer directivesContainer) {
-            super.copyExistingDirectives(directivesContainer);
         }
 
         @Override

--- a/src/main/java/graphql/schema/GraphQLEnumValueDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLEnumValueDefinition.java
@@ -224,6 +224,68 @@ public class GraphQLEnumValueDefinition implements GraphQLNamedSchemaElement, Gr
             return this;
         }
 
+        // -- the following are repeated to avoid a binary incompatibility problem --
+
+        @Override
+        public Builder replaceAppliedDirectives(List<GraphQLAppliedDirective> directives) {
+            return super.replaceAppliedDirectives(directives);
+        }
+
+        @Override
+        public Builder withAppliedDirectives(GraphQLAppliedDirective... directives) {
+            return super.withAppliedDirectives(directives);
+        }
+
+        @Override
+        public Builder withAppliedDirective(GraphQLAppliedDirective directive) {
+            return super.withAppliedDirective(directive);
+        }
+
+        @Override
+        public Builder withAppliedDirective(GraphQLAppliedDirective.Builder builder) {
+            return super.withAppliedDirective(builder);
+        }
+
+        @Override
+        public Builder replaceDirectives(List<GraphQLDirective> directives) {
+            return super.replaceDirectives(directives);
+        }
+
+        @Override
+        public Builder withDirectives(GraphQLDirective... directives) {
+            return super.withDirectives(directives);
+        }
+
+        @Override
+        public Builder withDirective(GraphQLDirective directive) {
+            return super.withDirective(directive);
+        }
+
+        @Override
+        public Builder withDirective(GraphQLDirective.Builder builder) {
+            return super.withDirective(builder);
+        }
+
+        @Override
+        public Builder clearDirectives() {
+            return super.clearDirectives();
+        }
+
+        @Override
+        protected void copyExistingDirectives(GraphQLDirectiveContainer directivesContainer) {
+            super.copyExistingDirectives(directivesContainer);
+        }
+
+        @Override
+        public Builder name(String name) {
+            return super.name(name);
+        }
+
+        @Override
+        public Builder description(String description) {
+            return super.description(description);
+        }
+
         public GraphQLEnumValueDefinition build() {
             return new GraphQLEnumValueDefinition(name,
                     description,

--- a/src/main/java/graphql/schema/GraphQLFieldDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLFieldDefinition.java
@@ -436,6 +436,68 @@ public class GraphQLFieldDefinition implements GraphQLNamedSchemaElement, GraphQ
             return this;
         }
 
+        // -- the following are repeated to avoid a binary incompatibility problem --
+
+        @Override
+        public Builder replaceAppliedDirectives(List<GraphQLAppliedDirective> directives) {
+            return super.replaceAppliedDirectives(directives);
+        }
+
+        @Override
+        public Builder withAppliedDirectives(GraphQLAppliedDirective... directives) {
+            return super.withAppliedDirectives(directives);
+        }
+
+        @Override
+        public Builder withAppliedDirective(GraphQLAppliedDirective directive) {
+            return super.withAppliedDirective(directive);
+        }
+
+        @Override
+        public Builder withAppliedDirective(GraphQLAppliedDirective.Builder builder) {
+            return super.withAppliedDirective(builder);
+        }
+
+        @Override
+        public Builder replaceDirectives(List<GraphQLDirective> directives) {
+            return super.replaceDirectives(directives);
+        }
+
+        @Override
+        public Builder withDirectives(GraphQLDirective... directives) {
+            return super.withDirectives(directives);
+        }
+
+        @Override
+        public Builder withDirective(GraphQLDirective directive) {
+            return super.withDirective(directive);
+        }
+
+        @Override
+        public Builder withDirective(GraphQLDirective.Builder builder) {
+            return super.withDirective(builder);
+        }
+
+        @Override
+        public Builder clearDirectives() {
+            return super.clearDirectives();
+        }
+
+        @Override
+        protected void copyExistingDirectives(GraphQLDirectiveContainer directivesContainer) {
+            super.copyExistingDirectives(directivesContainer);
+        }
+
+        @Override
+        public Builder name(String name) {
+            return super.name(name);
+        }
+
+        @Override
+        public Builder description(String description) {
+            return super.description(description);
+        }
+
         public GraphQLFieldDefinition build() {
             return new GraphQLFieldDefinition(
                     name,

--- a/src/main/java/graphql/schema/GraphQLFieldDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLFieldDefinition.java
@@ -439,26 +439,6 @@ public class GraphQLFieldDefinition implements GraphQLNamedSchemaElement, GraphQ
         // -- the following are repeated to avoid a binary incompatibility problem --
 
         @Override
-        public Builder replaceAppliedDirectives(List<GraphQLAppliedDirective> directives) {
-            return super.replaceAppliedDirectives(directives);
-        }
-
-        @Override
-        public Builder withAppliedDirectives(GraphQLAppliedDirective... directives) {
-            return super.withAppliedDirectives(directives);
-        }
-
-        @Override
-        public Builder withAppliedDirective(GraphQLAppliedDirective directive) {
-            return super.withAppliedDirective(directive);
-        }
-
-        @Override
-        public Builder withAppliedDirective(GraphQLAppliedDirective.Builder builder) {
-            return super.withAppliedDirective(builder);
-        }
-
-        @Override
         public Builder replaceDirectives(List<GraphQLDirective> directives) {
             return super.replaceDirectives(directives);
         }
@@ -481,11 +461,6 @@ public class GraphQLFieldDefinition implements GraphQLNamedSchemaElement, GraphQ
         @Override
         public Builder clearDirectives() {
             return super.clearDirectives();
-        }
-
-        @Override
-        protected void copyExistingDirectives(GraphQLDirectiveContainer directivesContainer) {
-            super.copyExistingDirectives(directivesContainer);
         }
 
         @Override

--- a/src/main/java/graphql/schema/GraphQLInputObjectField.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectField.java
@@ -336,26 +336,6 @@ public class GraphQLInputObjectField implements GraphQLNamedSchemaElement, Graph
         // -- the following are repeated to avoid a binary incompatibility problem --
 
         @Override
-        public Builder replaceAppliedDirectives(List<GraphQLAppliedDirective> directives) {
-            return super.replaceAppliedDirectives(directives);
-        }
-
-        @Override
-        public Builder withAppliedDirectives(GraphQLAppliedDirective... directives) {
-            return super.withAppliedDirectives(directives);
-        }
-
-        @Override
-        public Builder withAppliedDirective(GraphQLAppliedDirective directive) {
-            return super.withAppliedDirective(directive);
-        }
-
-        @Override
-        public Builder withAppliedDirective(GraphQLAppliedDirective.Builder builder) {
-            return super.withAppliedDirective(builder);
-        }
-
-        @Override
         public Builder replaceDirectives(List<GraphQLDirective> directives) {
             return super.replaceDirectives(directives);
         }
@@ -378,11 +358,6 @@ public class GraphQLInputObjectField implements GraphQLNamedSchemaElement, Graph
         @Override
         public Builder clearDirectives() {
             return super.clearDirectives();
-        }
-
-        @Override
-        protected void copyExistingDirectives(GraphQLDirectiveContainer directivesContainer) {
-            super.copyExistingDirectives(directivesContainer);
         }
 
         @Override

--- a/src/main/java/graphql/schema/GraphQLInputObjectField.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectField.java
@@ -333,6 +333,68 @@ public class GraphQLInputObjectField implements GraphQLNamedSchemaElement, Graph
             return this;
         }
 
+        // -- the following are repeated to avoid a binary incompatibility problem --
+
+        @Override
+        public Builder replaceAppliedDirectives(List<GraphQLAppliedDirective> directives) {
+            return super.replaceAppliedDirectives(directives);
+        }
+
+        @Override
+        public Builder withAppliedDirectives(GraphQLAppliedDirective... directives) {
+            return super.withAppliedDirectives(directives);
+        }
+
+        @Override
+        public Builder withAppliedDirective(GraphQLAppliedDirective directive) {
+            return super.withAppliedDirective(directive);
+        }
+
+        @Override
+        public Builder withAppliedDirective(GraphQLAppliedDirective.Builder builder) {
+            return super.withAppliedDirective(builder);
+        }
+
+        @Override
+        public Builder replaceDirectives(List<GraphQLDirective> directives) {
+            return super.replaceDirectives(directives);
+        }
+
+        @Override
+        public Builder withDirectives(GraphQLDirective... directives) {
+            return super.withDirectives(directives);
+        }
+
+        @Override
+        public Builder withDirective(GraphQLDirective directive) {
+            return super.withDirective(directive);
+        }
+
+        @Override
+        public Builder withDirective(GraphQLDirective.Builder builder) {
+            return super.withDirective(builder);
+        }
+
+        @Override
+        public Builder clearDirectives() {
+            return super.clearDirectives();
+        }
+
+        @Override
+        protected void copyExistingDirectives(GraphQLDirectiveContainer directivesContainer) {
+            super.copyExistingDirectives(directivesContainer);
+        }
+
+        @Override
+        public Builder name(String name) {
+            return super.name(name);
+        }
+
+        @Override
+        public Builder description(String description) {
+            return super.description(description);
+        }
+
         public GraphQLInputObjectField build() {
             assertNotNull(type, () -> "type can't be null");
             return new GraphQLInputObjectField(

--- a/src/main/java/graphql/schema/GraphQLInputObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectType.java
@@ -318,26 +318,6 @@ public class GraphQLInputObjectType implements GraphQLNamedInputType, GraphQLUnm
         // -- the following are repeated to avoid a binary incompatibility problem --
 
         @Override
-        public Builder replaceAppliedDirectives(List<GraphQLAppliedDirective> directives) {
-            return super.replaceAppliedDirectives(directives);
-        }
-
-        @Override
-        public Builder withAppliedDirectives(GraphQLAppliedDirective... directives) {
-            return super.withAppliedDirectives(directives);
-        }
-
-        @Override
-        public Builder withAppliedDirective(GraphQLAppliedDirective directive) {
-            return super.withAppliedDirective(directive);
-        }
-
-        @Override
-        public Builder withAppliedDirective(GraphQLAppliedDirective.Builder builder) {
-            return super.withAppliedDirective(builder);
-        }
-
-        @Override
         public Builder replaceDirectives(List<GraphQLDirective> directives) {
             return super.replaceDirectives(directives);
         }
@@ -360,11 +340,6 @@ public class GraphQLInputObjectType implements GraphQLNamedInputType, GraphQLUnm
         @Override
         public Builder clearDirectives() {
             return super.clearDirectives();
-        }
-
-        @Override
-        protected void copyExistingDirectives(GraphQLDirectiveContainer directivesContainer) {
-            super.copyExistingDirectives(directivesContainer);
         }
 
         @Override

--- a/src/main/java/graphql/schema/GraphQLInputObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectType.java
@@ -315,6 +315,68 @@ public class GraphQLInputObjectType implements GraphQLNamedInputType, GraphQLUnm
             return this;
         }
 
+        // -- the following are repeated to avoid a binary incompatibility problem --
+
+        @Override
+        public Builder replaceAppliedDirectives(List<GraphQLAppliedDirective> directives) {
+            return super.replaceAppliedDirectives(directives);
+        }
+
+        @Override
+        public Builder withAppliedDirectives(GraphQLAppliedDirective... directives) {
+            return super.withAppliedDirectives(directives);
+        }
+
+        @Override
+        public Builder withAppliedDirective(GraphQLAppliedDirective directive) {
+            return super.withAppliedDirective(directive);
+        }
+
+        @Override
+        public Builder withAppliedDirective(GraphQLAppliedDirective.Builder builder) {
+            return super.withAppliedDirective(builder);
+        }
+
+        @Override
+        public Builder replaceDirectives(List<GraphQLDirective> directives) {
+            return super.replaceDirectives(directives);
+        }
+
+        @Override
+        public Builder withDirectives(GraphQLDirective... directives) {
+            return super.withDirectives(directives);
+        }
+
+        @Override
+        public Builder withDirective(GraphQLDirective directive) {
+            return super.withDirective(directive);
+        }
+
+        @Override
+        public Builder withDirective(GraphQLDirective.Builder builder) {
+            return super.withDirective(builder);
+        }
+
+        @Override
+        public Builder clearDirectives() {
+            return super.clearDirectives();
+        }
+
+        @Override
+        protected void copyExistingDirectives(GraphQLDirectiveContainer directivesContainer) {
+            super.copyExistingDirectives(directivesContainer);
+        }
+
+        @Override
+        public Builder name(String name) {
+            return super.name(name);
+        }
+
+        @Override
+        public Builder description(String description) {
+            return super.description(description);
+        }
+
         public GraphQLInputObjectType build() {
             return new GraphQLInputObjectType(
                     name,

--- a/src/main/java/graphql/schema/GraphQLInterfaceType.java
+++ b/src/main/java/graphql/schema/GraphQLInterfaceType.java
@@ -409,6 +409,68 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLCompositeT
             return this;
         }
 
+        // -- the following are repeated to avoid a binary incompatibility problem --
+
+        @Override
+        public Builder replaceAppliedDirectives(List<GraphQLAppliedDirective> directives) {
+            return super.replaceAppliedDirectives(directives);
+        }
+
+        @Override
+        public Builder withAppliedDirectives(GraphQLAppliedDirective... directives) {
+            return super.withAppliedDirectives(directives);
+        }
+
+        @Override
+        public Builder withAppliedDirective(GraphQLAppliedDirective directive) {
+            return super.withAppliedDirective(directive);
+        }
+
+        @Override
+        public Builder withAppliedDirective(GraphQLAppliedDirective.Builder builder) {
+            return super.withAppliedDirective(builder);
+        }
+
+        @Override
+        public Builder replaceDirectives(List<GraphQLDirective> directives) {
+            return super.replaceDirectives(directives);
+        }
+
+        @Override
+        public Builder withDirectives(GraphQLDirective... directives) {
+            return super.withDirectives(directives);
+        }
+
+        @Override
+        public Builder withDirective(GraphQLDirective directive) {
+            return super.withDirective(directive);
+        }
+
+        @Override
+        public Builder withDirective(GraphQLDirective.Builder builder) {
+            return super.withDirective(builder);
+        }
+
+        @Override
+        public Builder clearDirectives() {
+            return super.clearDirectives();
+        }
+
+        @Override
+        protected void copyExistingDirectives(GraphQLDirectiveContainer directivesContainer) {
+            super.copyExistingDirectives(directivesContainer);
+        }
+
+        @Override
+        public Builder name(String name) {
+            return super.name(name);
+        }
+
+        @Override
+        public Builder description(String description) {
+            return super.description(description);
+        }
+
         public GraphQLInterfaceType build() {
             return new GraphQLInterfaceType(
                     name,

--- a/src/main/java/graphql/schema/GraphQLInterfaceType.java
+++ b/src/main/java/graphql/schema/GraphQLInterfaceType.java
@@ -411,25 +411,6 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLCompositeT
 
         // -- the following are repeated to avoid a binary incompatibility problem --
 
-        @Override
-        public Builder replaceAppliedDirectives(List<GraphQLAppliedDirective> directives) {
-            return super.replaceAppliedDirectives(directives);
-        }
-
-        @Override
-        public Builder withAppliedDirectives(GraphQLAppliedDirective... directives) {
-            return super.withAppliedDirectives(directives);
-        }
-
-        @Override
-        public Builder withAppliedDirective(GraphQLAppliedDirective directive) {
-            return super.withAppliedDirective(directive);
-        }
-
-        @Override
-        public Builder withAppliedDirective(GraphQLAppliedDirective.Builder builder) {
-            return super.withAppliedDirective(builder);
-        }
 
         @Override
         public Builder replaceDirectives(List<GraphQLDirective> directives) {
@@ -454,11 +435,6 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLCompositeT
         @Override
         public Builder clearDirectives() {
             return super.clearDirectives();
-        }
-
-        @Override
-        protected void copyExistingDirectives(GraphQLDirectiveContainer directivesContainer) {
-            super.copyExistingDirectives(directivesContainer);
         }
 
         @Override

--- a/src/main/java/graphql/schema/GraphQLObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLObjectType.java
@@ -397,26 +397,6 @@ public class GraphQLObjectType implements GraphQLNamedOutputType, GraphQLComposi
         // -- the following are repeated to avoid a binary incompatibility problem --
 
         @Override
-        public Builder replaceAppliedDirectives(List<GraphQLAppliedDirective> directives) {
-            return super.replaceAppliedDirectives(directives);
-        }
-
-        @Override
-        public Builder withAppliedDirectives(GraphQLAppliedDirective... directives) {
-            return super.withAppliedDirectives(directives);
-        }
-
-        @Override
-        public Builder withAppliedDirective(GraphQLAppliedDirective directive) {
-            return super.withAppliedDirective(directive);
-        }
-
-        @Override
-        public Builder withAppliedDirective(GraphQLAppliedDirective.Builder builder) {
-            return super.withAppliedDirective(builder);
-        }
-
-        @Override
         public Builder replaceDirectives(List<GraphQLDirective> directives) {
             return super.replaceDirectives(directives);
         }
@@ -439,11 +419,6 @@ public class GraphQLObjectType implements GraphQLNamedOutputType, GraphQLComposi
         @Override
         public Builder clearDirectives() {
             return super.clearDirectives();
-        }
-
-        @Override
-        protected void copyExistingDirectives(GraphQLDirectiveContainer directivesContainer) {
-            super.copyExistingDirectives(directivesContainer);
         }
 
         @Override

--- a/src/main/java/graphql/schema/GraphQLObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLObjectType.java
@@ -394,6 +394,68 @@ public class GraphQLObjectType implements GraphQLNamedOutputType, GraphQLComposi
             return this;
         }
 
+        // -- the following are repeated to avoid a binary incompatibility problem --
+
+        @Override
+        public Builder replaceAppliedDirectives(List<GraphQLAppliedDirective> directives) {
+            return super.replaceAppliedDirectives(directives);
+        }
+
+        @Override
+        public Builder withAppliedDirectives(GraphQLAppliedDirective... directives) {
+            return super.withAppliedDirectives(directives);
+        }
+
+        @Override
+        public Builder withAppliedDirective(GraphQLAppliedDirective directive) {
+            return super.withAppliedDirective(directive);
+        }
+
+        @Override
+        public Builder withAppliedDirective(GraphQLAppliedDirective.Builder builder) {
+            return super.withAppliedDirective(builder);
+        }
+
+        @Override
+        public Builder replaceDirectives(List<GraphQLDirective> directives) {
+            return super.replaceDirectives(directives);
+        }
+
+        @Override
+        public Builder withDirectives(GraphQLDirective... directives) {
+            return super.withDirectives(directives);
+        }
+
+        @Override
+        public Builder withDirective(GraphQLDirective directive) {
+            return super.withDirective(directive);
+        }
+
+        @Override
+        public Builder withDirective(GraphQLDirective.Builder builder) {
+            return super.withDirective(builder);
+        }
+
+        @Override
+        public Builder clearDirectives() {
+            return super.clearDirectives();
+        }
+
+        @Override
+        protected void copyExistingDirectives(GraphQLDirectiveContainer directivesContainer) {
+            super.copyExistingDirectives(directivesContainer);
+        }
+
+        @Override
+        public Builder name(String name) {
+            return super.name(name);
+        }
+
+        @Override
+        public Builder description(String description) {
+            return super.description(description);
+        }
+
         public GraphQLObjectType build() {
             return new GraphQLObjectType(
                     name,

--- a/src/main/java/graphql/schema/GraphQLScalarType.java
+++ b/src/main/java/graphql/schema/GraphQLScalarType.java
@@ -256,26 +256,6 @@ GraphQLScalarType implements GraphQLNamedInputType, GraphQLNamedOutputType, Grap
         // -- the following are repeated to avoid a binary incompatibility problem --
 
         @Override
-        public Builder replaceAppliedDirectives(List<GraphQLAppliedDirective> directives) {
-            return super.replaceAppliedDirectives(directives);
-        }
-
-        @Override
-        public Builder withAppliedDirectives(GraphQLAppliedDirective... directives) {
-            return super.withAppliedDirectives(directives);
-        }
-
-        @Override
-        public Builder withAppliedDirective(GraphQLAppliedDirective directive) {
-            return super.withAppliedDirective(directive);
-        }
-
-        @Override
-        public Builder withAppliedDirective(GraphQLAppliedDirective.Builder builder) {
-            return super.withAppliedDirective(builder);
-        }
-
-        @Override
         public Builder replaceDirectives(List<GraphQLDirective> directives) {
             return super.replaceDirectives(directives);
         }
@@ -298,11 +278,6 @@ GraphQLScalarType implements GraphQLNamedInputType, GraphQLNamedOutputType, Grap
         @Override
         public Builder clearDirectives() {
             return super.clearDirectives();
-        }
-
-        @Override
-        protected void copyExistingDirectives(GraphQLDirectiveContainer directivesContainer) {
-            super.copyExistingDirectives(directivesContainer);
         }
 
         @Override

--- a/src/main/java/graphql/schema/GraphQLScalarType.java
+++ b/src/main/java/graphql/schema/GraphQLScalarType.java
@@ -253,6 +253,67 @@ GraphQLScalarType implements GraphQLNamedInputType, GraphQLNamedOutputType, Grap
             return this;
         }
 
+        // -- the following are repeated to avoid a binary incompatibility problem --
+
+        @Override
+        public Builder replaceAppliedDirectives(List<GraphQLAppliedDirective> directives) {
+            return super.replaceAppliedDirectives(directives);
+        }
+
+        @Override
+        public Builder withAppliedDirectives(GraphQLAppliedDirective... directives) {
+            return super.withAppliedDirectives(directives);
+        }
+
+        @Override
+        public Builder withAppliedDirective(GraphQLAppliedDirective directive) {
+            return super.withAppliedDirective(directive);
+        }
+
+        @Override
+        public Builder withAppliedDirective(GraphQLAppliedDirective.Builder builder) {
+            return super.withAppliedDirective(builder);
+        }
+
+        @Override
+        public Builder replaceDirectives(List<GraphQLDirective> directives) {
+            return super.replaceDirectives(directives);
+        }
+
+        @Override
+        public Builder withDirectives(GraphQLDirective... directives) {
+            return super.withDirectives(directives);
+        }
+
+        @Override
+        public Builder withDirective(GraphQLDirective directive) {
+            return super.withDirective(directive);
+        }
+
+        @Override
+        public Builder withDirective(GraphQLDirective.Builder builder) {
+            return super.withDirective(builder);
+        }
+
+        @Override
+        public Builder clearDirectives() {
+            return super.clearDirectives();
+        }
+
+        @Override
+        protected void copyExistingDirectives(GraphQLDirectiveContainer directivesContainer) {
+            super.copyExistingDirectives(directivesContainer);
+        }
+
+        @Override
+        public Builder name(String name) {
+            return super.name(name);
+        }
+
+        @Override
+        public Builder description(String description) {
+            return super.description(description);
+        }
 
         public GraphQLScalarType build() {
             return new GraphQLScalarType(name,

--- a/src/main/java/graphql/schema/GraphQLUnionType.java
+++ b/src/main/java/graphql/schema/GraphQLUnionType.java
@@ -224,6 +224,14 @@ public class GraphQLUnionType implements GraphQLNamedOutputType, GraphQLComposit
         return super.hashCode();
     }
 
+    @Override
+    public String toString() {
+        return "GraphQLUnionType{" +
+                "name='" + name + '\'' +
+                ", description='" + description + '\'' +
+                ", definition=" + definition +
+                '}';
+    }
 
     public static Builder newUnionType() {
         return new Builder();
@@ -324,6 +332,68 @@ public class GraphQLUnionType implements GraphQLNamedOutputType, GraphQLComposit
             return types.containsKey(name);
         }
 
+        // -- the following are repeated to avoid a binary incompatibility problem --
+
+        @Override
+        public Builder replaceAppliedDirectives(List<GraphQLAppliedDirective> directives) {
+            return super.replaceAppliedDirectives(directives);
+        }
+
+        @Override
+        public Builder withAppliedDirectives(GraphQLAppliedDirective... directives) {
+            return super.withAppliedDirectives(directives);
+        }
+
+        @Override
+        public Builder withAppliedDirective(GraphQLAppliedDirective directive) {
+            return super.withAppliedDirective(directive);
+        }
+
+        @Override
+        public Builder withAppliedDirective(GraphQLAppliedDirective.Builder builder) {
+            return super.withAppliedDirective(builder);
+        }
+
+        @Override
+        public Builder replaceDirectives(List<GraphQLDirective> directives) {
+            return super.replaceDirectives(directives);
+        }
+
+        @Override
+        public Builder withDirectives(GraphQLDirective... directives) {
+            return super.withDirectives(directives);
+        }
+
+        @Override
+        public Builder withDirective(GraphQLDirective directive) {
+            return super.withDirective(directive);
+        }
+
+        @Override
+        public Builder withDirective(GraphQLDirective.Builder builder) {
+            return super.withDirective(builder);
+        }
+
+        @Override
+        public Builder clearDirectives() {
+            return super.clearDirectives();
+        }
+
+        @Override
+        protected void copyExistingDirectives(GraphQLDirectiveContainer directivesContainer) {
+            super.copyExistingDirectives(directivesContainer);
+        }
+
+        @Override
+        public Builder name(String name) {
+            return super.name(name);
+        }
+
+        @Override
+        public Builder description(String description) {
+            return super.description(description);
+        }
+
         public GraphQLUnionType build() {
             return new GraphQLUnionType(
                     name,
@@ -337,12 +407,5 @@ public class GraphQLUnionType implements GraphQLNamedOutputType, GraphQLComposit
         }
     }
 
-    @Override
-    public String toString() {
-        return "GraphQLUnionType{" +
-                "name='" + name + '\'' +
-                ", description='" + description + '\'' +
-                ", definition=" + definition +
-                '}';
-    }
+
 }

--- a/src/main/java/graphql/schema/GraphQLUnionType.java
+++ b/src/main/java/graphql/schema/GraphQLUnionType.java
@@ -335,26 +335,6 @@ public class GraphQLUnionType implements GraphQLNamedOutputType, GraphQLComposit
         // -- the following are repeated to avoid a binary incompatibility problem --
 
         @Override
-        public Builder replaceAppliedDirectives(List<GraphQLAppliedDirective> directives) {
-            return super.replaceAppliedDirectives(directives);
-        }
-
-        @Override
-        public Builder withAppliedDirectives(GraphQLAppliedDirective... directives) {
-            return super.withAppliedDirectives(directives);
-        }
-
-        @Override
-        public Builder withAppliedDirective(GraphQLAppliedDirective directive) {
-            return super.withAppliedDirective(directive);
-        }
-
-        @Override
-        public Builder withAppliedDirective(GraphQLAppliedDirective.Builder builder) {
-            return super.withAppliedDirective(builder);
-        }
-
-        @Override
         public Builder replaceDirectives(List<GraphQLDirective> directives) {
             return super.replaceDirectives(directives);
         }
@@ -377,11 +357,6 @@ public class GraphQLUnionType implements GraphQLNamedOutputType, GraphQLComposit
         @Override
         public Builder clearDirectives() {
             return super.clearDirectives();
-        }
-
-        @Override
-        protected void copyExistingDirectives(GraphQLDirectiveContainer directivesContainer) {
-            super.copyExistingDirectives(directivesContainer);
         }
 
         @Override


### PR DESCRIPTION
The removal of the builder methods into a common base lib created a binary incompatible change.  This moves them back