### PR TITLE
Defaults Locale when calling validation

### DIFF
--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -625,7 +626,8 @@ public class GraphQL {
         validationCtx.onDispatched(cf);
 
         Predicate<Class<?>> validationRulePredicate = executionInput.getGraphQLContext().getOrDefault(ParseAndValidate.INTERNAL_VALIDATION_PREDICATE_HINT, r -> true);
-        List<ValidationError> validationErrors = ParseAndValidate.validate(graphQLSchema, document, validationRulePredicate, executionInput.getLocale());
+        Locale locale = executionInput.getLocale() != null ? executionInput.getLocale() : Locale.getDefault();
+        List<ValidationError> validationErrors = ParseAndValidate.validate(graphQLSchema, document, validationRulePredicate, locale);
 
         validationCtx.onCompleted(validationErrors, null);
         cf.complete(validationErrors);

--- a/src/main/java/graphql/ParseAndValidate.java
+++ b/src/main/java/graphql/ParseAndValidate.java
@@ -7,6 +7,7 @@ import graphql.parser.ParserOptions;
 import graphql.schema.GraphQLSchema;
 import graphql.validation.ValidationError;
 import graphql.validation.Validator;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 import java.util.Locale;
@@ -40,7 +41,7 @@ public class ParseAndValidate {
      *
      * @return a result object that indicates how this operation went
      */
-    public static ParseAndValidateResult parseAndValidate(GraphQLSchema graphQLSchema, ExecutionInput executionInput) {
+    public static ParseAndValidateResult parseAndValidate(@NotNull GraphQLSchema graphQLSchema, @NotNull ExecutionInput executionInput) {
         ParseAndValidateResult result = parse(executionInput);
         if (!result.isFailure()) {
             List<ValidationError> errors = validate(graphQLSchema, result.getDocument(), executionInput.getLocale());
@@ -56,7 +57,7 @@ public class ParseAndValidate {
      *
      * @return a result object that indicates how this operation went
      */
-    public static ParseAndValidateResult parse(ExecutionInput executionInput) {
+    public static ParseAndValidateResult parse(@NotNull ExecutionInput executionInput) {
         try {
             //
             // we allow the caller to specify new parser options by context
@@ -80,7 +81,7 @@ public class ParseAndValidate {
      *
      * @return a result object that indicates how this operation went
      */
-    public static List<ValidationError> validate(GraphQLSchema graphQLSchema, Document parsedDocument, Locale locale) {
+    public static List<ValidationError> validate(@NotNull GraphQLSchema graphQLSchema, @NotNull Document parsedDocument, @NotNull Locale locale) {
         return validate(graphQLSchema, parsedDocument, ruleClass -> true, locale);
     }
 
@@ -92,7 +93,7 @@ public class ParseAndValidate {
      *
      * @return a result object that indicates how this operation went
      */
-    public static List<ValidationError> validate(GraphQLSchema graphQLSchema, Document parsedDocument) {
+    public static List<ValidationError> validate(@NotNull GraphQLSchema graphQLSchema, @NotNull Document parsedDocument) {
         return validate(graphQLSchema, parsedDocument, ruleClass -> true, Locale.getDefault());
     }
 
@@ -106,7 +107,7 @@ public class ParseAndValidate {
      *
      * @return a result object that indicates how this operation went
      */
-    public static List<ValidationError> validate(GraphQLSchema graphQLSchema, Document parsedDocument, Predicate<Class<?>> rulePredicate, Locale locale) {
+    public static List<ValidationError> validate(@NotNull GraphQLSchema graphQLSchema, @NotNull Document parsedDocument, @NotNull Predicate<Class<?>> rulePredicate, @NotNull Locale locale) {
         Validator validator = new Validator();
         return validator.validateDocument(graphQLSchema, parsedDocument, rulePredicate, locale);
     }
@@ -120,7 +121,7 @@ public class ParseAndValidate {
      *
      * @return a result object that indicates how this operation went
      */
-    public static List<ValidationError> validate(GraphQLSchema graphQLSchema, Document parsedDocument, Predicate<Class<?>> rulePredicate) {
+    public static List<ValidationError> validate(@NotNull GraphQLSchema graphQLSchema, @NotNull Document parsedDocument, @NotNull Predicate<Class<?>> rulePredicate) {
         Validator validator = new Validator();
         return validator.validateDocument(graphQLSchema, parsedDocument, rulePredicate, Locale.getDefault());
     }

--- a/src/test/groovy/graphql/GraphQLTest.groovy
+++ b/src/test/groovy/graphql/GraphQLTest.groovy
@@ -1352,4 +1352,15 @@ many lines''']
         graphQL.getMutationStrategy() instanceof AsyncSerialExecutionStrategy
         graphQL.getSubscriptionStrategy() instanceof SubscriptionExecutionStrategy
     }
+
+    def "null locale on input is handled under the covers"() {
+
+        def graphQL = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema).build()
+        def ei = newExecutionInput("query q { validationError } ").locale(null).build()
+
+        when:
+        def er = graphQL.execute(ei)
+        then:
+        ! er.errors.isEmpty()
+    }
 }


### PR DESCRIPTION
If a caller explicitly sets the Locale to null (for whatever reason) we need to be able to default it so the validation I18n code works.

See https://github.com/graphql-java/graphql-java/issues/2907

The design question is - should we default this on `ExecutionInput` construction OR like I have done it here.

This fixes the bug - however defaulting it in EI construction is more systemic.  It would mean that DataFetcherEnvs etc... would always get a Locale say.