### PR TITLE
RawVariables and CoercedVariables are public API

### DIFF
--- a/src/main/java/graphql/ExecutionInput.java
+++ b/src/main/java/graphql/ExecutionInput.java
@@ -367,7 +367,7 @@ public class ExecutionInput {
          */
         public Builder variables(Map<String, Object> rawVariables) {
             assertNotNull(rawVariables, () -> "variables map can't be null");
-            this.rawVariables = new RawVariables(rawVariables);
+            this.rawVariables = RawVariables.of(rawVariables);
             return this;
         }
 

--- a/src/main/java/graphql/analysis/NodeVisitorWithTypeTracking.java
+++ b/src/main/java/graphql/analysis/NodeVisitorWithTypeTracking.java
@@ -155,7 +155,7 @@ public class NodeVisitorWithTypeTracking extends NodeVisitorStub {
         boolean isTypeNameIntrospectionField = fieldDefinition == schema.getIntrospectionTypenameFieldDefinition();
         GraphQLFieldsContainer fieldsContainer = !isTypeNameIntrospectionField ? (GraphQLFieldsContainer) unwrapAll(parentEnv.getOutputType()) : null;
         GraphQLCodeRegistry codeRegistry = schema.getCodeRegistry();
-        Map<String, Object> argumentValues = valuesResolver.getArgumentValues(codeRegistry, fieldDefinition.getArguments(), field.getArguments(), new CoercedVariables(variables));
+        Map<String, Object> argumentValues = valuesResolver.getArgumentValues(codeRegistry, fieldDefinition.getArguments(), field.getArguments(), CoercedVariables.of(variables));
         QueryVisitorFieldEnvironment environment = new QueryVisitorFieldEnvironmentImpl(isTypeNameIntrospectionField,
                 field,
                 fieldDefinition,

--- a/src/main/java/graphql/analysis/QueryTraverser.java
+++ b/src/main/java/graphql/analysis/QueryTraverser.java
@@ -257,7 +257,7 @@ public class QueryTraverser {
          */
         public Builder variables(Map<String, Object> variables) {
             assertNotNull(variables, () -> "variables can't be null");
-            this.rawVariables = new RawVariables(variables);
+            this.rawVariables = RawVariables.of(variables);
             return this;
         }
 
@@ -326,7 +326,7 @@ public class QueryTraverser {
                     // When traversing with an arbitrary root, there is no variable definition context available
                     // Thus, the variables must have already been coerced
                     // Retaining this builder for backwards compatibility
-                    return new QueryTraverser(schema, root, rootParentType, fragmentsByName, new CoercedVariables(rawVariables.toMap()));
+                    return new QueryTraverser(schema, root, rootParentType, fragmentsByName, CoercedVariables.of(rawVariables.toMap()));
                 }
                 return new QueryTraverser(schema, root, rootParentType, fragmentsByName, coercedVariables);
             }

--- a/src/main/java/graphql/execution/CoercedVariables.java
+++ b/src/main/java/graphql/execution/CoercedVariables.java
@@ -1,15 +1,15 @@
 package graphql.execution;
 
-import graphql.Internal;
+import graphql.PublicApi;
 import graphql.collect.ImmutableKit;
 import graphql.collect.ImmutableMapWithNullValues;
 
 import java.util.Map;
 
 /**
- * Holds coerced variables
+ * Holds coerced variables, that is their values are now in a canonical form.
  */
-@Internal
+@PublicApi
 public class CoercedVariables {
     private final ImmutableMapWithNullValues<String, Object> coercedVariables;
 
@@ -31,5 +31,9 @@ public class CoercedVariables {
 
     public static CoercedVariables emptyVariables() {
         return new CoercedVariables(ImmutableKit.emptyMap());
+    }
+
+    public static CoercedVariables of(Map<String, Object> coercedVariables) {
+        return new CoercedVariables(coercedVariables);
     }
 }

--- a/src/main/java/graphql/execution/ConditionalNodes.java
+++ b/src/main/java/graphql/execution/ConditionalNodes.java
@@ -34,7 +34,7 @@ public class ConditionalNodes {
     private boolean getDirectiveResult(Map<String, Object> variables, List<Directive> directives, String directiveName, boolean defaultValue) {
         Directive foundDirective = NodeUtil.findNodeByName(directives, directiveName);
         if (foundDirective != null) {
-            Map<String, Object> argumentValues = valuesResolver.getArgumentValues(SkipDirective.getArguments(), foundDirective.getArguments(), new CoercedVariables(variables));
+            Map<String, Object> argumentValues = valuesResolver.getArgumentValues(SkipDirective.getArguments(), foundDirective.getArguments(), CoercedVariables.of(variables));
             Object flag = argumentValues.get("if");
             Assert.assertTrue(flag instanceof Boolean, () -> String.format("The '%s' directive MUST have a value for the 'if' argument", directiveName));
             return (Boolean) flag;

--- a/src/main/java/graphql/execution/ExecutionContextBuilder.java
+++ b/src/main/java/graphql/execution/ExecutionContextBuilder.java
@@ -158,7 +158,7 @@ public class ExecutionContextBuilder {
      */
     @Deprecated
     public ExecutionContextBuilder variables(Map<String, Object> variables) {
-        this.coercedVariables = new CoercedVariables(variables);
+        this.coercedVariables = CoercedVariables.of(variables);
         return this;
     }
 

--- a/src/main/java/graphql/execution/RawVariables.java
+++ b/src/main/java/graphql/execution/RawVariables.java
@@ -1,15 +1,15 @@
 package graphql.execution;
 
-import graphql.Internal;
+import graphql.PublicApi;
 import graphql.collect.ImmutableKit;
 import graphql.collect.ImmutableMapWithNullValues;
 
 import java.util.Map;
 
 /**
- * Holds raw variables, which not have been coerced yet
+ * Holds raw variables, which have not been coerced yet into {@link CoercedVariables}
  */
-@Internal
+@PublicApi
 public class RawVariables {
     private final ImmutableMapWithNullValues<String, Object> rawVariables;
 
@@ -30,6 +30,10 @@ public class RawVariables {
     }
 
     public static RawVariables emptyVariables() {
-        return new RawVariables(ImmutableKit.emptyMap());
+        return RawVariables.of(ImmutableKit.emptyMap());
+    }
+
+    public static RawVariables of(Map<String, Object> rawVariables) {
+        return new RawVariables(rawVariables);
     }
 }

--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -249,7 +249,7 @@ public class ValuesResolver {
             return inputValueWithState.getValue();
         }
         if (inputValueWithState.isLiteral()) {
-            return new ValuesResolver().literalToInternalValue(fieldVisibility, type, (Value<?>) inputValueWithState.getValue(), new CoercedVariables(emptyMap()));
+            return new ValuesResolver().literalToInternalValue(fieldVisibility, type, (Value<?>) inputValueWithState.getValue(), CoercedVariables.emptyVariables());
         }
         if (inputValueWithState.isExternal()) {
             return new ValuesResolver().externalValueToInternalValue(fieldVisibility, type, inputValueWithState.getValue());
@@ -422,7 +422,7 @@ public class ValuesResolver {
             }
         }
 
-        return new CoercedVariables(coercedValues);
+        return CoercedVariables.of(coercedValues);
     }
 
 

--- a/src/main/java/graphql/execution/directives/DirectivesResolver.java
+++ b/src/main/java/graphql/execution/directives/DirectivesResolver.java
@@ -39,7 +39,7 @@ public class DirectivesResolver {
     }
 
     private void buildArguments(GraphQLDirective.Builder directiveBuilder, GraphQLCodeRegistry codeRegistry, GraphQLDirective protoType, Directive fieldDirective, Map<String, Object> variables) {
-        Map<String, Object> argumentValues = valuesResolver.getArgumentValues(codeRegistry, protoType.getArguments(), fieldDirective.getArguments(), new CoercedVariables(variables));
+        Map<String, Object> argumentValues = valuesResolver.getArgumentValues(codeRegistry, protoType.getArguments(), fieldDirective.getArguments(), CoercedVariables.of(variables));
         directiveBuilder.clearArguments();
         protoType.getArguments().forEach(protoArg -> {
             if (argumentValues.containsKey(protoArg.getName())) {

--- a/src/main/java/graphql/normalized/ExecutableNormalizedOperationFactory.java
+++ b/src/main/java/graphql/normalized/ExecutableNormalizedOperationFactory.java
@@ -305,7 +305,7 @@ public class ExecutableNormalizedOperationFactory {
         String fieldName = field.getName();
         GraphQLFieldDefinition fieldDefinition = Introspection.getFieldDef(parameters.getGraphQLSchema(), objectTypes.iterator().next(), fieldName);
 
-        Map<String, Object> argumentValues = valuesResolver.getArgumentValues(fieldDefinition.getArguments(), field.getArguments(), new CoercedVariables(parameters.getCoercedVariableValues()));
+        Map<String, Object> argumentValues = valuesResolver.getArgumentValues(fieldDefinition.getArguments(), field.getArguments(),CoercedVariables.of(parameters.getCoercedVariableValues()));
         Map<String, NormalizedInputValue> normalizedArgumentValues = null;
         if (parameters.getNormalizedVariableValues() != null) {
             normalizedArgumentValues = valuesResolver.getNormalizedArgumentValues(fieldDefinition.getArguments(), field.getArguments(), parameters.getNormalizedVariableValues());

--- a/src/test/groovy/graphql/execution/ExecutionContextBuilderTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionContextBuilderTest.groovy
@@ -66,7 +66,7 @@ class ExecutionContextBuilderTest extends Specification {
 
     def "builds the correct ExecutionContext with coerced variables"() {
         given:
-        def coercedVariables = new CoercedVariables([var: 'value'])
+        def coercedVariables = CoercedVariables.of([var: 'value'])
 
         when:
         def executionContext = new ExecutionContextBuilder()
@@ -105,7 +105,7 @@ class ExecutionContextBuilderTest extends Specification {
 
     def "builds the correct ExecutionContext, if both variables and coercedVariables are set, latest value set takes precedence"() {
         given:
-        def coercedVariables = new CoercedVariables([var: 'value'])
+        def coercedVariables = CoercedVariables.of([var: 'value'])
 
         when:
         def executionContext = new ExecutionContextBuilder()
@@ -164,7 +164,7 @@ class ExecutionContextBuilderTest extends Specification {
             .build()
 
         when:
-        def coercedVariables = new CoercedVariables([var: 'value'])
+        def coercedVariables = CoercedVariables.of([var: 'value'])
         def executionContext = executionContextOld.transform(builder -> builder
                                                         .coercedVariables(coercedVariables))
 
@@ -207,7 +207,7 @@ class ExecutionContextBuilderTest extends Specification {
                 .build()
 
         when:
-        def coercedVariables = new CoercedVariables([var: 'value'])
+        def coercedVariables = CoercedVariables.of([var: 'value'])
         def executionContext = executionContextOld.transform(builder -> builder
                 .variables([var: 'value'])
                 .coercedVariables(coercedVariables))

--- a/src/test/groovy/graphql/execution/ValuesResolverTest.groovy
+++ b/src/test/groovy/graphql/execution/ValuesResolverTest.groovy
@@ -45,7 +45,7 @@ class ValuesResolverTest extends Specification {
         def schema = TestUtil.schemaWithInputType(inputType)
         VariableDefinition variableDefinition = new VariableDefinition("variable", variableType, null)
         when:
-        def resolvedValues = resolver.coerceVariableValues(schema, [variableDefinition], new RawVariables([variable: inputValue]))
+        def resolvedValues = resolver.coerceVariableValues(schema, [variableDefinition], RawVariables.of([variable: inputValue]))
         then:
         resolvedValues.get('variable') == outputValue
 
@@ -74,7 +74,7 @@ class ValuesResolverTest extends Specification {
         VariableDefinition variableDefinition = new VariableDefinition("variable", new TypeName("Person"))
 
         when:
-        def resolvedValues = resolver.coerceVariableValues(schema, [variableDefinition], new RawVariables([variable: inputValue]))
+        def resolvedValues = resolver.coerceVariableValues(schema, [variableDefinition], RawVariables.of([variable: inputValue]))
         then:
         resolvedValues.get('variable') == outputValue
         where:
@@ -114,7 +114,7 @@ class ValuesResolverTest extends Specification {
 
         when:
         def obj = new Person('a', 123)
-        resolver.coerceVariableValues(schema, [variableDefinition], new RawVariables([variable: obj]))
+        resolver.coerceVariableValues(schema, [variableDefinition], RawVariables.of([variable: obj]))
         then:
         thrown(CoercingParseValueException)
     }
@@ -125,7 +125,7 @@ class ValuesResolverTest extends Specification {
         VariableDefinition variableDefinition = new VariableDefinition("variable", new ListType(new TypeName("String")))
         String value = "world"
         when:
-        def resolvedValues = resolver.coerceVariableValues(schema, [variableDefinition], new RawVariables([variable: value]))
+        def resolvedValues = resolver.coerceVariableValues(schema, [variableDefinition], RawVariables.of([variable: value]))
         then:
         resolvedValues.get('variable') == ['world']
     }
@@ -136,7 +136,7 @@ class ValuesResolverTest extends Specification {
         VariableDefinition variableDefinition = new VariableDefinition("variable", new ListType(new TypeName("String")))
         List<String> value = ["hello","world"]
         when:
-        def resolvedValues = resolver.coerceVariableValues(schema, [variableDefinition], new RawVariables([variable: value]))
+        def resolvedValues = resolver.coerceVariableValues(schema, [variableDefinition], RawVariables.of([variable: value]))
         then:
         resolvedValues.get('variable') == ['hello','world']
     }
@@ -147,14 +147,14 @@ class ValuesResolverTest extends Specification {
         VariableDefinition variableDefinition = new VariableDefinition("variable", new ListType(new TypeName("String")))
         String[] value = ["hello","world"] as String[]
         when:
-        def resolvedValues = resolver.coerceVariableValues(schema, [variableDefinition], new RawVariables([variable: value]))
+        def resolvedValues = resolver.coerceVariableValues(schema, [variableDefinition], RawVariables.of([variable: value]))
         then:
         resolvedValues.get('variable') == ['hello','world']
     }
 
     def "getArgumentValues: resolves argument with variable reference"() {
         given:
-        def variables = new CoercedVariables([var: 'hello'])
+        def variables = CoercedVariables.of([var: 'hello'])
         def fieldArgument = newArgument().name("arg").type(GraphQLString).build()
         def argument = new Argument("arg", new VariableReference("var"))
 
@@ -351,7 +351,7 @@ class ValuesResolverTest extends Specification {
         VariableDefinition variableDefinition = new VariableDefinition("variable", new TypeName("Test"))
 
         when:
-        def resolvedValues = resolver.coerceVariableValues(schema, [variableDefinition], new RawVariables([variable: inputValue]))
+        def resolvedValues = resolver.coerceVariableValues(schema, [variableDefinition], RawVariables.of([variable: inputValue]))
         then:
         resolvedValues.get('variable') == outputValue
         where:
@@ -379,7 +379,7 @@ class ValuesResolverTest extends Specification {
         VariableDefinition variableDefinition = new VariableDefinition("variable", new TypeName("InputObject"))
 
         when:
-        def resolvedValues = resolver.coerceVariableValues(schema, [variableDefinition], new RawVariables([variable: inputValue]))
+        def resolvedValues = resolver.coerceVariableValues(schema, [variableDefinition], RawVariables.of([variable: inputValue]))
 
         then:
         resolvedValues.get('variable') == outputValue
@@ -406,7 +406,7 @@ class ValuesResolverTest extends Specification {
         VariableDefinition variableDefinition = new VariableDefinition("variable", new TypeName("InputObject"))
 
         when:
-        resolver.coerceVariableValues(schema, [variableDefinition], new RawVariables([variable: inputValue]))
+        resolver.coerceVariableValues(schema, [variableDefinition], RawVariables.of([variable: inputValue]))
 
         then:
         thrown(GraphQLException)
@@ -425,7 +425,7 @@ class ValuesResolverTest extends Specification {
         VariableDefinition barVarDef = new VariableDefinition("bar", new TypeName("String"))
 
         when:
-        def resolvedValues = resolver.coerceVariableValues(schema, [fooVarDef, barVarDef], new RawVariables(InputValue))
+        def resolvedValues = resolver.coerceVariableValues(schema, [fooVarDef, barVarDef], RawVariables.of(InputValue))
 
         then:
         resolvedValues.toMap() == outputValue
@@ -459,7 +459,7 @@ class ValuesResolverTest extends Specification {
         def defaultValueForBar = new StringValue("defaultValueForBar")
         VariableDefinition barVarDef = new VariableDefinition("bar", new TypeName("String"), defaultValueForBar)
 
-        def variableValuesMap = new RawVariables(["foo": null, "bar": "barValue"])
+        def variableValuesMap = RawVariables.of(["foo": null, "bar": "barValue"])
 
         when:
         def resolvedVars = resolver.coerceVariableValues(schema, [fooVarDef, barVarDef], variableValuesMap)
@@ -476,7 +476,7 @@ class ValuesResolverTest extends Specification {
         def defaultValueForFoo = new StringValue("defaultValueForFoo")
         VariableDefinition fooVarDef = new VariableDefinition("foo", new NonNullType(new TypeName("String")), defaultValueForFoo)
 
-        def variableValuesMap = new RawVariables(["foo": null])
+        def variableValuesMap = RawVariables.of(["foo": null])
 
         when:
         resolver.coerceVariableValues(schema, [fooVarDef], variableValuesMap)
@@ -494,7 +494,7 @@ class ValuesResolverTest extends Specification {
         def type = new ListType(new NonNullType(new TypeName("String")))
         VariableDefinition fooVarDef = new VariableDefinition("foo", type, defaultValueForFoo)
 
-        def variableValuesMap = new RawVariables(["foo": [null]])
+        def variableValuesMap = RawVariables.of(["foo": [null]])
 
         when:
         resolver.coerceVariableValues(schema, [fooVarDef], variableValuesMap)
@@ -533,7 +533,7 @@ class ValuesResolverTest extends Specification {
         def argument = new Argument("arg", new VariableReference("var"))
 
         when:
-        def variables = new CoercedVariables(["var": null])
+        def variables = CoercedVariables.of(["var": null])
         def values = resolver.getArgumentValues([fieldArgument], [argument], variables)
 
         then:
@@ -550,7 +550,7 @@ class ValuesResolverTest extends Specification {
         def argument = new Argument("arg", new VariableReference("var"))
 
         when:
-        def variables = new CoercedVariables(["var": null])
+        def variables = CoercedVariables.of(["var": null])
         resolver.getArgumentValues([fieldArgument], [argument], variables)
 
         then:

--- a/src/test/groovy/graphql/normalized/ExecutableNormalizedOperationFactoryTest.groovy
+++ b/src/test/groovy/graphql/normalized/ExecutableNormalizedOperationFactoryTest.groovy
@@ -1353,7 +1353,7 @@ schema {
         // the normalized arg value should be the same regardless of how the value was provided
         def expectedNormalizedArgValue = [foo: new NormalizedInputValue("String", parseValue('"foo"')), input2: new NormalizedInputValue("Input2", [bar: new NormalizedInputValue("Int", parseValue("123"))])]
         when:
-        def tree = dependencyGraph.createExecutableNormalizedOperationWithRawVariables(graphQLSchema, document, null, new RawVariables(variables))
+        def tree = dependencyGraph.createExecutableNormalizedOperationWithRawVariables(graphQLSchema, document, null, RawVariables.of(variables))
         def topLevelField = tree.getTopLevelFields().get(0)
         def secondField = topLevelField.getChildren().get(0)
         def arg1 = secondField.getNormalizedArgument("arg1")
@@ -1395,7 +1395,7 @@ schema {
         def dependencyGraph = new ExecutableNormalizedOperationFactory()
         def variables = [:]
         when:
-        def tree = dependencyGraph.createExecutableNormalizedOperationWithRawVariables(graphQLSchema, document, null, new RawVariables(variables))
+        def tree = dependencyGraph.createExecutableNormalizedOperationWithRawVariables(graphQLSchema, document, null, RawVariables.of(variables))
 
         then:
         def topLevelField = tree.getTopLevelFields().get(0)
@@ -1434,7 +1434,7 @@ schema {
                 otherVar: null,
         ]
         when:
-        def tree = dependencyGraph.createExecutableNormalizedOperationWithRawVariables(graphQLSchema, document, null, new RawVariables(variables))
+        def tree = dependencyGraph.createExecutableNormalizedOperationWithRawVariables(graphQLSchema, document, null, RawVariables.of(variables))
 
         then:
         def topLevelField = tree.getTopLevelFields().get(0)
@@ -1486,7 +1486,7 @@ schema {
         Document document = TestUtil.parseQuery(query)
         ExecutableNormalizedOperationFactory dependencyGraph = new ExecutableNormalizedOperationFactory()
         when:
-        def tree = dependencyGraph.createExecutableNormalizedOperationWithRawVariables(graphQLSchema, document, null, new RawVariables(variables))
+        def tree = dependencyGraph.createExecutableNormalizedOperationWithRawVariables(graphQLSchema, document, null, RawVariables.of(variables))
         def topLevelField = tree.getTopLevelFields().get(0)
         def arg1 = topLevelField.getNormalizedArgument("arg1")
         def arg2 = topLevelField.getNormalizedArgument("arg2")
@@ -1539,7 +1539,7 @@ schema {
         Document document = TestUtil.parseQuery(query)
         ExecutableNormalizedOperationFactory dependencyGraph = new ExecutableNormalizedOperationFactory()
         when:
-        def tree = dependencyGraph.createExecutableNormalizedOperationWithRawVariables(graphQLSchema, document, null, new RawVariables(variables))
+        def tree = dependencyGraph.createExecutableNormalizedOperationWithRawVariables(graphQLSchema, document, null, RawVariables.of(variables))
         def topLevelField = tree.getTopLevelFields().get(0)
         def arg1 = topLevelField.getNormalizedArgument("arg1")
         def arg2 = topLevelField.getNormalizedArgument("arg2")
@@ -2368,7 +2368,7 @@ schema {
         Document document = TestUtil.parseQuery(query)
         ExecutableNormalizedOperationFactory dependencyGraph = new ExecutableNormalizedOperationFactory()
         when:
-        def tree = dependencyGraph.createExecutableNormalizedOperationWithRawVariables(graphQLSchema, document, null, new RawVariables(variables))
+        def tree = dependencyGraph.createExecutableNormalizedOperationWithRawVariables(graphQLSchema, document, null, RawVariables.of(variables))
         println String.join("\n", printTree(tree))
         def printedTree = printTree(tree)
 

--- a/src/test/groovy/graphql/normalized/ExecutableNormalizedOperationToAstCompilerTest.groovy
+++ b/src/test/groovy/graphql/normalized/ExecutableNormalizedOperationToAstCompilerTest.groovy
@@ -2082,7 +2082,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         Document originalDocument = TestUtil.parseQuery(query)
 
         ExecutableNormalizedOperationFactory dependencyGraph = new ExecutableNormalizedOperationFactory()
-        return dependencyGraph.createExecutableNormalizedOperationWithRawVariables(schema, originalDocument, null, new RawVariables(variables))
+        return dependencyGraph.createExecutableNormalizedOperationWithRawVariables(schema, originalDocument, null, RawVariables.of(variables))
     }
 
     private List<ExecutableNormalizedField> createNormalizedFields(GraphQLSchema schema, String query, Map<String, Object> variables = [:]) {


### PR DESCRIPTION
The new RawVariables and CoercedVariables are currently marked as `@Internal` but they are not - they can be read back from very public places like ExecutionInput and they are required as parameters into very public places like QueryTraverser