### PR TITLE
Add RuntimeWiring.newBuilder

### DIFF
--- a/src/main/java/graphql/schema/idl/RuntimeWiring.java
+++ b/src/main/java/graphql/schema/idl/RuntimeWiring.java
@@ -14,6 +14,7 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 
 import static graphql.Assert.assertNotNull;
@@ -87,6 +88,20 @@ public class RuntimeWiring {
         builder.codeRegistry = original.codeRegistry;
         builder.comparatorRegistry = original.comparatorRegistry;
         return builder;
+    }
+
+    /**
+     * This helps you transform the current RuntimeWiring object into another one by starting a builder with all
+     * the current values and allows you to transform it how you want.
+     *
+     * @param builderConsumer the consumer code that will be given a builder to transform
+     *
+     * @return a new RuntimeWiring object based on calling build on that builder
+     */
+    public RuntimeWiring transform(Consumer<Builder> builderConsumer) {
+        Builder builder = newRuntimeWiring(this);
+        builderConsumer.accept(builder);
+        return builder.build();
     }
 
     public GraphQLCodeRegistry getCodeRegistry() {

--- a/src/main/java/graphql/schema/idl/RuntimeWiring.java
+++ b/src/main/java/graphql/schema/idl/RuntimeWiring.java
@@ -69,6 +69,26 @@ public class RuntimeWiring {
         return new Builder();
     }
 
+    /**
+     * @return a builder of Runtime Wiring based on the provided one
+     */
+    public static Builder newRuntimeWiring(RuntimeWiring original) {
+        Builder builder = new Builder();
+        builder.dataFetchers.putAll(original.dataFetchers);
+        builder.defaultDataFetchers.putAll(original.defaultDataFetchers);
+        builder.scalars.putAll(original.scalars);
+        builder.typeResolvers.putAll(original.typeResolvers);
+        builder.registeredDirectiveWiring.putAll(original.registeredDirectiveWiring);
+        builder.directiveWiring.addAll(original.directiveWiring);
+        builder.wiringFactory = original.wiringFactory;
+        builder.enumValuesProviders.putAll(original.enumValuesProviders);
+        builder.schemaGeneratorPostProcessings.addAll(original.schemaGeneratorPostProcessings);
+        builder.fieldVisibility = original.fieldVisibility;
+        builder.codeRegistry = original.codeRegistry;
+        builder.comparatorRegistry = original.comparatorRegistry;
+        return builder;
+    }
+
     public GraphQLCodeRegistry getCodeRegistry() {
         return codeRegistry;
     }
@@ -119,26 +139,6 @@ public class RuntimeWiring {
 
     public GraphqlTypeComparatorRegistry getComparatorRegistry() {
         return comparatorRegistry;
-    }
-
-    /**
-     * @return a Builder based on this RuntimeWiring
-     */
-    public Builder newBuilder() {
-        Builder builder = new Builder();
-        builder.dataFetchers.putAll(dataFetchers);
-        builder.defaultDataFetchers.putAll(defaultDataFetchers);
-        builder.scalars.putAll(scalars);
-        builder.typeResolvers.putAll(typeResolvers);
-        builder.registeredDirectiveWiring.putAll(registeredDirectiveWiring);
-        builder.directiveWiring.addAll(directiveWiring);
-        builder.wiringFactory = wiringFactory;
-        builder.enumValuesProviders.putAll(enumValuesProviders);
-        builder.schemaGeneratorPostProcessings.addAll(schemaGeneratorPostProcessings);
-        builder.fieldVisibility = fieldVisibility;
-        builder.codeRegistry = codeRegistry;
-        builder.comparatorRegistry = comparatorRegistry;
-        return builder;
     }
 
     @PublicApi

--- a/src/main/java/graphql/schema/idl/RuntimeWiring.java
+++ b/src/main/java/graphql/schema/idl/RuntimeWiring.java
@@ -121,6 +121,26 @@ public class RuntimeWiring {
         return comparatorRegistry;
     }
 
+    /**
+     * @return a Builder based on this RuntimeWiring
+     */
+    public Builder newBuilder() {
+        Builder builder = new Builder();
+        builder.dataFetchers.putAll(dataFetchers);
+        builder.defaultDataFetchers.putAll(defaultDataFetchers);
+        builder.scalars.putAll(scalars);
+        builder.typeResolvers.putAll(typeResolvers);
+        builder.registeredDirectiveWiring.putAll(registeredDirectiveWiring);
+        builder.directiveWiring.addAll(directiveWiring);
+        builder.wiringFactory = wiringFactory;
+        builder.enumValuesProviders.putAll(enumValuesProviders);
+        builder.schemaGeneratorPostProcessings.addAll(schemaGeneratorPostProcessings);
+        builder.fieldVisibility = fieldVisibility;
+        builder.codeRegistry = codeRegistry;
+        builder.comparatorRegistry = comparatorRegistry;
+        return builder;
+    }
+
     @PublicApi
     public static class Builder {
         private final Map<String, Map<String, DataFetcher>> dataFetchers = new LinkedHashMap<>();


### PR DESCRIPTION
Hi!

In [Federation-JVM](https://github.com/apollographql/federation-jvm) we have a use-case where we need to 'augment' an existing `RuntimeWiring`, but there is no straightforward way to do that ([here](https://github.com/apollographql/federation-jvm/blob/master/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/Federation.java#L174) is how we do it currently, but it's not ideal).

This PR adds a `newBuilder` method for this use-case.