### PR TITLE
Fix `AstPrinter` to print field descriptions

### DIFF
--- a/src/main/java/graphql/language/AstPrinter.java
+++ b/src/main/java/graphql/language/AstPrinter.java
@@ -5,10 +5,7 @@ import graphql.PublicApi;
 
 import java.io.PrintWriter;
 import java.io.Writer;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static graphql.Assert.assertTrue;
 import static graphql.util.EscapeUtil.escapeJsonString;
@@ -593,8 +590,8 @@ public class AstPrinter {
         for (int i = 0; i < maybeString.length(); i++) {
             char c = maybeString.charAt(i);
             if (c == '\n') {
-                maybeString.replace(i, i + 1, "\n  ");
-                i += 3;
+                maybeString.replace(i,i+1,"\n  ");
+                i+=3;
             }
         }
         return maybeString;

--- a/src/main/java/graphql/language/AstPrinter.java
+++ b/src/main/java/graphql/language/AstPrinter.java
@@ -162,9 +162,9 @@ public class AstPrinter {
     private NodePrinter<FieldDefinition> fieldDefinition() {
         final String argSep = compactMode ? "," : ", ";
         return (out, node) -> {
+            out.append(description(node));
             String args;
             if (hasDescription(node.getInputValueDefinitions()) && !compactMode) {
-                out.append(description(node));
                 args = join(node.getInputValueDefinitions(), "\n");
                 out.append(node.getName())
                         .append(wrap("(\n", args, ")"))

--- a/src/main/java/graphql/language/AstPrinter.java
+++ b/src/main/java/graphql/language/AstPrinter.java
@@ -162,9 +162,9 @@ public class AstPrinter {
     private NodePrinter<FieldDefinition> fieldDefinition() {
         final String argSep = compactMode ? "," : ", ";
         return (out, node) -> {
-            out.append(description(node));
             String args;
-            if (hasDescription(node.getInputValueDefinitions()) && !compactMode) {
+            if (hasDescription(Collections.singletonList(node)) && !compactMode) {
+                out.append(description(node));
                 args = join(node.getInputValueDefinitions(), "\n");
                 out.append(node.getName())
                         .append(wrap("(\n", args, ")"))
@@ -593,8 +593,8 @@ public class AstPrinter {
         for (int i = 0; i < maybeString.length(); i++) {
             char c = maybeString.charAt(i);
             if (c == '\n') {
-                maybeString.replace(i,i+1,"\n  ");
-                i+=3;
+                maybeString.replace(i, i + 1, "\n  ");
+                i += 3;
             }
         }
         return maybeString;
@@ -612,7 +612,6 @@ public class AstPrinter {
      * This will pretty print the AST node in graphql language format
      *
      * @param node the AST node to print
-     *
      * @return the printed node in graphql language format
      */
     public static String printAst(Node node) {
@@ -638,7 +637,6 @@ public class AstPrinter {
      * and comments stripped out of the text.
      *
      * @param node the AST node to print
-     *
      * @return the printed node in a compact graphql language format
      */
     public static String printAstCompact(Node node) {

--- a/src/main/java/graphql/language/AstPrinter.java
+++ b/src/main/java/graphql/language/AstPrinter.java
@@ -5,7 +5,10 @@ import graphql.PublicApi;
 
 import java.io.PrintWriter;
 import java.io.Writer;
-import java.util.*;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 import static graphql.Assert.assertTrue;
 import static graphql.util.EscapeUtil.escapeJsonString;
@@ -609,6 +612,7 @@ public class AstPrinter {
      * This will pretty print the AST node in graphql language format
      *
      * @param node the AST node to print
+     *
      * @return the printed node in graphql language format
      */
     public static String printAst(Node node) {
@@ -634,6 +638,7 @@ public class AstPrinter {
      * and comments stripped out of the text.
      *
      * @param node the AST node to print
+     *
      * @return the printed node in a compact graphql language format
      */
     public static String printAstCompact(Node node) {

--- a/src/test/groovy/graphql/introspection/IntrospectionResultToSchemaTest.groovy
+++ b/src/test/groovy/graphql/introspection/IntrospectionResultToSchemaTest.groovy
@@ -415,7 +415,7 @@ type QueryType {
   id: String!): Human
   droid("id of the droid"
   id: String!): Droid
-}   
+}
 
 "A character in the Star Wars Trilogy"
 interface Character {

--- a/src/test/groovy/graphql/introspection/IntrospectionResultToSchemaTest.groovy
+++ b/src/test/groovy/graphql/introspection/IntrospectionResultToSchemaTest.groovy
@@ -104,13 +104,11 @@ class IntrospectionResultToSchemaTest extends Specification {
 
         then:
         result == """type QueryType implements Query {
-  hero(
-  \"\"\"
+  hero(\"\"\"
   comment about episode
   on two lines
   \"\"\"
-  episode: Episode
-  foo: String = \"bar\"): Character @deprecated(reason: "killed off character")
+  episode: Episode, foo: String = \"bar\"): Character @deprecated(reason: "killed off character")
 }"""
 
     }
@@ -212,9 +210,13 @@ class IntrospectionResultToSchemaTest extends Specification {
         then:
         result == """"A character in the Star Wars Trilogy"
 interface Character {
+  "The id of the character."
   id: String!
+  "The name of the character."
   name: String
+  "The friends of the character, or an empty list if they have none."
   friends: [Character]
+  "Which movies they appear in."
   appearsIn: [Episode]
 }"""
 
@@ -407,22 +409,23 @@ input CharacterInput {
 }
 
 type QueryType {
-  hero(
-  "If omitted, returns the hero of the whole saga. If provided, returns the hero of that particular episode."
+  hero("If omitted, returns the hero of the whole saga. If provided, returns the hero of that particular episode."
   episode: Episode): Character
-  human(
-  "id of the human"
+  human("id of the human"
   id: String!): Human
-  droid(
-  "id of the droid"
+  droid("id of the droid"
   id: String!): Droid
-}
+}   
 
 "A character in the Star Wars Trilogy"
 interface Character {
+  "The id of the character."
   id: String!
+  "The name of the character."
   name: String
+  "The friends of the character, or an empty list if they have none."
   friends: [Character]
+  "Which movies they appear in."
   appearsIn: [Episode]
 }
 
@@ -438,19 +441,29 @@ enum Episode {
 
 "A humanoid creature in the Star Wars universe."
 type Human implements Character {
+  "The id of the human."
   id: String!
+  "The name of the human."
   name: String
+  "The friends of the human, or an empty list if they have none."
   friends: [Character]
+  "Which movies they appear in."
   appearsIn: [Episode]
+  "The home planet of the human, or null if unknown."
   homePlanet: String
 }
 
 "A mechanical creature in the Star Wars universe."
 type Droid implements Character {
+  "The id of the droid."
   id: String!
+  "The name of the droid."
   name: String
+  "The friends of the droid, or an empty list if they have none."
   friends: [Character]
+  "Which movies they appear in."
   appearsIn: [Episode]
+  "The primary function of the droid."
   primaryFunction: String
 }
 """

--- a/src/test/groovy/graphql/language/AstPrinterTest.groovy
+++ b/src/test/groovy/graphql/language/AstPrinterTest.groovy
@@ -472,6 +472,22 @@ type Query {
 
     }
 
+    def "print field descriptions"() {
+        def query = '''type Query {
+  "comment"
+  field: String
+}
+'''
+        def document = parse(query)
+        String output = printAst(document)
+        expect:
+        output == '''type Query {
+  "comment"
+  field: String
+}
+'''
+    }
+
     def "print empty description"() {
         def query = '''
 ""

--- a/src/test/groovy/graphql/language/AstPrinterTest.groovy
+++ b/src/test/groovy/graphql/language/AstPrinterTest.groovy
@@ -474,16 +474,20 @@ type Query {
 
     def "print field descriptions"() {
         def query = '''type Query {
-  "comment"
-  field: String
+  "description"
+  field(
+  "description"
+  a: String): String
 }
 '''
         def document = parse(query)
         String output = printAst(document)
         expect:
         output == '''type Query {
-  "comment"
-  field: String
+  "description"
+  field(
+  "description"
+  a: String): String
 }
 '''
     }


### PR DESCRIPTION
`AstPrinter.printAst` omits field descriptions when there are no arguments or the arguments have no descriptions.

**To reproduce** 

```graphql
AstPrinter.printAst(Parser().parseDocument("""type Query { "comment" a: String }"""))
```

```graphql
AstPrinter.printAst(Parser().parseDocument("""type Query { "comment" a("comment2" s: String): String }"""))
```