### PR TITLE
READY - Stop DOS attacks by making the lexer stop early on evil input.

### DIFF
--- a/src/main/java/graphql/ParseAndValidate.java
+++ b/src/main/java/graphql/ParseAndValidate.java
@@ -9,7 +9,10 @@ import graphql.validation.ValidationError;
 import graphql.validation.Validator;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
+
+import static java.util.Optional.ofNullable;
 
 /**
  * This class allows you to parse and validate a graphql query without executing it.  It will tell you
@@ -58,6 +61,8 @@ public class ParseAndValidate {
             //
             // we allow the caller to specify new parser options by context
             ParserOptions parserOptions = executionInput.getGraphQLContext().get(ParserOptions.class);
+            // we use the query parser options by default if they are not specified
+            parserOptions = ofNullable(parserOptions).orElse(ParserOptions.getDefaultQueryParserOptions());
             Parser parser = new Parser();
             Document document = parser.parseDocument(executionInput.getQuery(), parserOptions);
             return ParseAndValidateResult.newResult().document(document).variables(executionInput.getVariables()).build();

--- a/src/main/java/graphql/ParseAndValidate.java
+++ b/src/main/java/graphql/ParseAndValidate.java
@@ -9,7 +9,6 @@ import graphql.validation.ValidationError;
 import graphql.validation.Validator;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Predicate;
 
 import static java.util.Optional.ofNullable;
@@ -62,7 +61,7 @@ public class ParseAndValidate {
             // we allow the caller to specify new parser options by context
             ParserOptions parserOptions = executionInput.getGraphQLContext().get(ParserOptions.class);
             // we use the query parser options by default if they are not specified
-            parserOptions = ofNullable(parserOptions).orElse(ParserOptions.getDefaultQueryParserOptions());
+            parserOptions = ofNullable(parserOptions).orElse(ParserOptions.getDefaultOperationParserOptions());
             Parser parser = new Parser();
             Document document = parser.parseDocument(executionInput.getQuery(), parserOptions);
             return ParseAndValidateResult.newResult().document(document).variables(executionInput.getVariables()).build();

--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -77,6 +77,7 @@ import static graphql.collect.ImmutableKit.emptyList;
 import static graphql.collect.ImmutableKit.map;
 import static graphql.parser.StringValueParsing.parseSingleQuotedString;
 import static graphql.parser.StringValueParsing.parseTripleQuotedString;
+import static java.util.Optional.ofNullable;
 
 @Internal
 public class GraphqlAntlrToLanguage {
@@ -96,7 +97,7 @@ public class GraphqlAntlrToLanguage {
     public GraphqlAntlrToLanguage(CommonTokenStream tokens, MultiSourceReader multiSourceReader, ParserOptions parserOptions) {
         this.tokens = tokens;
         this.multiSourceReader = multiSourceReader;
-        this.parserOptions = ParserOptions.orDefaultOnes(parserOptions);
+        this.parserOptions = ofNullable(parserOptions).orElse(ParserOptions.getDefaultParserOptions());
     }
 
     public ParserOptions getParserOptions() {

--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -76,7 +76,7 @@ import static graphql.Assert.assertShouldNeverHappen;
 import static graphql.collect.ImmutableKit.emptyList;
 import static graphql.collect.ImmutableKit.map;
 import static graphql.parser.Parser.CHANNEL_COMMENTS;
-import static graphql.parser.Parser.CHANNEL_IGNORED_CHARS;
+import static graphql.parser.Parser.CHANNEL_WHITESPACE;
 import static graphql.parser.StringValueParsing.parseSingleQuotedString;
 import static graphql.parser.StringValueParsing.parseTripleQuotedString;
 import static java.util.Optional.ofNullable;
@@ -791,12 +791,12 @@ public class GraphqlAntlrToLanguage {
         }
         Token start = ctx.getStart();
         int tokenStartIndex = start.getTokenIndex();
-        List<Token> leftChannel = tokens.getHiddenTokensToLeft(tokenStartIndex, CHANNEL_IGNORED_CHARS);
+        List<Token> leftChannel = tokens.getHiddenTokensToLeft(tokenStartIndex, CHANNEL_WHITESPACE);
         List<IgnoredChar> ignoredCharsLeft = mapTokenToIgnoredChar(leftChannel);
 
         Token stop = ctx.getStop();
         int tokenStopIndex = stop.getTokenIndex();
-        List<Token> rightChannel = tokens.getHiddenTokensToRight(tokenStopIndex, CHANNEL_IGNORED_CHARS);
+        List<Token> rightChannel = tokens.getHiddenTokensToRight(tokenStopIndex, CHANNEL_WHITESPACE);
         List<IgnoredChar> ignoredCharsRight = mapTokenToIgnoredChar(rightChannel);
 
         nodeBuilder.ignoredChars(new IgnoredChars(ignoredCharsLeft, ignoredCharsRight));

--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -75,6 +75,8 @@ import java.util.List;
 import static graphql.Assert.assertShouldNeverHappen;
 import static graphql.collect.ImmutableKit.emptyList;
 import static graphql.collect.ImmutableKit.map;
+import static graphql.parser.Parser.CHANNEL_COMMENTS;
+import static graphql.parser.Parser.CHANNEL_IGNORED_CHARS;
 import static graphql.parser.StringValueParsing.parseSingleQuotedString;
 import static graphql.parser.StringValueParsing.parseTripleQuotedString;
 import static java.util.Optional.ofNullable;
@@ -83,8 +85,6 @@ import static java.util.Optional.ofNullable;
 public class GraphqlAntlrToLanguage {
 
     private static final List<Comment> NO_COMMENTS = ImmutableKit.emptyList();
-    private static final int CHANNEL_COMMENTS = 2;
-    private static final int CHANNEL_IGNORED_CHARS = 3;
     private final CommonTokenStream tokens;
     private final MultiSourceReader multiSourceReader;
     private final ParserOptions parserOptions;

--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -96,7 +96,7 @@ public class GraphqlAntlrToLanguage {
     public GraphqlAntlrToLanguage(CommonTokenStream tokens, MultiSourceReader multiSourceReader, ParserOptions parserOptions) {
         this.tokens = tokens;
         this.multiSourceReader = multiSourceReader;
-        this.parserOptions = parserOptions == null ? ParserOptions.getDefaultParserOptions() : parserOptions;
+        this.parserOptions = ParserOptions.orDefaultOnes(parserOptions);
     }
 
     public ParserOptions getParserOptions() {

--- a/src/main/java/graphql/parser/Parser.java
+++ b/src/main/java/graphql/parser/Parser.java
@@ -52,7 +52,7 @@ public class Parser {
     @Internal
     public static final int CHANNEL_COMMENTS = 2;
     @Internal
-    public static final int CHANNEL_IGNORED_CHARS = 3;
+    public static final int CHANNEL_WHITESPACE = 3;
 
     /**
      * Parses a string input into a graphql AST {@link Document}
@@ -325,7 +325,7 @@ public class Parser {
         String offendingToken = null;
         if (token != null) {
             int channel = token.getChannel();
-            tokenType = channel == CHANNEL_IGNORED_CHARS ? "whitespace" : (channel == CHANNEL_COMMENTS ? "comments" : "grammar");
+            tokenType = channel == CHANNEL_WHITESPACE ? "whitespace" : (channel == CHANNEL_COMMENTS ? "comments" : "grammar");
 
             offendingToken = token.getText();
             sourceLocation = AntlrHelper.createSourceLocation(multiSourceReader, token.getLine(), token.getCharPositionInLine());

--- a/src/main/java/graphql/parser/Parser.java
+++ b/src/main/java/graphql/parser/Parser.java
@@ -324,7 +324,8 @@ public class Parser {
         SourceLocation sourceLocation = null;
         String offendingToken = null;
         if (token != null) {
-            tokenType = token.getChannel() == CHANNEL_IGNORED_CHARS ? "whitespace" : tokenType;
+            int channel = token.getChannel();
+            tokenType = channel == CHANNEL_IGNORED_CHARS ? "whitespace" : (channel == CHANNEL_COMMENTS ? "comments" : "grammar");
 
             offendingToken = token.getText();
             sourceLocation = AntlrHelper.createSourceLocation(multiSourceReader, token.getLine(), token.getCharPositionInLine());

--- a/src/main/java/graphql/parser/Parser.java
+++ b/src/main/java/graphql/parser/Parser.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.UncheckedIOException;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
@@ -224,7 +225,7 @@ public class Parser {
         });
 
         // default in the parser options if they are not set
-        parserOptions = ParserOptions.orDefaultOnes(parserOptions);
+        parserOptions = Optional.ofNullable(parserOptions).orElse(ParserOptions.getDefaultParserOptions());
 
         int maxTokens = parserOptions.getMaxTokens();
         Consumer<Token> onTooManyTokens = token -> throwCancelParseIfTooManyTokens(token, maxTokens, multiSourceReader);

--- a/src/main/java/graphql/parser/ParserOptions.java
+++ b/src/main/java/graphql/parser/ParserOptions.java
@@ -65,6 +65,18 @@ public class ParserOptions {
         defaultJvmParserOptions = assertNotNull(options);
     }
 
+    /**
+     * This will return the passed in parser options or the system-wide default ones if they
+     * are null
+     *
+     * @param parserOptions the options to check
+     *
+     * @return a non-null set of parser options
+     */
+    public static ParserOptions orDefaultOnes(ParserOptions parserOptions) {
+        return parserOptions == null ? getDefaultParserOptions() : parserOptions;
+    }
+
     private final boolean captureIgnoredChars;
     private final boolean captureSourceLocation;
     private final boolean captureLineComments;

--- a/src/main/java/graphql/parser/ParserOptions.java
+++ b/src/main/java/graphql/parser/ParserOptions.java
@@ -28,17 +28,23 @@ public class ParserOptions {
             .captureSourceLocation(true)
             .captureLineComments(true)
             .maxTokens(MAX_QUERY_TOKENS) // to prevent a billion laughs style attacks, we set a default for graphql-java
+            .build();
 
+    private static ParserOptions defaultJvmQueryParserOptions = newParserOptions()
+            .captureIgnoredChars(false)
+            .captureSourceLocation(true)
+            .captureLineComments(false) // #comments are not useful in query parsing
+            .maxTokens(MAX_QUERY_TOKENS) // to prevent a billion laughs style attacks, we set a default for graphql-java
             .build();
 
     /**
-     * By default the Parser will not capture ignored characters.  A static holds this default
+     * By default, the Parser will not capture ignored characters.  A static holds this default
      * value in a JVM wide basis options object.
      *
      * Significant memory savings can be made if we do NOT capture ignored characters,
      * especially in SDL parsing.
      *
-     * @return the static default value on whether to capture ignored chars
+     * @return the static default JVM value
      *
      * @see graphql.language.IgnoredChar
      * @see graphql.language.SourceLocation
@@ -48,7 +54,20 @@ public class ParserOptions {
     }
 
     /**
-     * By default the Parser will not capture ignored characters.  A static holds this default
+     * By default, for query parsing, the Parser will not capture ignored characters and it will not capture line comments into AST
+     * elements .  A static holds this default value for query parsing in a JVM wide basis options object.
+     *
+     * @return the static default JVM value for query parsing
+     *
+     * @see graphql.language.IgnoredChar
+     * @see graphql.language.SourceLocation
+     */
+    public static ParserOptions getDefaultQueryParserOptions() {
+        return defaultJvmQueryParserOptions;
+    }
+
+    /**
+     * By default, the Parser will not capture ignored characters.  A static holds this default
      * value in a JVM wide basis options object.
      *
      * Significant memory savings can be made if we do NOT capture ignored characters,
@@ -66,16 +85,20 @@ public class ParserOptions {
     }
 
     /**
-     * This will return the passed in parser options or the system-wide default ones if they
-     * are null
+     * By default, the Parser will not capture ignored characters or line comments.  A static holds this default
+     * value in a JVM wide basis options object for query parsing.
      *
-     * @param parserOptions the options to check
+     * This static can be set to true to allow the behavior of version 16.x or before.
      *
-     * @return a non-null set of parser options
+     * @param options - the new default JVM parser options for query parsing
+     *
+     * @see graphql.language.IgnoredChar
+     * @see graphql.language.SourceLocation
      */
-    public static ParserOptions orDefaultOnes(ParserOptions parserOptions) {
-        return parserOptions == null ? getDefaultParserOptions() : parserOptions;
+    public static void setDefaultQueryParserOptions(ParserOptions options) {
+        defaultJvmQueryParserOptions = assertNotNull(options);
     }
+
 
     private final boolean captureIgnoredChars;
     private final boolean captureSourceLocation;

--- a/src/main/java/graphql/parser/ParserOptions.java
+++ b/src/main/java/graphql/parser/ParserOptions.java
@@ -23,8 +23,8 @@ public class ParserOptions {
      */
     public static final int MAX_QUERY_TOKENS = 15_000;
     /**
-     * Another graphql hacking vector is to send large amounts of whitespace in queries that burn lots of parsing CPU time and burn
-     * memory representing a document.  Whitespace token processing in ANTLR is 2 order of magnitude faster than grammar token processing
+     * Another graphql hacking vector is to send large amounts of whitespace in operations that burn lots of parsing CPU time and burn
+     * memory representing a document.  Whitespace token processing in ANTLR is 2 orders of magnitude faster than grammar token processing
      * however it still takes some time to happen.
      *
      * If you want to allow more, then {@link #setDefaultParserOptions(ParserOptions)} allows you to change this
@@ -163,7 +163,7 @@ public class ParserOptions {
     }
 
     /**
-     * A graphql hacking vector is to send nonsensical queries that burn lots of parsing CPU time and burn
+     * A graphql hacking vector is to send nonsensical queries that burn lots of parsing CPU time and burns
      * memory representing a document that won't ever execute.  To prevent this you can set a maximum number of parse
      * tokens that will be accepted before an exception is thrown and the parsing is stopped.
      *
@@ -175,7 +175,7 @@ public class ParserOptions {
 
     /**
      * A graphql hacking vector is to send larges amounts of whitespace that burn lots of parsing CPU time and burn
-     * memory representing a document.  To prevent this you can set a maximum number of whitepsace parse
+     * memory representing a document.  To prevent this you can set a maximum number of whitespace parse
      * tokens that will be accepted before an exception is thrown and the parsing is stopped.
      *
      * @return the maximum number of raw whitespace tokens the parser will accept, after which an exception will be thrown.

--- a/src/main/java/graphql/parser/ParserOptions.java
+++ b/src/main/java/graphql/parser/ParserOptions.java
@@ -37,6 +37,7 @@ public class ParserOptions {
             .captureSourceLocation(true)
             .captureLineComments(true)
             .maxTokens(MAX_QUERY_TOKENS) // to prevent a billion laughs style attacks, we set a default for graphql-java
+            .maxWhitespaceTokens(MAX_WHITESPACE_TOKENS)
             .build();
 
     private static ParserOptions defaultJvmOperationParserOptions = newParserOptions()
@@ -44,6 +45,7 @@ public class ParserOptions {
             .captureSourceLocation(true)
             .captureLineComments(false) // #comments are not useful in query parsing
             .maxTokens(MAX_QUERY_TOKENS) // to prevent a billion laughs style attacks, we set a default for graphql-java
+            .maxWhitespaceTokens(MAX_WHITESPACE_TOKENS)
             .build();
 
     /**

--- a/src/main/java/graphql/parser/ParserOptions.java
+++ b/src/main/java/graphql/parser/ParserOptions.java
@@ -48,6 +48,14 @@ public class ParserOptions {
             .maxWhitespaceTokens(MAX_WHITESPACE_TOKENS)
             .build();
 
+    private static ParserOptions defaultJvmSdlParserOptions = newParserOptions()
+            .captureIgnoredChars(false)
+            .captureSourceLocation(true)
+            .captureLineComments(true) // #comments are useful in SDL parsing
+            .maxTokens(Integer.MAX_VALUE) // we are less worried about a billion laughs with SDL parsing since the call path is not facing attackers
+            .maxWhitespaceTokens(Integer.MAX_VALUE)
+            .build();
+
     /**
      * By default, the Parser will not capture ignored characters.  A static holds this default
      * value in a JVM wide basis options object.
@@ -62,19 +70,6 @@ public class ParserOptions {
      */
     public static ParserOptions getDefaultParserOptions() {
         return defaultJvmParserOptions;
-    }
-
-    /**
-     * By default, for operation parsing, the Parser will not capture ignored characters, and it will not capture line comments into AST
-     * elements .  A static holds this default value for operation parsing in a JVM wide basis options object.
-     *
-     * @return the static default JVM value for query parsing
-     *
-     * @see graphql.language.IgnoredChar
-     * @see graphql.language.SourceLocation
-     */
-    public static ParserOptions getDefaultOperationParserOptions() {
-        return defaultJvmOperationParserOptions;
     }
 
     /**
@@ -95,6 +90,20 @@ public class ParserOptions {
         defaultJvmParserOptions = assertNotNull(options);
     }
 
+
+    /**
+     * By default, for operation parsing, the Parser will not capture ignored characters, and it will not capture line comments into AST
+     * elements .  A static holds this default value for operation parsing in a JVM wide basis options object.
+     *
+     * @return the static default JVM value for operation parsing
+     *
+     * @see graphql.language.IgnoredChar
+     * @see graphql.language.SourceLocation
+     */
+    public static ParserOptions getDefaultOperationParserOptions() {
+        return defaultJvmOperationParserOptions;
+    }
+
     /**
      * By default, the Parser will not capture ignored characters or line comments.  A static holds this default
      * value in a JVM wide basis options object for operation parsing.
@@ -110,6 +119,37 @@ public class ParserOptions {
         defaultJvmOperationParserOptions = assertNotNull(options);
     }
 
+    /**
+     * By default, for SDL parsing, the Parser will not capture ignored characters, but it will capture line comments into AST
+     * elements.  The SDL default options allow unlimited tokens and whitespace, since a DOS attack vector is
+     * not commonly available via schema SDL parsing.
+     *
+     * A static holds this default value for SDL parsing in a JVM wide basis options object.
+     *
+     * @return the static default JVM value for SDL parsing
+     *
+     * @see graphql.language.IgnoredChar
+     * @see graphql.language.SourceLocation
+     * @see graphql.schema.idl.SchemaParser
+     */
+    public static ParserOptions getDefaultSdlParserOptions() {
+        return defaultJvmSdlParserOptions;
+    }
+
+    /**
+     * By default, for SDL parsing, the Parser will not capture ignored characters, but it will capture line comments into AST
+     * elements .  A static holds this default value for operation parsing in a JVM wide basis options object.
+     *
+     * This static can be set to true to allow the behavior of version 16.x or before.
+     *
+     * @param options - the new default JVM parser options for operation parsing
+     *
+     * @see graphql.language.IgnoredChar
+     * @see graphql.language.SourceLocation
+     */
+    public static void setDefaultSdlParserOptions(ParserOptions options) {
+        defaultJvmSdlParserOptions = assertNotNull(options);
+    }
 
     private final boolean captureIgnoredChars;
     private final boolean captureSourceLocation;

--- a/src/main/java/graphql/parser/SafeTokenSource.java
+++ b/src/main/java/graphql/parser/SafeTokenSource.java
@@ -1,0 +1,82 @@
+package graphql.parser;
+
+import graphql.Internal;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.TokenFactory;
+import org.antlr.v4.runtime.TokenSource;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+/**
+ * This token source can wrap a lexer and if it asks for more than a maximum number of tokens
+ * the user can take some action, typically throw an exception to stop lexing.
+ *
+ * It tracks the maximum number per token channel, so we have 3 at the moment, and they will all be tracked.
+ *
+ * This is used to protect us from evil input.  The lexer will eagerly try to find all tokens
+ * at times and certain inputs (directives butted together for example) will cause the lexer
+ * to keep doing work even though before the tokens are presented back to the parser
+ * and hence before it has a chance to stop work once too much as been done.
+ */
+@Internal
+public class SafeTokenSource implements TokenSource {
+    private final TokenSource lexer;
+    private final int maxTokens;
+    private final Consumer<Token> whenMaxTokensExceeded;
+    private final Map<Integer, Integer> channelCounts;
+
+    public SafeTokenSource(TokenSource lexer, int maxTokens, Consumer<Token> whenMaxTokensExceeded) {
+        this.lexer = lexer;
+        this.maxTokens = maxTokens;
+        this.whenMaxTokensExceeded = whenMaxTokensExceeded;
+        this.channelCounts = new HashMap<>();
+    }
+
+    @Override
+    public Token nextToken() {
+        Token token = lexer.nextToken();
+        if (token != null) {
+            int channel = token.getChannel();
+            Integer currentCount = channelCounts.getOrDefault(channel, 0);
+            currentCount = currentCount + 1;
+            if (currentCount > maxTokens) {
+                whenMaxTokensExceeded.accept(token);
+            }
+            channelCounts.put(channel, currentCount);
+        }
+        return token;
+    }
+
+    @Override
+    public int getLine() {
+        return lexer.getLine();
+    }
+
+    @Override
+    public int getCharPositionInLine() {
+        return lexer.getCharPositionInLine();
+    }
+
+    @Override
+    public CharStream getInputStream() {
+        return lexer.getInputStream();
+    }
+
+    @Override
+    public String getSourceName() {
+        return lexer.getSourceName();
+    }
+
+    @Override
+    public void setTokenFactory(TokenFactory<?> factory) {
+        lexer.setTokenFactory(factory);
+    }
+
+    @Override
+    public TokenFactory<?> getTokenFactory() {
+        return lexer.getTokenFactory();
+    }
+}

--- a/src/main/java/graphql/parser/SafeTokenSource.java
+++ b/src/main/java/graphql/parser/SafeTokenSource.java
@@ -46,7 +46,7 @@ public class SafeTokenSource implements TokenSource {
         if (token != null) {
             int channel = token.getChannel();
             int currentCount = ++channelCounts[channel];
-            if (channel == Parser.CHANNEL_IGNORED_CHARS) {
+            if (channel == Parser.CHANNEL_WHITESPACE) {
                 // whitespace gets its own max count
                 callbackIfMaxExceeded(maxWhitespaceTokens, currentCount, token);
             } else {

--- a/src/main/java/graphql/parser/SafeTokenSource.java
+++ b/src/main/java/graphql/parser/SafeTokenSource.java
@@ -33,7 +33,9 @@ public class SafeTokenSource implements TokenSource {
         this.maxTokens = maxTokens;
         this.maxWhitespaceTokens = maxWhitespaceTokens;
         this.whenMaxTokensExceeded = whenMaxTokensExceeded;
+        // this could be a Map<int,int> however we want it to be faster as possible.
         // we only have 3 channels - but they are 0,2 and 3 so use 5 for safety - still faster than a map get/put
+        // if we ever add another channel beyond 5 it will IOBEx during tests so future changes will be handled before release!
         this.channelCounts = new int[]{0, 0, 0, 0, 0};
     }
 

--- a/src/main/java/graphql/schema/idl/SchemaParser.java
+++ b/src/main/java/graphql/schema/idl/SchemaParser.java
@@ -114,9 +114,7 @@ public class SchemaParser {
     private TypeDefinitionRegistry parseImpl(Reader schemaInput, ParserOptions parseOptions) {
         try {
             if (parseOptions == null) {
-                // for SDL we don't stop how many parser tokens there are - it's not the attack vector
-                // to be prevented compared to queries
-                parseOptions = ParserOptions.getDefaultParserOptions().transform(opts -> opts.maxTokens(Integer.MAX_VALUE));
+                parseOptions = ParserOptions.getDefaultSdlParserOptions();
             }
             Parser parser = new Parser();
             Document document = parser.parseDocument(schemaInput, parseOptions);

--- a/src/test/groovy/graphql/parser/BadParserSituations.java
+++ b/src/test/groovy/graphql/parser/BadParserSituations.java
@@ -22,6 +22,10 @@ import static graphql.schema.idl.RuntimeWiring.newRuntimeWiring;
 
 /**
  * This is not a test - it's a program we can run to show the system reacts to certain bad inputs
+ *
+ * You can run this to discover scenarios and see what happens at what levels.
+ *
+ * I used this to help discover more on the behavior of ANTLR and its moving parts
  */
 public class BadParserSituations {
     static Integer STEP = 5000;
@@ -36,9 +40,9 @@ public class BadParserSituations {
             String runState = "Limited Tokens";
             // on the second run - have unlimited tokens
             if (runNumber > 1) {
-                ParserOptions unlimitedTokens = ParserOptions.getDefaultQueryParserOptions().transform(
-                        builder -> builder.maxTokens(Integer.MAX_VALUE));
-                ParserOptions.setDefaultQueryParserOptions(unlimitedTokens);
+                ParserOptions unlimitedTokens = ParserOptions.getDefaultOperationParserOptions().transform(
+                        builder -> builder.maxTokens(Integer.MAX_VALUE).maxWhitespaceTokens(Integer.MAX_VALUE));
+                ParserOptions.setDefaultOperationParserOptions(unlimitedTokens);
 
                 runState = "Unlimited Tokens";
             }

--- a/src/test/groovy/graphql/parser/BadParserSituations.java
+++ b/src/test/groovy/graphql/parser/BadParserSituations.java
@@ -1,0 +1,106 @@
+package graphql.parser;
+
+import com.google.common.base.Strings;
+import graphql.ExecutionInput;
+import graphql.ExecutionResult;
+import graphql.GraphQL;
+import graphql.GraphQLError;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.StaticDataFetcher;
+import graphql.schema.idl.RuntimeWiring;
+import graphql.schema.idl.SchemaGenerator;
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.TypeDefinitionRegistry;
+
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.time.Duration;
+import java.util.List;
+
+import static graphql.schema.idl.RuntimeWiring.newRuntimeWiring;
+
+/**
+ * This is not a test - it's a program we can run to show the system reacts to certain bad inputs
+ */
+public class BadParserSituations {
+    static Integer STEP = 5000;
+    static Integer CHECKS_AMOUNT = 15;
+
+    public static void main(String[] args) {
+        GraphQL graphQL = setupSchema();
+
+        System.setErr(toDevNull());
+
+        for (int runNumber = 1; runNumber <=2; runNumber++) {
+            // on the second run - have unlimited tokens
+            if (runNumber > 1) {
+                ParserOptions unlimitedTokens = ParserOptions.getDefaultParserOptions().transform(builder -> builder.maxTokens(Integer.MAX_VALUE));
+                ParserOptions.setDefaultParserOptions(unlimitedTokens);
+            }
+            runScenarios("Whitespace Bad Payloads",runNumber, Strings.repeat(" ", 10), graphQL);
+            runScenarios("Grammar Directives Bad Payloads",runNumber, "@lol", graphQL);
+            runScenarios("Grammar Field Bad Payloads",runNumber, "f(id:null)", graphQL);
+
+        }
+
+    }
+
+    private static void runScenarios(String scenarioName, int runNumber, String badPayload, GraphQL graphQL) {
+        long maxRuntime = 0;
+        for (int i = 1; i < CHECKS_AMOUNT; i++) {
+
+            int howManyBadPayloads = i * STEP;
+            String repeatedPayload = Strings.repeat(badPayload, howManyBadPayloads);
+            String query = "query {__typename " + repeatedPayload + " }";
+
+            ExecutionInput executionInput = ExecutionInput.newExecutionInput().query(query).build();
+            long startTime = System.nanoTime();
+
+            ExecutionResult executionResult = graphQL.execute(executionInput);
+
+            Duration duration = Duration.ofNanos(System.nanoTime() - startTime);
+
+            System.out.printf("%s(run #%d)(%d of %d) - | query length %d | bad payloads %d | duration %dms \n", scenarioName, runNumber, i, CHECKS_AMOUNT, query.length(), howManyBadPayloads, duration.toMillis());
+            printLastError(executionResult.getErrors());
+
+            if (duration.toMillis() > maxRuntime) {
+                maxRuntime = duration.toMillis();
+            }
+        }
+        System.out.printf("%s(run #%d) - finished | max time was %s ms \n" +
+                "=======================\n\n", scenarioName, runNumber, maxRuntime);
+    }
+
+    private static void printLastError(List<GraphQLError> errors) {
+        if (errors.size() > 0) {
+            GraphQLError lastError = errors.get(errors.size() - 1);
+            System.out.printf("\terror : %s \n", lastError.getMessage());
+        }
+
+    }
+
+    private static PrintStream toDevNull() {
+        return new PrintStream(new OutputStream() {
+            public void write(int b) {
+                //DO NOTHING
+            }
+        });
+    }
+
+    private static GraphQL setupSchema() {
+        String schema = "type Query{hello: String}";
+
+        SchemaParser schemaParser = new SchemaParser();
+        TypeDefinitionRegistry typeDefinitionRegistry = schemaParser.parse(schema);
+
+        RuntimeWiring runtimeWiring = newRuntimeWiring()
+                .type("Query", builder -> builder.dataFetcher("hello", new StaticDataFetcher("world")))
+                .build();
+
+        SchemaGenerator schemaGenerator = new SchemaGenerator();
+        GraphQLSchema graphQLSchema = schemaGenerator.makeExecutableSchema(typeDefinitionRegistry, runtimeWiring);
+
+        GraphQL graphQL = GraphQL.newGraphQL(graphQLSchema).build();
+        return graphQL;
+    }
+}

--- a/src/test/groovy/graphql/parser/ParserOptionsTest.groovy
+++ b/src/test/groovy/graphql/parser/ParserOptionsTest.groovy
@@ -1,0 +1,56 @@
+package graphql.parser
+
+import spock.lang.Specification
+
+class ParserOptionsTest extends Specification {
+    static defaultOptions = ParserOptions.getDefaultParserOptions()
+    static defaultQueryOptions = ParserOptions.getDefaultQueryParserOptions()
+
+    void setup() {
+        ParserOptions.setDefaultParserOptions(defaultOptions)
+        ParserOptions.setDefaultQueryParserOptions(defaultQueryOptions)
+    }
+
+    void cleanup() {
+        ParserOptions.setDefaultParserOptions(defaultOptions)
+        ParserOptions.setDefaultQueryParserOptions(defaultQueryOptions)
+    }
+
+    def "lock in default settings"() {
+        expect:
+        defaultOptions.getMaxTokens() == 15_000
+        defaultOptions.isCaptureSourceLocation()
+        defaultOptions.isCaptureLineComments()
+        !defaultOptions.isCaptureIgnoredChars()
+
+        defaultQueryOptions.getMaxTokens() == 15_000
+        defaultQueryOptions.isCaptureSourceLocation()
+        !defaultQueryOptions.isCaptureLineComments()
+        !defaultQueryOptions.isCaptureIgnoredChars()
+    }
+
+    def "can set in new option JVM wide"() {
+        def newDefaultOptions = defaultOptions.transform({ it.captureIgnoredChars(true) })
+        def newDefaultQueryOptions = defaultQueryOptions.transform({ it.captureIgnoredChars(true).captureLineComments(true) })
+
+        when:
+        ParserOptions.setDefaultParserOptions(newDefaultOptions)
+        ParserOptions.setDefaultQueryParserOptions(newDefaultQueryOptions)
+
+        def currentDefaultOptions = ParserOptions.getDefaultParserOptions()
+        def currentDefaultQueryOptions = ParserOptions.getDefaultQueryParserOptions()
+
+        then:
+
+        currentDefaultOptions.getMaxTokens() == 15_000
+        currentDefaultOptions.isCaptureSourceLocation()
+        currentDefaultOptions.isCaptureLineComments()
+        currentDefaultOptions.isCaptureIgnoredChars()
+
+        currentDefaultQueryOptions.getMaxTokens() == 15_000
+        currentDefaultQueryOptions.isCaptureSourceLocation()
+        currentDefaultQueryOptions.isCaptureLineComments()
+        currentDefaultQueryOptions.isCaptureIgnoredChars()
+
+    }
+}

--- a/src/test/groovy/graphql/parser/ParserOptionsTest.groovy
+++ b/src/test/groovy/graphql/parser/ParserOptionsTest.groovy
@@ -4,53 +4,57 @@ import spock.lang.Specification
 
 class ParserOptionsTest extends Specification {
     static defaultOptions = ParserOptions.getDefaultParserOptions()
-    static defaultQueryOptions = ParserOptions.getDefaultQueryParserOptions()
+    static defaultOperationOptions = ParserOptions.getDefaultOperationParserOptions()
 
     void setup() {
         ParserOptions.setDefaultParserOptions(defaultOptions)
-        ParserOptions.setDefaultQueryParserOptions(defaultQueryOptions)
+        ParserOptions.setDefaultOperationParserOptions(defaultOperationOptions)
     }
 
     void cleanup() {
         ParserOptions.setDefaultParserOptions(defaultOptions)
-        ParserOptions.setDefaultQueryParserOptions(defaultQueryOptions)
+        ParserOptions.setDefaultOperationParserOptions(defaultOperationOptions)
     }
 
     def "lock in default settings"() {
         expect:
         defaultOptions.getMaxTokens() == 15_000
+        defaultOptions.getMaxWhitespaceTokens() == 200_000
         defaultOptions.isCaptureSourceLocation()
         defaultOptions.isCaptureLineComments()
         !defaultOptions.isCaptureIgnoredChars()
 
-        defaultQueryOptions.getMaxTokens() == 15_000
-        defaultQueryOptions.isCaptureSourceLocation()
-        !defaultQueryOptions.isCaptureLineComments()
-        !defaultQueryOptions.isCaptureIgnoredChars()
+        defaultOperationOptions.getMaxTokens() == 15_000
+        defaultOperationOptions.getMaxWhitespaceTokens() == 200_000
+        defaultOperationOptions.isCaptureSourceLocation()
+        !defaultOperationOptions.isCaptureLineComments()
+        !defaultOperationOptions.isCaptureIgnoredChars()
     }
 
     def "can set in new option JVM wide"() {
         def newDefaultOptions = defaultOptions.transform({ it.captureIgnoredChars(true) })
-        def newDefaultQueryOptions = defaultQueryOptions.transform({ it.captureIgnoredChars(true).captureLineComments(true) })
+        def newDefaultOperationOptions = defaultOperationOptions.transform(
+                { it.captureIgnoredChars(true).captureLineComments(true).maxWhitespaceTokens(300_000) })
 
         when:
         ParserOptions.setDefaultParserOptions(newDefaultOptions)
-        ParserOptions.setDefaultQueryParserOptions(newDefaultQueryOptions)
+        ParserOptions.setDefaultOperationParserOptions(newDefaultOperationOptions)
 
         def currentDefaultOptions = ParserOptions.getDefaultParserOptions()
-        def currentDefaultQueryOptions = ParserOptions.getDefaultQueryParserOptions()
+        def currentDefaultOperationOptions = ParserOptions.getDefaultOperationParserOptions()
 
         then:
 
         currentDefaultOptions.getMaxTokens() == 15_000
+        currentDefaultOptions.getMaxWhitespaceTokens() == 200_000
         currentDefaultOptions.isCaptureSourceLocation()
         currentDefaultOptions.isCaptureLineComments()
         currentDefaultOptions.isCaptureIgnoredChars()
 
-        currentDefaultQueryOptions.getMaxTokens() == 15_000
-        currentDefaultQueryOptions.isCaptureSourceLocation()
-        currentDefaultQueryOptions.isCaptureLineComments()
-        currentDefaultQueryOptions.isCaptureIgnoredChars()
-
+        currentDefaultOperationOptions.getMaxTokens() == 15_000
+        currentDefaultOperationOptions.getMaxWhitespaceTokens() == 300_000
+        currentDefaultOperationOptions.isCaptureSourceLocation()
+        currentDefaultOperationOptions.isCaptureLineComments()
+        currentDefaultOperationOptions.isCaptureIgnoredChars()
     }
 }

--- a/src/test/groovy/graphql/parser/ParserOptionsTest.groovy
+++ b/src/test/groovy/graphql/parser/ParserOptionsTest.groovy
@@ -5,15 +5,18 @@ import spock.lang.Specification
 class ParserOptionsTest extends Specification {
     static defaultOptions = ParserOptions.getDefaultParserOptions()
     static defaultOperationOptions = ParserOptions.getDefaultOperationParserOptions()
+    static defaultSdlOptions = ParserOptions.getDefaultSdlParserOptions()
 
     void setup() {
         ParserOptions.setDefaultParserOptions(defaultOptions)
         ParserOptions.setDefaultOperationParserOptions(defaultOperationOptions)
+        ParserOptions.setDefaultSdlParserOptions(defaultSdlOptions)
     }
 
     void cleanup() {
         ParserOptions.setDefaultParserOptions(defaultOptions)
         ParserOptions.setDefaultOperationParserOptions(defaultOperationOptions)
+        ParserOptions.setDefaultSdlParserOptions(defaultSdlOptions)
     }
 
     def "lock in default settings"() {
@@ -29,19 +32,29 @@ class ParserOptionsTest extends Specification {
         defaultOperationOptions.isCaptureSourceLocation()
         !defaultOperationOptions.isCaptureLineComments()
         !defaultOperationOptions.isCaptureIgnoredChars()
+
+        defaultSdlOptions.getMaxTokens() == Integer.MAX_VALUE
+        defaultSdlOptions.getMaxWhitespaceTokens() == Integer.MAX_VALUE
+        defaultSdlOptions.isCaptureSourceLocation()
+        defaultSdlOptions.isCaptureLineComments()
+        !defaultSdlOptions.isCaptureIgnoredChars()
     }
 
     def "can set in new option JVM wide"() {
         def newDefaultOptions = defaultOptions.transform({ it.captureIgnoredChars(true) })
         def newDefaultOperationOptions = defaultOperationOptions.transform(
                 { it.captureIgnoredChars(true).captureLineComments(true).maxWhitespaceTokens(300_000) })
+        def newDefaultSDlOptions = defaultSdlOptions.transform(
+                { it.captureIgnoredChars(true).captureLineComments(true).maxWhitespaceTokens(300_000) })
 
         when:
         ParserOptions.setDefaultParserOptions(newDefaultOptions)
         ParserOptions.setDefaultOperationParserOptions(newDefaultOperationOptions)
+        ParserOptions.setDefaultSdlParserOptions(newDefaultSDlOptions)
 
         def currentDefaultOptions = ParserOptions.getDefaultParserOptions()
         def currentDefaultOperationOptions = ParserOptions.getDefaultOperationParserOptions()
+        def currentDefaultSdlOptions = ParserOptions.getDefaultSdlParserOptions()
 
         then:
 
@@ -56,5 +69,11 @@ class ParserOptionsTest extends Specification {
         currentDefaultOperationOptions.isCaptureSourceLocation()
         currentDefaultOperationOptions.isCaptureLineComments()
         currentDefaultOperationOptions.isCaptureIgnoredChars()
+
+        currentDefaultSdlOptions.getMaxTokens() == Integer.MAX_VALUE
+        currentDefaultSdlOptions.getMaxWhitespaceTokens() == 300_000
+        currentDefaultSdlOptions.isCaptureSourceLocation()
+        currentDefaultSdlOptions.isCaptureLineComments()
+        currentDefaultSdlOptions.isCaptureIgnoredChars()
     }
 }

--- a/src/test/groovy/graphql/parser/ParserTest.groovy
+++ b/src/test/groovy/graphql/parser/ParserTest.groovy
@@ -1151,11 +1151,43 @@ triple3 : """edge cases \\""" "" " \\"" \\" edge cases"""
         er.errors[0].message.contains("parsing has been cancelled")
     }
 
+    def "a large whitespace laughs attack will be prevented by default"() {
+        def spaces = " " * 300_000
+        def text = "query { f $spaces }"
+        when:
+        Parser.parse(text)
+
+        then:
+        def e = thrown(ParseCancelledException)
+        e.getMessage().contains("parsing has been cancelled")
+
+        when: "integration test to prove it cancels by default"
+
+        def sdl = """type Query { f : ID} """
+        def graphQL = TestUtil.graphQL(sdl).build()
+        def er = graphQL.execute(text)
+        then:
+        er.errors.size() == 1
+        er.errors[0].message.contains("parsing has been cancelled")
+    }
+
     def "they can shoot themselves if they want to with large documents"() {
         def lol = "@lol" * 10000 // two tokens = 20000+ tokens
         def text = "query { f $lol }"
 
         def options = ParserOptions.newParserOptions().maxTokens(30000).build()
+        when:
+        def doc = new Parser().parseDocument(text, options)
+
+        then:
+        doc != null
+    }
+
+    def "they can shoot themselves if they want to with large documents with lots of whitespace"() {
+        def spaces = " " * 300_000
+        def text = "query { f $spaces }"
+
+        def options = ParserOptions.newParserOptions().maxWhitespaceTokens(Integer.MAX_VALUE).build()
         when:
         def doc = new Parser().parseDocument(text, options)
 

--- a/src/test/groovy/graphql/parser/SafeTokenSourceTest.groovy
+++ b/src/test/groovy/graphql/parser/SafeTokenSourceTest.groovy
@@ -1,0 +1,92 @@
+package graphql.parser
+
+import graphql.parser.antlr.GraphqlLexer
+import org.antlr.v4.runtime.CharStreams
+import org.antlr.v4.runtime.Token
+import spock.lang.Specification
+
+import java.util.function.Consumer
+
+class SafeTokenSourceTest extends Specification {
+
+    private void consumeAllTokens(SafeTokenSource tokenSource) {
+        def nextToken = tokenSource.nextToken()
+        while (nextToken != null && nextToken.getType() != Token.EOF) {
+            nextToken = tokenSource.nextToken()
+        }
+    }
+
+    private GraphqlLexer lexer(doc) {
+        def charStream = CharStreams.fromString(doc)
+        def graphqlLexer = new GraphqlLexer(charStream)
+        graphqlLexer
+    }
+
+    def "can call back to the consumer when max whitespace tokens are encountered"() {
+
+        def offendingText = " " * 1000
+        GraphqlLexer graphqlLexer = lexer("""
+                query foo { _typename $offendingText @lol@lol@lol }
+        """)
+        when:
+        Token offendingToken = null
+        Consumer<Token> onToMany = { token ->
+            offendingToken = token
+            throw new IllegalStateException("stop!")
+        }
+        def tokenSource = new SafeTokenSource(graphqlLexer, 1000, onToMany)
+
+        consumeAllTokens(tokenSource)
+        assert false, "This is not meant to actually consume all tokens"
+
+        then:
+        thrown(IllegalStateException)
+        offendingToken != null
+        offendingToken.getChannel() == 3 // whitespace
+        offendingToken.getText() == " "
+    }
+
+    def "can call back to the consumer when max graphql tokens are encountered"() {
+
+        def offendingText = "@lol" * 1000
+        GraphqlLexer graphqlLexer = lexer("""
+                query foo { _typename $offendingText }
+        """)
+        when:
+        Token offendingToken = null
+        Consumer<Token> onToMany = { token ->
+            offendingToken = token
+            throw new IllegalStateException("stop!")
+        }
+        def tokenSource = new SafeTokenSource(graphqlLexer, 1000, onToMany)
+
+        consumeAllTokens(tokenSource)
+        assert false, "This is not meant to actually consume all tokens"
+
+        then:
+        thrown(IllegalStateException)
+        offendingToken != null
+        offendingToken.getChannel() == 0 // grammar
+    }
+
+    def "can safely get to the end of text if its ok"() {
+
+        GraphqlLexer graphqlLexer = lexer("""
+                query foo { _typename @lol@lol@lol }
+        """)
+        when:
+        Token offendingToken = null
+        Consumer<Token> onToMany = { token ->
+            offendingToken = token
+            throw new IllegalStateException("stop!")
+        }
+        def tokenSource = new SafeTokenSource(graphqlLexer, 1000, onToMany)
+
+        consumeAllTokens(tokenSource)
+
+        then:
+        noExceptionThrown()
+        offendingToken == null
+    }
+
+}

--- a/src/test/groovy/graphql/schema/idl/SchemaParserTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaParserTest.groovy
@@ -343,6 +343,7 @@ class SchemaParserTest extends Specification {
         def sdl = "type Query {\n"
         for (int i = 0; i < 30000; i++) {
             sdl += " f" + i + " : ID\n"
+            sdl += " " * 10 // 10 whitespace as well
         }
         sdl += "}"
 


### PR DESCRIPTION
This is related to #2888

The bug was that we do indeed have a max token counting mechanism in graphql-java BUt it was being enacted too late.

Testing showed that the max token code was indeed being hit BUT the ANTLR lexing and parsing code was taking proportionally longer to get to the max token state as the input size increased

This is cause bv the greedy nature of the ANTLR Lexer - it will look ahead and store tokens in memory under certain grammar conditions and butted directives like `@lol@lol` are one of them.  This meant that the lexer was the code contributing to CPU time and not the parser - BUT the max token code check was in the parser.

This PR puts the same max token checks on the lexer as it does in the parser.  In fact it debatable if the parser checks should still be retained (since the lexer will be the main way this will be hit) but the logic is common so I left it in place.

The current existing billion `@lols` test still parse with this change - The difference is where cancel parse exception is being thrown.

The use of the lexer as the place to count means the counting checks are done in constant time.  As soon as the max tokens is encountered, the parse is stopped.

graphql-java also uses 3 channels for tokens (0 for the grammar and 2 and 3 for comments and whitespace).  The lexing of whitespace and comments also take up CPU time so they counters have been put in place to watch tokens on those channels as well.

This will stop a "mostly whitespace" attack, even though whitespace costs less to aggregate in practice

