### PR TITLE
SchemaPrinter should include schema description in printed SDL

### DIFF
--- a/src/main/java/graphql/schema/idl/SchemaPrinter.java
+++ b/src/main/java/graphql/schema/idl/SchemaPrinter.java
@@ -15,11 +15,12 @@ import graphql.language.InputValueDefinition;
 import graphql.language.InterfaceTypeDefinition;
 import graphql.language.ObjectTypeDefinition;
 import graphql.language.ScalarTypeDefinition;
+import graphql.language.SchemaDefinition;
 import graphql.language.TypeDefinition;
 import graphql.language.UnionTypeDefinition;
 import graphql.schema.DefaultGraphqlTypeComparatorRegistry;
-import graphql.schema.GraphQLAppliedDirectiveArgument;
 import graphql.schema.GraphQLAppliedDirective;
+import graphql.schema.GraphQLAppliedDirectiveArgument;
 import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLDirectiveContainer;
@@ -742,6 +743,9 @@ public class SchemaPrinter {
             }
 
             if (needsSchemaPrinted) {
+                if (hasDescription(schema)) {
+                    out.print(printComments(schema, ""));
+                }
                 List<GraphQLAppliedDirective> directives = DirectivesUtil.toAppliedDirectives(schema.getSchemaAppliedDirectives(), schema.getSchemaDirectives());
                 out.format("schema %s{\n", directivesString(GraphQLSchemaElement.class, false, directives));
                 if (queryType != null) {
@@ -1099,6 +1103,9 @@ public class SchemaPrinter {
         } else if (descriptionHolder instanceof GraphQLDirective) {
             GraphQLDirective type = (GraphQLDirective) descriptionHolder;
             return description(type.getDescription(), null);
+        } else if (descriptionHolder instanceof GraphQLSchema) {
+            GraphQLSchema type = (GraphQLSchema) descriptionHolder;
+            return description(type.getDescription(), ofNullable(type.getDefinition()).map(SchemaDefinition::getDescription).orElse(null));
         } else {
             return Assert.assertShouldNeverHappen();
         }

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -2130,4 +2130,26 @@ type Query {
 '''
 
     }
+
+    def "prints schema description as comment"() {
+        given:
+        GraphQLFieldDefinition fieldDefinition = newFieldDefinition()
+                .name("field").type(GraphQLString).build()
+        def queryType = newObject().name("Query").field(fieldDefinition).build()
+        def schema = GraphQLSchema.newSchema().description("About Schema").query(queryType).build()
+        when:
+        def result = new SchemaPrinter(noDirectivesOption.includeSchemaDefinition(true)).print(schema)
+        println(result)
+
+        then:
+        result == '''"About Schema"
+schema {
+  query: Query
+}
+
+type Query {
+  field: String
+}
+'''
+    }
 }


### PR DESCRIPTION
Schema description is available through introspection but is not included in the printed SDL. Update `SchemaPrinter` to also include schema description in the printed SDL.