### PR TITLE
Use ImmutableKit emptyMap and emptyList

### DIFF
--- a/src/main/java/graphql/ExecutionInput.java
+++ b/src/main/java/graphql/ExecutionInput.java
@@ -1,11 +1,11 @@
 package graphql;
 
 import graphql.cachecontrol.CacheControl;
+import graphql.collect.ImmutableKit;
 import graphql.execution.ExecutionId;
 import graphql.execution.instrumentation.dataloader.DataLoaderDispatcherInstrumentationState;
 import org.dataloader.DataLoaderRegistry;
 
-import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -209,8 +209,8 @@ public class ExecutionInput {
         private Object context = graphQLContext; // we make these the same object on purpose - legacy code will get the same object if this change nothing
         private Object localContext;
         private Object root;
-        private Map<String, Object> variables = Collections.emptyMap();
-        public Map<String, Object> extensions = Collections.emptyMap();
+        private Map<String, Object> variables = ImmutableKit.emptyMap();
+        public Map<String, Object> extensions = ImmutableKit.emptyMap();
         //
         // this is important - it allows code to later known if we never really set a dataloader and hence it can optimize
         // dataloader field tracking away.

--- a/src/main/java/graphql/ParseAndValidateResult.java
+++ b/src/main/java/graphql/ParseAndValidateResult.java
@@ -7,7 +7,6 @@ import graphql.parser.InvalidSyntaxException;
 import graphql.validation.ValidationError;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -105,7 +104,7 @@ public class ParseAndValidateResult {
         private Document document;
         private Map<String, Object> variables = ImmutableKit.emptyMap();
         private InvalidSyntaxException syntaxException;
-        private List<ValidationError> validationErrors = Collections.emptyList();
+        private List<ValidationError> validationErrors = ImmutableKit.emptyList();
 
         public Builder document(Document document) {
             this.document = document;

--- a/src/main/java/graphql/ParseAndValidateResult.java
+++ b/src/main/java/graphql/ParseAndValidateResult.java
@@ -1,5 +1,6 @@
 package graphql;
 
+import graphql.collect.ImmutableKit;
 import graphql.execution.instrumentation.DocumentAndVariables;
 import graphql.language.Document;
 import graphql.parser.InvalidSyntaxException;
@@ -25,9 +26,9 @@ public class ParseAndValidateResult {
 
     private ParseAndValidateResult(Builder builder) {
         this.document = builder.document;
-        this.variables = builder.variables == null ? Collections.emptyMap() : builder.variables;
+        this.variables = builder.variables == null ? ImmutableKit.emptyMap() : builder.variables;
         this.syntaxException = builder.syntaxException;
-        this.validationErrors = builder.validationErrors == null ? Collections.emptyList() : builder.validationErrors;
+        this.validationErrors = builder.validationErrors == null ? ImmutableKit.emptyList() : builder.validationErrors;
     }
 
     /**
@@ -102,7 +103,7 @@ public class ParseAndValidateResult {
 
     public static class Builder {
         private Document document;
-        private Map<String, Object> variables = Collections.emptyMap();
+        private Map<String, Object> variables = ImmutableKit.emptyMap();
         private InvalidSyntaxException syntaxException;
         private List<ValidationError> validationErrors = Collections.emptyList();
 

--- a/src/main/java/graphql/collect/ImmutableMapWithNullValues.java
+++ b/src/main/java/graphql/collect/ImmutableMapWithNullValues.java
@@ -36,7 +36,7 @@ public final class ImmutableMapWithNullValues<K, V> implements Map<K, V> {
      * Only used to construct the singleton empty map
      */
     private ImmutableMapWithNullValues() {
-        this(Collections.emptyMap());
+        this(ImmutableKit.emptyMap());
     }
 
 

--- a/src/main/java/graphql/execution/AbortExecutionException.java
+++ b/src/main/java/graphql/execution/AbortExecutionException.java
@@ -13,7 +13,7 @@ import java.util.Collection;
 import java.util.List;
 
 import static graphql.Assert.assertNotNull;
-import static java.util.Collections.emptyList;
+import static graphql.collect.ImmutableKit.emptyList;
 
 /**
  * This Exception indicates that the current execution should be aborted.

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -10,6 +10,7 @@ import graphql.SerializationError;
 import graphql.TrivialDataFetcher;
 import graphql.TypeMismatchError;
 import graphql.UnresolvedTypeError;
+import graphql.collect.ImmutableKit;
 import graphql.execution.directives.QueryDirectives;
 import graphql.execution.directives.QueryDirectivesImpl;
 import graphql.execution.instrumentation.Instrumentation;
@@ -354,9 +355,9 @@ public abstract class ExecutionStrategy {
 
     private <T> CompletableFuture<T> asyncHandleException(DataFetcherExceptionHandler handler, DataFetcherExceptionHandlerParameters handlerParameters, ExecutionContext executionContext) {
         //noinspection unchecked
-        return  handler.handleException(handlerParameters)
-            .thenApply(handlerResult -> (T) DataFetcherResult.<FetchedValue>newResult().errors(handlerResult.getErrors()).build()
-            );
+        return handler.handleException(handlerParameters)
+                .thenApply(handlerResult -> (T) DataFetcherResult.<FetchedValue>newResult().errors(handlerResult.getErrors()).build()
+                );
     }
 
     /**
@@ -810,7 +811,7 @@ public abstract class ExecutionStrategy {
         ExecutionStepInfo parentStepInfo = parameters.getExecutionStepInfo();
         GraphQLOutputType fieldType = fieldDefinition.getType();
         List<GraphQLArgument> fieldArgDefs = fieldDefinition.getArguments();
-        Supplier<Map<String, Object>> argumentValues = Collections::emptyMap;
+        Supplier<Map<String, Object>> argumentValues = ImmutableKit::emptyMap;
         //
         // no need to create args at all if there are none on the field def
         //

--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -6,6 +6,7 @@ import graphql.AssertException;
 import graphql.Internal;
 import graphql.Scalars;
 import graphql.VisibleForTesting;
+import graphql.collect.ImmutableKit;
 import graphql.language.Argument;
 import graphql.language.ArrayValue;
 import graphql.language.BooleanValue;
@@ -162,7 +163,7 @@ public class ValuesResolver {
                                                                          List<Argument> arguments,
                                                                          Map<String, NormalizedInputValue> normalizedVariables) {
         if (argumentTypes.isEmpty()) {
-            return Collections.emptyMap();
+            return ImmutableKit.emptyMap();
         }
 
         Map<String, NormalizedInputValue> result = new LinkedHashMap<>();
@@ -399,7 +400,7 @@ public class ValuesResolver {
                 boolean hasValue = rawVariables.containsKey(variableName);
                 Object value = rawVariables.get(variableName);
                 if (!hasValue && defaultValue != null) {
-                    Object coercedDefaultValue = literalToInternalValue(fieldVisibility, variableType, defaultValue, Collections.emptyMap());
+                    Object coercedDefaultValue = literalToInternalValue(fieldVisibility, variableType, defaultValue, ImmutableKit.emptyMap());
                     coercedValues.put(variableName, coercedDefaultValue);
                 } else if (isNonNull(variableType) && (!hasValue || value == null)) {
                     throw new NonNullableValueCoercedAsNullException(variableDefinition, variableType);
@@ -433,7 +434,7 @@ public class ValuesResolver {
                                                       Map<String, Object> coercedVariables
     ) {
         if (argumentTypes.isEmpty()) {
-            return Collections.emptyMap();
+            return ImmutableKit.emptyMap();
         }
 
         Map<String, Object> coercedValues = new LinkedHashMap<>();
@@ -813,7 +814,7 @@ public class ValuesResolver {
         }
         if (defaultValue.isLiteral()) {
             // default value literals can't reference variables, this is why the variables are empty
-            return literalToInternalValue(fieldVisibility, type, (Value) defaultValue.getValue(), Collections.emptyMap());
+            return literalToInternalValue(fieldVisibility, type, (Value) defaultValue.getValue(), ImmutableKit.emptyMap());
         }
         if (defaultValue.isExternal()) {
             // performs validation too

--- a/src/main/java/graphql/execution/directives/QueryDirectivesImpl.java
+++ b/src/main/java/graphql/execution/directives/QueryDirectivesImpl.java
@@ -16,7 +16,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import static java.util.Collections.emptyList;
+import static graphql.collect.ImmutableKit.emptyList;
 
 /**
  * These objects are ALWAYS in the context of a single MergedField

--- a/src/main/java/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentation.java
@@ -3,7 +3,7 @@ package graphql.execution.instrumentation.dataloader;
 import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.PublicApi;
-import graphql.execution.Async;
+import graphql.collect.ImmutableKit;
 import graphql.execution.AsyncExecutionStrategy;
 import graphql.execution.ExecutionContext;
 import graphql.execution.ExecutionStrategy;
@@ -25,7 +25,6 @@ import org.dataloader.stats.Statistics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -160,7 +159,7 @@ public class DataLoaderDispatcherInstrumentation extends SimpleInstrumentation {
         }
         DataLoaderDispatcherInstrumentationState state = parameters.getInstrumentationState();
         Map<Object, Object> currentExt = executionResult.getExtensions();
-        Map<Object, Object> statsMap = new LinkedHashMap<>(currentExt == null ? Collections.emptyMap() : currentExt);
+        Map<Object, Object> statsMap = new LinkedHashMap<>(currentExt == null ? ImmutableKit.emptyMap() : currentExt);
         Map<Object, Object> dataLoaderStats = buildStatsMap(state);
         statsMap.put("dataloader", dataLoaderStats);
 

--- a/src/main/java/graphql/execution/instrumentation/nextgen/InstrumentationExecutionParameters.java
+++ b/src/main/java/graphql/execution/instrumentation/nextgen/InstrumentationExecutionParameters.java
@@ -3,10 +3,10 @@ package graphql.execution.instrumentation.nextgen;
 import graphql.ExecutionInput;
 import graphql.GraphQLContext;
 import graphql.Internal;
+import graphql.collect.ImmutableKit;
 import graphql.execution.instrumentation.InstrumentationState;
 import graphql.schema.GraphQLSchema;
 
-import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -29,7 +29,7 @@ public class InstrumentationExecutionParameters {
         this.operation = executionInput.getOperationName();
         this.context = executionInput.getContext();
         this.graphQLContext = executionInput.getGraphQLContext();
-        this.variables = executionInput.getVariables() != null ? executionInput.getVariables() : Collections.emptyMap();
+        this.variables = executionInput.getVariables() != null ? executionInput.getVariables() : ImmutableKit.emptyMap();
         this.instrumentationState = instrumentationState;
         this.schema = schema;
     }
@@ -59,6 +59,7 @@ public class InstrumentationExecutionParameters {
 
     /**
      * @param <T> for two
+     *
      * @return the legacy context
      *
      * @deprecated use {@link #getGraphQLContext()} instead

--- a/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationExecutionParameters.java
+++ b/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationExecutionParameters.java
@@ -3,11 +3,11 @@ package graphql.execution.instrumentation.parameters;
 import graphql.ExecutionInput;
 import graphql.GraphQLContext;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationState;
 import graphql.schema.GraphQLSchema;
 
-import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -30,7 +30,7 @@ public class InstrumentationExecutionParameters {
         this.operation = executionInput.getOperationName();
         this.context = executionInput.getContext();
         this.graphQLContext = executionInput.getGraphQLContext();
-        this.variables = executionInput.getVariables() != null ? executionInput.getVariables() : Collections.emptyMap();
+        this.variables = executionInput.getVariables() != null ? executionInput.getVariables() : ImmutableKit.emptyMap();
         this.instrumentationState = instrumentationState;
         this.schema = schema;
     }
@@ -60,6 +60,7 @@ public class InstrumentationExecutionParameters {
 
     /**
      * @param <T> for two
+     *
      * @return the legacy context
      *
      * @deprecated use {@link #getGraphQLContext()} instead

--- a/src/main/java/graphql/execution/instrumentation/tracing/TracingInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/tracing/TracingInstrumentation.java
@@ -3,6 +3,7 @@ package graphql.execution.instrumentation.tracing;
 import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.InstrumentationState;
@@ -77,7 +78,7 @@ public class TracingInstrumentation extends SimpleInstrumentation {
         Map<Object, Object> currentExt = executionResult.getExtensions();
 
         TracingSupport tracingSupport = parameters.getInstrumentationState();
-        Map<Object, Object> withTracingExt = new LinkedHashMap<>(currentExt == null ? Collections.emptyMap() : currentExt);
+        Map<Object, Object> withTracingExt = new LinkedHashMap<>(currentExt == null ? ImmutableKit.emptyMap() : currentExt);
         withTracingExt.put("tracing", tracingSupport.snapshotTracingData());
 
         return CompletableFuture.completedFuture(new ExecutionResultImpl(executionResult.getData(), executionResult.getErrors(), withTracingExt));

--- a/src/main/java/graphql/execution/nextgen/ValueFetcher.java
+++ b/src/main/java/graphql/execution/nextgen/ValueFetcher.java
@@ -91,7 +91,7 @@ public class ValueFetcher {
             if (i == 0) {
                 errors = fetchedValueContainingList.getErrors();
             } else {
-                errors = Collections.emptyList();
+                errors = ImmutableKit.emptyList();
             }
             FetchedValue fetchedValue = FetchedValue.newFetchedValue()
                     .fetchedValue(list.get(i))

--- a/src/main/java/graphql/execution/nextgen/result/LeafExecutionResultNode.java
+++ b/src/main/java/graphql/execution/nextgen/result/LeafExecutionResultNode.java
@@ -3,6 +3,7 @@ package graphql.execution.nextgen.result;
 import graphql.Assert;
 import graphql.GraphQLError;
 import graphql.Internal;
+import graphql.collect.ImmutableKit;
 import graphql.execution.ExecutionStepInfo;
 import graphql.execution.NonNullableFieldWasNullException;
 
@@ -20,14 +21,14 @@ public class LeafExecutionResultNode extends ExecutionResultNode {
     public LeafExecutionResultNode(ExecutionStepInfo executionStepInfo,
                                    ResolvedValue resolvedValue,
                                    NonNullableFieldWasNullException nonNullableFieldWasNullException) {
-        this(executionStepInfo, resolvedValue, nonNullableFieldWasNullException, Collections.emptyList());
+        this(executionStepInfo, resolvedValue, nonNullableFieldWasNullException, ImmutableKit.emptyList());
     }
 
     public LeafExecutionResultNode(ExecutionStepInfo executionStepInfo,
                                    ResolvedValue resolvedValue,
                                    NonNullableFieldWasNullException nonNullableFieldWasNullException,
                                    List<GraphQLError> errors) {
-        super(executionStepInfo, resolvedValue, nonNullableFieldWasNullException, Collections.emptyList(), errors);
+        super(executionStepInfo, resolvedValue, nonNullableFieldWasNullException, ImmutableKit.emptyList(), errors);
     }
 
 

--- a/src/main/java/graphql/execution/nextgen/result/ListExecutionResultNode.java
+++ b/src/main/java/graphql/execution/nextgen/result/ListExecutionResultNode.java
@@ -2,10 +2,10 @@ package graphql.execution.nextgen.result;
 
 import graphql.GraphQLError;
 import graphql.Internal;
+import graphql.collect.ImmutableKit;
 import graphql.execution.ExecutionStepInfo;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -18,7 +18,7 @@ public class ListExecutionResultNode extends ExecutionResultNode {
     public ListExecutionResultNode(ExecutionStepInfo executionStepInfo,
                                    ResolvedValue resolvedValue,
                                    List<ExecutionResultNode> children) {
-        this(executionStepInfo, resolvedValue, children, Collections.emptyList());
+        this(executionStepInfo, resolvedValue, children, ImmutableKit.emptyList());
 
     }
 

--- a/src/main/java/graphql/execution/nextgen/result/ObjectExecutionResultNode.java
+++ b/src/main/java/graphql/execution/nextgen/result/ObjectExecutionResultNode.java
@@ -2,10 +2,10 @@ package graphql.execution.nextgen.result;
 
 import graphql.GraphQLError;
 import graphql.Internal;
+import graphql.collect.ImmutableKit;
 import graphql.execution.ExecutionStepInfo;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -19,7 +19,7 @@ public class ObjectExecutionResultNode extends ExecutionResultNode {
     public ObjectExecutionResultNode(ExecutionStepInfo executionStepInfo,
                                      ResolvedValue resolvedValue,
                                      List<ExecutionResultNode> children) {
-        this(executionStepInfo, resolvedValue, children, Collections.emptyList());
+        this(executionStepInfo, resolvedValue, children, ImmutableKit.emptyList());
 
     }
 

--- a/src/main/java/graphql/execution/nextgen/result/ResolvedValue.java
+++ b/src/main/java/graphql/execution/nextgen/result/ResolvedValue.java
@@ -3,9 +3,9 @@ package graphql.execution.nextgen.result;
 import com.google.common.collect.ImmutableList;
 import graphql.GraphQLError;
 import graphql.Internal;
+import graphql.collect.ImmutableKit;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -60,7 +60,7 @@ public class ResolvedValue {
         private Object completedValue;
         private Object localContext;
         private boolean nullValue;
-        private List<GraphQLError> errors = Collections.emptyList();
+        private List<GraphQLError> errors = ImmutableKit.emptyList();
 
         private Builder() {
 

--- a/src/main/java/graphql/execution/nextgen/result/ResultNodesUtil.java
+++ b/src/main/java/graphql/execution/nextgen/result/ResultNodesUtil.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 
 import static graphql.collect.ImmutableKit.map;
 import static graphql.execution.nextgen.result.ResultNodeAdapter.RESULT_NODE_ADAPTER;
-import static java.util.Collections.emptyList;
+import static graphql.collect.ImmutableKit.emptyList;
 import static java.util.Collections.singleton;
 
 /**

--- a/src/main/java/graphql/execution/nextgen/result/RootExecutionResultNode.java
+++ b/src/main/java/graphql/execution/nextgen/result/RootExecutionResultNode.java
@@ -2,10 +2,10 @@ package graphql.execution.nextgen.result;
 
 import graphql.GraphQLError;
 import graphql.Internal;
+import graphql.collect.ImmutableKit;
 import graphql.execution.ExecutionStepInfo;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import static graphql.Assert.assertShouldNeverHappen;
@@ -23,7 +23,7 @@ public class RootExecutionResultNode extends ObjectExecutionResultNode {
     }
 
     public RootExecutionResultNode(List<ExecutionResultNode> children) {
-        super(null, null, children, Collections.emptyList());
+        super(null, null, children, ImmutableKit.emptyList());
     }
 
     @Override

--- a/src/main/java/graphql/execution/nextgen/result/UnresolvedObjectResultNode.java
+++ b/src/main/java/graphql/execution/nextgen/result/UnresolvedObjectResultNode.java
@@ -1,9 +1,8 @@
 package graphql.execution.nextgen.result;
 
 import graphql.Internal;
+import graphql.collect.ImmutableKit;
 import graphql.execution.ExecutionStepInfo;
-
-import java.util.Collections;
 
 /**
  * @deprecated Jan 2022 - We have decided to deprecate the NextGen engine, and it will be removed in a future release.
@@ -13,7 +12,7 @@ import java.util.Collections;
 public class UnresolvedObjectResultNode extends ObjectExecutionResultNode {
 
     public UnresolvedObjectResultNode(ExecutionStepInfo executionStepInfo, ResolvedValue resolvedValue) {
-        super(executionStepInfo, resolvedValue, Collections.emptyList(), Collections.emptyList());
+        super(executionStepInfo, resolvedValue, ImmutableKit.emptyList(), ImmutableKit.emptyList());
     }
 
 }

--- a/src/main/java/graphql/language/AbstractNode.java
+++ b/src/main/java/graphql/language/AbstractNode.java
@@ -5,8 +5,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import graphql.Assert;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -21,7 +21,7 @@ public abstract class AbstractNode<T extends Node> implements Node<T> {
     private final ImmutableMap<String, String> additionalData;
 
     public AbstractNode(SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars) {
-        this(sourceLocation, comments, ignoredChars, Collections.emptyMap());
+        this(sourceLocation, comments, ignoredChars, ImmutableKit.emptyMap());
     }
 
     public AbstractNode(SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars, Map<String, String> additionalData) {

--- a/src/main/java/graphql/language/Argument.java
+++ b/src/main/java/graphql/language/Argument.java
@@ -15,8 +15,8 @@ import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
 import static graphql.collect.ImmutableKit.emptyList;
+import static graphql.collect.ImmutableKit.emptyMap;
 import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
-import static java.util.Collections.emptyMap;
 
 @PublicApi
 public class Argument extends AbstractNode<Argument> implements NamedNode<Argument> {

--- a/src/main/java/graphql/language/AstPrinter.java
+++ b/src/main/java/graphql/language/AstPrinter.java
@@ -2,6 +2,7 @@ package graphql.language;
 
 import graphql.AssertException;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 
 import java.io.PrintWriter;
 import java.io.Writer;
@@ -468,7 +469,7 @@ public class AstPrinter {
     }
 
     private <T> List<T> nvl(List<T> list) {
-        return list != null ? list : Collections.emptyList();
+        return list != null ? list : ImmutableKit.emptyList();
     }
 
     private NodePrinter<Value> value() {
@@ -593,8 +594,8 @@ public class AstPrinter {
         for (int i = 0; i < maybeString.length(); i++) {
             char c = maybeString.charAt(i);
             if (c == '\n') {
-                maybeString.replace(i,i+1,"\n  ");
-                i+=3;
+                maybeString.replace(i, i + 1, "\n  ");
+                i += 3;
             }
         }
         return maybeString;

--- a/src/main/java/graphql/language/AstSignature.java
+++ b/src/main/java/graphql/language/AstSignature.java
@@ -2,12 +2,12 @@ package graphql.language;
 
 import com.google.common.collect.ImmutableList;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -23,7 +23,7 @@ public class AstSignature {
 
     /**
      * This can produce a "signature" canonical AST that conforms to the algorithm as outlined
-     *  <a href="https://github.com/apollographql/apollo-tooling/blob/master/packages/apollo-graphql/src/operationId.ts">here</a>
+     * <a href="https://github.com/apollographql/apollo-tooling/blob/master/packages/apollo-graphql/src/operationId.ts">here</a>
      * which removes excess operations, removes any field aliases, hides literal values and sorts the result into a canonical
      * query.
      *
@@ -45,7 +45,7 @@ public class AstSignature {
 
     /**
      * This can produce a "privacy safe" AST that some what conforms to the algorithm as outlined
-     *  <a href="https://github.com/apollographql/apollo-tooling/blob/master/packages/apollo-graphql/src/operationId.ts">here</a>
+     * <a href="https://github.com/apollographql/apollo-tooling/blob/master/packages/apollo-graphql/src/operationId.ts">here</a>
      * which removes excess operations, removes any field aliases, hides some literal values and sorts the result.
      *
      * This is not a signature.  For example object literal structures are retained like `{ a : "", b : 0}` which means
@@ -94,7 +94,7 @@ public class AstSignature {
             @Override
             public TraversalControl visitArrayValue(ArrayValue node, TraverserContext<Node> context) {
                 if (signatureMode) {
-                    return changeNode(context, node.transform(builder -> builder.values(Collections.emptyList())));
+                    return changeNode(context, node.transform(builder -> builder.values(ImmutableKit.emptyList())));
                 }
                 return TraversalControl.CONTINUE;
             }
@@ -102,7 +102,7 @@ public class AstSignature {
             @Override
             public TraversalControl visitObjectValue(ObjectValue node, TraverserContext<Node> context) {
                 if (signatureMode) {
-                    return changeNode(context, node.transform(builder -> builder.objectFields(Collections.emptyList())));
+                    return changeNode(context, node.transform(builder -> builder.objectFields(ImmutableKit.emptyList())));
                 }
                 return TraversalControl.CONTINUE;
             }

--- a/src/main/java/graphql/language/DirectiveDefinition.java
+++ b/src/main/java/graphql/language/DirectiveDefinition.java
@@ -16,9 +16,9 @@ import java.util.Objects;
 import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
+import static graphql.collect.ImmutableKit.addToList;
 import static graphql.collect.ImmutableKit.emptyList;
 import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
-import static java.util.Collections.emptyMap;
 
 @PublicApi
 public class DirectiveDefinition extends AbstractDescribedNode<DirectiveDefinition> implements SDLNamedDefinition<DirectiveDefinition>, NamedNode<DirectiveDefinition> {
@@ -53,7 +53,7 @@ public class DirectiveDefinition extends AbstractDescribedNode<DirectiveDefiniti
      * @param name of the directive definition
      */
     public DirectiveDefinition(String name) {
-        this(name, false, null, emptyList(), emptyList(), null, emptyList(), IgnoredChars.EMPTY, emptyMap());
+        this(name, false, null, emptyList(), emptyList(), null, emptyList(), IgnoredChars.EMPTY, ImmutableKit.emptyMap());
     }
 
     @Override
@@ -211,7 +211,7 @@ public class DirectiveDefinition extends AbstractDescribedNode<DirectiveDefiniti
         }
 
         public Builder inputValueDefinition(InputValueDefinition inputValueDefinition) {
-            this.inputValueDefinitions = ImmutableKit.addToList(inputValueDefinitions, inputValueDefinition);
+            this.inputValueDefinitions = addToList(inputValueDefinitions, inputValueDefinition);
             return this;
         }
 
@@ -222,7 +222,7 @@ public class DirectiveDefinition extends AbstractDescribedNode<DirectiveDefiniti
         }
 
         public Builder directiveLocation(DirectiveLocation directiveLocation) {
-            this.directiveLocations = ImmutableKit.addToList(directiveLocations, directiveLocation);
+            this.directiveLocations = addToList(directiveLocations, directiveLocation);
             return this;
         }
 

--- a/src/main/java/graphql/language/DirectivesContainer.java
+++ b/src/main/java/graphql/language/DirectivesContainer.java
@@ -7,8 +7,8 @@ import graphql.PublicApi;
 import java.util.List;
 import java.util.Map;
 
+import static graphql.collect.ImmutableKit.emptyList;
 import static graphql.language.NodeUtil.allDirectivesByName;
-import static java.util.Collections.emptyList;
 
 /**
  * Represents a language node that can contain Directives.  Directives can be repeatable and (by default) non repeatable.

--- a/src/main/java/graphql/language/IgnoredChars.java
+++ b/src/main/java/graphql/language/IgnoredChars.java
@@ -2,11 +2,10 @@ package graphql.language;
 
 import com.google.common.collect.ImmutableList;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 
 import java.io.Serializable;
 import java.util.List;
-
-import static graphql.collect.ImmutableKit.emptyList;
 
 /**
  * Graphql syntax has a series of characters, such as spaces, new lines and commas that are not considered relevant
@@ -20,7 +19,7 @@ public class IgnoredChars implements Serializable {
     private final ImmutableList<IgnoredChar> left;
     private final ImmutableList<IgnoredChar> right;
 
-    public static final IgnoredChars EMPTY = new IgnoredChars(emptyList(), emptyList());
+    public static final IgnoredChars EMPTY = new IgnoredChars(ImmutableKit.emptyList(), ImmutableKit.emptyList());
 
     public IgnoredChars(List<IgnoredChar> left, List<IgnoredChar> right) {
         this.left = ImmutableList.copyOf(left);

--- a/src/main/java/graphql/language/NodeTraverser.java
+++ b/src/main/java/graphql/language/NodeTraverser.java
@@ -1,6 +1,7 @@
 package graphql.language;
 
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 import graphql.util.DefaultTraverserContext;
 import graphql.util.TraversalControl;
 import graphql.util.Traverser;
@@ -29,7 +30,7 @@ public class NodeTraverser {
     }
 
     public NodeTraverser() {
-        this(Collections.emptyMap(), Node::getChildren);
+        this(ImmutableKit.emptyMap(), Node::getChildren);
     }
 
 

--- a/src/main/java/graphql/language/NullValue.java
+++ b/src/main/java/graphql/language/NullValue.java
@@ -4,10 +4,10 @@ package graphql.language;
 import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,7 +32,7 @@ public class NullValue extends AbstractNode<NullValue> implements Value<NullValu
 
     @Override
     public List<Node> getChildren() {
-        return Collections.emptyList();
+        return ImmutableKit.emptyList();
     }
 
     @Override

--- a/src/main/java/graphql/normalized/ExecutableNormalizedOperationFactory.java
+++ b/src/main/java/graphql/normalized/ExecutableNormalizedOperationFactory.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import graphql.Internal;
+import graphql.collect.ImmutableKit;
 import graphql.execution.ConditionalNodes;
 import graphql.execution.MergedField;
 import graphql.execution.ValuesResolver;
@@ -35,12 +36,10 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Predicate;
 
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertShouldNeverHappen;
@@ -218,7 +217,7 @@ public class ExecutableNormalizedOperationFactory {
         List<GraphQLFieldDefinition> fieldDefs = executableNormalizedField.getFieldDefinitions(parameters.getGraphQLSchema());
         Set<GraphQLObjectType> possibleObjects = resolvePossibleObjects(fieldDefs, parameters.getGraphQLSchema());
         if (possibleObjects.isEmpty()) {
-            return new CollectNFResult(Collections.emptyList(), ImmutableListMultimap.of());
+            return new CollectNFResult(ImmutableKit.emptyList(), ImmutableListMultimap.of());
         }
 
         List<CollectedField> collectedFields = new ArrayList<>();

--- a/src/main/java/graphql/normalized/ExecutableNormalizedOperationToAstCompiler.java
+++ b/src/main/java/graphql/normalized/ExecutableNormalizedOperationToAstCompiler.java
@@ -31,6 +31,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import static graphql.collect.ImmutableKit.emptyList;
 import static graphql.collect.ImmutableKit.map;
 import static graphql.language.Argument.newArgument;
 import static graphql.language.Field.newField;
@@ -38,7 +39,6 @@ import static graphql.language.InlineFragment.newInlineFragment;
 import static graphql.language.SelectionSet.newSelectionSet;
 import static graphql.language.TypeName.newTypeName;
 import static graphql.schema.GraphQLTypeUtil.unwrapAll;
-import static java.util.Collections.emptyList;
 
 @Internal
 public class ExecutableNormalizedOperationToAstCompiler {

--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -70,7 +70,6 @@ import org.antlr.v4.runtime.tree.TerminalNode;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import static graphql.Assert.assertShouldNeverHappen;
@@ -804,7 +803,7 @@ public class GraphqlAntlrToLanguage {
 
     private List<IgnoredChar> mapTokenToIgnoredChar(List<Token> tokens) {
         if (tokens == null) {
-            return Collections.emptyList();
+            return ImmutableKit.emptyList();
         }
         return map(tokens, this::createIgnoredChar);
 

--- a/src/main/java/graphql/relay/SimpleListConnection.java
+++ b/src/main/java/graphql/relay/SimpleListConnection.java
@@ -2,12 +2,12 @@ package graphql.relay;
 
 import graphql.PublicApi;
 import graphql.TrivialDataFetcher;
+import graphql.collect.ImmutableKit;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import static graphql.Assert.assertNotNull;
@@ -59,7 +59,9 @@ public class SimpleListConnection<T> implements DataFetcher<Connection<T>>, Triv
         int beforeOffset = getOffsetFromCursor(environment.getArgument("before"), edges.size());
         int end = Math.min(beforeOffset, edges.size());
 
-        if (begin > end) begin = end;
+        if (begin > end) {
+            begin = end;
+        }
 
         edges = edges.subList(begin, end);
         if (edges.size() == 0) {
@@ -104,7 +106,7 @@ public class SimpleListConnection<T> implements DataFetcher<Connection<T>>, Triv
 
     private Connection<T> emptyConnection() {
         PageInfo pageInfo = new DefaultPageInfo(null, null, false, false);
-        return new DefaultConnection<>(Collections.emptyList(), pageInfo);
+        return new DefaultConnection<>(ImmutableKit.emptyList(), pageInfo);
     }
 
     /**

--- a/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
@@ -19,7 +19,6 @@ import graphql.language.OperationDefinition;
 import org.dataloader.DataLoader;
 import org.dataloader.DataLoaderRegistry;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -53,7 +52,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
 
     private DataFetchingEnvironmentImpl(Builder builder) {
         this.source = builder.source;
-        this.arguments = builder.arguments == null ? Collections::emptyMap : builder.arguments;
+        this.arguments = builder.arguments == null ? ImmutableKit::emptyMap : builder.arguments;
         this.context = builder.context;
         this.graphQLContext = builder.graphQLContext;
         this.localContext = builder.localContext;

--- a/src/main/java/graphql/schema/DataFetchingFieldSelectionSetImpl.java
+++ b/src/main/java/graphql/schema/DataFetchingFieldSelectionSetImpl.java
@@ -25,8 +25,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static graphql.Assert.assertNotNull;
+import static graphql.collect.ImmutableKit.emptyList;
 import static graphql.util.FpKit.newList;
-import static java.util.Collections.emptyList;
 
 @Internal
 public class DataFetchingFieldSelectionSetImpl implements DataFetchingFieldSelectionSet {
@@ -64,7 +64,7 @@ public class DataFetchingFieldSelectionSetImpl implements DataFetchingFieldSelec
 
         @Override
         public List<SelectedField> getFields(String fieldGlobPattern, String... fieldGlobPatterns) {
-            return Collections.emptyList();
+            return ImmutableKit.emptyList();
         }
 
         @Override

--- a/src/main/java/graphql/schema/DataFetchingFieldSelectionSetImpl.java
+++ b/src/main/java/graphql/schema/DataFetchingFieldSelectionSetImpl.java
@@ -3,6 +3,7 @@ package graphql.schema;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import graphql.Internal;
+import graphql.collect.ImmutableKit;
 import graphql.normalized.ExecutableNormalizedField;
 
 import java.io.File;
@@ -68,12 +69,12 @@ public class DataFetchingFieldSelectionSetImpl implements DataFetchingFieldSelec
 
         @Override
         public Map<String, List<SelectedField>> getFieldsGroupedByResultKey() {
-            return Collections.emptyMap();
+            return ImmutableKit.emptyMap();
         }
 
         @Override
         public Map<String, List<SelectedField>> getFieldsGroupedByResultKey(String fieldGlobPattern, String... fieldGlobPatterns) {
-            return Collections.emptyMap();
+            return ImmutableKit.emptyMap();
         }
     };
 

--- a/src/main/java/graphql/schema/GraphQLAppliedDirectiveArgument.java
+++ b/src/main/java/graphql/schema/GraphQLAppliedDirectiveArgument.java
@@ -3,6 +3,7 @@ package graphql.schema;
 
 import graphql.Assert;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 import graphql.language.Argument;
 import graphql.language.Value;
 import graphql.util.TraversalControl;
@@ -10,7 +11,6 @@ import graphql.util.TraverserContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -104,7 +104,7 @@ public class GraphQLAppliedDirectiveArgument implements GraphQLNamedSchemaElemen
 
     @Override
     public List<GraphQLSchemaElement> getChildren() {
-        return Collections.emptyList();
+        return ImmutableKit.emptyList();
     }
 
 

--- a/src/main/java/graphql/schema/GraphQLDirectiveContainer.java
+++ b/src/main/java/graphql/schema/GraphQLDirectiveContainer.java
@@ -5,7 +5,7 @@ import graphql.PublicApi;
 import java.util.List;
 import java.util.Map;
 
-import static java.util.Collections.emptyList;
+import static graphql.collect.ImmutableKit.emptyList;
 
 /**
  * Represents a graphql runtime type that can have {@link graphql.schema.GraphQLAppliedDirective}'s.
@@ -72,6 +72,7 @@ public interface GraphQLDirectiveContainer extends GraphQLNamedSchemaElement {
      * @param directiveName the name of the directive
      *
      * @return true if there is a directive on this element with that name
+     *
      * @deprecated use {@link #hasAppliedDirective(String)} instead
      */
     @Deprecated
@@ -142,6 +143,7 @@ public interface GraphQLDirectiveContainer extends GraphQLNamedSchemaElement {
      * @param directiveName the name of the directives to retrieve
      *
      * @return the directives or empty list if there is not one with that name
+     *
      * @deprecated - use the {@link GraphQLAppliedDirective} methods instead
      */
     @Deprecated

--- a/src/main/java/graphql/schema/GraphQLEnumType.java
+++ b/src/main/java/graphql/schema/GraphQLEnumType.java
@@ -23,9 +23,9 @@ import java.util.function.Consumer;
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertShouldNeverHappen;
 import static graphql.Assert.assertValidName;
+import static graphql.collect.ImmutableKit.emptyList;
 import static graphql.schema.GraphQLEnumValueDefinition.newEnumValueDefinition;
 import static graphql.util.FpKit.getByName;
-import static java.util.Collections.emptyList;
 
 /**
  * A graphql enumeration type has a limited set of values.
@@ -295,7 +295,7 @@ public class GraphQLEnumType implements GraphQLNamedInputType, GraphQLNamedOutpu
         return new Builder(existing);
     }
 
-    public static class Builder extends GraphqlDirectivesContainerTypeBuilder<Builder,Builder> {
+    public static class Builder extends GraphqlDirectivesContainerTypeBuilder<Builder, Builder> {
 
         private EnumTypeDefinition definition;
         private List<EnumTypeExtensionDefinition> extensionDefinitions = emptyList();

--- a/src/main/java/graphql/schema/GraphQLInputObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectType.java
@@ -21,8 +21,8 @@ import java.util.function.UnaryOperator;
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertShouldNeverHappen;
 import static graphql.Assert.assertValidName;
+import static graphql.collect.ImmutableKit.emptyList;
 import static graphql.util.FpKit.getByName;
-import static java.util.Collections.emptyList;
 
 /**
  * graphql clearly delineates between the types of objects that represent the output of a query and input objects that
@@ -225,7 +225,7 @@ public class GraphQLInputObjectType implements GraphQLNamedInputType, GraphQLUnm
     }
 
     @PublicApi
-    public static class Builder extends GraphqlDirectivesContainerTypeBuilder<Builder,Builder> {
+    public static class Builder extends GraphqlDirectivesContainerTypeBuilder<Builder, Builder> {
         private InputObjectTypeDefinition definition;
         private List<InputObjectTypeExtensionDefinition> extensionDefinitions = emptyList();
         private final Map<String, GraphQLInputObjectField> fields = new LinkedHashMap<>();

--- a/src/main/java/graphql/schema/GraphQLInterfaceType.java
+++ b/src/main/java/graphql/schema/GraphQLInterfaceType.java
@@ -21,11 +21,11 @@ import java.util.function.UnaryOperator;
 
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
+import static graphql.collect.ImmutableKit.emptyList;
 import static graphql.schema.GraphqlTypeComparators.sortTypes;
 import static graphql.util.FpKit.getByName;
 import static graphql.util.FpKit.valuesToList;
 import static java.lang.String.format;
-import static java.util.Collections.emptyList;
 
 /**
  * In graphql, an interface is an abstract type that defines the set of fields that a type must include to
@@ -263,7 +263,7 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLCompositeT
 
 
     @PublicApi
-    public static class Builder extends GraphqlDirectivesContainerTypeBuilder<Builder,Builder> {
+    public static class Builder extends GraphqlDirectivesContainerTypeBuilder<Builder, Builder> {
         private TypeResolver typeResolver;
         private InterfaceTypeDefinition definition;
         private List<InterfaceTypeExtensionDefinition> extensionDefinitions = emptyList();

--- a/src/main/java/graphql/schema/GraphQLObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLObjectType.java
@@ -23,10 +23,10 @@ import java.util.function.UnaryOperator;
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertShouldNeverHappen;
 import static graphql.Assert.assertValidName;
+import static graphql.collect.ImmutableKit.emptyList;
 import static graphql.schema.GraphqlTypeComparators.sortTypes;
 import static graphql.util.FpKit.getByName;
 import static graphql.util.FpKit.valuesToList;
-import static java.util.Collections.emptyList;
 
 /**
  * This is the work horse type and represents an object with one or more field values that can be retrieved
@@ -250,7 +250,7 @@ public class GraphQLObjectType implements GraphQLNamedOutputType, GraphQLComposi
     }
 
     @PublicApi
-    public static class Builder extends GraphqlDirectivesContainerTypeBuilder<Builder,Builder> {
+    public static class Builder extends GraphqlDirectivesContainerTypeBuilder<Builder, Builder> {
         private ObjectTypeDefinition definition;
         private List<ObjectTypeExtensionDefinition> extensionDefinitions = emptyList();
         private final Map<String, GraphQLFieldDefinition> fields = new LinkedHashMap<>();

--- a/src/main/java/graphql/schema/GraphQLScalarType.java
+++ b/src/main/java/graphql/schema/GraphQLScalarType.java
@@ -17,8 +17,8 @@ import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
+import static graphql.collect.ImmutableKit.emptyList;
 import static graphql.schema.SchemaElementChildrenContainer.newSchemaElementChildrenContainer;
-import static java.util.Collections.emptyList;
 
 /**
  * A scalar type is a leaf node in the graphql tree of types.  This class allows you to define new scalar types.
@@ -83,7 +83,7 @@ GraphQLScalarType implements GraphQLNamedInputType, GraphQLNamedOutputType, Grap
         return specifiedByUrl;
     }
 
-    public Coercing<?,?> getCoercing() {
+    public Coercing<?, ?> getCoercing() {
         return coercing;
     }
 

--- a/src/main/java/graphql/schema/GraphQLSchemaElement.java
+++ b/src/main/java/graphql/schema/GraphQLSchemaElement.java
@@ -1,10 +1,10 @@
 package graphql.schema;
 
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
-import java.util.Collections;
 import java.util.List;
 
 import static graphql.schema.SchemaElementChildrenContainer.newSchemaElementChildrenContainer;
@@ -17,7 +17,7 @@ import static graphql.schema.SchemaElementChildrenContainer.newSchemaElementChil
 public interface GraphQLSchemaElement {
 
     default List<GraphQLSchemaElement> getChildren() {
-        return Collections.emptyList();
+        return ImmutableKit.emptyList();
     }
 
     default SchemaElementChildrenContainer getChildrenWithTypeReferences() {

--- a/src/main/java/graphql/schema/GraphQLUnionType.java
+++ b/src/main/java/graphql/schema/GraphQLUnionType.java
@@ -20,9 +20,9 @@ import java.util.function.Consumer;
 import static graphql.Assert.assertNotEmpty;
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
+import static graphql.collect.ImmutableKit.emptyList;
 import static graphql.schema.SchemaElementChildrenContainer.newSchemaElementChildrenContainer;
 import static graphql.util.FpKit.getByName;
-import static java.util.Collections.emptyList;
 
 /**
  * A union type is a polymorphic type that dynamically represents one of more concrete object types.
@@ -242,7 +242,7 @@ public class GraphQLUnionType implements GraphQLNamedOutputType, GraphQLComposit
     }
 
     @PublicApi
-    public static class Builder extends GraphqlDirectivesContainerTypeBuilder<Builder,Builder> {
+    public static class Builder extends GraphqlDirectivesContainerTypeBuilder<Builder, Builder> {
         private TypeResolver typeResolver;
         private UnionTypeDefinition definition;
         private List<UnionTypeExtensionDefinition> extensionDefinitions = emptyList();

--- a/src/main/java/graphql/schema/SchemaTransformer.java
+++ b/src/main/java/graphql/schema/SchemaTransformer.java
@@ -3,6 +3,7 @@ package graphql.schema;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 import graphql.util.Breadcrumb;
 import graphql.util.NodeAdapter;
 import graphql.util.NodeLocation;
@@ -14,7 +15,6 @@ import graphql.util.TraverserVisitor;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -504,7 +504,7 @@ public class SchemaTransformer {
         if (oldBreadcrumbs.size() > 1) {
             newBreadcrumbs = oldBreadcrumbs.subList(1, oldBreadcrumbs.size());
         } else {
-            newBreadcrumbs = Collections.emptyList();
+            newBreadcrumbs = ImmutableKit.emptyList();
         }
         return new NodeZipper<>(newNode, newBreadcrumbs, SCHEMA_ELEMENT_ADAPTER);
     }

--- a/src/main/java/graphql/schema/SchemaTraverser.java
+++ b/src/main/java/graphql/schema/SchemaTraverser.java
@@ -2,6 +2,7 @@ package graphql.schema;
 
 
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 import graphql.util.TraversalControl;
 import graphql.util.Traverser;
 import graphql.util.TraverserContext;
@@ -41,7 +42,7 @@ public class SchemaTraverser {
      * @return a traversal result
      */
     public TraverserResult depthFirstFullSchema(GraphQLTypeVisitor typeVisitor, GraphQLSchema schema) {
-        return depthFirstFullSchema(Collections.singletonList(typeVisitor), schema, Collections.emptyMap());
+        return depthFirstFullSchema(Collections.singletonList(typeVisitor), schema, ImmutableKit.emptyMap());
     }
 
     /**

--- a/src/main/java/graphql/schema/idl/ArgValueOfAllowedTypeChecker.java
+++ b/src/main/java/graphql/schema/idl/ArgValueOfAllowedTypeChecker.java
@@ -37,6 +37,7 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static graphql.Assert.assertShouldNeverHappen;
+import static graphql.collect.ImmutableKit.emptyList;
 import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.DUPLICATED_KEYS_MESSAGE;
 import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.EXPECTED_ENUM_MESSAGE;
 import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.EXPECTED_LIST_MESSAGE;
@@ -47,7 +48,6 @@ import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.MUST_B
 import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.NOT_A_VALID_SCALAR_LITERAL_MESSAGE;
 import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.UNKNOWN_FIELDS_MESSAGE;
 import static java.lang.String.format;
-import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.counting;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.joining;

--- a/src/main/java/graphql/schema/idl/ImplementingTypesChecker.java
+++ b/src/main/java/graphql/schema/idl/ImplementingTypesChecker.java
@@ -35,7 +35,7 @@ import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import static java.util.Collections.emptyList;
+import static graphql.collect.ImmutableKit.emptyList;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 

--- a/src/main/java/graphql/schema/idl/SchemaGeneratorAppliedDirectiveHelper.java
+++ b/src/main/java/graphql/schema/idl/SchemaGeneratorAppliedDirectiveHelper.java
@@ -25,10 +25,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
+import static graphql.collect.ImmutableKit.emptyList;
 import static graphql.collect.ImmutableKit.map;
 import static graphql.schema.idl.SchemaGeneratorHelper.buildDescription;
 import static graphql.util.Pair.pair;
-import static java.util.Collections.emptyList;
 
 /**
  * This contains helper code to build out appliedm directives on schema element

--- a/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
+++ b/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
@@ -55,7 +55,6 @@ import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
 import graphql.schema.GraphQLTypeReference;
 import graphql.schema.GraphQLUnionType;
-import graphql.schema.GraphqlDirectivesContainerTypeBuilder;
 import graphql.schema.GraphqlTypeComparatorRegistry;
 import graphql.schema.PropertyDataFetcher;
 import graphql.schema.TypeResolver;
@@ -83,6 +82,7 @@ import static graphql.Assert.assertNotNull;
 import static graphql.Directives.DEPRECATED_DIRECTIVE_DEFINITION;
 import static graphql.Directives.SPECIFIED_BY_DIRECTIVE_DEFINITION;
 import static graphql.Directives.SpecifiedByDirective;
+import static graphql.collect.ImmutableKit.emptyList;
 import static graphql.introspection.Introspection.DirectiveLocation.ARGUMENT_DEFINITION;
 import static graphql.introspection.Introspection.DirectiveLocation.ENUM;
 import static graphql.introspection.Introspection.DirectiveLocation.ENUM_VALUE;
@@ -97,7 +97,6 @@ import static graphql.schema.GraphQLTypeReference.typeRef;
 import static graphql.schema.idl.SchemaGeneratorAppliedDirectiveHelper.buildAppliedDirectives;
 import static graphql.schema.idl.SchemaGeneratorAppliedDirectiveHelper.buildDirectiveDefinitionFromAst;
 import static java.lang.String.format;
-import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toMap;
 
 @Internal

--- a/src/main/java/graphql/schema/idl/SchemaTypeChecker.java
+++ b/src/main/java/graphql/schema/idl/SchemaTypeChecker.java
@@ -2,6 +2,7 @@ package graphql.schema.idl;
 
 import graphql.GraphQLError;
 import graphql.Internal;
+import graphql.collect.ImmutableKit;
 import graphql.introspection.Introspection;
 import graphql.language.Argument;
 import graphql.language.Directive;
@@ -30,7 +31,6 @@ import graphql.schema.idl.errors.SchemaProblem;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -171,7 +171,7 @@ public class SchemaTypeChecker {
     private void checkScalarImplementationsArePresent(List<GraphQLError> errors, TypeDefinitionRegistry typeRegistry, RuntimeWiring wiring) {
         typeRegistry.scalars().forEach((scalarName, scalarTypeDefinition) -> {
             WiringFactory wiringFactory = wiring.getWiringFactory();
-            ScalarWiringEnvironment environment = new ScalarWiringEnvironment(typeRegistry, scalarTypeDefinition, Collections.emptyList());
+            ScalarWiringEnvironment environment = new ScalarWiringEnvironment(typeRegistry, scalarTypeDefinition, ImmutableKit.emptyList());
             if (!wiringFactory.providesScalar(environment) && !wiring.getScalars().containsKey(scalarName)) {
                 errors.add(new MissingScalarImplementationError(scalarName));
             }

--- a/src/main/java/graphql/schema/validation/TypeAndFieldRule.java
+++ b/src/main/java/graphql/schema/validation/TypeAndFieldRule.java
@@ -1,5 +1,6 @@
 package graphql.schema.validation;
 
+import graphql.collect.ImmutableKit;
 import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLEnumValueDefinition;
@@ -206,7 +207,7 @@ public class TypeAndFieldRule extends GraphQLTypeVisitorStub {
 
     private List<GraphQLNamedType> filterBuiltInTypes(List<GraphQLNamedType> graphQLNamedTypes) {
         if (graphQLNamedTypes == null || graphQLNamedTypes.isEmpty()) {
-            return Collections.emptyList();
+            return ImmutableKit.emptyList();
         }
 
         Predicate<GraphQLNamedType> filterFunction = namedType -> {

--- a/src/main/java/graphql/util/Anonymizer.java
+++ b/src/main/java/graphql/util/Anonymizer.java
@@ -12,6 +12,7 @@ import graphql.analysis.QueryVisitorFieldArgumentValueEnvironment;
 import graphql.analysis.QueryVisitorFieldEnvironment;
 import graphql.analysis.QueryVisitorFragmentSpreadEnvironment;
 import graphql.analysis.QueryVisitorInlineFragmentEnvironment;
+import graphql.collect.ImmutableKit;
 import graphql.execution.ValuesResolver;
 import graphql.introspection.Introspection;
 import graphql.language.Argument;
@@ -125,19 +126,19 @@ public class Anonymizer {
     }
 
     public static GraphQLSchema anonymizeSchema(String sdl) {
-        return anonymizeSchemaAndQueries(createdMockedSchema(sdl), Collections.emptyList(), Collections.emptyMap()).schema;
+        return anonymizeSchemaAndQueries(createdMockedSchema(sdl), ImmutableKit.emptyList(), ImmutableKit.emptyMap()).schema;
     }
 
     public static GraphQLSchema anonymizeSchema(GraphQLSchema schema) {
-        return anonymizeSchemaAndQueries(schema, Collections.emptyList(), Collections.emptyMap()).schema;
+        return anonymizeSchemaAndQueries(schema, ImmutableKit.emptyList(), ImmutableKit.emptyMap()).schema;
     }
 
     public static AnonymizeResult anonymizeSchemaAndQueries(String sdl, List<String> queries) {
-        return anonymizeSchemaAndQueries(createdMockedSchema(sdl), queries, Collections.emptyMap());
+        return anonymizeSchemaAndQueries(createdMockedSchema(sdl), queries, ImmutableKit.emptyMap());
     }
 
     public static AnonymizeResult anonymizeSchemaAndQueries(GraphQLSchema schema, List<String> queries) {
-        return anonymizeSchemaAndQueries(schema, queries, Collections.emptyMap());
+        return anonymizeSchemaAndQueries(schema, queries, ImmutableKit.emptyMap());
     }
 
     public static AnonymizeResult anonymizeSchemaAndQueries(String sdl, List<String> queries, Map<String, Object> variables) {

--- a/src/main/java/graphql/util/Anonymizer.java
+++ b/src/main/java/graphql/util/Anonymizer.java
@@ -841,7 +841,7 @@ public class Anonymizer {
             public TraversalControl visitVariableDefinition(VariableDefinition node, TraverserContext<Node> context) {
                 String newName = assertNotNull(variableNames.get(node.getName()));
                 VariableDefinition newNode = node.transform(builder -> {
-                    builder.name(newName).comments(Collections.emptyList());
+                    builder.name(newName).comments(ImmutableKit.emptyList());
 
                     // convert variable language type to renamed language type
                     TypeName typeName = TypeUtil.unwrapAll(node.getType());

--- a/src/main/java/graphql/util/TreeParallelTransformer.java
+++ b/src/main/java/graphql/util/TreeParallelTransformer.java
@@ -1,6 +1,7 @@
 package graphql.util;
 
 import graphql.Internal;
+import graphql.collect.ImmutableKit;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -104,7 +105,7 @@ public class TreeParallelTransformer<T> {
             assertNotNull(traversalControl, () -> "result of enter must not be null");
             assertTrue(QUIT != traversalControl, () -> "can't return QUIT for parallel traversing");
             if (traversalControl == ABORT) {
-                this.children = Collections.emptyList();
+                this.children = ImmutableKit.emptyList();
                 tryComplete();
                 return;
             }

--- a/src/main/java/graphql/util/TreeTransformer.java
+++ b/src/main/java/graphql/util/TreeTransformer.java
@@ -2,6 +2,7 @@ package graphql.util;
 
 
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 
 import java.util.Collections;
 import java.util.LinkedList;
@@ -20,7 +21,7 @@ public class TreeTransformer<T> {
     }
 
     public T transform(T root, TraverserVisitor<T> traverserVisitor) {
-        return transform(root, traverserVisitor, Collections.emptyMap());
+        return transform(root, traverserVisitor, ImmutableKit.emptyMap());
     }
 
     public T transform(T root, TraverserVisitor<T> traverserVisitor, Map<Class<?>, Object> rootVars) {

--- a/src/main/java/graphql/validation/rules/UniqueDirectiveNamesPerLocation.java
+++ b/src/main/java/graphql/validation/rules/UniqueDirectiveNamesPerLocation.java
@@ -1,6 +1,5 @@
 package graphql.validation.rules;
 
-import graphql.DirectivesUtil;
 import graphql.Internal;
 import graphql.language.Directive;
 import graphql.language.Document;
@@ -18,10 +17,7 @@ import graphql.validation.ValidationErrorType;
 
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-
-import static java.util.Collections.emptyList;
 
 /**
  * https://facebook.github.io/graphql/June2018/#sec-Directives-Are-Unique-Per-Location


### PR DESCRIPTION
This is a very small improvement to use ImmutableKit.emptyMap() / emptyList() which is a micro optimisation whenever its every copied.  Not all of these are copied but the main code base now used 1 emptyXXX impl