### PR TITLE
Deprecate Apollo Cache Control

### DIFF
--- a/src/main/java/graphql/ExecutionInput.java
+++ b/src/main/java/graphql/ExecutionInput.java
@@ -120,7 +120,10 @@ public class ExecutionInput {
 
     /**
      * @return the cache control helper associated with this execution
+     *
+     * @deprecated - Apollo has deprecated the Cache Control specification
      */
+    @Deprecated
     public CacheControl getCacheControl() {
         return cacheControl;
     }
@@ -390,6 +393,7 @@ public class ExecutionInput {
             return this;
         }
 
+        @Deprecated
         public Builder cacheControl(CacheControl cacheControl) {
             this.cacheControl = assertNotNull(cacheControl);
             return this;

--- a/src/main/java/graphql/cachecontrol/CacheControl.java
+++ b/src/main/java/graphql/cachecontrol/CacheControl.java
@@ -17,6 +17,11 @@ import static graphql.Assert.assertNotNull;
 import static graphql.collect.ImmutableKit.map;
 
 /**
+ * Apollo has deprecated their Cache Control specification https://github.com/apollographql/apollo-cache-control
+ * This has been deprecated/removed from Apollo some time.
+ * Apollo now provides an alternative approach via the @cacheControl directive https://www.apollographql.com/docs/apollo-server/performance/caching/
+ * We are deprecating CacheControl inside graphql-java and this will be deleted in a future release.
+ *
  * This class implements the graphql Cache Control specification as outlined in https://github.com/apollographql/apollo-cache-control
  * <p>
  * To best use this class you need to pass a CacheControl object to each {@link graphql.schema.DataFetcher} and have them decide on
@@ -28,6 +33,7 @@ import static graphql.collect.ImmutableKit.map;
  * Then at the end of the query you would call {@link #addTo(graphql.ExecutionResult)} to record the cache control hints into the {@link graphql.ExecutionResult}
  * extensions map as per the specification.
  */
+@Deprecated
 @PublicApi
 public class CacheControl {
 
@@ -81,7 +87,10 @@ public class CacheControl {
      * @param maxAge the caching time in seconds
      * @param scope  the scope of the cache control hint
      * @return this object builder style
+     *
+     * @deprecated - Apollo has deprecated the Cache Control specification
      */
+    @Deprecated
     public CacheControl hint(ResultPath path, Integer maxAge, Scope scope) {
         assertNotNull(path);
         assertNotNull(scope);
@@ -95,7 +104,10 @@ public class CacheControl {
      * @param path  the path to the field that has the cache control hint
      * @param scope the scope of the cache control hint
      * @return this object builder style
+     *
+     * @deprecated - Apollo has deprecated the Cache Control specification
      */
+    @Deprecated
     public CacheControl hint(ResultPath path, Scope scope) {
         return hint(path, null, scope);
     }
@@ -106,7 +118,10 @@ public class CacheControl {
      * @param path   the path to the field that has the cache control hint
      * @param maxAge the caching time in seconds
      * @return this object builder style
+     *
+     * @deprecated - Apollo has deprecated the Cache Control specification
      */
+    @Deprecated
     public CacheControl hint(ResultPath path, Integer maxAge) {
         return hint(path, maxAge, Scope.PUBLIC);
     }
@@ -118,7 +133,10 @@ public class CacheControl {
      * @param maxAge                  the caching time in seconds
      * @param scope                   the scope of the cache control hint
      * @return this object builder style
+     *
+     * @deprecated - Apollo has deprecated the Cache Control specification
      */
+    @Deprecated
     public CacheControl hint(DataFetchingEnvironment dataFetchingEnvironment, Integer maxAge, Scope scope) {
         assertNotNull(dataFetchingEnvironment);
         assertNotNull(scope);
@@ -132,7 +150,10 @@ public class CacheControl {
      * @param dataFetchingEnvironment the path to the field that has the cache control hint
      * @param maxAge                  the caching time in seconds
      * @return this object builder style
+     *
+     * @deprecated - Apollo has deprecated the Cache Control specification
      */
+    @Deprecated
     public CacheControl hint(DataFetchingEnvironment dataFetchingEnvironment, Integer maxAge) {
         hint(dataFetchingEnvironment, maxAge, Scope.PUBLIC);
         return this;
@@ -144,7 +165,10 @@ public class CacheControl {
      * @param dataFetchingEnvironment the path to the field that has the cache control hint
      * @param scope                   the scope of the cache control hint
      * @return this object builder style
+     *
+     * @deprecated - Apollo has deprecated the Cache Control specification
      */
+    @Deprecated
     public CacheControl hint(DataFetchingEnvironment dataFetchingEnvironment, Scope scope) {
         return hint(dataFetchingEnvironment, null, scope);
     }
@@ -153,7 +177,10 @@ public class CacheControl {
      * Creates a new CacheControl object that can be used to trick caching hints
      *
      * @return the new object
+     *
+     * @deprecated - Apollo has deprecated the Cache Control specification
      */
+    @Deprecated
     public static CacheControl newCacheControl() {
         return new CacheControl();
     }
@@ -164,7 +191,10 @@ public class CacheControl {
      *
      * @param executionResult the starting execution result object
      * @return a new execution result with the hints in the extensions map.
+     *
+     * @deprecated - Apollo has deprecated the Cache Control specification
      */
+    @Deprecated
     public ExecutionResult addTo(ExecutionResult executionResult) {
         return ExecutionResultImpl.newExecutionResult()
                 .from(executionResult)

--- a/src/main/java/graphql/execution/ExecutionContext.java
+++ b/src/main/java/graphql/execution/ExecutionContext.java
@@ -163,6 +163,7 @@ public class ExecutionContext {
         return dataLoaderRegistry;
     }
 
+    @Deprecated
     public CacheControl getCacheControl() {
         return cacheControl;
     }

--- a/src/main/java/graphql/execution/ExecutionContextBuilder.java
+++ b/src/main/java/graphql/execution/ExecutionContextBuilder.java
@@ -187,6 +187,7 @@ public class ExecutionContextBuilder {
         return this;
     }
 
+    @Deprecated
     public ExecutionContextBuilder cacheControl(CacheControl cacheControl) {
         this.cacheControl = cacheControl;
         return this;

--- a/src/main/java/graphql/schema/DataFetchingEnvironment.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironment.java
@@ -238,7 +238,10 @@ public interface DataFetchingEnvironment extends IntrospectionDataFetchingEnviro
 
     /**
      * @return the current {@link CacheControl} instance used to add cache hints to the response
+     *
+     * @deprecated - Apollo has deprecated the Cache Control specification
      */
+    @Deprecated
     CacheControl getCacheControl();
 
     /**

--- a/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
@@ -218,6 +218,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
     }
 
     @Override
+    @Deprecated
     public CacheControl getCacheControl() {
         return cacheControl;
     }
@@ -391,6 +392,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
             return this;
         }
 
+        @Deprecated
         public Builder cacheControl(CacheControl cacheControl) {
             this.cacheControl = cacheControl;
             return this;

--- a/src/main/java/graphql/schema/DelegatingDataFetchingEnvironment.java
+++ b/src/main/java/graphql/schema/DelegatingDataFetchingEnvironment.java
@@ -162,6 +162,7 @@ public class DelegatingDataFetchingEnvironment implements DataFetchingEnvironmen
     }
 
     @Override
+    @Deprecated
     public CacheControl getCacheControl() {
         return delegateEnvironment.getCacheControl();
     }


### PR DESCRIPTION
Fixes #2759 

Apollo has deprecated their Cache Control specification for a while now, and they offer an alternative directive driven approach. Thus we no longer should have `CacheControl` inside graphql-java.

Deprecation notice: https://github.com/apollographql/apollo-cache-control
New directive driven approach: https://github.com/apollographql/apollo-cache-control

This PR deprecates everything related to Cache Control. It will be deleted in an upcoming release.