### PR TITLE
Make ValuesResolver methods static

### DIFF
--- a/src/main/java/graphql/analysis/NodeVisitorWithTypeTracking.java
+++ b/src/main/java/graphql/analysis/NodeVisitorWithTypeTracking.java
@@ -43,16 +43,12 @@ import static java.lang.String.format;
 @Internal
 public class NodeVisitorWithTypeTracking extends NodeVisitorStub {
 
-
     private final QueryVisitor preOrderCallback;
     private final QueryVisitor postOrderCallback;
     private final Map<String, Object> variables;
     private final GraphQLSchema schema;
     private final Map<String, FragmentDefinition> fragmentsByName;
-
     private final ConditionalNodes conditionalNodes = new ConditionalNodes();
-    private final ValuesResolver valuesResolver = new ValuesResolver();
-
 
     public NodeVisitorWithTypeTracking(QueryVisitor preOrderCallback, QueryVisitor postOrderCallback, Map<String, Object> variables, GraphQLSchema schema, Map<String, FragmentDefinition> fragmentsByName) {
         this.preOrderCallback = preOrderCallback;
@@ -155,7 +151,7 @@ public class NodeVisitorWithTypeTracking extends NodeVisitorStub {
         boolean isTypeNameIntrospectionField = fieldDefinition == schema.getIntrospectionTypenameFieldDefinition();
         GraphQLFieldsContainer fieldsContainer = !isTypeNameIntrospectionField ? (GraphQLFieldsContainer) unwrapAll(parentEnv.getOutputType()) : null;
         GraphQLCodeRegistry codeRegistry = schema.getCodeRegistry();
-        Map<String, Object> argumentValues = valuesResolver.getArgumentValues(codeRegistry, fieldDefinition.getArguments(), field.getArguments(), CoercedVariables.of(variables));
+        Map<String, Object> argumentValues = ValuesResolver.getArgumentValues(codeRegistry, fieldDefinition.getArguments(), field.getArguments(), CoercedVariables.of(variables));
         QueryVisitorFieldEnvironment environment = new QueryVisitorFieldEnvironmentImpl(isTypeNameIntrospectionField,
                 field,
                 fieldDefinition,

--- a/src/main/java/graphql/analysis/QueryTraverser.java
+++ b/src/main/java/graphql/analysis/QueryTraverser.java
@@ -70,7 +70,7 @@ public class QueryTraverser {
         this.fragmentsByName = getOperationResult.fragmentsByName;
         this.roots = singletonList(getOperationResult.operationDefinition);
         this.rootParentType = getRootTypeFromOperation(getOperationResult.operationDefinition);
-        this.coercedVariables = new ValuesResolver().coerceVariableValues(schema, variableDefinitions, rawVariables);
+        this.coercedVariables = ValuesResolver.coerceVariableValues(schema, variableDefinitions, rawVariables);
     }
 
     private QueryTraverser(GraphQLSchema schema,

--- a/src/main/java/graphql/execution/ConditionalNodes.java
+++ b/src/main/java/graphql/execution/ConditionalNodes.java
@@ -2,7 +2,6 @@ package graphql.execution;
 
 import graphql.Assert;
 import graphql.Internal;
-import graphql.VisibleForTesting;
 import graphql.language.Directive;
 import graphql.language.NodeUtil;
 
@@ -14,9 +13,6 @@ import static graphql.Directives.SkipDirective;
 
 @Internal
 public class ConditionalNodes {
-
-    @VisibleForTesting
-    ValuesResolver valuesResolver = new ValuesResolver();
 
     public boolean shouldInclude(Map<String, Object> variables, List<Directive> directives) {
         // shortcut on no directives
@@ -34,7 +30,7 @@ public class ConditionalNodes {
     private boolean getDirectiveResult(Map<String, Object> variables, List<Directive> directives, String directiveName, boolean defaultValue) {
         Directive foundDirective = NodeUtil.findNodeByName(directives, directiveName);
         if (foundDirective != null) {
-            Map<String, Object> argumentValues = valuesResolver.getArgumentValues(SkipDirective.getArguments(), foundDirective.getArguments(), CoercedVariables.of(variables));
+            Map<String, Object> argumentValues = ValuesResolver.getArgumentValues(SkipDirective.getArguments(), foundDirective.getArguments(), CoercedVariables.of(variables));
             Object flag = argumentValues.get("if");
             Assert.assertTrue(flag instanceof Boolean, () -> String.format("The '%s' directive MUST have a value for the 'if' argument", directiveName));
             return (Boolean) flag;

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -40,7 +40,6 @@ public class Execution {
     private static final Logger logNotSafe = LogKit.getNotPrivacySafeLogger(Execution.class);
 
     private final FieldCollector fieldCollector = new FieldCollector();
-    private final ValuesResolver valuesResolver = new ValuesResolver();
     private final ExecutionStrategy queryStrategy;
     private final ExecutionStrategy mutationStrategy;
     private final ExecutionStrategy subscriptionStrategy;
@@ -66,7 +65,7 @@ public class Execution {
 
         CoercedVariables coercedVariables;
         try {
-            coercedVariables = valuesResolver.coerceVariableValues(graphQLSchema, variableDefinitions, inputVariables);
+            coercedVariables = ValuesResolver.coerceVariableValues(graphQLSchema, variableDefinitions, inputVariables);
         } catch (RuntimeException rte) {
             if (rte instanceof GraphQLError) {
                 return completedFuture(new ExecutionResultImpl((GraphQLError) rte));

--- a/src/main/java/graphql/execution/ExecutionStepInfoFactory.java
+++ b/src/main/java/graphql/execution/ExecutionStepInfoFactory.java
@@ -17,17 +17,13 @@ import java.util.function.Supplier;
 @Internal
 public class ExecutionStepInfoFactory {
 
-
-    ValuesResolver valuesResolver = new ValuesResolver();
-
-
     public ExecutionStepInfo newExecutionStepInfoForSubField(ExecutionContext executionContext, MergedField mergedField, ExecutionStepInfo parentInfo) {
         GraphQLObjectType parentType = (GraphQLObjectType) parentInfo.getUnwrappedNonNullType();
         GraphQLFieldDefinition fieldDefinition = Introspection.getFieldDef(executionContext.getGraphQLSchema(), parentType, mergedField.getName());
         GraphQLOutputType fieldType = fieldDefinition.getType();
         List<Argument> fieldArgs = mergedField.getArguments();
         GraphQLCodeRegistry codeRegistry = executionContext.getGraphQLSchema().getCodeRegistry();
-        Supplier<Map<String, Object>> argumentValues = FpKit.intraThreadMemoize(() -> valuesResolver.getArgumentValues(codeRegistry, fieldDefinition.getArguments(), fieldArgs, executionContext.getCoercedVariables()));
+        Supplier<Map<String, Object>> argumentValues = FpKit.intraThreadMemoize(() -> ValuesResolver.getArgumentValues(codeRegistry, fieldDefinition.getArguments(), fieldArgs, executionContext.getCoercedVariables()));
 
         ResultPath newPath = parentInfo.getPath().segment(mergedField.getResultKey());
 

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -126,7 +126,6 @@ public abstract class ExecutionStrategy {
     private static final Logger log = LoggerFactory.getLogger(ExecutionStrategy.class);
     private static final Logger logNotSafe = LogKit.getNotPrivacySafeLogger(ExecutionStrategy.class);
 
-    protected final ValuesResolver valuesResolver = new ValuesResolver();
     protected final FieldCollector fieldCollector = new FieldCollector();
     protected final ExecutionStepInfoFactory executionStepInfoFactory = new ExecutionStepInfoFactory();
     private final ResolveType resolvedType = new ResolveType();
@@ -818,7 +817,7 @@ public abstract class ExecutionStrategy {
         if (!fieldArgDefs.isEmpty()) {
             List<Argument> fieldArgs = field.getArguments();
             GraphQLCodeRegistry codeRegistry = executionContext.getGraphQLSchema().getCodeRegistry();
-            argumentValues = FpKit.intraThreadMemoize(() -> valuesResolver.getArgumentValues(codeRegistry, fieldArgDefs, fieldArgs, executionContext.getCoercedVariables()));
+            argumentValues = FpKit.intraThreadMemoize(() -> ValuesResolver.getArgumentValues(codeRegistry, fieldArgDefs, fieldArgs, executionContext.getCoercedVariables()));
         }
 
 

--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -54,7 +54,6 @@ import java.util.Map;
 import static graphql.Assert.assertShouldNeverHappen;
 import static graphql.Assert.assertTrue;
 import static graphql.collect.ImmutableKit.emptyList;
-import static graphql.collect.ImmutableKit.emptyMap;
 import static graphql.collect.ImmutableKit.map;
 import static graphql.execution.ValuesResolver.ValueMode.NORMALIZED;
 import static graphql.language.NullValue.newNullValue;
@@ -88,7 +87,7 @@ public class ValuesResolver {
      *
      * @return coerced variable values as a map
      */
-    public CoercedVariables coerceVariableValues(GraphQLSchema schema,
+    public static CoercedVariables coerceVariableValues(GraphQLSchema schema,
                                                  List<VariableDefinition> variableDefinitions,
                                                  RawVariables rawVariables) throws CoercingParseValueException, NonNullableValueCoercedAsNullException {
 
@@ -104,7 +103,7 @@ public class ValuesResolver {
      *
      * @return a map of the normalised values
      */
-    public Map<String, NormalizedInputValue> getNormalizedVariableValues(GraphQLSchema schema,
+    public static Map<String, NormalizedInputValue> getNormalizedVariableValues(GraphQLSchema schema,
                                                                          List<VariableDefinition> variableDefinitions,
                                                                          RawVariables rawVariables) {
         GraphqlFieldVisibility fieldVisibility = schema.getCodeRegistry().getFieldVisibility();
@@ -144,7 +143,7 @@ public class ValuesResolver {
      *
      * @return a map of named argument values
      */
-    public Map<String, Object> getArgumentValues(List<GraphQLArgument> argumentTypes,
+    public static Map<String, Object> getArgumentValues(List<GraphQLArgument> argumentTypes,
                                                  List<Argument> arguments,
                                                  CoercedVariables coercedVariables) {
         return getArgumentValuesImpl(DEFAULT_FIELD_VISIBILITY, argumentTypes, arguments, coercedVariables);
@@ -159,7 +158,7 @@ public class ValuesResolver {
      *
      * @return a map of named normalised values
      */
-    public Map<String, NormalizedInputValue> getNormalizedArgumentValues(List<GraphQLArgument> argumentTypes,
+    public static Map<String, NormalizedInputValue> getNormalizedArgumentValues(List<GraphQLArgument> argumentTypes,
                                                                          List<Argument> arguments,
                                                                          Map<String, NormalizedInputValue> normalizedVariables) {
         if (argumentTypes.isEmpty()) {
@@ -187,7 +186,7 @@ public class ValuesResolver {
         return result;
     }
 
-    public Map<String, Object> getArgumentValues(GraphQLCodeRegistry codeRegistry,
+    public static Map<String, Object> getArgumentValues(GraphQLCodeRegistry codeRegistry,
                                                  List<GraphQLArgument> argumentTypes,
                                                  List<Argument> arguments,
                                                  CoercedVariables coercedVariables) {
@@ -224,7 +223,7 @@ public class ValuesResolver {
             return inputValueWithState.getValue();
         }
         if (inputValueWithState.isExternal()) {
-            return new ValuesResolver().externalValueToLiteral(fieldVisibility, inputValueWithState.getValue(), (GraphQLInputType) type, valueMode);
+            return ValuesResolver.externalValueToLiteral(fieldVisibility, inputValueWithState.getValue(), (GraphQLInputType) type, valueMode);
         }
         return assertShouldNeverHappen("unexpected value state " + inputValueWithState);
     }
@@ -240,7 +239,7 @@ public class ValuesResolver {
      * @return a value converted to an internal value
      */
     public static Object externalValueToInternalValue(GraphqlFieldVisibility fieldVisibility, Object externalValue, GraphQLInputType type) {
-        return new ValuesResolver().externalValueToInternalValue(fieldVisibility, type, externalValue);
+        return ValuesResolver.externalValueToInternalValue(fieldVisibility, type, externalValue);
     }
 
     public static Object valueToInternalValue(InputValueWithState inputValueWithState, GraphQLType type) throws CoercingParseValueException, CoercingParseLiteralException {
@@ -249,10 +248,10 @@ public class ValuesResolver {
             return inputValueWithState.getValue();
         }
         if (inputValueWithState.isLiteral()) {
-            return new ValuesResolver().literalToInternalValue(fieldVisibility, type, (Value<?>) inputValueWithState.getValue(), CoercedVariables.emptyVariables());
+            return ValuesResolver.literalToInternalValue(fieldVisibility, type, (Value<?>) inputValueWithState.getValue(), CoercedVariables.emptyVariables());
         }
         if (inputValueWithState.isExternal()) {
-            return new ValuesResolver().externalValueToInternalValue(fieldVisibility, type, inputValueWithState.getValue());
+            return ValuesResolver.externalValueToInternalValue(fieldVisibility, type, inputValueWithState.getValue());
         }
         return assertShouldNeverHappen("unexpected value state " + inputValueWithState);
     }
@@ -270,7 +269,7 @@ public class ValuesResolver {
     /**
      * No validation: the external value is assumed to be valid.
      */
-    private Object externalValueToLiteral(GraphqlFieldVisibility fieldVisibility,
+    private static Object externalValueToLiteral(GraphqlFieldVisibility fieldVisibility,
                                           @Nullable Object value,
                                           GraphQLInputType type,
                                           ValueMode valueMode
@@ -297,7 +296,7 @@ public class ValuesResolver {
     /**
      * No validation
      */
-    private Value externalValueToLiteralForScalar(GraphQLScalarType scalarType, Object value) {
+    private static Value externalValueToLiteralForScalar(GraphQLScalarType scalarType, Object value) {
         return scalarType.getCoercing().valueToLiteral(value);
 
     }
@@ -305,7 +304,7 @@ public class ValuesResolver {
     /**
      * No validation
      */
-    private Value externalValueToLiteralForEnum(GraphQLEnumType enumType, Object value) {
+    private static Value externalValueToLiteralForEnum(GraphQLEnumType enumType, Object value) {
         return enumType.valueToLiteral(value);
     }
 
@@ -313,7 +312,7 @@ public class ValuesResolver {
      * No validation
      */
     @SuppressWarnings("unchecked")
-    private Object externalValueToLiteralForList(GraphqlFieldVisibility fieldVisibility, GraphQLList listType, Object value, ValueMode valueMode) {
+    private static Object externalValueToLiteralForList(GraphqlFieldVisibility fieldVisibility, GraphQLList listType, Object value, ValueMode valueMode) {
         GraphQLInputType wrappedType = (GraphQLInputType) listType.getWrappedType();
         List result = FpKit.toListOrSingletonList(value)
                 .stream()
@@ -330,7 +329,7 @@ public class ValuesResolver {
      * No validation
      */
     @SuppressWarnings("unchecked")
-    private Object externalValueToLiteralForObject(GraphqlFieldVisibility fieldVisibility,
+    private static Object externalValueToLiteralForObject(GraphqlFieldVisibility fieldVisibility,
                                                    GraphQLInputObjectType inputObjectType,
                                                    Object inputValue,
                                                    ValueMode valueMode) {
@@ -383,7 +382,7 @@ public class ValuesResolver {
     /**
      * performs validation too
      */
-    private CoercedVariables externalValueToInternalValueForVariables(GraphQLSchema schema,
+    private static CoercedVariables externalValueToInternalValueForVariables(GraphQLSchema schema,
                                                                       List<VariableDefinition> variableDefinitions,
                                                                       RawVariables rawVariables) {
         GraphqlFieldVisibility fieldVisibility = schema.getCodeRegistry().getFieldVisibility();
@@ -426,7 +425,7 @@ public class ValuesResolver {
     }
 
 
-    private Map<String, Object> getArgumentValuesImpl(GraphqlFieldVisibility fieldVisibility,
+    private static Map<String, Object> getArgumentValuesImpl(GraphqlFieldVisibility fieldVisibility,
                                                       List<GraphQLArgument> argumentTypes,
                                                       List<Argument> arguments,
                                                       CoercedVariables coercedVariables) {
@@ -474,7 +473,7 @@ public class ValuesResolver {
         return coercedValues;
     }
 
-    private Map<String, Argument> argumentMap(List<Argument> arguments) {
+    private static Map<String, Argument> argumentMap(List<Argument> arguments) {
         Map<String, Argument> result = new LinkedHashMap<>(arguments.size());
         for (Argument argument : arguments) {
             result.put(argument.getName(), argument);
@@ -487,7 +486,7 @@ public class ValuesResolver {
      * Performs validation too
      */
     @SuppressWarnings("unchecked")
-    private Object externalValueToInternalValue(GraphqlFieldVisibility fieldVisibility,
+    private static Object externalValueToInternalValue(GraphqlFieldVisibility fieldVisibility,
                                                 GraphQLType graphQLType,
                                                 Object value) throws NonNullableValueCoercedAsNullException, CoercingParseValueException {
         if (isNonNull(graphQLType)) {
@@ -526,7 +525,7 @@ public class ValuesResolver {
     /**
      * performs validation
      */
-    private Object externalValueToInternalValueForObject(GraphqlFieldVisibility fieldVisibility,
+    private static Object externalValueToInternalValueForObject(GraphqlFieldVisibility fieldVisibility,
                                                          GraphQLInputObjectType inputObjectType,
                                                          Map<String, Object> inputMap
     ) throws NonNullableValueCoercedAsNullException, CoercingParseValueException {
@@ -571,21 +570,21 @@ public class ValuesResolver {
     /**
      * including validation
      */
-    private Object externalValueToInternalValueForScalar(GraphQLScalarType graphQLScalarType, Object value) throws CoercingParseValueException {
+    private static Object externalValueToInternalValueForScalar(GraphQLScalarType graphQLScalarType, Object value) throws CoercingParseValueException {
         return graphQLScalarType.getCoercing().parseValue(value);
     }
 
     /**
      * including validation
      */
-    private Object externalValueToInternalValueForEnum(GraphQLEnumType graphQLEnumType, Object value) throws CoercingParseValueException {
+    private static Object externalValueToInternalValueForEnum(GraphQLEnumType graphQLEnumType, Object value) throws CoercingParseValueException {
         return graphQLEnumType.parseValue(value);
     }
 
     /**
      * including validation
      */
-    private List externalValueToInternalValueForList(GraphqlFieldVisibility fieldVisibility,
+    private static List externalValueToInternalValueForList(GraphqlFieldVisibility fieldVisibility,
                                                      GraphQLList graphQLList,
                                                      Object value
     ) throws CoercingParseValueException, NonNullableValueCoercedAsNullException {
@@ -597,7 +596,7 @@ public class ValuesResolver {
                 .collect(toList());
     }
 
-    public Object literalToNormalizedValue(GraphqlFieldVisibility fieldVisibility,
+    public static Object literalToNormalizedValue(GraphqlFieldVisibility fieldVisibility,
                                            GraphQLType type,
                                            Value inputValue,
                                            Map<String, NormalizedInputValue> normalizedVariables
@@ -628,7 +627,7 @@ public class ValuesResolver {
         return null;
     }
 
-    private Object literalToNormalizedValueForInputObject(GraphqlFieldVisibility fieldVisibility,
+    private static Object literalToNormalizedValueForInputObject(GraphqlFieldVisibility fieldVisibility,
                                                           GraphQLInputObjectType type,
                                                           ObjectValue inputObjectLiteral,
                                                           Map<String, NormalizedInputValue> normalizedVariables) {
@@ -647,7 +646,7 @@ public class ValuesResolver {
         return result;
     }
 
-    private List<Object> literalToNormalizedValueForList(GraphqlFieldVisibility fieldVisibility,
+    private static List<Object> literalToNormalizedValueForList(GraphqlFieldVisibility fieldVisibility,
                                                          GraphQLList type,
                                                          Value value,
                                                          Map<String, NormalizedInputValue> normalizedVariables) {
@@ -673,7 +672,7 @@ public class ValuesResolver {
      *
      * @return literal converted to an internal value
      */
-    public Object literalToInternalValue(GraphqlFieldVisibility fieldVisibility,
+    public static Object literalToInternalValue(GraphqlFieldVisibility fieldVisibility,
                                          GraphQLType type,
                                          Value inputValue,
                                          CoercedVariables coercedVariables) {
@@ -705,7 +704,7 @@ public class ValuesResolver {
     /**
      * no validation
      */
-    private Object literalToInternalValueForScalar(Value inputValue, GraphQLScalarType scalarType, CoercedVariables coercedVariables) {
+    private static Object literalToInternalValueForScalar(Value inputValue, GraphQLScalarType scalarType, CoercedVariables coercedVariables) {
         // the CoercingParseLiteralException exception that could happen here has been validated earlier via ValidationUtil
         return scalarType.getCoercing().parseLiteral(inputValue, coercedVariables.toMap());
     }
@@ -713,7 +712,7 @@ public class ValuesResolver {
     /**
      * no validation
      */
-    private Object literalToInternalValueForList(GraphqlFieldVisibility fieldVisibility,
+    private static Object literalToInternalValueForList(GraphqlFieldVisibility fieldVisibility,
                                                  GraphQLList graphQLList,
                                                  Value value,
                                                  CoercedVariables coercedVariables) {
@@ -737,7 +736,7 @@ public class ValuesResolver {
     /**
      * no validation
      */
-    private Object literalToInternalValueForInputObject(GraphqlFieldVisibility fieldVisibility,
+    private static Object literalToInternalValueForInputObject(GraphqlFieldVisibility fieldVisibility,
                                                         GraphQLInputObjectType type,
                                                         ObjectValue inputValue,
                                                         CoercedVariables coercedVariables) {
@@ -782,7 +781,7 @@ public class ValuesResolver {
         return coercedValues;
     }
 
-    private boolean isNullValue(Object value) {
+    private static boolean isNullValue(Object value) {
         if (value == null) {
             return true;
         }
@@ -792,7 +791,7 @@ public class ValuesResolver {
         return ((NormalizedInputValue) value).getValue() == null;
     }
 
-    private Map<String, ObjectField> mapObjectValueFieldsByName(ObjectValue inputValue) {
+    private static Map<String, ObjectField> mapObjectValueFieldsByName(ObjectValue inputValue) {
         Map<String, ObjectField> inputValueFieldsByName = new LinkedHashMap<>();
         for (ObjectField objectField : inputValue.getObjectFields()) {
             inputValueFieldsByName.put(objectField.getName(), objectField);
@@ -800,7 +799,7 @@ public class ValuesResolver {
         return inputValueFieldsByName;
     }
 
-    private Object defaultValueToInternalValue(GraphqlFieldVisibility fieldVisibility,
+    private static Object defaultValueToInternalValue(GraphqlFieldVisibility fieldVisibility,
                                                InputValueWithState defaultValue,
                                                GraphQLInputType type
     ) {

--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -70,6 +70,9 @@ import static java.util.stream.Collectors.toList;
 @Internal
 public class ValuesResolver {
 
+    private ValuesResolver() {
+    }
+
     public enum ValueMode {
         LITERAL,
         NORMALIZED

--- a/src/main/java/graphql/execution/directives/DirectivesResolver.java
+++ b/src/main/java/graphql/execution/directives/DirectivesResolver.java
@@ -20,8 +20,6 @@ import java.util.Map;
 @Internal
 public class DirectivesResolver {
 
-    private final ValuesResolver valuesResolver = new ValuesResolver();
-
     public DirectivesResolver() {
     }
 
@@ -39,7 +37,7 @@ public class DirectivesResolver {
     }
 
     private void buildArguments(GraphQLDirective.Builder directiveBuilder, GraphQLCodeRegistry codeRegistry, GraphQLDirective protoType, Directive fieldDirective, Map<String, Object> variables) {
-        Map<String, Object> argumentValues = valuesResolver.getArgumentValues(codeRegistry, protoType.getArguments(), fieldDirective.getArguments(), CoercedVariables.of(variables));
+        Map<String, Object> argumentValues = ValuesResolver.getArgumentValues(codeRegistry, protoType.getArguments(), fieldDirective.getArguments(), CoercedVariables.of(variables));
         directiveBuilder.clearArguments();
         protoType.getArguments().forEach(protoArg -> {
             if (argumentValues.containsKey(protoArg.getName())) {

--- a/src/main/java/graphql/execution/nextgen/ExecutionHelper.java
+++ b/src/main/java/graphql/execution/nextgen/ExecutionHelper.java
@@ -50,11 +50,10 @@ public class ExecutionHelper {
         Map<String, FragmentDefinition> fragmentsByName = getOperationResult.fragmentsByName;
         OperationDefinition operationDefinition = getOperationResult.operationDefinition;
 
-        ValuesResolver valuesResolver = new ValuesResolver();
         RawVariables inputVariables = executionInput.getRawVariables();
         List<VariableDefinition> variableDefinitions = operationDefinition.getVariableDefinitions();
 
-        CoercedVariables coercedVariables = valuesResolver.coerceVariableValues(graphQLSchema, variableDefinitions, inputVariables);
+        CoercedVariables coercedVariables = ValuesResolver.coerceVariableValues(graphQLSchema, variableDefinitions, inputVariables);
 
         ExecutionContext executionContext = newExecutionContextBuilder()
                 .executionId(executionId)

--- a/src/main/java/graphql/execution/nextgen/ValueFetcher.java
+++ b/src/main/java/graphql/execution/nextgen/ValueFetcher.java
@@ -36,7 +36,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -52,10 +51,6 @@ import static java.util.Collections.singletonList;
 @Deprecated
 @Internal
 public class ValueFetcher {
-
-
-    ValuesResolver valuesResolver = new ValuesResolver();
-
     private static final Logger log = LoggerFactory.getLogger(ValueFetcher.class);
     private static final Logger logNotSafe = LogKit.getNotPrivacySafeLogger(ExecutionStrategy.class);
 
@@ -123,7 +118,7 @@ public class ValueFetcher {
         GraphQLCodeRegistry codeRegistry = executionContext.getGraphQLSchema().getCodeRegistry();
         GraphQLFieldsContainer parentType = getFieldsContainer(executionInfo);
 
-        Supplier<Map<String, Object>> argumentValues = FpKit.intraThreadMemoize(() -> valuesResolver.getArgumentValues(codeRegistry, fieldDef.getArguments(), field.getArguments(), executionContext.getCoercedVariables()));
+        Supplier<Map<String, Object>> argumentValues = FpKit.intraThreadMemoize(() -> ValuesResolver.getArgumentValues(codeRegistry, fieldDef.getArguments(), field.getArguments(), executionContext.getCoercedVariables()));
 
         QueryDirectivesImpl queryDirectives = new QueryDirectivesImpl(sameFields, executionContext.getGraphQLSchema(), executionContext.getVariables());
 

--- a/src/main/java/graphql/normalized/ExecutableNormalizedOperationFactory.java
+++ b/src/main/java/graphql/normalized/ExecutableNormalizedOperationFactory.java
@@ -56,7 +56,6 @@ import static java.util.Collections.singletonList;
 @Internal
 public class ExecutableNormalizedOperationFactory {
 
-    private final ValuesResolver valuesResolver = new ValuesResolver();
     private final ConditionalNodes conditionalNodes = new ConditionalNodes();
 
     public static ExecutableNormalizedOperation createExecutableNormalizedOperation(GraphQLSchema graphQLSchema,
@@ -89,8 +88,8 @@ public class ExecutableNormalizedOperationFactory {
     ) {
 
         List<VariableDefinition> variableDefinitions = operationDefinition.getVariableDefinitions();
-        CoercedVariables coercedVariableValues = valuesResolver.coerceVariableValues(graphQLSchema, variableDefinitions, rawVariables);
-        Map<String, NormalizedInputValue> normalizedVariableValues = valuesResolver.getNormalizedVariableValues(graphQLSchema, variableDefinitions, rawVariables);
+        CoercedVariables coercedVariableValues = ValuesResolver.coerceVariableValues(graphQLSchema, variableDefinitions, rawVariables);
+        Map<String, NormalizedInputValue> normalizedVariableValues = ValuesResolver.getNormalizedVariableValues(graphQLSchema, variableDefinitions, rawVariables);
         return createNormalizedQueryImpl(graphQLSchema, operationDefinition, fragments, coercedVariableValues, normalizedVariableValues);
     }
 
@@ -305,10 +304,10 @@ public class ExecutableNormalizedOperationFactory {
         String fieldName = field.getName();
         GraphQLFieldDefinition fieldDefinition = Introspection.getFieldDef(parameters.getGraphQLSchema(), objectTypes.iterator().next(), fieldName);
 
-        Map<String, Object> argumentValues = valuesResolver.getArgumentValues(fieldDefinition.getArguments(), field.getArguments(),CoercedVariables.of(parameters.getCoercedVariableValues()));
+        Map<String, Object> argumentValues = ValuesResolver.getArgumentValues(fieldDefinition.getArguments(), field.getArguments(),CoercedVariables.of(parameters.getCoercedVariableValues()));
         Map<String, NormalizedInputValue> normalizedArgumentValues = null;
         if (parameters.getNormalizedVariableValues() != null) {
-            normalizedArgumentValues = valuesResolver.getNormalizedArgumentValues(fieldDefinition.getArguments(), field.getArguments(), parameters.getNormalizedVariableValues());
+            normalizedArgumentValues = ValuesResolver.getNormalizedArgumentValues(fieldDefinition.getArguments(), field.getArguments(), parameters.getNormalizedVariableValues());
         }
         ImmutableList<String> objectTypeNames = map(objectTypes, GraphQLObjectType::getName);
 

--- a/src/test/groovy/graphql/execution/ValuesResolverTest.groovy
+++ b/src/test/groovy/graphql/execution/ValuesResolverTest.groovy
@@ -37,15 +37,13 @@ import static graphql.schema.GraphQLNonNull.nonNull
 
 class ValuesResolverTest extends Specification {
 
-    ValuesResolver resolver = new ValuesResolver()
-
     @Unroll
     def "getVariableValues: simple variable input #inputValue"() {
         given:
         def schema = TestUtil.schemaWithInputType(inputType)
         VariableDefinition variableDefinition = new VariableDefinition("variable", variableType, null)
         when:
-        def resolvedValues = resolver.coerceVariableValues(schema, [variableDefinition], RawVariables.of([variable: inputValue]))
+        def resolvedValues = ValuesResolver.coerceVariableValues(schema, [variableDefinition], RawVariables.of([variable: inputValue]))
         then:
         resolvedValues.get('variable') == outputValue
 
@@ -74,7 +72,7 @@ class ValuesResolverTest extends Specification {
         VariableDefinition variableDefinition = new VariableDefinition("variable", new TypeName("Person"))
 
         when:
-        def resolvedValues = resolver.coerceVariableValues(schema, [variableDefinition], RawVariables.of([variable: inputValue]))
+        def resolvedValues = ValuesResolver.coerceVariableValues(schema, [variableDefinition], RawVariables.of([variable: inputValue]))
         then:
         resolvedValues.get('variable') == outputValue
         where:
@@ -114,7 +112,7 @@ class ValuesResolverTest extends Specification {
 
         when:
         def obj = new Person('a', 123)
-        resolver.coerceVariableValues(schema, [variableDefinition], RawVariables.of([variable: obj]))
+        ValuesResolver.coerceVariableValues(schema, [variableDefinition], RawVariables.of([variable: obj]))
         then:
         thrown(CoercingParseValueException)
     }
@@ -125,7 +123,7 @@ class ValuesResolverTest extends Specification {
         VariableDefinition variableDefinition = new VariableDefinition("variable", new ListType(new TypeName("String")))
         String value = "world"
         when:
-        def resolvedValues = resolver.coerceVariableValues(schema, [variableDefinition], RawVariables.of([variable: value]))
+        def resolvedValues = ValuesResolver.coerceVariableValues(schema, [variableDefinition], RawVariables.of([variable: value]))
         then:
         resolvedValues.get('variable') == ['world']
     }
@@ -136,7 +134,7 @@ class ValuesResolverTest extends Specification {
         VariableDefinition variableDefinition = new VariableDefinition("variable", new ListType(new TypeName("String")))
         List<String> value = ["hello","world"]
         when:
-        def resolvedValues = resolver.coerceVariableValues(schema, [variableDefinition], RawVariables.of([variable: value]))
+        def resolvedValues = ValuesResolver.coerceVariableValues(schema, [variableDefinition], RawVariables.of([variable: value]))
         then:
         resolvedValues.get('variable') == ['hello','world']
     }
@@ -147,7 +145,7 @@ class ValuesResolverTest extends Specification {
         VariableDefinition variableDefinition = new VariableDefinition("variable", new ListType(new TypeName("String")))
         String[] value = ["hello","world"] as String[]
         when:
-        def resolvedValues = resolver.coerceVariableValues(schema, [variableDefinition], RawVariables.of([variable: value]))
+        def resolvedValues = ValuesResolver.coerceVariableValues(schema, [variableDefinition], RawVariables.of([variable: value]))
         then:
         resolvedValues.get('variable') == ['hello','world']
     }
@@ -159,7 +157,7 @@ class ValuesResolverTest extends Specification {
         def argument = new Argument("arg", new VariableReference("var"))
 
         when:
-        def values = resolver.getArgumentValues([fieldArgument], [argument], variables)
+        def values = ValuesResolver.getArgumentValues([fieldArgument], [argument], variables)
 
         then:
         values['arg'] == 'hello'
@@ -176,7 +174,7 @@ class ValuesResolverTest extends Specification {
 
         when:
         def variables = CoercedVariables.emptyVariables()
-        def values = resolver.getArgumentValues([fieldArgument], [argument], variables)
+        def values = ValuesResolver.getArgumentValues([fieldArgument], [argument], variables)
 
         then:
         values['arg'] == 'hello'
@@ -206,7 +204,7 @@ class ValuesResolverTest extends Specification {
 
         when:
         def argument = new Argument("arg", inputValue)
-        def values = resolver.getArgumentValues([fieldArgument], [argument], CoercedVariables.emptyVariables())
+        def values = ValuesResolver.getArgumentValues([fieldArgument], [argument], CoercedVariables.emptyVariables())
 
         then:
         values['arg'] == outputValue
@@ -254,7 +252,7 @@ class ValuesResolverTest extends Specification {
 
         when:
         def argument = new Argument("arg", inputValue)
-        def values = resolver.getArgumentValues([fieldArgument], [argument], CoercedVariables.emptyVariables())
+        def values = ValuesResolver.getArgumentValues([fieldArgument], [argument], CoercedVariables.emptyVariables())
 
         then:
         values['arg'] == outputValue
@@ -302,7 +300,7 @@ class ValuesResolverTest extends Specification {
         def fieldArgument1 = newArgument().name("arg1").type(enumType).build()
         def fieldArgument2 = newArgument().name("arg2").type(enumType).build()
         when:
-        def values = resolver.getArgumentValues([fieldArgument1, fieldArgument2], [argument1, argument2], CoercedVariables.emptyVariables())
+        def values = ValuesResolver.getArgumentValues([fieldArgument1, fieldArgument2], [argument1, argument2], CoercedVariables.emptyVariables())
 
         then:
         values['arg1'] == 'PLUTO'
@@ -319,7 +317,7 @@ class ValuesResolverTest extends Specification {
         def fieldArgument = newArgument().name("arg").type(list(GraphQLBoolean)).build()
 
         when:
-        def values = resolver.getArgumentValues([fieldArgument], [argument], CoercedVariables.emptyVariables())
+        def values = ValuesResolver.getArgumentValues([fieldArgument], [argument], CoercedVariables.emptyVariables())
 
         then:
         values['arg'] == [true, false]
@@ -333,7 +331,7 @@ class ValuesResolverTest extends Specification {
         def fieldArgument = newArgument().name("arg").type(list(GraphQLString)).build()
 
         when:
-        def values = resolver.getArgumentValues([fieldArgument], [argument], CoercedVariables.emptyVariables())
+        def values = ValuesResolver.getArgumentValues([fieldArgument], [argument], CoercedVariables.emptyVariables())
 
         then:
         values['arg'] == ['world']
@@ -351,7 +349,7 @@ class ValuesResolverTest extends Specification {
         VariableDefinition variableDefinition = new VariableDefinition("variable", new TypeName("Test"))
 
         when:
-        def resolvedValues = resolver.coerceVariableValues(schema, [variableDefinition], RawVariables.of([variable: inputValue]))
+        def resolvedValues = ValuesResolver.coerceVariableValues(schema, [variableDefinition], RawVariables.of([variable: inputValue]))
         then:
         resolvedValues.get('variable') == outputValue
         where:
@@ -379,7 +377,7 @@ class ValuesResolverTest extends Specification {
         VariableDefinition variableDefinition = new VariableDefinition("variable", new TypeName("InputObject"))
 
         when:
-        def resolvedValues = resolver.coerceVariableValues(schema, [variableDefinition], RawVariables.of([variable: inputValue]))
+        def resolvedValues = ValuesResolver.coerceVariableValues(schema, [variableDefinition], RawVariables.of([variable: inputValue]))
 
         then:
         resolvedValues.get('variable') == outputValue
@@ -406,7 +404,7 @@ class ValuesResolverTest extends Specification {
         VariableDefinition variableDefinition = new VariableDefinition("variable", new TypeName("InputObject"))
 
         when:
-        resolver.coerceVariableValues(schema, [variableDefinition], RawVariables.of([variable: inputValue]))
+        ValuesResolver.coerceVariableValues(schema, [variableDefinition], RawVariables.of([variable: inputValue]))
 
         then:
         thrown(GraphQLException)
@@ -425,7 +423,7 @@ class ValuesResolverTest extends Specification {
         VariableDefinition barVarDef = new VariableDefinition("bar", new TypeName("String"))
 
         when:
-        def resolvedValues = resolver.coerceVariableValues(schema, [fooVarDef, barVarDef], RawVariables.of(InputValue))
+        def resolvedValues = ValuesResolver.coerceVariableValues(schema, [fooVarDef, barVarDef], RawVariables.of(InputValue))
 
         then:
         resolvedValues.toMap() == outputValue
@@ -443,7 +441,7 @@ class ValuesResolverTest extends Specification {
         VariableDefinition fooVarDef = new VariableDefinition("foo", new NonNullType(new TypeName("String")))
 
         when:
-        resolver.coerceVariableValues(schema, [fooVarDef], RawVariables.emptyVariables())
+        ValuesResolver.coerceVariableValues(schema, [fooVarDef], RawVariables.emptyVariables())
 
         then:
         thrown(GraphQLException)
@@ -462,7 +460,7 @@ class ValuesResolverTest extends Specification {
         def variableValuesMap = RawVariables.of(["foo": null, "bar": "barValue"])
 
         when:
-        def resolvedVars = resolver.coerceVariableValues(schema, [fooVarDef, barVarDef], variableValuesMap)
+        def resolvedVars = ValuesResolver.coerceVariableValues(schema, [fooVarDef, barVarDef], variableValuesMap)
 
         then:
         resolvedVars.get('foo') == null
@@ -479,7 +477,7 @@ class ValuesResolverTest extends Specification {
         def variableValuesMap = RawVariables.of(["foo": null])
 
         when:
-        resolver.coerceVariableValues(schema, [fooVarDef], variableValuesMap)
+        ValuesResolver.coerceVariableValues(schema, [fooVarDef], variableValuesMap)
 
         then:
         def error = thrown(NonNullableValueCoercedAsNullException)
@@ -497,7 +495,7 @@ class ValuesResolverTest extends Specification {
         def variableValuesMap = RawVariables.of(["foo": [null]])
 
         when:
-        resolver.coerceVariableValues(schema, [fooVarDef], variableValuesMap)
+        ValuesResolver.coerceVariableValues(schema, [fooVarDef], variableValuesMap)
 
         then:
         def error = thrown(NonNullableValueCoercedAsNullException)
@@ -517,7 +515,7 @@ class ValuesResolverTest extends Specification {
 
         when:
         def variables = CoercedVariables.emptyVariables()
-        def values = resolver.getArgumentValues([fieldArgument], [argument], variables)
+        def values = ValuesResolver.getArgumentValues([fieldArgument], [argument], variables)
 
         then:
         values['arg'] == null
@@ -534,7 +532,7 @@ class ValuesResolverTest extends Specification {
 
         when:
         def variables = CoercedVariables.of(["var": null])
-        def values = resolver.getArgumentValues([fieldArgument], [argument], variables)
+        def values = ValuesResolver.getArgumentValues([fieldArgument], [argument], variables)
 
         then:
         values['arg'] == null
@@ -551,7 +549,7 @@ class ValuesResolverTest extends Specification {
 
         when:
         def variables = CoercedVariables.of(["var": null])
-        resolver.getArgumentValues([fieldArgument], [argument], variables)
+        ValuesResolver.getArgumentValues([fieldArgument], [argument], variables)
 
         then:
         def error = thrown(NonNullableValueCoercedAsNullException)


### PR DESCRIPTION
Make every method in `ValuesResolver` static and save some object allocations. It's a util class that doesn't need to have instances.