### PR TITLE
Avoiding Async array copies 

### DIFF
--- a/src/main/java/graphql/execution/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncExecutionStrategy.java
@@ -12,7 +12,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 
-import static graphql.collect.ImmutableKit.map;
 
 /**
  * The standard graphql execution strategy that runs fields asynchronously non-blocking.
@@ -47,7 +46,7 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
 
         MergedSelectionSet fields = parameters.getFields();
         Set<String> fieldNames = fields.keySet();
-        List<CompletableFuture<FieldValueInfo>> futures = new ArrayList<>(fieldNames.size());
+        Async.CombinedBuilder<FieldValueInfo> futures = Async.ofExpectedSize(fields.size());
         List<String> resolvedFields = new ArrayList<>(fieldNames.size());
         for (String fieldName : fieldNames) {
             MergedField currentField = fields.getSubField(fieldName);
@@ -63,15 +62,18 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
         CompletableFuture<ExecutionResult> overallResult = new CompletableFuture<>();
         executionStrategyCtx.onDispatched(overallResult);
 
-        Async.each(futures).whenComplete((completeValueInfos, throwable) -> {
+        futures.await().whenComplete((completeValueInfos, throwable) -> {
             BiConsumer<List<ExecutionResult>, Throwable> handleResultsConsumer = handleResults(executionContext, resolvedFields, overallResult);
             if (throwable != null) {
                 handleResultsConsumer.accept(null, throwable.getCause());
                 return;
             }
-            List<CompletableFuture<ExecutionResult>> executionResultFuture = map(completeValueInfos, FieldValueInfo::getFieldValue);
+            Async.CombinedBuilder<ExecutionResult> executionResultFutures = Async.ofExpectedSize(completeValueInfos.size());
+            for (FieldValueInfo completeValueInfo : completeValueInfos) {
+                executionResultFutures.add(completeValueInfo.getFieldValue());
+            }
             executionStrategyCtx.onFieldValuesInfo(completeValueInfos);
-            Async.each(executionResultFuture).whenComplete(handleResultsConsumer);
+            executionResultFutures.await().whenComplete(handleResultsConsumer);
         }).exceptionally((ex) -> {
             // if there are any issues with combining/handling the field results,
             // complete the future at all costs and bubble up any thrown exception so

--- a/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
@@ -11,8 +11,8 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * Async non-blocking execution, but serial: only one field at the the time will be resolved.
- * See {@link AsyncExecutionStrategy} for a non serial (parallel) execution of every field.
+ * Async non-blocking execution, but serial: only one field at the time will be resolved.
+ * See {@link AsyncExecutionStrategy} for a non-serial (parallel) execution of every field.
  */
 @PublicApi
 public class AsyncSerialExecutionStrategy extends AbstractAsyncExecutionStrategy {


### PR DESCRIPTION
@bbakerman @andimarek  hi guys :)

while profiling in YourKit, I spotted some extra array allocations for CompletableFuture. This is still an idea... and a work in progress... please have a look :-) There is a special handling for SelectionSet of only 1 field: in this case the array allocation  could be removed completely. 

Baseline:

```
    Benchmark                                    Mode  Cnt   Score   Error  Units
    BenchMark.benchMarkSimpleQueriesThroughput  thrpt   15  52.398 ± 0.944  ops/s
    BenchMark.benchMarkSimpleQueriesAvgTime      avgt   15  19.028 ± 0.376  ms/op
```

After this PR:
```
    Benchmark                                    Mode  Cnt   Score   Error  Units
    BenchMark.benchMarkSimpleQueriesThroughput  thrpt   15  55.134 ± 0.782  ops/s
    BenchMark.benchMarkSimpleQueriesAvgTime      avgt   15  17.925 ± 0.505  ms/op
```

is about 5-6% better on my machine (that is quite old, so maybe it is less on newer machines). Do you see other hot spots where this could beneficial?

