### PR TITLE
SchemaDirectiveWiringEnvironment now deprecates the old directive getters in lieu of applied directives

### DIFF
--- a/src/main/java/graphql/schema/idl/SchemaDirectiveWiringEnvironment.java
+++ b/src/main/java/graphql/schema/idl/SchemaDirectiveWiringEnvironment.java
@@ -39,11 +39,29 @@ public interface SchemaDirectiveWiringEnvironment<T extends GraphQLDirectiveCont
      *
      * @return the directive that was registered under specific directive name or null if it was not
      * registered this way
+     *
+     * @deprecated use {@link #getAppliedDirective()}
      */
     GraphQLDirective getDirective();
 
     /**
+     * This returns the applied directive that the {@link graphql.schema.idl.SchemaDirectiveWiring} was registered
+     * against during calls to {@link graphql.schema.idl.RuntimeWiring.Builder#directive(String, SchemaDirectiveWiring)}
+     * <p>
+     * If this method of registration is not used (say because
+     * {@link graphql.schema.idl.WiringFactory#providesSchemaDirectiveWiring(SchemaDirectiveWiringEnvironment)} or
+     * {@link graphql.schema.idl.RuntimeWiring.Builder#directiveWiring(SchemaDirectiveWiring)} was used)
+     * then this will return null.
+     *
+     * @return the applied directive that was registered under specific directive name or null if it was not
+     * registered this way
+     */
+    GraphQLAppliedDirective getAppliedDirective();
+
+    /**
      * @return all of the directives that are on the runtime element
+     *
+     * @deprecated use {@link #getAppliedDirectives()} instead
      */
     Map<String, GraphQLDirective> getDirectives();
 
@@ -53,6 +71,8 @@ public interface SchemaDirectiveWiringEnvironment<T extends GraphQLDirectiveCont
      * @param directiveName the name of the directive
      *
      * @return a named directive or null
+     *
+     * @deprecated use {@link #getAppliedDirective(String)}  instead
      */
     GraphQLDirective getDirective(String directiveName);
 

--- a/src/main/java/graphql/schema/idl/SchemaDirectiveWiringEnvironmentImpl.java
+++ b/src/main/java/graphql/schema/idl/SchemaDirectiveWiringEnvironmentImpl.java
@@ -34,9 +34,11 @@ public class SchemaDirectiveWiringEnvironmentImpl<T extends GraphQLDirectiveCont
     private final GraphQLFieldsContainer fieldsContainer;
     private final GraphQLFieldDefinition fieldDefinition;
     private final GraphQLDirective registeredDirective;
+    private final GraphQLAppliedDirective registeredAppliedDirective;
 
-    public SchemaDirectiveWiringEnvironmentImpl(T element, List<GraphQLDirective> directives, List<GraphQLAppliedDirective> appliedDirectives, GraphQLDirective registeredDirective, SchemaGeneratorDirectiveHelper.Parameters parameters) {
+    public SchemaDirectiveWiringEnvironmentImpl(T element, List<GraphQLDirective> directives, List<GraphQLAppliedDirective> appliedDirectives, GraphQLAppliedDirective registeredAppliedDirective, GraphQLDirective registeredDirective, SchemaGeneratorDirectiveHelper.Parameters parameters) {
         this.element = element;
+        this.registeredAppliedDirective = registeredAppliedDirective;
         this.registeredDirective = registeredDirective;
         this.typeDefinitionRegistry = parameters.getTypeRegistry();
         this.directives = FpKit.getByName(directives, GraphQLDirective::getName);
@@ -57,6 +59,11 @@ public class SchemaDirectiveWiringEnvironmentImpl<T extends GraphQLDirectiveCont
     @Override
     public GraphQLDirective getDirective() {
         return registeredDirective;
+    }
+
+    @Override
+    public GraphQLAppliedDirective getAppliedDirective() {
+        return registeredAppliedDirective;
     }
 
     @Override

--- a/src/main/java/graphql/schema/idl/SchemaGeneratorDirectiveHelper.java
+++ b/src/main/java/graphql/schema/idl/SchemaGeneratorDirectiveHelper.java
@@ -20,6 +20,7 @@ import graphql.schema.GraphQLScalarType;
 import graphql.schema.GraphQLSchemaElement;
 import graphql.schema.GraphQLUnionType;
 import graphql.schema.GraphqlElementParentTree;
+import graphql.util.FpKit;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -64,6 +65,7 @@ public class SchemaGeneratorDirectiveHelper {
         SchemaDirectiveWiringEnvironment<T> env = new SchemaDirectiveWiringEnvironmentImpl<>(directiveContainer,
                 directiveContainer.getDirectives(),
                 directiveContainer.getAppliedDirectives(),
+                null,
                 null,
                 params);
         // do they dynamically provide a wiring for this element?
@@ -206,9 +208,10 @@ public class SchemaGeneratorDirectiveHelper {
                 newObjectType,
                 newObjectType.getDirectives(),
                 newObjectType.getAppliedDirectives(),
-                (outputElement, directives, appliedDirectives, registeredDirective) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement,
+                (outputElement, directives, appliedDirectives, registeredAppliedDirective, registeredDirective) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement,
                         directives,
                         appliedDirectives,
+                        registeredAppliedDirective,
                         registeredDirective,
                         newParams),
                 SchemaDirectiveWiring::onObject);
@@ -231,9 +234,10 @@ public class SchemaGeneratorDirectiveHelper {
                 newInterfaceType,
                 newInterfaceType.getDirectives(),
                 newInterfaceType.getAppliedDirectives(),
-                (outputElement, directives, appliedDirectives, registeredDirective) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement,
+                (outputElement, directives, appliedDirectives, registeredAppliedDirective, registeredDirective) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement,
                         directives,
                         appliedDirectives,
+                        registeredAppliedDirective,
                         registeredDirective,
                         newParams),
                 SchemaDirectiveWiring::onInterface);
@@ -265,9 +269,10 @@ public class SchemaGeneratorDirectiveHelper {
                 newEnumType,
                 newEnumType.getDirectives(),
                 newEnumType.getAppliedDirectives(),
-                (outputElement, directives, appliedDirectives, registeredDirective) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement,
+                (outputElement, directives, appliedDirectives, registeredAppliedDirective, registeredDirective) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement,
                         directives,
                         appliedDirectives,
+                        registeredAppliedDirective,
                         registeredDirective,
                         newParams),
                 SchemaDirectiveWiring::onEnum);
@@ -297,9 +302,10 @@ public class SchemaGeneratorDirectiveHelper {
                 newInputObjectType,
                 newInputObjectType.getDirectives(),
                 newInputObjectType.getAppliedDirectives(),
-                (outputElement, directives, appliedDirectives, registeredDirective) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement,
+                (outputElement, directives, appliedDirectives, registeredAppliedDirective, registeredDirective) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement,
                         directives,
                         appliedDirectives,
+                        registeredAppliedDirective,
                         registeredDirective,
                         newParams),
                 SchemaDirectiveWiring::onInputObjectType);
@@ -315,9 +321,10 @@ public class SchemaGeneratorDirectiveHelper {
                 element,
                 element.getDirectives(),
                 element.getAppliedDirectives(),
-                (outputElement, directives, appliedDirectives, registeredDirective) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement,
+                (outputElement, directives, appliedDirectives, registeredAppliedDirective, registeredDirective) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement,
                         directives,
                         appliedDirectives,
+                        registeredAppliedDirective,
                         registeredDirective,
                         newParams),
                 SchemaDirectiveWiring::onUnion);
@@ -332,9 +339,10 @@ public class SchemaGeneratorDirectiveHelper {
                 element,
                 element.getDirectives(),
                 element.getAppliedDirectives(),
-                (outputElement, directives, appliedDirectives, registeredDirective) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement,
+                (outputElement, directives, appliedDirectives, registeredAppliedDirective, registeredDirective) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement,
                         directives,
                         appliedDirectives,
+                        registeredAppliedDirective,
                         registeredDirective,
                         newParams),
                 SchemaDirectiveWiring::onScalar);
@@ -345,9 +353,10 @@ public class SchemaGeneratorDirectiveHelper {
                 fieldDefinition,
                 fieldDefinition.getDirectives(),
                 fieldDefinition.getAppliedDirectives(),
-                (outputElement, directives, appliedDirectives, registeredDirective) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement,
+                (outputElement, directives, appliedDirectives, registeredAppliedDirective, registeredDirective) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement,
                         directives,
                         appliedDirectives,
+                        registeredAppliedDirective,
                         registeredDirective,
                         params),
                 SchemaDirectiveWiring::onField);
@@ -358,9 +367,10 @@ public class SchemaGeneratorDirectiveHelper {
                 element,
                 element.getDirectives(),
                 element.getAppliedDirectives(),
-                (outputElement, directives, appliedDirectives, registeredDirective) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement,
+                (outputElement, directives, appliedDirectives, registeredAppliedDirective, registeredDirective) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement,
                         directives,
                         appliedDirectives,
+                        registeredAppliedDirective,
                         registeredDirective,
                         params),
                 SchemaDirectiveWiring::onInputObjectField);
@@ -371,9 +381,10 @@ public class SchemaGeneratorDirectiveHelper {
                 enumValueDefinition,
                 enumValueDefinition.getDirectives(),
                 enumValueDefinition.getAppliedDirectives(),
-                (outputElement, directives, appliedDirectives, registeredDirective) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement,
+                (outputElement, directives, appliedDirectives, registeredAppliedDirective, registeredDirective) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement,
                         directives,
                         appliedDirectives,
+                        registeredAppliedDirective,
                         registeredDirective,
                         params),
                 SchemaDirectiveWiring::onEnumValue);
@@ -384,9 +395,10 @@ public class SchemaGeneratorDirectiveHelper {
                 argument,
                 argument.getDirectives(),
                 argument.getAppliedDirectives(),
-                (outputElement, directives, appliedDirectives, registeredDirective) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement,
+                (outputElement, directives, appliedDirectives, registeredAppliedDirective, registeredDirective) -> new SchemaDirectiveWiringEnvironmentImpl<>(outputElement,
                         directives,
                         appliedDirectives,
+                        registeredAppliedDirective,
                         registeredDirective,
                         params),
                 SchemaDirectiveWiring::onArgument);
@@ -397,7 +409,7 @@ public class SchemaGeneratorDirectiveHelper {
     // builds a type safe SchemaDirectiveWiringEnvironment
     //
     interface EnvBuilder<T extends GraphQLDirectiveContainer> {
-        SchemaDirectiveWiringEnvironment<T> apply(T outputElement, List<GraphQLDirective> allDirectives, List<GraphQLAppliedDirective> allAppliedDirectives, GraphQLDirective registeredDirective);
+        SchemaDirectiveWiringEnvironment<T> apply(T outputElement, List<GraphQLDirective> allDirectives, List<GraphQLAppliedDirective> allAppliedDirectives, GraphQLAppliedDirective registeredAppliedDirective, GraphQLDirective registeredDirective);
     }
 
     //
@@ -420,25 +432,28 @@ public class SchemaGeneratorDirectiveHelper {
 
         SchemaDirectiveWiringEnvironment<T> env;
         T outputObject = element;
+
+        Map<String, GraphQLDirective> allDirectivesByName = FpKit.getByName(allDirectives, GraphQLDirective::getName);
         //
         // first the specific named directives
         Map<String, SchemaDirectiveWiring> mapOfWiring = runtimeWiring.getRegisteredDirectiveWiring();
-        for (GraphQLDirective directive : allDirectives) {
-            schemaDirectiveWiring = mapOfWiring.get(directive.getName());
+        for (GraphQLAppliedDirective appliedDirective : allAppliedDirectives) {
+            schemaDirectiveWiring = mapOfWiring.get(appliedDirective.getName());
             if (schemaDirectiveWiring != null) {
-                env = envBuilder.apply(outputObject, allDirectives, allAppliedDirectives, directive);
+                GraphQLDirective directive = allDirectivesByName.get(appliedDirective.getName());
+                env = envBuilder.apply(outputObject, allDirectives, allAppliedDirectives, appliedDirective, directive);
                 outputObject = invokeWiring(outputObject, invoker, schemaDirectiveWiring, env);
             }
         }
         //
         // now call any statically added to the runtime
         for (SchemaDirectiveWiring directiveWiring : runtimeWiring.getDirectiveWiring()) {
-            env = envBuilder.apply(outputObject, allDirectives, allAppliedDirectives, null);
+            env = envBuilder.apply(outputObject, allDirectives, allAppliedDirectives, null, null);
             outputObject = invokeWiring(outputObject, invoker, directiveWiring, env);
         }
         //
         // wiring factory is last (if present)
-        env = envBuilder.apply(outputObject, allDirectives, allAppliedDirectives, null);
+        env = envBuilder.apply(outputObject, allDirectives, allAppliedDirectives, null, null);
         if (wiringFactory.providesSchemaDirectiveWiring(env)) {
             schemaDirectiveWiring = assertNotNull(wiringFactory.getSchemaDirectiveWiring(env), () -> "Your WiringFactory MUST provide a non null SchemaDirectiveWiring");
             outputObject = invokeWiring(outputObject, invoker, schemaDirectiveWiring, env);


### PR DESCRIPTION
This deprecation was missed in 18.0 and should have been done then

See #2824 