### PR TITLE
Fix instances of incorrectly sized Maps and Sets

### DIFF
--- a/src/main/java/graphql/execution/instrumentation/ChainedInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/ChainedInstrumentation.java
@@ -1,6 +1,7 @@
 package graphql.execution.instrumentation;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
 import graphql.ExecutionInput;
 import graphql.ExecutionResult;
 import graphql.PublicApi;
@@ -210,7 +211,7 @@ public class ChainedInstrumentation implements Instrumentation {
 
 
         private ChainedInstrumentationState(List<Instrumentation> instrumentations, InstrumentationCreateStateParameters parameters) {
-            instrumentationStates = new LinkedHashMap<>(instrumentations.size());
+            instrumentationStates = Maps.newLinkedHashMapWithExpectedSize(instrumentations.size());
             instrumentations.forEach(i -> instrumentationStates.put(i, i.createState(parameters)));
         }
 

--- a/src/main/java/graphql/validation/rules/UniqueArgumentNamesRule.java
+++ b/src/main/java/graphql/validation/rules/UniqueArgumentNamesRule.java
@@ -1,5 +1,6 @@
 package graphql.validation.rules;
 
+import com.google.common.collect.Sets;
 import graphql.Internal;
 import graphql.language.Argument;
 import graphql.language.Directive;
@@ -10,7 +11,6 @@ import graphql.validation.ValidationContext;
 import graphql.validation.ValidationErrorCollector;
 import graphql.validation.ValidationErrorType;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -31,7 +31,7 @@ public class UniqueArgumentNamesRule extends AbstractRule {
             return;
         }
 
-        Set<String> arguments = new HashSet<>();
+        Set<String> arguments = Sets.newHashSetWithExpectedSize(field.getArguments().size());
 
         for (Argument argument : field.getArguments()) {
             if (arguments.contains(argument.getName())) {
@@ -48,7 +48,7 @@ public class UniqueArgumentNamesRule extends AbstractRule {
             return;
         }
 
-        Set<String> arguments = new HashSet<>(directive.getArguments().size());
+        Set<String> arguments = Sets.newHashSetWithExpectedSize(directive.getArguments().size());
 
         for (Argument argument : directive.getArguments()) {
             if (arguments.contains(argument.getName())) {


### PR DESCRIPTION
Fix a few occurrences where a Map or Set was initialized with an initial capacity
value N, and then immediately filled with N items, which would always trigger
a resize.