### PR TITLE
ImmutableKit.map with pre-size

### DIFF
--- a/src/main/java/graphql/collect/ImmutableKit.java
+++ b/src/main/java/graphql/collect/ImmutableKit.java
@@ -61,26 +61,27 @@ public final class ImmutableKit {
     }
 
     public static <T> ImmutableList<T> concatLists(List<T> l1, List<T> l2) {
-        return ImmutableList.<T>builder().addAll(l1).addAll(l2).build();
+        //noinspection UnstableApiUsage
+        return ImmutableList.<T>builderWithExpectedSize(l1.size() + l2.size()).addAll(l1).addAll(l2).build();
     }
 
     /**
      * This is more efficient than `c.stream().map().collect()` because it does not create the intermediate objects needed
      * for the flexible style.  Benchmarking has shown this to outperform `stream()`.
      *
-     * @param iterable the iterable to map
+     * @param collection the collection to map
      * @param mapper   the mapper function
      * @param <T>      for two
      * @param <R>      for result
      *
      * @return a map immutable list of results
      */
-    public static <T, R> ImmutableList<R> map(Iterable<? extends T> iterable, Function<? super T, ? extends R> mapper) {
-        assertNotNull(iterable);
+    public static <T, R> ImmutableList<R> map(Collection<? extends T> collection, Function<? super T, ? extends R> mapper) {
+        assertNotNull(collection);
         assertNotNull(mapper);
-        @SuppressWarnings("RedundantTypeArguments")
-        ImmutableList.Builder<R> builder = ImmutableList.<R>builder();
-        for (T t : iterable) {
+        @SuppressWarnings({"RedundantTypeArguments", "UnstableApiUsage"})
+        ImmutableList.Builder<R> builder = ImmutableList.<R>builderWithExpectedSize(collection.size());
+        for (T t : collection) {
             R r = mapper.apply(t);
             builder.add(r);
         }
@@ -101,6 +102,7 @@ public final class ImmutableKit {
         assertNotNull(existing);
         assertNotNull(newValue);
         int expectedSize = existing.size() + 1 + extraValues.length;
+        @SuppressWarnings("UnstableApiUsage")
         ImmutableList.Builder<T> newList = ImmutableList.builderWithExpectedSize(expectedSize);
         newList.addAll(existing);
         newList.add(newValue);
@@ -124,6 +126,7 @@ public final class ImmutableKit {
         assertNotNull(existing);
         assertNotNull(newValue);
         int expectedSize = existing.size() + 1 + extraValues.length;
+        @SuppressWarnings("UnstableApiUsage")
         ImmutableSet.Builder<T> newSet = ImmutableSet.builderWithExpectedSize(expectedSize);
         newSet.addAll(existing);
         newSet.add(newValue);

--- a/src/test/java/benchmark/ListBenchmark.java
+++ b/src/test/java/benchmark/ListBenchmark.java
@@ -33,7 +33,7 @@ public class ListBenchmark {
         return list;
     }
 
-    Function<String, String> mapper = s -> new StringBuilder(s).reverse().toString();
+    private final Function<String, String> mapper = s -> new StringBuilder(s).reverse().toString();
 
     @Benchmark
     public void benchmarkListStream(Blackhole blackhole) {


### PR DESCRIPTION
@bbakerman  @andimarek a breaking change in `ImmutableKit`  that provides a nice "free lunch": 
by switching the signature from `Iterable` to `Collection` it is possible to pre-size the builder to avoid any extra allocation.

The class is is marked as `@Internal` so maybe it not a problem at all :)

List size = 10000

```
Benchmark                                          Mode  Cnt     Score     Error  Units
ListBenchmark.benchmarkArrayList                  thrpt   10  1879.357 ± 185.666  ops/s
ListBenchmark.benchmarkImmutableCollectorBuilder  thrpt   10  1879.835 ±  16.009  ops/s
ListBenchmark.benchmarkImmutableListBuilder       thrpt   10  1916.382 ±  13.232  ops/s
ListBenchmark.benchmarkImmutableListBuilder2      thrpt   10  1996.370 ±  15.618  ops/s <- new
ListBenchmark.benchmarkListStream                 thrpt   10  1833.081 ±  19.807  ops/s
```

List size = 10
```
ListBenchmark.benchmarkArrayList                  thrpt   10  1932469.875 ± 250182.583  ops/s
ListBenchmark.benchmarkImmutableCollectorBuilder  thrpt   10  1765995.264 ±   7710.397  ops/s
ListBenchmark.benchmarkImmutableListBuilder       thrpt   10  1992740.542 ±  10385.303  ops/s
ListBenchmark.benchmarkImmutableListBuilder2      thrpt   10  2104911.110 ±   5790.337  ops/s <- new
ListBenchmark.benchmarkListStream                 thrpt   10  1826454.508 ±  10735.506  ops/s
```