### PR TITLE
discuss: undeprecate setting data fetchers directly on fields

### DIFF
--- a/src/main/java/graphql/schema/GraphQLFieldDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLFieldDefinition.java
@@ -303,10 +303,7 @@ public class GraphQLFieldDefinition implements GraphQLNamedSchemaElement, GraphQ
          * @param dataFetcher the data fetcher to use
          *
          * @return this builder
-         *
-         * @deprecated use {@link graphql.schema.GraphQLCodeRegistry} instead
          */
-        @Deprecated
         public Builder dataFetcher(DataFetcher<?> dataFetcher) {
             assertNotNull(dataFetcher, () -> "dataFetcher must be not null");
             this.dataFetcherFactory = DataFetcherFactories.useDataFetcher(dataFetcher);
@@ -319,10 +316,7 @@ public class GraphQLFieldDefinition implements GraphQLNamedSchemaElement, GraphQ
          * @param dataFetcherFactory the data fetcher factory
          *
          * @return this builder
-         *
-         * @deprecated use {@link graphql.schema.GraphQLCodeRegistry} instead
          */
-        @Deprecated
         public Builder dataFetcherFactory(DataFetcherFactory<?> dataFetcherFactory) {
             assertNotNull(dataFetcherFactory, () -> "dataFetcherFactory must be not null");
             this.dataFetcherFactory = dataFetcherFactory;
@@ -335,10 +329,7 @@ public class GraphQLFieldDefinition implements GraphQLNamedSchemaElement, GraphQ
          * @param value the value to always return
          *
          * @return this builder
-         *
-         * @deprecated use {@link graphql.schema.GraphQLCodeRegistry} instead
          */
-        @Deprecated
         public Builder staticValue(final Object value) {
             this.dataFetcherFactory = DataFetcherFactories.useDataFetcher(environment -> value);
             return this;


### PR DESCRIPTION
We rely pretty heavily on being able to assign a data fetcher to a field at the point that we are generating it, in part because that's what our previous graphql implementation required and the ability to do this in graphql-java made our migration into GJ feasible.

The ability to configure a data fetcher on a field is currently deprecated, with an encouragement to migrate to a GraphQLCodeRegistry. This migration is considerably difficult for us, to the point that I'd like to test the waters of keeping this code-path well supported into the future. 

I believe that keeping this around as a first-class schema generation path would simplify GJ migration efforts for other services into the future, though I don't know what the cost of supporting this feature looks like for graphql-java. Thoughts?