### PR TITLE
Fix argument / format string mismatches

### DIFF
--- a/src/main/java/graphql/schema/idl/errors/NonSDLDefinitionError.java
+++ b/src/main/java/graphql/schema/idl/errors/NonSDLDefinitionError.java
@@ -9,7 +9,7 @@ import static java.lang.String.format;
 public class NonSDLDefinitionError extends BaseError {
 
     public NonSDLDefinitionError(Definition definition) {
-        super(definition, format("The schema definition text contains a non schema definition language (SDL) element '%s'",
-                definition.getClass().getSimpleName(), lineCol(definition), lineCol(definition)));
+        super(definition, format("%s The schema definition text contains a non schema definition language (SDL) element '%s'",
+                lineCol(definition), definition.getClass().getSimpleName()));
     }
 }

--- a/src/main/java/graphql/util/Anonymizer.java
+++ b/src/main/java/graphql/util/Anonymizer.java
@@ -702,7 +702,7 @@ public class Anonymizer {
             Set<GraphQLFieldDefinition> fieldDefinitions) {
         List<GraphQLArgument> result = new ArrayList<>();
         for (GraphQLFieldDefinition fieldDefinition : fieldDefinitions) {
-            Optional.ofNullable(fieldDefinition.getArgument(name)).map(result::add);
+            Optional.ofNullable(fieldDefinition.getArgument(name)).ifPresent(result::add);
         }
         return result;
     }
@@ -738,7 +738,7 @@ public class Anonymizer {
 
                     for (Argument argument : directive.getArguments()) {
                         GraphQLArgument argumentDefinition = directiveDefinition.getArgument(argument.getName());
-                        String newArgumentName = assertNotNull(newNames.get(argumentDefinition), () -> format("%s no new name found for directive argument %s %s", directiveName, argument.getName()));
+                        String newArgumentName = assertNotNull(newNames.get(argumentDefinition), () -> format("No new name found for directive %s argument %s", directiveName, argument.getName()));
                         astNodeToNewName.put(argument, newArgumentName);
                         visitDirectiveArgumentValues(directive, argument.getValue());
                     }


### PR DESCRIPTION
Fix instances where too many or too few arguments were supplied to String.format.