### PR TITLE
Make public static fields immutable in ScalarInfo

### DIFF
--- a/src/main/java/graphql/schema/idl/ScalarInfo.java
+++ b/src/main/java/graphql/schema/idl/ScalarInfo.java
@@ -1,12 +1,12 @@
 package graphql.schema.idl;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import graphql.PublicApi;
 import graphql.Scalars;
 import graphql.language.ScalarTypeDefinition;
 import graphql.schema.GraphQLScalarType;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -19,30 +19,22 @@ public class ScalarInfo {
     /**
      * A list of the built-in scalar types as defined by the graphql specification
      */
-    public static final List<GraphQLScalarType> GRAPHQL_SPECIFICATION_SCALARS = new ArrayList<>();
+    public static final List<GraphQLScalarType> GRAPHQL_SPECIFICATION_SCALARS = ImmutableList.of(
+            Scalars.GraphQLInt,
+            Scalars.GraphQLFloat,
+            Scalars.GraphQLString,
+            Scalars.GraphQLBoolean,
+            Scalars.GraphQLID);
 
     /**
      * A map of scalar type definitions provided by graphql-java
      */
-    public static final Map<String, ScalarTypeDefinition> GRAPHQL_SPECIFICATION_SCALARS_DEFINITIONS = new LinkedHashMap<>();
-
-    static {
-        GRAPHQL_SPECIFICATION_SCALARS.add(Scalars.GraphQLInt);
-        GRAPHQL_SPECIFICATION_SCALARS.add(Scalars.GraphQLFloat);
-        GRAPHQL_SPECIFICATION_SCALARS.add(Scalars.GraphQLString);
-        GRAPHQL_SPECIFICATION_SCALARS.add(Scalars.GraphQLBoolean);
-        GRAPHQL_SPECIFICATION_SCALARS.add(Scalars.GraphQLID);
-    }
-
-    static {
-        // graphql standard scalars
-        GRAPHQL_SPECIFICATION_SCALARS_DEFINITIONS.put("Int", ScalarTypeDefinition.newScalarTypeDefinition().name("Int").build());
-        GRAPHQL_SPECIFICATION_SCALARS_DEFINITIONS.put("Float", ScalarTypeDefinition.newScalarTypeDefinition().name("Float").build());
-        GRAPHQL_SPECIFICATION_SCALARS_DEFINITIONS.put("String", ScalarTypeDefinition.newScalarTypeDefinition().name("String").build());
-        GRAPHQL_SPECIFICATION_SCALARS_DEFINITIONS.put("Boolean", ScalarTypeDefinition.newScalarTypeDefinition().name("Boolean").build());
-        GRAPHQL_SPECIFICATION_SCALARS_DEFINITIONS.put("ID", ScalarTypeDefinition.newScalarTypeDefinition().name("ID").build());
-
-    }
+    public static final Map<String, ScalarTypeDefinition> GRAPHQL_SPECIFICATION_SCALARS_DEFINITIONS = ImmutableMap.of(
+            "Int", ScalarTypeDefinition.newScalarTypeDefinition().name("Int").build(),
+            "Float", ScalarTypeDefinition.newScalarTypeDefinition().name("Float").build(),
+            "String", ScalarTypeDefinition.newScalarTypeDefinition().name("String").build(),
+            "Boolean", ScalarTypeDefinition.newScalarTypeDefinition().name("Boolean").build(),
+            "ID", ScalarTypeDefinition.newScalarTypeDefinition().name("ID").build());
 
     /**
      * Returns true if the scalar type is a scalar that is specified by the graphql specification


### PR DESCRIPTION
Public static fields in ScalarInfo were exposing mutable collections
that are obviously not intended to be modified. Switch to immutable
collection types to avoid accidental mutation.