### PR TITLE
#2883 Fix classCastException when using an extension 

### DIFF
--- a/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
+++ b/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
@@ -96,7 +96,6 @@ import static graphql.introspection.Introspection.DirectiveLocation.UNION;
 import static graphql.schema.GraphQLEnumValueDefinition.newEnumValueDefinition;
 import static graphql.schema.GraphQLTypeReference.typeRef;
 import static graphql.schema.idl.SchemaGeneratorAppliedDirectiveHelper.buildAppliedDirectives;
-import static graphql.schema.idl.SchemaGeneratorAppliedDirectiveHelper.buildDeprecationReason;
 import static graphql.schema.idl.SchemaGeneratorAppliedDirectiveHelper.buildDirectiveDefinitionFromAst;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toMap;
@@ -548,7 +547,7 @@ public class SchemaGeneratorHelper {
         });
 
         extensions.forEach(extension -> extension.getImplements().forEach(type -> {
-            GraphQLInterfaceType interfaceType = buildOutputType(buildCtx, type);
+            GraphQLNamedOutputType interfaceType = buildOutputType(buildCtx, type);
             if (!interfaces.containsKey(interfaceType.getName())) {
                 interfaces.put(interfaceType.getName(), interfaceType);
             }
@@ -658,7 +657,7 @@ public class SchemaGeneratorHelper {
         });
 
         extensions.forEach(extension -> extension.getImplements().forEach(type -> {
-            GraphQLInterfaceType interfaceType = buildOutputType(buildCtx, type);
+            GraphQLNamedOutputType interfaceType = buildOutputType(buildCtx, type);
             if (!interfaces.containsKey(interfaceType.getName())) {
                 interfaces.put(interfaceType.getName(), interfaceType);
             }

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -2506,4 +2506,31 @@ class SchemaGeneratorTest extends Specification {
     }
 
 
+    def "classCastException when interface extension is before base and has recursion"() {
+        given:
+        def spec = '''
+        # order is important, moving extension below type Foo will fix the issue
+        extend type Foo implements HasFoo {
+          foo: Foo
+        }
+        
+        type Query {
+          test: ID
+        }
+        
+        interface HasFoo {
+          foo: Foo
+        }
+        
+        type Foo {
+          id: ID
+        }
+        '''
+
+        when:
+        TestUtil.schema(spec)
+
+        then:
+        noExceptionThrown()
+    }
 }


### PR DESCRIPTION
Fix for #2883.

Callers of `buildOutputType` were wrongly expecting result could be cast to `GraphQLInterfaceType`.  Using `GraphQLNamedOutputType` is a wider type that is compatible.