### PR TITLE
Fix bug in AstPrinter preventing query short form from being used

### DIFF
--- a/src/main/java/graphql/language/AstPrinter.java
+++ b/src/main/java/graphql/language/AstPrinter.java
@@ -294,7 +294,7 @@ public class AstPrinter {
 
             // Anonymous queries with no directives or variable definitions can use
             // the query short form.
-            if (isEmpty(name) && isEmpty(directives) && isEmpty(varDefinitions) && op.equals("QUERY")) {
+            if (isEmpty(name) && isEmpty(directives) && isEmpty(varDefinitions) && op.equals("query")) {
                 out.append(selectionSet);
             } else {
                 out.append(spaced(op, smooshed(name, varDefinitions), directives, selectionSet));

--- a/src/test/groovy/graphql/analysis/QueryTransformerTest.groovy
+++ b/src/test/groovy/graphql/analysis/QueryTransformerTest.groovy
@@ -80,7 +80,7 @@ class QueryTransformerTest extends Specification {
 
         then:
         printAstCompact(newDocument) ==
-                "query {root {fooA {midA-modified {leafA} midB {leafB}} fooB {midA-modified {leafA} midB {leafB}}}}"
+                "{root {fooA {midA-modified {leafA} midB {leafB}} fooB {midA-modified {leafA} midB {leafB}}}}"
     }
 
     def "transform query delete midA nodes"() {
@@ -102,7 +102,7 @@ class QueryTransformerTest extends Specification {
 
         then:
         printAstCompact(newDocument) ==
-                "query {root {fooA {midB {leafB}} fooB {midB {leafB}}}}"
+                "{root {fooA {midB {leafB}} fooB {midB {leafB}}}}"
     }
 
     def "transform query add midA sibling"() {
@@ -124,7 +124,7 @@ class QueryTransformerTest extends Specification {
 
         then:
         printAstCompact(newDocument) ==
-                "query {root {fooA {midA {leafA} addedField}}}"
+                "{root {fooA {midA {leafA} addedField}}}"
     }
 
     def "transform query delete fragment spread and inline fragment"() {
@@ -170,7 +170,7 @@ class QueryTransformerTest extends Specification {
         then:
 
         printAstCompact(newDocument) ==
-                "query {root {fooA {midB {leafB}} fooB {midB {leafB}}}} fragment frag on Foo {midA {leafA}}"
+                "{root {fooA {midB {leafB}} fooB {midB {leafB}}}} fragment frag on Foo {midA {leafA}}"
     }
 
     def "transform query does not traverse named fragments when started from query"() {

--- a/src/test/groovy/graphql/execution/preparsed/persisted/ApolloPersistedQuerySupportTest.groovy
+++ b/src/test/groovy/graphql/execution/preparsed/persisted/ApolloPersistedQuerySupportTest.groovy
@@ -69,7 +69,7 @@ class ApolloPersistedQuerySupportTest extends Specification {
         def documentEntry = apolloSupport.getDocument(ei, engineParser)
         def doc = documentEntry.getDocument()
         then:
-        printAstCompact(doc) == "query {oneTwoThree}"
+        printAstCompact(doc) == "{oneTwoThree}"
         persistedQueryCache.keyCount[hashOne] == 1
         persistedQueryCache.parseCount[hashOne] == 1
 
@@ -79,7 +79,7 @@ class ApolloPersistedQuerySupportTest extends Specification {
         doc = documentEntry.getDocument()
 
         then:
-        printAstCompact(doc) == "query {oneTwoThree}"
+        printAstCompact(doc) == "{oneTwoThree}"
         persistedQueryCache.keyCount[hashOne] == 2
         persistedQueryCache.parseCount[hashOne] == 1 // only compiled once cause we had it
     }
@@ -94,7 +94,7 @@ class ApolloPersistedQuerySupportTest extends Specification {
         def documentEntry = apolloSupport.getDocument(ei, engineParser)
         def doc = documentEntry.getDocument()
         then:
-        printAstCompact(doc) == "query {normal}"
+        printAstCompact(doc) == "{normal}"
         persistedQueryCache.keyCount.size() == 0
         persistedQueryCache.parseCount.size() == 0
     }
@@ -104,11 +104,11 @@ class ApolloPersistedQuerySupportTest extends Specification {
         def apolloSupport = new ApolloPersistedQuerySupport(persistedQueryCache)
 
         when:
-        def ei = mkEI(hashOne, "query {normal}")
+        def ei = mkEI(hashOne, "{normal}")
         def documentEntry = apolloSupport.getDocument(ei, engineParser)
         def doc = documentEntry.getDocument()
         then:
-        printAstCompact(doc) == "query {oneTwoThree}"
+        printAstCompact(doc) == "{oneTwoThree}"
         persistedQueryCache.keyCount[hashOne] == 1
         persistedQueryCache.parseCount[hashOne] == 1
 
@@ -140,14 +140,14 @@ class ApolloPersistedQuerySupportTest extends Specification {
         def documentEntry = apolloSupport.getDocument(ei, engineParser)
         def doc = documentEntry.getDocument()
         then:
-        printAstCompact(doc) == "query {oneTwoThree}"
+        printAstCompact(doc) == "{oneTwoThree}"
 
         when:
         ei = mkEI(hashTwo, PERSISTED_QUERY_MARKER)
         documentEntry = apolloSupport.getDocument(ei, engineParser)
         doc = documentEntry.getDocument()
         then:
-        printAstCompact(doc) == "query {fourFiveSix}"
+        printAstCompact(doc) == "{fourFiveSix}"
 
         when:
         ei = mkEI("nonExistent", PERSISTED_QUERY_MARKER)

--- a/src/test/groovy/graphql/execution/preparsed/persisted/InMemoryPersistedQueryCacheTest.groovy
+++ b/src/test/groovy/graphql/execution/preparsed/persisted/InMemoryPersistedQueryCacheTest.groovy
@@ -40,19 +40,19 @@ class InMemoryPersistedQueryCacheTest extends Specification {
         def getDoc = inMemCache.getPersistedQueryDocument(hash, ei, onMiss)
         def doc = getDoc.document
         then:
-        printAstCompact(doc) == "query {oneTwoThreeFour}"
+        printAstCompact(doc) == "{oneTwoThreeFour}"
     }
 
     def "When there's a cache miss, uses the query from known queries if the execution input's query is the APQ Marker"() {
         def hash = "somehash"
         def inMemCache = InMemoryPersistedQueryCache.newInMemoryPersistedQueryCache()
-                .addQuery(hash, "query {foo bar baz}")
+                .addQuery(hash, "{foo bar baz}")
                 .build()
         def ei = mkEI(hash, PersistedQuerySupport.PERSISTED_QUERY_MARKER)
         when:
         def getDoc = inMemCache.getPersistedQueryDocument(hash, ei, onMiss)
         def doc = getDoc.document
         then:
-        printAstCompact(doc) == "query {foo bar baz}"
+        printAstCompact(doc) == "{foo bar baz}"
     }
 }

--- a/src/test/groovy/graphql/language/AstPrinterTest.groovy
+++ b/src/test/groovy/graphql/language/AstPrinterTest.groovy
@@ -199,7 +199,7 @@ scalar DateTime
         String output = printAst(document)
 
         expect:
-        output == """query {
+        output == """{
   empireHero: hero(episode: EMPIRE) {
     name
   }
@@ -235,7 +235,7 @@ fragment comparisonFields on Character {
         String output = printAst(document)
 
         expect:
-        output == """query {
+        output == """{
   leftComparison: hero(episode: EMPIRE) {
     ...comparisonFields
   }
@@ -563,7 +563,7 @@ extend input Input @directive {
         String output = AstPrinter.printAstCompact(document)
 
         expect:
-        output == '''query {aliasOfFoo:foo(arg1:"val1",args2:"val2") @isCached {hello} world @neverCache @okThenCache} fragment FX on SomeType {aliased:field(withArgs:"argVal",andMoreArgs:"andMoreVals")}'''
+        output == '''{aliasOfFoo:foo(arg1:"val1",args2:"val2") @isCached {hello} world @neverCache @okThenCache} fragment FX on SomeType {aliased:field(withArgs:"argVal",andMoreArgs:"andMoreVals")}'''
     }
 
     def "print ast with inline fragment without type condition"() {
@@ -581,8 +581,8 @@ extend input Input @directive {
         String outputFull = AstPrinter.printAst(document)
 
         expect:
-        outputCompact == '''query {foo {... {hello}}}'''
-        outputFull == '''query {
+        outputCompact == '''{foo {... {hello}}}'''
+        outputFull == '''{
   foo {
     ... {
       hello

--- a/src/test/groovy/graphql/language/AstSignatureTest.groovy
+++ b/src/test/groovy/graphql/language/AstSignatureTest.groovy
@@ -110,7 +110,7 @@ fragment X on SomeType {
         }
     }"""
 
-        def expectedQuery = """query {
+        def expectedQuery = """{
   allIssues(arg1: "", arg2: 0) {
     id
   }

--- a/src/test/groovy/graphql/language/AstSorterTest.groovy
+++ b/src/test/groovy/graphql/language/AstSorterTest.groovy
@@ -97,7 +97,7 @@ class AstSorterTest extends Specification {
     
 '''
 
-        def expectedQuery = '''query {
+        def expectedQuery = '''{
   unamedQueryX
   unamedQueryY
   unamedQueryZ
@@ -340,7 +340,7 @@ input InputZ {
             }
         '''
 
-        def expectedQuery = '''query {
+        def expectedQuery = '''{
   field(arg: {x : {a : "vala", b : "valb", c : "valc"}, y : "valy", z : "valz"})
 }
 '''

--- a/src/test/groovy/graphql/language/AstTransformerTest.groovy
+++ b/src/test/groovy/graphql/language/AstTransformerTest.groovy
@@ -38,7 +38,7 @@ class AstTransformerTest extends Specification {
 
         then:
         printAstCompact(newDocument) ==
-                "query {root {foo {midA-modified {leafA} midB-modified {leafB}} bar {midC-modified {leafC} midD-modified {leafD}}}}"
+                "{root {foo {midA-modified {leafA} midB-modified {leafB}} bar {midC-modified {leafC} midD-modified {leafD}}}}"
     }
 
     def "modify multiple nodes parallel"() {
@@ -66,7 +66,7 @@ class AstTransformerTest extends Specification {
 
         then:
         printAstCompact(newDocument) ==
-                "query {root {foo {midA-modified {leafA} midB-modified {leafB}} bar {midC-modified {leafC} midD-modified {leafD}}}}"
+                "{root {foo {midA-modified {leafA} midB-modified {leafB}} bar {midC-modified {leafC} midD-modified {leafD}}}}"
     }
 
     def "no change at all"() {
@@ -116,7 +116,7 @@ class AstTransformerTest extends Specification {
         def newDocument = astTransformer.transform(document, visitor)
 
         then:
-        printAstCompact(newDocument) == "query {foo2}"
+        printAstCompact(newDocument) == "{foo2}"
 
     }
 
@@ -139,7 +139,7 @@ class AstTransformerTest extends Specification {
         def newDocument = astTransformer.transformParallel(document, visitor)
 
         then:
-        printAstCompact(newDocument) == "query {foo2}"
+        printAstCompact(newDocument) == "{foo2}"
 
     }
 
@@ -165,7 +165,7 @@ class AstTransformerTest extends Specification {
         def newDocument = astTransformer.transform(document, visitor)
 
         then:
-        printAstCompact(newDocument) == "query {foo2 {a b}}"
+        printAstCompact(newDocument) == "{foo2 {a b}}"
 
     }
 
@@ -191,7 +191,7 @@ class AstTransformerTest extends Specification {
         def newDocument = astTransformer.transformParallel(document, visitor)
 
         then:
-        printAstCompact(newDocument) == "query {foo2 {a b}}"
+        printAstCompact(newDocument) == "{foo2 {a b}}"
 
     }
 
@@ -217,7 +217,7 @@ class AstTransformerTest extends Specification {
         def newDocument = astTransformer.transform(document, visitor)
 
         then:
-        printAstCompact(newDocument) == "query {root {a(a_arg:2) {v w} b(b_arg:1) {x y}}}"
+        printAstCompact(newDocument) == "{root {a(a_arg:2) {v w} b(b_arg:1) {x y}}}"
 
     }
 
@@ -242,7 +242,7 @@ class AstTransformerTest extends Specification {
         def newDocument = astTransformer.transformParallel(document, visitor)
 
         then:
-        printAstCompact(newDocument) == "query {root {a(a_arg:2) {v w} b(b_arg:1) {x y}}}"
+        printAstCompact(newDocument) == "{root {a(a_arg:2) {v w} b(b_arg:1) {x y}}}"
 
     }
 
@@ -268,7 +268,7 @@ class AstTransformerTest extends Specification {
         def newDocument = astTransformer.transform(document, visitor)
 
         then:
-        printAstCompact(newDocument) == "query {root {a(arg:1) {x y}}}"
+        printAstCompact(newDocument) == "{root {a(arg:1) {x y}}}"
 
     }
 
@@ -293,7 +293,7 @@ class AstTransformerTest extends Specification {
         def newDocument = astTransformer.transformParallel(document, visitor)
 
         then:
-        printAstCompact(newDocument) == "query {root {a(arg:1) {x y}}}"
+        printAstCompact(newDocument) == "{root {a(arg:1) {x y}}}"
 
     }
 
@@ -318,7 +318,7 @@ class AstTransformerTest extends Specification {
         def newDocument = astTransformer.transform(document, visitor)
 
         then:
-        printAstCompact(newDocument) == "query {root {a(arg:1) {x y}}}"
+        printAstCompact(newDocument) == "{root {a(arg:1) {x y}}}"
 
     }
 
@@ -347,7 +347,7 @@ class AstTransformerTest extends Specification {
         def newDocument = astTransformer.transform(document, visitor, rootVars)
 
         then:
-        printAstCompact(newDocument) == "query {root {a(arg:1) {x y}}}"
+        printAstCompact(newDocument) == "{root {a(arg:1) {x y}}}"
 
     }
 
@@ -373,7 +373,7 @@ class AstTransformerTest extends Specification {
         def newDocument = astTransformer.transformParallel(document, visitor)
 
         then:
-        printAstCompact(newDocument) == "query {root {a(arg:1) {x y}}}"
+        printAstCompact(newDocument) == "{root {a(arg:1) {x y}}}"
 
     }
 
@@ -407,8 +407,8 @@ class AstTransformerTest extends Specification {
 
         then:
 
-        printAstCompact(newDocument) == "query {root {aChanged(arg:1) {y1} b {y2} new}}"
-        printAstCompact(newDocumentParallel) == "query {root {aChanged(arg:1) {y1} b {y2} new}}"
+        printAstCompact(newDocument) == "{root {aChanged(arg:1) {y1} b {y2} new}}"
+        printAstCompact(newDocumentParallel) == "{root {aChanged(arg:1) {y1} b {y2} new}}"
 
     }
 
@@ -431,8 +431,8 @@ class AstTransformerTest extends Specification {
         def newDocumentParallel = astTransformer.transformParallel(document, visitor)
 
         then:
-        printAstCompact(newDocument) == "query {foo foo2}"
-        printAstCompact(newDocumentParallel) == "query {foo foo2}"
+        printAstCompact(newDocument) == "{foo foo2}"
+        printAstCompact(newDocumentParallel) == "{foo foo2}"
 
     }
 
@@ -455,8 +455,8 @@ class AstTransformerTest extends Specification {
         def newDocumentParallel = astTransformer.transformParallel(document, visitor)
 
         then:
-        printAstCompact(newDocument) == "query {foo2 foo}"
-        printAstCompact(newDocumentParallel) == "query {foo2 foo}"
+        printAstCompact(newDocument) == "{foo2 foo}"
+        printAstCompact(newDocumentParallel) == "{foo2 foo}"
 
     }
 
@@ -480,7 +480,7 @@ class AstTransformerTest extends Specification {
         def newDocument = astTransformer.transform(document, visitor)
 
         then:
-        printAstCompact(newDocument) == "query {foo2 foo foo3}"
+        printAstCompact(newDocument) == "{foo2 foo foo3}"
 
     }
 
@@ -504,7 +504,7 @@ class AstTransformerTest extends Specification {
         def newDocument = astTransformer.transformParallel(document, visitor)
 
         then:
-        printAstCompact(newDocument) == "query {foo2 foo foo3}"
+        printAstCompact(newDocument) == "{foo2 foo foo3}"
 
     }
 
@@ -532,8 +532,8 @@ class AstTransformerTest extends Specification {
         def newDocumentParallel = astTransformer.transformParallel(document, visitor)
 
         then:
-        printAstCompact(newDocument) == "query {root {a(arg:1) {x y} newOne}}"
-        printAstCompact(newDocumentParallel) == "query {root {a(arg:1) {x y} newOne}}"
+        printAstCompact(newDocument) == "{root {a(arg:1) {x y} newOne}}"
+        printAstCompact(newDocumentParallel) == "{root {a(arg:1) {x y} newOne}}"
 
     }
 
@@ -562,8 +562,8 @@ class AstTransformerTest extends Specification {
         def newDocumentParallel = astTransformer.transformParallel(document, visitor)
 
         then:
-        printAstCompact(newDocument) == "query {root {a-changed(arg:1) {x y}}}"
-        printAstCompact(newDocumentParallel) == "query {root {a-changed(arg:1) {x y}}}"
+        printAstCompact(newDocument) == "{root {a-changed(arg:1) {x y}}}"
+        printAstCompact(newDocumentParallel) == "{root {a-changed(arg:1) {x y}}}"
 
 
     }
@@ -629,8 +629,8 @@ class AstTransformerTest extends Specification {
         def newDocumentParallel = astTransformer.transformParallel(document, visitor)
 
         then:
-        printAstCompact(newDocument) == "query {field(newArg1:10,arg2:2,arg3:10) @directive1 @after1Directive @newDirective2}"
-        printAstCompact(newDocumentParallel) == "query {field(newArg1:10,arg2:2,arg3:10) @directive1 @after1Directive @newDirective2}"
+        printAstCompact(newDocument) == "{field(newArg1:10,arg2:2,arg3:10) @directive1 @after1Directive @newDirective2}"
+        printAstCompact(newDocumentParallel) == "{field(newArg1:10,arg2:2,arg3:10) @directive1 @after1Directive @newDirective2}"
 
     }
 
@@ -661,8 +661,8 @@ class AstTransformerTest extends Specification {
         def newDocumentParallel = astTransformer.transformParallel(document, visitor)
 
         then:
-        printAstCompact(newDocument) == "query {field @before @directive1 @after @directive2}"
-        printAstCompact(newDocumentParallel) == "query {field @before @directive1 @after @directive2}"
+        printAstCompact(newDocument) == "{field @before @directive1 @after @directive2}"
+        printAstCompact(newDocumentParallel) == "{field @before @directive1 @after @directive2}"
 
     }
 
@@ -708,8 +708,8 @@ class AstTransformerTest extends Specification {
         def newDocumentParallel = astTransformer.transformParallel(document, visitor)
 
         then:
-        printAstCompact(newDocument) == "query {field(arg1:1,a1:10,a4:10,a2:10,a3:10) @d5 @directive1 @d4 @d1 @d2 @d3}"
-        printAstCompact(newDocumentParallel) == "query {field(arg1:1,a1:10,a4:10,a2:10,a3:10) @d5 @directive1 @d4 @d1 @d2 @d3}"
+        printAstCompact(newDocument) == "{field(arg1:1,a1:10,a4:10,a2:10,a3:10) @d5 @directive1 @d4 @d1 @d2 @d3}"
+        printAstCompact(newDocumentParallel) == "{field(arg1:1,a1:10,a4:10,a2:10,a3:10) @d5 @directive1 @d4 @d1 @d2 @d3}"
 
     }
 
@@ -741,8 +741,8 @@ class AstTransformerTest extends Specification {
         def newDocumentParallel = astTransformer.transformParallel(document, visitor)
 
         then:
-        printAstCompact(newDocument) == "query {first-changed second-changed after-second-1 after-second-2}"
-        printAstCompact(newDocumentParallel) == "query {first-changed second-changed after-second-1 after-second-2}"
+        printAstCompact(newDocument) == "{first-changed second-changed after-second-1 after-second-2}"
+        printAstCompact(newDocumentParallel) == "{first-changed second-changed after-second-1 after-second-2}"
 
     }
 
@@ -772,7 +772,7 @@ class AstTransformerTest extends Specification {
         def newDocument = astTransformer.transform(document, visitor)
 
         then:
-        printAstCompact(newDocument) == "query {before-1 before-2 changed after-1 after-2 after-3}"
+        printAstCompact(newDocument) == "{before-1 before-2 changed after-1 after-2 after-3}"
 
     }
 
@@ -797,8 +797,8 @@ class AstTransformerTest extends Specification {
         def newDocumentParallel = astTransformer.transformParallel(document, visitor)
 
         then:
-        printAstCompact(newDocument) == "query {change3}"
-        printAstCompact(newDocumentParallel) == "query {change3}"
+        printAstCompact(newDocument) == "{change3}"
+        printAstCompact(newDocumentParallel) == "{change3}"
 
     }
 

--- a/src/test/groovy/graphql/normalized/ExecutableNormalizedOperationToAstCompilerTest.groovy
+++ b/src/test/groovy/graphql/normalized/ExecutableNormalizedOperationToAstCompilerTest.groovy
@@ -125,7 +125,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         def result = compileToDocument(schema, QUERY, null, fields, noVariables)
         def printed = AstPrinter.printAst(new AstSorter().sort(result.document))
         then:
-        printed == '''query {
+        printed == '''{
   animal {
     name
     otherName: name
@@ -197,7 +197,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         def printed = AstPrinter.printAst(new AstSorter().sort(result.document))
 
         then:
-        printed == """query {
+        printed == """{
   animal {
     parent {
       name
@@ -248,7 +248,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         def printed = AstPrinter.printAst(new AstSorter().sort(result.document))
 
         then:
-        printed == """query {
+        printed == """{
   animal {
     parent {
       name
@@ -329,7 +329,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         def printed = AstPrinter.printAst(new AstSorter().sort(result.document))
 
         then:
-        printed == """query {
+        printed == """{
   animal {
     parent {
       name
@@ -420,7 +420,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         def printed = AstPrinter.printAst(new AstSorter().sort(result.document))
 
         then:
-        printed == """query {
+        printed == """{
   animal {
     parent {
       name
@@ -515,7 +515,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         def printed = AstPrinter.printAst(new AstSorter().sort(result.document))
 
         then:
-        printed == """query {
+        printed == """{
   animal {
     parent {
       name
@@ -582,7 +582,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         def printed = AstPrinter.printAst(new AstSorter().sort(result.document))
 
         then:
-        printed == """query {
+        printed == """{
   animal {
     ... on Cat {
       __typename
@@ -639,7 +639,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         def printed = AstPrinter.printAst(new AstSorter().sort(result.document))
 
         then:
-        printed == """query {
+        printed == """{
   animal {
     __typename
     ... on Cat {
@@ -704,7 +704,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         // --Cat.name: String
         // --Dog.name: String
         // --Dog.isGoodBoy: Boolean
-        printed == """query {
+        printed == """{
   animal {
     __typename
     ... on Cat {
@@ -765,7 +765,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
 
         then:
         // Note: the name field is spread across both fragments
-        printed == """query {
+        printed == """{
   animal {
     ... on Cat {
       parent {
@@ -863,7 +863,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
 
         then:
         // Ensure that age location name etc are not surrounded by fragments unnecessarily
-        printed == """query {
+        printed == """{
   animal {
     __typename
     age
@@ -961,7 +961,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
 
         then:
         // Ensure that __typename id fieldId fieldName etc. are not surrounded by fragments unnecessarily
-        printed == """query {
+        printed == """{
   issue {
     fields {
       __typename
@@ -1027,7 +1027,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
 
         then:
-        documentPrinted == '''query {
+        documentPrinted == '''{
   foo(arg: {arg1 : "fooArg"}) {
     bar(arg: {arg1 : "barArg"}) {
       baz {
@@ -1061,7 +1061,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
 
         then:
-        documentPrinted == '''query {
+        documentPrinted == '''{
   foo1(arg: "hello")
   foo2(a: 123, b: true, c: 123.45)
 }
@@ -1132,7 +1132,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
 
         then:
-        documentPrinted == '''query {
+        documentPrinted == '''{
   foo1(arg: {arg1 : "Hello", arg2 : 123, arg3 : "IDID", arg4 : false, arg5 : 123.123, nested : {arg1 : "Hello2", arg2 : 1234, arg3 : "IDID1", arg4 : null, arg5 : null}})
 }
 '''
@@ -1278,7 +1278,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         def result = compileToDocument(schema, QUERY, null, fields, noVariables)
         def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
         then:
-        documentPrinted == '''query {
+        documentPrinted == '''{
   foo1(arg: {arg1 : "Query"}) {
     test
   }
@@ -1324,7 +1324,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         def result = compileToDocument(schema, QUERY, null, fields, noVariables)
         def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
         then:
-        documentPrinted == '''query {
+        documentPrinted == '''{
   __schema {
     queryType {
       fields(includeDeprecated: false) {
@@ -1374,7 +1374,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         def result = compileToDocument(schema, QUERY, null, fields, noVariables)
         def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
         then:
-        documentPrinted == '''query {
+        documentPrinted == '''{
   foo1 {
     test
     ... on AFoo {
@@ -1396,7 +1396,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
             aFoo: String
         }
         '''
-        def query = '''query {
+        def query = '''{
             ... on Query {
                 foo1 {
                     ... on AFoo {
@@ -1413,7 +1413,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         def result = compileToDocument(schema, QUERY, null, fields, noVariables)
         def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
         then:
-        documentPrinted == '''query {
+        documentPrinted == '''{
   foo1 {
     ... on AFoo {
       aFoo
@@ -1465,7 +1465,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
         then:
         // Note: the typename field moves out of a fragment because AFoo is the only impl
-        documentPrinted == '''query {
+        documentPrinted == '''{
   foo1(arg: {arg1 : "Query"}) {
     __typename
     test
@@ -1516,7 +1516,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
         then:
         // Note: the typename field moves out of a fragment because AFoo is the only impl
-        documentPrinted == '''query {
+        documentPrinted == '''{
   foo1(arg: {arg1 : "Query"}) {
     __typename
     test
@@ -1546,7 +1546,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
             arg1: String
         }
         '''
-        def query = '''query {
+        def query = '''{
             ... on Query {
                 foo1(arg: {
                     arg1: "Query"
@@ -1566,7 +1566,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
         then:
         // Note: the typename field moves out of a fragment because AFoo is the only impl
-        documentPrinted == '''query {
+        documentPrinted == '''{
   foo1(arg: {arg1 : "Query"}) {
     test
     ... on AFoo {

--- a/src/test/groovy/graphql/util/AnonymizerTest.groovy
+++ b/src/test/groovy/graphql/util/AnonymizerTest.groovy
@@ -40,7 +40,7 @@ type Object2 {
   field3: ID
 }
 """
-        newQuery == "query {field1 {field2 field3}}"
+        newQuery == "{field1 {field2 field3}}"
     }
 
     def "query with fragments"() {
@@ -75,7 +75,7 @@ type Object2 {
   field3: ID
 }
 """
-        newQuery == "query {...Fragment1 field1 {... on Object2 {field2 field3}}} fragment Fragment1 on Object1 {field1 {field2 field3}}"
+        newQuery == "{...Fragment1 field1 {... on Object2 {field2 field3}}} fragment Fragment1 on Object1 {field1 {field2 field3}}"
 
     }
 
@@ -111,7 +111,7 @@ type Object2 {
   field3: ID
 }
 """
-        newQuery == 'query {field1(argument1:"stringValue1",argument2:"stringValue2") {field2 field3}}'
+        newQuery == '{field1(argument1:"stringValue1",argument2:"stringValue2") {field2 field3}}'
 
     }
 
@@ -285,7 +285,7 @@ type Object2 {
         def newQuery = result.queries[0]
 
         then:
-        newQuery == "query {alias1:field1 {alias2:field3}}"
+        newQuery == "{alias1:field1 {alias2:field3}}"
     }
 
     def "complex schema"() {
@@ -501,7 +501,7 @@ type Object2 {
         def newQuery = result.queries[0]
 
         then:
-        newQuery == "query {field2 {__typename alias1:__typename field1}}"
+        newQuery == "{field2 {__typename alias1:__typename field1}}"
     }
 
     def "handles cyclic types"() {
@@ -791,7 +791,7 @@ type Object2 {
   field2: String
 }
 """
-        newQuery == "query {field1 @Directive1 {field2 @Directive1}}"
+        newQuery == "{field1 @Directive1 {field2 @Directive1}}"
 
     }
 
@@ -806,7 +806,7 @@ type Object2 {
             bar: String
         }
         """)
-        def query = 'query{foo @whatever(myArg: "secret2") {bar @whatever(myArg: "secret3") }}'
+        def query = '{foo @whatever(myArg: "secret2") {bar @whatever(myArg: "secret3") }}'
 
         when:
         def result = Anonymizer.anonymizeSchemaAndQueries(schema, [query])
@@ -828,7 +828,7 @@ type Object2 {
   field2: String
 }
 """
-        newQuery == 'query {field1 @Directive1(argument1:"stringValue2") {field2 @Directive1(argument1:"stringValue1")}}'
+        newQuery == '{field1 @Directive1(argument1:"stringValue2") {field2 @Directive1(argument1:"stringValue1")}}'
 
     }
 

--- a/src/test/groovy/graphql/util/TreeParallelTransformerTest.groovy
+++ b/src/test/groovy/graphql/util/TreeParallelTransformerTest.groovy
@@ -31,7 +31,7 @@ class TreeParallelTransformerTest extends Specification {
         def newDocument = parallelTransformer.transform(document, visitor)
 
         then:
-        printAstCompact(newDocument) == "query {foo2}"
+        printAstCompact(newDocument) == "{foo2}"
 
     }
 
@@ -56,7 +56,7 @@ class TreeParallelTransformerTest extends Specification {
         def newDocument = parallelTransformer.transform(document, visitor)
 
         then:
-        printAstCompact(newDocument) == "query {foo2}"
+        printAstCompact(newDocument) == "{foo2}"
 
     }
 }


### PR DESCRIPTION
AstPrinter's operationDefinition method had a String comparison that would
always fail when checking the node's operation; the String contained in
the op variable was already lowercased, while the constant "QUERY" was
used in the comparison. The result was that query short form was
never used when printing queries.