### PR TITLE
Max query depth called later in beginExecuteOperation

### DIFF
--- a/src/main/java/graphql/analysis/MaxQueryComplexityInstrumentation.java
+++ b/src/main/java/graphql/analysis/MaxQueryComplexityInstrumentation.java
@@ -1,9 +1,14 @@
 package graphql.analysis;
 
+import graphql.ExecutionResult;
 import graphql.PublicApi;
 import graphql.execution.AbortExecutionException;
+import graphql.execution.ExecutionContext;
 import graphql.execution.instrumentation.InstrumentationContext;
+import graphql.execution.instrumentation.InstrumentationState;
 import graphql.execution.instrumentation.SimpleInstrumentation;
+import graphql.execution.instrumentation.parameters.InstrumentationCreateStateParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationExecuteOperationParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationValidationParameters;
 import graphql.validation.ValidationError;
 import org.slf4j.Logger;
@@ -15,7 +20,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 import static graphql.Assert.assertNotNull;
-import static graphql.execution.instrumentation.SimpleInstrumentationContext.whenCompleted;
+import static graphql.execution.instrumentation.SimpleInstrumentationContext.noOp;
 import static java.util.Optional.ofNullable;
 
 /**
@@ -77,40 +82,51 @@ public class MaxQueryComplexityInstrumentation extends SimpleInstrumentation {
     }
 
     @Override
+    public InstrumentationState createState(InstrumentationCreateStateParameters parameters) {
+        return new State();
+    }
+
+    @Override
     public InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters) {
-        return whenCompleted((errors, throwable) -> {
-            if ((errors != null && errors.size() > 0) || throwable != null) {
-                return;
-            }
-            QueryTraverser queryTraverser = newQueryTraverser(parameters);
+        State state = parameters.getInstrumentationState();
+        // for API backwards compatibility reasons we capture the validation parameters, so we can put them into QueryComplexityInfo
+        state.instrumentationValidationParameters = parameters;
+        return noOp();
+    }
 
-            Map<QueryVisitorFieldEnvironment, Integer> valuesByParent = new LinkedHashMap<>();
-            queryTraverser.visitPostOrder(new QueryVisitorStub() {
-                @Override
-                public void visitField(QueryVisitorFieldEnvironment env) {
-                    int childsComplexity = valuesByParent.getOrDefault(env, 0);
-                    int value = calculateComplexity(env, childsComplexity);
+    @Override
+    public InstrumentationContext<ExecutionResult> beginExecuteOperation(InstrumentationExecuteOperationParameters instrumentationExecuteOperationParameters) {
+        State state = instrumentationExecuteOperationParameters.getInstrumentationState();
+        QueryTraverser queryTraverser = newQueryTraverser(instrumentationExecuteOperationParameters.getExecutionContext());
 
-                    valuesByParent.compute(env.getParentEnvironment(), (key, oldValue) ->
-                            ofNullable(oldValue).orElse(0) + value
-                    );
-                }
-            });
-            int totalComplexity = valuesByParent.getOrDefault(null, 0);
-            if (log.isDebugEnabled()) {
-                log.debug("Query complexity: {}", totalComplexity);
-            }
-            if (totalComplexity > maxComplexity) {
-                QueryComplexityInfo queryComplexityInfo = QueryComplexityInfo.newQueryComplexityInfo()
-                        .complexity(totalComplexity)
-                        .instrumentationValidationParameters(parameters)
-                        .build();
-                boolean throwAbortException = maxQueryComplexityExceededFunction.apply(queryComplexityInfo);
-                if (throwAbortException) {
-                    throw mkAbortException(totalComplexity, maxComplexity);
-                }
+        Map<QueryVisitorFieldEnvironment, Integer> valuesByParent = new LinkedHashMap<>();
+        queryTraverser.visitPostOrder(new QueryVisitorStub() {
+            @Override
+            public void visitField(QueryVisitorFieldEnvironment env) {
+                int childsComplexity = valuesByParent.getOrDefault(env, 0);
+                int value = calculateComplexity(env, childsComplexity);
+
+                valuesByParent.compute(env.getParentEnvironment(), (key, oldValue) ->
+                        ofNullable(oldValue).orElse(0) + value
+                );
             }
         });
+        int totalComplexity = valuesByParent.getOrDefault(null, 0);
+        if (log.isDebugEnabled()) {
+            log.debug("Query complexity: {}", totalComplexity);
+        }
+        if (totalComplexity > maxComplexity) {
+            QueryComplexityInfo queryComplexityInfo = QueryComplexityInfo.newQueryComplexityInfo()
+                    .complexity(totalComplexity)
+                    .instrumentationValidationParameters(state.instrumentationValidationParameters)
+                    .instrumentationExecuteOperationParameters(instrumentationExecuteOperationParameters)
+                    .build();
+            boolean throwAbortException = maxQueryComplexityExceededFunction.apply(queryComplexityInfo);
+            if (throwAbortException) {
+                throw mkAbortException(totalComplexity, maxComplexity);
+            }
+        }
+        return noOp();
     }
 
     /**
@@ -125,12 +141,12 @@ public class MaxQueryComplexityInstrumentation extends SimpleInstrumentation {
         return new AbortExecutionException("maximum query complexity exceeded " + totalComplexity + " > " + maxComplexity);
     }
 
-    QueryTraverser newQueryTraverser(InstrumentationValidationParameters parameters) {
+    QueryTraverser newQueryTraverser(ExecutionContext executionContext) {
         return QueryTraverser.newQueryTraverser()
-                .schema(parameters.getSchema())
-                .document(parameters.getDocument())
-                .operationName(parameters.getOperation())
-                .variables(parameters.getVariables())
+                .schema(executionContext.getGraphQLSchema())
+                .document(executionContext.getDocument())
+                .operationName(executionContext.getExecutionInput().getOperationName())
+                .variables(executionContext.getVariables())
                 .build();
     }
 
@@ -156,5 +172,8 @@ public class MaxQueryComplexityInstrumentation extends SimpleInstrumentation {
         );
     }
 
+    private static class State implements InstrumentationState {
+        InstrumentationValidationParameters instrumentationValidationParameters;
+    }
 
 }

--- a/src/main/java/graphql/analysis/MaxQueryDepthInstrumentation.java
+++ b/src/main/java/graphql/analysis/MaxQueryDepthInstrumentation.java
@@ -1,18 +1,18 @@
 package graphql.analysis;
 
+import graphql.ExecutionResult;
 import graphql.PublicApi;
 import graphql.execution.AbortExecutionException;
+import graphql.execution.ExecutionContext;
 import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.SimpleInstrumentation;
-import graphql.execution.instrumentation.parameters.InstrumentationValidationParameters;
-import graphql.validation.ValidationError;
+import graphql.execution.instrumentation.parameters.InstrumentationExecuteOperationParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
 import java.util.function.Function;
 
-import static graphql.execution.instrumentation.SimpleInstrumentationContext.whenCompleted;
+import static graphql.execution.instrumentation.SimpleInstrumentationContext.noOp;
 
 /**
  * Prevents execution if the query depth is greater than the specified maxDepth.
@@ -49,26 +49,22 @@ public class MaxQueryDepthInstrumentation extends SimpleInstrumentation {
     }
 
     @Override
-    public InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters) {
-        return whenCompleted((errors, throwable) -> {
-            if ((errors != null && errors.size() > 0) || throwable != null) {
-                return;
+    public InstrumentationContext<ExecutionResult> beginExecuteOperation(InstrumentationExecuteOperationParameters parameters) {
+        QueryTraverser queryTraverser = newQueryTraverser(parameters.getExecutionContext());
+        int depth = queryTraverser.reducePreOrder((env, acc) -> Math.max(getPathLength(env.getParentEnvironment()), acc), 0);
+        if (log.isDebugEnabled()) {
+            log.debug("Query depth info: {}", depth);
+        }
+        if (depth > maxDepth) {
+            QueryDepthInfo queryDepthInfo = QueryDepthInfo.newQueryDepthInfo()
+                    .depth(depth)
+                    .build();
+            boolean throwAbortException = maxQueryDepthExceededFunction.apply(queryDepthInfo);
+            if (throwAbortException) {
+                throw mkAbortException(depth, maxDepth);
             }
-            QueryTraverser queryTraverser = newQueryTraverser(parameters);
-            int depth = queryTraverser.reducePreOrder((env, acc) -> Math.max(getPathLength(env.getParentEnvironment()), acc), 0);
-            if (log.isDebugEnabled()) {
-                log.debug("Query depth info: {}", depth);
-            }
-            if (depth > maxDepth) {
-                QueryDepthInfo queryDepthInfo = QueryDepthInfo.newQueryDepthInfo()
-                        .depth(depth)
-                        .build();
-                boolean throwAbortException = maxQueryDepthExceededFunction.apply(queryDepthInfo);
-                if (throwAbortException) {
-                    throw mkAbortException(depth, maxDepth);
-                }
-            }
-        });
+        }
+        return noOp();
     }
 
     /**
@@ -83,12 +79,12 @@ public class MaxQueryDepthInstrumentation extends SimpleInstrumentation {
         return new AbortExecutionException("maximum query depth exceeded " + depth + " > " + maxDepth);
     }
 
-    QueryTraverser newQueryTraverser(InstrumentationValidationParameters parameters) {
+    QueryTraverser newQueryTraverser(ExecutionContext executionContext) {
         return QueryTraverser.newQueryTraverser()
-                .schema(parameters.getSchema())
-                .document(parameters.getDocument())
-                .operationName(parameters.getOperation())
-                .variables(parameters.getVariables())
+                .schema(executionContext.getGraphQLSchema())
+                .document(executionContext.getDocument())
+                .operationName(executionContext.getExecutionInput().getOperationName())
+                .variables(executionContext.getVariables())
                 .build();
     }
 

--- a/src/main/java/graphql/analysis/QueryComplexityInfo.java
+++ b/src/main/java/graphql/analysis/QueryComplexityInfo.java
@@ -1,6 +1,7 @@
 package graphql.analysis;
 
 import graphql.PublicApi;
+import graphql.execution.instrumentation.parameters.InstrumentationExecuteOperationParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationValidationParameters;
 
 /**
@@ -10,11 +11,13 @@ import graphql.execution.instrumentation.parameters.InstrumentationValidationPar
 public class QueryComplexityInfo {
 
     private final int complexity;
-    private InstrumentationValidationParameters instrumentationValidationParameters;
+    private final InstrumentationValidationParameters instrumentationValidationParameters;
+    private final InstrumentationExecuteOperationParameters instrumentationExecuteOperationParameters;
 
-    private QueryComplexityInfo(int complexity, InstrumentationValidationParameters parameters) {
-        this.complexity = complexity;
-        this.instrumentationValidationParameters = parameters;
+    private QueryComplexityInfo(Builder builder) {
+        this.complexity = builder.complexity;
+        this.instrumentationValidationParameters = builder.instrumentationValidationParameters;
+        this.instrumentationExecuteOperationParameters = builder.instrumentationExecuteOperationParameters;
     }
 
     /**
@@ -33,6 +36,15 @@ public class QueryComplexityInfo {
      */
     public InstrumentationValidationParameters getInstrumentationValidationParameters() {
         return instrumentationValidationParameters;
+    }
+
+    /**
+     * This returns the instrumentation execute operation parameters.
+     *
+     * @return the instrumentation execute operation parameters.
+     */
+    public InstrumentationExecuteOperationParameters getInstrumentationExecuteOperationParameters() {
+        return instrumentationExecuteOperationParameters;
     }
 
     @Override
@@ -54,6 +66,7 @@ public class QueryComplexityInfo {
 
         private int complexity;
         private InstrumentationValidationParameters instrumentationValidationParameters;
+        private InstrumentationExecuteOperationParameters instrumentationExecuteOperationParameters;
 
         private Builder() {
         }
@@ -62,6 +75,7 @@ public class QueryComplexityInfo {
          * The query complexity.
          *
          * @param complexity the query complexity
+         *
          * @return this builder
          */
         public Builder complexity(int complexity) {
@@ -73,6 +87,7 @@ public class QueryComplexityInfo {
          * The instrumentation validation parameters.
          *
          * @param parameters the instrumentation validation parameters.
+         *
          * @return this builder
          */
         public Builder instrumentationValidationParameters(InstrumentationValidationParameters parameters) {
@@ -80,11 +95,16 @@ public class QueryComplexityInfo {
             return this;
         }
 
+        public Builder instrumentationExecuteOperationParameters(InstrumentationExecuteOperationParameters instrumentationExecuteOperationParameters) {
+            this.instrumentationExecuteOperationParameters = instrumentationExecuteOperationParameters;
+            return this;
+        }
+
         /**
          * @return a built {@link QueryComplexityInfo} object
          */
         public QueryComplexityInfo build() {
-            return new QueryComplexityInfo(complexity, instrumentationValidationParameters);
+            return new QueryComplexityInfo(this);
         }
     }
 }

--- a/src/test/groovy/graphql/analysis/MaxQueryComplexityInstrumentationTest.groovy
+++ b/src/test/groovy/graphql/analysis/MaxQueryComplexityInstrumentationTest.groovy
@@ -3,12 +3,14 @@ package graphql.analysis
 import graphql.ExecutionInput
 import graphql.TestUtil
 import graphql.execution.AbortExecutionException
-import graphql.execution.instrumentation.InstrumentationContext
+import graphql.execution.ExecutionContext
+import graphql.execution.ExecutionContextBuilder
+import graphql.execution.ExecutionId
+import graphql.execution.instrumentation.parameters.InstrumentationExecuteOperationParameters
 import graphql.execution.instrumentation.parameters.InstrumentationValidationParameters
 import graphql.language.Document
 import graphql.parser.Parser
-import graphql.validation.ValidationError
-import graphql.validation.ValidationErrorType
+import graphql.schema.GraphQLSchema
 import spock.lang.Specification
 
 import java.util.function.Function
@@ -20,61 +22,6 @@ class MaxQueryComplexityInstrumentationTest extends Specification {
         parser.parseDocument(query)
     }
 
-    def "doesn't do anything if validation errors occur"() {
-        given:
-        def schema = TestUtil.schema("""
-            type Query{
-                bar: String
-            }
-        """)
-        def query = createQuery("""
-            { bar { thisIsWrong } }
-            """)
-        def queryTraversal = Mock(QueryTraverser)
-        MaxQueryComplexityInstrumentation maxQueryComplexityInstrumentation = new MaxQueryComplexityInstrumentation(6) {
-
-            @Override
-            QueryTraverser newQueryTraverser(InstrumentationValidationParameters parameters) {
-                return queryTraversal
-            }
-        }
-        ExecutionInput executionInput = Mock(ExecutionInput)
-        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, null)
-        InstrumentationContext instrumentationContext = maxQueryComplexityInstrumentation.beginValidation(validationParameters)
-        when:
-        instrumentationContext.onCompleted([new ValidationError(ValidationErrorType.SubSelectionNotAllowed)], null)
-        then:
-        0 * queryTraversal._(_)
-
-    }
-
-    def "doesn't do anything if exception was thrown"() {
-        given:
-        def schema = TestUtil.schema("""
-            type Query{
-                bar: String
-            }
-        """)
-        def query = createQuery("""
-            { bar { thisIsWrong } }
-            """)
-        def queryTraversal = Mock(QueryTraverser)
-        MaxQueryComplexityInstrumentation maxQueryComplexityInstrumentation = new MaxQueryComplexityInstrumentation(6) {
-
-            @Override
-            QueryTraverser newQueryTraverser(InstrumentationValidationParameters parameters) {
-                return queryTraversal
-            }
-        }
-        ExecutionInput executionInput = Mock(ExecutionInput)
-        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, null)
-        InstrumentationContext instrumentationContext = maxQueryComplexityInstrumentation.beginValidation(validationParameters)
-        when:
-        instrumentationContext.onCompleted(null, new RuntimeException())
-        then:
-        0 * queryTraversal._(_)
-
-    }
 
     def "default complexity calculator"() {
         given:
@@ -93,15 +40,15 @@ class MaxQueryComplexityInstrumentationTest extends Specification {
             """)
         MaxQueryComplexityInstrumentation queryComplexityInstrumentation = new MaxQueryComplexityInstrumentation(10)
         ExecutionInput executionInput = Mock(ExecutionInput)
-        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, null)
-        InstrumentationContext instrumentationContext = queryComplexityInstrumentation.beginValidation(validationParameters)
+        InstrumentationExecuteOperationParameters executeOperationParameters = createExecuteOperationParameters(queryComplexityInstrumentation, executionInput, query, schema)
         when:
-        instrumentationContext.onCompleted(null, null)
+        queryComplexityInstrumentation.beginExecuteOperation(executeOperationParameters)
         then:
         def e = thrown(AbortExecutionException)
         e.message == "maximum query complexity exceeded 11 > 10"
 
     }
+
 
     def "complexity calculator works with __typename field with score 0"() {
         given:
@@ -115,10 +62,9 @@ class MaxQueryComplexityInstrumentationTest extends Specification {
             """)
         MaxQueryComplexityInstrumentation queryComplexityInstrumentation = new MaxQueryComplexityInstrumentation(1)
         ExecutionInput executionInput = Mock(ExecutionInput)
-        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, null)
-        InstrumentationContext instrumentationContext = queryComplexityInstrumentation.beginValidation(validationParameters)
+        InstrumentationExecuteOperationParameters executeOperationParameters = createExecuteOperationParameters(queryComplexityInstrumentation, executionInput, query, schema)
         when:
-        instrumentationContext.onCompleted(null, null)
+        queryComplexityInstrumentation.beginExecuteOperation(executeOperationParameters)
         then:
         def e = thrown(AbortExecutionException)
         e.message == "maximum query complexity exceeded 2 > 1"
@@ -143,10 +89,9 @@ class MaxQueryComplexityInstrumentationTest extends Specification {
         def calculator = Mock(FieldComplexityCalculator)
         MaxQueryComplexityInstrumentation queryComplexityInstrumentation = new MaxQueryComplexityInstrumentation(5, calculator)
         ExecutionInput executionInput = Mock(ExecutionInput)
-        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, null)
-        InstrumentationContext instrumentationContext = queryComplexityInstrumentation.beginValidation(validationParameters)
+        InstrumentationExecuteOperationParameters executeOperationParameters = createExecuteOperationParameters(queryComplexityInstrumentation, executionInput, query, schema)
         when:
-        instrumentationContext.onCompleted(null, null)
+        queryComplexityInstrumentation.beginExecuteOperation(executeOperationParameters)
 
         then:
         1 * calculator.calculate({ FieldComplexityEnvironment env -> env.field.name == "scalar" }, 0) >> 10
@@ -171,22 +116,23 @@ class MaxQueryComplexityInstrumentationTest extends Specification {
         def query = createQuery("""
             {f2: foo {scalar foo{scalar}} f1: foo { foo {foo {foo {foo{foo{scalar}}}}}} }
             """)
-        Boolean test = false
+        Boolean customFunctionCalled = false
         Function<QueryComplexityInfo, Boolean> maxQueryComplexityExceededFunction = new Function<QueryComplexityInfo, Boolean>() {
             @Override
             Boolean apply(final QueryComplexityInfo queryComplexityInfo) {
-                test = true
+                assert queryComplexityInfo.instrumentationExecuteOperationParameters != null
+                assert queryComplexityInfo.instrumentationValidationParameters != null
+                customFunctionCalled = true
                 return false
             }
         }
         MaxQueryComplexityInstrumentation queryComplexityInstrumentation = new MaxQueryComplexityInstrumentation(10, maxQueryComplexityExceededFunction)
         ExecutionInput executionInput = Mock(ExecutionInput)
-        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, null)
-        InstrumentationContext instrumentationContext = queryComplexityInstrumentation.beginValidation(validationParameters)
+        InstrumentationExecuteOperationParameters executeOperationParameters = createExecuteOperationParameters(queryComplexityInstrumentation, executionInput, query, schema)
         when:
-        instrumentationContext.onCompleted(null, null)
+        queryComplexityInstrumentation.beginExecuteOperation(executeOperationParameters)
         then:
-        test == true
+        customFunctionCalled
         notThrown(Exception)
     }
 
@@ -205,13 +151,28 @@ class MaxQueryComplexityInstrumentationTest extends Specification {
 
         MaxQueryComplexityInstrumentation queryComplexityInstrumentation = new MaxQueryComplexityInstrumentation(0)
         ExecutionInput executionInput = Mock(ExecutionInput)
-        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, null)
-        InstrumentationContext instrumentationContext = queryComplexityInstrumentation.beginValidation(validationParameters)
+        InstrumentationExecuteOperationParameters executeOperationParameters = createExecuteOperationParameters(queryComplexityInstrumentation, executionInput, query, schema)
         when:
-        instrumentationContext.onCompleted(null, null)
+        queryComplexityInstrumentation.beginExecuteOperation(executeOperationParameters)
         then:
         def e = thrown(AbortExecutionException)
         e.message == "maximum query complexity exceeded 1 > 0"
+    }
+
+    private InstrumentationExecuteOperationParameters createExecuteOperationParameters(MaxQueryComplexityInstrumentation queryComplexityInstrumentation, ExecutionInput executionInput, Document query, GraphQLSchema schema) {
+        // we need to run N steps to create instrumentation state
+        def instrumentationState = queryComplexityInstrumentation.createState(null)
+        def validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, instrumentationState)
+        queryComplexityInstrumentation.beginValidation(validationParameters)
+        def executionContext = executionCtx(executionInput, query, schema)
+        def executeOperationParameters = new InstrumentationExecuteOperationParameters(executionContext).withNewState(instrumentationState)
+        executeOperationParameters
+    }
+
+    private ExecutionContext executionCtx(ExecutionInput executionInput, Document query, GraphQLSchema schema) {
+        ExecutionContextBuilder.newExecutionContextBuilder()
+                .executionInput(executionInput).document(query).graphQLSchema(schema).executionId(ExecutionId.generate())
+                .build()
     }
 }
 

--- a/src/test/groovy/graphql/analysis/MaxQueryDepthInstrumentationTest.groovy
+++ b/src/test/groovy/graphql/analysis/MaxQueryDepthInstrumentationTest.groovy
@@ -1,16 +1,16 @@
 package graphql.analysis
 
 import graphql.ExecutionInput
-import graphql.ExecutionResult
 import graphql.GraphQL
 import graphql.TestUtil
 import graphql.execution.AbortExecutionException
-import graphql.execution.instrumentation.InstrumentationContext
-import graphql.execution.instrumentation.parameters.InstrumentationValidationParameters
+import graphql.execution.ExecutionContext
+import graphql.execution.ExecutionContextBuilder
+import graphql.execution.ExecutionId
+import graphql.execution.instrumentation.parameters.InstrumentationExecuteOperationParameters
 import graphql.language.Document
 import graphql.parser.Parser
-import graphql.validation.ValidationError
-import graphql.validation.ValidationErrorType
+import graphql.schema.GraphQLSchema
 import spock.lang.Specification
 
 import java.util.function.Function
@@ -23,63 +23,7 @@ class MaxQueryDepthInstrumentationTest extends Specification {
     }
 
 
-    def "doesn't do anything if validation errors occur"() {
-        given:
-        def schema = TestUtil.schema("""
-            type Query{
-                bar: String
-            }
-        """)
-        def query = createQuery("""
-            { bar { thisIsWrong } }
-            """)
-        def queryTraversal = Mock(QueryTraverser)
-        MaxQueryDepthInstrumentation maximumQueryDepthInstrumentation = new MaxQueryDepthInstrumentation(6) {
-
-            @Override
-            QueryTraverser newQueryTraverser(InstrumentationValidationParameters parameters) {
-                return queryTraversal
-            }
-        }
-        ExecutionInput executionInput = Mock(ExecutionInput)
-        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, null)
-        InstrumentationContext instrumentationContext = maximumQueryDepthInstrumentation.beginValidation(validationParameters)
-        when:
-        instrumentationContext.onCompleted([new ValidationError(ValidationErrorType.SubSelectionNotAllowed)], null)
-        then:
-        0 * queryTraversal._(_)
-
-    }
-
-    def "doesn't do anything if exception was thrown"() {
-        given:
-        def schema = TestUtil.schema("""
-            type Query{
-                bar: String
-            }
-        """)
-        def query = createQuery("""
-            { bar { thisIsWrong } }
-            """)
-        def queryTraversal = Mock(QueryTraverser)
-        MaxQueryDepthInstrumentation maximumQueryDepthInstrumentation = new MaxQueryDepthInstrumentation(6) {
-
-            @Override
-            QueryTraverser newQueryTraverser(InstrumentationValidationParameters parameters) {
-                return queryTraversal
-            }
-        }
-        ExecutionInput executionInput = Mock(ExecutionInput)
-        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, null)
-        InstrumentationContext instrumentationContext = maximumQueryDepthInstrumentation.beginValidation(validationParameters)
-        when:
-        instrumentationContext.onCompleted(null, new RuntimeException())
-        then:
-        0 * queryTraversal._(_)
-
-    }
-
-    def "throws exception"() {
+    def "throws exception if too deep"() {
         given:
         def schema = TestUtil.schema("""
             type Query{
@@ -96,16 +40,16 @@ class MaxQueryDepthInstrumentationTest extends Specification {
             """)
         MaxQueryDepthInstrumentation maximumQueryDepthInstrumentation = new MaxQueryDepthInstrumentation(6)
         ExecutionInput executionInput = Mock(ExecutionInput)
-        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, null)
-        InstrumentationContext instrumentationContext = maximumQueryDepthInstrumentation.beginValidation(validationParameters)
+        def executionContext = executionCtx(executionInput, query, schema)
+        def executeOperationParameters = new InstrumentationExecuteOperationParameters(executionContext)
         when:
-        instrumentationContext.onCompleted(null, null)
+        maximumQueryDepthInstrumentation.beginExecuteOperation(executeOperationParameters)
         then:
         def e = thrown(AbortExecutionException)
         e.message.contains("maximum query depth exceeded 7 > 6")
     }
 
-    def "doesn't throw exception"() {
+    def "doesn't throw exception if not deep enough"() {
         given:
         def schema = TestUtil.schema("""
             type Query{
@@ -122,10 +66,10 @@ class MaxQueryDepthInstrumentationTest extends Specification {
             """)
         MaxQueryDepthInstrumentation maximumQueryDepthInstrumentation = new MaxQueryDepthInstrumentation(7)
         ExecutionInput executionInput = Mock(ExecutionInput)
-        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, null)
-        InstrumentationContext instrumentationContext = maximumQueryDepthInstrumentation.beginValidation(validationParameters)
+        def executionContext = executionCtx(executionInput, query, schema)
+        def executeOperationParameters = new InstrumentationExecuteOperationParameters(executionContext)
         when:
-        instrumentationContext.onCompleted(null, null)
+        maximumQueryDepthInstrumentation.beginExecuteOperation(executeOperationParameters)
         then:
         notThrown(Exception)
     }
@@ -145,26 +89,26 @@ class MaxQueryDepthInstrumentationTest extends Specification {
         def query = createQuery("""
             {f1: foo {foo {foo {scalar}}} f2: foo { foo {foo {foo {foo{foo{scalar}}}}}} }
             """)
-        Boolean test = false
+        Boolean calledFunction = false
         Function<QueryDepthInfo, Boolean> maxQueryDepthExceededFunction = new Function<QueryDepthInfo, Boolean>() {
             @Override
             Boolean apply(final QueryDepthInfo queryDepthInfo) {
-                test = true
+                calledFunction = true
                 return false
             }
         }
         MaxQueryDepthInstrumentation maximumQueryDepthInstrumentation = new MaxQueryDepthInstrumentation(6, maxQueryDepthExceededFunction)
         ExecutionInput executionInput = Mock(ExecutionInput)
-        InstrumentationValidationParameters validationParameters = new InstrumentationValidationParameters(executionInput, query, schema, null)
-        InstrumentationContext instrumentationContext = maximumQueryDepthInstrumentation.beginValidation(validationParameters)
+        def executionContext = executionCtx(executionInput, query, schema)
+        def executeOperationParameters = new InstrumentationExecuteOperationParameters(executionContext)
         when:
-        instrumentationContext.onCompleted(null, null)
+        maximumQueryDepthInstrumentation.beginExecuteOperation(executeOperationParameters)
         then:
-        test == true
+        calledFunction
         notThrown(Exception)
     }
 
-    def "coercing null variables that are marked as non nullable"() {
+    def "coercing null variables that are marked as non nullable wont blow up early"() {
 
         given:
         def schema = TestUtil.schema("""
@@ -186,7 +130,11 @@ class MaxQueryDepthInstrumentationTest extends Specification {
         def er = graphQL.execute(executionInput)
 
         then:
-        ! er.errors.isEmpty()
+        !er.errors.isEmpty()
+    }
 
+    private ExecutionContext executionCtx(ExecutionInput executionInput, Document query, GraphQLSchema schema) {
+        ExecutionContextBuilder.newExecutionContextBuilder()
+                .executionInput(executionInput).document(query).graphQLSchema(schema).executionId(ExecutionId.generate()).build()
     }
 }


### PR DESCRIPTION
Previously the MaxQuery depth instrumentation was called on the end of the validation step.  But this is too early if there are null / non null variables mismatched.  This caused and exception to be thrown and not a graphql error.

We now call the instrumentation during the `beginExecuteOperation` which is JUST before execution proper and not after validation - because the `Execution` code does some more sensibility checks on the state of the call

I started this branch from https://github.com/graphql-java/graphql-java/pull/2763 which showed the problem happening

I am leaving that PR so we can improve the error messages - but this PR fixes the actual problem in the sense query checks are done a smidge later and avoid the problem all together