### PR TITLE
Improve NonNullableValueCoercedAsNullException message

### DIFF
--- a/src/main/java/graphql/execution/NonNullableValueCoercedAsNullException.java
+++ b/src/main/java/graphql/execution/NonNullableValueCoercedAsNullException.java
@@ -43,6 +43,18 @@ public class NonNullableValueCoercedAsNullException extends GraphQLException imp
         this.path = path;
     }
 
+    public NonNullableValueCoercedAsNullException(List<Object> path, GraphQLType graphQLType) {
+        super(format("Coerced Null value for NonNull type '%s'",
+                GraphQLTypeUtil.simplePrint(graphQLType)));
+        this.path = path;
+    }
+
+    public NonNullableValueCoercedAsNullException(VariableDefinition variableDefinition, String causeMessage) {
+        super(format("Variable '%s' has invalid value: %s",
+                variableDefinition.getName(), causeMessage));
+        this.sourceLocations = Collections.singletonList(variableDefinition.getSourceLocation());
+    }
+
     public NonNullableValueCoercedAsNullException(String fieldName, List<Object> path, GraphQLType graphQLType) {
         super(format("Field '%s' has coerced Null value for NonNull type '%s'",
                 fieldName, GraphQLTypeUtil.simplePrint(graphQLType)));

--- a/src/main/java/graphql/execution/NonNullableValueCoercedAsNullException.java
+++ b/src/main/java/graphql/execution/NonNullableValueCoercedAsNullException.java
@@ -43,15 +43,12 @@ public class NonNullableValueCoercedAsNullException extends GraphQLException imp
         this.path = path;
     }
 
-    public NonNullableValueCoercedAsNullException(List<Object> path, GraphQLType graphQLType) {
-        super(format("Coerced Null value for NonNull type '%s'",
-                GraphQLTypeUtil.simplePrint(graphQLType)));
-        this.path = path;
+    public NonNullableValueCoercedAsNullException(GraphQLType graphQLType) {
+        super(format("Coerced Null value for NonNull type '%s'", GraphQLTypeUtil.simplePrint(graphQLType)));
     }
 
     public NonNullableValueCoercedAsNullException(VariableDefinition variableDefinition, String causeMessage) {
-        super(format("Variable '%s' has invalid value: %s",
-                variableDefinition.getName(), causeMessage));
+        super(format("Variable '%s' has an invalid value: %s", variableDefinition.getName(), causeMessage));
         this.sourceLocations = Collections.singletonList(variableDefinition.getSourceLocation());
     }
 

--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -497,7 +497,7 @@ public class ValuesResolver {
             Object returnValue =
                     externalValueToInternalValue(fieldVisibility, unwrapOne(graphQLType), value);
             if (returnValue == null) {
-                throw new NonNullableValueCoercedAsNullException(emptyList(), graphQLType);
+                throw new NonNullableValueCoercedAsNullException(graphQLType);
             }
             return returnValue;
         }

--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -418,6 +418,8 @@ public class ValuesResolver {
                         .cause(e.getCause())
                         .sourceLocation(variableDefinition.getSourceLocation())
                         .build();
+            } catch (NonNullableValueCoercedAsNullException e) {
+                throw new NonNullableValueCoercedAsNullException(variableDefinition, e.getMessage());
             }
         }
 
@@ -495,7 +497,7 @@ public class ValuesResolver {
             Object returnValue =
                     externalValueToInternalValue(fieldVisibility, unwrapOne(graphQLType), value);
             if (returnValue == null) {
-                throw new NonNullableValueCoercedAsNullException("", emptyList(), graphQLType);
+                throw new NonNullableValueCoercedAsNullException(emptyList(), graphQLType);
             }
             return returnValue;
         }

--- a/src/test/groovy/graphql/Issue743.groovy
+++ b/src/test/groovy/graphql/Issue743.groovy
@@ -28,6 +28,6 @@ class Issue743 extends Specification {
         executionResult.data == null
         executionResult.errors.size() == 1
         executionResult.errors[0].errorType == ErrorType.ValidationError
-        executionResult.errors[0].message == "Variable 'isTrue' has invalid value: Variable 'isTrue' has coerced Null value for NonNull type 'Boolean!'"
+        executionResult.errors[0].message == "Variable 'isTrue' has an invalid value: Variable 'isTrue' has coerced Null value for NonNull type 'Boolean!'"
     }
 }

--- a/src/test/groovy/graphql/Issue743.groovy
+++ b/src/test/groovy/graphql/Issue743.groovy
@@ -28,6 +28,6 @@ class Issue743 extends Specification {
         executionResult.data == null
         executionResult.errors.size() == 1
         executionResult.errors[0].errorType == ErrorType.ValidationError
-        executionResult.errors[0].message == "Variable 'isTrue' has coerced Null value for NonNull type 'Boolean!'"
+        executionResult.errors[0].message == "Variable 'isTrue' has invalid value: Variable 'isTrue' has coerced Null value for NonNull type 'Boolean!'"
     }
 }

--- a/src/test/groovy/graphql/NullVariableCoercionTest.groovy
+++ b/src/test/groovy/graphql/NullVariableCoercionTest.groovy
@@ -1,6 +1,6 @@
 package graphql
 
-
+import graphql.language.SourceLocation
 import graphql.schema.DataFetcher
 import graphql.schema.GraphQLObjectType
 import graphql.schema.idl.RuntimeWiring
@@ -68,8 +68,8 @@ class NullVariableCoercionTest extends Specification {
         varResult.data == null
         varResult.errors.size() == 1
         varResult.errors[0].errorType == ErrorType.ValidationError
-        varResult.errors[0].message == "Field 'baz' has coerced Null value for NonNull type 'String!'"
-//        varResult.errors[0].locations == [new SourceLocation(1, 11)]
+        varResult.errors[0].message == "Variable 'input' has invalid value: Field 'baz' has coerced Null value for NonNull type 'String!'"
+        varResult.errors[0].locations == [new SourceLocation(1, 11)]
     }
 
     def "can handle defaulting on complex input objects"() {

--- a/src/test/groovy/graphql/NullVariableCoercionTest.groovy
+++ b/src/test/groovy/graphql/NullVariableCoercionTest.groovy
@@ -68,7 +68,7 @@ class NullVariableCoercionTest extends Specification {
         varResult.data == null
         varResult.errors.size() == 1
         varResult.errors[0].errorType == ErrorType.ValidationError
-        varResult.errors[0].message == "Variable 'input' has invalid value: Field 'baz' has coerced Null value for NonNull type 'String!'"
+        varResult.errors[0].message == "Variable 'input' has an invalid value: Field 'baz' has coerced Null value for NonNull type 'String!'"
         varResult.errors[0].locations == [new SourceLocation(1, 11)]
     }
 

--- a/src/test/groovy/graphql/execution/ValuesResolverTest.groovy
+++ b/src/test/groovy/graphql/execution/ValuesResolverTest.groovy
@@ -495,7 +495,25 @@ class ValuesResolverTest extends Specification {
 
         then:
         def error = thrown(NonNullableValueCoercedAsNullException)
-        error.message == "Variable 'foo' has coerced Null value for NonNull type 'String!'"
+        error.message == "Variable 'foo' has invalid value: Variable 'foo' has coerced Null value for NonNull type 'String!'"
+    }
+
+    def "coerceVariableValues: if variableType is a list of Non-Nullable type, and element value is null, throw a query error"() {
+        given:
+        def schema = TestUtil.schemaWithInputType(list(nonNull(GraphQLString)))
+
+        def defaultValueForFoo = new ArrayValue([new StringValue("defaultValueForFoo")])
+        def type = new ListType(new NonNullType(new TypeName("String")))
+        VariableDefinition fooVarDef = new VariableDefinition("foo", type, defaultValueForFoo)
+
+        def variableValuesMap = ["foo": [null]]
+
+        when:
+        resolver.coerceVariableValues(schema, [fooVarDef], variableValuesMap)
+
+        then:
+        def error = thrown(NonNullableValueCoercedAsNullException)
+        error.message == "Variable 'foo' has invalid value: Coerced Null value for NonNull type 'String!'"
     }
 
     // Note: use NullValue defined in Field when it exists,

--- a/src/test/groovy/graphql/execution/ValuesResolverTest.groovy
+++ b/src/test/groovy/graphql/execution/ValuesResolverTest.groovy
@@ -495,7 +495,7 @@ class ValuesResolverTest extends Specification {
 
         then:
         def error = thrown(NonNullableValueCoercedAsNullException)
-        error.message == "Variable 'foo' has invalid value: Variable 'foo' has coerced Null value for NonNull type 'String!'"
+        error.message == "Variable 'foo' has an invalid value: Variable 'foo' has coerced Null value for NonNull type 'String!'"
     }
 
     def "coerceVariableValues: if variableType is a list of Non-Nullable type, and element value is null, throw a query error"() {
@@ -513,7 +513,7 @@ class ValuesResolverTest extends Specification {
 
         then:
         def error = thrown(NonNullableValueCoercedAsNullException)
-        error.message == "Variable 'foo' has invalid value: Coerced Null value for NonNull type 'String!'"
+        error.message == "Variable 'foo' has an invalid value: Coerced Null value for NonNull type 'String!'"
     }
 
     // Note: use NullValue defined in Field when it exists,


### PR DESCRIPTION
In #2761, the message from `NonNullableValueCoercedAsNullException` made it hard to identify the offending value. This PR improves the exception's message.

## Before and after
**Before**, we would throw
```
throw new NonNullableValueCoercedAsNullException("", emptyList(), graphQLType);
```
Which led to this unclear message
```
Field '' has coerced Null value for NonNull type 'String!'
```

**Now**, the message will include the offending variable's name and the reason for the exception
```
Variable 'foo' has invalid value: Coerced Null value for NonNull type 'String!'
```