### PR TITLE
Populate PreparsedDocumentEntry with both errors and the parsed docum…

### DIFF
--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -589,7 +589,7 @@ public class GraphQL {
             final List<ValidationError> errors = validate(executionInput, document, graphQLSchema, instrumentationState);
             if (!errors.isEmpty()) {
                 logNotSafe.warn("Query did not validate : '{}'", query);
-                return new PreparsedDocumentEntry(errors);
+                return new PreparsedDocumentEntry(document, errors);
             }
 
             return new PreparsedDocumentEntry(document);

--- a/src/main/java/graphql/execution/preparsed/PreparsedDocumentEntry.java
+++ b/src/main/java/graphql/execution/preparsed/PreparsedDocumentEntry.java
@@ -39,6 +39,12 @@ public class PreparsedDocumentEntry implements Serializable {
         this.errors = null;
     }
 
+    public PreparsedDocumentEntry(List<? extends GraphQLError> errors) {
+        assertNotNull(errors);
+        this.document = null;
+        this.errors = errors;
+    }
+
     public PreparsedDocumentEntry(GraphQLError error) {
         assertNotNull(error);
         this.document = null;

--- a/src/main/java/graphql/execution/preparsed/PreparsedDocumentEntry.java
+++ b/src/main/java/graphql/execution/preparsed/PreparsedDocumentEntry.java
@@ -46,9 +46,7 @@ public class PreparsedDocumentEntry implements Serializable {
     }
 
     public PreparsedDocumentEntry(GraphQLError error) {
-        assertNotNull(error);
-        this.document = null;
-        this.errors = singletonList(error);
+        this(singletonList(assertNotNull(error)));
     }
 
     public Document getDocument() {

--- a/src/main/java/graphql/execution/preparsed/PreparsedDocumentEntry.java
+++ b/src/main/java/graphql/execution/preparsed/PreparsedDocumentEntry.java
@@ -11,8 +11,9 @@ import static graphql.Assert.assertNotNull;
 import static java.util.Collections.singletonList;
 
 /**
- * An instance of a preparsed document entry represents the result of a query parse and validation, like
- * an either implementation it contains either the correct result in the document property or the errors.
+ * An instance of a preparsed document entry represents the result of a query parse and validation. In the case of
+ * failed parsing or no validation errors this class acts as an either implementation. In the case of successful
+ * parsing and failed validation this class provides both the document and the validation errors.
  *
  * NOTE: This class implements {@link java.io.Serializable} and hence it can be serialised and placed into a distributed cache.  However we
  * are not aiming to provide long term compatibility and do not intend for you to place this serialised data into permanent storage,
@@ -24,20 +25,24 @@ public class PreparsedDocumentEntry implements Serializable {
     private final Document document;
     private final List<? extends GraphQLError> errors;
 
+    public PreparsedDocumentEntry(Document document,
+                                  List<? extends GraphQLError> errors) {
+        assertNotNull(document);
+        assertNotNull(errors);
+        this.document = document;
+        this.errors = errors;
+    }
+
     public PreparsedDocumentEntry(Document document) {
         assertNotNull(document);
         this.document = document;
         this.errors = null;
     }
 
-    public PreparsedDocumentEntry(List<? extends GraphQLError> errors) {
-        assertNotNull(errors);
-        this.document = null;
-        this.errors = errors;
-    }
-
     public PreparsedDocumentEntry(GraphQLError error) {
-        this(singletonList(assertNotNull(error)));
+        assertNotNull(error);
+        this.document = null;
+        this.errors = singletonList(error);
     }
 
     public Document getDocument() {

--- a/src/main/java/graphql/nextgen/GraphQL.java
+++ b/src/main/java/graphql/nextgen/GraphQL.java
@@ -231,7 +231,7 @@ public class GraphQL {
             final List<ValidationError> errors = validate(executionInput, document, graphQLSchema, instrumentationState);
             if (!errors.isEmpty()) {
                 logNotSafe.warn("Query did not validate : '{}'", query);
-                return new PreparsedDocumentEntry(errors);
+                return new PreparsedDocumentEntry(document, errors);
             }
 
             return new PreparsedDocumentEntry(document);

--- a/src/test/groovy/graphql/execution/preparsed/PreparsedDocumentEntryTest.groovy
+++ b/src/test/groovy/graphql/execution/preparsed/PreparsedDocumentEntryTest.groovy
@@ -30,6 +30,19 @@ class PreparsedDocumentEntryTest extends Specification {
         thrown(AssertException)
     }
 
+    def "Ensure a non-null errors returns"() {
+        given:
+        def errors = [new InvalidSyntaxError(new SourceLocation(0, 0), "bang"),
+                      new ValidationError(ValidationErrorType.InvalidSyntax)]
+
+        when:
+        def docEntry = new PreparsedDocumentEntry(errors)
+
+        then:
+        docEntry.document == null
+        docEntry.errors == errors
+    }
+
     def "Ensure a non-null error returns"() {
         given:
         def error = new InvalidSyntaxError(new SourceLocation(0, 0), "bang")

--- a/src/test/groovy/graphql/execution/preparsed/PreparsedDocumentEntryTest.groovy
+++ b/src/test/groovy/graphql/execution/preparsed/PreparsedDocumentEntryTest.groovy
@@ -63,6 +63,14 @@ class PreparsedDocumentEntryTest extends Specification {
         thrown(AssertException)
     }
 
+    def "Ensure a null errors throws Exception"() {
+        when:
+        new PreparsedDocumentEntry((List<GraphQLError>) null)
+
+        then:
+        thrown(AssertException)
+    }
+
     def "Ensure a null error and valid document throws Exception"() {
         given:
         def document = Document.newDocument().build()

--- a/src/test/groovy/graphql/execution/preparsed/PreparsedDocumentEntryTest.groovy
+++ b/src/test/groovy/graphql/execution/preparsed/PreparsedDocumentEntryTest.groovy
@@ -30,25 +30,16 @@ class PreparsedDocumentEntryTest extends Specification {
         thrown(AssertException)
     }
 
-    def "Ensure a non-null errors returns"() {
+    def "Ensure a non-null error returns"() {
         given:
-        def errors = [new InvalidSyntaxError(new SourceLocation(0, 0), "bang"),
-                      new ValidationError(ValidationErrorType.InvalidSyntax)]
+        def error = new InvalidSyntaxError(new SourceLocation(0, 0), "bang")
 
         when:
-        def docEntry = new PreparsedDocumentEntry(errors)
+        def docEntry = new PreparsedDocumentEntry(error)
 
         then:
         docEntry.document == null
-        docEntry.errors == errors
-    }
-
-    def "Ensure a null errors throws Exception"() {
-        when:
-        new PreparsedDocumentEntry((List<GraphQLError>) null)
-
-        then:
-        thrown(AssertException)
+        docEntry.errors == Collections.singletonList(error)
     }
 
     def "Ensure a null error throws Exception"() {
@@ -59,5 +50,38 @@ class PreparsedDocumentEntryTest extends Specification {
         thrown(AssertException)
     }
 
+    def "Ensure a null error and valid document throws Exception"() {
+        given:
+        def document = Document.newDocument().build()
 
+        when:
+        new PreparsedDocumentEntry(document, (List<GraphQLError>) null)
+
+        then:
+        thrown(AssertException)
+    }
+
+    def "Ensure a non-null error and null document throws Exception"() {
+        given:
+        def error = new InvalidSyntaxError(new SourceLocation(0, 0), "bang")
+
+        when:
+        new PreparsedDocumentEntry(null, [error])
+
+        then:
+        thrown(AssertException)
+    }
+
+    def "Ensure a non-null error and non-null document returns"() {
+        given:
+        def error = new InvalidSyntaxError(new SourceLocation(0, 0), "bang")
+        def document = Document.newDocument().build()
+
+        when:
+        def docEntry = new PreparsedDocumentEntry(document, [error])
+
+        then:
+        docEntry.document == document
+        docEntry.errors.get(0) == error
+    }
 }

--- a/src/test/groovy/graphql/language/SerialisationTest.groovy
+++ b/src/test/groovy/graphql/language/SerialisationTest.groovy
@@ -108,6 +108,24 @@ class SerialisationTest extends Specification {
         originalAst == newAst
     }
 
+    def "PreparsedDocumentEntry with errors is serializable"() {
+
+        when:
+        GraphQLError syntaxError1 = new InvalidSyntaxError(srcLoc(1, 1), "Bad Syntax 1")
+        GraphQLError validationError2 = new ValidationError(ValidationErrorType.FieldUndefined, srcLoc(2, 2), "Bad Query 2")
+        def originalEntry = new PreparsedDocumentEntry([syntaxError1, validationError2])
+
+        PreparsedDocumentEntry newEntry = serialisedDownAndBack(originalEntry)
+
+        then:
+
+        newEntry.getErrors().size() == 2
+        newEntry.getErrors().get(0).getMessage() == syntaxError1.getMessage()
+        newEntry.getErrors().get(0).getLocations() == syntaxError1.getLocations()
+        newEntry.getErrors().get(1).getMessage() == validationError2.getMessage()
+        newEntry.getErrors().get(1).getLocations() == validationError2.getLocations()
+    }
+
     def "PreparsedDocumentEntry with error is serializable"() {
 
         when:


### PR DESCRIPTION
…ent when parsing succeeds and validation fails

See #2843 for more details

Added doc and errors in the case of successful parsing and failed validation.

Updated tests + docs