### PR TITLE
Upgrade ANTLR to 4.10.1 WIP

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ targetCompatibility = 1.8
 def reactiveStreamsVersion = '1.0.3'
 def slf4jVersion = '1.7.35'
 def releaseVersion = System.env.RELEASE_VERSION
-def antlrVersion = '4.9.3' // https://mvnrepository.com/artifact/org.antlr/antlr4-runtime
+def antlrVersion = '4.10.1' // https://mvnrepository.com/artifact/org.antlr/antlr4-runtime
 version = releaseVersion ? releaseVersion : getDevelopmentVersion()
 group = 'com.graphql-java'
 


### PR DESCRIPTION
Update to the latest ANTLR version and unblock others relying on this dependency update #2809 and https://github.com/openrewrite/rewrite/issues/1615

The key change with this update is that the lexers/parsers etc needed to be regenerated in order to be compatible with the new ANTLR version. 

In case you're wondering why those files don't appear in the diff - we regenerate these files on every build with the `generateGrammarSource` task, we do not check in these files into the repo.