### PR TITLE
Upgrade dataloader to 3.1.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:23.0.0'
     implementation 'org.antlr:antlr4-runtime:' + antlrVersion
     implementation 'org.slf4j:slf4j-api:' + slf4jVersion
-    api 'com.graphql-java:java-dataloader:3.1.2'
+    api 'com.graphql-java:java-dataloader:3.1.4'
     api 'org.reactivestreams:reactive-streams:' + reactiveStreamsVersion
     antlr 'org.antlr:antlr4:' + antlrVersion
     implementation 'com.google.guava:guava:31.0.1-jre'


### PR DESCRIPTION
[The issue preventing the current version of graphql-java from working with the Java module system](https://github.com/graphql-java/java-dataloader/issues/110) has been resolved, so the java-dataloader dependency should be upgraded.

The latest version update for java-dataloader was in graphql-java 18.0 (Mar 15, 2022) to version 3.1.2. This update will pull in the 3.1.4 fix and also the 3.1.3 changes.