### PR TITLE
Introspection performance investigation

### DIFF
--- a/src/main/java/graphql/introspection/Introspection.java
+++ b/src/main/java/graphql/introspection/Introspection.java
@@ -31,7 +31,6 @@ import graphql.schema.GraphQLScalarType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLUnionType;
 import graphql.schema.InputValueWithState;
-import graphql.schema.visibility.GraphqlFieldVisibility;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -262,10 +261,14 @@ public class Introspection {
             Boolean includeDeprecated = environment.getArgument("includeDeprecated");
             List<GraphQLFieldDefinition> fieldDefinitions = environment
                     .getGraphQLSchema()
+                    .getCodeRegistry()
                     .getFieldVisibility()
                     .getFieldDefinitions(fieldsContainer);
+            if (includeDeprecated) {
+                return fieldDefinitions;
+            }
             return fieldDefinitions.stream()
-                    .filter(field -> includeDeprecated || !field.isDeprecated())
+                    .filter(field -> !field.isDeprecated())
                     .collect(Collectors.toList());
         }
         return null;
@@ -296,11 +299,14 @@ public class Introspection {
 
     private static final IntrospectionDataFetcher<?> enumValuesTypesFetcher = environment -> {
         Object type = environment.getSource();
-        Boolean includeDeprecated = environment.getArgument("includeDeprecated");
         if (type instanceof GraphQLEnumType) {
+            Boolean includeDeprecated = environment.getArgument("includeDeprecated");
             List<GraphQLEnumValueDefinition> values = ((GraphQLEnumType) type).getValues();
+            if (includeDeprecated) {
+                return values;
+            }
             return values.stream()
-                    .filter(enumValue -> includeDeprecated || !enumValue.isDeprecated())
+                    .filter(enumValue -> !enumValue.isDeprecated())
                     .collect(Collectors.toList());
         }
         return null;
@@ -310,11 +316,16 @@ public class Introspection {
         Object type = environment.getSource();
         if (type instanceof GraphQLInputObjectType) {
             Boolean includeDeprecated = environment.getArgument("includeDeprecated");
-            GraphqlFieldVisibility fieldVisibility = environment
+            List<GraphQLInputObjectField> inputFields = environment
                     .getGraphQLSchema()
-                    .getFieldVisibility();
-            return fieldVisibility.getFieldDefinitions((GraphQLInputObjectType) type)
-                    .stream().filter(inputField -> includeDeprecated || !inputField.isDeprecated())
+                    .getCodeRegistry()
+                    .getFieldVisibility()
+                    .getFieldDefinitions((GraphQLInputObjectType) type);
+            if (includeDeprecated) {
+                return inputFields;
+            }
+            return inputFields
+                    .stream().filter(inputField -> !inputField.isDeprecated())
                     .collect(Collectors.toList());
         }
         return null;
@@ -631,6 +642,7 @@ public class Introspection {
      * @param schema     the schema to use
      * @param parentType the type of the parent object
      * @param fieldName  the field to look up
+     *
      * @return a field definition otherwise throws an assertion exception if its null
      */
     public static GraphQLFieldDefinition getFieldDef(GraphQLSchema schema, GraphQLCompositeType parentType, String fieldName) {

--- a/src/test/java/benchmark/IntrospectionBenchmark.java
+++ b/src/test/java/benchmark/IntrospectionBenchmark.java
@@ -79,7 +79,9 @@ public class IntrospectionBenchmark {
     public IntrospectionBenchmark() {
         String largeSchema = readFromClasspath("large-schema-4.graphqls");
         GraphQLSchema graphQLSchema = SchemaGenerator.createdMockedSchema(largeSchema);
-        graphQL = GraphQL.newGraphQL(graphQLSchema).instrumentation(countingInstrumentation).build();
+        graphQL = GraphQL.newGraphQL(graphQLSchema)
+                //.instrumentation(countingInstrumentation)
+                .build();
     }
 
 

--- a/src/test/java/benchmark/IntrospectionBenchmark.java
+++ b/src/test/java/benchmark/IntrospectionBenchmark.java
@@ -1,0 +1,137 @@
+package benchmark;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+import graphql.ExecutionResult;
+import graphql.GraphQL;
+import graphql.execution.DataFetcherResult;
+import graphql.execution.instrumentation.SimpleInstrumentation;
+import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
+import graphql.introspection.IntrospectionQuery;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLNamedType;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.idl.SchemaGenerator;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.io.Resources.getResource;
+
+@State(Scope.Benchmark)
+public class IntrospectionBenchmark {
+
+    private final GraphQL graphQL;
+    private final DFCountingInstrumentation countingInstrumentation = new DFCountingInstrumentation();
+
+    static class DFCountingInstrumentation extends SimpleInstrumentation {
+        Map<String, Long> counts = new LinkedHashMap<>();
+        Map<String, Long> times = new LinkedHashMap<>();
+
+        @Override
+        public DataFetcher<?> instrumentDataFetcher(DataFetcher<?> dataFetcher, InstrumentationFieldFetchParameters parameters) {
+            return (DataFetcher<Object>) env -> {
+                long then = System.nanoTime();
+                Object value = dataFetcher.get(env);
+                long nanos = System.nanoTime() - then;
+                DataFetcherResult.Builder<Object> result = DataFetcherResult.newResult().data(value);
+
+                String path = env.getExecutionStepInfo().getPath().toString();
+                String prevTypePath = env.getLocalContext();
+
+                Object source = env.getSource();
+                if (isSchemaTypesFetch(env, source)) {
+                    String typeName = ((GraphQLNamedType) source).getName();
+
+                    String prefix = "/__schema/types[" + typeName + "]";
+                    result.localContext(prefix);
+                    prevTypePath = prefix;
+                }
+                if (prevTypePath != null) {
+                    path = path.replaceAll("/__schema/types\\[.*\\]", prevTypePath);
+                }
+                counts.compute(path, (k, v) -> v == null ? 1 : v++);
+                if (nanos > 200_000) {
+                    times.compute(path, (k, v) -> v == null ? nanos : v + nanos);
+                }
+                return result.build();
+            };
+        }
+
+        private boolean isSchemaTypesFetch(DataFetchingEnvironment env, Object source) {
+            String parentPath = env.getExecutionStepInfo().getParent().getPath().getPathWithoutListEnd().toString();
+            return "/__schema/types".equals(parentPath) && source instanceof GraphQLNamedType;
+        }
+    }
+
+    public IntrospectionBenchmark() {
+        String largeSchema = readFromClasspath("large-schema-4.graphqls");
+        GraphQLSchema graphQLSchema = SchemaGenerator.createdMockedSchema(largeSchema);
+        graphQL = GraphQL.newGraphQL(graphQLSchema).instrumentation(countingInstrumentation).build();
+    }
+
+
+    private static String readFromClasspath(String file) {
+        URL url = getResource(file);
+        try {
+            return Resources.toString(url, Charsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void main(String[] args) {
+        IntrospectionBenchmark introspectionBenchmark = new IntrospectionBenchmark();
+//        while (true) {
+//            long then = System.currentTimeMillis();
+//            ExecutionResult er = introspectionBenchmark.benchMarkIntrospection();
+//            long ms = System.currentTimeMillis() - then;
+//            System.out.println("Took " + ms + "ms");
+//        }
+
+        introspectionBenchmark.benchMarkIntrospection();
+
+        Map<String, Long> counts = sortByValue(introspectionBenchmark.countingInstrumentation.counts);
+        Map<String, Long> times = sortByValue(introspectionBenchmark.countingInstrumentation.times);
+
+        System.out.println("Counts");
+        counts.forEach((k, v) -> System.out.printf("C %-70s : %020d\n", k, v));
+        System.out.println("Times");
+        times.forEach((k, v) -> System.out.printf("T %-70s : %020d\n", k, v));
+
+
+    }
+
+    public static <K, V extends Comparable<? super V>> Map<K, V> sortByValue(Map<K, V> map) {
+        List<Map.Entry<K, V>> list = new ArrayList<>(map.entrySet());
+        list.sort(Map.Entry.comparingByValue());
+
+        Map<K, V> result = new LinkedHashMap<>();
+        for (Map.Entry<K, V> entry : list) {
+            result.put(entry.getKey(), entry.getValue());
+        }
+
+        return result;
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    @Warmup(iterations = 2)
+    @Measurement(iterations = 3)
+    public ExecutionResult benchMarkIntrospection() {
+        return graphQL.execute(IntrospectionQuery.INTROSPECTION_QUERY);
+    }
+
+}


### PR DESCRIPTION
I spent some time trying to see if Introspection could be made faster.  But after some half a day at it - I learnt its pretty much as fast as its going to be.

This particular test file (large-schema-4) has 18,850 types and that results in 1,271,620 data fetcher calls.

df fetches like
```
/__schema/types[18375]/fields[4]/args               
/__schema/types[18375]/fields[4]/type                 
/__schema/types[18375]/fields[4]/type/kind        
/__schema/types[18375]/fields[4]/type/name             
/__schema/types[18375]/fields[4]/type/ofType               
/__schema/types[18375]/fields[4]/isDeprecated                 
/__schema/types[18375]/fields[4]/deprecationReason                    
/__schema/types[18375]/fields[5]/name                     
/__schema/types[18375]/fields[5]/description                
/__schema/types[18375]/fields[5]/args                       
/__schema/types[18375]/fields[5]/type                  
/__schema/types[18375]/fields[5]/type/kind                  
/__schema/types[18375]/fields[5]/type/name                  
/__schema/types[18375]/fields[5]/type/ofType                
/__schema/types[18375]/fields[5]/isDeprecated              
/__schema/types[18375]/fields[5]/deprecationReason
```

This has  micro optimisation of deprecated field fetching but not much else.