### PR TITLE
Remove redundant NaN check, already handled in GraphqlFloatCoercing

### DIFF
--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -599,11 +599,6 @@ public abstract class ExecutionStrategy {
             serialized = handleCoercionProblem(executionContext, parameters, e);
         }
 
-        // TODO: fix that: this should not be handled here
-        //6.6.1 http://facebook.github.io/graphql/#sec-Field-entries
-        if (serialized instanceof Double && ((Double) serialized).isNaN()) {
-            serialized = null;
-        }
         try {
             serialized = parameters.getNonNullFieldValidator().validate(parameters.getPath(), serialized);
         } catch (NonNullableFieldWasNullException e) {

--- a/src/test/resources/extra-large-schema-1.graphqls
+++ b/src/test/resources/extra-large-schema-1.graphqls
@@ -824,12 +824,10 @@ enum JiraAttachmentsPermissions {
 
 input JiraOrderDirection {
     id: ID
-    #TODO
 }
 
 input JiraAttachmentsOrderField {
     id: ID
-    #TODO
 }
 """
 Represents the avatar size urls.
@@ -1655,7 +1653,6 @@ type JiraComponent implements Node {
     Component description.
     """
     description: String
-    # TODO: lead, default assignee ...
 }
 
 """


### PR DESCRIPTION
The removed logic belongs inside a scalar's `serialize` method and should not be handled in this location inside `ExecutionStrategy`.

We have already handled the `NaN` case inside `GraphqlFloatCoercing` and we already had a `NaN` test in `ScalarsFloatTest`, see `serialize throws exception for invalid input #value`.

This is an old TODO from 2018. The Float spec has changed since then, now an error is to be raised for non-finite values such as `NaN`. 
Spec: https://spec.graphql.org/draft/#sec-Float
Spec PR: https://github.com/graphql/graphql-spec/issues/778