### PR TITLE
This fixes the ImmutableMap .map problem where lists can have null in them

### DIFF
--- a/src/main/java/graphql/normalized/ValueToVariableValueCompiler.java
+++ b/src/main/java/graphql/normalized/ValueToVariableValueCompiler.java
@@ -22,7 +22,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import static graphql.collect.ImmutableKit.map;
 import static java.util.stream.Collectors.toList;
 
 @Internal
@@ -66,13 +65,15 @@ public class ValueToVariableValueCompiler {
         } else if (maybeValue instanceof Map) {
             variableValue = normalisedValueToVariableValues((Map<String, Object>) maybeValue);
         } else {
-            throw new AssertException("Should never happen. Did not expect type: " + maybeClass(maybeValue));
+                throw new AssertException("Should never happen. Did not expect type: " + maybeClass(maybeValue));
         }
         return variableValue;
     }
 
     private static List<Object> normalisedValueToVariableValues(List<Object> arrayValues) {
-        return map(arrayValues, ValueToVariableValueCompiler::normalisedValueToVariableValue);
+        return arrayValues.stream()
+                .map(ValueToVariableValueCompiler::normalisedValueToVariableValue)
+                .collect(toList());
     }
 
     @NotNull


### PR DESCRIPTION
Some values in the NIV can be a list with null values.  So we cant use ImmutabvleList in the mapper as its wont accept nulls entries

```
java.lang.NullPointerException: null
    at graphql.com.google.common.base.Preconditions.checkNotNull(Preconditions.java:889)
    at graphql.com.google.common.collect.ImmutableList$Builder.add(ImmutableList.java:813)
    at graphql.collect.ImmutableKit.map(ImmutableKit.java:85)
    at graphql.normalized.ValueToVariableValueCompiler.normalisedValueToVariableValues(ValueToVariableValueCompiler.java:75)
    at graphql.normalized.ValueToVariableValueCompiler.normalisedValueToVariableValue(ValueToVariableValueCompiler.java:53)
    at graphql.normalized.ValueToVariableValueCompiler.lambda$normalisedValueToVariableValues$0(ValueToVariableValueCompiler.java:82)
    at java.util.LinkedHashMap.forEach(LinkedHashMap.java:684)
    at graphql.normalized.ValueToVariableValueCompiler.normalisedValueToVariableValues(ValueToVariableValueCompiler.java:81)
    at graphql.normalized.ValueToVariableValueCompiler.normalisedValueToVariableValue(ValueToVariableValueCompiler.java:55)
    at graphql.normalized.ValueToVariableValueCompiler.lambda$normalisedValueToVariableValues$0(ValueToVariableValueCompiler.java:82)
    at java.util.LinkedHashMap.forEach(LinkedHashMap.java:684)
    at graphql.normalized.ValueToVariableValueCompiler.normalisedValueToVariableValues(ValueToVariableValueCompiler.java:81)
    at graphql.normalized.ValueToVariableValueCompiler.normalisedValueToVariableValue(ValueToVariableValueCompiler.java:55)
    at graphql.normalized.ValueToVariableValueCompiler.normalizedInputValueToVariable(ValueToVariableValueCompiler.java:32)
    at graphql.normalized.VariableAccumulator.accumulateVariable(VariableAccumulator.java:36)
    at graphql.normalized.ExecutableNormalizedOperationToAstCompiler.argValue(ExecutableNormalizedOperationToAstCompiler.java:228)
    at graphql.normalized.ExecutableNormalizedOperationToAstCompiler.createArguments(ExecutableNormalizedOperationToAstCompiler.java:187)
    at graphql.normalized.ExecutableNormalizedOperationToAstCompiler.selectionForNormalizedField(ExecutableNormalizedOperationToAstCompiler.java:162)
    at graphql.normalized.ExecutableNormalizedOperationToAstCompiler.subselectionsForNormalizedField(ExecutableNormalizedOperationToAstCompiler.java:108)
    at graphql.normalized.ExecutableNormalizedOperationToAstCompiler.selectionForNormalizedField(ExecutableNormalizedOperationToAstCompiler.java:153)
    at graphql.normalized.ExecutableNormalizedOperationToAstCompiler.subselectionsForNormalizedField(ExecutableNormalizedOperationToAstCompiler.java:108)
    at graphql.normalized.ExecutableNormalizedOperationToAstCompiler.compileToDocument(ExecutableNormalizedOperationToAstCompiler.java:72)
```