### PR TITLE
Change Instrumentation production implementations to use non deprecated methods

### DIFF
--- a/src/main/java/graphql/analysis/MaxQueryDepthInstrumentation.java
+++ b/src/main/java/graphql/analysis/MaxQueryDepthInstrumentation.java
@@ -5,8 +5,10 @@ import graphql.PublicApi;
 import graphql.execution.AbortExecutionException;
 import graphql.execution.ExecutionContext;
 import graphql.execution.instrumentation.InstrumentationContext;
+import graphql.execution.instrumentation.InstrumentationState;
 import graphql.execution.instrumentation.SimpleInstrumentation;
 import graphql.execution.instrumentation.parameters.InstrumentationExecuteOperationParameters;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,7 +18,7 @@ import static graphql.execution.instrumentation.SimpleInstrumentationContext.noO
 
 /**
  * Prevents execution if the query depth is greater than the specified maxDepth.
- *
+ * <p>
  * Use the {@code Function<QueryDepthInfo, Boolean>} parameter to supply a function to perform a custom action when the max depth is
  * exceeded. If the function returns {@code true} a {@link AbortExecutionException} is thrown.
  */
@@ -49,7 +51,7 @@ public class MaxQueryDepthInstrumentation extends SimpleInstrumentation {
     }
 
     @Override
-    public InstrumentationContext<ExecutionResult> beginExecuteOperation(InstrumentationExecuteOperationParameters parameters) {
+    public @Nullable InstrumentationContext<ExecutionResult> beginExecuteOperation(InstrumentationExecuteOperationParameters parameters, InstrumentationState state) {
         QueryTraverser queryTraverser = newQueryTraverser(parameters.getExecutionContext());
         int depth = queryTraverser.reducePreOrder((env, acc) -> Math.max(getPathLength(env.getParentEnvironment()), acc), 0);
         if (log.isDebugEnabled()) {
@@ -73,7 +75,7 @@ public class MaxQueryDepthInstrumentation extends SimpleInstrumentation {
      * @param depth    the depth of the query
      * @param maxDepth the maximum depth allowed
      *
-     * @return a instance of AbortExecutionException
+     * @return an instance of AbortExecutionException
      */
     protected AbortExecutionException mkAbortException(int depth, int maxDepth) {
         return new AbortExecutionException("maximum query depth exceeded " + depth + " > " + maxDepth);

--- a/src/main/java/graphql/execution/instrumentation/SimpleInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/SimpleInstrumentation.java
@@ -16,7 +16,9 @@ import java.util.concurrent.CompletableFuture;
 
 /**
  * An implementation of {@link graphql.execution.instrumentation.Instrumentation} that does nothing.  It can be used
- * as a base for derived classes where you only implement the methods you want to
+ * as a base for derived classes where you only implement the methods you want to.  With all the methods in {@link Instrumentation}
+ * now defaulted (post Java 6) this class is really not needed anymore but has been retained for backwards compatibility
+ * reasons.
  */
 @PublicApi
 public class SimpleInstrumentation implements Instrumentation {
@@ -26,48 +28,4 @@ public class SimpleInstrumentation implements Instrumentation {
      */
     public static final SimpleInstrumentation INSTANCE = new SimpleInstrumentation();
 
-    @Override
-    public InstrumentationContext<ExecutionResult> beginExecution(InstrumentationExecutionParameters parameters) {
-        return SimpleInstrumentationContext.noOp();
-    }
-
-    @Override
-    public InstrumentationContext<Document> beginParse(InstrumentationExecutionParameters parameters) {
-        return SimpleInstrumentationContext.noOp();
-    }
-
-    @Override
-    public InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters) {
-        return SimpleInstrumentationContext.noOp();
-    }
-
-    @Override
-    public ExecutionStrategyInstrumentationContext beginExecutionStrategy(InstrumentationExecutionStrategyParameters parameters) {
-        return new ExecutionStrategyInstrumentationContext() {
-            @Override
-            public void onDispatched(CompletableFuture<ExecutionResult> result) {
-
-            }
-
-            @Override
-            public void onCompleted(ExecutionResult result, Throwable t) {
-
-            }
-        };
-    }
-
-    @Override
-    public InstrumentationContext<ExecutionResult> beginExecuteOperation(InstrumentationExecuteOperationParameters parameters) {
-        return SimpleInstrumentationContext.noOp();
-    }
-
-    @Override
-    public InstrumentationContext<ExecutionResult> beginField(InstrumentationFieldParameters parameters) {
-        return SimpleInstrumentationContext.noOp();
-    }
-
-    @Override
-    public InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters) {
-        return SimpleInstrumentationContext.noOp();
-    }
 }

--- a/src/main/java/graphql/execution/instrumentation/fieldvalidation/FieldValidationInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/fieldvalidation/FieldValidationInstrumentation.java
@@ -5,8 +5,10 @@ import graphql.GraphQLError;
 import graphql.PublicApi;
 import graphql.execution.AbortExecutionException;
 import graphql.execution.instrumentation.InstrumentationContext;
+import graphql.execution.instrumentation.InstrumentationState;
 import graphql.execution.instrumentation.SimpleInstrumentation;
 import graphql.execution.instrumentation.parameters.InstrumentationExecuteOperationParameters;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -36,8 +38,7 @@ public class FieldValidationInstrumentation extends SimpleInstrumentation {
     }
 
     @Override
-    public InstrumentationContext<ExecutionResult> beginExecuteOperation(InstrumentationExecuteOperationParameters parameters) {
-
+    public @Nullable InstrumentationContext<ExecutionResult> beginExecuteOperation(InstrumentationExecuteOperationParameters parameters, InstrumentationState state) {
         List<GraphQLError> errors = FieldValidationSupport.validateFieldsAndArguments(fieldValidation, parameters.getExecutionContext());
         if (errors != null && !errors.isEmpty()) {
             throw new AbortExecutionException(errors);

--- a/src/main/java/graphql/execution/instrumentation/tracing/TracingInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/tracing/TracingInstrumentation.java
@@ -8,11 +8,13 @@ import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.InstrumentationState;
 import graphql.execution.instrumentation.SimpleInstrumentation;
+import graphql.execution.instrumentation.parameters.InstrumentationCreateStateParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationValidationParameters;
 import graphql.language.Document;
 import graphql.validation.ValidationError;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -69,15 +71,15 @@ public class TracingInstrumentation extends SimpleInstrumentation {
     private final Options options;
 
     @Override
-    public InstrumentationState createState() {
+    public @Nullable InstrumentationState createState(InstrumentationCreateStateParameters parameters) {
         return new TracingSupport(options.includeTrivialDataFetchers);
     }
 
     @Override
-    public CompletableFuture<ExecutionResult> instrumentExecutionResult(ExecutionResult executionResult, InstrumentationExecutionParameters parameters) {
+    public CompletableFuture<ExecutionResult> instrumentExecutionResult(ExecutionResult executionResult, InstrumentationExecutionParameters parameters, InstrumentationState rawState) {
         Map<Object, Object> currentExt = executionResult.getExtensions();
 
-        TracingSupport tracingSupport = parameters.getInstrumentationState();
+        TracingSupport tracingSupport = (TracingSupport) rawState;
         Map<Object, Object> withTracingExt = new LinkedHashMap<>(currentExt == null ? ImmutableKit.emptyMap() : currentExt);
         withTracingExt.put("tracing", tracingSupport.snapshotTracingData());
 
@@ -85,22 +87,22 @@ public class TracingInstrumentation extends SimpleInstrumentation {
     }
 
     @Override
-    public InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters) {
-        TracingSupport tracingSupport = parameters.getInstrumentationState();
+    public InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters, InstrumentationState rawState) {
+        TracingSupport tracingSupport = (TracingSupport) rawState;
         TracingSupport.TracingContext ctx = tracingSupport.beginField(parameters.getEnvironment(), parameters.isTrivialDataFetcher());
         return whenCompleted((result, t) -> ctx.onEnd());
     }
 
     @Override
-    public InstrumentationContext<Document> beginParse(InstrumentationExecutionParameters parameters) {
-        TracingSupport tracingSupport = parameters.getInstrumentationState();
+    public InstrumentationContext<Document> beginParse(InstrumentationExecutionParameters parameters,InstrumentationState rawState) {
+        TracingSupport tracingSupport = (TracingSupport) rawState;
         TracingSupport.TracingContext ctx = tracingSupport.beginParse();
         return whenCompleted((result, t) -> ctx.onEnd());
     }
 
     @Override
-    public InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters) {
-        TracingSupport tracingSupport = parameters.getInstrumentationState();
+    public InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters, InstrumentationState rawState) {
+        TracingSupport tracingSupport = (TracingSupport) rawState;
         TracingSupport.TracingContext ctx = tracingSupport.beginValidation();
         return whenCompleted((result, t) -> ctx.onEnd());
     }

--- a/src/test/groovy/graphql/analysis/MaxQueryDepthInstrumentationTest.groovy
+++ b/src/test/groovy/graphql/analysis/MaxQueryDepthInstrumentationTest.groovy
@@ -43,7 +43,7 @@ class MaxQueryDepthInstrumentationTest extends Specification {
         def executionContext = executionCtx(executionInput, query, schema)
         def executeOperationParameters = new InstrumentationExecuteOperationParameters(executionContext)
         when:
-        maximumQueryDepthInstrumentation.beginExecuteOperation(executeOperationParameters)
+        maximumQueryDepthInstrumentation.beginExecuteOperation(executeOperationParameters, null)
         then:
         def e = thrown(AbortExecutionException)
         e.message.contains("maximum query depth exceeded 7 > 6")
@@ -102,7 +102,7 @@ class MaxQueryDepthInstrumentationTest extends Specification {
         def executionContext = executionCtx(executionInput, query, schema)
         def executeOperationParameters = new InstrumentationExecuteOperationParameters(executionContext)
         when:
-        maximumQueryDepthInstrumentation.beginExecuteOperation(executeOperationParameters)
+        maximumQueryDepthInstrumentation.beginExecuteOperation(executeOperationParameters, null)
         then:
         calledFunction
         notThrown(Exception)

--- a/src/test/groovy/graphql/execution/instrumentation/threadpools/ExecutorInstrumentationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/threadpools/ExecutorInstrumentationTest.groovy
@@ -77,7 +77,7 @@ class ExecutorInstrumentationTest extends Specification {
     def "can handle a data fetcher that throws exceptions"() {
         when:
         DataFetcher df = { env -> throw new RuntimeException("BANG") }
-        def modifiedDataFetcher = instrumentation.instrumentDataFetcher(df, null)
+        def modifiedDataFetcher = instrumentation.instrumentDataFetcher(df, null,null)
         def returnedValue = modifiedDataFetcher.get(null)
 
         then:
@@ -96,7 +96,7 @@ class ExecutorInstrumentationTest extends Specification {
 
         when:
         DataFetcher df = PropertyDataFetcher.fetching({ o -> "trivial" })
-        def modifiedDataFetcher = instrumentation.instrumentDataFetcher(df, null)
+        def modifiedDataFetcher = instrumentation.instrumentDataFetcher(df, null,null)
         def returnedValue = modifiedDataFetcher.get(dfEnv("source"))
 
         then:
@@ -111,7 +111,7 @@ class ExecutorInstrumentationTest extends Specification {
         instrumentation = build(FetchExecutor, ProcessingExecutor, observer)
 
         DataFetcher df = { env -> currentThread().getName() }
-        def modifiedDataFetcher = instrumentation.instrumentDataFetcher(df, null)
+        def modifiedDataFetcher = instrumentation.instrumentDataFetcher(df, null, null)
         def returnedValue = modifiedDataFetcher.get(null)
 
         then:
@@ -131,7 +131,7 @@ class ExecutorInstrumentationTest extends Specification {
         instrumentation = build(FetchExecutor, null, observer)
 
         DataFetcher df = { env -> currentThread().getName() }
-        def modifiedDataFetcher = instrumentation.instrumentDataFetcher(df, null)
+        def modifiedDataFetcher = instrumentation.instrumentDataFetcher(df, null, null)
         def returnedValue = modifiedDataFetcher.get(null)
 
         then:
@@ -152,7 +152,7 @@ class ExecutorInstrumentationTest extends Specification {
         instrumentation = build(null, ProcessingExecutor, observer)
 
         DataFetcher df = { env -> currentThread().getName() }
-        def modifiedDataFetcher = instrumentation.instrumentDataFetcher(df, null)
+        def modifiedDataFetcher = instrumentation.instrumentDataFetcher(df, null, null)
         def returnedValue = modifiedDataFetcher.get(null)
 
         then:
@@ -171,7 +171,7 @@ class ExecutorInstrumentationTest extends Specification {
         instrumentation = build(FetchExecutor, ProcessingExecutor, observer)
 
         DataFetcher df = { env -> CompletableFuture.completedFuture(currentThread().getName()) }
-        def modifiedDataFetcher = instrumentation.instrumentDataFetcher(df, null)
+        def modifiedDataFetcher = instrumentation.instrumentDataFetcher(df, null, null)
         def returnedValue = modifiedDataFetcher.get(null)
 
         then:

--- a/src/test/groovy/graphql/execution/preparsed/PreparsedDocumentProviderTest.groovy
+++ b/src/test/groovy/graphql/execution/preparsed/PreparsedDocumentProviderTest.groovy
@@ -6,8 +6,9 @@ import graphql.GraphQL
 import graphql.StarWarsSchema
 import graphql.execution.AsyncExecutionStrategy
 import graphql.execution.instrumentation.InstrumentationContext
-import graphql.execution.instrumentation.SimpleInstrumentation
+import graphql.execution.instrumentation.InstrumentationState
 import graphql.execution.instrumentation.LegacyTestingInstrumentation
+import graphql.execution.instrumentation.SimpleInstrumentation
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters
 import graphql.language.Document
 import graphql.parser.Parser
@@ -16,6 +17,7 @@ import spock.lang.Specification
 import java.util.function.Function
 
 import static graphql.ExecutionInput.newExecutionInput
+import static graphql.execution.instrumentation.SimpleInstrumentationContext.noOp
 
 class PreparsedDocumentProviderTest extends Specification {
 
@@ -110,14 +112,14 @@ class PreparsedDocumentProviderTest extends Specification {
                 .instrumentation(instrumentation)
                 .preparsedDocumentProvider(preparsedCache)
                 .build()
-                .execute(ExecutionInput.newExecutionInput().query(query).build()).data
+                .execute(newExecutionInput().query(query).build()).data
 
         def data2 = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema)
                 .queryExecutionStrategy(strategy)
                 .instrumentation(instrumentationPreparsed)
                 .preparsedDocumentProvider(preparsedCache)
                 .build()
-                .execute(ExecutionInput.newExecutionInput().query(query).build()).data
+                .execute(newExecutionInput().query(query).build()).data
 
 
         then:
@@ -145,12 +147,12 @@ class PreparsedDocumentProviderTest extends Specification {
         def result1 = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema)
                 .preparsedDocumentProvider(preparsedCache)
                 .build()
-                .execute(ExecutionInput.newExecutionInput().query(query).build())
+                .execute(newExecutionInput().query(query).build())
 
         def result2 = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema)
                 .preparsedDocumentProvider(preparsedCache)
                 .build()
-                .execute(ExecutionInput.newExecutionInput().query(query).build())
+                .execute(newExecutionInput().query(query).build())
 
         then: "Both the first and the second result should give the same validation error"
         result1.errors.size() == 1
@@ -165,9 +167,9 @@ class PreparsedDocumentProviderTest extends Specification {
         ExecutionInput capturedInput
 
         @Override
-        InstrumentationContext<Document> beginParse(InstrumentationExecutionParameters parameters) {
+        InstrumentationContext<Document> beginParse(InstrumentationExecutionParameters parameters, InstrumentationState state) {
             capturedInput = parameters.getExecutionInput()
-            return super.beginParse(parameters)
+            return noOp()
         }
     }
 
@@ -206,14 +208,14 @@ class PreparsedDocumentProviderTest extends Specification {
                 .preparsedDocumentProvider(documentProvider)
                 .instrumentation(instrumentationA)
                 .build()
-                .execute(ExecutionInput.newExecutionInput().query("#A").build())
+                .execute(newExecutionInput().query("#A").build())
 
         def instrumentationB = new InputCapturingInstrumentation()
         def resultB = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema)
                 .preparsedDocumentProvider(documentProvider)
                 .instrumentation(instrumentationB)
                 .build()
-                .execute(ExecutionInput.newExecutionInput().query("#B").build())
+                .execute(newExecutionInput().query("#B").build())
 
         expect:
 


### PR DESCRIPTION
This is mostly the production classes and their tests.

I have NOT gone to all the tests class implementations of `Instrumentation` and fixed them up

This works because the callers of the instrumentation methods (our code) only ever come in on the on deprecated methods.