### PR TITLE
Complete level fetching when data loading finishes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:23.0.0'
     implementation 'org.antlr:antlr4-runtime:' + antlrVersion
     implementation 'org.slf4j:slf4j-api:' + slf4jVersion
-    api 'com.graphql-java:java-dataloader:3.1.2'
+    api 'com.graphql-java:java-dataloader:3.1.3-SNAPSHOT'
     api 'org.reactivestreams:reactive-streams:' + reactiveStreamsVersion
     antlr 'org.antlr:antlr4:' + antlrVersion
     implementation 'com.google.guava:guava:31.0.1-jre'

--- a/src/main/java/graphql/execution/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncExecutionStrategy.java
@@ -70,8 +70,9 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
                 return;
             }
             List<CompletableFuture<ExecutionResult>> executionResultFuture = map(completeValueInfos, FieldValueInfo::getFieldValue);
-            executionStrategyCtx.onFieldValuesInfo(completeValueInfos);
-            Async.each(executionResultFuture).whenComplete(handleResultsConsumer);
+            Async.each(executionResultFuture)
+                .thenCombine(executionStrategyCtx.onFieldValuesInfo(completeValueInfos), (result, __) -> result)
+                .whenComplete(handleResultsConsumer);
         }).exceptionally((ex) -> {
             // if there are any issues with combining/handling the field results,
             // complete the future at all costs and bubble up any thrown exception so

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -286,8 +286,7 @@ public abstract class ExecutionStrategy {
             fetchedValue = new CompletableFuture<>();
             fetchedValue.completeExceptionally(e);
         }
-        fetchCtx.onDispatched(fetchedValue);
-        return fetchedValue
+        return fetchCtx.onDispatched(fetchedValue)
                 .handle((result, exception) -> {
                     fetchCtx.onCompleted(result, exception);
                     if (exception != null) {

--- a/src/main/java/graphql/execution/instrumentation/ChainedInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/ChainedInstrumentation.java
@@ -1,6 +1,7 @@
 package graphql.execution.instrumentation;
 
 import com.google.common.collect.ImmutableList;
+
 import graphql.ExecutionInput;
 import graphql.ExecutionResult;
 import graphql.PublicApi;
@@ -229,8 +230,11 @@ public class ChainedInstrumentation implements Instrumentation {
         }
 
         @Override
-        public void onDispatched(CompletableFuture<T> result) {
-            contexts.forEach(context -> context.onDispatched(result));
+        public CompletableFuture<T> onDispatched(CompletableFuture<T> result) {
+            return CompletableFuture.allOf(contexts.stream()
+                    .map(context -> context.onDispatched(result))
+                    .toArray(CompletableFuture<?>[]::new))
+                .thenCompose(__ -> result);
         }
 
         @Override
@@ -248,8 +252,11 @@ public class ChainedInstrumentation implements Instrumentation {
         }
 
         @Override
-        public void onDispatched(CompletableFuture<ExecutionResult> result) {
-            contexts.forEach(context -> context.onDispatched(result));
+        public CompletableFuture<ExecutionResult> onDispatched(CompletableFuture<ExecutionResult> result) {
+            return CompletableFuture.allOf(contexts.stream()
+                    .map(context -> context.onDispatched(result))
+                    .toArray(CompletableFuture<?>[]::new))
+                .thenCompose(__ -> result);
         }
 
         @Override
@@ -258,8 +265,10 @@ public class ChainedInstrumentation implements Instrumentation {
         }
 
         @Override
-        public void onFieldValuesInfo(List<FieldValueInfo> fieldValueInfoList) {
-            contexts.forEach(context -> context.onFieldValuesInfo(fieldValueInfoList));
+        public CompletableFuture<Void> onFieldValuesInfo(List<FieldValueInfo> fieldValueInfoList) {
+            return CompletableFuture.allOf(contexts.stream()
+                    .map(context -> context.onFieldValuesInfo(fieldValueInfoList))
+                    .toArray(CompletableFuture<?>[]::new));
         }
 
     }

--- a/src/main/java/graphql/execution/instrumentation/ExecutionStrategyInstrumentationContext.java
+++ b/src/main/java/graphql/execution/instrumentation/ExecutionStrategyInstrumentationContext.java
@@ -5,12 +5,13 @@ import graphql.PublicSpi;
 import graphql.execution.FieldValueInfo;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 @PublicSpi
 public interface ExecutionStrategyInstrumentationContext extends InstrumentationContext<ExecutionResult> {
 
-    default void onFieldValuesInfo(List<FieldValueInfo> fieldValueInfoList) {
-
+    default CompletableFuture<Void> onFieldValuesInfo(List<FieldValueInfo> fieldValueInfoList) {
+        return CompletableFuture.completedFuture(null);
     }
 
     default void onFieldValuesException() {

--- a/src/main/java/graphql/execution/instrumentation/InstrumentationContext.java
+++ b/src/main/java/graphql/execution/instrumentation/InstrumentationContext.java
@@ -19,8 +19,9 @@ public interface InstrumentationContext<T> {
      * This is invoked when the instrumentation step is initially dispatched
      *
      * @param result the result of the step as a completable future
+     * @return instrumented or unmodified result
      */
-    void onDispatched(CompletableFuture<T> result);
+    CompletableFuture<T> onDispatched(CompletableFuture<T> result);
 
     /**
      * This is invoked when the instrumentation step is fully completed

--- a/src/main/java/graphql/execution/instrumentation/SimpleInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/SimpleInstrumentation.java
@@ -45,8 +45,8 @@ public class SimpleInstrumentation implements Instrumentation {
     public ExecutionStrategyInstrumentationContext beginExecutionStrategy(InstrumentationExecutionStrategyParameters parameters) {
         return new ExecutionStrategyInstrumentationContext() {
             @Override
-            public void onDispatched(CompletableFuture<ExecutionResult> result) {
-
+            public CompletableFuture<ExecutionResult> onDispatched(CompletableFuture<ExecutionResult> result) {
+                return result;
             }
 
             @Override

--- a/src/main/java/graphql/execution/instrumentation/SimpleInstrumentationContext.java
+++ b/src/main/java/graphql/execution/instrumentation/SimpleInstrumentationContext.java
@@ -39,10 +39,11 @@ public class SimpleInstrumentationContext<T> implements InstrumentationContext<T
     }
 
     @Override
-    public void onDispatched(CompletableFuture<T> result) {
+    public CompletableFuture<T> onDispatched(CompletableFuture<T> result) {
         if (codeToRunOnDispatch != null) {
             codeToRunOnDispatch.accept(result);
         }
+        return result;
     }
 
     @Override

--- a/src/test/groovy/graphql/ChainedDataLoadersTest.groovy
+++ b/src/test/groovy/graphql/ChainedDataLoadersTest.groovy
@@ -1,0 +1,69 @@
+package graphql
+
+import graphql.schema.GraphQLSchema
+import org.dataloader.BatchLoader
+import org.dataloader.DataLoader
+import org.dataloader.DataLoaderFactory
+import org.dataloader.DataLoaderRegistry
+import spock.lang.Specification
+
+import static graphql.Scalars.GraphQLInt
+import static graphql.Scalars.GraphQLString
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
+import static graphql.schema.GraphQLObjectType.newObject
+import static java.util.concurrent.CompletableFuture.completedFuture
+
+class ChainedDataLoadersTest extends Specification {
+
+    private static final def QUERY = '{ level1field1 { level2field1 level2field2 } }'
+
+    private static final BatchLoader<Integer, Integer> LOADER = v -> completedFuture(v.collect() {++it})
+
+    private static final def REGISTRY = DataLoaderRegistry.newRegistry()
+            .register('loader', DataLoaderFactory.newDataLoader(LOADER))
+            .build()
+
+    private static def dummyQuerySubtype = newObject()
+            .name('Subtype')
+            .field(newFieldDefinition()
+                    .name('level2field1')
+                    .type(GraphQLString)
+                    .dataFetcher(environment -> {
+                        DataLoader<Integer, Integer> loader = REGISTRY.getDataLoader('loader')
+                        loader.load(1).thenCompose(loader::load)
+                    }))
+            .field(newFieldDefinition()
+                    .name('level2field2')
+                    .type(GraphQLInt)
+                    .dataFetcher(environment -> {
+                        DataLoader<Integer, Integer> loader = REGISTRY.getDataLoader('loader')
+                        loader.load(5).thenCompose(loader::load)
+                    }))
+            .build()
+
+    private static def dummyQueryType = newObject()
+            .name('Query')
+            .field(newFieldDefinition()
+                    .name('level1field1')
+                    .type(dummyQuerySubtype)
+                    .dataFetcher(environment -> {
+                        DataLoader<Integer, Integer> loader = REGISTRY.getDataLoader('loader')
+                        loader.load(11).thenCompose(loader::load).thenApply {[:]}
+                    })
+            .build())
+
+    def 'composed data loaders must complete to finish field fetching level'() {
+        given:
+        def graphQL = GraphQL.newGraphQL(GraphQLSchema.newSchema().query(dummyQueryType).build()).build()
+        when:
+        def result = graphQL.execute(ExecutionInput.newExecutionInput(QUERY).dataLoaderRegistry(REGISTRY).build()).data
+        then:
+        result == [
+                level1field1: [
+                        level2field1: '3',
+                        level2field2: 7
+                ]
+        ]
+    }
+
+}

--- a/src/test/groovy/graphql/ComposedDataLoadersTest.groovy
+++ b/src/test/groovy/graphql/ComposedDataLoadersTest.groovy
@@ -13,7 +13,7 @@ import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
 import static graphql.schema.GraphQLObjectType.newObject
 import static java.util.concurrent.CompletableFuture.completedFuture
 
-class ChainedDataLoadersTest extends Specification {
+class ComposedDataLoadersTest extends Specification {
 
     private static final def QUERY = '{ level1field1 { level2field1 level2field2 } }'
 
@@ -23,38 +23,38 @@ class ChainedDataLoadersTest extends Specification {
             .register('loader', DataLoaderFactory.newDataLoader(LOADER))
             .build()
 
-    private static def dummyQuerySubtype = newObject()
+    private static final def DUMMY_QUERY_SUBTYPE = newObject()
             .name('Subtype')
             .field(newFieldDefinition()
                     .name('level2field1')
                     .type(GraphQLString)
                     .dataFetcher(environment -> {
-                        DataLoader<Integer, Integer> loader = REGISTRY.getDataLoader('loader')
+                        DataLoader<Integer, Integer> loader = environment.getDataLoader('loader')
                         loader.load(1).thenCompose(loader::load)
                     }))
             .field(newFieldDefinition()
                     .name('level2field2')
                     .type(GraphQLInt)
                     .dataFetcher(environment -> {
-                        DataLoader<Integer, Integer> loader = REGISTRY.getDataLoader('loader')
+                        DataLoader<Integer, Integer> loader = environment.getDataLoader('loader')
                         loader.load(5).thenCompose(loader::load)
                     }))
             .build()
 
-    private static def dummyQueryType = newObject()
+    private static final def DUMMY_QUERY_TYPE = newObject()
             .name('Query')
             .field(newFieldDefinition()
                     .name('level1field1')
-                    .type(dummyQuerySubtype)
+                    .type(DUMMY_QUERY_SUBTYPE)
                     .dataFetcher(environment -> {
-                        DataLoader<Integer, Integer> loader = REGISTRY.getDataLoader('loader')
+                        DataLoader<Integer, Integer> loader = environment.getDataLoader('loader')
                         loader.load(11).thenCompose(loader::load).thenApply {[:]}
                     })
             .build())
 
     def 'composed data loaders must complete to finish field fetching level'() {
         given:
-        def graphQL = GraphQL.newGraphQL(GraphQLSchema.newSchema().query(dummyQueryType).build()).build()
+        def graphQL = GraphQL.newGraphQL(GraphQLSchema.newSchema().query(DUMMY_QUERY_TYPE).build()).build()
         when:
         def result = graphQL.execute(ExecutionInput.newExecutionInput(QUERY).dataLoaderRegistry(REGISTRY).build()).data
         then:

--- a/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy
@@ -246,17 +246,17 @@ class AsyncExecutionStrategyTest extends Specification {
                         return new ExecutionStrategyInstrumentationContext() {
 
                             @Override
-                            void onFieldValuesInfo(List<FieldValueInfo> fieldValueInfoList) {
+                            CompletableFuture<Void> onFieldValuesInfo(List<FieldValueInfo> fieldValueInfoList) {
                                 throw new RuntimeException("Exception raised from instrumentation")
                             }
 
                             @Override
-                            public void onDispatched(CompletableFuture<ExecutionResult> result) {
-
+                            CompletableFuture<ExecutionResult> onDispatched(CompletableFuture<ExecutionResult> result) {
+                                return result;
                             }
 
                             @Override
-                            public void onCompleted(ExecutionResult result, Throwable t) {
+                            void onCompleted(ExecutionResult result, Throwable t) {
 
                             }
                         }

--- a/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
@@ -169,9 +169,10 @@ class InstrumentationTest extends Specification {
             return new ExecutionStrategyInstrumentationContext() {
 
                 @Override
-                void onDispatched(CompletableFuture<ExecutionResult> result) {
+                CompletableFuture<ExecutionResult> onDispatched(CompletableFuture<ExecutionResult> result) {
                     System.out.println(String.format("t%s setting go signal on", Thread.currentThread().getId()))
                     goSignal.set(true)
+                    return result;
                 }
 
                 @Override

--- a/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
@@ -146,7 +146,7 @@ class InstrumentationTest extends Specification {
 
         then:
         instrumentation.throwableList.size() == 1
-        instrumentation.throwableList[0].getMessage() == "DF BANG!"
+        instrumentation.throwableList[0].getCause().getMessage() == "DF BANG!"
     }
 
     /**

--- a/src/test/groovy/graphql/execution/instrumentation/TestingInstrumentContext.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/TestingInstrumentContext.groovy
@@ -25,10 +25,11 @@ class TestingInstrumentContext<T> implements InstrumentationContext<T> {
     }
 
     @Override
-    void onDispatched(CompletableFuture<T> result) {
+    CompletableFuture<T> onDispatched(CompletableFuture<T> result) {
         if (useOnDispatch) {
             this.executionList << "onDispatched:$op"
         }
+        result
     }
 
     @Override

--- a/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentationTest.groovy
@@ -99,9 +99,9 @@ class DataLoaderDispatcherInstrumentationTest extends Specification {
         def dispatchedCalled = false
         def dataLoaderRegistry = new DataLoaderRegistry() {
             @Override
-            void dispatchAll() {
+            CompletableFuture<?> dispatch() {
                 dispatchedCalled = true
-                super.dispatchAll()
+                super.dispatch()
             }
         }
         def dataLoader = DataLoader.newDataLoader(new BatchLoader() {


### PR DESCRIPTION
This PR is an attempt to solve a problem described here
https://github.com/graphql-java/java-dataloader/issues/54

The general idea is that data loader registry can return a completable future as a result of `public CompletableFuture<Integer> dispatch()` call. This future can be used by graphql-java to reliably identify level fetching completion.

The current change is using the code from this PR in data loader library: https://github.com/graphql-java/java-dataloader/pull/111
