### PR TITLE
Make ExecutionStepInfo values be lazy

### DIFF
--- a/src/main/java/graphql/TypeResolutionEnvironment.java
+++ b/src/main/java/graphql/TypeResolutionEnvironment.java
@@ -10,6 +10,7 @@ import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
 
 import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * This is passed to a {@link graphql.schema.TypeResolver} to help with object type resolution.
@@ -21,7 +22,7 @@ import java.util.Map;
 public class TypeResolutionEnvironment {
 
     private final Object object;
-    private final ImmutableMapWithNullValues<String, Object> arguments;
+    private final Supplier<ImmutableMapWithNullValues<String, Object>> arguments;
     private final MergedField field;
     private final GraphQLType fieldType;
     private final GraphQLSchema schema;
@@ -33,7 +34,7 @@ public class TypeResolutionEnvironment {
     @Internal
     public TypeResolutionEnvironment(TypeResolutionParameters parameters) {
         this.object = parameters.getValue();
-        this.arguments = ImmutableMapWithNullValues.copyOf(parameters.getArgumentValues());
+        this.arguments = () -> ImmutableMapWithNullValues.copyOf(parameters.getArgumentValues());
         this.field = parameters.getField();
         this.fieldType = parameters.getFieldType();
         this.schema = parameters.getSchema();
@@ -60,7 +61,7 @@ public class TypeResolutionEnvironment {
      * @return the runtime arguments to this the graphql field
      */
     public Map<String, Object> getArguments() {
-        return arguments;
+        return arguments.get();
     }
 
     /**

--- a/src/main/java/graphql/execution/ExecutionStepInfo.java
+++ b/src/main/java/graphql/execution/ExecutionStepInfo.java
@@ -11,6 +11,7 @@ import graphql.schema.GraphQLTypeUtil;
 
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertTrue;
@@ -64,28 +65,23 @@ public class ExecutionStepInfo {
     private final MergedField field;
     private final GraphQLFieldDefinition fieldDefinition;
     private final GraphQLObjectType fieldContainer;
-    private final ImmutableMapWithNullValues<String, Object> arguments;
+    private final Supplier<ImmutableMapWithNullValues<String, Object>> arguments;
 
-    private ExecutionStepInfo(GraphQLOutputType type,
-                              GraphQLFieldDefinition fieldDefinition,
-                              MergedField field,
-                              ResultPath path,
-                              ExecutionStepInfo parent,
-                              ImmutableMapWithNullValues<String, Object> arguments,
-                              GraphQLObjectType fieldsContainer) {
-        this.fieldDefinition = fieldDefinition;
-        this.field = field;
-        this.path = path;
-        this.parent = parent;
-        this.type = assertNotNull(type, () -> "you must provide a graphql type");
-        this.arguments = arguments;
-        this.fieldContainer = fieldsContainer;
+    private ExecutionStepInfo(Builder builder) {
+        this.fieldDefinition = builder.fieldDefinition;
+        this.field = builder.field;
+        this.path = builder.path;
+        this.parent = builder.parentInfo;
+        this.type = assertNotNull(builder.type, () -> "you must provide a graphql type");
+        this.arguments = builder.arguments;
+        this.fieldContainer = builder.fieldContainer;
     }
 
     /**
      * @return the GraphQLObjectType defining the {@link #getFieldDefinition()}
-     * @deprecated use {@link #getObjectType()} instead as it is named better
+     *
      * @see ExecutionStepInfo#getObjectType()
+     * @deprecated use {@link #getObjectType()} instead as it is named better
      */
     @Deprecated
     public GraphQLObjectType getFieldContainer() {
@@ -165,7 +161,7 @@ public class ExecutionStepInfo {
      * @return the resolved arguments that have been passed to this field
      */
     public Map<String, Object> getArguments() {
-        return arguments;
+        return arguments.get();
     }
 
     /**
@@ -173,11 +169,12 @@ public class ExecutionStepInfo {
      *
      * @param name the name of the argument
      * @param <T>  you decide what type it is
+     *
      * @return the named argument or null if its not present
      */
     @SuppressWarnings("unchecked")
     public <T> T getArgument(String name) {
-        return (T) arguments.get(name);
+        return (T) getArguments().get(name);
     }
 
     /**
@@ -201,14 +198,15 @@ public class ExecutionStepInfo {
      * after type resolution has occurred
      *
      * @param newType the new type to be
+     *
      * @return a new type info with the same
      */
     public ExecutionStepInfo changeTypeWithPreservedNonNull(GraphQLOutputType newType) {
         assertTrue(!GraphQLTypeUtil.isNonNull(newType), () -> "newType can't be non null");
         if (isNonNullType()) {
-            return new ExecutionStepInfo(GraphQLNonNull.nonNull(newType), fieldDefinition, field, path, this.parent, arguments, this.fieldContainer);
+            return newExecutionStepInfo(this).type(GraphQLNonNull.nonNull(newType)).build();
         } else {
-            return new ExecutionStepInfo(newType, fieldDefinition, field, path, this.parent, arguments, this.fieldContainer);
+            return newExecutionStepInfo(this).type(newType).build();
         }
     }
 
@@ -257,13 +255,13 @@ public class ExecutionStepInfo {
         GraphQLObjectType fieldContainer;
         MergedField field;
         ResultPath path;
-        ImmutableMapWithNullValues<String, Object> arguments;
+        Supplier<ImmutableMapWithNullValues<String, Object>> arguments;
 
         /**
          * @see ExecutionStepInfo#newExecutionStepInfo()
          */
         private Builder() {
-            arguments = ImmutableMapWithNullValues.emptyMap();
+            arguments = ImmutableMapWithNullValues::emptyMap;
         }
 
         private Builder(ExecutionStepInfo existing) {
@@ -273,7 +271,7 @@ public class ExecutionStepInfo {
             this.fieldContainer = existing.fieldContainer;
             this.field = existing.field;
             this.path = existing.path;
-            this.arguments = ImmutableMapWithNullValues.copyOf(existing.getArguments());
+            this.arguments = existing.arguments;
         }
 
         public Builder type(GraphQLOutputType type) {
@@ -301,8 +299,11 @@ public class ExecutionStepInfo {
             return this;
         }
 
-        public Builder arguments(Map<String, Object> arguments) {
-            this.arguments = arguments == null ? ImmutableMapWithNullValues.emptyMap() : ImmutableMapWithNullValues.copyOf(arguments);
+        public Builder arguments(Supplier<Map<String, Object>> arguments) {
+            this.arguments = () -> {
+                Map<String, Object> map = arguments.get();
+                return map == null ? ImmutableMapWithNullValues.emptyMap() : ImmutableMapWithNullValues.copyOf(map);
+            };
             return this;
         }
 
@@ -312,7 +313,7 @@ public class ExecutionStepInfo {
         }
 
         public ExecutionStepInfo build() {
-            return new ExecutionStepInfo(type, fieldDefinition, field, path, parentInfo, arguments, fieldContainer);
+            return new ExecutionStepInfo(this);
         }
     }
 }

--- a/src/main/java/graphql/execution/ExecutionStepInfoFactory.java
+++ b/src/main/java/graphql/execution/ExecutionStepInfoFactory.java
@@ -8,9 +8,11 @@ import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLOutputType;
+import graphql.util.FpKit;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 @Internal
 public class ExecutionStepInfoFactory {
@@ -25,7 +27,7 @@ public class ExecutionStepInfoFactory {
         GraphQLOutputType fieldType = fieldDefinition.getType();
         List<Argument> fieldArgs = mergedField.getArguments();
         GraphQLCodeRegistry codeRegistry = executionContext.getGraphQLSchema().getCodeRegistry();
-        Map<String, Object> argumentValues = valuesResolver.getArgumentValues(codeRegistry, fieldDefinition.getArguments(), fieldArgs, executionContext.getVariables());
+        Supplier<Map<String, Object>> argumentValues = FpKit.intraThreadMemoize(() -> valuesResolver.getArgumentValues(codeRegistry, fieldDefinition.getArguments(), fieldArgs, executionContext.getVariables()));
 
         ResultPath newPath = parentInfo.getPath().segment(mergedField.getResultKey());
 

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -810,14 +810,14 @@ public abstract class ExecutionStrategy {
         ExecutionStepInfo parentStepInfo = parameters.getExecutionStepInfo();
         GraphQLOutputType fieldType = fieldDefinition.getType();
         List<GraphQLArgument> fieldArgDefs = fieldDefinition.getArguments();
-        Map<String, Object> argumentValues = Collections.emptyMap();
+        Supplier<Map<String, Object>> argumentValues = Collections::emptyMap;
         //
         // no need to create args at all if there are none on the field def
         //
         if (!fieldArgDefs.isEmpty()) {
             List<Argument> fieldArgs = field.getArguments();
             GraphQLCodeRegistry codeRegistry = executionContext.getGraphQLSchema().getCodeRegistry();
-            argumentValues = valuesResolver.getArgumentValues(codeRegistry, fieldArgDefs, fieldArgs, executionContext.getVariables());
+            argumentValues = FpKit.intraThreadMemoize(() -> valuesResolver.getArgumentValues(codeRegistry, fieldArgDefs, fieldArgs, executionContext.getVariables()));
         }
 
 

--- a/src/main/java/graphql/execution/ResolveType.java
+++ b/src/main/java/graphql/execution/ResolveType.java
@@ -27,7 +27,7 @@ public class ResolveType {
                 .field(field)
                 .fieldType(fieldType)
                 .value(source)
-                .argumentValues(executionStepInfo.getArguments())
+                .argumentValues(executionStepInfo::getArguments)
                 .selectionSet(fieldSelectionSet)
                 .context(executionContext.getContext())
                 .graphQLContext(executionContext.getGraphQLContext())

--- a/src/main/java/graphql/execution/TypeResolutionParameters.java
+++ b/src/main/java/graphql/execution/TypeResolutionParameters.java
@@ -9,6 +9,7 @@ import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
 
 import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * This class is a classic builder style one that SHOULD have been on have been on {@link TypeResolutionEnvironment}
@@ -20,7 +21,7 @@ public class TypeResolutionParameters {
     private final MergedField field;
     private final GraphQLType fieldType;
     private final Object value;
-    private final ImmutableMapWithNullValues<String, Object> argumentValues;
+    private final Supplier<ImmutableMapWithNullValues<String, Object>> argumentValues;
     private final GraphQLSchema schema;
     private final Object context;
     private final Object localContext;
@@ -52,7 +53,7 @@ public class TypeResolutionParameters {
     }
 
     public Map<String, Object> getArgumentValues() {
-        return argumentValues;
+        return argumentValues.get();
     }
 
     public GraphQLSchema getSchema() {
@@ -90,7 +91,7 @@ public class TypeResolutionParameters {
         private MergedField field;
         private GraphQLType fieldType;
         private Object value;
-        private ImmutableMapWithNullValues<String, Object> argumentValues;
+        private Supplier<ImmutableMapWithNullValues<String, Object>> argumentValues;
         private GraphQLSchema schema;
         private Object context;
         private GraphQLContext graphQLContext;
@@ -112,8 +113,8 @@ public class TypeResolutionParameters {
             return this;
         }
 
-        public Builder argumentValues(Map<String, Object> argumentValues) {
-            this.argumentValues = ImmutableMapWithNullValues.copyOf(argumentValues);
+        public Builder argumentValues(Supplier<Map<String, Object>> argumentValues) {
+            this.argumentValues = () -> ImmutableMapWithNullValues.copyOf(argumentValues.get());
             return this;
         }
 

--- a/src/test/groovy/graphql/TypeResolutionEnvironmentTest.groovy
+++ b/src/test/groovy/graphql/TypeResolutionEnvironmentTest.groovy
@@ -47,7 +47,7 @@ class TypeResolutionEnvironmentTest extends Specification {
 
         def environment = TypeResolutionParameters.newParameters()
                 .value("source")
-                .argumentValues([a: "b"])
+                .argumentValues(() -> [a: "b"])
                 .field(mergedField(new Field("field")))
                 .fieldType(interfaceType)
                 .schema(schema)
@@ -117,7 +117,7 @@ class TypeResolutionEnvironmentTest extends Specification {
         when:
         def environmentFooBar = TypeResolutionParameters.newParameters()
                 .value("source")
-                .argumentValues([:])
+                .argumentValues(() -> [:])
                 .field(mergedField(new Field("field")))
                 .fieldType(interfaceType)
                 .schema(schema)
@@ -133,7 +133,7 @@ class TypeResolutionEnvironmentTest extends Specification {
         when:
         def environmentFooImpl = TypeResolutionParameters.newParameters()
                 .value("source")
-                .argumentValues([:])
+                .argumentValues(() -> [:])
                 .field(mergedField(new Field("field")))
                 .fieldType(interfaceType)
                 .schema(schema)


### PR DESCRIPTION
This will improve memory usage if you don't use the ESI arguments, and it will reduce CPU usage somewhat in heavy systems by doing less work (albeit by a small amount)

If a DFE or other code does not ask for the arguments - then no value resolving will happen for them.