### PR TITLE
Reduce calculation for fragments in ExecutableNormalizedOperation

### DIFF
--- a/src/main/java/graphql/normalized/ExecutableNormalizedOperationFactory.java
+++ b/src/main/java/graphql/normalized/ExecutableNormalizedOperationFactory.java
@@ -453,6 +453,15 @@ public class ExecutableNormalizedOperationFactory {
         if (currentOnes.isEmpty()) {
             return resolvedTypeCondition;
         }
+
+        // Intersection calculation is expensive when either set is large.
+        // If a set only has one member, it is equivalent and cheaper to calculate via contains.
+        if (resolvedTypeCondition.size() == 1 && currentOnes.contains(resolvedTypeCondition.iterator().next())) {
+            return resolvedTypeCondition;
+        } else if (currentOnes.size() == 1 && resolvedTypeCondition.contains(currentOnes.iterator().next())) {
+            return currentOnes;
+        }
+
         return Sets.intersection(currentOnes, resolvedTypeCondition);
     }
 

--- a/src/main/java/graphql/normalized/ExecutableNormalizedOperationFactory.java
+++ b/src/main/java/graphql/normalized/ExecutableNormalizedOperationFactory.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import graphql.Internal;
 import graphql.collect.ImmutableKit;
 import graphql.execution.CoercedVariables;
@@ -50,6 +49,7 @@ import static graphql.execution.MergedField.newMergedField;
 import static graphql.schema.GraphQLTypeUtil.unwrapAll;
 import static graphql.util.FpKit.filterSet;
 import static graphql.util.FpKit.groupingBy;
+import static graphql.util.FpKit.intersection;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 
@@ -454,15 +454,8 @@ public class ExecutableNormalizedOperationFactory {
             return resolvedTypeCondition;
         }
 
-        // Intersection calculation is expensive when either set is large.
-        // If a set only has one member, it is equivalent and cheaper to calculate via contains.
-        if (resolvedTypeCondition.size() == 1 && currentOnes.contains(resolvedTypeCondition.iterator().next())) {
-            return resolvedTypeCondition;
-        } else if (currentOnes.size() == 1 && resolvedTypeCondition.contains(currentOnes.iterator().next())) {
-            return currentOnes;
-        }
-
-        return Sets.intersection(currentOnes, resolvedTypeCondition);
+        // Faster intersection, as either set often has a size of 1.
+        return intersection(currentOnes, resolvedTypeCondition);
     }
 
     private ImmutableSet<GraphQLObjectType> resolvePossibleObjects(List<GraphQLFieldDefinition> defs, GraphQLSchema graphQLSchema) {

--- a/src/main/java/graphql/util/FpKit.java
+++ b/src/main/java/graphql/util/FpKit.java
@@ -3,6 +3,7 @@ package graphql.util;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import graphql.Internal;
 
 import java.lang.reflect.Array;
@@ -10,7 +11,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -328,6 +328,29 @@ public class FpKit {
      */
     public static <T> Supplier<T> interThreadMemoize(Supplier<T> delegate) {
         return new InterThreadMemoizedSupplier<>(delegate);
+    }
+
+    /**
+     * Faster set intersection.
+     *
+     * @param set1 first set
+     * @param set2 second set
+     * @return intersection set
+     */
+    public static <T> Set<T> intersection(Set<T> set1, Set<T> set2) {
+        // Set intersection calculation is expensive when either set is large. Often, either set has only one member.
+        // When either set contains only one member, it is equivalent and much cheaper to calculate intersection via contains.
+        if (set1.size() == 1 && set2.contains(set1.iterator().next())) {
+            return set1;
+        } else if (set2.size() == 1 && set1.contains(set2.iterator().next())) {
+            return set2;
+        }
+
+        // Guava's Sets.intersection is faster when the smaller set is passed as the first argument.
+        if (set1.size() < set2.size()) {
+            return Sets.intersection(set1, set2);
+        }
+        return Sets.intersection(set2, set1);
     }
 
 }

--- a/src/test/groovy/graphql/util/FpKitTest.groovy
+++ b/src/test/groovy/graphql/util/FpKitTest.groovy
@@ -97,4 +97,41 @@ class FpKitTest extends Specification {
         then:
         l == ["Parrot"]
     }
+
+    def "set intersection works"() {
+        def set1 = ["A","B","C"] as Set
+        def set2 = ["A","C","D"] as Set
+        def singleSetA = ["A"] as Set
+        def disjointSet = ["X","Y"] as Set
+
+        when:
+        def intersection = FpKit.intersection(set1, set2)
+        then:
+        intersection == ["A","C"] as Set
+
+        when: // reversed parameters
+        intersection = FpKit.intersection(set2, set1)
+        then:
+        intersection == ["A","C"] as Set
+
+        when: // singles
+        intersection = FpKit.intersection(set1, singleSetA)
+        then:
+        intersection == ["A"] as Set
+
+        when: // singles reversed
+        intersection = FpKit.intersection(singleSetA, set1)
+        then:
+        intersection == ["A"] as Set
+
+        when: // disjoint
+        intersection = FpKit.intersection(set1, disjointSet)
+        then:
+        intersection.isEmpty()
+
+        when: // disjoint reversed
+        intersection = FpKit.intersection(disjointSet,set1)
+        then:
+        intersection.isEmpty()
+    }
 }

--- a/src/test/java/benchmark/NQExtraLargeBenchmark.java
+++ b/src/test/java/benchmark/NQExtraLargeBenchmark.java
@@ -1,0 +1,89 @@
+package benchmark;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+import graphql.execution.CoercedVariables;
+import graphql.language.Document;
+import graphql.normalized.ExecutableNormalizedOperation;
+import graphql.normalized.ExecutableNormalizedOperationFactory;
+import graphql.parser.Parser;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.idl.SchemaGenerator;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.io.Resources.getResource;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 2)
+@Measurement(iterations = 2, timeUnit = TimeUnit.NANOSECONDS)
+public class NQExtraLargeBenchmark {
+
+    @State(Scope.Benchmark)
+    public static class MyState {
+
+        GraphQLSchema schema;
+        Document document;
+
+        @Setup
+        public void setup() {
+            try {
+                String schemaString = readFromClasspath("extra-large-schema-1.graphqls");
+                schema = SchemaGenerator.createdMockedSchema(schemaString);
+
+                String query = readFromClasspath("extra-large-schema-1-query.graphql");
+                document = Parser.parse(query);
+            } catch (Exception e) {
+                System.out.println(e);
+                throw new RuntimeException(e);
+            }
+        }
+
+        private String readFromClasspath(String file) throws IOException {
+            URL url = getResource(file);
+            return Resources.toString(url, Charsets.UTF_8);
+        }
+    }
+
+    @Benchmark
+    @Warmup(iterations = 2)
+    @Measurement(iterations = 3, time = 10)
+    @Threads(1)
+    @Fork(3)
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public void benchMarkAvgTime(MyState myState, Blackhole blackhole )  {
+        runImpl(myState, blackhole);
+    }
+
+    @Benchmark
+    @Warmup(iterations = 2)
+    @Measurement(iterations = 3, time = 10)
+    @Threads(1)
+    @Fork(3)
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public void benchMarkThroughput(MyState myState, Blackhole blackhole )  {
+        runImpl(myState, blackhole);
+    }
+
+    private void runImpl(MyState myState, Blackhole blackhole) {
+        ExecutableNormalizedOperation executableNormalizedOperation = ExecutableNormalizedOperationFactory.createExecutableNormalizedOperation(myState.schema, myState.document, null, CoercedVariables.emptyVariables());
+        blackhole.consume(executableNormalizedOperation);
+    }
+}

--- a/src/test/resources/extra-large-schema-1-query.graphql
+++ b/src/test/resources/extra-large-schema-1-query.graphql
@@ -1,0 +1,2761 @@
+query extra_large {
+    jira {
+        epicLinkFieldKey
+        screenIdByIssueKey(issueKey: "GJ-1")
+        issueByKey(key: "GJ-1", cloudId: "abc123") {
+            issueId
+            fields {
+                edges {
+                    node {
+                        __typename
+                        ... on JiraAffectedServicesField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            selectedAffectedServicesConnection {
+                                totalCount
+                                edges {
+                                    node {
+                                        serviceId
+                                    }
+                                }
+                            }
+                            affectedServices {
+                                totalCount
+                                edges {
+                                    node {
+                                        serviceId
+                                    }
+                                }
+                            }
+                            searchUrl
+                        }
+                        ... on JiraAssetField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            selectedAssetsConnection {
+                                totalCount
+                                edges {
+                                    node {
+                                        appKey
+                                        originId
+                                        serializedOrigin
+                                        value
+                                    }
+                                }
+                            }
+                            searchUrl
+                        }
+                        ... on JiraCMDBField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            isMulti
+                            searchUrl
+                            selectedCmdbObjectsConnection {
+                                totalCount
+                                edges {
+                                    node {
+                                        id
+                                        objectGlobalId
+                                        objectId
+                                        workspaceId
+                                        label
+                                    }
+                                }
+                            }
+                            attributesIncludedInAutoCompleteSearch
+                        }
+                        ... on JiraCascadingSelectField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            cascadingOption {
+                                parentOptionValue {
+                                    id
+                                    optionId
+                                    value
+                                    isDisabled
+                                }
+                                childOptionValue {
+                                    id
+                                    optionId
+                                    value
+                                    isDisabled
+                                }
+                            }
+                            cascadingOptions {
+                                totalCount
+                                edges {
+                                    node {
+                                        parentOptionValue {
+                                            id
+                                            optionId
+                                            value
+                                            isDisabled
+                                        }
+                                        childOptionValues {
+                                            id
+                                            optionId
+                                            value
+                                            isDisabled
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        ... on JiraCheckboxesField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            selectedOptions {
+                                totalCount
+                                edges {
+                                    node {
+                                        id
+                                        optionId
+                                        value
+                                        isDisabled
+                                    }
+                                }
+                            }
+                            fieldOptions {
+                                totalCount
+                                edges {
+                                    node {
+                                        id
+                                        optionId
+                                        value
+                                        isDisabled
+                                    }
+                                }
+                            }
+                        }
+                        ... on JiraColorField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            color {
+                                id
+                                colorKey
+                            }
+                        }
+                        ... on JiraComponentsField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            selectedComponentsConnection {
+                                totalCount
+                                edges {
+                                    node {
+                                        id
+                                        componentId
+                                        name
+                                        description
+                                    }
+                                }
+                            }
+                            components {
+                                totalCount
+                                edges {
+                                    node {
+                                        id
+                                        componentId
+                                        name
+                                        description
+                                    }
+                                }
+                            }
+                        }
+                        ... on JiraConnectMultipleSelectField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            selectedOptions {
+                                totalCount
+                                edges {
+                                    node {
+                                        id
+                                        optionId
+                                        value
+                                        isDisabled
+                                    }
+                                }
+                            }
+                            fieldOptions {
+                                totalCount
+                                edges {
+                                    node {
+                                        id
+                                        optionId
+                                        value
+                                        isDisabled
+                                    }
+                                }
+                            }
+                            searchUrl
+                        }
+                        ... on JiraConnectNumberField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            number
+                        }
+                        ... on JiraConnectRichTextField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            richText {
+                                plainText
+                                adfValue {
+                                    json
+                                }
+                            }
+                            renderer
+                        }
+                        ... on JiraConnectSingleSelectField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            fieldOption {
+                                id
+                                optionId
+                                value
+                                isDisabled
+                            }
+                            fieldOptions {
+                                totalCount
+                                edges {
+                                    node {
+                                        id
+                                        optionId
+                                        value
+                                        isDisabled
+                                    }
+                                }
+                            }
+                            searchUrl
+                        }
+                        ... on JiraConnectTextField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            text
+                        }
+                        ... on JiraDatePickerField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            date
+                        }
+                        ... on JiraDateTimePickerField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            dateTime
+                        }
+                        ... on JiraEpicLinkField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            epic {
+                                id
+                                issueId
+                                name
+                                key
+                                summary
+                                color
+                                done
+                            }
+                            epics {
+                                totalCount
+                                edges {
+                                    node {
+                                        id
+                                        issueId
+                                        name
+                                        key
+                                        summary
+                                        color
+                                        done
+                                    }
+                                }
+                            }
+                            searchUrl
+                        }
+                        ... on JiraFlagField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            flag {
+                                isFlagged
+                            }
+                        }
+                        ... on JiraForgeGroupField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            selectedGroup {
+                                id
+                                groupId
+                                name
+                            }
+                            groups {
+                                totalCount
+                                edges {
+                                    node {
+                                        id
+                                        groupId
+                                        name
+                                    }
+                                }
+                            }
+                            searchUrl
+                            renderer
+                        }
+                        ... on JiraForgeGroupsField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            selectedGroupsConnection {
+                                edges {
+                                    node {
+                                        id
+                                        groupId
+                                        name
+                                    }
+                                }
+                            }
+                            renderer
+                        }
+                        ... on JiraForgeNumberField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            number
+                            renderer
+                        }
+                        ... on JiraForgeObjectField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            object
+                            renderer
+                        }
+                        ... on JiraForgeStringField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            text
+                            renderer
+                        }
+                        ... on JiraForgeStringsField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            selectedLabelsConnection {
+                                totalCount
+                                edges {
+                                    node {
+                                        labelId
+                                        name
+                                    }
+                                }
+                            }
+                            labels {
+                                totalCount
+                                edges {
+                                    node {
+                                        labelId
+                                        name
+                                    }
+                                }
+                            }
+                            renderer
+                            searchUrl
+                        }
+                        ... on JiraForgeUserField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            user {
+                                __typename
+                                __isUser: __typename
+                                accountId
+                                accountStatus
+                                name
+                                picture
+                                ... on AtlassianAccountUser {
+                                    email
+                                    zoneinfo
+                                    locale
+                                }
+                            }
+                            searchUrl
+                        }
+                        ... on JiraIssueRestrictionField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            selectedRolesConnection {
+                                totalCount
+                                edges {
+                                    node {
+                                        id
+                                        roleId
+                                        name
+                                        description
+                                    }
+                                }
+                            }
+                            roles {
+                                totalCount
+                                edges {
+                                    node {
+                                        id
+                                        roleId
+                                        name
+                                        description
+                                    }
+                                }
+                            }
+                            searchUrl
+                        }
+                        ... on JiraIssueTypeField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            issueType {
+                                id
+                                issueTypeId
+                                name
+                                description
+                                avatar {
+                                    xsmall
+                                    small
+                                    medium
+                                    large
+                                }
+                                hierarchy {
+                                    level
+                                    name
+                                }
+                            }
+                            issueTypes {
+                                edges {
+                                    node {
+                                        id
+                                        issueTypeId
+                                        name
+                                        description
+                                        avatar {
+                                            xsmall
+                                            small
+                                            medium
+                                            large
+                                        }
+                                        hierarchy {
+                                            level
+                                            name
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        ... on JiraLabelsField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            selectedLabelsConnection {
+                                totalCount
+                                edges {
+                                    node {
+                                        labelId
+                                        name
+                                    }
+                                }
+                            }
+                            labels {
+                                totalCount
+                                edges {
+                                    node {
+                                        labelId
+                                        name
+                                    }
+                                }
+                            }
+                            searchUrl
+                        }
+                        ... on JiraMultipleGroupPickerField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            selectedGroupsConnection {
+                                totalCount
+                                edges {
+                                    node {
+                                        groupId
+                                        name
+                                        id
+                                    }
+                                }
+                            }
+                            groups {
+                                totalCount
+                                edges {
+                                    node {
+                                        id
+                                        groupId
+                                        name
+                                    }
+                                }
+                            }
+                            searchUrl
+                        }
+                        ... on JiraMultipleSelectField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            selectedOptions {
+                                totalCount
+                                edges {
+                                    node {
+                                        id
+                                        optionId
+                                        value
+                                        isDisabled
+                                    }
+                                }
+                            }
+                            fieldOptions {
+                                totalCount
+                                edges {
+                                    node {
+                                        id
+                                        optionId
+                                        value
+                                        isDisabled
+                                    }
+                                }
+                            }
+                            searchUrl
+                        }
+                        ... on JiraMultipleSelectUserPickerField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            selectedUsersConnection {
+                                totalCount
+                                edges {
+                                    node {
+                                        __typename
+                                        __isUser: __typename
+                                        accountId
+                                        accountStatus
+                                        name
+                                        picture
+                                        ... on AtlassianAccountUser {
+                                            email
+                                            zoneinfo
+                                            locale
+                                        }
+                                    }
+                                }
+                            }
+                            users {
+                                edges {
+                                    node {
+                                        __typename
+                                        __isUser: __typename
+                                        accountId
+                                        accountStatus
+                                        name
+                                        picture
+                                        ... on AtlassianAccountUser {
+                                            email
+                                            zoneinfo
+                                            locale
+                                        }
+                                    }
+                                }
+                            }
+                            searchUrl
+                        }
+                        ... on JiraMultipleVersionPickerField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            selectedVersionsConnection {
+                                totalCount
+                                edges {
+                                    node {
+                                        id
+                                        versionId
+                                        name
+                                        iconUrl
+                                        status
+                                        description
+                                        startDate
+                                        releaseDate
+                                    }
+                                }
+                            }
+                            versions {
+                                totalCount
+                                edges {
+                                    node {
+                                        id
+                                        versionId
+                                        name
+                                        iconUrl
+                                        status
+                                        description
+                                        startDate
+                                        releaseDate
+                                    }
+                                }
+                            }
+                        }
+                        ... on JiraNumberField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            number
+                            isStoryPointField
+                        }
+                        ... on JiraParentIssueField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            parentIssue {
+                                id
+                                issueId
+                                key
+                                webUrl
+                                fieldsById(ids: ["issuetype ", "project ", "summary "]) {
+                                    edges {
+                                        node {
+                                            __typename
+                                            ... on JiraIssueTypeField {
+                                                fieldId
+                                                name
+                                                type
+                                                description
+                                                issueType {
+                                                    id
+                                                    issueTypeId
+                                                    name
+                                                    description
+                                                    avatar {
+                                                        xsmall
+                                                        small
+                                                        medium
+                                                        large
+                                                    }
+                                                    hierarchy {
+                                                        level
+                                                        name
+                                                    }
+                                                }
+                                                issueTypes {
+                                                    edges {
+                                                        node {
+                                                            id
+                                                            issueTypeId
+                                                            name
+                                                            description
+                                                            avatar {
+                                                                xsmall
+                                                                small
+                                                                medium
+                                                                large
+                                                            }
+                                                            hierarchy {
+                                                                level
+                                                                name
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                            ... on JiraProjectField {
+                                                fieldId
+                                                name
+                                                type
+                                                description
+                                                project {
+                                                    projectId
+                                                    key
+                                                    name
+                                                    avatar {
+                                                        medium
+                                                    }
+                                                    projectType
+                                                    status
+                                                    projectStyle
+                                                    id
+                                                }
+                                            }
+                                            ... on JiraSingleLineTextField {
+                                                fieldId
+                                                name
+                                                type
+                                                description
+                                                text
+                                            }
+                                            id
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        ... on JiraPeopleField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            selectedUsersConnection {
+                                totalCount
+                                edges {
+                                    node {
+                                        __typename
+                                        __isUser: __typename
+                                        accountId
+                                        accountStatus
+                                        name
+                                        picture
+                                        ... on AtlassianAccountUser {
+                                            email
+                                            zoneinfo
+                                            locale
+                                        }
+                                    }
+                                }
+                            }
+                            users {
+                                totalCount
+                                edges {
+                                    node {
+                                        __typename
+                                        __isUser: __typename
+                                        accountId
+                                        accountStatus
+                                        name
+                                        picture
+                                        ... on AtlassianAccountUser {
+                                            email
+                                            zoneinfo
+                                            locale
+                                        }
+                                    }
+                                }
+                            }
+                            isMulti
+                            searchUrl
+                        }
+                        ... on JiraPriorityField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            priority {
+                                priorityId
+                                name
+                                iconUrl
+                                color
+                                id
+                            }
+                            priorities {
+                                edges {
+                                    node {
+                                        priorityId
+                                        name
+                                        iconUrl
+                                        color
+                                        id
+                                    }
+                                }
+                            }
+                        }
+                        ... on JiraProjectField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            project {
+                                projectId
+                                key
+                                name
+                                avatar {
+                                    medium
+                                }
+                                projectType
+                                status
+                                projectStyle
+                                id
+                            }
+                        }
+                        ... on JiraRadioSelectField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            selectedOption {
+                                id
+                                optionId
+                                value
+                                isDisabled
+                            }
+                            fieldOptions {
+                                totalCount
+                                edges {
+                                    node {
+                                        id
+                                        optionId
+                                        value
+                                        isDisabled
+                                    }
+                                }
+                            }
+                        }
+                        ... on JiraResolutionField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            resolution {
+                                id
+                                resolutionId
+                                name
+                                description
+                            }
+                            resolutions {
+                                totalCount
+                                edges {
+                                    node {
+                                        id
+                                        resolutionId
+                                        name
+                                        description
+                                    }
+                                }
+                            }
+                        }
+                        ... on JiraRichTextField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            richText {
+                                plainText
+                                adfValue {
+                                    json
+                                }
+                            }
+                            renderer
+                        }
+                        ... on JiraSecurityLevelField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            securityLevel {
+                                id
+                                name
+                                securityId
+                                description
+                            }
+                        }
+                        ... on JiraServiceManagementDateTimeField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            dateTime
+                        }
+                        ... on JiraServiceManagementIncidentLinkingField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            incident {
+                                hasLinkedIncidents
+                            }
+                        }
+                        ... on JiraServiceManagementMultipleSelectUserPickerField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            selectedUsersConnection {
+                                totalCount
+                                edges {
+                                    node {
+                                        __typename
+                                        __isUser: __typename
+                                        accountId
+                                        accountStatus
+                                        name
+                                        picture
+                                        ... on AtlassianAccountUser {
+                                            email
+                                            zoneinfo
+                                            locale
+                                        }
+                                    }
+                                }
+                            }
+                            users {
+                                totalCount
+                                edges {
+                                    node {
+                                        __typename
+                                        __isUser: __typename
+                                        accountId
+                                        accountStatus
+                                        name
+                                        picture
+                                        ... on AtlassianAccountUser {
+                                            email
+                                            zoneinfo
+                                            locale
+                                        }
+                                    }
+                                }
+                            }
+                            searchUrl
+                        }
+                        ... on JiraServiceManagementOrganizationField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            selectedOrganizationsConnection {
+                                totalCount
+                                edges {
+                                    node {
+                                        organizationId
+                                        organizationName
+                                        domain
+                                    }
+                                }
+                            }
+                            searchUrl
+                        }
+                        ... on JiraServiceManagementPeopleField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            selectedUsersConnection {
+                                totalCount
+                                edges {
+                                    node {
+                                        __typename
+                                        __isUser: __typename
+                                        accountId
+                                        accountStatus
+                                        name
+                                        picture
+                                        ... on AtlassianAccountUser {
+                                            email
+                                            zoneinfo
+                                            locale
+                                        }
+                                    }
+                                }
+                            }
+                            users {
+                                totalCount
+                                edges {
+                                    node {
+                                        __typename
+                                        __isUser: __typename
+                                        accountId
+                                        accountStatus
+                                        name
+                                        picture
+                                        ... on AtlassianAccountUser {
+                                            email
+                                            zoneinfo
+                                            locale
+                                        }
+                                    }
+                                }
+                            }
+                            isMulti
+                            searchUrl
+                        }
+                        ... on JiraServiceManagementRequestFeedbackField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            feedback {
+                                rating
+                            }
+                        }
+                        ... on JiraServiceManagementRequestLanguageField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            language {
+                                languageCode
+                                displayName
+                            }
+                            languages {
+                                languageCode
+                                displayName
+                            }
+                        }
+                        ... on JiraServiceManagementRequestTypeField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            requestType {
+                                id
+                                requestTypeId
+                                name
+                                key
+                                description
+                                helpText
+                                issueType {
+                                    id
+                                    issueTypeId
+                                    name
+                                    description
+                                    avatar {
+                                        xsmall
+                                        small
+                                        medium
+                                        large
+                                    }
+                                }
+                                portalId
+                                avatar {
+                                    xsmall
+                                    small
+                                    medium
+                                    large
+                                }
+                                practices {
+                                    key
+                                }
+                            }
+                            requestTypes {
+                                totalCount
+                                edges {
+                                    node {
+                                        id
+                                        requestTypeId
+                                        name
+                                        key
+                                        description
+                                        helpText
+                                        issueType {
+                                            id
+                                            name
+                                            description
+                                            avatar {
+                                                xsmall
+                                                small
+                                                medium
+                                                large
+                                            }
+                                        }
+                                        portalId
+                                        avatar {
+                                            xsmall
+                                            small
+                                            medium
+                                            large
+                                        }
+                                        practices {
+                                            key
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        ... on JiraServiceManagementRespondersField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            respondersConnection {
+                                edges {
+                                    node {
+                                        __typename
+                                        ... on JiraServiceManagementUserResponder {
+                                            user {
+                                                __typename
+                                                picture
+                                                name
+                                            }
+                                        }
+                                        ... on JiraServiceManagementTeamResponder {
+                                            teamId
+                                            teamName
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        ... on JiraSingleGroupPickerField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            selectedGroup {
+                                id
+                                groupId
+                                name
+                            }
+                            groups {
+                                totalCount
+                                edges {
+                                    node {
+                                        id
+                                        groupId
+                                        name
+                                    }
+                                }
+                            }
+                            searchUrl
+                        }
+                        ... on JiraSingleLineTextField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            text
+                        }
+                        ... on JiraSingleSelectField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            fieldOption {
+                                id
+                                optionId
+                                value
+                                isDisabled
+                            }
+                            fieldOptions {
+                                totalCount
+                                edges {
+                                    node {
+                                        id
+                                        optionId
+                                        value
+                                        isDisabled
+                                    }
+                                }
+                            }
+                            searchUrl
+                        }
+                        ... on JiraSingleSelectUserPickerField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            user {
+                                __typename
+                                __isUser: __typename
+                                accountId
+                                accountStatus
+                                name
+                                picture
+                                ... on AtlassianAccountUser {
+                                    email
+                                    zoneinfo
+                                    locale
+                                }
+                            }
+                            searchUrl
+                        }
+                        ... on JiraSingleVersionPickerField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            version {
+                                id
+                                versionId
+                                name
+                                iconUrl
+                                status
+                                description
+                                startDate
+                                releaseDate
+                            }
+                            versions {
+                                totalCount
+                                edges {
+                                    node {
+                                        id
+                                        versionId
+                                        name
+                                        iconUrl
+                                        status
+                                        description
+                                        startDate
+                                        releaseDate
+                                    }
+                                }
+                            }
+                        }
+                        ... on JiraSprintField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            selectedSprintsConnection {
+                                totalCount
+                                edges {
+                                    node {
+                                        id
+                                        sprintId
+                                        name
+                                        state
+                                        boardName
+                                        startDate
+                                        endDate
+                                        completionDate
+                                        goal
+                                    }
+                                }
+                            }
+                            sprints {
+                                totalCount
+                                edges {
+                                    node {
+                                        id
+                                        sprintId
+                                        name
+                                        state
+                                        boardName
+                                        startDate
+                                        endDate
+                                        completionDate
+                                        goal
+                                    }
+                                }
+                            }
+                            searchUrl
+                        }
+                        ... on JiraStatusField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            status {
+                                id
+                                name
+                                description
+                                statusId
+                                statusCategory {
+                                    id
+                                    statusCategoryId
+                                    key
+                                    name
+                                    colorName
+                                }
+                            }
+                        }
+                        ... on JiraTeamField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            selectedTeam {
+                                id
+                                teamId
+                                name
+                                avatar {
+                                    xsmall
+                                    small
+                                    medium
+                                    large
+                                }
+                                members {
+                                    totalCount
+                                    edges {
+                                        node {
+                                            __typename
+                                        }
+                                    }
+                                }
+                            }
+                            teams {
+                                totalCount
+                                edges {
+                                    node {
+                                        id
+                                        teamId
+                                        name
+                                        avatar {
+                                            xsmall
+                                            small
+                                            medium
+                                            large
+                                        }
+                                        members {
+                                            totalCount
+                                            edges {
+                                                node {
+                                                    __typename
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            searchUrl
+                        }
+                        ... on JiraTeamViewField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            selectedTeam {
+                                jiraSuppliedVisibility
+                                jiraSuppliedName
+                                jiraSuppliedId
+                                jiraSuppliedTeamId
+                                jiraSuppliedAvatar {
+                                    xsmall
+                                    small
+                                    medium
+                                    large
+                                }
+                            }
+                            searchUrl
+                        }
+                        ... on JiraTimeTrackingField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            originalEstimate {
+                                timeInSeconds
+                            }
+                            remainingEstimate {
+                                timeInSeconds
+                            }
+                            timeSpent {
+                                timeInSeconds
+                            }
+                            timeTrackingSettings {
+                                isJiraConfiguredTimeTrackingEnabled
+                                workingHoursPerDay
+                                workingDaysPerWeek
+                                defaultFormat
+                                defaultUnit
+                            }
+                        }
+                        ... on JiraUrlField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            url
+                        }
+                        ... on JiraVotesField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            vote {
+                                hasVoted
+                                count
+                            }
+                        }
+                        ... on JiraWatchesField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            watch {
+                                isWatching
+                                count
+                            }
+                        }
+                        ... on JiraForgeDatetimeField {
+                            ... on JiraIssueField {
+                                __isJiraIssueField: __typename
+                                ... on JiraIssueFieldConfiguration {
+                                    __isJiraIssueFieldConfiguration: __typename
+                                    fieldConfig {
+                                        isRequired
+                                        isEditable
+                                    }
+                                }
+                                ... on JiraUserIssueFieldConfiguration {
+                                    __isJiraUserIssueFieldConfiguration: __typename
+                                    userFieldConfig {
+                                        isPinned
+                                    }
+                                }
+                            }
+                            fieldId
+                            name
+                            type
+                            description
+                            dateTime
+                            renderer
+                        }
+                        id
+                    }
+                }
+            }
+            childIssues {
+                __typename
+                ... on JiraChildIssuesWithinLimit {
+                    issues {
+                        totalCount
+                        edges {
+                            node {
+                                id
+                                key
+                                issueId
+                                webUrl
+                                fieldsById(
+                                    ids: [
+                                        "assignee "
+                                        "created "
+                                        "issuetype "
+                                        "priority "
+                                        "status "
+                                        "summary "
+                                        "timetracking "
+                                        "updated "
+                                    ]
+                                ) {
+                                    edges {
+                                        node {
+                                            __typename
+                                            ... on JiraIssueTypeField {
+                                                fieldId
+                                                name
+                                                type
+                                                description
+                                                issueType {
+                                                    id
+                                                    issueTypeId
+                                                    name
+                                                    description
+                                                    avatar {
+                                                        xsmall
+                                                        small
+                                                        medium
+                                                        large
+                                                    }
+                                                    hierarchy {
+                                                        level
+                                                        name
+                                                    }
+                                                }
+                                                issueTypes {
+                                                    edges {
+                                                        node {
+                                                            id
+                                                            issueTypeId
+                                                            name
+                                                            description
+                                                            avatar {
+                                                                xsmall
+                                                                small
+                                                                medium
+                                                                large
+                                                            }
+                                                            hierarchy {
+                                                                level
+                                                                name
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                            ... on JiraSingleLineTextField {
+                                                fieldId
+                                                name
+                                                type
+                                                description
+                                                text
+                                            }
+                                            ... on JiraPriorityField {
+                                                fieldId
+                                                name
+                                                type
+                                                description
+                                                priority {
+                                                    priorityId
+                                                    name
+                                                    iconUrl
+                                                    color
+                                                    id
+                                                }
+                                                priorities {
+                                                    edges {
+                                                        node {
+                                                            priorityId
+                                                            name
+                                                            iconUrl
+                                                            color
+                                                            id
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                            ... on JiraStatusField {
+                                                fieldId
+                                                name
+                                                type
+                                                description
+                                                status {
+                                                    id
+                                                    name
+                                                    description
+                                                    statusId
+                                                    statusCategory {
+                                                        id
+                                                        statusCategoryId
+                                                        key
+                                                        name
+                                                        colorName
+                                                    }
+                                                }
+                                            }
+                                            ... on JiraSingleSelectUserPickerField {
+                                                fieldId
+                                                name
+                                                type
+                                                description
+                                                user {
+                                                    __typename
+                                                    __isUser: __typename
+                                                    accountId
+                                                    accountStatus
+                                                    name
+                                                    picture
+                                                    ... on AtlassianAccountUser {
+                                                        email
+                                                        zoneinfo
+                                                        locale
+                                                    }
+                                                }
+                                                searchUrl
+                                            }
+                                            ... on JiraTimeTrackingField {
+                                                fieldId
+                                                name
+                                                type
+                                                description
+                                                originalEstimate {
+                                                    timeInSeconds
+                                                }
+                                                remainingEstimate {
+                                                    timeInSeconds
+                                                }
+                                                timeSpent {
+                                                    timeInSeconds
+                                                }
+                                                timeTrackingSettings {
+                                                    isJiraConfiguredTimeTrackingEnabled
+                                                    workingHoursPerDay
+                                                    workingDaysPerWeek
+                                                    defaultFormat
+                                                    defaultUnit
+                                                }
+                                            }
+                                            ... on JiraDateTimePickerField {
+                                                fieldId
+                                                name
+                                                type
+                                                description
+                                                dateTime
+                                            }
+                                            ... on JiraDatePickerField {
+                                                fieldId
+                                                name
+                                                type
+                                                description
+                                                date
+                                            }
+                                            id
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                ... on JiraChildIssuesExceedingLimit {
+                    search
+                }
+            }
+            issueLinks {
+                totalCount
+                edges {
+                    node {
+                        id
+                        issueLinkId
+                        relatedBy {
+                            id
+                            relationName
+                            linkTypeId
+                            linkTypeName
+                            direction
+                        }
+                        issue {
+                            id
+                            issueId
+                            key
+                            webUrl
+                            fieldsById(
+                                ids: [
+                                    "assignee "
+                                    "issuetype "
+                                    "priority "
+                                    "status "
+                                    "summary "
+                                ]
+                            ) {
+                                edges {
+                                    node {
+                                        __typename
+                                        ... on JiraStatusField {
+                                            fieldId
+                                            name
+                                            type
+                                            description
+                                            status {
+                                                id
+                                                name
+                                                description
+                                                statusId
+                                                statusCategory {
+                                                    id
+                                                    statusCategoryId
+                                                    key
+                                                    name
+                                                    colorName
+                                                }
+                                            }
+                                        }
+                                        ... on JiraPriorityField {
+                                            fieldId
+                                            name
+                                            type
+                                            description
+                                            priority {
+                                                priorityId
+                                                name
+                                                iconUrl
+                                                color
+                                                id
+                                            }
+                                            priorities {
+                                                edges {
+                                                    node {
+                                                        priorityId
+                                                        name
+                                                        iconUrl
+                                                        color
+                                                        id
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        ... on JiraIssueTypeField {
+                                            fieldId
+                                            name
+                                            type
+                                            description
+                                            issueType {
+                                                id
+                                                issueTypeId
+                                                name
+                                                description
+                                                avatar {
+                                                    xsmall
+                                                    small
+                                                    medium
+                                                    large
+                                                }
+                                                hierarchy {
+                                                    level
+                                                    name
+                                                }
+                                            }
+                                            issueTypes {
+                                                edges {
+                                                    node {
+                                                        id
+                                                        issueTypeId
+                                                        name
+                                                        description
+                                                        avatar {
+                                                            xsmall
+                                                            small
+                                                            medium
+                                                            large
+                                                        }
+                                                        hierarchy {
+                                                            level
+                                                            name
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        ... on JiraSingleLineTextField {
+                                            fieldId
+                                            name
+                                            type
+                                            description
+                                            text
+                                        }
+                                        ... on JiraSingleSelectUserPickerField {
+                                            fieldId
+                                            name
+                                            type
+                                            description
+                                            searchUrl
+                                            user {
+                                                __typename
+                                                __isUser: __typename
+                                                accountId
+                                                accountStatus
+                                                name
+                                                picture
+                                                ... on AtlassianAccountUser {
+                                                    email
+                                                    zoneinfo
+                                                    locale
+                                                }
+                                            }
+                                        }
+                                        id
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            id
+        }
+    }
+}

--- a/src/test/resources/extra-large-schema-1.graphqls
+++ b/src/test/resources/extra-large-schema-1.graphqls
@@ -1,0 +1,15363 @@
+"""
+Represents an affected service entity for a Jira Issue.
+AffectedService provides context on what has been changed.
+"""
+type JiraAffectedService {
+    """
+    The ID of the affected service. E.g. ari:cloud:graph::service/<UUID>/<UUID>.
+    """
+    serviceId: ID!
+    """
+    The name of the affected service. E.g. Jira.
+    """
+    name: String
+}
+
+"""
+The connection type for JiraAffectedService.
+"""
+type JiraAffectedServiceConnection {
+    """
+    The total count of items in the connection.
+    """
+    totalCount: Int
+    """
+    Information about the current page. Used to aid in pagination.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraAffectedServiceEdge]
+}
+
+"""
+An edge in a JiraAffectedService connection.
+"""
+type JiraAffectedServiceEdge {
+    """
+    The node at the edge.
+    """
+    node: JiraAffectedService
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}
+"""
+Represents an approval that is completed.
+"""
+type JiraServiceManagementCompletedApproval implements Node {
+    """
+    ID of the completed approval.
+    """
+    id: ID!
+    """
+    Name of the approval that has been provided.
+    """
+    name: String
+    """
+    Outcome of the approval, based on the approvals provided by all approvers.
+    """
+    finalDecision: JiraServiceManagementApprovalDecisionResponseType
+    """
+    Detailed list of the users who responded to the approval.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    approvers(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraServiceManagementApproverConnection
+    """
+    Date the approval was created.
+    """
+    createdDate: DateTime
+    """
+    Date the approval was completed.
+    """
+    completedDate: DateTime
+    """
+    Status details in which the approval is applicable.
+    """
+    status: JiraServiceManagementApprovalStatus
+}
+
+"""
+The connection type for JiraServiceManagementCompletedApproval.
+"""
+type JiraServiceManagementCompletedApprovalConnection {
+    """
+    The total count of items in the connection.
+    """
+    totalCount: Int
+    """
+    Information about the current page. Used to aid in pagination.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraServiceManagementCompletedApprovalEdge]
+}
+
+"""
+An edge in a JiraServiceManagementCompletedApproval connection.
+"""
+type JiraServiceManagementCompletedApprovalEdge {
+    """
+    The node at the edge.
+    """
+    node: JiraServiceManagementCompletedApproval
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}
+
+"""
+The connection type for JiraServiceManagementApprover.
+"""
+type JiraServiceManagementApproverConnection {
+    """
+    The total count of items in the connection.
+    """
+    totalCount: Int
+    """
+    Information about the current page. Used to aid in pagination.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraServiceManagementApproverEdge]
+}
+
+"""
+An edge in a JiraServiceManagementApprover connection.
+"""
+type JiraServiceManagementApproverEdge {
+    """
+    The node at the edge.
+    """
+    node: JiraServiceManagementApprover
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}
+
+"""
+Represents an approval that is still active.
+"""
+type JiraServiceManagementActiveApproval implements Node {
+    """
+    ID of the active approval.
+    """
+    id: ID!
+    """
+    Name of the approval being sought.
+    """
+    name: String
+    """
+    Outcome of the approval, based on the approvals provided by all approvers.
+    """
+    finalDecision: JiraServiceManagementApprovalDecisionResponseType
+    """
+    Detailed list of the users who responded to the approval with a decision.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    approvers(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraServiceManagementApproverConnection
+    """
+    Detailed list of the users who are excluded to approve the approval.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    excludedApprovers(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraUserConnection
+    """
+    Indicates whether the user making the request is one of the approvers and can respond to the approval (true) or not (false).
+    """
+    canAnswerApproval: Boolean
+    """
+    List of the users' decisions. Does not include undecided users.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    decisions(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraServiceManagementDecisionConnection
+    """
+    Date the approval was created.
+    """
+    createdDate: DateTime
+    """
+    Configurations of the approval including the approval condition and approvers configuration.
+    There is a maximum limit of how many configurations an active approval can have.
+    """
+    configurations: [JiraServiceManagementApprovalConfiguration]
+    """
+    Status details of the approval.
+    """
+    status: JiraServiceManagementApprovalStatus
+    """
+    Approver principals can be a connection of users or groups that may decide on an approval.
+    The list includes undecided members.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    approverPrincipals(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraServiceManagementApproverPrincipalConnection
+    """
+    The number of approvals needed to complete.
+    """
+    pendingApprovalCount: Int
+    """
+    Active Approval state, can it be achieved or not.
+    """
+    approvalState: JiraServiceManagementApprovalState
+}
+
+"""
+The connection type for JiraServiceManagementDecision.
+"""
+type JiraServiceManagementDecisionConnection {
+    """
+    The total count of items in the connection.
+    """
+    totalCount: Int
+    """
+    Information about the current page. Used to aid in pagination.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraServiceManagementDecisionEdge]
+}
+
+"""
+An edge in a JiraServiceManagementDecision connection.
+"""
+type JiraServiceManagementDecisionEdge {
+    """
+    The node at the edge.
+    """
+    node: JiraServiceManagementDecision
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}
+
+"""
+The connection type for JiraServiceManagementApproverPrincipal.
+"""
+type JiraServiceManagementApproverPrincipalConnection {
+    """
+    The total count of items in the connection.
+    """
+    totalCount: Int
+    """
+    Information about the current page. Used to aid in pagination.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraServiceManagementApproverPrincipalEdge]
+}
+
+"""
+An edge in a JiraServiceManagementApproverPrincipal connection.
+"""
+type JiraServiceManagementApproverPrincipalEdge {
+    """
+    The node at the edge.
+    """
+    node: JiraServiceManagementApproverPrincipal
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}
+
+"""
+Approver principals are either users or groups that may decide on an approval.
+"""
+union JiraServiceManagementApproverPrincipal = JiraServiceManagementUserApproverPrincipal | JiraServiceManagementGroupApproverPrincipal
+
+
+"""
+Contains information about the approvers when approver is a user.
+"""
+type JiraServiceManagementUserApproverPrincipal {
+    """
+    A approver principal who's a user type
+    """
+    user: User
+    """
+    URL for the principal.
+    """
+    jiraRest: URL
+}
+"""
+The user and decision that approved the approval.
+"""
+type JiraServiceManagementApprover {
+    """
+    Details of the User who is providing approval.
+    """
+    approver: User
+    """
+    Decision made by the approver.
+    """
+    approverDecision: JiraServiceManagementApprovalDecisionResponseType
+}
+
+"""
+Represents the user and decision details.
+"""
+type JiraServiceManagementDecision {
+    """
+    The user providing a decision.
+    """
+    approver: User
+    """
+    The decision made by the approver.
+    """
+    approverDecision: JiraServiceManagementApprovalDecisionResponseType
+}
+
+"""
+Represents the possible decisions that can be made by an approver.
+"""
+enum JiraServiceManagementApprovalDecisionResponseType {
+    """
+    Indicates that the decision is approved by the approver.
+    """
+    approved
+    """
+    Indicates that the decision is declined by the approver.
+    """
+    declined
+    """
+    Indicates that the decision is pending by the approver.
+    """
+    pending
+}
+
+"""
+Represent whether approval can be achieved or not.
+"""
+enum JiraServiceManagementApprovalState {
+    """
+    Indicates that approval can not be completed due to lack of approvers.
+    """
+    INSUFFICIENT_APPROVERS
+    """
+    Indicates that approval has sufficient user to complete.
+    """
+    OK
+}
+
+"""
+Represents the configuration details of an approval.
+"""
+type JiraServiceManagementApprovalConfiguration {
+    """
+    Contains information about approvers configuration.
+    There is a maximum number of fields that can be set for the approvers configuration.
+    """
+    approversConfigurations: [JiraServiceManagementApproversConfiguration]
+    """
+    Contains information about approval condition.
+    """
+    condition: JiraServiceManagementApprovalCondition
+}
+
+"""
+Represents the configuration details of the users providing approval.
+"""
+type JiraServiceManagementApproversConfiguration {
+    """
+    Approvers configuration type. E.g. custom_field.
+    """
+    type: String
+    """
+    The field's name configured for the approvers. Only set for type "field".
+    """
+    fieldName: String
+    """
+    The field's id configured for the approvers.
+    """
+    fieldId: String
+}
+
+"""
+Represents the details of an approval condition.
+"""
+type JiraServiceManagementApprovalCondition {
+    """
+    Condition type for approval.
+    """
+    type: String
+    """
+    Condition value for approval.
+    """
+    value: String
+}
+
+"""
+Contains information about the approvers when approver is a group.
+"""
+type JiraServiceManagementGroupApproverPrincipal {
+    """
+    A group identifier.
+    Note: Group identifiers are nullable.
+    """
+    groupId: String
+    """
+    Display name for a group.
+    """
+    name: String
+    """
+    This contains the number of members.
+    """
+    memberCount: Int
+    """
+    This contains the number of members that have approved a decision.
+    """
+    approvedCount: Int
+}
+
+"""
+Represents details of the approval status.
+"""
+type JiraServiceManagementApprovalStatus {
+    """
+    Status id of approval.
+    """
+    id: String
+    """
+    Status name of approval. E.g. Waiting for approval.
+    """
+    name: String
+    """
+    Status category Id of approval.
+    """
+    categoryId: String
+}
+"""
+Represents a single option value for an asset field.
+"""
+type JiraAsset {
+    """
+    The app key, which should be the Connect app key.
+    This parameter is used to scope the originId.
+    """
+    appKey: String
+    """
+    The identifier of an asset.
+    This is the same identifier for the asset in its origin (external) system.
+    """
+    originId: String
+    """
+    The appKey + originId separated by a forward slash.
+    """
+    serializedOrigin: String
+    """
+    The appKey + originId separated by a forward slash.
+    """
+    value: String
+}
+
+"""
+The connection type for JiraAsset.
+"""
+type JiraAssetConnection {
+    """
+    The total count of items in the connection.
+    """
+    totalCount: Int
+    """
+    Information about the current page. Used to aid in pagination.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraAssetEdge]
+}
+
+"""
+An edge in a JiraAsset connection.
+"""
+type JiraAssetEdge {
+    """
+    The node at the edge.
+    """
+    node: JiraAsset
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}"""
+Deprecated type. Please use `JiraTeamView` instead.
+"""
+type JiraAtlassianTeam {
+    """
+    The UUID of team.
+    """
+    teamId: String
+    """
+    The name of the team.
+    """
+    name: String
+    """
+    The avatar of the team.
+    """
+    avatar: JiraAvatar
+}
+
+"""
+Deprecated type.
+"""
+type JiraAtlassianTeamConnection {
+    """
+    The total count of items in the connection.
+    """
+    totalCount: Int
+    """
+    Information about the current page. Used to aid in pagination.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraAtlassianTeamEdge]
+}
+
+"""
+Deprecated type.
+"""
+type JiraAtlassianTeamEdge {
+    """
+    The node at the edge.
+    """
+    node: JiraAtlassianTeam
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}
+"""
+An interface shared across all attachment types.
+"""
+interface JiraAttachment {
+    """
+    Identifier for the attachment.
+    """
+    attachmentId: String!
+    """
+    User profile of the attachment author.
+    """
+    author: User
+    """
+    Date the attachment was created in seconds since the epoch.
+    """
+    created: DateTime!
+    """
+    Media Services file id of this Attachment, May be absent if the attachment has not yet been migrated to Media Services.
+    """
+    mediaApiFileId: String
+    """
+    The mimetype (also called content type) of the attachment. This may be {@code null}.
+    """
+    mimeType: String
+    """
+    Filename of the attachment.
+    """
+    fileName: String
+    """
+    Size of the attachment in bytes.
+    """
+    fileSize: Long
+    """
+    Parent name that this attachment is contained in e.g Issue, Field, Comment, Worklog.
+    """
+    parentName: String
+    """
+    Parent id that this attachment is contained in.
+    """
+    parentId: String
+}
+
+"""
+Represents a Jira platform attachment.
+"""
+type JiraPlatformAttachment implements JiraAttachment & Node {
+    """
+    Global identifier for the attachment
+    """
+    id: ID!
+    """
+    Identifier for the attachment.
+    """
+    attachmentId: String!
+    """
+    User profile of the attachment author.
+    """
+    author: User
+    """
+    Date the attachment was created in seconds since the epoch.
+    """
+    created: DateTime!
+    """
+    Media Services file id of this Attachment, May be absent if the attachment has not yet been migrated to Media Services.
+    """
+    mediaApiFileId: String
+    """
+    The mimetype (also called content type) of the attachment. This may be {@code null}.
+    """
+    mimeType: String
+    """
+    Filename of the attachment.
+    """
+    fileName: String
+    """
+    Size of the attachment in bytes.
+    """
+    fileSize: Long
+    """
+    Parent name that this attachment is contained in e.g Issue, Field, Comment, Worklog.
+    """
+    parentName: String
+    """
+    Parent id that this attachment is contained in.
+    """
+    parentId: String
+}
+
+"""
+Represents an attachment within a JiraServiceManagement project.
+"""
+type JiraServiceManagementAttachment implements JiraAttachment & Node {
+    """
+    Global identifier for the attachment
+    """
+    id: ID!
+    """
+    Identifier for the attachment.
+    """
+    attachmentId: String!
+    """
+    User profile of the attachment author.
+    """
+    author: User
+    """
+    Media Services file id of this Attachment, May be absent if the attachment has not yet been migrated to Media Services.
+    """
+    mediaApiFileId: String
+    """
+    Date the attachment was created in seconds since the epoch.
+    """
+    created: DateTime!
+    """
+    The mimetype (also called content type) of the attachment. This may be {@code null}.
+    """
+    mimeType: String
+    """
+    Filename of the attachment.
+    """
+    fileName: String
+    """
+    Size of the attachment in bytes.
+    """
+    fileSize: Long
+    """
+    Parent name that this attachment is contained in e.g Issue, Field, Comment, Worklog.
+    """
+    parentName: String
+    """
+    Parent id that this attachment is contained in.
+    """
+    parentId: String
+    """
+    If the parent for the JSM attachment is a comment, this represents the JSM visibility property associated with this comment.
+    """
+    parentCommentVisibility: JiraServiceManagementCommentVisibility
+}
+
+"""
+The connection type for JiraAttachment.
+"""
+type JiraAttachmentConnection {
+    """
+    The approximate count of items in the connection.
+    """
+    indicativeCount: Int
+    """
+    The page info of the current page of results.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraAttachmentEdge]
+}
+
+"""
+An edge in a JiraAttachment connection.
+"""
+type JiraAttachmentEdge {
+    """
+    The node at the the edge.
+    """
+    node: JiraAttachment
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}
+
+enum JiraAttachmentsPermissions {
+    "Allows the user to create atachments on the correspondig Issue."
+    CREATE_ATTACHMENTS,
+    "Allows the user to delete attachments on the corresponding Issue."
+    DELETE_OWN_ATTACHMENTS
+}
+
+input JiraOrderDirection {
+    id: ID
+    #TODO
+}
+
+input JiraAttachmentsOrderField {
+    id: ID
+    #TODO
+}
+"""
+Represents the avatar size urls.
+"""
+type JiraAvatar {
+  """
+  An extra-small avatar (16x16 pixels).
+  """
+  xsmall: String
+  """
+  A small avatar (24x24 pixels).
+  """
+  small: String
+  """
+  A medium avatar (32x32 pixels).
+  """
+  medium: String
+  """
+  A large avatar (48x48 pixels).
+  """
+  large: String
+}
+"""
+A union type representing childIssues available within a Jira Issue.
+The *WithinLimit type is used for childIssues with a count that is within a limit specified by the server.
+The *ExceedsLimit type is used for childIssues with a count that exceeds a limit specified by the server.
+"""
+union JiraChildIssues = JiraChildIssuesWithinLimit | JiraChildIssuesExceedingLimit
+
+"""
+Represents childIssues with a count that is within the count limit set by the server.
+"""
+type JiraChildIssuesWithinLimit {
+    """
+    Paginated list of childIssues within this Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    issues(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraIssueConnection
+}
+
+"""
+Represents childIssues with a count that exceeds a limit set by the server.
+"""
+type JiraChildIssuesExceedingLimit {
+    """
+    Search string to query childIssues when limit is exceeded.
+    """
+    search: String
+}"""
+Jira Configuration Management Database.
+"""
+type JiraCmdbObject implements Node {
+    """
+    Global identifier for the CMDB field.
+    """
+    id: ID!
+    """
+    Unique object id formed with `workspaceId`:`objectId`.
+    """
+    objectGlobalId: String
+    """
+    Unique id in the workspace of the CMDB object.
+    """
+    objectId: String
+    """
+    Workspace id of the CMDB object.
+    """
+    workspaceId: String
+    """
+    Label of the CMDB object.
+    """
+    label: String
+    """
+    The key associated with the CMDB object.
+    """
+    objectKey: String
+    """
+    The avatar associated with this CMDB object.
+    """
+    avatar: JiraCmdbAvatar
+    """
+    The CMDB object type.
+    """
+    objectType: JiraCmdbObjectType
+    """
+    Paginated list of attributes present on the CMDB object.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    attributes(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraCmdbAttributeConnection
+    """
+    The URL link for this CMDB object.
+    """
+    webUrl: String
+}
+
+"""
+Represents a CMDB avatar.
+"""
+type JiraCmdbAvatar {
+    """
+    The ID of the CMDB avatar.
+    """
+    id: String
+    """
+    The UUID of the CMDB avatar.
+    """
+    avatarUUID: String
+    """
+    The 16x16 pixel CMDB avatar.
+    """
+    url16: String
+    """
+    The 48x48 pixel CMDB avatar.
+    """
+    url48: String
+    """
+    The 72x72 pixel CMDB avatar.
+    """
+    url72: String
+    """
+    The 144x144 pixel CMDB avatar.
+    """
+    url144: String
+    """
+    The 288x288 pixel CMDB avatar.
+    """
+    url288: String
+    """
+    The media client config used for retrieving the CMDB Avatar.
+    """
+    mediaClientConfig: JiraCmdbMediaClientConfig
+}
+
+"""
+Represents the media client config used for retrieving the CMDB Avatar.
+"""
+type JiraCmdbMediaClientConfig {
+    """
+    The media client ID for the CMDB avatar.
+    """
+    clientId: String
+    """
+    The ASAP issuer of the media token.
+    """
+    issuer: String
+    """
+    The media file ID for the CMDB avatar.
+    """
+    fileId: String
+    """
+    The media base URL for the CMDB avatar.
+    """
+    mediaBaseUrl: URL
+    """
+    The media JWT token for the CMDB avatar.
+    """
+    mediaJwtToken: String
+}
+
+"""
+Represents the attribute associated with the CMDB object.
+"""
+type JiraCmdbAttribute {
+    """
+    The attribute ID.
+    """
+    attributeId: String
+    """
+    The object type attribute ID.
+    """
+    objectTypeAttributeId: String
+    """
+    The object type attribute.
+    """
+    objectTypeAttribute: JiraCmdbObjectTypeAttribute
+    """
+    Paginated list of attribute values present on the CMDB object.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    objectAttributeValues(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraCmdbObjectAttributeValueConnection
+}
+
+"""
+Represents the CMDB object type attribute.
+"""
+type JiraCmdbObjectTypeAttribute {
+    """
+    The name of the CMDB object type attribute.
+    """
+    name: String
+    """
+    A boolean representing whether this attribute is set as the label attribute or not.
+    """
+    label: Boolean
+    """
+    The category of the CMDB attribute that can be created.
+    """
+    type: JiraCmdbAttributeType
+    """
+    The description of the CMDB object type attribute.
+    """
+    description: String
+    """
+    The object type of the CMDB object type attribute.
+    """
+    objectType: JiraCmdbObjectType
+    """
+    The default type of the CMDB object type attribute.
+    This property will be present if the `type` of the attribute is `DEFAULT`.
+    """
+    defaultType: JiraCmdbDefaultType
+    """
+    The reference type of the CMDB object type attribute.
+    This property will be present if the `type` of the attribute is `REFERENCED_OBJECT`.
+    """
+    referenceType: JiraCmdbReferenceType
+    """
+    The reference object type ID of the CMDB object type attribute.
+    This property will be present if the `type` of the attribute is `REFERENCED_OBJECT`.
+    """
+    referenceObjectTypeId: String
+    """
+    The reference object type of the CMDB object type attribute.
+    This property will be present if the `type` of the attribute is `REFERENCED_OBJECT`.
+    """
+    referenceObjectType: JiraCmdbObjectType
+    """
+    The additional value of the CMDB object type attribute.
+    """
+    additionalValue: String
+    """
+    The suffix associated with the CMDB object type attribute.
+    """
+    suffix: String
+}
+
+"""
+The category of the CMDB attribute that can be created.
+"""
+enum JiraCmdbAttributeType {
+    """
+    Default attributes, e.g. text, boolean, integer, date.
+    """
+    DEFAULT
+    """
+    Reference object attribute.
+    """
+    REFERENCED_OBJECT
+    """
+    User attribute.
+    """
+    USER
+    """
+    Confluence attribute.
+    """
+    CONFLUENCE
+    """
+    Group attribute.
+    """
+    GROUP
+    """
+    Version attribute.
+    """
+    VERSION
+    """
+    Project attribute.
+    """
+    PROJECT
+    """
+    Status attribute.
+    """
+    STATUS
+}
+
+"""
+Represents the CMDB object type.
+"""
+type JiraCmdbObjectType {
+    """
+    The ID of the CMDB object type.
+    """
+    objectTypeId: String!
+    """
+    The name of the CMDB object type.
+    """
+    name: String
+    """
+    The description of the CMDB object type.
+    """
+    description: String
+    """
+    The icon of the CMDB object type.
+    """
+    icon: JiraCmdbIcon
+    """
+    The object schema id of the CMDB object type.
+    """
+    objectSchemaId: String
+}
+
+"""
+Represents a CMDB icon.
+"""
+type JiraCmdbIcon {
+    """
+    The ID of the CMDB icon.
+    """
+    id: String!
+    """
+    The name of the CMDB icon.
+    """
+    name: String
+    """
+    The URL of the small CMDB icon.
+    """
+    url16: String
+    """
+    The URL of the large CMDB icon.
+    """
+    url48: String
+}
+
+"""
+Represents the CMDB default type.
+This contains information about what type of default attribute this is.
+The possible id: name values are as follows:
+    0: Text
+    1: Integer
+    2: Boolean
+    3: Float
+    4: Date
+    6: DateTime
+    7: URL
+    8: Email
+    9: Textarea
+    10: Select
+    11: IP Address
+"""
+type JiraCmdbDefaultType {
+    """
+    The ID of the CMDB default type.
+    """
+    id: String
+    """
+    The name of the CMDB default type.
+    """
+    name: String
+}
+
+"""
+Represents the CMDB reference type.
+This describes the type of connection between one object and another.
+"""
+type JiraCmdbReferenceType {
+    """
+    The ID of the CMDB reference type.
+    """
+    id: String
+    """
+    The name of the CMDB reference type.
+    """
+    name: String
+    """
+    The description of the CMDB reference type.
+    """
+    description: String
+    """
+    The color of the CMDB reference type.
+    """
+    color: String
+    """
+    The URL of the icon of the CMDB reference type.
+    """
+    webUrl: String
+    """
+    The object schema ID of the CMDB reference type.
+    """
+    objectSchemaId: String
+}
+
+"""
+Represents the CMDB object attribute value.
+The property values in this type will be defined depending on the attribute type.
+E.g. the `referenceObject` property value will only be defined if the attribute type is a reference object type.
+"""
+type JiraCmdbObjectAttributeValue {
+    """
+    The referenced CMDB object.
+    """
+    referencedObject: JiraCmdbObject
+    """
+    The user associated with this CMDB object attribute value.
+    """
+    user: User
+    """
+    The group associated with this CMDB object attribute value.
+    """
+    group: JiraGroup
+    """
+    The status of this CMDB object attribute value.
+    """
+    status: JiraCmdbStatusType
+    """
+    The value of this CMDB object attribute value.
+    """
+    value: String
+    """
+    The display value of this CMDB object attribute value.
+    """
+    displayValue: String
+    """
+    The search value of this CMDB object attribute value.
+    """
+    searchValue: String
+    """
+    The additional value of this CMDB object attribute value.
+    """
+    additionalValue: String
+}
+
+"""
+Represents the CMDB status type.
+"""
+type JiraCmdbStatusType {
+    """
+    The ID of the CMDB status type.
+    """
+    id: String
+    """
+    The name of the CMDB status type.
+    """
+    name: String
+    """
+    The description of the CMDB status type.
+    """
+    description: String
+    """
+    The category of the CMDB status type.
+    """
+    category: Int
+    """
+    The object schema ID associated with the CMDB status type.
+    """
+    objectSchemaId: String
+}
+
+"""
+The connection type for JiraCmdbAttribute.
+"""
+type JiraCmdbAttributeConnection {
+    """
+    The total count of items in the connection.
+    """
+    totalCount: Int
+    """
+    Information about the current page. Used to aid in pagination.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraCmdbAttributeEdge]
+}
+
+"""
+An edge in a JiraCmdbAttribute connection.
+"""
+type JiraCmdbAttributeEdge {
+    """
+    The node at the edge.
+    """
+    node: JiraCmdbAttribute
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}
+
+"""
+The connection type for JiraCmdbObjectAttributeValue.
+"""
+type JiraCmdbObjectAttributeValueConnection {
+    """
+    The total count of items in the connection.
+    """
+    totalCount: Int
+    """
+    Information about the current page. Used to aid in pagination.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraCmdbObjectAttributeValueEdge]
+}
+
+"""
+An edge in a JiraCmdbObjectAttributeValue connection.
+"""
+type JiraCmdbObjectAttributeValueEdge {
+    """
+    The node at the edge.
+    """
+    node: JiraCmdbObjectAttributeValue
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}
+
+"""
+The connection type for JiraCmdbObject.
+"""
+type JiraCmdbObjectConnection {
+    """
+    The total count of items in the connection.
+    """
+    totalCount: Int
+    """
+    Information about the current page. Used to aid in pagination.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraCmdbObjectEdge]
+}
+
+"""
+An edge in a JiraCmdbObject connection.
+"""
+type JiraCmdbObjectEdge {
+    """
+    The node at the edge.
+    """
+    node: JiraCmdbObject
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}"""
+Jira color that displays on a field.
+"""
+type JiraColor {
+    """
+    Global identifier for the color.
+    """
+    id: ID
+    """
+    The key associated with the color based on the field type (issue color, epic color).
+    """
+    colorKey: String
+}
+"""
+An interface shared across all comment types.
+"""
+interface JiraComment {
+    """
+    Identifier for the comment.
+    """
+    commentId: ID!
+    """
+    The issue to which this comment is belonged.
+    """
+    issue: JiraIssue
+    """
+    The browser clickable link of this comment.
+    """
+    webUrl: URL
+    """
+    User profile of the original comment author.
+    """
+    author: User
+    """
+    User profile of the author performing the comment update.
+    """
+    updateAuthor: User
+    """
+    Comment body rich text.
+    """
+    richText: JiraRichText
+    """
+    Time of comment creation.
+    """
+    created: DateTime!
+    """
+    Time of last comment update.
+    """
+    updated: DateTime
+    """
+    Either the group or the project role associated with this comment, but not both.
+    Null means the permission level is unspecified, i.e. the comment is public.
+    """
+    permissionLevel: JiraPermissionLevel
+}
+
+"""
+Represents a Jira platform comment.
+"""
+type JiraPlatformComment implements JiraComment & Node {
+    """
+    Global identifier for the comment
+    """
+    id: ID!
+    """
+    Identifier for the comment.
+    """
+    commentId: ID!
+    """
+    The issue to which this comment is belonged.
+    """
+    issue: JiraIssue
+    """
+    The browser clickable link of this comment.
+    """
+    webUrl: URL
+    """
+    User profile of the original comment author.
+    """
+    author: User
+    """
+    User profile of the author performing the comment update.
+    """
+    updateAuthor: User
+    """
+    Comment body rich text.
+    """
+    richText: JiraRichText
+    """
+    Time of comment creation.
+    """
+    created: DateTime!
+    """
+    Time of last comment update.
+    """
+    updated: DateTime
+    """
+    Either the group or the project role associated with this comment, but not both.
+    Null means the permission level is unspecified, i.e. the comment is public.
+    """
+    permissionLevel: JiraPermissionLevel
+}
+
+"""
+Represents a comment within a JiraServiceManagement project.
+"""
+type JiraServiceManagementComment implements JiraComment & Node {
+    """
+    Global identifier for the comment
+    """
+    id: ID!
+    """
+    Identifier for the comment.
+    """
+    commentId: ID!
+    """
+    The issue to which this comment is belonged.
+    """
+    issue: JiraIssue
+    """
+    The browser clickable link of this comment.
+    """
+    webUrl: URL
+    """
+    User profile of the original comment author.
+    """
+    author: User
+    """
+    User profile of the author performing the comment update.
+    """
+    updateAuthor: User
+    """
+    Comment body rich text.
+    """
+    richText: JiraRichText
+    """
+    Time of comment creation.
+    """
+    created: DateTime!
+    """
+    Time of last comment update.
+    """
+    updated: DateTime
+    """
+    Either the group or the project role associated with this comment, but not both.
+    Null means the permission level is unspecified, i.e. the comment is public.
+    """
+    permissionLevel: JiraPermissionLevel
+    """
+    The JSM visibility property associated with this comment.
+    """
+    visibility: JiraServiceManagementCommentVisibility
+    """
+    Indicates whether the comment author can see the request or not.
+    """
+    authorCanSeeRequest: Boolean
+}
+
+"""
+The connection type for JiraComment.
+"""
+type JiraCommentConnection {
+    """
+    The approximate count of items in the connection.
+    """
+    indicativeCount: Int
+    """
+    Information to aid in pagination.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraCommentEdge]
+}
+
+"""
+An edge in a JiraComment connection.
+"""
+type JiraCommentEdge {
+    """
+    The node at the the edge.
+    """
+    node: JiraComment
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}
+
+"""
+Represents the input for comments by issue ID and comment ID.
+"""
+input JiraCommentByIdInput {
+    """
+    Issue ID.
+    """
+    issueId: ID!
+    """
+    Comment ID.
+    """
+    id: ID!
+}"""
+Jira component defines a sub-selectin of a project.
+"""
+type JiraComponent implements Node {
+    """
+    Global identifier for the color.
+    """
+    id: ID!
+    """
+    Component id in digital format.
+    """
+    componentId: String!
+    """
+    The name of the component.
+    """
+    name: String
+    """
+    Component description.
+    """
+    description: String
+    # TODO: lead, default assignee ...
+}
+
+"""
+The connection type for JiraComponent.
+"""
+type JiraComponentConnection {
+    """
+    The total number of items in the connection.
+    """
+    totalCount: Int
+    """
+    Information about the current page. Used to aid in pagination.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraComponentEdge]
+}
+
+"""
+An edge in a JiraComponent connection.
+"""
+type JiraComponentEdge {
+    """
+    The node at the edge.
+    """
+    node: JiraComponent
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}
+"""
+The precondition state of the deployments JSW feature for a particular project and user.
+"""
+enum JiraDeploymentsFeaturePrecondition {
+    """
+    The deployments feature is not available as the precondition checks have not been satisfied.
+    """
+    NOT_AVAILABLE
+    """
+    The deployments feature is available and will show the empty-state page as no CI/CD provider is sending deployment data.
+    """
+    DEPLOYMENTS_EMPTY_STATE
+    """
+    The deployments feature is available as the project has satisfied all precondition checks.
+    """
+    ALL_SATISFIED
+}
+
+"""
+The precondition state of the install-deployments banner for a particular project and user.
+"""
+enum JiraInstallDeploymentsBannerPrecondition {
+    """
+    The deployments banner is not available as the precondition checks have not been satisfied.
+    """
+    NOT_AVAILABLE
+    """
+    The deployments banner is available but the feature has not been enabled.
+    """
+    FEATURE_NOT_ENABLED
+    """
+    The deployments banner is available but no CI/CD provider is sending deployment data.
+    """
+    DEPLOYMENTS_EMPTY_STATE
+}
+
+extend type JiraQuery {
+    """
+    Returns the precondition state of the deployments JSW feature for a particular project and user.
+    """
+    deploymentsFeaturePrecondition(
+        """
+        The identifier of the project to get the precondition for.
+        """
+        projectId: ID!
+    ): JiraDeploymentsFeaturePrecondition
+
+    """
+    Returns the precondition state of the deployments JSW feature for a particular project and user.
+    """
+    deploymentsFeaturePreconditionByProjectKey(
+        """
+        The identifier that indicates that cloud instance this data is to be fetched for
+        """
+        cloudId: ID!
+        """
+        The key identifier of the project to get the precondition for.
+        """
+        projectKey: String!
+    ): JiraDeploymentsFeaturePrecondition
+
+    """
+    Returns the precondition state of the install-deployments banner for a particular project and user.
+    """
+    installDeploymentsBannerPrecondition(
+        """
+        The identifier of the project to get the precondition for.
+        """
+        projectId: ID!
+    ): JiraInstallDeploymentsBannerPrecondition
+}
+extend type JiraQuery {
+    """
+    Container for all DevOps related queries in Jira
+    """
+    devOps: JiraDevOpsQuery
+}
+
+"""
+Container for all DevOps related queries in Jira
+"""
+type JiraDevOpsQuery {
+    """
+    Returns the JiraDevOpsIssuePanel for an issue
+    """
+    devOpsIssuePanel(issueId: ID!): JiraDevOpsIssuePanel
+}
+
+extend type JiraMutation {
+    """
+    Container for all DevOps related mutations in Jira
+    """
+    devOps: JiraDevOpsMutation
+}
+
+"""
+Container for all DevOps related mutations in Jira
+"""
+type JiraDevOpsMutation {
+    """
+    Lets a user opt-out of the "not-connected" state in the DevOps Issue Panel
+    """
+    optoutOfDevOpsIssuePanelNotConnectedState(
+        input: JiraOptoutDevOpsIssuePanelNotConnectedInput!
+    ): JiraOptoutDevOpsIssuePanelNotConnectedPayload
+    """
+    Lets a user dismiss a banner shown in the DevOps Issue Panel
+    """
+    dismissDevOpsIssuePanelBanner(
+        input: JiraDismissDevOpsIssuePanelBannerInput!
+    ): JiraDismissDevOpsIssuePanelBannerPayload
+}
+
+"""
+The input type for opting out of the Not Connected state in the DevOpsPanel
+"""
+input JiraOptoutDevOpsIssuePanelNotConnectedInput {
+    """
+    Cloud ID of the tenant this change is applied to
+    """
+    cloudId: ID!
+}
+
+"""
+The response payload for opting out of the Not Connected state in the DevOpsPanel
+"""
+type JiraOptoutDevOpsIssuePanelNotConnectedPayload implements Payload {
+    "The success indicator saying whether mutation operation was successful as a whole or not."
+    success: Boolean!
+    "The errors field represents additional mutation error information if exists."
+    errors: [MutationError!]
+}
+
+"""
+The input type for devops panel banner dismissal
+"""
+input JiraDismissDevOpsIssuePanelBannerInput {
+    """
+    ID of the issue this banner was dismissed on
+    """
+    issueId: ID!
+    """
+    Only "issue-key-onboarding" is supported currently as this is the only banner
+    that can be displayed in the panel for now
+    """
+    bannerType: JiraDevOpsIssuePanelBannerType!
+}
+
+"""
+The response payload for devops panel banner dismissal
+"""
+type JiraDismissDevOpsIssuePanelBannerPayload implements Payload {
+    "The success indicator saying whether mutation operation was successful as a whole or not."
+    success: Boolean!
+    "The errors field represents additional mutation error information if exists."
+    errors: [MutationError!]
+}
+"""
+Container for all DevOps data for an issue, to be displayed in the DevOps Panel of an issue
+"""
+type JiraDevOpsIssuePanel {
+    """
+    Specifies the state the DevOps panel in the issue view should be in
+    """
+    panelState: JiraDevOpsIssuePanelState
+
+    """
+    Specify a banner to show on top of the dev panel. `null` means that no banner should be displayed.
+    """
+    devOpsIssuePanelBanner: JiraDevOpsIssuePanelBannerType
+
+    """
+    Container for the Dev Summary of this issue
+    """
+    devSummaryResult: JiraIssueDevSummaryResult
+
+    """
+    Specify if tenant which hosts the project of this issue has installed SCM providers supporting Branch capabilities.
+    """
+    hasBranchCapabilities: Boolean
+}
+
+"""
+The possible States the DevOps Issue Panel can be in
+"""
+enum JiraDevOpsIssuePanelState {
+    """
+    Panel should be hidden
+    """
+    HIDDEN
+    """
+    Panel should show the "not connected" state to prompt user to integrate tools
+    """
+    NOT_CONNECTED
+    """
+    Panel should show the available Dev Summary
+    """
+    DEV_SUMMARY
+}
+
+enum JiraDevOpsIssuePanelBannerType {
+    """
+    Banner that explains how to add issue keys in your commits, branches and PRs
+    """
+    ISSUE_KEY_ONBOARDING
+}
+extend type JiraQuery {
+    """
+    Retrieves the list of devOps providers filtered by the types of capabilities they should support
+    Note: Bitbucket pipelines will be omitted from the result if Bitbucket SCM is not installed
+    """
+    devOpsProviders(
+        """
+        The ID of the tenant to get devOps providers for
+        """
+        cloudId: ID!
+        """
+        The capabilities the returned devOps providers will support
+        This result will contain providers that support *any* of the provided capabilities
+
+        e.g. Requesting [COMMIT, DEPLOYMENT] will return providers that support either COMMIT,
+        DEPLOYMENT or both
+
+        Note: The resulting list is bounded and is expected to *not* exceed 20 items with no filter.
+        Adding a filter will reduce the result even further. This is because a tenant will
+        reasonably install only handful of devOps integrations. i.e. It's possible but rare for
+        a site to have all of GitHub, GitLab, and Bitbucket providers installed
+
+        Note: Omitting or passing an empty filter will return all devOps providers
+        """
+        filter: [JiraDevOpsCapability!] = []
+    ): [JiraDevOpsProvider]
+}
+
+interface JiraDevOpsProvider {
+    """
+    The human-readable display name of the devOps provider
+    """
+    displayName: String
+    """
+    The link to the web URL of the devOps provider
+    """
+    webUrl: URL
+    """
+    The list of capabilities the devOps provider supports
+
+    This max size of the list is bounded by the total number of enum states
+    """
+    capabilities: [JiraDevOpsCapability]
+}
+
+"""
+A connect app which provides devOps capabilities.
+"""
+type JiraClassicConnectDevOpsProvider implements JiraDevOpsProvider {
+    """
+    The human-readable display name of the devOps provider
+    """
+    displayName: String
+    """
+    The link to the web URL of the devOps provider
+    """
+    webUrl: URL
+    """
+    The list of capabilities the devOps provider supports
+
+    This max size of the list is bounded by the total number of enum states
+    """
+    capabilities: [JiraDevOpsCapability]
+    """
+    The link to the icon of the devOps provider
+    """
+    iconUrl: URL
+    """
+    The connect app ID
+    """
+    connectAppId: ID
+}
+
+"""
+An oauth app which provides devOps capabilities.
+"""
+type JiraOAuthDevOpsProvider implements JiraDevOpsProvider {
+    """
+    The human-readable display name of the devOps provider
+    """
+    displayName: String
+    """
+    The link to the web URL of the devOps provider
+    """
+    webUrl: URL
+    """
+    The list of capabilities the devOps provider supports
+
+    This max size of the list is bounded by the total number of enum states
+    """
+    capabilities: [JiraDevOpsCapability]
+    """
+    The link to the icon of the devOps provider
+    """
+    iconUrl: URL
+    """
+    The oauth app ID
+    """
+    oauthAppId: ID
+    """
+    The corresponding marketplace app key for the oauth app
+    """
+    marketplaceAppKey: String
+}
+
+"""
+The internal BB app which provides devOps capabilities
+This provider will be filtered out from the list of providers if BB SCM is not installed
+"""
+type JiraBitbucketDevOpsProvider implements JiraDevOpsProvider {
+    """
+    The human-readable display name of the devOps provider
+    """
+    displayName: String
+    """
+    The link to the web URL of the devOps provider
+    """
+    webUrl: URL
+    """
+    The list of capabilities the devOps provider supports
+
+    This max size of the list is bounded by the total number of enum states
+    """
+    capabilities: [JiraDevOpsCapability]
+}
+
+"""
+The types of capabilities a devOps provider can support
+"""
+enum JiraDevOpsCapability {
+    COMMIT
+    BRANCH
+    PULL_REQUEST
+    BUILD
+    DEPLOYMENT
+    FEATURE_FLAG
+    REVIEW
+}
+"""
+The SCM entities (pullrequest, branches or commits) associated with a Jira issue.
+"""
+type JiraIssueDevInfoDetails {
+    """
+    Created pull-requests associated with a Jira issue.
+    """
+    pullRequests: JiraIssuePullRequests
+    """
+    Created SCM branches associated with a Jira issue.
+    """
+    branches: JiraIssueBranches
+    """
+    Created SCM commits associated with a Jira issue.
+    """
+    commits: JiraIssueCommits
+}
+
+"""
+The container of SCM pull requests info associated with a Jira issue.
+"""
+type JiraIssuePullRequests {
+    """
+    A list of pull request details from the original SCM providers.
+    Maximum of 50 latest updated pull-requests will be returned.
+    """
+    details: [JiraDevOpsPullRequestDetails!]
+    """
+    A list of config errors of underlined data-providers providing pull request details.
+    """
+    configErrors: [JiraDevInfoConfigError!]
+}
+
+"""
+The container of SCM branches info associated with a Jira issue.
+"""
+type JiraIssueBranches {
+    """
+    A list of branches details from the original SCM providers.
+    Maximum of 50 branches will be returned.
+    """
+    details: [JiraDevOpsBranchDetails!]
+    """
+    A list of config errors of underlined data-providers providing branches details.
+    """
+    configErrors: [JiraDevInfoConfigError!]
+}
+
+"""
+The container of SCM commits info associated with a Jira issue.
+"""
+type JiraIssueCommits {
+    """
+    A list of commits details from the original SCM providers.
+    Maximum of 50 latest created commits will be returned.
+    """
+    details: [JiraDevOpsCommitDetails!]
+    """
+    A list of config errors of underlined data-providers providing commit details.
+    """
+    configErrors: [JiraDevInfoConfigError!]
+}
+
+"""
+Details of a SCM Pull-request associated with a Jira issue
+"""
+type JiraDevOpsPullRequestDetails {
+    """
+    Value uniquely identify a pull request scoped to its original scm provider, not ARI format
+    """
+    providerPullRequestId: String,
+    """
+    Entity URL link to pull request in its original provider
+    """
+    entityUrl: URL,
+    """
+    Pull request title
+    """
+    name: String,
+    """
+    The name of the source branch of the PR.
+    """
+    branchName: String,
+    """
+    The timestamp of when the PR last updated in ISO 8601 format.
+    """
+    lastUpdated: DateTime,
+    """
+    Possible states for Pull Requests.
+    """
+    status: JiraPullRequestState,
+    """
+    Details of author who created the Pull Request.
+    """
+    author: JiraDevOpsEntityAuthor,
+    """
+    List of the reviewers for this pull request and their approval status.
+    Maximum of 50 reviewers will be returned.
+    """
+    reviewers: [JiraPullRequestReviewer!],
+}
+
+"""
+Details of a created SCM branch associated with a Jira issue.
+"""
+type JiraDevOpsBranchDetails {
+    """
+    Value uniquely identify the scm branch scoped to its original provider, not ARI format
+    """
+    providerBranchId: String,
+    """
+    Entity URL link to branch in its original provider
+    """
+    entityUrl: URL,
+    """
+    Branch name
+    """
+    name: String,
+    """
+    The scm repository contains the branch.
+    """
+    scmRepository: JiraScmRepository,
+}
+
+"""
+Details of a SCM commit associated with a Jira issue.
+"""
+type JiraDevOpsCommitDetails {
+    """
+    Value uniquely identify the commit (commit-hash), not ARI format.
+    """
+    providerCommitId: String,
+    """
+    Shorten value of the commit-hash, used for display.
+    """
+    displayCommitId: String,
+    """
+    Entity URL link to commit in its original provider
+    """
+    entityUrl: URL,
+    """
+    The commit message.
+    """
+    name: String,
+    """
+    The commit date in ISO 8601 format.
+    """
+    created: DateTime,
+    """
+    Details of author who created the commit.
+    """
+    author: JiraDevOpsEntityAuthor,
+    """
+    Flag represents if the commit is a merge commit.
+    """
+    isMergeCommit: Boolean,
+    """
+    The scm repository contains the commit.
+    """
+    scmRepository: JiraScmRepository,
+}
+
+"""
+Basic person information who created a SCM entity (Pull-request, Branches, or Commit)
+"""
+type JiraDevOpsEntityAuthor {
+    """
+    The author's avatar.
+    """
+    avatar: JiraAvatar,
+    """
+    Author name.
+    """
+    name: String,
+}
+
+"""
+Basic person information who reviews a pull-request.
+"""
+type JiraPullRequestReviewer {
+    """
+    The reviewer's avatar.
+    """
+    avatar: JiraAvatar,
+    """
+    Reviewer name.
+    """
+    name: String,
+    """
+    Represent the approval status from reviewer for the pull request.
+    """
+    hasApproved: Boolean,
+}
+
+"""
+Repository information provided by data-providers.
+"""
+type JiraScmRepository {
+    """
+    Repository name.
+    """
+    name: String
+    """
+    URL link to the repository in scm provider.
+    """
+    entityUrl: URL
+}
+
+"""
+User actionable error details.
+"""
+type JiraDevInfoConfigError {
+    """
+    Type of the error
+    """
+    errorType: JiraDevInfoConfigErrorType
+    """
+    id of the data provider associated with this error
+    """
+    dataProviderId: String
+}
+
+"""
+The possible config error type with a provider that feed devinfo details.
+"""
+enum JiraDevInfoConfigErrorType {
+    UNAUTHORIZED
+    NOT_CONFIGURED
+    INCAPABLE
+    UNKNOWN_CONFIG_ERROR
+}
+"""
+Represents an epic.
+"""
+type JiraEpic {
+    """
+    Global identifier for the epic/issue Id.
+    """
+    id: ID!
+    """
+    Issue Id for the epic.
+    """
+    issueId: String!
+    """
+    Name of the epic.
+    """
+    name: String
+    """
+    Key identifier for the Issue.
+    """
+    key: String
+    """
+    Summary of the epic.
+    """
+    summary: String
+    """
+    Color string for the epic.
+    """
+    color: String
+    """
+    Status of the epic, whether its completed or not.
+    """
+    done: Boolean
+}
+
+"""
+The connection type for JiraEpic.
+"""
+type JiraEpicConnection {
+    """
+    The total count of items in the connection.
+    """
+    totalCount: Int
+    """
+    Information about the current page. Used to aid in pagination.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraEpicEdge]
+}
+
+"""
+An edge in a JiraEpic connection.
+"""
+type JiraEpicEdge {
+    """
+    The node at the edge.
+    """
+    node: JiraEpic
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}
+"""
+Represents the JSM feedback rating.
+"""
+type JiraServiceManagementFeedback {
+    """
+    Represents the integer rating value available on the issue.
+    """
+    rating: Int
+}
+"""
+Represents the Jira flag.
+"""
+type JiraFlag {
+    """
+    Indicates whether the issue is flagged or not.
+    """
+    isFlagged: Boolean
+}
+"""
+Represents a Jira Group.
+"""
+type JiraGroup implements Node {
+    """
+    The global identifier of the group in ARI format.
+    Note: this will be populated with a fake ARI until the Group Rename project is complete.
+    """
+    id: ID!
+    "Group Id, can be null on group creation"
+    groupId: String!
+    "Name of the Group"
+    name: String!
+}
+
+"""
+The connection type for JiraGroup.
+"""
+type JiraGroupConnection {
+    """
+    The total count of items in the connection.
+    """
+    totalCount: Int
+    """
+    Information about the current page. Used to aid in pagination.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraGroupEdge]
+}
+
+"""
+An edge in a JiraGroupConnection connection.
+"""
+type JiraGroupEdge {
+    """
+    The node at the edge.
+    """
+    node: JiraGroup
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}
+"""
+Represents the JSM incident.
+"""
+type JiraServiceManagementIncident {
+    """
+    Indicates whether any incident is linked to the issue or not.
+    """
+    hasLinkedIncidents: Boolean
+}
+"""
+Jira Issue node. Includes the Issue data displayable in the current User context.
+"""
+type JiraIssue implements Node {
+    """
+    Unique identifier associated with this Issue.
+    """
+    id: ID!
+    """
+    Issue ID in numeric format. E.g. 10000
+    """
+    issueId: String!
+    """
+    The {projectKey}-{issueNumber} associated with this Issue.
+    """
+    key: String!
+    """
+    The browser clickable link of this Issue.
+    """
+    webUrl: URL
+    """
+    Loads the fields relevant to the current GraphQL Query, Issue and User contexts.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    fields(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraIssueFieldConnection
+    """
+    Paginated list of fields available on this issue. Allows clients to specify fields by their identifier.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    fieldsById(
+        """
+        A list of field identifiers corresponding to the fields to be returned.
+        E.g. ["ari:cloud:jira:{siteId}:issuefieldvalue/{issueId}/description", "ari:cloud:jira:{siteId}:issuefieldvalue/{issueId}/customfield_10000"].
+        """
+        ids: [ID!]!
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraIssueFieldConnection
+    """
+    Paginated list of comments available on this issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    comments(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraCommentConnection
+    """
+    Paginated list of worklogs available on this issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    worklogs(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraWorkLogConnection
+    """
+    Paginated list of attachments available on this issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    attachments(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraAttachmentConnection
+    """
+    Loads all field sets relevant to the current context for the Issue.
+    """
+    fieldSets(
+        """
+        The number of items after the cursor to be returned, if not specified it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items, if not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items to be sliced away from the bottom of the list after slicing with `first` argument.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items, if not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraIssueFieldSetConnection
+    """
+    Loads all field sets for a specified JiraIssueSearchView.
+    """
+    fieldSetsForIssueSearchView(
+        """
+        The namespace for a JiraIssueSearchView.
+        """
+        namespace: String
+        """
+        The viewId for a JiraIssueSearchView.
+        """
+        viewId: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String): JiraIssueFieldSetConnection
+
+    """
+    Loads the given field sets for the JiraIssue
+    """
+    fieldSetsById(
+        """
+        The identifiers of the field sets to retrieve e.g. ["assignee", "reporter", "checkbox_cf[Checkboxes]"]
+        """
+        fieldSetIds: [String!]!
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String): JiraIssueFieldSetConnection
+
+    """
+    Paginated list of issue links available on this issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    issueLinks(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraIssueLinkConnection
+    """
+    The childIssues within this issue.
+    """
+    childIssues: JiraChildIssues
+    """
+    The dev summary cache. This could be stale.
+    """
+    devSummaryCache: JiraIssueDevSummaryResult
+
+    """
+    The SCM development-info entities (pullrequests, branches, commits) associated with a Jira issue.
+    """
+    devInfoDetails: JiraIssueDevInfoDetails
+    """
+    Returns the hierarchy info that's directly below the current issue's hierarchy if the current issue's project is TMP.
+    """
+    hierarchyLevelBelow: JiraIssueTypeHierarchyLevel
+    """
+    Returns the hierarchy info that's directly below the current issue's hierarchy.
+    """
+    hierarchyLevelAbove: JiraIssueTypeHierarchyLevel
+    """
+    Returns the issue types within the same project and are directly below the current issue's hierarchy if the current issue's project is TMP.
+    """
+    issueTypesForHierarchyBelow: JiraIssueTypeConnection
+    """
+    Returns the issue types within the same project and are directly above the current issue's hierarchy.
+    """
+    issueTypesForHierarchyAbove: JiraIssueTypeConnection
+    """
+    Returns the issue types within the same project that are at the same level as the current issue's hierarchy if the current issue's project is TMP.
+    """
+    issueTypesForHierarchySame: JiraIssueTypeConnection
+    """
+    Indicates that there was at least one error in retrieving data for this Jira issue.
+    """
+    errorRetrievingData: Boolean @deprecated(reason: "Intended only for feature parity with legacy experiences.")
+    """
+    The story points field for the given issue.
+    """
+    storyPointsField: JiraNumberField
+    """
+    The story point estimate field for the given issue.
+    """
+    storyPointEstimateField: JiraNumberField
+    """
+    Returns the ID of the screen the issue is on.
+    """
+    screenId: Long @deprecated(reason: "The screen concept has been deprecated, and is only used for legacy reasons.")
+}
+
+"""
+The connection type for JiraIssue.
+"""
+type JiraIssueConnection {
+    """
+    The total count of items in the connection.
+    """
+    totalCount: Int
+    """
+    Information about the current page. Used to aid in pagination.
+    """
+    pageInfo: PageInfo!
+    """
+    jql if issues are returned by jql. This field will have value only when the context has jql
+    """
+    jql: String
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraIssueEdge]
+    """
+    The error that occurred during an issue search.
+    """
+    issueSearchError: JiraIssueSearchError
+
+    """
+    The total number of issues for a given JQL search.
+    This number will be capped based on the server's configured limit.
+    """
+    totalIssueSearchResultCount: Int
+
+    """
+    Returns whether or not there were more issues available for a given issue search.
+    """
+    isCappingIssueSearchResult: Boolean
+
+    """
+    Extra page information for the issue navigator.
+    """
+    issueNavigatorPageInfo: JiraIssueNavigatorPageInfo
+
+    """
+    Cursors to help with random access pagination.
+    """
+    pageCursors(maxCursors: Int!): JiraPageCursors
+}
+
+"""
+An edge in a JiraIssue connection.
+"""
+type JiraIssueEdge {
+    """
+    The node at the edge.
+    """
+    node: JiraIssue
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}
+
+"""
+Represents a field set which contains a set of JiraIssueFields, otherwise commonly referred to as collapsed fields.
+"""
+type JiraIssueFieldSet {
+    """
+    The identifer of the field set e.g. `assignee`, `reporter`, `checkbox_cf[Checkboxes]`.
+    """
+    fieldSetId: String
+    """
+    The field type key of the contained fields e.g: `project`, `issuetype`, `com.pyxis.greenhopper.jira:gh-epic-link`.
+    """
+    type: String
+    """
+    Retrieves a connection of JiraIssueFields
+    """
+    fields(
+        """
+        The number of items after the cursor to be returned, if not specified it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items, if not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items to be sliced away from the bottom of the list after slicing with `first` argument.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items, if not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraIssueFieldConnection
+}
+
+"""
+An edge in a JiraIssueFieldSet connection.
+"""
+type JiraIssueFieldSetEdge {
+    """
+    The node at the the edge.
+    """
+    node: JiraIssueFieldSet
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}
+
+"""
+The connection type for JiraIssueFieldSet.
+"""
+type JiraIssueFieldSetConnection {
+    """
+    The total number of JiraIssueFields matching the criteria.
+    """
+    totalCount: Int
+    """
+    The page info of the current page of results.
+    """
+    pageInfo: PageInfo
+    """
+    The data for Edges in the current page.
+    """
+    edges: [JiraIssueFieldSetEdge]
+}
+
+"""
+Extra page information to assist the Issue Navigator UI to display information about the current set of issues.
+"""
+type JiraIssueNavigatorPageInfo {
+    """
+    The position of the first issue in the current page, relative to the entire stable search.
+    The first issue's position will start at 1.
+    If there are no issues, the position returned is 0.
+    You can consider a position to effectively be a traditional index + 1.
+    """
+    firstIssuePosition: Int
+    """
+    The position of the last issue in the current page, relative to the entire stable search.
+    If there is only 1 issue, the last position is 1.
+    If there are no issues, the position returned is 0.
+    You can consider a position to effectively be a traditional index + 1.
+    """
+    lastIssuePosition: Int
+    """
+    The issue key of the first node from the next page of issues.
+    """
+    firstIssueKeyFromNextPage: String
+    """
+    The issue key of the last node from the previous page of issues.
+    """
+    lastIssueKeyFromPreviousPage: String
+}
+
+"""
+The base type cursor data necessary for random access pagination.
+"""
+type JiraPageCursor {
+    """
+    This is a Base64 encoded value containing the all the necessary data for retrieving the page items.
+    """
+    cursor: String
+    """
+    The number of the page it represents. First page is 1.
+    """
+    pageNumber: Int
+    """
+    Indicates if this page is the current page. Usually the current page is represented differently on the FE.
+    """
+    isCurrent: Boolean
+}
+
+"""
+This encapsulates all the necessary cursors for random access pagination.
+"""
+type JiraPageCursors {
+    """
+    Represents the cursor for the first page.
+    """
+    first: JiraPageCursor
+    """
+    Represents a list of cursors around the current page.
+    Even if the list is not bounded, there are strict limits set on the server (MAX_SIZE <= 7).
+    """
+    around: [JiraPageCursor]
+    """
+    Represents the cursor for the last page.
+    """
+    last: JiraPageCursor
+    """
+    Represents the cursor for the previous page.
+    E.g. currentPage=2 => previousPage=1
+    """
+    previous: JiraPageCursor
+}
+"""
+Represents a collection of system container types to be fetched by passing in an issue id.
+"""
+input JiraIssueItemSystemContainerTypeWithIdInput {
+    """
+    ARI of the issue.
+    """
+    issueId: ID!
+    """
+    The collection of system container types.
+    """
+    systemContainerTypes: [JiraIssueItemSystemContainerType!]!
+}
+
+"""
+Represents a collection of system container types to be fetched by passing in an issue key and a cloud id.
+"""
+input JiraIssueItemSystemContainerTypeWithKeyInput {
+    """
+    The {projectKey}-{issueNumber} associated with this Issue.
+    """
+    issueKey: String!
+    """
+    The cloudId associated with this Issue.
+    """
+    cloudId: ID!
+    """
+    The collection of system container types.
+    """
+    systemContainerTypes: [JiraIssueItemSystemContainerType!]!
+}
+
+"""
+Contains the fetched containers or an error.
+"""
+union JiraIssueItemContainersResult = JiraIssueItemContainers | QueryError
+
+"""
+Represents a related collection of system containers and their items, and the collection of default item locations.
+"""
+type JiraIssueItemContainers {
+    #id: ID - An id has not been added yet to allow room to make this a Node in future.
+    """
+    The collection of system containers.
+    """
+    containers: [JiraIssueItemContainer]
+    """
+    The collection of default item locations.
+    """
+    defaultItemLocations: [JiraIssueItemLayoutDefaultItemLocation]
+}
+"""
+Represents a system container and its items.
+"""
+type JiraIssueItemContainer {
+    """
+    The system container type.
+    """
+    containerType: JiraIssueItemSystemContainerType
+    """
+    The system container items.
+    """
+    items: JiraIssueItemContainerItemConnection
+}
+
+"""
+The connection type for `JiraIssueItemContainerItem`.
+"""
+type JiraIssueItemContainerItemConnection {
+    """
+    Information about the page. Used to aid in pagination.
+    """
+    pageInfo: PageInfo!
+    """
+    Deprecated.
+    """
+    nodes: [JiraIssueItemContainerItem] @deprecated(reason: "Please use edges instead.")
+    """
+    The data for edges in the page.
+    """
+    edges: [JiraIssueItemContainerItemEdge]
+    """
+    The total count of items in the connection.
+    """
+    totalCount: Int
+}
+
+"""
+An edge in a `JiraIssueItemContainerItem` connection.
+"""
+type JiraIssueItemContainerItemEdge {
+    """
+    The node at the edge.
+    """
+    node: JiraIssueItemContainerItem
+    """
+    The cursor to the edge.
+    """
+    cursor: String!
+}
+
+"""
+The system container types that are available for placing items.
+"""
+enum JiraIssueItemSystemContainerType {
+    """
+    The container type for the request portal in JSM projects.
+    """
+    REQUEST_PORTAL
+    """
+    The container type for the issue content.
+    """
+    CONTENT
+    """
+    The container type for the issue primary context.
+    """
+    PRIMARY
+    """
+    The container type for the issue secondary context.
+    """
+    SECONDARY
+    """
+    The container type for the issue context.
+    """
+    CONTEXT
+    """
+    The container type for the issue hidden items.
+    """
+    HIDDEN_ITEMS
+    """
+    The container type for the request in JSM projects.
+    """
+    REQUEST
+}
+
+"""
+Represents a default location rule for items that are not configured in a container.
+Example: A user picker is added to a screen. Until the administrator places it in the layout, the item is placed in
+the location specified by the 'PEOPLE' category. The categories available may vary based on the project type.
+"""
+type JiraIssueItemLayoutDefaultItemLocation {
+    """
+    A destination container type or the ID of a destination group.
+    """
+    containerLocation: String
+    """
+    The item location rule type.
+    """
+    itemLocationRuleType: JiraIssueItemLayoutItemLocationRuleType
+}
+
+"""
+Represents the type of items that the default location rule applies to.
+"""
+enum JiraIssueItemLayoutItemLocationRuleType {
+    """
+    People items. For example: user pickers, team pickers or group picker.
+    """
+    PEOPLE
+    """
+    Multiline text items. For example: a description field or custom multi-line test fields.
+    """
+    MULTILINE_TEXT
+    """
+    Time tracking items. For example: estimate, original estimate or time tracking panels.
+    """
+    TIMETRACKING
+    """
+    Date items. For example: date or time related fields.
+    """
+    DATES
+    """
+    Any other item types not covered by previous item types.
+    """
+    OTHER
+}
+
+"""
+Represents the items that can be placed in any system container.
+"""
+union JiraIssueItemContainerItem = JiraIssueItemFieldItem | JiraIssueItemPanelItem | JiraIssueItemGroupContainer | JiraIssueItemTabContainer
+
+"""
+Represents the items that can be placed in any group container.
+"""
+union JiraIssueItemGroupContainerItem = JiraIssueItemFieldItem | JiraIssueItemPanelItem
+
+"""
+Represents the items that can be placed in any tab container.
+"""
+union JiraIssueItemTabContainerItem = JiraIssueItemFieldItem
+
+"""
+Represents a collection of items that are held in a tab container.
+"""
+type JiraIssueItemTabContainer {
+    """
+    The tab container ID.
+    """
+    tabContainerId: String!
+    """
+    The tab container name.
+    """
+    name: String
+    """
+    The tab container items.
+    """
+    items: JiraIssueItemTabContainerItemConnection
+}
+
+"""
+Represents a collection of items that are held in a group container.
+"""
+type JiraIssueItemGroupContainer {
+    """
+    The group container ID.
+    """
+    groupContainerId: String!
+    """
+    The group container name.
+    """
+    name: String
+    """
+    Whether a group container is minimized.
+    """
+    minimised: Boolean
+    """
+    The group container items.
+    """
+    items: JiraIssueItemGroupContainerItemConnection
+}
+
+"""
+The connection type for `JiraIssueItemGroupContainerItem`.
+"""
+type JiraIssueItemGroupContainerItemConnection {
+    """
+    Information about the page. Used to aid in pagination.
+    """
+    pageInfo: PageInfo!
+    """
+    Deprecated.
+    """
+    nodes: [JiraIssueItemGroupContainerItem] @deprecated(reason: "Please use edges instead.")
+    """
+    The data for edges in the page.
+    """
+    edges: [JiraIssueItemGroupContainerItemEdge]
+    """
+    The total count of items in the connection.
+    """
+    totalCount: Int
+}
+
+"""
+An edge in a `JiraIssueItemGroupContainerItem` connection.
+"""
+type JiraIssueItemGroupContainerItemEdge {
+    """
+    The node at the edge.
+    """
+    node: JiraIssueItemGroupContainerItem
+    """
+    The cursor to the edge.
+    """
+    cursor: String!
+}
+
+"""
+The connection type for `JiraIssueItemTabContainerItem`.
+"""
+type JiraIssueItemTabContainerItemConnection {
+    """
+    Information about the page. Used to aid in pagination.
+    """
+    pageInfo: PageInfo!
+    """
+    Deprecated.
+    """
+    nodes: [JiraIssueItemTabContainerItem] @deprecated(reason: "Please use edges instead.")
+    """
+    The data for edges in the page.
+    """
+    edges: [JiraIssueItemTabContainerItemEdge]
+    """
+    The total count of items in the connection.
+    """
+    totalCount: Int
+}
+
+"""
+An edge in a `JiraIssueItemTabContainerItem` connection.
+"""
+type JiraIssueItemTabContainerItemEdge {
+    """
+    The node at the edge.
+    """
+    node: JiraIssueItemTabContainerItem
+    """
+    The cursor to the edge.
+    """
+    cursor: String!
+}
+
+"""
+Represents a reference to a field by field ID, used for laying out fields on an issue.
+"""
+type JiraIssueItemFieldItem {
+    """
+    The field item ID.
+    """
+    fieldItemId: String!
+    """
+    Represents the position of the field in the container.
+    Aid to preserve the field position when combining items in `PRIMARY` and `REQUEST` container types before saving in JSM projects.
+    """
+    containerPosition: Int!
+}
+
+"""
+Represents a reference to a panel by panel ID, used for laying out panels on an issue.
+"""
+type JiraIssueItemPanelItem {
+    """
+    The panel item ID.
+    """
+    panelItemId: String!
+}
+"""
+Container for the Dev Summary of an issue
+"""
+type JiraIssueDevSummaryResult {
+  """
+  Contains all available summaries for the issue
+  """
+  devSummary: JiraIssueDevSummary
+
+  """
+  Returns "transient errors". That is, errors that may be solved by retrying the fetch operation. 
+  This excludes configuration errors that require admin intervention to be solved.
+  """
+  errors: [JiraIssueDevSummaryError!]
+  """
+  Returns "non-transient errors". That is, configuration errors that require admin intervention to be solved. 
+  This returns an empty collection when called for users that are not administrators or system administrators.
+  """
+  configErrors: [JiraIssueDevSummaryError!]
+}
+
+"""
+Lists the summaries available for each type of dev info, for a given issue
+"""
+type JiraIssueDevSummary {
+  """
+  Summary of the Branches attached to the issue
+  """
+  branch: JiraIssueBranchDevSummaryContainer
+  """
+  Summary of the Commits attached to the issue
+  """
+  commit: JiraIssueCommitDevSummaryContainer
+  """
+  Summary of the Pull Requests attached to the issue
+  """
+  pullrequest: JiraIssuePullRequestDevSummaryContainer
+  """
+  Summary of the Builds attached to the issue
+  """
+  build: JiraIssueBuildDevSummaryContainer
+  """
+  Summary of the Reviews attached to the issue
+  """
+  review: JiraIssueReviewDevSummaryContainer
+  """
+  Summary of the deployment environments attached to some builds.
+  This is a legacy attribute only used by Bamboo builds
+  """
+  deploymentEnvironments: JiraIssueDeploymentEnvironmentDevSummaryContainer
+}
+
+"""
+Aggregates the `count` of entities for a given provider
+"""
+type JiraIssueDevSummaryByProvider {
+  """
+  UUID for a given provider, to allow aggregation
+  """
+  providerId: String
+  """
+  Provider name
+  """
+  name: String
+  """
+  Number of entities associated with that provider
+  """
+  count: Int
+}
+
+"""
+Error when querying the JiraIssueDevSummary
+"""
+type JiraIssueDevSummaryError {
+  """
+  A message describing the error
+  """
+  message: String
+  """
+  Information about the provider that triggered the error
+  """
+  instance: JiraIssueDevSummaryErrorProviderInstance
+}
+
+"""
+Basic information on a provider that triggered an error
+"""
+type JiraIssueDevSummaryErrorProviderInstance {
+  """
+  Provider's name
+  """
+  name: String
+  """
+  Provider's type
+  """
+  type: String
+  """
+  Base URL of the provider's instance that failed
+  """
+  baseUrl: String
+}
+
+"""
+Container for the summary of the Branches attached to the issue
+"""
+type JiraIssueBranchDevSummaryContainer {
+  """
+  The actual summary of the Branches attached to the issue
+  """
+  overall: JiraIssueBranchDevSummary
+  """
+  Count of Branches aggregated per provider
+  """
+  summaryByProvider: [JiraIssueDevSummaryByProvider!]
+}
+
+"""
+Summary of the Branches attached to the issue
+"""
+type JiraIssueBranchDevSummary {
+  """
+  Total number of Branches for the issue
+  """
+  count: Int
+  """
+  Date at which this summary was last updated
+  """
+  lastUpdated: DateTime
+}
+
+"""
+Container for the summary of the Commits attached to the issue
+"""
+type JiraIssueCommitDevSummaryContainer {
+  """
+  The actual summary of the Commits attached to the issue
+  """
+  overall: JiraIssueCommitDevSummary
+  """
+  Count of Commits aggregated per provider
+  """
+  summaryByProvider: [JiraIssueDevSummaryByProvider!]
+}
+
+"""
+Summary of the Commits attached to the issue
+"""
+type JiraIssueCommitDevSummary {
+  """
+  Total number of Commits for the issue
+  """
+  count: Int
+  """
+  Date at which this summary was last updated
+  """
+  lastUpdated: DateTime
+}
+
+"""
+Container for the summary of the Pull Requests attached to the issue
+"""
+type JiraIssuePullRequestDevSummaryContainer {
+  """
+  The actual summary of the Pull Requests attached to the issue
+  """
+  overall: JiraIssuePullRequestDevSummary
+  """
+  Count of Pull Requests aggregated per provider
+  """
+  summaryByProvider: [JiraIssueDevSummaryByProvider!]
+}
+
+"""
+Summary of the Pull Requests attached to the issue
+"""
+type JiraIssuePullRequestDevSummary {
+  """
+  Total number of Pull Requests for the issue
+  """
+  count: Int
+  """
+  Date at which this summary was last updated
+  """
+  lastUpdated: DateTime
+
+  """
+  State of the Pull Requests in the summary
+  """
+  state: JiraPullRequestState
+  """
+  Number of Pull Requests for the state
+  """
+  stateCount: Int
+  """
+  Whether the Pull Requests for the given state are open or not
+  """
+  open: Boolean
+}
+
+"""
+Possible states for Pull Requests
+"""
+enum JiraPullRequestState {
+  """
+  Pull Request is Open
+  """
+  OPEN
+  """
+  Pull Request is Declined
+  """
+  DECLINED
+  """
+  Pull Request is Merged
+  """
+  MERGED
+}
+
+"""
+Container for the summary of the Builds attached to the issue
+"""
+type JiraIssueBuildDevSummaryContainer {
+  """
+  The actual summary of the Builds attached to the issue
+  """
+  overall: JiraIssueBuildDevSummary
+  """
+  Count of Builds aggregated per provider
+  """
+  summaryByProvider: [JiraIssueDevSummaryByProvider!]
+}
+
+"""
+Summary of the Builds attached to the issue
+"""
+type JiraIssueBuildDevSummary {
+  """
+  Total number of Builds for the issue
+  """
+  count: Int
+  """
+  Date at which this summary was last updated
+  """
+  lastUpdated: DateTime
+
+  """
+  Number of failed buids for the issue
+  """
+  failedBuildCount: Int
+  """
+  Number of successful buids for the issue
+  """
+  successfulBuildCount: Int
+  """
+  Number of buids with unknown result for the issue
+  """
+  unknownBuildCount: Int
+}
+
+"""
+Container for the summary of the Reviews attached to the issue
+"""
+type JiraIssueReviewDevSummaryContainer {
+  """
+  The actual summary of the Reviews attached to the issue
+  """
+  overall: JiraIssueReviewDevSummary
+  """
+  Count of Reviews aggregated per provider
+  """
+  summaryByProvider: [JiraIssueDevSummaryByProvider!]
+}
+
+"""
+Summary of the Reviews attached to the issue
+"""
+type JiraIssueReviewDevSummary {
+  """
+  Total number of Reviews for the issue
+  """
+  count: Int
+  """
+  Date at which this summary was last updated
+  """
+  lastUpdated: DateTime
+
+  """
+  State of the Reviews in the summary
+  """
+  state: JiraReviewState
+  """
+  Number of Reviews for the state
+  """
+  stateCount: Int
+}
+
+"""
+Possible states for Reviews
+"""
+enum JiraReviewState {
+  """
+  Review is in Review state
+  """
+  REVIEW
+  """
+  Review is in Require Approval state
+  """
+  APPROVAL
+  """
+  Review is in Summarize state
+  """
+  SUMMARIZE
+  """
+  Review has been rejected
+  """
+  REJECTED
+  """
+  Review has been closed
+  """
+  CLOSED
+  """
+  Review is in Draft state
+  """
+  DRAFT
+  """
+  Review is in Dead state
+  """
+  DEAD
+  """
+  Review state is unknown
+  """
+  UNKNOWN
+}
+
+"""
+Container for the summary of the Deployment Environments attached to the issue
+"""
+type JiraIssueDeploymentEnvironmentDevSummaryContainer {
+  """
+  The actual summary of the Deployment Environments attached to the issue
+  """
+  overall: JiraIssueDeploymentEnvironmentDevSummary
+  """
+  Count of Deployment Environments aggregated per provider
+  """
+  summaryByProvider: [JiraIssueDevSummaryByProvider!]
+}
+
+"""
+Summary of the Deployment Environments attached to the issue
+"""
+type JiraIssueDeploymentEnvironmentDevSummary {
+  """
+  Total number of Reviews for the issue
+  """
+  count: Int
+  """
+  Date at which this summary was last updated
+  """
+  lastUpdated: DateTime
+
+  """
+  A list of the top environment there was a deployment on
+  """
+  topEnvironments: [JiraIssueDeploymentEnvironment!]
+}
+
+type JiraIssueDeploymentEnvironment {
+  """
+  Title of the deployment environment
+  """
+  title: String
+  """
+  State of the deployment
+  """
+  status: JiraIssueDeploymentEnvironmentState
+}
+
+"""
+Possible states for a deployment environment
+"""
+enum JiraIssueDeploymentEnvironmentState {
+  """
+  The deployment was not deployed successfully
+  """
+  NOT_DEPLOYED
+  """
+  The deployment was deployed successfully
+  """
+  DEPLOYED
+}"""
+Represents the common structure across Issue fields.
+"""
+interface JiraIssueField implements Node {
+    """
+    Unique identifier for the entity.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias.
+    Applies to managed or commonly known custom fields in Jira, which allow lookup without requiring the custom field ID.
+    E.g. rank or startdate.
+    """
+    aliasFieldId: ID
+    """
+    Field type key. E.g. project, issuetype, com.pyxis.greenhopper.Jira:gh-epic-link.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+}
+
+"""
+The connection type for JiraIssueField.
+"""
+type JiraIssueFieldConnection {
+    """
+    The total count of items in the connection.
+    """
+    totalCount: Int
+    """
+    Information about the current page. Used to aid in pagination.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraIssueFieldEdge]
+}
+
+union JiraIssueFieldConnectionResult = JiraIssueFieldConnection | QueryError
+
+"""
+An edge in a JiraIssueField connection.
+"""
+type JiraIssueFieldEdge {
+    """
+    The node at the edge.
+    """
+    node: JiraIssueField
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}
+
+"""
+Represents the configurations associated with an Issue field.
+"""
+interface JiraIssueFieldConfiguration {
+    """
+    Attributes of an Issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+}
+
+"""
+Attributes of field configuration.
+"""
+type JiraFieldConfig {
+    """
+    Defines if a field is required on a screen.
+    """
+    isRequired: Boolean
+    """
+    Defines if a field is editable.
+    """
+    isEditable: Boolean
+    """
+    Explains the reason why a field is not editable on a screen.
+    E.g. cases where a field needs a licensed premium version to be editable.
+    """
+    nonEditableReason: JiraFieldNonEditableReason
+}
+
+"""
+Attributes of CMDB field configuration.
+"""
+type JiraCmdbFieldConfig {
+    """
+    The object schema ID associated with the CMDB object.
+    """
+    objectSchemaId: String!
+    """
+    The object filter query.
+    """
+    objectFilterQuery: String
+    """
+    The issue scope filter query.
+    """
+    issueScopeFilterQuery: String
+    """
+    Indicates whether this CMDB field should contain multiple CMDB objects or not.
+    """
+    multiple: Boolean
+    """
+    Paginated list of CMDB attributes displayed on issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    attributesDisplayedOnIssue(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraCmdbConfigAttributeConnection
+    """
+    Paginated list of CMDB attributes included in autocomplete search.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    attributesIncludedInAutoCompleteSearch(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraCmdbConfigAttributeConnection
+}
+
+"""
+The connection type for CMDB config attributes.
+"""
+type JiraCmdbConfigAttributeConnection {
+    """
+    The total count of items in the connection.
+    """
+    totalCount: Int
+    """
+    Information about the current page. Used to aid in pagination.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraCmdbConfigAttributeEdge]
+}
+
+"""
+An edge in a JiraCmdbConfigAttributeConnection.
+"""
+type JiraCmdbConfigAttributeEdge {
+    """
+    The node at the edge.
+    """
+    node: String
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}
+
+"""
+Represents the information for a field being non-editable on Issue screens.
+"""
+type JiraFieldNonEditableReason {
+    """
+    Message explanining why the field is non-editable (if present).
+    """
+    message: String
+}
+
+"""
+Represents user made configurations associated with an Issue field.
+"""
+interface JiraUserIssueFieldConfiguration {
+    """
+    Attributes of an Issue field configuration info from a user's customisation.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Attributes of user made field configurations.
+"""
+type JiraUserFieldConfig {
+    """
+    Defines whether a field has been pinned by the user.
+    """
+    isPinned: Boolean
+    """
+    Defines if the user has preferred to check a field on Issue creation.
+    """
+    isSelected: Boolean
+}
+
+"""
+Represents a priority field on a Jira Issue.
+"""
+type JiraPriorityField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The priority selected on the Issue or default priority configured for the field.
+    """
+    priority: JiraPriority
+    """
+    Paginated list of priority options for the field or on an Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    priorities(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+        """
+        Determines if the results should be limited to suggested priorities.
+        """
+        suggested: Boolean
+    ): JiraPriorityConnection
+    """
+    Attributes of an Issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents a project field on a Jira Issue.
+Both the system & custom project field can be represented by this type.
+"""
+type JiraProjectField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The ID of the project field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The project selected on the Issue or default project configured for the field.
+    """
+    project: JiraProject
+    """
+    List of project options available for this field to be selected.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    projects(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+        """
+        Returns the recent items based on user history.
+        """
+        recent: Boolean = false
+    ) : JiraProjectConnection
+    """
+    Search url to fetch all available projects options on the field or an Issue.
+    To be deprecated once project connection is supported for custom project fields.
+    """
+    searchUrl: String @deprecated(reason: "Search URLs are planned to be replaced by Connections.")
+    """
+    Attributes of an Issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents an issue type field on a Jira Issue.
+"""
+type JiraIssueTypeField implements Node & JiraIssueField & JiraIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """"
+    The issue type selected on the Issue or default issue type configured for the field.
+    """
+    issueType: JiraIssueType
+    """
+    List of issuetype options available to be selected for the field.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    issueTypes(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+        """
+        Returns the recent items based on user history.
+        """
+        suggested: Boolean
+    ): JiraIssueTypeConnection
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+}
+
+"""
+Represents a rich text field on a Jira Issue. E.g. description, environment.
+"""
+type JiraRichTextField implements Node & JiraIssueField  & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The rich text selected on the Issue or default rich text configured for the field.
+    """
+    richText: JiraRichText
+    """
+    Determines what editor to render.
+    E.g. default text rendering or wiki text rendering.
+    """
+    renderer: String
+    """
+    Contains the information needed to add media content to the field.
+    """
+    mediaContext: JiraMediaContext
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents a version field on a Jira Issue. E.g. custom version picker field.
+"""
+type JiraSingleVersionPickerField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The version selected on the Issue or default version configured for the field.
+    """
+    version: JiraVersion
+    """
+    Paginated list of versions options for the field or on a Jira Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    versions(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+        """
+        Returns the recent items based on user history.
+        """
+        suggested: Boolean
+    ): JiraVersionConnection
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents a multi version picker field on a Jira Issue. E.g. fixVersions and multi version custom field.
+"""
+type JiraMultipleVersionPickerField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The versions selected on the Issue or default versions configured for the field.
+    """
+    selectedVersions: [JiraVersion] @deprecated(reason: "Please use selectedVersionsConnection instead.")
+    """
+    The versions selected on the Issue or default versions configured for the field.
+    """
+    selectedVersionsConnection(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraVersionConnection
+    """
+    Paginated list of versions options for the field or on a Jira Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    versions(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+        """
+        Returns the recent items based on user history.
+        """
+        suggested: Boolean
+    ): JiraVersionConnection
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents a labels field on a Jira Issue. Both system & custom field can be represented by this type.
+"""
+type JiraLabelsField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The labels selected on the Issue or default labels configured for the field.
+    """
+    selectedLabels: [JiraLabel] @deprecated(reason: "Please use selectedLabelsConnection instead.")
+    """
+    The labels selected on the Issue or default labels configured for the field.
+    """
+    selectedLabelsConnection(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraLabelConnection
+    """
+    Paginated list of label options for the field or the Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    labels(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+        """
+        Returns the recent items based on user history.
+        """
+        suggested: Boolean
+    ): JiraLabelConnection
+    """
+    Search url to fetch all available label options on a field or an Issue.
+    """
+    searchUrl: String @deprecated(reason: "Search URLs are planned to be replaced by Connections.")
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents a single select user field on a Jira Issue. E.g. assignee, reporter, custom user picker.
+"""
+type JiraSingleSelectUserPickerField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The user selected on the Issue or default user configured for the field.
+    """
+    user: User
+    """
+    Paginated list of user options available for the field or the Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    users(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+        """
+        Returns the recent items based on user history.
+        """
+        suggested: Boolean
+    ): JiraUserConnection
+    """
+    Search url to fetch all available users options for the field or the Issue.
+    """
+    searchUrl: String @deprecated(reason: "Search URLs are planned to be replaced by Connections.")
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents a multi select user picker field on a Jira Issue. E.g. custom user picker, sd-request-participants.
+"""
+type JiraMultipleSelectUserPickerField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the entity.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key of the field.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The users selected on the Issue or default users configured for the field.
+    """
+    selectedUsers: [User] @deprecated(reason: "Please use selectedUsersConnection instead.")
+    """
+    The users selected on the Issue or default users configured for the field.
+    """
+    selectedUsersConnection(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraUserConnection
+    """
+    Paginated list of user options available for the field or the Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    users(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+        """
+        Returns the recent items based on user history.
+        """
+        suggested: Boolean
+    ): JiraUserConnection
+    """
+    Search url to fetch all available users options for the field or the Issue.
+    """
+    searchUrl: String @deprecated(reason: "Search URLs are planned to be replaced by Connections.")
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+
+"""
+Represents a people picker field on a Jira Issue. E.g. people custom field, servicedesk-approvers-list.
+"""
+type JiraPeopleField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The people selected on the Issue or default people configured for the field.
+    """
+    selectedUsers: [User] @deprecated(reason: "Please use selectedUsersConnection instead.")
+    """
+    The users selected on the Issue or default users configured for the field.
+    """
+    selectedUsersConnection(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraUserConnection
+    """
+    Whether the field is configured to act as single/multi select user(s) field.
+    """
+    isMulti: Boolean
+    """
+    Paginated list of user options available for the field or the Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    users(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+        """
+        Returns the recent items based on user history.
+        """
+        suggested: Boolean
+    ): JiraUserConnection
+    """
+    Search url to fetch all available users options for the field or the Issue.
+    """
+    searchUrl: String @deprecated(reason: "Search URLs are planned to be replaced by Connections.")
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents a date time picker field on a Jira Issue. E.g. created, resolution date, custom date time, request-feedback-date.
+"""
+type JiraDateTimePickerField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The datetime selected on the Issue or default datetime configured for the field.
+    """
+    dateTime: DateTime
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents a date picker field on an issue. E.g. due date, custom date picker, baseline start, baseline end.
+"""
+type JiraDatePickerField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The date selected on the Issue or default date configured for the field.
+    """
+    date: Date
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents a resolution field on a Jira Issue.
+"""
+type JiraResolutionField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The resolution selected on the Issue or default resolution configured for the field.
+    """
+    resolution: JiraResolution
+    """
+    Paginated list of resolution options available for the field or the Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    resolutions(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+        """
+        Returns the recent items based on user history.
+        """
+        suggested: Boolean
+    ): JiraResolutionConnection
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents a number field on a Jira Issue. E.g. float, story points.
+"""
+type JiraNumberField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The number selected on the Issue or default number configured for the field.
+    """
+    number: Float
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+    """
+    Returns if the current number field is a story point field
+    """
+    isStoryPointField: Boolean @deprecated(reason: "Story point field is treated as a special field only on issue view")
+}
+
+"""
+Represents single line text field on a Jira Issue. E.g. summary, epic name, custom text field.
+"""
+type JiraSingleLineTextField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The text selected on the Issue or default text configured for the field.
+    """
+    text: String
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents epic link field on a Jira Issue.
+"""
+type JiraEpicLinkField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The epic selected on the Issue or default epic configured for the field.
+    """
+    epic: JiraEpic
+    """
+    Paginated list of epic options available for the field or the Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    epics(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+        """
+        Set to true to search only for epics that are done, false otherwise.
+        """
+        done: Boolean
+    ): JiraEpicConnection
+    """
+    Search url to fetch all available epics options for the field or the Issue.
+    """
+    searchUrl: String @deprecated(reason: "Search URLs are planned to be replaced by Connections.")
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents components field on a Jira Issue.
+"""
+type JiraComponentsField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The component selected on the Issue or default component configured for the field.
+    """
+    selectedComponents: [JiraComponent] @deprecated(reason: "Please use selectedComponentsConnection instead.")
+    """
+    The component selected on the Issue or default component configured for the field.
+    """
+    selectedComponentsConnection(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraComponentConnection
+    """
+    Paginated list of component options available for the field or the Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    components(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraComponentConnection
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents url field on a Jira Issue.
+"""
+type JiraUrlField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The url selected on the Issue or default url configured for the field. (deprecated)
+    """
+    url: URL @deprecated(reason: "Please use urlValue; replaced Url with String to accommodate values that are URI but not URL")
+    """
+    The url selected on the Issue or default url configured for the field.
+    """
+    urlValue: String
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents sprint field on a Jira Issue.
+"""
+type JiraSprintField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The sprints selected on the Issue or default sprints configured for the field.
+    """
+    selectedSprints: [JiraSprint] @deprecated(reason: "Please use selectedSprintsConnection instead.")
+    """
+    The sprints selected on the Issue or default sprints configured for the field.
+    """
+    selectedSprintsConnection(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraSprintConnection
+    """
+    Paginated list of sprint options available for the field or the Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    sprints(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+        """
+        The Result Sprints fetched will have particular Sprint State eg. ACTIVe.
+        """
+        state: JiraSprintState
+    ): JiraSprintConnection
+    """
+    Search url to fetch all available sprints options for the field or the Issue.
+    """
+    searchUrl: String @deprecated(reason: "Search URLs are planned to be replaced by Connections.")
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents linked issues field on a Jira Issue.
+"""
+type JiraIssueLinkField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    Represents all the issue links defined on a Jira Issue. Should be deprecated and replaced with issueLinksConnection.
+    """
+    issueLinks: [JiraIssueLink] @deprecated(reason: "Please use issueLinkConnection instead.")
+    """
+    Paginated list of issue links selected on the Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    issueLinkConnection(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraIssueLinkConnection
+    """
+    Represents the different issue link type relations/desc which can be mapped/linked to the issue in context.
+    Issue in context is the one which is being created/ which is being queried.
+    """
+    issueLinkTypeRelations(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraIssueLinkTypeRelationConnection
+    """
+    Paginated list of issues which can be related/linked with above issueLinkTypeRelations.
+    """
+    issues(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraIssueConnection
+    """
+    Search url to list all available issues which can be related/linked with above issueLinkTypeRelations.
+    """
+    searchUrl: String @deprecated(reason: "Search URLs are planned to be replaced by Connections.")
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents Parent field on a Jira Issue. E.g. JSW Parent, JPO Parent (to be unified).
+"""
+type JiraParentIssueField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The parent selected on the Issue or default parent configured for the field.
+    """
+    parentIssue: JiraIssue
+    """
+    Represents flags required to determine parent field visibility
+    """
+    parentVisibility: JiraParentVisibility
+    """
+    Search url to fetch all available parents for the field or the Issue.
+    """
+    searchUrl: String @deprecated(reason: "Search URLs are planned to be replaced by Connections.")
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents security level field on a Jira Issue. Issue Security allows you to control who can and cannot view issues.
+"""
+type JiraSecurityLevelField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The security level selected on the Issue or default security level configured for the field.
+    """
+    securityLevel: JiraSecurityLevel
+    """
+    Paginated list of security level options available for the field or the Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    securityLevels(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraSecurityLevelConnection
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents cascading select field. Currently only handles 2 level hierarchy.
+"""
+type JiraCascadingSelectField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The cascading option selected on the Issue or default cascading option configured for the field.
+    """
+    cascadingOption: JiraCascadingOption
+    """
+    Paginated list of cascading options available for the field or the Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    cascadingOptions(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraCascadingOptionsConnection
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents issue restriction field on an issue for next gen projects.
+"""
+type JiraIssueRestrictionField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The roles selected on the Issue or default roles configured for the field.
+    """
+    selectedRoles: [JiraRole] @deprecated(reason: "Please use selectedRolesConnection instead.")
+    """
+    The roles selected on the Issue or default roles configured for the field.
+    """
+    selectedRolesConnection(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraRoleConnection
+    """
+    Paginated list of roles available for the field or the Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    roles(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraRoleConnection
+    """
+    Search URL to fetch all the roles options for the fields on an issue.
+    """
+    searchUrl : String
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents color field on a Jira Issue. E.g. issue color, epic color.
+"""
+type JiraColorField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The color selected on the Issue or default color configured for the field.
+    """
+    color: JiraColor
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents single select field on a Jira Issue.
+"""
+type JiraSingleSelectField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The option selected on the Issue or default option configured for the field.
+    """
+    fieldOption: JiraOption
+    """
+    Paginated list of options available for the field or the Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    fieldOptions(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraOptionConnection
+    """
+    Search URL to fetch the select option for the field on a Jira Issue.
+    """
+    searchUrl: String @deprecated(reason: "Search URLs are planned to be replaced by Connections.")
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents the check boxes field on a Jira Issue.
+"""
+type JiraCheckboxesField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The options selected on the Issue or default options configured for the field.
+    """
+    selectedFieldOptions: [JiraOption] @deprecated(reason: "Please use selectedOptions instead.")
+    """
+    The options selected on the Issue or default options configured for the field.
+    """
+    selectedOptions(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraOptionConnection
+    """
+    Paginated list of options available for the field or the Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    fieldOptions(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraOptionConnection
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents the radio select field on a Jira Issue.
+"""
+type JiraRadioSelectField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The option selected on the Issue or default option configured for the field.
+    """
+    selectedOption: JiraOption
+    """
+    Paginated list of options available for the field or the Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    fieldOptions(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraOptionConnection
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents the Asset field on a Jira Issue.
+"""
+type JiraAssetField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The assets selected on the Issue or default assets configured for the field.
+    """
+    selectedAssets: [JiraAsset] @deprecated(reason: "Please use selectedAssetsConnection instead.")
+    """
+    The assets selected on the Issue or default assets configured for the field.
+    """
+    selectedAssetsConnection(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraAssetConnection
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Search URL to fetch all the assets for the field on a Jira Issue.
+    """
+    searchUrl: String @deprecated(reason: "Search URLs are planned to be replaced by Connections.")
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents the multi-select field on a Jira Issue.
+"""
+type JiraMultipleSelectField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The options selected on the Issue or default options configured for the field.
+    """
+    selectedFieldOptions: [JiraOption] @deprecated(reason: "Please use selectedOptions instead.")
+    """
+    The options selected on the Issue or default options configured for the field.
+    """
+    selectedOptions(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraOptionConnection
+    """
+    Paginated list of options available for the field or the Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    fieldOptions(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraOptionConnection
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Search URL to fetch all the teams options for the field on a Jira Issue.
+    """
+    searchUrl: String @deprecated(reason: "Search URLs are planned to be replaced by Connections.")
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents single group picker field. Allows you to select single Jira group to be associated with an issue.
+"""
+type JiraSingleGroupPickerField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The group selected on the Issue or default group configured for the field.
+    """
+    selectedGroup: JiraGroup
+    """
+    Paginated list of group options available for the field or the Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    groups(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraGroupConnection
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Search URL to fetch group picker field on a Jira Issue.
+    """
+    searchUrl: String @deprecated(reason: "Search URLs are planned to be replaced by Connections.")
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents a multiple group picker field on a Jira Issue.
+"""
+type JiraMultipleGroupPickerField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The groups selected on the Issue or default groups configured for the field.
+    """
+    selectedGroups: [JiraGroup] @deprecated(reason: "Please use selectedGroupsConnection instead.")
+    """
+    The groups selected on the Issue or default groups configured for the field.
+    """
+    selectedGroupsConnection(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraGroupConnection
+    """
+    Paginated list of group options available for the field or the Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    groups(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraGroupConnection
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Search URL to fetch all group pickers of the field on a Jira Issue.
+    """
+    searchUrl: String @deprecated(reason: "Search URLs are planned to be replaced by Connections.")
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Deprecated type. Please use `JiraTeamViewField` instead.
+"""
+type JiraTeamField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The team selected on the Issue or default team configured for the field.
+    """
+    selectedTeam: JiraTeam
+    """
+    Paginated list of team options available for the field or the Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    teams(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraTeamConnection
+    """
+    Search URL to fetch all the teams options for the field on a Jira Issue.
+    """
+    searchUrl: String @deprecated(reason: "Search URLs are planned to be replaced by Connections.")
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Deprecated type. Please use `JiraTeamViewField` instead.
+"""
+type JiraAtlassianTeamField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The team selected on the Issue or default team configured for the field.
+    """
+    selectedTeam: JiraAtlassianTeam
+    """
+    Paginated list of team options available for the field or the Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    teams(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraAtlassianTeamConnection
+    """
+    Search URL to fetch all the teams options for the field on a Jira Issue.
+    """
+    searchUrl: String @deprecated(reason: "Search URLs are planned to be replaced by Connections.")
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents the Team field on a Jira Issue. Allows you to select a team to be associated with an Issue.
+"""
+type JiraTeamViewField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The team selected on the Issue or default team configured for the field.
+    """
+    selectedTeam: JiraTeamView
+    """
+    Search URL to fetch all the teams options for the field on a Jira Issue.
+    """
+    searchUrl: String @deprecated(reason: "Search URLs are planned to be replaced by Connections.")
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents Affected Services field.
+"""
+type JiraAffectedServicesField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The affected services selected on the Issue or default affected services configured for the field.
+    """
+    selectedAffectedServices: [JiraAffectedService] @deprecated(reason: "Please use selectedAffectedServicesConnection instead.")
+    """
+    The affected services selected on the Issue or default affected services configured for the field.
+    """
+    selectedAffectedServicesConnection(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraAffectedServiceConnection
+    """
+    Paginated list of affected services available for the field or the Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    affectedServices(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+        """
+        Returns the recent items based on user history.
+        """
+        suggested: Boolean
+    ): JiraAffectedServiceConnection
+    """
+    Search url to query for all Affected Services when user interact with field.
+    """
+    searchUrl: String @deprecated(reason: "Search URLs are planned to be replaced by Connections.")
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents CMDB (Configuration Management Database) field on a Jira Issue.
+"""
+type JiraCMDBField implements Node & JiraIssueField & JiraIssueFieldConfiguration{
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    Whether the field is configured to act as single/multi select CMDB(s) field.
+    """
+    isMulti: Boolean @deprecated(reason: "Please use `multiple` defined in `JiraCmdbFieldConfig`.")
+    """
+    Search url to fetch all available cmdb options for the field or the Issue.
+    """
+    searchUrl: String @deprecated(reason: "Search URLs are planned to be replaced by Connections.")
+    """
+    The CMDB objects selected on the Issue or default CMDB objects configured for the field.
+    """
+    selectedCmdbObjects: [JiraCmdbObject] @deprecated(reason: "Please use selectedCmdbObjectsConnection instead.")
+    """
+    The CMDB objects selected on the Issue or default CMDB objects configured for the field.
+    """
+    selectedCmdbObjectsConnection(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraCmdbObjectConnection
+    """
+    Indicates whether the field has been enriched with data from Insight, allowing Jira to show correct error states.
+    """
+    wasInsightRequestSuccessful: Boolean
+    """
+    Indicates whether the current site has sufficient licence for the Insight feature, allowing Jira to show correct error states.
+    """
+    isInsightAvailable: Boolean
+    """
+    Attributes of a CMDB field’s configuration info.
+    """
+    cmdbFieldConfig: JiraCmdbFieldConfig
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+    """
+    Attributes that are configured for autocomplete search.
+    """
+    attributesIncludedInAutoCompleteSearch: [String] @deprecated(reason: "Please use `attributesIncludedInAutoCompleteSearch` defined in `JiraCmdbFieldConfig`.")
+}
+
+"""
+Represents the time tracking field on Jira issue screens.
+"""
+type JiraTimeTrackingField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    Original Estimate displays the amount of time originally anticipated to resolve the issue.
+    """
+    originalEstimate: JiraEstimate
+    """
+    Time Remaining displays the amount of time currently anticipated to resolve the issue.
+    """
+    remainingEstimate: JiraEstimate
+    """
+    Time Spent displays the amount of time that has been spent on resolving the issue.
+    """
+    timeSpent: JiraEstimate
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+    """
+    This represents the global time tracking settings configuration like working hours and days.
+    """
+    timeTrackingSettings: JiraTimeTrackingSettings
+}
+
+"""
+Represents the original time estimate field on Jira issue screens. Note that this is the same value as the originalEstimate from JiraTimeTrackingField
+This field should only be used on issue view because issue view hasn't deprecated the original estimation as a standalone field
+"""
+type JiraOriginalTimeEstimateField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    Original Estimate displays the amount of time originally anticipated to resolve the issue.
+    """
+    originalEstimate: JiraEstimate
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents a text field created by Connect App.
+"""
+type JiraConnectTextField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    Content of the connect text field.
+    """
+    text: String
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents a number field created by Connect App.
+"""
+type JiraConnectNumberField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    Connected number.
+    """
+    number: Float
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents a single select field created by Connect App.
+"""
+type JiraConnectSingleSelectField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The option selected on the Issue or default option configured for the field.
+    """
+    fieldOption: JiraOption
+    """
+    Paginated list of options available for the field or the Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    fieldOptions(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraOptionConnection
+    """
+    Search url to fetch all available options for the field or the Issue.
+    """
+    searchUrl: String @deprecated(reason: "Search URLs are planned to be replaced by Connections.")
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents a multi-select field created by Connect App.
+"""
+type JiraConnectMultipleSelectField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The options selected on the Issue or default options configured for the field.
+    """
+    selectedFieldOptions: [JiraOption] @deprecated(reason: "Please use selectedOptions instead.")
+    """
+    The options selected on the Issue or default options configured for the field.
+    """
+    selectedOptions(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraOptionConnection
+    """
+    Paginated list of options available for the field or the Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    fieldOptions(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraOptionConnection
+    """
+    Search url to fetch all available options for the field or the Issue.
+    """
+    searchUrl: String @deprecated(reason: "Search URLs are planned to be replaced by Connections.")
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents rich text field on a Jira Issue. E.g. description, environment.
+"""
+type JiraConnectRichTextField implements Node & JiraIssueField  & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The rich text selected on the Issue or default rich text configured for the field.
+    """
+    richText: JiraRichText
+    """
+    Determines what editor to render.
+    E.g. default text rendering or wiki text rendering.
+    """
+    renderer: String
+    """
+    Contains the information needed to add a media content to this field.
+    """
+    mediaContext: JiraMediaContext
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents Status field.
+"""
+type JiraStatusField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The status selected on the Issue or default status configured for the field.
+    """
+    status: JiraStatus!
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents Status Category field.
+"""
+type JiraStatusCategoryField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The status category for the issue or default status category configured for the field.
+    """
+    statusCategory: JiraStatusCategory!
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents a string field created by Forge App.
+"""
+type JiraForgeStringField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The text selected on the Issue or default text configured for the field.
+    """
+    text: String
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+    """
+    The renderer type of the forge app, returns 'forge' if it's customised in the app, otherwise returns the one of the predefined custom field renderer type.
+    """
+    renderer: String
+}
+
+"""
+Represents a strings field created by Forge App.
+"""
+type JiraForgeStringsField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The labels selected on the Issue or default labels configured for the field.
+    """
+    selectedLabels: [JiraLabel] @deprecated(reason: "Please use selectedLabelsConnection instead.")
+    """
+    The labels selected on the Issue or default labels configured for the field.
+    """
+    selectedLabelsConnection(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraLabelConnection
+    """
+    Paginated list of label options for the field or the Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    labels(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+        """
+        Returns the recent items based on user history.
+        """
+        suggested: Boolean
+    ): JiraLabelConnection
+    """
+    Search url to fetch all available labels options on the field or an Issue.
+    """
+    searchUrl: String @deprecated(reason: "Search URLs are planned to be replaced by Connections.")
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+    """
+    The renderer type of the forge app, returns 'forge' if it's customised in the app, otherwise returns the one of the predefined custom field renderer type.
+    """
+    renderer: String
+}
+
+"""
+Represents a number field created by Forge App.
+"""
+type JiraForgeNumberField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The number selected on the Issue or default number configured for the field.
+    """
+    number: Float
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+    """
+    The renderer type of the forge app, returns 'forge' if it's customised in the app, otherwise returns the one of the predefined custom field renderer type.
+    """
+    renderer: String
+}
+
+"""
+Represents a date time field created by Forge App.
+"""
+type JiraForgeDatetimeField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The datetime selected on the issue or default datetime configured for the field.
+    """
+    dateTime: DateTime
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+    """
+    The renderer type of the forge app, returns 'forge' if it's customised in the app, otherwise returns the one of the predefined custom field renderer type.
+    """
+    renderer: String
+}
+
+"""
+Represents a object field created by Forge App.
+"""
+type JiraForgeObjectField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The object string selected on the issue or default datetime configured for the field.
+    """
+    object: String
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+    """
+    The renderer type of the forge app, returns 'forge' if it's customised in the app, otherwise returns the one of the predefined custom field renderer type.
+    """
+    renderer: String
+}
+
+"""
+Represents a User field created by Forge App.
+"""
+type JiraForgeUserField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The user selected on the Issue or default user configured for the field.
+    """
+    user: User
+    """
+    Paginated list of user options available for the field or the Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    users(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+        """
+        Returns the recent items based on user history.
+        """
+        suggested: Boolean
+    ): JiraUserConnection
+    """
+    Search url to fetch all available users options for the field or the Issue.
+    """
+    searchUrl: String @deprecated(reason: "Search URLs are planned to be replaced by Connections.")
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+    """
+    The renderer type of the forge app, returns 'forge' if it's customised in the app, otherwise returns the one of the predefined custom field renderer type.
+    """
+    renderer: String
+}
+
+"""
+Represents a Users field created by Forge App.
+"""
+type JiraForgeUsersField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The users selected on the Issue or default users configured for the field.
+    """
+    selectedUsers: [User] @deprecated(reason: "Please use selectedUsersConnection instead.")
+    """
+    The users selected on the Issue or default users configured for the field.
+    """
+    selectedUsersConnection(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraUserConnection
+    """
+    Paginated list of user options available for the field or the Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    users(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+        """
+        Returns the recent items based on user history.
+        """
+        suggested: Boolean
+    ): JiraUserConnection
+    """
+    Search url to fetch all available users options for the field or the Issue.
+    """
+    searchUrl: String @deprecated(reason: "Search URLs are planned to be replaced by Connections.")
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+    """
+    The renderer type of the forge app, returns 'forge' if it's customised in the app, otherwise returns the one of the predefined custom field renderer type.
+    """
+    renderer: String
+}
+
+"""
+Represents a Group field created by Forge App.
+"""
+type JiraForgeGroupField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The group selected on the Issue or default group configured for the field.
+    """
+    selectedGroup: JiraGroup
+    """
+    Paginated list of group options available for the field or the Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    groups(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraGroupConnection
+    """
+    Search url to fetch all available groups for the field or the Issue.
+    """
+    searchUrl: String @deprecated(reason: "Search URLs are planned to be replaced by Connections.")
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+    """
+    The renderer type of the forge app, returns 'forge' if it's customised in the app, otherwise returns the one of the predefined custom field renderer type.
+    """
+    renderer: String
+}
+
+"""
+Represents a Groups field created by Forge App.
+"""
+type JiraForgeGroupsField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The groups selected on the Issue or default group configured for the field.
+    """
+    selectedGroups: [JiraGroup] @deprecated(reason: "Please use selectedGroupsConnection instead.")
+    """
+    The groups selected on the Issue or default group configured for the field.
+    """
+    selectedGroupsConnection(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraGroupConnection
+    """
+    Paginated list of group options available for the field or the Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    groups(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraGroupConnection
+    """
+    Search url to fetch all available groups for the field or the Issue.
+    """
+    searchUrl: String @deprecated(reason: "Search URLs are planned to be replaced by Connections.")
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+    """
+    The renderer type of the forge app, returns 'forge' if it's customised in the app, otherwise returns the one of the predefined custom field renderer type.
+    """
+    renderer: String
+}
+
+"""
+Represents a votes field on a Jira Issue.
+"""
+type JiraVotesField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    Represents the vote value selected on the Issue.
+    Can be null when voting is disabled.
+    """
+    vote: JiraVote
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents the Watches system field.
+"""
+type JiraWatchesField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    Represents the watch value selected on the Issue.
+    Can be null when watching is disabled.
+    """
+    watch: JiraWatch
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents a flag field on a Jira Issue. E.g. flagged.
+"""
+type JiraFlagField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The flag value selected on the Issue.
+    """
+    flag: JiraFlag
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Deprecated type. Please use `childIssues` field under `JiraIssue` instead.
+"""
+type JiraSubtasksField implements Node & JiraIssueField & JiraIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    Paginated list of subtasks on the Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    subtasks(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraIssueConnection
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+}
+
+"""
+Deprecated type. Please use `attachments` field under `JiraIssue` instead.
+"""
+type JiraAttachmentsField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    Defines the permissions of the attachment collection.
+    """
+    permissions: [JiraAttachmentsPermissions]
+    """
+    Paginated list of attachments available for the field or the Issue.
+    """
+    attachments(
+        startAt: Int
+        maxResults: Int
+        orderField: JiraAttachmentsOrderField,
+        orderDirection: JiraOrderDirection
+    ): JiraAttachmentConnection
+    """
+    Defines the maximum size limit (in bytes) of the total of all the attachments which can be associated with this field.
+    """
+    maxAllowedTotalAttachmentsSize: Long
+    """
+    Contains the information needed to add a media content to this field.
+    """
+    mediaContext: JiraMediaContext
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents dev summary for an issue. The identifier for this field is devSummary
+"""
+type JiraDevSummaryField implements Node & JiraIssueField {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    A summary of the development information (e.g. pull requests, commits) associated with
+    this issue.
+
+    WARNING: The data returned by this field may be stale/outdated. This field is temporary and
+    will be replaced by a `devSummary` field that returns up-to-date information.
+
+    In the meantime, if you only need data for a single issue you can use the `JiraDevOpsQuery.devOpsIssuePanel`
+    field to get up-to-date dev summary data.
+    """
+    devSummaryCache: JiraIssueDevSummaryResult
+}
+
+"""
+Represents the WorkCategory field on an Issue.
+"""
+type JiraWorkCategoryField implements Node & JiraIssueField & JiraIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The WorkCategory selected on the Issue or default WorkCategory configured for the field.
+    """
+    workCategory: JiraWorkCategory
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+}
+
+"""
+Represents a generic boolean field for an Issue. E.g. JSM alert linking.
+"""
+type JiraBooleanField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The value selected on the Issue or default value configured for the field.
+    """
+    value: Boolean
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents the proforma-forms field for an Issue.
+"""
+type JiraProformaFormsField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The proforma-forms selected on the Issue or default major incident configured for the field.
+    """
+    proformaForms: JiraProformaForms
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+############################################################
+########### Jira Service Management (JSM) Fields ###########
+############################################################
+
+"""
+Represents the Request Feedback custom field on an Issue in a JSM project.
+"""
+type JiraServiceManagementRequestFeedbackField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    Represents the JSM feedback rating value selected on the Issue.
+    """
+    feedback: JiraServiceManagementFeedback
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents a datetime field on an Issue in a JSM project.
+Deprecated: Please use `JiraDateTimePickerField`.
+"""
+type JiraServiceManagementDateTimeField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The datetime selected on the Issue or default datetime configured for the field.
+    """
+    dateTime: DateTime
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents the responders entity custom field on an Issue in a JSM project.
+"""
+type JiraServiceManagementRespondersField implements Node & JiraIssueField & JiraIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    Represents the list of responders.
+    """
+    responders: [JiraServiceManagementResponder] @deprecated(reason: "Please use respondersConnection instead.")
+    """
+    Represents the list of responders.
+    """
+    respondersConnection(
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraServiceManagementResponderConnection
+    """
+    Search URL to query for all responders available for the user to choose from when interacting with the field.
+    """
+    searchUrl: String @deprecated(reason: "Search URLs are planned to be replaced by Connections.")
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+}
+
+"""
+Represents the Incident Linking custom field on an Issue in a JSM project.
+Deprecated: please use `JiraBooleanField` instead.
+"""
+type JiraServiceManagementIncidentLinkingField implements Node & JiraIssueField & JiraIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    Represents the JSM incident linked to the issue.
+    """
+    incident: JiraServiceManagementIncident
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+}
+
+"""
+Represents the Approval custom field on an Issue in a JSM project.
+"""
+type JiraServiceManagementApprovalField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. customfield_10001 or description.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The active approval is used to render the approval panel that the users can interact with to approve/decline the request or update approvers.
+    """
+    activeApproval: JiraServiceManagementActiveApproval
+    """
+    The completed approvals are used to render the approval history section and contains records for all previous approvals for that issue.
+    """
+    completedApprovals: [JiraServiceManagementCompletedApproval] @deprecated(reason: "Please use completedApprovalsConnection instead.")
+    """
+    The completed approvals are used to render the approval history section and contains records for all previous approvals for that issue.
+    """
+    completedApprovalsConnection(
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraServiceManagementCompletedApprovalConnection
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Deprecated type. Please use `JiraMultipleSelectUserPickerField` instead.
+"""
+type JiraServiceManagementMultipleSelectUserPickerField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The users selected on the Issue or default users configured for the field.
+    """
+    selectedUsers: [User] @deprecated(reason: "Please use selectedUsersConnection instead.")
+    """
+    The users selected on the Issue or default users configured for the field.
+    """
+    selectedUsersConnection(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraUserConnection
+    """
+    Paginated list of user options available for the field or the Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    users(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+        """
+        Returns the recent items based on user history.
+        """
+        suggested: Boolean
+    ): JiraUserConnection
+    """
+    Search url to fetch all available users options for the field or the Issue.
+    """
+    searchUrl: String @deprecated(reason: "Search URLs are planned to be replaced by Connections.")
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents the Request Language field on an Issue in a JSM project.
+"""
+type JiraServiceManagementRequestLanguageField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The language selected on the Issue or default language configured for the field.
+    """
+    language: JiraServiceManagementLanguage
+    """
+    List of languages available.
+    """
+    languages: [JiraServiceManagementLanguage]
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents the Customer Organization field on an Issue in a JSM project.
+"""
+type JiraServiceManagementOrganizationField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The organizations selected on the Issue or default organizations configured for the field.
+    """
+    selectedOrganizations: [JiraServiceManagementOrganization] @deprecated(reason: "Please use selectedOrganizationsConnection instead.")
+    """
+    The organizations selected on the Issue or default organizations configured for the field.
+    """
+    selectedOrganizationsConnection(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraServiceManagementOrganizationConnection
+    """
+    Paginated list of organization options available for the field or the Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    organizations(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+        """
+        Returns the recent items based on user history.
+        """
+        suggested: Boolean
+    ): JiraServiceManagementOrganizationConnection
+    """
+    Search url to query for all Customer orgs when user interact with field.
+    """
+    searchUrl: String @deprecated(reason: "Search URLs are planned to be replaced by Connections.")
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Deprecated type. Please use `JiraPeopleField` instead.
+"""
+type JiraServiceManagementPeopleField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The people selected on the Issue or default people configured for the field.
+    """
+    selectedUsers: [User] @deprecated(reason: "Please use selectedUsersConnection instead.")
+    """
+    The users selected on the Issue or default users configured for the field.
+    """
+    selectedUsersConnection(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraUserConnection
+    """
+    Whether the field is configured to act as single/multi select user(s) field.
+    """
+    isMulti: Boolean
+    """
+    Paginated list of user options available for the field or the Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    users(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+        """
+        Returns the recent items based on user history.
+        """
+        suggested: Boolean
+    ): JiraUserConnection
+    """
+    Search url to fetch all available users options for the field or the Issue.
+    """
+    searchUrl: String @deprecated(reason: "Search URLs are planned to be replaced by Connections.")
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+
+"""
+Represents the request type field for an Issue in a JSM project.
+"""
+type JiraServiceManagementRequestTypeField implements Node & JiraIssueField & JiraIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The request type selected on the Issue or default request type configured for the field.
+    """
+    requestType: JiraServiceManagementRequestType
+    """
+    Paginated list of request type options available for the field or the Issue.
+    The server may throw an error if both a forward page (specified with `first`) and a backward page (specified with `last`) are requested simultaneously.
+    """
+    requestTypes(
+        """
+        Search by the id/name of the item.
+        """
+        searchBy: String
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+        """
+        Returns the recent items based on user history.
+        """
+        suggested: Boolean
+    ): JiraServiceManagementRequestTypeConnection
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+}
+
+"""
+Represents the major incident field for an Issue in a JSM project.
+"""
+type JiraServiceManagementMajorIncidentField implements Node & JiraIssueField & JiraIssueFieldConfiguration & JiraUserIssueFieldConfiguration {
+    """
+    Unique identifier for the field.
+    """
+    id: ID!
+    """
+    The identifier of the field. E.g. summary, customfield_10001, etc.
+    """
+    fieldId: String!
+    """
+    The field ID alias (if applicable).
+    """
+    aliasFieldId: ID
+    """
+    Field type key.
+    """
+    type: String!
+    """
+    Translated name for the field (if applicable).
+    """
+    name: String!
+    """
+    Description for the field (if present).
+    """
+    description: String
+    """
+    The major incident selected on the Issue or default major incident configured for the field.
+    """
+    majorIncident: JiraServiceManagementMajorIncident
+    """
+    Attributes of an issue field's configuration info.
+    """
+    fieldConfig: JiraFieldConfig
+    """
+    Configuration changes which a user can apply to a field. E.g. pin or hide the field.
+    """
+    userFieldConfig: JiraUserFieldConfig
+}
+extend type JiraQuery {
+    """
+    Container for all Issue Hierarchy Configuration related queries in Jira
+    """
+    issueHierarchyConfig(cloudId: ID!): JiraIssueHierarchyConfigurationQuery!
+
+    """
+    Container for all Issue Hierarchy Limits related queries in Jira
+    """
+    issueHierarchyLimits(cloudId: ID!): JiraIssueHierarchyLimits!
+
+    """
+    A List of JiraIssueType IDs that cannot be moved to a different hierarchy level.
+    """
+    lockedIssueTypeIds(cloudId: ID!): [ID!]!
+}
+
+extend type JiraMutation {
+    """
+    Used to update the Issue Hierarchy Configuration in Jira
+    """
+    updateIssueHierarchyConfig(
+        cloudId: ID!,
+        input: JiraIssueHierarchyConfigurationMutationInput!
+    ): JiraIssueHierarchyConfigurationMutationResult!
+}
+
+type JiraIssueHierarchyConfigurationMutationResult {
+    """
+    The field that indicates if the update action is successfully initiated
+    """
+    updateInitiated: Boolean!
+
+    """
+    The success indicator saying whether mutation operation was successful as a whole or not
+    """
+    success: Boolean!
+
+    """
+    The errors field represents additional mutation error information if exists
+    """
+    errors: [JiraHierarchyConfigError!]
+}
+
+type JiraIssueHierarchyConfigurationQuery {
+    """
+    This indicates data payload
+    """
+    data: [JiraIssueHierarchyConfigData!]
+
+    """
+    The success indicator saying whether mutation operation was successful as a whole or not
+    """
+    success: Boolean!
+
+    """
+    The errors field represents additional mutation error information if exists
+    """
+    errors: [JiraHierarchyConfigError!]
+}
+
+type JiraIssueHierarchyConfigData {
+    """
+    Each one of the levels with its basic data
+    """
+    hierarchyLevel: JiraIssueTypeHierarchyLevel
+
+    """
+    Issue types inside the level
+    """
+    cmpIssueTypes(
+        first: Int,
+        after: String,
+        last: Int,
+        before: String
+    ): JiraIssueTypeConnection
+}
+
+type JiraIssueHierarchyLimits {
+    """
+    Max levels that the user can set
+    """
+    maxLevels: Int!
+
+    """
+    Max name length
+    """
+    nameLength: Int!
+}
+
+type JiraHierarchyConfigError {
+    """
+    This indicates error code
+    """
+    code: String
+
+    """
+    This indicates error message
+    """
+    message: String
+}
+
+input JiraIssueHierarchyConfigInput {
+    """
+    Level number
+    """
+    level: Int!
+
+    """
+    Level title
+    """
+    title: String!
+
+    """
+    A list of issue type IDs
+    """
+    issueTypeIds: [ID!]!
+}
+
+input JiraIssueHierarchyConfigurationMutationInput {
+    """
+    This indicates if the service needs to make a simulation run
+    """
+    dryRun: Boolean!
+
+    """
+    A list of hierarchy config input objects
+    """
+    issueHierarchyConfig: [JiraIssueHierarchyConfigInput!]!
+}
+extend type JiraQuery {
+    """
+    Used to retrieve Issue layout information by type by `issueId`.
+    """
+    issueContainersByType(
+        input: JiraIssueItemSystemContainerTypeWithIdInput!
+    ): JiraIssueItemContainersResult!
+
+    """
+    Used to retrieve Issue layout information by `issueKey` and `cloudId`.
+    """
+    issueContainersByTypeByKey(
+        input: JiraIssueItemSystemContainerTypeWithKeyInput!
+    ): JiraIssueItemContainersResult!
+}type JiraIssueLinkTypeRelation implements Node {
+    "Global identifier for the Issue Link Type Relation."
+    id: ID!
+    """
+    Represents the description of the relation by which this link is identified.
+    This can be the inward or outward description of an IssueLinkType.
+    E.g. blocks, is blocked by, duplicates, is duplicated by, clones, is cloned by.
+    """
+    relationName: String
+    """
+    Represents the IssueLinkType id to which this type belongs to.
+    """
+    linkTypeId: String!
+    """
+    Display name of IssueLinkType to which this relation belongs to. E.g. Blocks, Duplicate, Cloners.
+    """
+    linkTypeName: String
+    """
+    Represents the direction of Issue link type. E.g. INWARD, OUTWARD.
+    """
+    direction: JiraIssueLinkDirection
+}
+
+"""
+Represents a single Issue link containing the link id, link type and destination Issue.
+
+For Issue create, JiraIssueLink will be populated with
+the default IssueLink types in the relatedBy field.
+The issueLinkId and Issue fields will be null.
+
+For Issue view, JiraIssueLink will be populated with
+the Issue link data available on the Issue.
+The Issue field will contain a nested JiraIssue that is atmost 1 level deep.
+The nested JiraIssue will not contain fields that can contain further nesting.
+"""
+type JiraIssueLink {
+    """
+    Global identifier for the Issue Link.
+    """
+    id: ID
+    """
+    Identifier for the Issue Link. Can be null to represent a link not yet created.
+    """
+    issueLinkId: String
+    """
+    Issue link type relation through which the source Issue is connected to the
+    destination Issue. Source Issue is the Issue being created/queried.
+    """
+    relatedBy: JiraIssueLinkTypeRelation
+    """
+    The destination Issue to which this link is connected.
+    """
+    issue: JiraIssue
+}
+
+"""
+The connection type for JiraIssueLink.
+"""
+type JiraIssueLinkConnection {
+    """
+    The total number of JiraIssueLink matching the criteria.
+    """
+    totalCount: Int
+    """
+    The page info of the current page of results.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraIssueLinkEdge]
+}
+
+"""
+An edge in a JiraIssueLink connection.
+"""
+type JiraIssueLinkEdge {
+    """
+    The node at the edge.
+    """
+    node: JiraIssueLink
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}
+
+"""
+The connection type for JiraIssueLinkTypeRelation.
+"""
+type JiraIssueLinkTypeRelationConnection {
+    """
+    The total number of JiraIssueLinkTypeRelation matching the criteria.
+    """
+    totalCount: Int
+    """
+    The page info of the current page of results.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraIssueLinkTypeRelationEdge]
+}
+
+"""
+An edge in a JiraIssueLinkType connection.
+"""
+type JiraIssueLinkTypeRelationEdge {
+    """
+    The node at the edge.
+    """
+    node: JiraIssueLinkTypeRelation
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}
+
+"""
+Represents the possible linking directions between issues.
+"""
+enum JiraIssueLinkDirection {
+    """
+    Going from the other issue to this issue.
+    """
+    INWARD
+    """
+    Going from this issue to the other issue.
+    """
+    OUTWARD
+}
+extend type JiraQuery {
+  """
+  Performs an issue search using the provided string of JQL.
+  This query will error if the JQL does not pass validation.
+  """
+  issueSearchByJql(cloudId: ID!, jql: String!): JiraIssueSearchByJqlResult
+
+  """
+  Performs an issue search using the underlying JQL saved as a filter.
+
+  The id provided MUST be in ARI format.
+
+  This query will error if the id parameter is not in ARI format, does not pass validation or does not correspond to a filter.
+  """
+  issueSearchByFilterId(id: ID!): JiraIssueSearchByFilterResult
+
+  """
+  Hydrate a list of issue IDs into issue data. The issue data retrieved will depend on
+  the subsequently specified view(s) and/or fields.
+
+  The ids provided MUST be in ARI format.
+
+  For each id provided, it will resolve to either a JiraIssue as a leaf node in an subsequent query, or a QueryError if:
+  - The ARI provided did not pass validation.
+  - The ARI did not resolve to an issue.
+  """
+  issueHydrateByIssueIds(ids: [ID!]!): JiraIssueSearchByHydration
+
+  """
+  Retrieves data about a JiraIssueSearchView.
+
+  The id provided MUST be in ARI format.
+
+  This query will error if the id parameter is not in ARI format, does not pass validation or does not correspond to a JiraIssueSearchView.
+  """
+  issueSearchView(id: ID!): JiraIssueSearchView
+
+  """
+  Retrieves a JiraIssueSearchView corresponding to the provided namespace and viewId.
+  """
+  issueSearchViewByNamespaceAndViewId(cloudId: ID!, namespace: String, viewId: String): JiraIssueSearchView
+
+  """
+  Performs an issue search using the issueSearchInput argument.
+  This relies on stable search where the issue ids from the initial search are preserved between pagination.
+  An "initial search" is when no cursors are specified.
+  The server will configure a limit on the maximum issue ids preserved for a given search e.g. 1000.
+  On pagination, we take the next page of issues from this stable set of 1000 ids and return hydrated issue data.
+  """
+  issueSearchStable(
+    """
+    The cloud id of the tenant.
+    """
+    cloudId: ID!
+    """
+    The input used for the issue search.
+    """
+    issueSearchInput: JiraIssueSearchInput!
+    """
+    The options used for an issue search.
+    """
+    options: JiraIssueSearchOptions
+    """
+    The number of items after the cursor to be returned in a forward page.
+    If not specified, it is up to the server to determine a page size.
+    """
+    first: Int
+    """
+    The index based cursor to specify the beginning of the items.
+    If not specified it's assumed as the cursor for the item before the beginning.
+    """
+    after: String
+    """
+    The number of items before the cursor to be returned in a backward page.
+    If not specified, it is up to the server to determine a page size.
+    """
+    last: Int
+    """
+    The index based cursor to specify the bottom limit of the items.
+    If not specified it's assumed as the cursor to the item after the last item.
+    """
+    before: String
+  ): JiraIssueConnection
+}
+
+extend type JiraMutation {
+  """
+  Replaces field config sets from the specified JiraIssueSearchView with the provided field config set id nodes.
+  If the provided nodes contain a node outside the given range of `before` and/or `after`, then those nodes will also be deleted and replaced within the range.
+  - If `before` is provided, then the entire range before that node will be replaced, or error if not found.
+  - If `after` is provided, then the entire range after that node will be replaced, or error if not found.
+  - If `before` and `after` are both provided, then the range between `before` and `after` will be replaced depending on the inclusive value.
+  - If neither `before` or `after` are provided, then the entire range will be replaced.
+
+  The id provided MUST be in ARI format. This mutation will error if the id parameter is not in ARI format, does not pass validation or does not correspond to a JiraIssueSearchView.
+  """
+  replaceIssueSearchViewFieldSets(
+    id: ID!
+    input: JiraReplaceIssueSearchViewFieldSetsInput!
+  ): JiraIssueSearchViewPayload
+}
+
+input JiraReplaceIssueSearchViewFieldSetsInput {
+  before: String
+  after: String
+  nodes: [String!]!
+  # Denotes whether `before` and/or `after` nodes will be replaced inclusively. If not specified, defaults to false.
+  inclusive: Boolean
+}
+
+"""
+The payload returned when a JiraIssueSearchView has been updated.
+"""
+type JiraIssueSearchViewPayload implements Payload {
+  success: Boolean!
+  errors: [MutationError!]
+  view: JiraIssueSearchView
+}
+
+"""
+A generic interface for issue search results in Jira.
+"""
+interface JiraIssueSearchResult {
+  """
+  Retrieves content controlled by the context of a JiraIssueSearchView.
+  To query multiple content views at once, use GraphQL aliases.
+
+  If a namespace is provided, and a viewId is:
+  - Not provided, then the last used view is returned within this namespace.
+  - Provided, then this view is returned if it exists in this namespace.
+
+  If a namespace is not provided, and a viewId is:
+  - Not provided, then the last used view across any namespace is returned.
+  - Provided, then this view is returned if it exists in the global namespace.
+  """
+  content(namespace: String, viewId: String): JiraIssueSearchContextualContent
+
+  """
+  Retrieves content by provided field config set ids, ignoring the active query context.
+  To query multiple content views at once, use GraphQL aliases.
+  """
+  contentByFieldSetIds(fieldSetIds: [String!]!): JiraIssueSearchContextlessContent
+}
+
+"""
+Represents an issue search result when querying with a JiraFilter.
+"""
+type JiraIssueSearchByFilter implements JiraIssueSearchResult {
+  """
+  Retrieves content controlled by the context of a JiraIssueSearchView.
+  To query multiple content views at once, use GraphQL aliases.
+
+  If a namespace is provided, and a viewId is:
+  - Not provided, then the last used view is returned within this namespace.
+  - Provided, then this view is returned if it exists in this namespace.
+
+  If a namespace is not provided, and a viewId is:
+  - Not provided, then the last used view across any namespace is returned.
+  - Provided, then this view is returned if it exists in the global namespace.
+  """
+  content(namespace: String, viewId: String): JiraIssueSearchContextualContent
+  """
+  Retrieves content by provided field config set ids, ignoring the active query context.
+  To query multiple content views at once, use GraphQL aliases.
+  """
+  contentByFieldSetIds(fieldSetIds: [String!]!): JiraIssueSearchContextlessContent
+  """
+  The Jira Filter corresponding to the filter ARI specified in the calling query.
+  """
+  filter: JiraFilter
+}
+
+
+union JiraIssueSearchByJqlResult = JiraIssueSearchByJql | QueryError
+
+union JiraIssueSearchByFilterResult = JiraIssueSearchByFilter | QueryError
+
+"""
+Represents an issue search result when querying with a Jira Query Language (JQL) string.
+"""
+type JiraIssueSearchByJql implements JiraIssueSearchResult {
+  """
+  Retrieves content controlled by the context of a JiraIssueSearchView.
+  To query multiple content views at once, use GraphQL aliases.
+
+  If a namespace is provided, and a viewId is:
+  - Not provided, then the last used view is returned within this namespace.
+  - Provided, then this view is returned if it exists in this namespace.
+
+  If a namespace is not provided, and a viewId is:
+  - Not provided, then the last used view across any namespace is returned.
+  - Provided, then this view is returned if it exists in the global namespace.
+  """
+  content(namespace: String, viewId: String): JiraIssueSearchContextualContent
+  """
+  Retrieves content by provided field config set ids, ignoring the active query context.
+  To query multiple content views at once, use GraphQL aliases.
+  """
+  contentByFieldSetIds(fieldSetIds: [String!]!): JiraIssueSearchContextlessContent
+  """
+  The JQL specified in the calling query.
+  """
+  jql: String
+}
+
+"""
+Represents an issue search result when querying with a set of issue ids.
+"""
+type JiraIssueSearchByHydration implements JiraIssueSearchResult {
+  """
+  Retrieves content controlled by the context of a JiraIssueSearchView.
+  To query multiple content views at once, use GraphQL aliases.
+
+  If a namespace is provided, and a viewId is:
+  - Not provided, then the last used view is returned within this namespace.
+  - Provided, then this view is returned if it exists in this namespace.
+
+  If a namespace is not provided, and a viewId is:
+  - Not provided, then the last used view across any namespace is returned.
+  - Provided, then this view is returned if it exists in the global namespace.
+  """
+  content(namespace: String, viewId: String): JiraIssueSearchContextualContent
+  """
+  Retrieves content by provided field config set ids, ignoring the active query context.
+  To query multiple content views at once, use GraphQL aliases.
+  """
+  contentByFieldSetIds(fieldSetIds: [String!]!): JiraIssueSearchContextlessContent
+}
+
+"""
+A generic interface for the content of an issue search result in Jira.
+"""
+interface JiraIssueSearchResultContent {
+  """
+  Retrieves JiraIssue limited by provided pagination params, or global search limits, whichever is smaller.
+  To retrieve multiple sets of issues, use GraphQL aliases.
+
+  An optimized search is run when only JiraIssue issue ids are requested.
+  """
+  issues(
+    first: Int
+    last: Int
+    before: String
+    after: String
+  ): JiraIssueConnection
+}
+
+"""
+Represents the contextual content for an issue search result in Jira.
+The context here is determined by the JiraIssueSearchView associated with the content.
+"""
+type JiraIssueSearchContextualContent implements JiraIssueSearchResultContent {
+  """
+  The JiraIssueSearchView that will be used as the context when retrieving JiraIssueField data.
+  """
+  view: JiraIssueSearchView
+  """
+  Retrieves a connection of JiraIssues for the current search context.
+  """
+  issues(
+    first: Int
+    last: Int
+    before: String
+    after: String
+  ): JiraIssueConnection
+}
+
+"""
+Represents the contextless content for an issue search result in Jira.
+There is no JiraIssueSearchView associated with this content and is therefore contextless.
+"""
+type JiraIssueSearchContextlessContent implements JiraIssueSearchResultContent {
+  """
+  Retrieves a connection of JiraIssues for the current search context.
+  """
+  issues(
+    first: Int
+    last: Int
+    before: String
+    after: String
+  ): JiraIssueConnection
+}
+
+"""
+Represents a grouping of search data to a particular UI behaviour.
+Built-in views are automatically created for certain Jira pages and global Jira system filters.
+"""
+type JiraIssueSearchView implements Node {
+  """
+  An ARI-format value that encodes both namespace and viewId.
+  """
+  id: ID!
+  """
+  A subscoping that affects where this view's last used data is stored and grouped by. If null, this view is in the global namespace.
+  """
+  namespace: String
+  """
+  A unique identifier for this view within its namespace, or the global namespace if no namespace is defined.
+  """
+  viewId: String
+  """
+  A connection of included fields' configurations, grouped where logical (e.g. collapsed fields).
+  """
+  fieldSets(first: Int, last: Int, before: String, after: String, filter: JiraIssueSearchFieldSetsFilter): JiraIssueSearchFieldSetConnection
+}
+
+"""
+Specifies which field config sets should be returned.
+"""
+enum JiraIssueSearchFieldSetSelectedState {
+  """
+  Both selected and non-selected field config sets.
+  """
+  ALL,
+  """
+  Only the field config sets selected in the current view.
+  """
+  SELECTED,
+  """
+  Only the field config sets that have not been selected in the current view.
+  """
+  NON_SELECTED
+}
+
+"""
+A filter for the JiraIssueSearchFieldSet connections.
+By default, if no fieldSetSelectedState is specified, only SELECTED fields are returned.
+"""
+input JiraIssueSearchFieldSetsFilter {
+  """
+  Only the fieldSets that case-insensitively, contain this searchString in their displayName will be returned.
+  """
+  searchString: String,
+  """
+  An enum specifying which field config sets should be returned based on the selected status.
+  """
+  fieldSetSelectedState: JiraIssueSearchFieldSetSelectedState,
+}
+
+"""
+A Connection of JiraIssueSearchFieldSet.
+"""
+type JiraIssueSearchFieldSetConnection {
+  """
+  The total number of JiraIssueSearchFieldSet matching the criteria
+  """
+  totalCount: Int
+  """
+  The page info of the current page of results
+  """
+  pageInfo: PageInfo!
+  """
+  The data for Edges in the current page
+  """
+  edges: [JiraIssueSearchFieldSetEdge]
+  """
+  Indicates if any fields in the column configuration cannot be shown as they're currently unsupported
+  """
+  isWithholdingUnsupportedSelectedFields: Boolean
+}
+
+"""
+Represents a field-value edge for a JiraIssueSearchFieldSet.
+"""
+type JiraIssueSearchFieldSetEdge {
+  """
+  The node at the the edge.
+  """
+  node: JiraIssueSearchFieldSet
+  """
+  The cursor to this edge
+  """
+  cursor: String!
+}
+
+"""
+Represents a configurable field in Jira issue searches.
+These fields can be used to update JiraIssueSearchViews or to directly query for issue fields.
+This mirrors the concept of collapsed fields where all collapsible fields with the same `name` and `type` will be
+collapsed into a single JiraIssueSearchFieldSet with `fieldSetId = name[type]`.
+Non-collapsible and system fields cannot be collapsed but can still be represented as this type where `fieldSetId = fieldId`.
+"""
+type JiraIssueSearchFieldSet {
+  """
+  The identifer of the field config set e.g. `assignee`, `reporter`, `checkbox_cf[Checkboxes]`.
+  """
+  fieldSetId: String
+  """
+  The user-friendly name for a JiraIssueSearchFieldSet, to be displayed in the UI.
+  """
+  displayName: String
+  """
+  The field-type of the current field set.
+  E.g. `Short Text`, `Number`, `Version Picker`, `Team`.
+  Important note: This information only exists for collapsed fields.
+  """
+  type: String
+  """
+  The jqlTerm for the current field config set.
+  E.g. `component`, `fixVersion`
+  """
+  jqlTerm: String
+  """
+  Determines whether or not the current field config set is sortable.
+  """
+  isSortable: Boolean
+  """
+  Tracks whether or not the current field config set has been selected.
+  """
+  isSelected: Boolean
+}
+
+"""
+The input used for an issue search.
+The issue search will either rely on the specified JQL or the specified filter's underlying JQL.
+
+"""
+input JiraIssueSearchInput {
+  jql: String
+  filterId: String
+}
+
+"""
+The options used for an issue search.
+The issueKey determines the target page for search.
+Do not provide pagination arguments alongside issueKey.
+
+"""
+input JiraIssueSearchOptions {
+  issueKey: String
+}
+
+"""
+The possible errors that can occur during an issue search.
+"""
+union JiraIssueSearchError = JiraInvalidJqlError | JiraInvalidSyntaxError
+
+"""
+The representation for an invalid JQL error.
+E.g. 'project = TMP' where 'TMP' has been deleted.
+"""
+type JiraInvalidJqlError {
+  """
+  A list of JQL validation messages.
+  """
+  messages: [String]
+}
+
+"""
+The representation for JQL syntax error.
+E.g. 'project asdf = TMP'.
+"""
+type JiraInvalidSyntaxError {
+  """
+  The specific error message.
+  """
+  message: String
+  """
+  The error type of this particular syntax error.
+  """
+  errorType: JiraJqlSyntaxError
+  """
+  The line of the JQL where the JQL syntax error occurred.
+  """
+  line: Int
+  """
+  The column of the JQL where the JQL syntax error occurred.
+  """
+  column: Int
+}
+
+enum JiraJqlSyntaxError {
+  RESERVED_WORD,
+  ILLEGAL_ESCAPE,
+  UNFINISHED_STRING,
+  ILLEGAL_CHARACTER,
+  RESERVED_CHARACTER,
+  UNKNOWN,
+  ILLEGAL_NUMBER,
+  EMPTY_FIELD,
+  EMPTY_FUNCTION,
+  MISSING_FIELD_NAME,
+  NO_ORDER,
+  UNEXPECTED_TEXT,
+  NO_OPERATOR,
+  BAD_FIELD_ID,
+  BAD_PROPERTY_ID,
+  BAD_FUNCTION_ARGUMENT,
+  EMPTY_FUNCTION_ARGUMENT,
+  MISSING_LOGICAL_OPERATOR,
+  BAD_OPERATOR,
+  PREDICATE_UNSUPPORTED,
+  OPERAND_UNSUPPORTED
+}# Copied over from jira-project, will extend this type after deprecating rest bridge project
+
+"""
+Represents an Issue type, e.g. story, task, bug.
+"""
+type JiraIssueType implements Node {
+  """
+  Global identifier of the Issue type.
+  """
+  id: ID!
+  """
+  This is the internal id of the IssueType.
+  """
+  issueTypeId: String
+  """
+  Name of the Issue type.
+  """
+  name: String!
+  """
+  Description of the Issue type.
+  """
+  description: String
+  """
+  Avatar of the Issue type.
+  """
+  avatar: JiraAvatar
+  """
+  The IssueType hierarchy level
+  """
+  hierarchy: JiraIssueTypeHierarchyLevel
+}
+
+"""
+The connection type for JiraIssueType.
+"""
+type JiraIssueTypeConnection {
+  """
+  The total count of items in the connection.
+  """
+  totalCount: Int
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+  """
+  A list of edges in the current page.
+  """
+  edges: [JiraIssueTypeEdge]
+}
+
+"""
+An edge in a JiraCommentConnection connection.
+"""
+type JiraIssueTypeEdge {
+  """
+  The node at the the edge.
+  """
+  node: JiraIssueType
+  """
+  The cursor to this edge.
+  """
+  cursor: String!
+}
+
+"""
+The Jira IssueType hierarchy level.
+Hierarchy levels represent Issue parent-child relationships using an integer scale.
+"""
+type JiraIssueTypeHierarchyLevel {
+  """
+  The global hierarchy level of the IssueType.
+  E.g. -1 for the subtask level, 0 for the base level, 1 for the epic level.
+  """
+  level: Int
+  """
+  The name of the IssueType hierarchy level.
+  """
+  name: String
+}
+extend type JiraQuery {
+    """
+    Returns an Issue by the Issue Key and Jira instance Cloud ID.
+    """
+    issueByKey (
+        key: String!
+        cloudId: ID!
+    ): JiraIssue
+
+    """
+    Returns an Issue by the Issue ID and Jira instance Cloud ID.
+    """
+    issueById (
+        id: ID!
+    ): JiraIssue
+
+    """
+    Returns an Issue by the issue ID (ARI).
+    Prefer this over issueByKey/issueById as the latter are still experimental.
+    """
+    issue(
+      id: ID
+    ): JiraIssue
+
+    """
+    Returns Issues by the Issue ID.
+    At first input and output sizes are limited to 1 per API call.
+    Once the bulk API is implemented, input and output sizes will be limited to 50 per API call.
+    The server will return an error if the limit is exceeded.
+    """
+    issuesById (
+        ids: [ID!]!
+    ): [JiraIssue]
+
+    """
+    Returns Screen Id by the Issue ID.
+    """
+    screenIdByIssueId(
+        issueId: ID!
+    ): Long @deprecated(reason: "The screen concept has been deprecated, and is only used for legacy reasons.")
+
+    """
+    Returns Screen Id by the Issue Key.
+    """
+    screenIdByIssueKey (
+        issueKey: String!
+    ): Long @deprecated(reason: "The screen concept has been deprecated, and is only used for legacy reasons.")
+
+    """
+    Returns comments by the Issue ID and the Comment ID.
+    At first input and output sizes are limited to 1 per API call.
+    Once the bulk API is implemented, input and output sizes will be limited to 50 per API call.
+    The server will return an error if the limit is exceeded.
+    """
+    commentsById (
+        input: [JiraCommentByIdInput!]!
+    ): [JiraComment]
+
+    """
+    The id of the tenant's epic link field.
+    """
+    epicLinkFieldKey: String @deprecated(reason: "A temp attribute before issue creation modal supports unified parent")
+}extend type JiraQuery {
+    """
+    Retrieves application properties for the given instance.
+
+    Returns an array containing application properties for each of the provided keys. If a matching application property
+    cannot be found, then no entry is added to the array for that key.
+
+    A maximum of 50 keys can be provided. If the limit is exceeded then then an error may be returned.
+    """
+    applicationPropertiesByKey(cloudId: ID!, keys: [String!]!): [JiraApplicationProperty!]
+}
+
+"""
+Jira application properties is effectively a key/value store scoped to a Jira instance. A JiraApplicationProperty
+represents one of these key/value pairs, along with associated metadata about the property.
+"""
+type JiraApplicationProperty implements Node {
+    """
+    Globally unique identifier
+    """
+    id: ID!,
+
+    """
+    The unique key of the application property
+    """
+    key: String!,
+
+    """
+    Although all application properties are stored as strings, they notionally have a type (e.g. boolean, int, enum,
+    string). The type can be anything (for example, there is even a colour type), and there may be associated validation
+    on the server based on the property's type.
+    """
+    type: String!,
+
+    """
+    The value of the application property, encoded as a string. If no value is stored the default value will
+    be returned.
+    """
+    value: String!,
+
+    """
+    The default value which will be returned if there is no value stored. This might be useful for UIs which allow a
+    user to 'reset' an application property to the default value.
+    """
+    defaultValue: String!,
+
+    """
+    The human readable name for the application property. If no human readable name has been defined then the key will
+    be returned.
+    """
+    name: String!,
+
+    """
+    The human readable description for the application property
+    """
+    description: String,
+
+    """
+    Example is mostly used for application properties which store some sort of format pattern (e.g. date formats).
+    Example will contain an example string formatted according to the format stored in the property.
+    """
+    example: String,
+
+    """
+    If the type is 'enum', then allowedValues may optionally contain a list of values which are valid for this property.
+    Otherwise the value will be null.
+    """
+    allowedValues: [String!],
+
+    """
+    True if the user is allowed to edit the property, false otherwise
+    """
+    isEditable: Boolean!
+}
+
+extend type JiraMutation {
+    """
+    Sets application properties for the given instance.
+
+    Takes a list of key/value pairs to be updated, and returns a summary of the mutation result.
+    """
+    setApplicationProperties(cloudId: ID!, input: [JiraSetApplicationPropertyInput!]!): JiraSetApplicationPropertiesPayload
+}
+
+"""
+The key of the property you want to update, and the new value you want to set it to
+"""
+input JiraSetApplicationPropertyInput {
+    key: String!,
+    value: String!
+}
+
+type JiraSetApplicationPropertiesPayload implements Payload {
+    """
+    True if the mutation was successfully applied. False if the mutation was either partially successful or if the
+    mutation failed completely.
+    """
+    success: Boolean!,
+
+    """
+    A list of errors which encountered during the mutation
+    """
+    errors: [MutationError!],
+
+    """
+    A list of application properties which were successfully updated
+    """
+    applicationProperties: [JiraApplicationProperty!]!
+}
+type JiraQuery {
+    "Empty types are not allowed in schema language, even if they are later extended"
+    _empty: String
+}
+
+type Mutation {
+    """
+    this field is added to enable self governed onboarding of Jira GraphQL types to AGG
+    see https://hello.atlassian.net/wiki/spaces/PSRV/pages/1010287708/Announcing+self+governed+APIs for more details
+    """
+    jira: JiraMutation
+}
+
+type JiraMutation {
+    "Empty types are not allowed in schema language, even if they are later extended"
+    _empty: String
+}
+extend type JiraQuery {
+    """
+    Grabs jira entities that have been favourited, filtered by type.
+    """
+    favourites(
+        cloudId: ID!,
+        filter: JiraFavouriteFilter!,
+        first: Int,
+        after: String,
+        last: Int,
+        before: String
+    ): JiraFavouriteConnection!
+}
+
+type JiraFavouriteConnection {
+    edges: [JiraFavouriteEdge]
+    pageInfo: PageInfo!
+}
+
+type JiraFavouriteEdge {
+    node: JiraFavourite
+    cursor: String!
+}
+
+input JiraFavouriteFilter {
+    """The Jira entity type to get."""
+    type: JiraFavouriteType!
+}
+
+"""Currently supported favouritable entities in Jira."""
+enum JiraFavouriteType {
+    PROJECT
+}
+
+union JiraFavourite = JiraProject
+extend type JiraQuery {
+    """
+    A parent field to get information about a given Jira filter. The id provided must be in ARI format.
+    """
+    filter (id: ID!): JiraFilter
+
+    """
+    A field to get a list of favourited filters.
+    """
+    favouriteFilters (
+        """
+        The cloud id of the tenant.
+        """
+        cloudId: ID!
+
+        """
+        The number of items after the cursor to be returned, if not specified it is up to the server to determine a page size.
+        """
+        first: Int
+
+        """
+        The index based cursor to specify the beginning of the items, if not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+
+        """
+        The number of items to be sliced away from the bottom of the list after slicing with `first` argument.
+        """
+        last: Int
+
+        """
+        The index based cursor to specify the bottom limit of the items, if not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraFilterConnection
+
+    """
+    A field to get a list of system filters. Accepts `isFavourite` argument to return list of favourited system filters or to exclude favourited
+    filters from the list.
+    """
+    systemFilters (
+        """
+        The cloud id of the tenant.
+        """
+        cloudId: ID!
+
+        """
+        Whether the filters are favourited by the user.
+        """
+        isFavourite: Boolean, 
+
+        """
+        The number of items after the cursor to be returned, if not specified it is up to the server to determine a page size.
+        """
+        first: Int
+
+        """
+        The index based cursor to specify the beginning of the items, if not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+
+        """
+        The number of items to be sliced away from the bottom of the list after slicing with `first` argument.
+        """
+        last: Int
+
+        """
+        The index based cursor to specify the bottom limit of the items, if not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraSystemFilterConnection
+}
+
+"""
+JiraFilterResult can resolve to a system filter, custom filter or a QueryError when filter does not exist or the user has no permission to access the filter.
+"""
+union JiraFilterResult = JiraCustomFilter | JiraSystemFilter | QueryError
+
+"""
+A generic interface for Jira Filter. 
+"""
+interface JiraFilter implements Node {
+    """
+    An ARI value in the format `ari:cloud:jira:{siteId}:filter/activation/{activationId}/{filterId}`that encodes the filterId.
+    """
+    id: ID!
+
+    """
+    A tenant local filterId. This value is used for interoperability with REST APIs (eg vendors).
+    """
+    filterId: String!
+
+    """
+    JQL associated with the filter.
+    """
+    jql: String!
+
+    """
+    A string representing the filter name.
+    """
+    name: String!
+
+    """
+    Determines whether the filter is currently starred by the user viewing the filter.
+    """
+    isFavourite: Boolean
+}
+
+"""
+Represents a pre-defined filter in Jira.
+"""
+type JiraSystemFilter implements JiraFilter & Node {
+    """
+    An ARI value in the format `ari:cloud:jira:{siteId}:filter/activation/{activationId}/{filterId}`that encodes the filterId.
+    """
+    id: ID!
+
+    """
+    A tenant local filterId. For system filters the ID is in the range from -9 to -1. This value is used for interoperability with REST APIs (eg vendors).
+    """
+    filterId: String!
+
+    """
+    JQL associated with the filter.
+    """
+    jql: String!
+
+    """
+    A string representing the filter name.
+    """
+    name: String!
+
+    """
+    Determines whether the filter is currently starred by the user viewing the filter.
+    """
+    isFavourite: Boolean
+}
+
+"""
+Represents a user generated custom filter.
+"""
+type JiraCustomFilter implements JiraFilter & Node {
+    """
+    An ARI value in the format `ari:cloud:jira:{siteId}:filter/activation/{activationId}/{filterId}`that encodes the filterId.
+    """
+    id: ID!
+
+    """
+    A tenant local filterId. This value is used for interoperability with REST APIs (eg vendors).
+    """
+    filterId: String!
+
+    """
+    JQL associated with the filter.
+    """
+    jql: String!
+
+    """
+    The user that owns the filter.
+    """
+    ownerAccountId: String
+
+    """
+    A string representing the filter name.
+    """
+    name: String!
+
+    """
+    A string containing filter description.
+    """
+    description: String
+
+    """
+    Determines whether the filter is currently starred by the user viewing the filter.
+    """
+    isFavourite: Boolean
+
+    """
+    Determines whether the user has permissions to edit the filter 
+    """
+    isEditable: Boolean
+
+    """
+    Retrieves a connection of email subscriptions for the filter.
+    """
+    emailSubscriptions(
+        """
+        The number of items after the cursor to be returned, if not specified it is up to the server to determine a page size.
+        """
+        first: Int
+
+        """
+        The index based cursor to specify the beginning of the items, if not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+
+        """
+        The number of items to be sliced away from the bottom of the list after slicing with `first` argument.
+        """
+        last: Int
+
+        """
+        The index based cursor to specify the bottom limit of the items, if not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraFilterEmailSubscriptionConnection
+
+    """
+    Retrieves a connection of share grants for the filter. Share grants represent collections of users who can access the filter.
+    """
+    shareGrants(
+        """
+        The number of items after the cursor to be returned, if not specified it is up to the server to determine a page size.
+        """
+        first: Int
+
+        """
+        The index based cursor to specify the beginning of the items, if not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+
+        """
+        The number of items to be sliced away from the bottom of the list after slicing with `first` argument.
+        """
+        last: Int
+
+        """
+        The index based cursor to specify the bottom limit of the items, if not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraShareableEntityShareGrantConnection
+
+    """
+    Retrieves a connection of edit grants for the filter. Edit grants represent collections of users who can edit the filter.
+    """
+    editGrants(
+        """
+        The number of items after the cursor to be returned, if not specified it is up to the server to determine a page size.
+        """
+        first: Int
+
+        """
+        The index based cursor to specify the beginning of the items, if not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+
+        """
+        The number of items to be sliced away from the bottom of the list after slicing with `first` argument.
+        """
+        last: Int
+
+        """
+        The index based cursor to specify the bottom limit of the items, if not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraShareableEntityEditGrantConnection    
+}
+
+"""
+Represents connection of JiraFilters
+"""
+type JiraFilterConnection {
+    """
+    The page info of the current page of results.
+    """
+    pageInfo: PageInfo!
+
+    """
+    The data for the edges in the current page.
+    """
+    edges: [JiraFilterEdge]
+}
+
+"""
+Represents a filter edge
+"""
+type JiraFilterEdge {
+    """
+    The node at the edge
+    """
+    node: JiraFilter
+
+    """
+    The cursor to this edge
+    """
+    cursor: String!
+}
+
+"""
+Represents connection of JiraSystemFilters
+"""
+type JiraSystemFilterConnection {
+    """
+    The page info of the current page of results.
+    """
+    pageInfo: PageInfo!
+
+    """
+    The data for the edges in the current page.
+    """
+    edges: [JiraSystemFilterEdge]
+}
+
+"""
+Represents a system filter edge
+"""
+type JiraSystemFilterEdge {
+    """
+    The node at the edge
+    """
+    node: JiraSystemFilter
+
+    """
+    The cursor to this edge
+    """
+    cursor: String!
+}
+
+"""
+Represents an email subscription to a Jira Filter
+"""
+type JiraFilterEmailSubscription implements Node {
+    """
+    ARI of the email subscription.
+    """
+    id: ID!
+
+    """
+    User that created the subscription. If no group is specified then the subscription is personal for this user.
+    """
+    userAccountId: String
+
+    """
+    The group subscribed to the filter.
+    """
+    group: JiraGroup
+}
+
+"""
+Represents a connection of JiraFilterEmailSubscriptions.
+"""
+type JiraFilterEmailSubscriptionConnection {
+    """
+    The page info of the current page of results.
+    """
+    pageInfo: PageInfo!
+
+    """
+    The data for the edges in the current page.
+    """
+    edges: [JiraFilterEmailSubscriptionEdge]
+}
+
+"""
+Represents a filter email subscription edge
+"""
+type JiraFilterEmailSubscriptionEdge {
+    """
+    The node at the edge
+    """
+    node: JiraFilterEmailSubscription
+
+    """
+    The cursor to this edge
+    """
+    cursor: String!
+}
+
+extend type JiraMutation {
+    jiraFilterMutation: JiraFilterMutation
+}
+
+"""
+Mutations for JiraFilters
+"""
+type JiraFilterMutation {
+    """
+    Mutation to create JiraCustomFilter
+    """
+    createJiraCustomFilter(cloudId: ID!, input: JiraCreateCustomFilterInput!): JiraCreateCustomFilterPayload
+    """
+    Mutation to update JiraCustomFilter details
+    """
+    updateJiraCustomFilterDetails(input: JiraUpdateCustomFilterDetailsInput!): JiraUpdateCustomFilterPayload
+    """
+    Mutation to update JiraCustomFilter JQL
+    """
+    updateJiraCustomFilterJql(input: JiraUpdateCustomFilterJqlInput!): JiraUpdateCustomFilterJqlPayload
+}
+
+
+"""
+The payload returned after creating a JiraCustomFilter.
+"""
+type JiraCreateCustomFilterPayload implements Payload {
+    """
+    Was this mutation successful
+    """
+    success: Boolean!
+    """
+    A list of errors if the mutation was not successful
+    """
+    errors: [MutationError!]
+    """
+    JiraFilter created or updated by the mutation
+    """
+    filter: JiraCustomFilter
+}
+
+
+"""
+The payload returned after updating a JiraCustomFilter.
+"""
+type JiraUpdateCustomFilterPayload implements Payload {
+    """
+    Was this mutation successful
+    """
+    success: Boolean!
+    """
+    A list of errors if the mutation was not successful
+    """
+    errors: [MutationError!]
+    """
+    JiraFilter created or updated by the mutation
+    """
+    filter: JiraCustomFilter
+}
+
+"""
+The payload returned after updating a JiraCustomFilter's JQL.
+"""
+type JiraUpdateCustomFilterJqlPayload implements Payload {
+    """
+    Was this mutation successful
+    """
+    success: Boolean!
+    """
+    A list of errors if the mutation was not successful
+    """
+    errors: [MutationError!]
+    """
+    JiraFilter updated by the mutation
+    """
+    filter: JiraCustomFilter
+}
+
+"""
+Error extension for filter name validation errors.
+"""
+type JiraFilterNameMutationErrorExtension implements MutationErrorExtension {
+    """
+    A numerical code (example: HTTP status code) representing the error category
+    For example: 412 for operation preconditions failure.
+    """
+    statusCode: Int
+    """
+    Application specific error type in human readable format.
+    For example: FilterNameError
+    """
+    errorType: String
+}
+
+"""
+Input for creating a JiraCustomFilter.
+"""
+input JiraCreateCustomFilterInput {
+    """
+    JQL associated with the filter
+    """
+    jql: String!
+    """
+    A string representing the name of the filter
+    """
+    name: String!
+    """
+    A string containing filter description
+    """
+    description: String
+    """
+    Determines whether the filter is currently starred by the user viewing the filter
+    """
+    isFavourite: Boolean!
+    """
+    The list of share grants for the filter. Share Grants represent different ways that users have been granted access to the filter.
+    Empty array represents private and null represents default share grant.
+    """
+    shareGrants: [JiraShareableEntityShareGrantInput]!
+    """
+    The list of edit grants for the filter. Edit Grants represent different ways that users have been granted access to edit the filter.
+    Empty array represents private edit grant.
+    """
+    editGrants: [JiraShareableEntityEditGrantInput]!
+}
+
+"""
+Input for updating a JiraCustomFilter.
+"""
+input JiraUpdateCustomFilterDetailsInput {
+    """
+    ARI of the filter
+    """
+    id: ID!
+    """
+    A string representing the name of the filter
+    """
+    name: String!
+    """
+    A string containing filter description
+    """
+    description: String
+    """
+    The list of share grants for the filter. Share Grants represent different ways that users have been granted access to the filter.
+    Empty array represents private share grant.
+    """
+    shareGrants: [JiraShareableEntityShareGrantInput]!
+    """
+    The list of edit grants for the filter. Edit Grants represent different ways that users have been granted access to edit the filter.
+    Empty array represents private edit grant.
+    """
+    editGrants: [JiraShareableEntityEditGrantInput]!
+}
+
+"""
+Input for updating the JQL of a JiraCustomFilter.
+"""
+input JiraUpdateCustomFilterJqlInput {
+    """
+    An ARI-format value that encodes the filterId.
+    """
+    id: ID!
+    """
+    JQL associated with the filter
+    """
+    jql: String!
+}
+"""
+The grant types to share or edit ShareableEntities.
+"""
+enum JiraShareableEntityGrant {
+    """
+    The anonymous access represents the public access without logging in.
+    """
+    ANONYMOUS_ACCESS
+
+    """
+    Any user who has the product access.
+    """
+    ANY_LOGGEDIN_USER_APPLICATION_ROLE
+  
+    """
+    A group is a collection of users who can be given access together.
+    It represents group in the organization's user base.
+    """
+    GROUP
+
+    """
+    A project or a role that user can play in a project.
+    """
+    PROJECT
+
+    """
+    A project or a role that user can play in a project.
+    """
+    PROJECT_ROLE
+
+    """
+    Indicates that the user does not have access to the project 
+    the members of which have been granted permission.
+    """
+    PROJECT_UNKNOWN
+      
+    """
+    An individual user who can be given the access to work on one or more projects.
+    """
+    USER
+
+}
+
+"""
+Union of grant types to share entities.
+"""
+union JiraShareableEntityShareGrant = JiraShareableEntityGroupGrant | JiraShareableEntityProjectRoleGrant | JiraShareableEntityProjectGrant | JiraShareableEntityAnonymousAccessGrant | JiraShareableEntityAnyLoggedInUserGrant | JiraShareableEntityUnknownProjectGrant 
+
+"""
+Union of grant types to edit entities.
+"""
+union JiraShareableEntityEditGrant = JiraShareableEntityGroupGrant | JiraShareableEntityProjectRoleGrant | JiraShareableEntityUserGrant | JiraShareableEntityProjectGrant | JiraShareableEntityUnknownProjectGrant
+
+"""
+GROUP grant type.
+"""
+type JiraShareableEntityGroupGrant {
+    """
+    'GROUP' type of Jira ShareableEntity Grant Types.
+    """
+    type: JiraShareableEntityGrant
+
+    """
+    Jira Group, members of which will be granted permission.
+    """
+    group: JiraGroup
+}
+
+"""
+PROJECT grant type.
+"""
+type JiraShareableEntityProjectGrant {
+    """
+    'PROJECT_ROLE' type of Jira ShareableEntity Grant Types.
+    """
+    type: JiraShareableEntityGrant
+
+    """
+    Jira Project, members of which will have the permission. 
+    """
+    project: JiraProject
+}
+
+"""
+PROJECT_ROLE grant type.
+"""
+type JiraShareableEntityProjectRoleGrant {
+    """
+    'PROJECT_ROLE' type of Jira ShareableEntity Grant Types.
+    """
+    type: JiraShareableEntityGrant
+
+    """
+    Jira Project, members of which will have the permission. 
+    """
+    project: JiraProject
+
+    """
+    Users with the specified Jira Project Role in the Jira Project will have have the permission.
+    If no role is specified then all members of the project have the permisison.
+    """
+    role: JiraRole
+}
+
+"""
+ANONYMOUS_ACCESS grant type.
+"""
+type JiraShareableEntityAnonymousAccessGrant {
+    """
+    'ANONYMOUS_ACCESS' type of Jira ShareableEntity Grant Types.
+    """
+    type: JiraShareableEntityGrant
+}
+
+"""
+ANY_LOGGEDIN_USER_APPLICATION_ROLE grant type.
+"""
+type JiraShareableEntityAnyLoggedInUserGrant {
+    """
+    'ANY_LOGGEDIN_USER_APPLICATION_ROLE' type of Jira ShareableEntity Grant Types. 
+    """
+    type: JiraShareableEntityGrant
+}
+
+"""
+USER grant type 
+"""
+type JiraShareableEntityUserGrant {
+    """
+    'USER' grant type of Jira ShareableEntity Grant Types.
+    """
+    type: JiraShareableEntityGrant
+
+    """
+    User that is granted the permission
+    """
+    userAccountId: String
+}
+
+"""
+PROJECT_UNKNOWN grant type
+"""
+type JiraShareableEntityUnknownProjectGrant {
+    """
+    PROJECT_UNKNOWN grant type of Jira ShareableEntity Grant Types.
+    """
+    type: JiraShareableEntityGrant
+}
+
+"""
+Represents a connection of share permissions for a shared entity.
+"""
+type JiraShareableEntityShareGrantConnection {
+    """
+    The page info of the current page of results.
+    """
+    pageInfo: PageInfo!
+
+    """
+    The data for the edges in the current page.
+    """
+    edges: [JiraShareableEntityShareGrantEdge]
+}
+
+"""
+Represents a share permission edge for a shared entity.
+"""
+type JiraShareableEntityShareGrantEdge {
+    """
+    The node at the the edge.
+    """
+    node: JiraShareableEntityShareGrant
+
+    """
+    The cursor to this edge.
+    """
+    cursor: String
+}
+
+"""
+Represents a connection of edit permissions for a shared entity.
+"""
+type JiraShareableEntityEditGrantConnection {
+    """
+    The page info of the current page of results.
+    """
+    pageInfo: PageInfo!
+
+    """
+    The data for the edges in the current page.
+    """
+    edges: [JiraShareableEntityEditGrantEdge]
+}
+
+"""
+Represents an edit permission edge for a shared entity.
+"""
+type JiraShareableEntityEditGrantEdge {
+    """
+    The node at the the edge.
+    """
+    node: JiraShareableEntityEditGrant
+
+    """
+    The cursor to this edge.
+    """
+    cursor: String
+}
+
+# INPUTS
+
+"""
+Input type for JiraShareableEntityShareGrants.
+"""
+input JiraShareableEntityShareGrantInput {
+    """
+    User group that will be granted permission.
+    """
+    group: JiraShareableEntityGroupGrantInput
+
+    """
+    Members of the specified project will be granted permission.
+    """
+    project: JiraShareableEntityProjectGrantInput
+
+    """
+    Users with the specified role in the project will be granted permission.
+    """
+    projectRole: JiraShareableEntityProjectRoleGrantInput
+    """
+    All users with access to the instance and anonymous users will be granted permission.
+    """
+    anonymousAccess: JiraShareableEntityAnonymousAccessGrantInput
+    """
+    All users with access to the instance will be granted permission.
+    """
+    anyLoggedInUser: JiraShareableEntityAnyLoggedInUserGrantInput
+}
+
+"""
+Input type for JiraShareableEntityEditGrants.
+"""
+input JiraShareableEntityEditGrantInput {
+    """
+    User group that will be granted permission.
+    """
+    group: JiraShareableEntityGroupGrantInput
+
+    """
+    Members of the specifid project will be granted permission.
+    """
+    project: JiraShareableEntityProjectGrantInput
+
+    """
+    Users with the specified role in the project will be granted permission.
+    """
+    projectRole: JiraShareableEntityProjectRoleGrantInput
+
+    """
+    User that will be granted permission.
+    """
+    user: JiraShareableEntityUserGrantInput
+}
+
+"""
+Input for the group that will be granted permission.
+"""
+input JiraShareableEntityGroupGrantInput {
+    """
+    JiraShareableEntityGrant ARI.
+    """
+    id: ID
+
+    """
+    Id of the user group
+    """
+    groupId: ID!
+}
+
+"""
+Input for the project ID, members of which will be granted permission.
+"""
+input JiraShareableEntityProjectGrantInput {
+    """
+    JiraShareableEntityGrant ARI.
+    """
+    id: ID
+    """
+    ARI of the project in the format `ari:cloud:jira:{siteId}:project/{projectId}`.
+    """
+    projectId: ID!
+}
+
+"""
+Input for the id of the role.
+Users with the specified role will be granted permission.
+"""
+input JiraShareableEntityProjectRoleGrantInput {
+    """
+    JiraShareableEntityGrant ARI.
+    """
+    id: ID
+    """
+    ARI of the project in the format `ari:cloud:jira:{siteId}:project/{projectId}`.
+    """
+    projectId: ID!
+    """
+    Tenant local roleId.
+    """
+    projectRoleId: Int!
+}
+
+"""
+Input for user that will be granted permission.
+"""
+input JiraShareableEntityUserGrantInput {
+    """
+    JiraShareableEntityGrant ARI.
+    """
+    id: ID
+    """
+    ARI of the user in the form of ARI: ari:cloud:identity::user/{userId}.
+    """
+    userId: ID!
+}
+
+"""
+Input for when the shareable entity is intended to be shared with all users on a Jira instance
+and anonymous users.
+"""
+input JiraShareableEntityAnonymousAccessGrantInput {
+    """
+    JiraShareableEntityGrant ARI.
+    """
+    id: ID
+}
+
+"""
+Input for when the shareable entity is intended to be shared with all users on a Jira instance
+and NOT anonymous users.
+"""
+input JiraShareableEntityAnyLoggedInUserGrantInput {
+    """
+    JiraShareableEntityGrant ARI.
+    """
+    id: ID
+}
+extend type JiraQuery {
+  """
+  A parent field to get information about jql related aspects from a given jira instance.
+  """
+  jqlBuilder(cloudId: ID!): JiraJqlBuilder
+}
+
+"""
+Encapsulates queries and fields necessary to power the JQL builder.
+
+It also exposes generic JQL capabilities that can be leveraged to power other experiences.
+"""
+type JiraJqlBuilder {
+  """
+  A list of available JQL functions.
+  """
+  functions: [JiraJqlFunction!]!
+
+  """
+  The last used JQL builder search mode.
+
+  This can either be the Basic or JQL search mode.
+  """
+  lastUsedMode: JiraJqlBuilderMode
+
+  """
+  Hydrates the JQL fields and field-values of a given JQL query.
+  """
+  hydrateJqlQuery(query: String): JiraJqlHydratedQueryResult
+  """
+  Hydrates the JQL fields and field-values of a filter corresponding to the provided filter ID.
+
+  The id provided MUST be in ARI format.
+
+  This query will error if the id parameter is not in ARI format, does not pass validation or does not correspond to a JiraFilter.
+  """
+  hydrateJqlQueryForFilter(id: ID!): JiraJqlHydratedQueryResult
+
+  """
+  Retrieves a connection of searchable Jira JQL fields.
+
+  In a given JQL, fields will precede operators and operators precede field-values/ functions.
+
+  E.g. `${FIELD} ${OPERATOR} ${FUNCTION}()` => `Assignee = currentUser()`
+  """
+  fields(
+    """
+    The JQL query that will be parsed and used to form a search context.
+
+    Only the Jira fields that are scoped to this search context will be returned.
+
+    E.g. `Project IN (KEY1, KEY2) AND issueType = Task`.
+    """
+    jqlContext: String
+    """
+    Only the fields that contain this searchString in their displayName will be returned.
+    """
+    searchString: String
+    """
+    Only the fields that support the provided JqlClauseType will be returned.
+    """
+    forClause: JiraJqlClauseType
+    """
+    The number of items after the cursor to be returned, if not specified it is up to the server to determine a page size.
+    """
+    first: Int
+    """
+    The index based cursor to specify the beginning of the items, if not specified the cursor is assumed to be the beginning.
+    """
+    after: String
+  ): JiraJqlFieldConnectionResult
+
+  """
+  Retrieves a connection of Jira fields recently used in JQL searches.
+  """
+  recentFields(
+    """
+    The JQL query that will be parsed and used to form a search context.
+
+    Only the Jira fields that are scoped to this search context will be returned.
+
+    E.g. `Project IN (KEY1, KEY2) AND issueType = Task`.
+    """
+    jqlContext: String
+    """
+    Only the Jira fields that support the provided forClause will be returned.
+    """
+    forClause: JiraJqlClauseType
+    """
+    The number of items after the cursor to be returned. Either `first` or `last` is required.
+    """
+    first: Int
+    """
+    The index based cursor to specify the beginning of the items. If not specified it's assumed as the cursor for the item before the beginning.
+    """
+    after: String
+    """
+    The number of items to be sliced away from the bottom of the list after slicing with `first` argument. Either `first` or `last` is required.
+    """
+    last: Int
+    """
+    The index based cursor to specify the bottom limit of the items. If not specified it's assumed as the cursor to the item after the last item.
+    """
+    before: String
+  ): JiraJqlFieldConnectionResult
+
+  """
+  Retrieves a connection of field-values for a specified Jira Field.
+
+  E.g. A given Jira checkbox field may have the following field-values: `Option 1`, `Option 2` and `Option 3`.
+  """
+  fieldValues(
+    """
+    The JQL query that will be parsed and used to form a search context.
+
+    Only the Jira fields that are scoped to this search context will be returned.
+
+    E.g. `Project IN (KEY1, KEY2) AND issueType = Task`
+    """
+    jqlContext: String
+    """
+    An identifier that a client should use in a JQL query when it’s referring to a field-value.
+
+    Important note: this jqlTerm could require proper escaping before placing it  into a query (e.g. wrap it in "" ).
+    """
+    jqlTerm: String!
+    """
+    Only the Jira field-values with their diplayName matching this searchString will be retrieved.
+    """
+    searchString: String
+    """
+    The number of items after the cursor to be returned, if not specified it is up to the server to determine a page size.
+    """
+    first: Int
+    """
+    The index based cursor to specify the beginning of the items, if not specified the cursor is assumed to be the beginning.
+    """
+    after: String
+  ): JiraJqlFieldValueConnection
+
+  """
+  Retrieves a connection of users recently used in Jira user fields.
+  """
+  recentlyUsedUsers(
+    """
+    The number of items after the cursor to be returned, if not specified it is up to the server to determine a page size.
+    """
+    first: Int
+    """
+    The index based cursor to specify the beginning of the items, if not specified it's assumed as the cursor for the item before the beginning.
+    """
+    after: String
+    """
+    The number of items to be sliced away from the bottom of the list after slicing with `first` argument.
+    """
+    last: Int
+    """
+    The index based cursor to specify the bottom limit of the items, if not specified it's assumed as the cursor to the item after the last item.
+    """
+    before: String
+  ): JiraJqlUserFieldValueConnection
+
+  """
+  Retrieves a connection of suggested groups.
+
+  Groups are suggested when the current user is a member.
+  """
+  suggestedGroups(
+    """
+    The number of items after the cursor to be returned, if not specified it is up to the server to determine a page size.
+    """
+    first: Int
+    """
+    The index based cursor to specify the beginning of the items, if not specified it's assumed as the cursor for the item before the beginning.
+    """
+    after: String
+    """
+    The number of items to be sliced away from the bottom of the list after slicing with `first` argument.
+    """
+    last: Int
+    """
+    The index based cursor to specify the bottom limit of the items, if not specified it's assumed as the cursor to the item after the last item.
+    """
+    before: String
+  ): JiraJqlGroupFieldValueConnection
+
+  """
+  Retrieves a connection of projects that have recently been viewed by the current user.
+  """
+  recentlyUsedProjects(
+    """
+    The number of items after the cursor to be returned, if not specified it is up to the server to determine a page size.
+    """
+    first: Int
+    """
+    The index based cursor to specify the beginning of the items, if not specified it's assumed as the cursor for the item before the beginning.
+    """
+    after: String
+    """
+    The number of items to be sliced away from the bottom of the list after slicing with `first` argument.
+    """
+    last: Int
+    """
+    The index based cursor to specify the bottom limit of the items, if not specified it's assumed as the cursor to the item after the last item.
+    """
+    before: String
+  ): JiraJqlProjectFieldValueConnection
+
+  """
+  Retrieves a connection of sprints that have recently been viewed by the current user.
+  """
+  recentlyUsedSprints(
+    """
+    The JQL query that will be parsed and used to form a search context.
+
+    Only the Jira fields that are scoped to this search context will be returned.
+
+    E.g. `Project IN (KEY1, KEY2) AND issueType = Task`
+    """
+    jqlContext: String
+    """
+    The number of items after the cursor to be returned, if not specified it is up to the server to determine a page size.
+    """
+    first: Int
+    """
+    The index based cursor to specify the beginning of the items, if not specified it's assumed as the cursor for the item before the beginning.
+    """
+    after: String
+    """
+    The number of items to be sliced away from the bottom of the list after slicing with `first` argument.
+    """
+    last: Int
+    """
+    The index based cursor to specify the bottom limit of the items, if not specified it's assumed as the cursor to the item after the last item.
+    """
+    before: String
+  ): JiraJqlSprintFieldValueConnection
+
+  """
+  Retrieves the field-values for the Jira issueType field.
+  """
+  issueTypes(jqlContext: String): JiraJqlIssueTypes
+
+  """
+  Retrieves the field-values for the Jira cascading options field.
+  """
+  cascadingSelectOptions(
+    """
+    The number of items to be sliced away to target between the after and before cursors.
+    """
+    first: Int
+    """
+    The index based cursor to specify the beginning of the items, if not specified it's assumed as the cursor for the item before the beginning.
+    """
+    after: String
+    """
+    The number of items to be sliced away from the bottom of the list after slicing with `first` argument.
+    """
+    last: Int
+    """
+    The index based cursor to specify the bottom limit of the items, if not specified it's assumed as the cursor to the item after the last item.
+    """
+    before: String
+    """
+    The JQL query that will be parsed and used to form a search context.
+
+    Only the Jira fields that are scoped to this search context will be returned.
+
+    E.g. `Project IN (KEY1, KEY2) AND issueType = Task`
+    """
+    jqlContext: String
+    """
+    An identifier that a client should use in a JQL query when it’s referring to an instance of a Jira cascading option field.
+
+    Important note: this jqlTerm could require proper escaping before placing it  into a query (e.g. wrap it in "" ).
+    """
+    jqlTerm: String!
+    """
+    Only the Jira field-values with their diplayName matching this searchString will be retrieved.
+    """
+    searchString: String
+    """
+    Only the cascading options matching this filter will be retrieved.
+    """
+    filter: JiraCascadingSelectOptionsFilter!
+  ): JiraJqlOptionFieldValueConnection
+
+  """
+  Retrieves the field-values for the Jira version field.
+  """
+  versions(
+    """
+    The JQL query that will be parsed and used to form a search context.
+
+    Only the Jira fields that are scoped to this search context will be returned.
+
+    E.g. `Project IN (KEY1, KEY2) AND issueType = Task`.
+    """
+    jqlContext: String,
+    """
+    An identifier that a client should use in a JQL query when it’s referring to an instance of a Jira version field.
+
+    Important note: this jqlTerm could require proper escaping before placing it  into a query (e.g. wrap it in "" ).
+    """
+    jqlTerm: String!
+  ): JiraJqlVersions
+}
+
+"""
+A function in JQL appears as a word followed by parentheses, which may contain one or more explicit values or Jira fields.
+
+In a clause, a function is preceded by an operator, which in turn is preceded by a field.
+
+A function performs a calculation on either specific Jira data or the function's content in parentheses,
+such that only true results are retrieved by the function, and then again by the clause in which the function is used.
+
+E.g. `approved()`, `currentUser()`, `endOfMonth()` etc.
+"""
+type JiraJqlFunction {
+  """
+  The user-friendly name for the function, to be displayed in the UI.
+  """
+  displayName: String
+  """
+  A JQL-function safe encoded name. This value will not be encoded if the displayName is already safe.
+  """
+  value: String
+  """
+  Indicates whether or not the function is meant to be used with IN or NOT IN operators, that is,
+  if the function should be viewed as returning a list.
+
+  The method should return false when it is to be used with the other relational operators (e.g. =, !=, <, >, ...)
+  that only work with single values.
+  """
+  isList: Boolean
+  """
+  The data types that this function handles and creates values for.
+
+  This allows consumers to infer information on the JiraJqlField type such as which functions are supported.
+  """
+  dataTypes: [String!]!
+}
+
+"""
+The modes the JQL builder can be displayed and used in.
+"""
+enum JiraJqlBuilderMode {
+  """
+  The JQL mode, allows queries to be built and executed via the JQL advanced editor.
+
+  This mode allows users to manually type and construct complex JQL queries.
+  """
+  JQL
+  """
+  The basic mode, allows queries to be built and executed via the JQL basic editor.
+
+  This mode allows users to easily construct JQL queries by interacting with the UI.
+  """
+  BASIC
+}
+
+"""
+A union of a Jira JQL hydrated query and a GraphQL query error.
+"""
+union JiraJqlHydratedQueryResult = JiraJqlHydratedQuery | QueryError
+
+"""
+Represents a JQL query with hydrated fields and field-values.
+"""
+type JiraJqlHydratedQuery {
+  """
+  The JQL query to be hydrated.
+  """
+  jql: String
+  """
+  A list of hydrated fields from the provided JQL.
+  """
+  fields: [JiraJqlQueryHydratedFieldResult!]!
+}
+
+"""
+A union of a JQL query hydrated field and a GraphQL query error.
+"""
+union JiraJqlQueryHydratedFieldResult =
+  JiraJqlQueryHydratedField
+  | JiraJqlQueryHydratedError
+
+"""
+Represents an error for a JQL query hydration.
+"""
+type JiraJqlQueryHydratedError {
+  """
+  An identifier for the hydrated Jira JQL field where the error occurred.
+  """
+  jqlTerm: String!
+  """
+  The error that occurred whilst hydrating the Jira JQL field.
+  """
+  error: QueryError
+}
+
+"""
+Represents a hydrated field for a JQL query.
+"""
+type JiraJqlQueryHydratedField {
+  """
+  An identifier for the hydrated Jira JQL field.
+  """
+  jqlTerm: String!
+  """
+  The Jira JQL field associated with the hydrated field.
+  """
+  field: JiraJqlField!
+  """
+  The hydrated value results.
+  """
+  values: [JiraJqlQueryHydratedValueResult]!
+}
+
+"""
+A union of a JQL query hydrated field-value and a GraphQL query error.
+"""
+union JiraJqlQueryHydratedValueResult =
+  JiraJqlQueryHydratedValue
+  | JiraJqlQueryHydratedError
+
+"""
+Represents a hydrated field-value for a given field in the JQL query.
+"""
+type JiraJqlQueryHydratedValue {
+  """
+  An identifier for the hydrated Jira JQL field value.
+  """
+  jqlTerm: String!
+  """
+  The hydrated field values.
+  """
+  values: [JiraJqlFieldValue]!
+}
+
+"""
+A union of a Jira JQL field connection and a GraphQL query error.
+"""
+union JiraJqlFieldConnectionResult = JiraJqlFieldConnection | QueryError
+
+"""
+Represents a connection of Jira JQL fields.
+"""
+type JiraJqlFieldConnection {
+  """
+  The total number of JiraJqlFields matching the criteria.
+  """
+  totalCount: Int
+  """
+  The page info of the current page of results.
+  """
+  pageInfo: PageInfo!
+  """
+  The data for the edges in the current page.
+  """
+  edges: [JiraJqlFieldEdge]
+}
+
+"""
+Represents a Jira JQL field edge.
+"""
+type JiraJqlFieldEdge {
+  """
+  The node at the edge.
+  """
+  node: JiraJqlField
+  """
+  The cursor to this edge.
+  """
+  cursor: String!
+}
+
+
+"""
+The representation of a Jira field within the context of the Jira Query Language.
+"""
+type JiraJqlField {
+  """
+  An identifier that a client should use in a JQL query when it’s referring to a Jira JQL field.
+
+  Important note: this jqlTerm could require proper escaping before placing it  into a query (e.g. wrap it in "" ).
+  """
+  jqlTerm: ID!
+  """
+  The user-friendly name for the current field, to be displayed in the UI.
+  """
+  displayName: String
+  """
+  The data types handled by the current field.
+  These can be used to identify which JQL functions are supported.
+  """
+  dataTypes: [String]
+  """
+  The JQL clause types that can be used with this field.
+  """
+  allowedClauseTypes: [JiraJqlClauseType!]!
+  """
+  The JQL operators that can be used with this field.
+  """
+  operators: [JiraJqlOperator!]!
+  """
+  Defines how a field should be represented in the basic search mode of the JQL builder.
+  """
+  searchTemplate: JiraJqlSearchTemplate
+  """
+  Defines how the field-values should be shown for a field in the JQL-Builder's JQL mode.
+  """
+  autoCompleteTemplate: JiraJqlAutocompleteType
+  """
+  The field-type of the current field.
+  E.g. `Short Text`, `Number`, `Version Picker`, `Team` etc.
+  Important note: This information only exists for collapsed fields.
+  """
+  jqlFieldType: JiraJqlFieldType
+  """
+  Determines whether or not the current field should be accessible in the current search context.
+  """
+  shouldShowInContext: Boolean
+}
+
+"""
+The types of JQL clauses supported by Jira.
+"""
+enum JiraJqlClauseType {
+  """
+  This denotes both WHERE and ORDER_BY.
+  """
+  ANY
+  """
+  This corresponds to jql fields used as filter criteria of Jira issues.
+  """
+  WHERE
+  """
+  This corresponds to fields used to sort Jira Issues.
+  """
+  ORDER_BY
+}
+
+"""
+The types of JQL operators supported by Jira.
+
+An operator in JQL is one or more symbols or words,which compares the value of a field on its left with one or more values (or functions) on its right,
+such that only true results are retrieved by the clause.
+
+For more information on JQL operators please visit: https://support.atlassian.com/jira-software-cloud/docs/advanced-search-reference-jql-operators.
+"""
+enum JiraJqlOperator {
+  """
+  The `=` operator is used to search for issues where the value of the specified field exactly matches the specified value.
+  """
+  EQUALS
+  """
+  The `!=` operator is used to search for issues where the value of the specified field does not match the specified value.
+  """
+  NOT_EQUALS
+  """
+  The `IN` operator is used to search for issues where the value of the specified field is one of multiple specified values.
+  """
+  IN
+  """
+  The `NOT IN` operator is used to search for issues where the value of the specified field is not one of multiple specified values.
+  """
+  NOT_IN
+  """
+  The `IS` operator can only be used with EMPTY or NULL. That is, it is used to search for issues where the specified field has no value.
+  """
+  IS
+  """
+  The `IS NOT` operator can only be used with EMPTY or NULL. That is, it is used to search for issues where the specified field has a value.
+  """
+  IS_NOT
+  """
+  The `<` operator is used to search for issues where the value of the specified field is less than the specified value.
+  """
+  LESS_THAN
+  """
+  The `<=` operator is used to search for issues where the value of the specified field is less than or equal to than the specified value.
+  """
+  LESS_THAN_OR_EQUAL
+  """
+  The `>` operator is used to search for issues where the value of the specified field is greater than the specified value.
+  """
+  GREATER_THAN
+  """
+  The `>=` operator is used to search for issues where the value of the specified field is greater than or equal to the specified value.
+  """
+  GREATER_THAN_OR_EQUAL
+  """
+  The `CHANGED` operator is used to find issues that have a value that had changed for the specified field.
+  """
+  CONTAINS
+  """
+  The `!~` operator is used to search for issues where the value of the specified field is not a "fuzzy" match for the specified value.
+  """
+  NOT_CONTAINS
+  """
+  The `WAS NOT IN` operator is used to search for issues where the value of the specified field has never been one of multiple specified values.
+  """
+  WAS_NOT_IN
+  """
+  The `CHANGED` operator is used to find issues that have a value that had changed for the specified field.
+  """
+  CHANGED
+  """
+  The `WAS IN` operator is used to find issues that currently have or previously had any of multiple specified values for the specified field.
+  """
+  WAS_IN
+  """
+  The `WAS` operator is used to find issues that currently have or previously had the specified value for the specified field.
+  """
+  WAS
+  """
+  The `WAS NOT` operator is used to find issues that have never had the specified value for the specified field.
+  """
+  WAS_NOT
+}
+
+"""
+The representation of a Jira field in the basic search mode of the JQL builder.
+"""
+type JiraJqlSearchTemplate {
+  key: String
+}
+
+"""
+The autocomplete types available for Jira fields in the context of the Jira Query Language.
+
+This enum also describes which fields have field-value support from this schema.
+"""
+enum JiraJqlAutocompleteType {
+  """
+  No autocomplete support.
+  """
+  NONE
+  """
+  The Jira component field JQL autocomplete type.
+  """
+  COMPONENT
+  """
+  The Jira group field JQL autocomplete type.
+  """
+  GROUP
+  """
+  The Jira issue field JQL autocomplete type.
+  """
+  ISSUE
+  """
+  The Jira issue field type JQL autocomplete type.
+  """
+  ISSUETYPE
+  """
+  The Jira priority field JQL autocomplete type.
+  """
+  PRIORITY
+  """
+  The Jira project field JQL autocomplete type.
+  """
+  PROJECT
+  """
+  The Jira sprint field JQL autocomplete type.
+  """
+  SPRINT
+  """
+  The Jira status category field JQL autocomplete type.
+  """
+  STATUSCATEGORY
+  """
+  The Jira status field JQL autocomplete type.
+  """
+  STATUS
+  """
+  The Jira user field JQL autocomplete type.
+  """
+  USER
+  """
+  The Jira version field JQL autocomplete type.
+  """
+  VERSION
+}
+
+"""
+The representation of a Jira JQL field-type in the context of the Jira Query Language.
+
+E.g. `Short Text`, `Number`, `Version Picker`, `Team` etc.
+
+Important note: This information only exists for collapsed fields.
+"""
+type JiraJqlFieldType {
+  """
+  The non-translated name of the field type.
+  """
+  jqlTerm: String!
+  """
+  The translated name of the field type.
+  """
+  displayName: String!
+}
+
+"""
+Represents a connection of field-values for a JQL field.
+"""
+type JiraJqlFieldValueConnection {
+  """
+  The total number of JiraJqlFieldValues matching the criteria.
+  """
+  totalCount: Int
+  """
+  The page info of the current page of results.
+  """
+  pageInfo: PageInfo!
+  """
+  The data for the edges in the current page.
+  """
+  edges: [JiraJqlFieldValueEdge]
+}
+
+"""
+Represents a field-value edge for a JQL field.
+"""
+type JiraJqlFieldValueEdge {
+  """
+  The node at the edge.
+  """
+  node: JiraJqlFieldValue
+  """
+  The cursor to this edge.
+  """
+  cursor: String!
+}
+
+"""
+A generic interface for JQL fields in Jira.
+"""
+interface JiraJqlFieldValue {
+  """
+  An identifier that a client should use in a JQL query when it’s referring to a Jira JQL field-value.
+
+  Important note: this jqlTerm could require proper escaping before placing it  into a query (e.g. wrap it in "" ).
+  """
+  jqlTerm: String!
+  """
+  The user-friendly name for a component JQL field value, to be displayed in the UI.
+  """
+  displayName: String!
+}
+
+"""
+Represents a field-value for a JQL component field.
+"""
+type JiraJqlComponentFieldValue implements JiraJqlFieldValue {
+  """
+  An identifier that a client should use in a JQL query when it’s referring to a Jira component field-value.
+
+  Important note: this jqlTerm could require proper escaping before placing it  into a query (e.g. wrap it in "" ).
+  """
+  jqlTerm: String!
+  """
+  The user-friendly name for a component JQL field value, to be displayed in the UI.
+  """
+  displayName: String!
+}
+
+"""
+Represents a field-value for a JQL group field.
+"""
+type JiraJqlGroupFieldValue implements JiraJqlFieldValue {
+  """
+  An identifier that a client should use in a JQL query when it’s referring to a Jira group field-value.
+
+  Important note: this jqlTerm could require proper escaping before placing it into a query (e.g. wrap it in "" )
+  """
+  jqlTerm: String!
+  """
+  The user-friendly name for a group JQL field value, to be displayed in the UI.
+  """
+  displayName: String!
+  """
+  The Jira group associated with this JQL field value.
+  """
+  group: JiraGroup!
+}
+
+"""
+Represents a field-value for a JQL Issue field.
+"""
+type JiraJqlIssueFieldValue implements JiraJqlFieldValue {
+  """
+  An identifier that a client should use in a JQL query when it’s referring to a field-value.
+
+  Important note: this jqlTerm could require proper escaping before placing it  into a query (e.g. wrap it in "" ).
+  """
+  jqlTerm: String!
+  """
+  The user-friendly name for an issue JQL field value, to be displayed in the UI.
+  """
+  displayName: String!
+  """
+  The Jira issue associated with this JQL field value.
+  """
+  issue: JiraIssue!
+}
+
+"""
+Represents a field-value for a JQL issue type field.
+"""
+type JiraJqlIssueTypeFieldValue implements JiraJqlFieldValue {
+  """
+  An identifier that a client should use in a JQL query when it’s referring to a Jira issue type field-value.
+
+  Important note: this jqlTerm could require proper escaping before placing it  into a query (e.g. wrap it in "" ).
+  """
+  jqlTerm: String!
+  """
+  The user-friendly name for an issue type JQL field value, to be displayed in the UI.
+  """
+  displayName: String!
+  """
+  The Jira issue types associated with this JQL field value.
+  """
+  issueTypes: [JiraIssueType!]!
+}
+
+"""
+Represents a field-value for a JQL sprint field.
+"""
+type JiraJqlSprintFieldValue implements JiraJqlFieldValue {
+  """
+  An identifier that a client should use in a JQL query when it’s referring to a Jira sprint field-value.
+
+  Important note: this jqlTerm could require proper escaping before placing it  into a query (e.g. wrap it in "" ).
+  """
+  jqlTerm: String!
+  """
+  The user-friendly name for a sprint JQL field value, to be displayed in the UI.
+  """
+  displayName: String!
+  """
+  The Jira sprint associated with this JQL field value.
+  """
+  sprint: JiraSprint!
+}
+
+"""
+Represents a field-value for a JQL priority field.
+"""
+type JiraJqlPriorityFieldValue implements JiraJqlFieldValue {
+  """
+  An identifier that a client should use in a JQL query when it’s referring to a Jira priority field-value.
+
+  Important note: this jqlTerm could require proper escaping before placing it  into a query (e.g. wrap it in "" ).
+  """
+  jqlTerm: String!
+  """
+  The user-friendly name for a priority JQL field value, to be displayed in the UI.
+  """
+  displayName: String!
+  """
+  The Jira property associated with this JQL field value.
+  """
+  priority: JiraPriority!
+}
+
+"""
+Represents a field-value for a JQL option field.
+"""
+type JiraJqlOptionFieldValue implements JiraJqlFieldValue {
+  """
+  An identifier that a client should use in a JQL query when it’s referring to a Jira option field-value.
+
+  Important note: this jqlTerm could require proper escaping before placing it  into a query (e.g. wrap it in "" ).
+  """
+  jqlTerm: String!
+  """
+  The user-friendly name for an option JQL field value, to be displayed in the UI.
+  """
+  displayName: String!
+}
+
+"""
+Represents a field-value for a JQL cascading option field.
+"""
+type JiraJqlCascadingOptionFieldValue implements JiraJqlFieldValue {
+  """
+  An identifier that a client should use in a JQL query when it’s referring to a Jira cascading option field-value.
+
+  Important note: this jqlTerm could require proper escaping before placing it  into a query (e.g. wrap it in "" ).
+  """
+  jqlTerm: String!
+  """
+  The user-friendly name for a cascading option JQL field value, to be displayed in the UI.
+  """
+  displayName: String!
+  """
+  The Jira JQL parent option associated with this JQL field value.
+  """
+  parentOption: JiraJqlOptionFieldValue
+}
+
+"""
+Represents a field-value for a JQL status category field.
+"""
+type JiraJqlStatusCategoryFieldValue implements JiraJqlFieldValue {
+  """
+  An identifier that a client should use in a JQL query when it’s referring to a Jira status category field-value.
+
+  Important note: this jqlTerm could require proper escaping before placing it  into a query (e.g. wrap it in "" ).
+  """
+  jqlTerm: String!
+  """
+  The user-friendly name for a status category JQL field value, to be displayed in the UI.
+  """
+  displayName: String!
+  """
+  The Jira status category associated with this JQL field value.
+  """
+  statusCategory: JiraStatusCategory!
+}
+
+"""
+Represents a field-value for a JQL status field.
+"""
+type JiraJqlStatusFieldValue implements JiraJqlFieldValue {
+  """
+  An identifier that a client should use in a JQL query when it’s referring to a Jira status field-value.
+
+  Important note: this jqlTerm could require proper escaping before placing it  into a query (e.g. wrap it in "" ).
+  """
+  jqlTerm: String!
+  """
+  The user-friendly name for a status JQL field value, to be displayed in the UI.
+  """
+  displayName: String!
+  """
+  The Jira status category associated with this JQL field value.
+  """
+  statusCategory: JiraStatusCategory!
+}
+
+"""
+Represents a field-value for a JQL user field.
+"""
+type JiraJqlUserFieldValue implements JiraJqlFieldValue {
+  """
+  An identifier that a client should use in a JQL query when it’s referring to a Jira user field-value.
+
+  Important note: this jqlTerm could require proper escaping before placing it  into a query (e.g. wrap it in "" ).
+  """
+  jqlTerm: String!
+  """
+  The user-friendly name for a user JQL field value, to be displayed in the UI.
+  """
+  displayName: String!
+  """
+  The user associated with this JQL field value.
+  """
+  user: User!
+}
+
+"""
+Represents a field-value for a JQL resolution field.
+"""
+type JiraJqlResolutionFieldValue implements JiraJqlFieldValue {
+  """
+  An identifier that a client should use in a JQL query when it’s referring to a Jira resolution field-value.
+
+  Important note: this jqlTerm could require proper escaping before placing it  into a query (e.g. wrap it in "" ).
+  """
+  jqlTerm: String!
+  """
+  The user-friendly name for a resolution JQL field value, to be displayed in the UI.
+  """
+  displayName: String!
+  """
+  The Jira resolution associated with this JQL field value.
+  """
+  resolution: JiraResolution
+}
+
+"""
+Represents a field-value for a JQL label field.
+"""
+type JiraJqlLabelFieldValue implements JiraJqlFieldValue {
+  """
+  An identifier that a client should use in a JQL query when it’s referring to a Jira label field-value.
+
+  Important note: this jqlTerm could require proper escaping before placing it  into a query (e.g. wrap it in "" ).
+  """
+  jqlTerm: String!
+  """
+  The user-friendly name for a label JQL field value, to be displayed in the UI.
+  """
+  displayName: String!
+  """
+  The Jira label associated with this JQL field value.
+  """
+  label: JiraLabel
+}
+
+"""
+Represents a field-value for a JQL project field.
+"""
+type JiraJqlProjectFieldValue implements JiraJqlFieldValue {
+  """
+  An identifier that a client should use in a JQL query when it’s referring to a Jira project field-value.
+
+  Important note: this jqlTerm could require proper escaping before placing it  into a query (e.g. wrap it in "" ).
+  """
+  jqlTerm: String!
+  """
+  The user-friendly name for a project JQL field value, to be displayed in the UI.
+  """
+  displayName: String!
+  """
+  The Jira project associated with this JQL field value.
+  """
+  project: JiraProject!
+}
+
+"""
+Represents a field-value for a JQL version field.
+"""
+type JiraJqlVersionFieldValue implements JiraJqlFieldValue {
+  """
+  An identifier that a client should use in a JQL query when it’s referring to a Jira version field-value.
+
+  Important note: this jqlTerm could require proper escaping before placing it  into a query (e.g. wrap it in "" ).
+  """
+  jqlTerm: String!
+  """
+  The user-friendly name for a version JQL field value, to be displayed in the UI.
+  """
+  displayName: String!
+}
+
+"""
+Represents a connection of field-values for a JQL user field.
+"""
+type JiraJqlUserFieldValueConnection {
+  """
+  The total number of JiraJqlUserFieldValues matching the criteria.
+  """
+  totalCount: Int
+  """
+  The page info of the current page of results.
+  """
+  pageInfo: PageInfo!
+  """
+  The data for the edges in the current page.
+  """
+  edges: [JiraJqlUserFieldValueEdge]
+}
+
+"""
+Represents a field-value edge for a JQL user field.
+"""
+type JiraJqlUserFieldValueEdge {
+  """
+  The node at the edge.
+  """
+  node: JiraJqlUserFieldValue
+  """
+  The cursor to this edge.
+  """
+  cursor: String!
+}
+
+"""
+Represents a connection of field-values for a JQL group field.
+"""
+type JiraJqlGroupFieldValueConnection {
+  """
+  The total number of JiraJqlGroupFieldValues matching the criteria.
+  """
+  totalCount: Int
+  """
+  The page info of the current page of results.
+  """
+  pageInfo: PageInfo!
+  """
+  The data for the edges in the current page.
+  """
+  edges: [JiraJqlGroupFieldValueEdge]
+}
+
+"""
+Represents a field-value edge for a JQL group field.
+"""
+type JiraJqlGroupFieldValueEdge {
+  """
+  The node at the edge.
+  """
+  node: JiraJqlGroupFieldValue
+  """
+  The cursor to this edge.
+  """
+  cursor: String!
+}
+
+"""
+Represents a connection of field-values for a JQL project field.
+"""
+type JiraJqlProjectFieldValueConnection {
+  """
+  The total number of JiraJqlProjectFieldValues matching the criteria.
+  """
+  totalCount: Int
+  """
+  The page info of the current page of results.
+  """
+  pageInfo: PageInfo!
+  """
+  The data for the edges in the current page.
+  """
+  edges: [JiraJqlProjectFieldValueEdge]
+}
+
+"""
+Represents a field-value edge for a JQL project field.
+"""
+type JiraJqlProjectFieldValueEdge {
+  """
+  The node at the edge.
+  """
+  node: JiraJqlProjectFieldValue
+  """
+  The cursor to this edge.
+  """
+  cursor: String!
+}
+
+"""
+Represents a connection of field-values for a JQL sprint field.
+"""
+type JiraJqlSprintFieldValueConnection {
+  """
+  The total number of JiraJqlSprintFieldValues matching the criteria
+  """
+  totalCount: Int
+  """
+  The page info of the current page of results.
+  """
+  pageInfo: PageInfo!
+  """
+  The data for the edges in the current page.
+  """
+  edges: [JiraJqlSprintFieldValueEdge]
+}
+
+"""
+Represents a field-value edge for a JQL sprint field.
+"""
+type JiraJqlSprintFieldValueEdge {
+  """
+  The node at the edge.
+  """
+  node: JiraJqlSprintFieldValue
+  """
+  The cursor to this edge.
+  """
+  cursor: String!
+}
+
+"""
+A variation of the fieldValues query for retrieving specifically Jira issue type field-values.
+"""
+type JiraJqlIssueTypes {
+  """
+  Retrieves top-level issue types that encapsulate all others.
+
+  E.g. The `Epic` issue type in company-managed projects.
+  """
+  aboveBaseLevel(
+    """
+    The number of items after the cursor to be returned, if not specified it is up to the server to determine a page size.
+    """
+    first: Int
+    """
+    The index based cursor to specify the beginning of the items, if not specified it's assumed as the cursor for the item before the beginning.
+    """
+    after: String
+    """
+    The number of items to be sliced away from the bottom of the list after slicing with `first` argument.
+    """
+    last: Int
+    """
+    The index based cursor to specify the bottom limit of the items, if not specified it's assumed as the cursor to the item after the last item.
+    """
+    before: String
+  ): JiraJqlIssueTypeFieldValueConnection
+  """
+  Retrieves mid-level issue types.
+
+  E.g. The `Bug`, `Story` and `Task` issue type in company-managed projects.
+  """
+  baseLevel(
+    """
+    The number of items after the cursor to be returned, if not specified it is up to the server to determine a page size.
+    """
+    first: Int
+    """
+    The index based cursor to specify the beginning of the items, if not specified it's assumed as the cursor for the item before the beginning.
+    """
+    after: String
+    """
+    The number of items to be sliced away from the bottom of the list after slicing with `first` argument.
+    """
+    last: Int
+    """
+    The index based cursor to specify the bottom limit of the items, if not specified it's assumed as the cursor to the item after the last item.
+    """
+    before: String
+  ): JiraJqlIssueTypeFieldValueConnection
+  """
+  Retrieves the lowest level issue types.
+
+  E.g. The `Subtask` issue type in company-managed projects.
+  """
+  belowBaseLevel(
+    """
+    The number of items after the cursor to be returned, if not specified it is up to the server to determine a page size.
+    """
+    first: Int
+    """
+    The index based cursor to specify the beginning of the items, if not specified it's assumed as the cursor for the item before the beginning.
+    """
+    after: String
+    """
+    The number of items to be sliced away from the bottom of the list after slicing with `first` argument.
+    """
+    last: Int
+    """
+    The index based cursor to specify the bottom limit of the items, if not specified it's assumed as the cursor to the item after the last item.
+    """
+    before: String
+  ): JiraJqlIssueTypeFieldValueConnection
+}
+
+"""
+Represents a connection of field-values for a JQL issue type field.
+"""
+type JiraJqlIssueTypeFieldValueConnection {
+  """
+  The total number of JiraJqlIssueTypeFieldValues matching the criteria
+  """
+  totalCount: Int
+  """
+  The page info of the current page of results.
+  """
+  pageInfo: PageInfo!
+  """
+  The data for the edges in the current page.
+  """
+  edges: [JiraJqlIssueTypeFieldValueEdge]
+}
+
+"""
+Represents a field-value edge for a JQL issue type field.
+"""
+type JiraJqlIssueTypeFieldValueEdge {
+  """
+  The node at the edge.
+  """
+  node: JiraJqlIssueTypeFieldValue
+  """
+  The cursor to this edge.
+  """
+  cursor: String!
+}
+
+"""
+An input filter used to specify the cascading options returned.
+"""
+input JiraCascadingSelectOptionsFilter {
+  """
+  The type of cascading option to be returned.
+  """
+  optionType: JiraCascadingSelectOptionType!
+  """
+  Used for retrieving CHILD cascading options by specifying the PARENT cascading option's name.
+
+  The parent name is case-sensitive and it will not be applied to non-child cascading options.
+  """
+  parentOptionName: String
+}
+
+"""
+Represents a connection of field-values for a JQL option field.
+"""
+type JiraJqlOptionFieldValueConnection {
+  """
+  The total number of JiraJqlOptionFieldValues matching the criteria.
+  """
+  totalCount: Int
+  """
+  The page info of the current page of results.
+  """
+  pageInfo: PageInfo!
+  """
+  The data for the edges in the current page.
+  """
+  edges: [JiraJqlOptionFieldValueEdge]
+}
+
+"""
+Represents a field-value edge for a JQL option field.
+"""
+type JiraJqlOptionFieldValueEdge {
+  """
+  The node at the edge.
+  """
+  node: JiraJqlOptionFieldValue
+  """
+  The cursor to this edge.
+  """
+  cursor: String!
+}
+
+"""
+Cascading options can either be a parent or a child - this enum captures this characteristic.
+
+E.g. If there is a parent cascading option named `P1`, it may or may not have
+child cascading options named `C1` and `C2`.
+- `P1` would be a `PARENT` enum
+- `C1` and `C2` would be `CHILD` enums
+"""
+enum JiraCascadingSelectOptionType {
+  """
+  Parent option only
+  """
+  PARENT
+  """
+  Child option only
+  """
+  CHILD
+  """
+  All options, regardless of whether they're a parent or child.
+  """
+  ALL
+}
+
+"""
+A variation of the fieldValues query for retrieving specifically Jira version field-values.
+
+This type provides the capability to retrieve connections of released, unreleased and archived versions.
+
+Important note: that released and unreleased versions can be archived and vice versa.
+"""
+type JiraJqlVersions {
+  """
+  Retrieves a connection of released versions.
+  """
+  released(
+    """
+    The number of items to be sliced away to target between the after and before cursors.
+    """
+    first: Int
+    """
+    The index based cursor to specify the beginning of the items, if not specified it's assumed as the cursor for the item before the beginning.
+    """
+    after: String
+    """
+    The number of items to be sliced away from the bottom of the list after slicing with `first` argument.
+    """
+    last: Int
+    """
+    The index based cursor to specify the bottom limit of the items, if not specified it's assumed as the cursor to the item after the last item.
+    """
+    before: String
+    """
+    Determines whether or not archived versions are returned. By default it will be false.
+    """
+    includeArchived: Boolean
+  ): JiraJqlVersionFieldValueConnection
+  """
+  Retrieves a connection of unreleased versions.
+  """
+  unreleased(
+    """
+    The number of items to be sliced away to target between the after and before cursors.
+    """
+    first: Int
+    """
+    The index based cursor to specify the beginning of the items, if not specified it's assumed as the cursor for the item before the beginning.
+    """
+    after: String
+    """
+    The number of items to be sliced away from the bottom of the list after slicing with `first` argument.
+    """
+    last: Int
+    """
+    The index based cursor to specify the bottom limit of the items, if not specified it's assumed as the cursor to the item after the last item.
+    """
+    before: String
+    """
+    Determines whether or not archived versions are returned. By default it will be false.
+    """
+    includeArchived: Boolean
+  ): JiraJqlVersionFieldValueConnection
+
+  """
+  Retrieves a connection of archived versions.
+  """
+  archived(
+    """
+    The number of items to be sliced away to target between the after and before cursors.
+    """
+    first: Int
+    """
+    The index based cursor to specify the beginning of the items, if not specified it's assumed as the cursor for the item before the beginning.
+    """
+    after: String
+    """
+    The number of items to be sliced away from the bottom of the list after slicing with `first` argument.
+    """
+    last: Int
+    """
+    The index based cursor to specify the bottom limit of the items, if not specified it's assumed as the cursor to the item after the last item.
+    """
+    before: String
+  ): JiraJqlVersionFieldValueConnection
+}
+
+"""
+Represents a connection of field-values for a JQL version field.
+"""
+type JiraJqlVersionFieldValueConnection {
+  """
+  The total number of JiraJqlVersionFieldValues matching the criteria.
+  """
+  totalCount: Int
+  """
+  The page info of the current page of results.
+  """
+  pageInfo: PageInfo!
+  """
+  The data for the edges in the current page.
+  """
+  edges: [JiraJqlVersionFieldValueEdge]
+}
+
+"""
+Represents a field-value edge for a JQL version field.
+"""
+type JiraJqlVersionFieldValueEdge {
+  """
+  The node at the edge.
+  """
+  node: JiraJqlVersionFieldValue
+  """
+  The cursor to this edge.
+  """
+  cursor: String!
+}
+"""
+The visibility property of a comment within a JSM project type.
+"""
+enum JiraServiceManagementCommentVisibility {
+    """
+    This comment will appear in the portal, visible to all customers. Also called public.
+    """
+    VISIBLE_TO_HELPSEEKER
+    """
+    This comment will only appear in JIRA's issue view. Also called private.
+    """
+    INTERNAL
+}
+"""
+Represents the label of a custom label field.
+"""
+type JiraLabel {
+    """
+    The identifier of the label.
+    Can be null when label is not yet created or label was returned without providing an Issue id.
+    """
+    labelId: String
+    """
+    The name of the label.
+    """
+    name: String
+}
+
+"""
+The connection type for JiraLabel.
+"""
+type JiraLabelConnection {
+    """
+    The total count of items in the connection.
+    """
+    totalCount: Int
+    """
+    Information about the current page. Used to aid in pagination.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraLabelEdge]
+}
+
+"""
+An edge in a Jiralabel connection.
+"""
+type JiraLabelEdge {
+    """
+    The node at the edge.
+    """
+    node: JiraLabel
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}
+"""
+Represents the language that can be used for fields such as JSM Requested Language.
+"""
+type JiraServiceManagementLanguage {
+    """
+    A unique language code that represents the language.
+    """
+    languageCode: String
+    """
+    A readable common name for this language.
+    """
+    displayName: String
+}
+"""
+An enum representing possible values for Major Incident JSM field.
+"""
+enum JiraServiceManagementMajorIncident {
+    MAJOR_INCIDENT
+}"""
+Represents a media context used for file uploads.
+"""
+type JiraMediaContext {
+    """
+    Contains the token information for uploading a media content.
+    """
+    uploadToken: JiraMediaUploadTokenResult
+}
+
+"""
+Contains either the successful fetched media token information or an error.
+"""
+union JiraMediaUploadTokenResult = JiraMediaUploadToken | QueryError
+
+"""
+Contains the information needed for uploading a media content in jira on issue create/view screens.
+"""
+type JiraMediaUploadToken {
+    """
+    Endpoint where the media content will be uploaded.
+    """
+    endpointUrl: URL
+    """
+    Registered client id of media API.
+    """
+    clientId: String
+    """
+    The collection in which to put the new files.
+    It can be user-scoped (such as upload-user-collection-*)
+    or project scoped (such as upload-project-*).
+    """
+    targetCollection: String
+    """
+    token string value which can be used with Media API requests.
+    """
+    token: String
+    """
+    Represents the duration (in minutes) for which token will be valid.
+    """
+    tokenDurationInMin: Int
+}
+"""
+Represents the pair of values (parent & child combination) in a cascading select.
+This type is used to represent a selected cascading field value on a Jira Issue.
+Since this is 2 level hierarchy, it is not possible to represent the same underlying
+type for both single cascadingOption and list of cascadingOptions. Thus, we have created different types.
+"""
+type JiraCascadingOption {
+    """
+    Defines the parent option value.
+    """
+    parentOptionValue: JiraOption
+    """
+    Defines the selected single child option value for the parent.
+    """
+    childOptionValue: JiraOption
+}
+
+"""
+Represents the childs options allowed values for a parent option in cascading select operation.
+"""
+type JiraCascadingOptions {
+    """
+    Defines the parent option value.
+    """
+    parentOptionValue: JiraOption
+    """
+    Defines all the list of child options available for the parent option.
+    """
+    childOptionValues: [JiraOption]
+}
+
+"""
+Represents a single option value in a select operation.
+"""
+type JiraOption implements Node {
+    """
+    Global Identifier of the option.
+    """
+    id: ID!
+    """
+    Identifier of the option.
+    """
+    optionId: String!
+    """
+    Value of the option.
+    """
+    value: String
+    """
+    Whether or not the option has been disabled by the user. Disabled options are typically not accessible in the UI.
+    """
+    isDisabled: Boolean
+}
+
+"""
+The connection type for JiraOption.
+"""
+type JiraOptionConnection {
+    """
+    The total count of items in the connection.
+    """
+    totalCount: Int
+    """
+    Information about the current page. Used to aid in pagination.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraOptionEdge]
+}
+
+"""
+An edge in a JiraOption connection.
+"""
+type JiraOptionEdge {
+    """
+    The node at the edge.
+    """
+    node: JiraOption
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}
+
+"""
+The connection type for JiraCascadingOptions.
+"""
+type JiraCascadingOptionsConnection {
+    """
+    The total count of items in the connection.
+    """
+    totalCount: Int
+    """
+    Information about the current page. Used to aid in pagination.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraCascadingOptionsEdge]
+}
+
+"""
+An edge in a JiraCascadingOptions connection.
+"""
+type JiraCascadingOptionsEdge {
+    """
+    The node at the edge.
+    """
+    node: JiraCascadingOptions
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}
+"""
+Represents the customer organization on an Issue in a JiraServiceManagement project.
+"""
+type JiraServiceManagementOrganization {
+    """
+    Globally unique id within this schema.
+    """
+    organizationId: ID
+    """
+    The organization's name.
+    """
+    organizationName: String
+    """
+    The organization's domain.
+    """
+    domain: String
+}
+
+"""
+The connection type for JiraServiceManagementOrganization.
+"""
+type JiraServiceManagementOrganizationConnection {
+    """
+    The total count of items in the connection.
+    """
+    totalCount: Int
+    """
+    Information about the current page. Used to aid in pagination.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraServiceManagementOrganizationEdge]
+}
+
+"""
+An edge in a JiraServiceManagementOrganization connection.
+"""
+type JiraServiceManagementOrganizationEdge {
+    """
+    The node at the edge.
+    """
+    node: JiraServiceManagementOrganization
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}
+"""
+Represents flags required to determine parent field visibility
+"""
+type JiraParentVisibility {
+    """
+    Flag to disable editing the Parent Link field and showing the error that the issue has an epic link set, and thus cannot use the Parent Link field.
+    """
+    hasEpicLinkFieldDependency: Boolean
+    """
+    Flag which along with hasEpicLinkFieldDependency is used to determine the Parent Link field visiblity.
+    """
+    canUseParentLinkField: Boolean
+}
+"""
+Contains either the group or the projectRole associated with a comment/worklog, but not both.
+If both are null, then the permission level is unspecified and the comment/worklog is public.
+"""
+type JiraPermissionLevel {
+    """
+    The Jira Group associated with the comment/worklog.
+    """
+    group: JiraGroup
+    """
+    The Jira ProjectRole associated with the comment/worklog.
+    """
+    role: JiraRole
+}
+"""
+A permission scheme is a collection of permission grants.
+"""
+type JiraPermissionScheme implements Node {
+    "The ARI of the permission scheme."
+    id: ID!
+    "The display name of the permission scheme."
+    name: String!
+    "The description of the permission scheme."
+    description: String
+}
+
+"""
+The project permission in Jira and it is scoped to projects.
+"""
+type JiraProjectPermission {
+    "The unique key of the permission."
+    key: String!
+    "The display name of the permission."
+    name: String!
+    "The description of the permission."
+    description: String!
+    "The category of the permission."
+    type: JiraProjectPermissionCategory!
+}
+
+"""
+The category of the project permission.
+The category information is typically seen in the permission scheme Admin UI.
+It is used to group the project permissions in general and available for connect app developers when registering new project permissions.
+"""
+type JiraProjectPermissionCategory {
+    "The unique key of the permission category."
+    key: JiraProjectPermissionCategoryEnum!
+    "The display name of the permission category."
+    name: String!
+}
+
+"""
+The category of the project permission.
+It represents the logical grouping of the project permissions.
+"""
+enum JiraProjectPermissionCategoryEnum {
+    "Represents one or more permissions applicable at project level such as project administration, view project information, and manage sprints."
+    PROJECTS
+    "Represents one or more permissions applicable at issue level to manage operations such as create, delete, edit, and transition."
+    ISSUES
+    "Represents one or more permissions to manage watchers and voters of an issue."
+    VOTERS_AND_WATCHERS
+    "Represents one or more permissions to manage issue comments such as add, delete and edit."
+    COMMENTS
+    "Represents one or more permissions to manage issue attacments such as create and delete."
+    ATTACHMENTS
+    "Represents one or more permissions to manage worklogs, time tracking for billing purpose in some cases."
+    TIME_TRACKING
+    "Represents one or more permissions representing default category if not any other existing category."
+    OTHER
+}
+
+"""
+The unique key of the grant type such as PROJECT_ROLE.
+"""
+type JiraGrantTypeKey {
+    "The key to identify the grant type such as PROJECT_ROLE."
+    key: JiraGrantTypeKeyEnum!
+    "The display name of the grant type key such as Project Role."
+    name: String!
+}
+
+"""
+The grant type key enum represents all the possible grant types available in Jira.
+A grant type may take an optional parameter value.
+For example: PROJECT_ROLE grant type takes project role id as parameter. And, PROJECT_LEAD grant type do not.
+
+The actual ARI formats are documented on the various concrete grant type values.
+"""
+enum JiraGrantTypeKeyEnum {
+    """
+    A role that user/group can play in a project.
+    It takes project role as parameter.
+    """
+    PROJECT_ROLE
+
+    """
+    A application role is used to grant a user/group access to the application group.
+    It takes application role as parameter.
+    """
+    APPLICATION_ROLE
+
+    """
+    An individual user who can be given the access to work on one or more projects.
+    It takes user account id as parameter.
+    """
+    USER
+
+    """
+    A group is a collection of users who can be given access together.
+    It represents group in the organization's user base.
+    It takes group id as parameter.
+    """
+    GROUP
+
+    """
+    A multi user picker custom field.
+    It takes multi user picker custom field id as parameter.
+    """
+    MULTI_USER_PICKER
+
+    """
+    A multi group picker custom field.
+    It takes multi group picker custom field id as parameter.
+    """
+    MULTI_GROUP_PICKER
+
+    """
+    The grant type defines what the customers can do from the portal view.
+    It takes no parameter.
+    """
+    SERVICE_PROJECT_CUSTOMER_PORTAL_ACCESS
+
+    """
+    The issue reporter role.
+    It takes platform defined 'reporter' as parameter to represent the issue field value.
+    """
+    REPORTER
+
+    """
+    The project lead role.
+    It takes no parameter.
+    """
+    PROJECT_LEAD
+
+    """
+    The issue assignee role.
+    It takes platform defined 'assignee' as parameter to represent the issue field value.
+    """
+    ASSIGNEE
+
+    """
+    The anonymous access represents the public access without logging in.
+    It takes no parameter.
+    """
+    ANONYMOUS_ACCESS
+
+    """
+    Any user who has the product access.
+    It takes no parameter.
+    """
+    ANY_LOGGEDIN_USER_APPLICATION_ROLE
+}
+
+"""
+The default grant type with only id and name to return data for grant types such as PROJECT_LEAD, APPLICATION_ROLE,
+ANY_LOGGEDIN_USER_APPLICATION_ROLE, ANONYMOUS_ACCESS, SERVICE_PROJECT_CUSTOMER_PORTAL_ACCESS
+"""
+type JiraDefaultGrantTypeValue implements Node {
+    """
+    The ARI to represent the default grant type value.
+    For example:
+    PROJECT_LEAD ari - ari:cloud:jira:a2520569-493f-45bc-807b-54b02bc724d1:role/project-lead/activation/bd0c43a9-a23a-4302-8ffa-ca04bde7c747/project/f67c73a8-545e-455b-a6bd-3d53cb7e0524
+    APPLICATION_ROLE ari for JSM - ari:cloud:jira-servicedesk::role/123
+    ANY_LOGGEDIN_USER_APPLICATION_ROLE ari - ari:cloud:jira::role/product/member
+    ANONYMOUS_ACCESS ari - ari:cloud:identity::user/unidentified
+    """
+    id: ID!
+    "The display name of the grant type value such as GROUP."
+    name: String!
+}
+
+"""
+The USER grant type value where user data is provided by identity service.
+"""
+type JiraUserGrantTypeValue implements Node {
+    """
+    The ARI to represent the grant user type value.
+    For example: ari:cloud:identity::user/123
+    """
+    id: ID!
+    "The GDPR compliant user profile information."
+    user: User!
+}
+
+"""
+The GROUP grant type value where group data is provided by identity service.
+"""
+type JiraGroupGrantTypeValue implements Node {
+    """
+    The ARI to represent the group grant type value.
+    For example: ari:cloud:identity::group/123
+    """
+    id: ID!
+    "The group information such as name, and description."
+    group: JiraGroup!
+}
+
+"""
+The project role grant type value having the project role information.
+"""
+type JiraProjectRoleGrantTypeValue implements Node {
+    """
+    The ARI to represent the project role grant type value.
+    For example: ari:cloud:jira:a2520569-493f-45bc-807b-54b02bc724d1:role/project-role/activation/bd0c43a9-a23a-4302-8ffa-ca04bde7c747/projectrole/b434089d-7f6d-476b-884b-7811661f91d2
+    """
+    id: ID!
+    "The project role information such as name, description."
+    role: JiraRole!
+}
+
+"""
+The issue field grant type used to represent field of an issue.
+Grant types such as ASSIGNEE, REPORTER, MULTI USER PICKER, and MULTI GROUP PICKER use this grant type value.
+"""
+type JiraIssueFieldGrantTypeValue implements Node {
+    """
+    The ARI to represent the issue field grant type value.
+    For example:
+    assignee field ARI is ari:cloud:jira:a2520569-493f-45bc-807b-54b02bc724d1:issuefieldvalue/10000/assignee
+    reporter field ARI is ari:cloud:jira:a2520569-493f-45bc-807b-54b02bc724d1:issuefieldvalue/10000/reporter
+    multi user picker field ARI is ari:cloud:jira:a2520569-493f-45bc-807b-54b02bc724d1:issuefieldvalue/10000/customfield_10126
+    """
+    id: ID!
+    "The issue field information such as name, description, field id."
+    field: JiraIssueField!
+}
+extend type JiraQuery {
+
+    """
+    Get all the available grant type keys such as project role, application access, user, group.
+    """
+    allGrantTypeKeys(cloudId: ID!): [JiraGrantTypeKey!]!
+
+    """
+    Get the grant type values by search term and grant type key.
+    It only supports fetching values for APPLICATION_ROLE, PROJECT_ROLE, MULTI_USER_PICKER and MULTI_GROUP_PICKER grant types.
+    """
+    grantTypeValues(
+        "Returns the first n elements from the list."
+        first: Int
+        "Returns the elements in the list that come after the specified cursor."
+        after: String
+        "Returns the last n elements from the list."
+        last: Int
+        "Returns the elements in the list that come before the specified cursor."
+        before: String
+        "The mandatory grant type key to search within specific grant type such as project role."
+        grantTypeKey: JiraGrantTypeKeyEnum!
+        "search term to filter down on the grant type values."
+        searchTerm: String
+        "The cloud id of the tenant."
+        cloudId: ID!
+    ): JiraGrantTypeValueConnection
+
+    """
+    Get the permission scheme based on scheme id. The scheme ID input represent an ARI.
+    """
+    viewPermissionScheme(schemeId: ID!): JiraPermissionSchemeViewResult
+
+    """
+    Get the list of paginated projects associated with the given permission scheme ID.
+    The project objects will be returned based on implicit ascending order by project name.
+    """
+    getProjectsByPermissionScheme(
+        "Returns the first n elements from the list."
+        first: Int
+        "Returns the elements in the list that come after the specified cursor."
+        after: String
+        "Returns the last n elements from the list."
+        last: Int
+        "Returns the elements in the list that come before the specified cursor."
+        before: String
+        "The permission scheme ARI to filter the results."
+        schemeId: ID!
+    ): JiraProjectConnection
+
+    """
+    A list of paginated permission scheme grants based on the given permission scheme ID.
+    """
+    permissionSchemeGrants(
+        "Returns the first n elements from the list."
+        first: Int
+        "Returns the elements in the list that come after the specified cursor."
+        after: String
+        "Returns the last n elements from the list."
+        last: Int
+        "Returns the elements in the list that come before the specified cursor."
+        before: String
+        "The permission scheme ARI to filter the results."
+        schemeId: ID!
+        "The optional project permission key to filter the results."
+        permissionKey: String
+    ): JiraPermissionGrantValueConnection @deprecated(reason: "Please use getPermissionSchemeGrants instead.")
+
+    """
+    A list of paginated permission scheme grants based on the given permission scheme ID and permission key.
+    """
+    getPermissionSchemeGrants(
+        "Returns the first n elements from the list."
+        first: Int
+        "Returns the elements in the list that come after the specified cursor."
+        after: String
+        "Returns the last n elements from the list."
+        last: Int
+        "Returns the elements in the list that come before the specified cursor."
+        before: String
+        "The permission scheme ARI to filter the results."
+        schemeId: ID!
+        "The mandatory project permission key to filter the results."
+        permissionKey: String!
+        "The optional grant type key to filter the results."
+        grantTypeKey: JiraGrantTypeKeyEnum
+    ): JiraPermissionGrantConnection
+
+    """
+    Gets the permission scheme grants hierarchy (by grant type key) based on the given permission scheme ID and permission key.
+    This returns a bounded list of data with limit set to 50. For getting the complete list in paginated manner, use getPermissionSchemeGrants.
+    """
+    getPermissionSchemeGrantsHierarchy(
+        "The permission scheme ARI to filter the results."
+        schemeId: ID!
+        "The mandatory project permission key to filter the results."
+        permissionKey: String!
+    ): [JiraPermissionGrants!]!
+
+}
+
+extend type JiraMutation {
+
+    """
+    The mutation operation to add one or more new permission grants to the given permission scheme.
+    The operation takes mandatory permission scheme ID.
+    The limit on the new permission grants can be added is set to 50.
+    """
+    addPermissionSchemeGrants(input: JiraPermissionSchemeAddGrantInput!): JiraPermissionSchemeAddGrantPayload
+
+    """
+    The mutation operation to remove one or more existing permission scheme grants in the given permission scheme.
+    The operation takes mandatory permission scheme ID.
+    The limit on the new permission grants can be removed is set to 50.
+    """
+    removePermissionSchemeGrants(input: JiraPermissionSchemeRemoveGrantInput!): JiraPermissionSchemeRemoveGrantPayload
+
+}
+
+"""
+The JiraPermissionSchemeView represents the composite view to capture basic information of
+the permission scheme such as id, name, description and a bounded list of one or more grant groups.
+A grant group contains existing permission grant information such as permission, permission category, grant type and grant type value.
+"""
+type JiraPermissionSchemeView {
+    "The basic permission scheme information such as id, name and description."
+    scheme: JiraPermissionScheme!
+    "The additional configuration information regarding the permission scheme."
+    configuration: JiraPermissionSchemeConfiguration!
+    "The bounded list of one or more grant groups represent each group of permission grants based on project permission category such as PROJECTS, ISSUES."
+    grantGroups: [JiraPermissionSchemeGrantGroup!]
+}
+
+"""
+The JiraPermissionSchemeConfiguration represents additional configuration information regarding the permission scheme such as its editability.
+"""
+type JiraPermissionSchemeConfiguration {
+    "The indicator saying whether a permission scheme is editable or not."
+    isEditable: Boolean!
+}
+
+"""
+The JiraPermissionSchemeGrantGroup is an association between project permission category information and a bounded list of one or more
+associated permission grant holder. A grant holder represents project permission information and its associated permission grants.
+"""
+type JiraPermissionSchemeGrantGroup {
+    "The basic project permission category information such as key and display name."
+    category: JiraProjectPermissionCategory!
+    "A bounded list of one or more permission grant holders."
+    grantHolders: [JiraPermissionGrantHolder]
+}
+
+"""
+The JiraPermissionGrantHolder represents an association between project permission information and
+a bounded list of one or more permission grant.
+A permission grant holds association between grant type and a paginated list of grant values.
+"""
+type JiraPermissionGrantHolder {
+    "The basic information about the project permission."
+    permission: JiraProjectPermission!
+    "The additional configuration information regarding the permission."
+    configuration: JiraPermissionConfiguration
+    "A bounded list of jira permission grant."
+    grants: [JiraPermissionGrants!]
+}
+
+"""
+The JiraPermissionConfiguration represents additional configuration information regarding the permission such as
+deprecation, new addition etc. It contains documentation/notice and/or actionable items for the permission
+such as deprecation of BROWSE_PROJECTS in favour of VIEW_PROJECTS and VIEW_ISSUES.
+"""
+type JiraPermissionConfiguration {
+    "The tag for the permission key."
+    tag: JiraPermissionTagEnum!
+    "The message contains actionable information for the permission key."
+    message: JiraPermissionMessageExtension
+    "The documentation for the permission key."
+    documentation: JiraPermissionDocumentationExtension
+}
+
+"""
+The JiraPermissionTagEnum represents additional tags for the permission key.
+"""
+enum JiraPermissionTagEnum {
+    "Represents a permission that is about to be deprecated."
+    DEPRECATED,
+    "Represents a permission that is newly added."
+    NEW
+}
+
+"""
+The JiraPermissionMessageExtension represents actionable information for a permission such as deprecation of
+BROWSE_PROJECTS in favour of VIEW_PROJECTS and VIEW_ISSUES.
+"""
+type JiraPermissionMessageExtension {
+    "The category of the message such as WARNING, INFORMATION etc."
+    type: JiraPermissionMessageTypeEnum!
+    "The display text of the message."
+    text: String!
+}
+
+"""
+The JiraPermissionMessageTypeEnum represents category of the message section.
+"""
+enum JiraPermissionMessageTypeEnum {
+    "Represents a basic message."
+    INFORMATION,
+    "Represents a warning message."
+    WARNING
+}
+
+"""
+The JiraPermissionDocumentationExtension contains developer documentation for a permission key.
+"""
+type JiraPermissionDocumentationExtension {
+    "The display text of the developer documentation."
+    text: String!
+    "The link to the developer documentation."
+    url: String!
+}
+
+"""
+The JiraPermissionGrants represents an association between grant type information and a bounded list of one or more grant
+values associated with given grant type.
+Each grant value has grant type specific information.
+For example, PROJECT_ROLE grant type value contains project role ID in ARI format and role specific details.
+"""
+type JiraPermissionGrants {
+    "The grant type information includes key and display name."
+    grantType: JiraGrantTypeKey!
+    "A bounded list of grant values. Each grant value has grant type specific information."
+    grantValues: [JiraPermissionGrantValue!]
+    "The total number of items matching the criteria"
+    totalCount: Int
+}
+
+"""
+The type represents a paginated view of permission grants in the form of connection object.
+"""
+type JiraPermissionGrantConnection {
+    "The page info of the current page of results."
+    pageInfo: PageInfo!
+    "A list of edges in the current page."
+    edges: [JiraPermissionGrantEdge]
+    "The total number of items matching the criteria."
+    totalCount: Int
+}
+
+"""
+The permission grant edge object used in connection object for representing an edge.
+"""
+type JiraPermissionGrantEdge {
+    "The node at this edge."
+    node: JiraPermissionGrant!
+    "The cursor to this edge."
+    cursor: String!
+}
+
+"""
+The JiraPermissionGrant represents an association between the grant type key and the grant value.
+Each grant value has grant type specific information.
+For example, PROJECT_ROLE grant type value contains project role ID in ARI format and role specific details.
+"""
+type JiraPermissionGrant {
+    "The grant type information includes key and display name."
+    grantType: JiraGrantTypeKey!
+    "The grant value has grant type key specific information."
+    grantValue: JiraPermissionGrantValue!
+}
+
+"""
+The type represents a paginated view of permission grant values in the form of connection object.
+"""
+type JiraPermissionGrantValueConnection {
+    "The page info of the current page of results."
+    pageInfo: PageInfo!
+    "A list of edges in the current page."
+    edges: [JiraPermissionGrantValueEdge]
+    "The total number of items matching the criteria."
+    totalCount: Int
+}
+
+"""
+The permission grant value edge object used in connection object for representing an edge.
+"""
+type JiraPermissionGrantValueEdge {
+    "The node at this edge."
+    node: JiraPermissionGrantValue!
+    "The cursor to this edge."
+    cursor: String!
+}
+
+"""
+The permission grant value represents the actual permission grant value.
+The id field represent the grant ID and its not an ARI. The value represents actual value information specific to grant type.
+For example: PROJECT_ROLE grant type value contains project role ID in ARI format and role specific details
+"""
+type JiraPermissionGrantValue {
+    """
+    The ID of the permission grant.
+    It represents the relationship among permission, grant type and grant type specific value.
+    """
+    id: ID!
+    """
+    The optional grant type value is a union type.
+    The value itself may resolve to one of the concrete types such as JiraDefaultGrantTypeValue, JiraProjectRoleGrantTypeValue.
+    """
+    value: JiraGrantTypeValue
+}
+
+"""
+The JiraGrantTypeValue union resolves to one of the concrete types such as JiraDefaultGrantTypeValue, JiraProjectRoleGrantTypeValue.
+"""
+union JiraGrantTypeValue = JiraDefaultGrantTypeValue | JiraUserGrantTypeValue | JiraProjectRoleGrantTypeValue | JiraGroupGrantTypeValue | JiraIssueFieldGrantTypeValue
+
+"""
+A type to represent one or more paginated list of one or more permission grant values available for a given grant type.
+"""
+type JiraGrantTypeValueConnection {
+    "A list of edges in the current page."
+    edges: [JiraGrantTypeValueEdge]
+    "The page info of the current page of results."
+    pageInfo: PageInfo!
+    "The total number of items matching the criteria."
+    totalCount: Int
+}
+
+"""
+An edge object representing grant type value information used within connection object.
+"""
+type JiraGrantTypeValueEdge {
+    "The node at this edge."
+    node: JiraGrantTypeValue!
+    "The cursor to this edge."
+    cursor: String!
+}
+
+"""
+The union result representing either the composite view of the permission scheme or the query error information.
+"""
+union JiraPermissionSchemeViewResult = JiraPermissionSchemeView | QueryError
+
+"""
+Specifies permission scheme grant for the combination of permission key, grant type key, and grant type value ARI.
+"""
+input JiraPermissionSchemeGrantInput {
+    "the project permission key."
+    permissionKey: String!
+    "The grant type key such as USER."
+    grantType: JiraGrantTypeKeyEnum!
+    """
+    The optional grant value in ARI format. Some grantType like PROJECT_LEAD, REPORTER etc. have no grantValue. Any grantValue passed will be silently ignored.
+    For example: project role ID ari is of the format - ari:cloud:jira:a2520569-493f-45bc-807b-54b02bc724d1:role/project-role/activation/bd0c43a9-a23a-4302-8ffa-ca04bde7c747/projectrole/b434089d-7f6d-476b-884b-7811661f91d2
+    """
+    grantValue: ID
+}
+
+"""
+The input type to add new permission grants to the given permission scheme.
+"""
+input JiraPermissionSchemeAddGrantInput {
+    "The permission scheme ID in ARI format."
+    schemeId: ID!
+    "The list of one or more grants to be added."
+    grants: [JiraPermissionSchemeGrantInput!]!
+}
+
+"""
+The response payload for add permission grants mutation operation for a given permission scheme.
+"""
+type JiraPermissionSchemeAddGrantPayload implements Payload {
+    "The success indicator saying whether mutation operation was successful as a whole or not."
+    success: Boolean!
+    "The errors field represents additional mutation error information if exists."
+    errors: [MutationError!]
+}
+
+"""
+The input type to remove permission grants from the given permission scheme.
+"""
+input JiraPermissionSchemeRemoveGrantInput {
+    "The permission scheme ID in ARI format."
+    schemeId: ID!
+    "The list of one or more grants to be removed."
+    grants: [JiraPermissionSchemeGrantInput!] @deprecated(reason: "Please use grantIds field instead")
+    "The list of permission grant ids."
+    grantIds: [Long!]!
+}
+
+"""
+The response payload for remove existing permission grants mutation operation for a given permission scheme.
+"""
+type JiraPermissionSchemeRemoveGrantPayload implements Payload {
+    "The success indicator saying whether mutation operation was successful as a whole or not."
+    success: Boolean!
+    "The errors field represents additional mutation error information if exists."
+    errors: [MutationError!]
+}"""
+Represents an issue's priority field
+"""
+type JiraPriority implements Node {
+    """
+    Unique identifier referencing the priority ID.
+    """
+    id: ID!
+    """"
+    The priority ID. E.g. 10000.
+    """
+    priorityId: String!
+    """
+    The priority name.
+    """
+    name: String
+    """
+    The priority icon URL.
+    """
+    iconUrl: URL
+    """
+    The priority color.
+    """
+    color: String
+}
+
+"""
+The connection type for JiraPriority.
+"""
+type JiraPriorityConnection {
+    """
+    The total count of items in the connection.
+    """
+    totalCount: Int
+    """
+    Information about the current page. Used to aid in pagination.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraPriorityEdge]
+}
+
+"""
+An edge in a JiraPriority connection.
+"""
+type JiraPriorityEdge {
+    """
+    The node at the edge.
+    """
+    node: JiraPriority
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}
+"""
+Represents proforma-forms.
+"""
+type JiraProformaForms {
+    """
+    Indicates whether the project has proforma-forms or not.
+    """
+    hasProjectForms: Boolean
+    """
+    Indicates whether the issue has proforma-forms or not.
+    """
+    hasIssueForms: Boolean
+}# Copied over from jira-project, will extend this type after deprecating rest bridge project
+
+"""
+Represents a Jira project.
+"""
+type JiraProject implements Node {
+    """
+    Global identifier for the project.
+    """
+    id: ID!
+    """
+    The key of the project.
+    """
+    key: String!
+    """
+    The project id of the project. e.g. 10000. Temporarily needed to support interoperability with REST.
+    """
+    projectId: String
+    """
+    The name of the project.
+    """
+    name: String!
+    """
+    The cloudId associated with the project.
+    """
+    cloudId: ID!
+    """
+    The description of the project.
+    """
+    description: String
+    """
+    The ID of the project lead.
+    """
+    leadId: ID
+    """
+    The category of the project.
+    """
+    category: JiraProjectCategory
+    """
+    The avatar of the project.
+    """
+    avatar: JiraAvatar
+    """
+    The URL associated with the project.
+    """
+    projectUrl: String
+    """
+    Specifies the type to which project belongs to ex:- software, service_desk, business etc.
+    """
+    projectType: JiraProjectType
+    """
+    Specifies the style of the project.
+    The use of this field is discouraged. API deviations between project styles are deprecated.
+    This field only exists to support legacy use cases. This field will be removed in the future.
+    """
+    projectStyle: JiraProjectStyle @deprecated(reason: "The `projectStyle` is a deprecated field.")
+    """
+    Specifies the status of the project e.g. archived, deleted.
+    """
+    status: JiraProjectStatus
+    """
+    Represents the SimilarIssues feature associated with this project.
+    """
+    similarIssues: JiraSimilarIssues
+    """
+    Returns if the user has the access to set issue restriction with the current project
+    """
+    canSetIssueRestriction: Boolean
+    """
+    Returns navigation specific information to aid in transitioning from a project to a landing page eg. board, queue, list, etc
+    """
+    navigationMetadata: JiraProjectNavigationMetadata
+}
+
+"""
+"""
+type JiraProjectCategory implements Node {
+    """
+    Global id of this project category.
+    """
+    id: ID!
+    """
+    Display name of the Project category.
+    """
+    name: String
+    """
+    Description of the Project category.
+    """
+    description: String
+}
+
+"""
+The connection type for JiraProject.
+"""
+type JiraProjectConnection {
+    """
+    The total count of items in the connection.
+    """
+    totalCount: Int
+    """
+    Information about the current page. Used to aid in pagination.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraProjectEdge]
+}
+
+"""
+An edge in a JiraProject connection.
+"""
+type JiraProjectEdge {
+    """
+    The node at the edge.
+    """
+    node: JiraProject
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}
+
+"""
+Jira Project types.
+"""
+enum JiraProjectType {
+    """
+    A service desk project.
+    """
+    SERVICE_DESK
+    """
+    A business project.
+    """
+    BUSINESS
+    """
+    A software project.
+    """
+    SOFTWARE
+}
+
+"""
+Jira Project statuses.
+"""
+enum JiraProjectStatus {
+    """
+    An active project.
+    """
+    ACTIVE
+    """
+    An archived project.
+    """
+    ARCHIVED
+    """
+    A deleted project.
+    """
+    DELETED
+}
+
+"""
+Jira Project Styles.
+"""
+enum JiraProjectStyle {
+    """
+    A team-managed project.
+    """
+    TEAM_MANAGED_PROJECT
+    """
+    A company-managed project.
+    """
+    COMPANY_MANAGED_PROJECT
+}type JiraSoftwareProjectNavigationMetadata {
+    id: ID!,
+    boardId: ID!,
+    boardName: String!
+    # Used to tell the difference between classic and next generation boards (agility, simple, nextgen, CMP)
+    isSimpleBoard: Boolean!
+}
+
+type JiraServiceManagementProjectNavigationMetadata {
+    queueId: ID!,
+    queueName: String!
+}
+
+type JiraWorkManagementProjectNavigationMetadata {
+    boardName: String!
+}
+
+union JiraProjectNavigationMetadata = JiraSoftwareProjectNavigationMetadata | JiraServiceManagementProjectNavigationMetadata | JiraWorkManagementProjectNavigationMetadata
+"""
+Represents a Jira ProjectRole.
+"""
+type JiraRole implements Node {
+    """
+    Global identifier of the ProjectRole.
+    """
+    id: ID!
+    """
+    Id of the ProjectRole.
+    """
+    roleId: String!
+    """
+    Name of the ProjectRole.
+    """
+    name: String
+    """
+    Description of the ProjectRole.
+    """
+    description: String
+}
+
+"""
+The connection type for JiraRole.
+"""
+type JiraRoleConnection {
+    """
+    The total count of items in the connection.
+    """
+    totalCount: Int
+    """
+    The page infor of the current page of results.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraRoleEdge]
+}
+
+"""
+An edge in a JiraRoleConnection connection.
+"""
+type JiraRoleEdge {
+    """
+    The node at the edge.
+    """
+    node: JiraRole
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}
+"""
+Requests the request type structure on an Issue.
+"""
+type JiraServiceManagementRequestType implements Node {
+    """
+    Global identifier representing the request type id.
+    """
+    id: ID!
+    """
+    Identifier for the request type.
+    """
+    requestTypeId: String!
+    """
+    Name of the request type.
+    """
+    name: String
+    """
+    A deprecated unique identifier string for Request Types.
+    It is still necessary due to the lack of request-type-id in critical parts of JiraServiceManagement backend.
+    """
+    key: String @deprecated(reason: "The `key` field is deprecated. Please use the `requestTypeId` instead.")
+    """
+    Description of the request type if applicable.
+    """
+    description: String
+    """
+    Help text for the request type.
+    """
+    helpText: String
+    """
+    Issue type to which request type belongs to.
+    """
+    issueType: JiraIssueType
+    """
+    Id of the portal that this request type belongs to.
+    """
+    portalId: String
+    """
+    Avatar for the request type.
+    """
+    avatar: JiraAvatar
+    """
+    Request type practice. E.g. incidents, service_request.
+    """
+    practices: [JiraServiceManagementRequestTypePractice]
+}
+
+"""
+Defines grouping of the request types,currently only applicable for JiraServiceManagement ITSM projects.
+"""
+type JiraServiceManagementRequestTypePractice {
+    """
+    Practice in which the request type is categorized.
+    """
+    key: JiraServiceManagementPractice
+}
+
+"""
+ITSM project practice categorization.
+"""
+enum JiraServiceManagementPractice {
+    """
+    Manage work across teams with one platform so the employees and customers quickly get the help they need.
+    """
+    SERVICE_REQUEST
+    """
+    Bring the development and IT operations teams together to rapidly respond to, resolve, and continuously learn from incidents.
+    """
+    INCIDENT_MANAGEMENT
+    """
+    Group incidents to problems, fast-track root cause analysis, and record workarounds to minimize the impact of incidents.
+    """
+    PROBLEM_MANAGEMENT
+    """
+    Empower the IT operations teams with richer contextual information around changes from software development tools so they can make better decisions and minimize risk.
+    """
+    CHANGE_MANAGEMENT
+    """
+    Bring people and teams together to discuss the details of an incident: why it happened, what impact it had, what actions were taken to resolve it, and how the team can prevent it from happening again.
+    """
+    POST_INCIDENT_REVIEW
+}
+
+"""
+The connection type for JiraServiceManagementRequestType.
+"""
+type JiraServiceManagementRequestTypeConnection {
+    """
+    The total count of items in the connection.
+    """
+    totalCount: Int
+    """
+    Information about the current page. Used to aid in pagination.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraServiceManagementRequestTypeEdge]
+}
+
+"""
+An edge in a JiraServiceManagementIssueType connection.
+"""
+type JiraServiceManagementRequestTypeEdge {
+    """
+    The node at the edge.
+    """
+    node: JiraServiceManagementRequestType
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}
+"""
+Represents the resolution field of an issue.
+"""
+type JiraResolution implements Node {
+    """
+    Global identifier representing the resolution id.
+    """
+    id: ID!
+    """
+    Resolution Id in the digital format.
+    """
+    resolutionId: String!
+    """
+    Resolution name.
+    """
+    name: String
+    """
+    Resolution description.
+    """
+    description: String
+}
+
+"""
+The connection type for JiraResolution.
+"""
+type JiraResolutionConnection {
+    """
+    The total count of items in the connection.
+    """
+    totalCount: Int
+    """
+    Information about the current page. Used to aid in pagination.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraResolutionEdge]
+}
+
+"""
+An edge in a JiraResolution connection.
+"""
+type JiraResolutionEdge {
+    """
+    The node at the edge.
+    """
+    node: JiraResolution
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}
+"""
+Responder field of a JSM issue, can be either a user or a team.
+"""
+union JiraServiceManagementResponder = JiraServiceManagementUserResponder | JiraServiceManagementTeamResponder
+
+"""
+A user as a responder.
+"""
+type JiraServiceManagementUserResponder {
+    user: User
+}
+
+"""
+An Opsgenie team as a responder.
+"""
+type JiraServiceManagementTeamResponder {
+    """
+    Opsgenie team id.
+    """
+    teamId : String
+    """
+    Opsgenie team name.
+    """
+    teamName : String
+}
+
+"""
+The connection type for JiraServiceManagementResponder.
+"""
+type JiraServiceManagementResponderConnection {
+    """
+    The total count of items in the connection.
+    """
+    totalCount: Int
+    """
+    Information about the current page. Used to aid in pagination.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraServiceManagementResponderEdge]
+}
+
+"""
+An edge in a JiraServiceManagementResponder connection.
+"""
+type JiraServiceManagementResponderEdge {
+    """
+    The node at the edge.
+    """
+    node: JiraServiceManagementResponder
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}"""
+Represents the rich text format of a rich text field.
+"""
+type JiraRichText {
+    """
+    Text in Atlassian Document Format.
+    """
+    adfValue: JiraADF
+    """
+    Plain text version of the text.
+    """
+    plainText: String @deprecated(reason: "`plainText` is deprecated. Please use `adfValue` for all rich text in Jira.")
+    """
+    Text in wiki format.
+    """
+    wikiValue: String @deprecated(reason: "`wikiValue` is deprecated. Please use `adfValue` for all rich text in Jira.")
+}
+
+"""
+Represents the Atlassian Document Format content in JSON format.
+"""
+type JiraADF {
+    """
+    The content of ADF in JSON.
+    """
+    json: JSON
+}
+"""
+Represents the security levels on an Issue.
+"""
+type JiraSecurityLevel implements Node {
+    """
+    Global identifier for the security level.
+    """
+    id: ID!
+    """
+    identifier for the security level.
+    """
+    securityId: String!
+    """
+    Name of the security level.
+    """
+    name: String
+    """
+    Description of the security level.
+    """
+    description: String
+}
+
+"""
+The connection type for JiraSecurityLevel.
+"""
+type JiraSecurityLevelConnection {
+    """
+    The total count of items in the connection.
+    """
+    totalCount: Int
+    """
+    Information about the current page. Used to aid in pagination.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraSecurityLevelEdge]
+}
+
+"""
+An edge in a JiraSecurityLevel connection.
+"""
+type JiraSecurityLevelEdge {
+    """
+    The node at the edge.
+    """
+    node: JiraSecurityLevel
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}
+"""
+Represents the SimilarIssues feature associated with a JiraProject.
+"""
+type JiraSimilarIssues {
+    """
+    Indicates whether the SimilarIssues feature is enabled or not.
+    """
+    featureEnabled: Boolean!
+}
+"""
+Represents the sprint field of an issue.
+"""
+type JiraSprint implements Node {
+    """
+    Global identifier for the sprint.
+    """
+    id: ID!
+    """
+    Sprint id in the digital format.
+    """
+    sprintId: String!
+    """
+    Sprint name.
+    """
+    name: String
+    """
+    Current state of the sprint.
+    """
+    state: JiraSprintState
+    """
+    The board name that the sprint belongs to.
+    """
+    boardName: String
+    """
+    Start date of the sprint.
+    """
+    startDate: DateTime
+    """
+    End date of the sprint.
+    """
+    endDate: DateTime
+    """
+    Completion date of the sprint.
+    """
+    completionDate: DateTime
+    """
+    The goal of the sprint.
+    """
+    goal: String
+}
+
+"""
+Represents the state of the sprint.
+"""
+enum JiraSprintState {
+    """
+    The sprint is in progress.
+    """
+    ACTIVE
+    """
+    The sprint hasn't been started yet.
+    """
+    FUTURE
+    """
+    The sprint has been completed.
+    """
+    CLOSED
+}
+
+"""
+The connection type for JiraSprint.
+"""
+type JiraSprintConnection {
+    """
+    The total count of items in the connection.
+    """
+    totalCount: Int
+    """
+    Information about the current page. Used to aid in pagination.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraSprintEdge]
+}
+
+"""
+An edge in a JiraSprint connection.
+"""
+type JiraSprintEdge {
+    """
+    The node at the edge.
+    """
+    node: JiraSprint
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}
+"""
+Represents the status field of an issue.
+"""
+type JiraStatus implements Node {
+  """
+  Global identifier for the Status.
+  """
+  id: ID!
+  """
+  Status id in the digital format.
+  """
+  statusId: String!
+  """
+  Name of status. E.g. Backlog, Selected for Development, In Progress, Done.
+  """
+  name: String
+  """
+  Optional description of the status. E.g. "This issue is actively being worked on by the assignee".
+  """
+  description: String
+  """
+  Represents a group of Jira statuses.
+  """
+  statusCategory: JiraStatusCategory
+}
+
+"""
+Represents the category of a status.
+"""
+type JiraStatusCategory implements Node {
+  """
+  Global identifier for the Status Category.
+  """
+  id: ID!
+  """
+  Status category id in the digital format.
+  """
+  statusCategoryId: String!
+  """
+  A unique key to identify this status category. E.g. new, indeterminate, done.
+  """
+  key: String
+  """
+  Name of status category. E.g. New, In Progress, Complete.
+  """
+  name: String
+  """
+  Color of status category.
+  """
+  colorName: JiraStatusCategoryColor
+}
+
+"""
+Color of the status category.
+"""
+enum JiraStatusCategoryColor {
+  """
+  #707070
+  """
+  MEDIUM_GRAY
+  """
+  #14892c
+  """
+  GREEN
+  """
+  #f6c342
+  """
+  YELLOW
+  """
+  #815b3a
+  """
+  BROWN
+  """
+  #d04437
+  """
+  WARM_RED
+  """
+  #4a6785
+  """
+  BLUE_GRAY
+}
+"""
+Represents a single team in Jira
+"""
+type JiraTeam implements Node {
+    """
+    Global identifier of team.
+    """
+    id: ID!
+    """
+    Team id in the digital format.
+    """
+    teamId: String!
+    """
+    Name of the team.
+    """
+    name: String
+    """
+    Description of the team.
+    """
+    description: String @deprecated(reason: "JPO Team does not have a description field.")
+    """
+    Avatar of the team.
+    """
+    avatar: JiraAvatar
+    """
+    Members available in the team.
+    """
+    members: JiraUserConnection
+    """
+    Indicates whether the team is publicly shared or not.
+    """
+    isShared: Boolean
+}
+
+"""
+The connection type for JiraTeam.
+"""
+type JiraTeamConnection {
+    """
+    The total count of items in the connection.
+    """
+    totalCount: Int
+    """
+    Information about the current page. Used to aid in pagination.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraTeamEdge]
+}
+
+"""
+An edge in a JiraTeam connection.
+"""
+type JiraTeamEdge {
+    """
+    The node at the edge.
+    """
+    node: JiraTeam
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}
+"""
+Represents a view on a Team in Jira.
+"""
+type JiraTeamView {
+    """
+    The ARI of the team.
+    """
+    jiraSuppliedId: ID!
+    """
+    The unique identifier of the team.
+    """
+    jiraSuppliedTeamId: String!
+    """
+    If this is false, team data is no longer available. For example, a deleted team.
+    """
+    jiraSuppliedVisibility: Boolean
+    """
+    The name of the team.
+    """
+    jiraSuppliedName: String
+    """
+    The avatar of the team.
+    """
+    jiraSuppliedAvatar: JiraAvatar @deprecated(reason: "in future, team avatar will no longer be exposed")
+}
+"""
+Represents the type for representing global time tracking settings.
+"""
+type JiraTimeTrackingSettings {
+    """
+    Returns whether time tracking implementation is provided by Jira or some external providers.
+    """
+    isJiraConfiguredTimeTrackingEnabled: Boolean
+    """
+    Number of hours in a working day.
+    """
+    workingHoursPerDay: Float
+    """
+    Number of days in a working week.
+    """
+    workingDaysPerWeek: Float
+    """
+    Format in which the time tracking details are presented to the user.
+    """
+    defaultFormat: JiraTimeFormat
+    """
+    Default unit for time tracking wherever not specified.
+    """
+    defaultUnit: JiraTimeUnit
+}
+
+"""
+Different time formats supported for entering & displaying time tracking related data.
+"""
+enum JiraTimeFormat {
+    """
+    E.g. 2 days, 4 hours, 30 minutes
+    """
+    PRETTY
+    """
+    E.g. 2d 4.5h
+    """
+    DAYS
+    """
+    E.g. 52.5h
+    """
+    HOURS
+}
+
+"""
+Different time units supported for entering & displaying time tracking related data.
+Get the currently configured default duration to use when parsing duration string for time tracking.
+"""
+enum JiraTimeUnit {
+    """
+    When the current duration is in minutes.
+    """
+    MINUTE
+    """
+    When the current duration is in hours.
+    """
+    HOUR
+    """
+    When the current duration is in days.
+    """
+    DAY
+    """
+    When the current duration is in weeks.
+    """
+    WEEK
+}
+
+"""
+Represents the Jira time tracking estimate type.
+"""
+type JiraEstimate {
+    """
+    The estimated time in seconds.
+    """
+    timeInSeconds: Long
+}
+"""
+A connection to a list of users.
+"""
+type JiraUserConnection {
+  "The page info of the current page of results."
+  pageInfo: PageInfo!
+  "A list of User edges."
+  edges: [JiraUserEdge]
+  "A count of filtered result set across all pages."
+  totalCount: Int
+}
+
+"""
+An edge in an User connection object.
+"""
+type JiraUserEdge {
+  "The node at this edge."
+  node: User
+  "The cursor to this edge."
+  cursor: String
+}
+"""
+Jira Version type that can be either Versions system fields or Versions Custom fields.
+"""
+type JiraVersion implements Node {
+    id: ID!
+    """
+    Version Id.
+    """
+    versionId: String!
+    """
+    Version name.
+    """
+    name: String
+    """
+    Version icon URL.
+    """
+    iconUrl: URL
+    """
+    Status to which version belongs to.
+    """
+    status: JiraVersionStatus
+    """
+    Version description.
+    """
+    description: String
+    """
+    The date at which work on the version began.
+    """
+    startDate: DateTime
+    """
+    The date at which the version was released to customers. Must occur after startDate.
+    """
+    releaseDate: DateTime
+    """
+    Warning config of the version. This is per project setting.
+    """
+    warningConfig: JiraVersionWarningConfig
+    """
+    Marketplace connect app iframe data for Version details page's top right corner extension
+    point(location: atl.jira.releasereport.top.right.panels)
+    An empty array will be returned in case there isn't any marketplace apps installed.
+    """
+    connectAddonIframeData: [JiraVersionConnectAddonIframeData]
+    """
+    List of issues with the version.
+    """
+    issues(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+        """
+        filter of the issues under this version. If not given, the default filter will be determined by the server
+        """
+        filter: JiraVersionIssuesFilter = ALL
+    ): JiraIssueConnection
+
+    """
+    List of related work items linked to the version.
+    """
+    relatedWork(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified, it is assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraVersionRelatedWorkConnection
+
+    """
+    List of suggested categories to be displayed when creating a new related work item for a given
+    version.
+    """
+    suggestedRelatedWorkCategories: [String]
+
+    """
+    Indicates whether the user has permission to edit the version such as releasing it or
+    associating related work to it.
+    """
+    canEdit: Boolean
+}
+
+"""
+Input to update the version name.
+"""
+input JiraUpdateVersionNameInput {
+    """
+    The identifier of the Jira version.
+    """
+    id: ID!
+    """
+    Version name.
+    """
+    name: String!
+}
+
+"""
+Input to update the version description.
+"""
+input JiraUpdateVersionDescriptionInput {
+    """
+    The identifier of the Jira version.
+    """
+    id: ID!
+    """
+    Version description.
+    """
+    description: String
+}
+
+"""
+Input to update the version start date.
+"""
+input JiraUpdateVersionStartDateInput {
+    """
+    The identifier of the Jira version.
+    """
+    id: ID!
+    """
+    The date at which work on the version began.
+    """
+    startDate: DateTime
+}
+
+"""
+Input to update the version release date.
+"""
+input JiraUpdateVersionReleaseDateInput {
+    """
+    The identifier of the Jira version.
+    """
+    id: ID!
+    """
+    The date at which the version was released to customers. Must occur after startDate.
+    """
+    releaseDate: DateTime
+}
+
+"""
+The return payload of updating a version.
+"""
+type JiraUpdateVersionPayload implements Payload {
+    """
+    Whether the mutation was successful or not.
+    """
+    success: Boolean!
+    """
+    A list of errors that occurred during the mutation.
+    """
+    errors: [MutationError!]
+    """
+    The updated version.
+    """
+    version: JiraVersion
+}
+
+"""
+The connection type for JiraVersionRelatedWork.
+"""
+type JiraVersionRelatedWorkConnection {
+    """
+    Information about the current page; used to aid in pagination.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraVersionRelatedWorkEdge]
+}
+
+"""
+An edge in a JiraVersionRelatedWork connection.
+"""
+type JiraVersionRelatedWorkEdge {
+    """
+    The cursor to this edge.
+    """
+    cursor: String
+    """
+    The node at this edge.
+    """
+    node: JiraVersionRelatedWork
+}
+
+"""
+Jira version related work type, which is used to associate "smart links" with a given Jira version.
+"""
+type JiraVersionRelatedWork {
+    """
+    Client-generated ID for the related work item.
+    """
+    relatedWorkId: ID
+    """
+    Related work URL.
+    """
+    url: URL
+    """
+    Related work title; can be null if user didn't enter a title when adding the link.
+    """
+    title: String
+    """
+    Category for the related work item.
+    """
+    category: String
+    """
+    Creation date.
+    """
+    addedOn: DateTime
+    """
+    ID of user who created the related work item.
+    """
+    addedById: ID
+}
+
+"""
+Input to create a new related work item and associated with a version.
+"""
+input JiraAddRelatedWorkToVersionInput {
+    """
+    The identifier of the Jira version.
+    """
+    versionId: ID!
+    """
+    Client-generated ID for the related work item.
+    """
+    relatedWorkId: ID!
+    """
+    Related work URL.
+    """
+    url: URL!
+    """
+    Related work title; can be null if user didn't enter a title when adding the link.
+    """
+    title: String
+    """
+    Category for the related work item.
+    """
+    category: String!
+}
+
+"""
+Input to delete a related work item and unlink it from a version.
+"""
+input JiraRemoveRelatedWorkFromVersionInput {
+    """
+    The identifier of the Jira version.
+    """
+    versionId: ID!
+    """
+    Client-generated ID for the related work item.
+    """
+    relatedWorkId: ID!
+}
+
+"""
+The return payload of creating a new related work item and associating it with a version.
+"""
+type JiraAddRelatedWorkToVersionPayload implements Payload {
+    """
+    Whether the mutation was successful or not.
+    """
+    success: Boolean!
+    """
+    A list of errors that occurred during the mutation.
+    """
+    errors: [MutationError!]
+    """
+    The newly added edge and associated data.
+    """
+    relatedWorkEdge: JiraVersionRelatedWorkEdge
+}
+
+"""
+The return payload of deleting a related work item and unlinking it from a version.
+"""
+type JiraRemoveRelatedWorkFromVersionPayload implements Payload {
+    """
+    Whether the mutation was successful or not.
+    """
+    success: Boolean!
+    """
+    A list of errors that occurred during the mutation.
+    """
+    errors: [MutationError!]
+}
+
+"""
+Marketplace connect app iframe data for Version details page's top right corner extension
+point(location: atl.jira.releasereport.top.right.panels)
+If options is null, parsing string json into json object failed while mapping.
+"""
+type JiraVersionConnectAddonIframeData {
+    appKey: String
+    moduleKey: String
+    appName: String
+    location: String
+    options: JSON
+}
+
+"""
+The filter for a version's issues
+"""
+enum JiraVersionIssuesFilter {
+    ALL
+    TODO
+    IN_PROGRESS
+    DONE
+    UNREVIEWED_CODE
+    OPEN_REVIEW
+    OPEN_PULL_REQUEST
+    FAILING_BUILD
+}
+
+"""
+The status of a version field.
+"""
+enum JiraVersionStatus {
+    """
+    Indicates the version is available to public
+    """
+    RELEASED
+    """
+    Indicates the version is not launched yet
+    """
+    UNRELEASED
+    """
+    Indicates the version is archived, no further changes can be made to this version unless it is un-archived
+    """
+    ARCHIVED
+}
+
+"""
+The connection type for JiraVersion.
+"""
+type JiraVersionConnection {
+    """
+    The total count of items in the connection.
+    """
+    totalCount: Int
+    """
+    Information about the current page. Used to aid in pagination.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraVersionEdge]
+}
+
+"""
+An edge in a JiraVersion connection.
+"""
+type JiraVersionEdge {
+    """
+    The node at the edge.
+    """
+    node: JiraVersion
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}
+
+extend type JiraQuery {
+    "Get version by ARI"
+    version(
+        """
+        The identifier of the Jira version
+        """
+        id: ID!
+    ): JiraVersionResult
+
+    """
+    This field returns a connection over JiraVersion.
+    """
+    versionsForProject(
+        """
+        The identifier for the Jira project
+        """
+        jiraProjectId: ID!
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+        """
+        The filter array dictates what versions to return by their status.
+        Defaults to unreleased versions only
+        """
+        filter: [JiraVersionStatus] = [UNRELEASED]
+    ): JiraVersionConnection
+}
+
+"""
+The input to associate issues with a fix version
+"""
+input JiraAddIssuesToFixVersionInput {
+    """
+    The issues to be associated with the fix version
+    """
+    issueIds: [ID!]!
+    """
+    The version to be associated with the issues
+    """
+    versionId: ID!
+}
+
+"""
+The return payload of associating issues with a fix version
+"""
+type JiraAddIssuesToFixVersionPayload implements Payload {
+    """
+    The updated version
+    """
+    version: JiraVersion
+    """
+    Whether the mutation was successful or not.
+    """
+    success: Boolean!
+    """
+    A list of errors that occurred during the mutation.
+    """
+    errors: [MutationError!]
+}
+
+"""
+Contains either the successful fetched version information or an error.
+"""
+union JiraVersionResult = JiraVersion | QueryError
+
+"""
+The warning config for version details page to generate warning report. Depending on tenant settings and providers installed, some warning config could be in NOT_APPLICABLE state.
+"""
+enum JiraVersionWarningConfigState {
+    ENABLED
+    DISABLED
+    NOT_APPLICABLE
+}
+
+"""
+The warning configuration to generate version details page warning report.
+"""
+type JiraVersionWarningConfig {
+    """
+    The warnings for issues that has open pull request and in done issue status category.
+    """
+    openPullRequest: JiraVersionWarningConfigState
+    """
+    The warnings for issues that has open review and in done issue status category (only applicable for FishEye/Crucible integration to Jira).
+    """
+    openReview: JiraVersionWarningConfigState
+    """
+    The warnings for issues that has unreviewed code and in done issue status category.
+    """
+    unreviewedCode: JiraVersionWarningConfigState
+    """
+    The warnings for issues that has failing build and in done issue status category.
+    """
+    failingBuild: JiraVersionWarningConfigState
+    """
+    Whether the user requesting the warning config has edit permissions.
+    """
+    canEdit: Boolean
+}
+
+"""
+The warning configuration to be updated for version details page warning report.
+Applicable values will have their value updated. Null values will default to true.
+"""
+input JiraVersionUpdatedWarningConfigInput {
+    """
+    The warnings for issues that has open pull request and in done issue status category.
+    """
+    isOpenPullRequestEnabled: Boolean = true
+    """
+    The warnings for issues that has open review(FishEye/Crucible integration) and in done issue status category.
+    """
+    isOpenReviewEnabled: Boolean = true
+    """
+    The warnings for issues that has unreviewed code and in done issue status category.
+    """
+    isUnreviewedCodeEnabled: Boolean = true
+    """
+    The warnings for issues that has failing build and in done issue status category.
+    """
+    isFailingBuildEnabled: Boolean = true
+}
+
+"""
+The input to update the version details page warning report.
+"""
+input JiraUpdateVersionWarningConfigInput {
+    """
+    The ARI of the Jira project.
+    """
+    jiraProjectId: ID!
+    """
+    The version configuration options to be updated.
+    """
+    updatedVersionWarningConfig: JiraVersionUpdatedWarningConfigInput!
+}
+
+type JiraUpdateVersionWarningConfigPayload implements Payload {
+    "Whether the mutation was successful or not."
+    success: Boolean!
+
+    "A list of errors that occurred during the mutation."
+    errors: [MutationError!]
+}
+
+extend type JiraMutation {
+    """
+    Associate issues with a fix version
+    """
+    addIssuesToFixVersion(
+        input: JiraAddIssuesToFixVersionInput!
+    ): JiraAddIssuesToFixVersionPayload
+    """
+    Update version warning configuration by enabling/disabling warnings
+    for specific scenarios.
+    """
+    updateVersionWarningConfig(
+        input: JiraUpdateVersionWarningConfigInput!
+    ): JiraUpdateVersionWarningConfigPayload
+
+    """
+    Create a related work item and link it to a version.
+    """
+    addRelatedWorkToVersion(
+        input: JiraAddRelatedWorkToVersionInput!
+    ): JiraAddRelatedWorkToVersionPayload
+
+    """
+    Delete a related work item from a version.
+    """
+    removeRelatedWorkFromVersion(
+        input: JiraRemoveRelatedWorkFromVersionInput!
+    ): JiraRemoveRelatedWorkFromVersionPayload
+
+    """
+    Update a version's name.
+    """
+    updateVersionName(
+        input: JiraUpdateVersionNameInput!
+    ): JiraUpdateVersionPayload
+
+    """
+    Update a version's description.
+    """
+    updateVersionDescription(
+        input: JiraUpdateVersionDescriptionInput!
+    ): JiraUpdateVersionPayload
+
+    """
+    Update a version's start date.
+    """
+    updateVersionStartDate(
+        input: JiraUpdateVersionStartDateInput!
+    ): JiraUpdateVersionPayload
+
+    """
+    Update a version's release date.
+    """
+    updateVersionReleaseDate(
+        input: JiraUpdateVersionReleaseDateInput!
+    ): JiraUpdateVersionPayload
+}
+"""
+A list of issues and JQL that results the list of issues.
+"""
+type JiraVersionDetailPageIssues {
+    """
+    JQL that is used to list issues
+    """
+    jql: String
+    """
+    Issues returned by the provided JQL query
+    """
+    issues(
+        """
+        The number of items after the cursor to be returned in a forward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        first: Int
+        """
+        The index based cursor to specify the beginning of the items.
+        If not specified it's assumed as the cursor for the item before the beginning.
+        """
+        after: String
+        """
+        The number of items before the cursor to be returned in a backward page.
+        If not specified, it is up to the server to determine a page size.
+        """
+        last: Int
+        """
+        The index based cursor to specify the bottom limit of the items.
+        If not specified it's assumed as the cursor to the item after the last item.
+        """
+        before: String
+    ): JiraIssueConnection
+}
+
+extend type JiraQuery {
+    """
+    Contains the lists of issues per table and the warning config for the version detail page under Releases home page.
+    """
+    versionDetailPage(versionId: ID!): JiraVersionDetailPage @deprecated(reason:"use the fields that is used to live under this type from JiraVersion instead. It is simply migrated.")
+}
+
+"""
+This type holds specific information for version details page holding warning config for the version and issues for each category.
+"""
+type JiraVersionDetailPage {
+    """
+    Warning config of the version. This is per project setting.
+    """
+    warningConfig: JiraVersionWarningConfig
+    """
+    List of issues and its JQL, that have failing build, and its status is in done issue status category.
+    """
+    failingBuildIssues: JiraVersionDetailPageIssues
+    """
+    List of issues and its JQL, that have open pull request, and its status is in done issue status category.
+    """
+    openPullRequestIssues: JiraVersionDetailPageIssues
+    """
+    List of issues and its JQL, that have commits that are not a part of pull request, and its status is in done issue status category.
+    """
+    unreviewedCodeIssues: JiraVersionDetailPageIssues
+    """
+    List of issues and its JQL, that are in to-do issue status category.
+    """
+    toDoIssues: JiraVersionDetailPageIssues
+    """
+    List of issues and its JQL, that are in-progress issue status category.
+    """
+    inProgressIssues: JiraVersionDetailPageIssues
+    """
+    List of issues and its JQL, that are done issue status category.
+    """
+    doneIssues: JiraVersionDetailPageIssues
+    """
+    List of issues and its JQL, that have the given version as its fixed version.
+    """
+    allIssues: JiraVersionDetailPageIssues
+}
+"""
+Represents the votes information of an Issue.
+"""
+type JiraVote {
+    """
+    Indicates whether the current user has voted for this Issue.
+    """
+    hasVoted: Boolean
+    """
+    Count of users who have voted for this Issue.
+    """
+    count: Long
+}
+"""
+Represents the watches information.
+"""
+type JiraWatch {
+    """
+    Indicates whether the current user is watching this issue.
+    """
+    isWatching: Boolean
+    """
+    Count of users who are watching this issue.
+    """
+    count: Long
+}"""
+Represents a WorkCategory.
+"""
+type JiraWorkCategory {
+    """
+    The value of the WorkCategory.
+    """
+    value: String
+}"""
+Represents a Jira worklog.
+"""
+type JiraWorklog implements Node {
+    """
+    Global identifier for the worklog.
+    """
+    id: ID!
+    """
+    Identifier for the worklog.
+    """
+    worklogId: ID!
+    """
+    User profile of the original worklog author.
+    """
+    author: User
+    """
+    User profile of the author performing the worklog update.
+    """
+    updateAuthor: User
+    """
+    Time spent displays the amount of time logged working on the issue so far.
+    """
+    timeSpent: JiraEstimate
+    """
+    Time Remaining displays the amount of time currently anticipated to resolve the issue.
+    """
+    remainingEstimate: JiraEstimate
+    """
+    Time of worklog creation.
+    """
+    created: DateTime!
+    """
+    Time of last worklog update.
+    """
+    updated: DateTime
+    """
+    Date and time when this unit of work was started.
+    """
+    startDate: DateTime
+    """
+    Either the group or the project role associated with this worklog, but not both.
+    Null means the permission level is unspecified, i.e. the worklog is public.
+    """
+    permissionLevel: JiraPermissionLevel
+    """
+    Description related to the achieved work.
+    """
+    workDescription: JiraRichText
+}
+
+"""
+The connection type for JiraWorklog.
+"""
+type JiraWorkLogConnection {
+    """
+    The approximate count of items in the connection.
+    """
+    indicativeCount: Int
+    """
+    The page info of the current page of results.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of edges in the current page.
+    """
+    edges: [JiraWorkLogEdge]
+}
+
+"""
+An edge in a JiraWorkLog connection.
+"""
+type JiraWorkLogEdge {
+    """
+    The node at the the edge.
+    """
+    node: JiraWorklog
+    """
+    The cursor to this edge.
+    """
+    cursor: String!
+}
+"""
+ AGG requirement - The combination of all *.graphqls in the directory need to be self contained.
+ So all the Dependencies from base schema need to be copied over here
+"""
+scalar URL
+scalar DateTime
+scalar Date
+scalar Long
+scalar JSON
+
+type Query {
+  """
+   this field is added to enable self governed onboarding of Jira GraphQL types to AGG
+   see https://hello.atlassian.net/wiki/spaces/PSRV/pages/1010287708/Announcing+self+governed+APIs for more details
+  """
+  jira: JiraQuery
+  
+  node(id: ID!): Node
+}
+
+"Standard Relay node interface"
+interface Node {
+  "The id of the node"
+  id: ID!
+}
+
+type PageInfo {
+  """
+  `true` if having more items when navigating forward
+  """
+  hasNextPage: Boolean!
+  """
+  `true` if having more items when navigating backward
+  """
+  hasPreviousPage: Boolean!
+  """
+  When paginating backwards, the cursor to continue.
+  """
+  startCursor: String
+  """
+  When paginating forwards, the cursor to continue.
+  """
+  endCursor: String
+}
+
+interface QueryErrorExtension {
+  """
+  A numerical code (such as an HTTP status code) representing the error category.
+  """
+  statusCode: Int
+
+  """
+  A code representing the type of error. See the CompassErrorType enum for possible values.
+  """
+  errorType: String
+}
+
+type QueryError {
+  """
+  The ID of the requested object, or null when the ID is not available.
+  """
+  identifier: ID
+
+  """
+  A message describing the error.
+  """
+  message: String
+
+  """
+  Contains extra data describing the error.
+  """
+  extensions: [QueryErrorExtension!]
+}
+
+"""
+A very generic query error extension type with no additional fields specific to service.
+"""
+type GenericQueryErrorExtension implements QueryErrorExtension {
+    "A numerical code (such as a HTTP status code) representing the error category"
+    statusCode: Int
+    "Application specific error type"
+    errorType: String
+}
+
+"""
+The payload represents the mutation response structure.
+It represents both success and error responses.
+"""
+interface Payload {
+  "The success field returns true if operation is successful. Otherwise, false."
+  success: Boolean!
+  """
+  A bounded list of one or more mutation error information in case of unsuccessful execution.
+  If success field value is false, then errors field may offer additional information.
+  """
+  errors: [MutationError!]
+}
+
+"""
+It represents mutation operation error details.
+"""
+type MutationError {
+  "The error message related to mutation operation"
+  message: String
+  "An extension to mutation error representing more details about the mutation error such as application specific codes and error types"
+  extensions : MutationErrorExtension
+}
+
+"""
+An extension to mutation error information to offer application specific error codes and error types.
+It helps to pinpoint and classify the error response.
+"""
+interface MutationErrorExtension {
+  """
+  A numerical code (example: HTTP status code) representing the error category
+  For example: 412 for operation preconditions failure.
+  """
+  statusCode: Int
+  """
+  Application specific error type in the readable format.
+  For example: unable to process request because application is at an illegal state.
+  """
+  errorType: String
+}
+
+"""
+A very generic mutation error extension type with no additional fields specific to service.
+"""
+type GenericMutationErrorExtension implements MutationErrorExtension {
+  """
+  A numerical code (example: HTTP status code) representing the error category
+  For example: 412 for operation preconditions failure.
+  """
+  statusCode: Int
+  """
+  Application specific error type in the readable format.
+  For example: unable to process request because application is at an illegal state.
+  """
+  errorType: String
+}"""
+ AGG requirement - The combination of all *.graphqls in the directory need to be self contained.
+So all gira Dependencies from identity schema need to be copied over here
+"""
+
+interface User {
+  accountId: ID!
+  canonicalAccountId: ID!
+  accountStatus: AccountStatus!
+  name: String!
+  picture: URL!
+}
+
+enum AccountStatus {
+  active
+  inactive
+  closed
+}
+
+type AtlassianAccountUser implements User {
+  accountId: ID!
+  canonicalAccountId: ID!
+  accountStatus: AccountStatus!
+  name: String!
+  picture: URL!
+  email: String
+  zoneinfo: String
+  locale: String
+}


### PR DESCRIPTION
After parsing and validating an incoming GraphQL operation, the engine creates a normalized version of that operation, the `ExecutableNormalizedOperation`.

For fragments, there is a little more work involved to determine the possible types. Inside `narrowDownPossibleObjects`, there is a set intersection between the current set of possible objects and the set of types from the resolved type condition.

This set intersection can be expensive for very large queries with hundreds of fragments. This PR includes one such example.

In almost every case in the example query, one of the sets being compared only has one member. For example, the resolved types set often has only 1 member, because an inline fragment on a concrete type has only one possible type. It would be equivalent, and much cheaper, to calculate via Set `contains` rather than `intersection`.

And I've added a more general tweak to always pass the smallest set first to Guava's `Sets.intersection`. The implementation is faster when the first set is smaller.

### Benchmark results
**Baseline**
```
Benchmark                                 Mode  Cnt    Score    Error  Units
NQExtraLargeBenchmark.benchMarkThroughput  thrpt    9  274.744 ± 14.909  ops/s
NQExtraLargeBenchmark.benchMarkAvgTime      avgt    9    3.658 ±  0.310  ms/op
```

**Optimised**
```
Benchmark                                 Mode  Cnt    Score    Error  Units
NQExtraLargeBenchmark.benchMarkThroughput  thrpt    9  333.346 ± 25.986  ops/s
NQExtraLargeBenchmark.benchMarkAvgTime      avgt    9    2.905 ±  0.124  ms/op
```

Note: For throughput, a higher number is better. For average time, a lower number is better.