### PR TITLE
Fixes SchemaDiff Bug where unchanged deprecated enum marked DEPRECATION_ADDED

### DIFF
--- a/src/main/java/graphql/schema/diff/SchemaDiff.java
+++ b/src/main/java/graphql/schema/diff/SchemaDiff.java
@@ -477,7 +477,7 @@ public class SchemaDiff {
                         .components(enumName)
                         .reasonMsg("The new API has added a new enum value '%s'", enumName)
                         .build());
-            } else if (isDeprecated(newDefinitionMap.get(enumName))) {
+            } else if (isDeprecated(newDefinitionMap.get(enumName)) && !isDeprecated(oldEnum)) {
                 ctx.report(DiffEvent.apiDanger()
                         .category(DiffCategory.DEPRECATION_ADDED)
                         .typeName(oldDef.getName())

--- a/src/test/groovy/graphql/schema/diff/SchemaDiffTest.groovy
+++ b/src/test/groovy/graphql/schema/diff/SchemaDiffTest.groovy
@@ -495,10 +495,6 @@ class SchemaDiffTest extends Specification {
         expect:
         reporter.dangerCount == 0
         reporter.breakageCount == 0
-        reporter.dangers.every {
-            it.getCategory() == DiffCategory.DEPRECATION_ADDED
-        }
-
     }
 
     def "field was deprecated"() {

--- a/src/test/groovy/graphql/schema/diff/SchemaDiffTest.groovy
+++ b/src/test/groovy/graphql/schema/diff/SchemaDiffTest.groovy
@@ -485,6 +485,22 @@ class SchemaDiffTest extends Specification {
 
     }
 
+    def "deprecated fields are unchanged"() {
+        def schema = TestUtil.schemaFile("diff/" + "schema_deprecated_fields_new.graphqls", wireWithNoFetching())
+        DiffSet diffSet = DiffSet.diffSet(schema, schema)
+
+        def diff = new SchemaDiff()
+        diff.diffSchema(diffSet, chainedReporter)
+
+        expect:
+        reporter.dangerCount == 0
+        reporter.breakageCount == 0
+        reporter.dangers.every {
+            it.getCategory() == DiffCategory.DEPRECATION_ADDED
+        }
+
+    }
+
     def "field was deprecated"() {
         DiffSet diffSet = diffSet("schema_deprecated_fields_new.graphqls")
 


### PR DESCRIPTION
Hello from Twitter!
We've discovered that our deprecated enums were marked as DEPRECATION_ADDED when they were unchanged. We used a pre-existing test schema file that already contained a deprecated enum but if you'd like us to create a new schema file, let me know!

Thank you,
Cynthia Qian