### PR TITLE
Deprecation test cleanup: GraphQLFieldDefinition datafetcher builder

### DIFF
--- a/src/test/groovy/graphql/DataFetcherWithErrorsAndDataTest.groovy
+++ b/src/test/groovy/graphql/DataFetcherWithErrorsAndDataTest.groovy
@@ -3,6 +3,10 @@ package graphql
 import graphql.execution.AsyncExecutionStrategy
 import graphql.execution.AsyncSerialExecutionStrategy
 import graphql.language.SourceLocation
+import graphql.schema.DataFetcher
+import graphql.schema.DataFetchingEnvironment
+import graphql.schema.FieldCoordinates
+import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLOutputType
 import graphql.schema.GraphQLSchema
 import graphql.schema.idl.RuntimeWiring
@@ -32,55 +36,91 @@ class DataFetcherWithErrorsAndDataTest extends Specification {
         ChildObject child = new ChildObject()
     }
 
-    def executionInput(String query) {
+    static def executionInput(String query) {
         newExecutionInput().query(query).build()
+    }
+
+    class ParentDataFetcher implements DataFetcher {
+        @Override
+        Object get(DataFetchingEnvironment environment) throws Exception {
+            return newResult()
+                    .data(new ParentObject())
+                    .errors([newError()
+                                     .message("badField is bad")
+                                     .path(["root", "parent", "child", "badField"])
+                                     .location(environment.getField().getSourceLocation())
+                                     .build()])
+                    .build()
+        }
+    }
+
+    class ChildDataFetcher implements DataFetcher {
+        @Override
+        Object get(DataFetchingEnvironment environment) throws Exception {
+            return newResult()
+                    .data(["goodField": null, "badField": null])
+                    .errors([newError()
+                                     .message("goodField is bad")
+                                     .path(["root", "parent", "child", "goodField"])
+                                     .location(environment.getField().getSourceLocation())
+                                     .build(),
+                             newError().message("badField is bad")
+                                     .path(["root", "parent", "child", "badField"])
+                                     .location(environment.getField().getSourceLocation())
+                                     .build()])
+                    .build()
+        }
     }
 
     @Unroll
     def "#820 - data fetcher can return data and errors (strategy: #strategyName)"() {
-
         // see https://github.com/graphql-java/graphql-java/issues/820
 
         given:
-
+        def queryTypeName = "QueryType"
+        def rootFieldName = "root"
+        def rootTypeName = "rootType"
+        def parentFieldName = "parent"
 
         GraphQLOutputType childType = newObject()
                 .name("childType")
-                .field(newFieldDefinition().name("goodField")
+                .field(newFieldDefinition()
+                        .name("goodField")
                         .type(GraphQLString))
-                .field(newFieldDefinition().name("badField")
+                .field(newFieldDefinition()
+                        .name("badField")
                         .type(GraphQLString))
                 .build()
         GraphQLOutputType parentType = newObject()
                 .name("parentType")
-                .field(newFieldDefinition().name("child")
+                .field(newFieldDefinition()
+                        .name("child")
                         .type(childType))
                 .build()
         GraphQLOutputType rootType = newObject()
-                .name("rootType")
-                .field(newFieldDefinition().name("parent")
-                        .type(parentType)
-                        .dataFetcher({ env ->
-                            newResult()
-                                    .data(new ParentObject())
-                                    .errors([newError()
-                                                     .message("badField is bad")
-                                                     .path(["root", "parent", "child", "badField"])
-                                                     .location(env.getField().getSourceLocation())
-                                                     .build()])
-                                    .build()
-
-                        }))
+                .name(rootTypeName)
+                .field(newFieldDefinition()
+                        .name(parentFieldName)
+                        .type(parentType))
                 .build()
 
-        GraphQLSchema schema = newSchema().query(
-                newObject()
-                        .name("QueryType")
-                        .field(newFieldDefinition()
-                                .name("root")
-                                .type(rootType)
-                                .dataFetcher({ env -> [:] })
+        def rootTypeCoordinates = FieldCoordinates.coordinates(queryTypeName, rootFieldName)
+        def parentTypeCoordinates = FieldCoordinates.coordinates(rootTypeName, parentFieldName)
+        DataFetcher<?> rootTypeDataFetcher = { env -> [:] }
+        DataFetcher<?> parentTypeDataFetcher = new ParentDataFetcher()
 
+        GraphQLCodeRegistry codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .dataFetcher(rootTypeCoordinates, rootTypeDataFetcher)
+                .dataFetcher(parentTypeCoordinates, parentTypeDataFetcher)
+                .build()
+
+        GraphQLSchema schema = newSchema()
+                .codeRegistry(codeRegistry)
+                .query(newObject()
+                        .name(queryTypeName)
+                        .field(newFieldDefinition()
+                                .name(rootFieldName)
+                                .type(rootType)
                         ))
                 .build()
 
@@ -122,52 +162,53 @@ class DataFetcherWithErrorsAndDataTest extends Specification {
 
     @Unroll
     def "#820 - data fetcher can return multiple errors (strategy: #strategyName)"() {
-
         // see https://github.com/graphql-java/graphql-java/issues/820
 
         given:
-
+        def queryTypeName = "QueryType"
+        def rootFieldName = "root"
+        def parentTypeName = "parentType"
+        def childFieldName = "child"
 
         GraphQLOutputType childType = newObject()
                 .name("childType")
-                .field(newFieldDefinition().name("goodField")
+                .field(newFieldDefinition()
+                        .name("goodField")
                         .type(GraphQLString))
-                .field(newFieldDefinition().name("badField")
+                .field(newFieldDefinition()
+                        .name("badField")
                         .type(GraphQLString))
                 .build()
         GraphQLOutputType parentType = newObject()
-                .name("parentType")
-                .field(newFieldDefinition().name("child")
-                        .type(childType)
-                        .dataFetcher({ env ->
-                            newResult()
-                                    .data(["goodField": null, "badField": null])
-                                    .errors([
-                                            newError().message("goodField is bad")
-                                                    .path(["root", "parent", "child", "goodField"])
-                                                    .location(env.getField().getSourceLocation())
-                                                    .build(),
-                                            newError().message("badField is bad")
-                                                    .path(["root", "parent", "child", "badField"])
-                                                    .location(env.getField().getSourceLocation())
-                                                    .build()
-                                    ]).build()
-                        }))
+                .name(parentTypeName)
+                .field(newFieldDefinition()
+                        .name(childFieldName)
+                        .type(childType))
                 .build()
         GraphQLOutputType rootType = newObject()
                 .name("rootType")
-                .field(newFieldDefinition().name("parent")
+                .field(newFieldDefinition()
+                        .name("parent")
                         .type(parentType))
                 .build()
 
-        GraphQLSchema schema = newSchema().query(
-                newObject()
-                        .name("QueryType")
-                        .field(newFieldDefinition()
-                                .name("root")
-                                .type(rootType)
-                                .dataFetcher({ env -> ["parent": [:]] })
+        def rootTypeCoordinates = FieldCoordinates.coordinates(queryTypeName, rootFieldName)
+        def childTypeCoordinates = FieldCoordinates.coordinates(parentTypeName, childFieldName)
+        DataFetcher<?> rootTypeDataFetcher = { env -> ["parent": [:]] }
+        DataFetcher<?> childTypeDataFetcher = new ChildDataFetcher()
 
+        GraphQLCodeRegistry codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .dataFetcher(rootTypeCoordinates, rootTypeDataFetcher)
+                .dataFetcher(childTypeCoordinates, childTypeDataFetcher)
+                .build()
+
+        GraphQLSchema schema = newSchema()
+                .codeRegistry(codeRegistry)
+                .query(newObject()
+                        .name(queryTypeName)
+                        .field(newFieldDefinition()
+                                .name(rootFieldName)
+                                .type(rootType)
                         ))
                 .build()
 
@@ -209,7 +250,6 @@ class DataFetcherWithErrorsAndDataTest extends Specification {
         'async'       | new AsyncExecutionStrategy()
         'asyncSerial' | new AsyncSerialExecutionStrategy()
     }
-
 
     @Unroll
     def "data fetcher can return context down each level (strategy: #strategyName)"() {

--- a/src/test/groovy/graphql/RelaySchema.java
+++ b/src/test/groovy/graphql/RelaySchema.java
@@ -1,6 +1,9 @@
 package graphql;
 
 import graphql.relay.Relay;
+import graphql.schema.DataFetcher;
+import graphql.schema.FieldCoordinates;
+import graphql.schema.GraphQLCodeRegistry;
 import graphql.schema.GraphQLInterfaceType;
 import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLObjectType;
@@ -57,15 +60,18 @@ public class RelaySchema {
                     .argument(newArgument()
                             .name("id")
                             .description("id of the thing")
-                            .type(GraphQLNonNull.nonNull(GraphQLString)))
-                    .dataFetcher(environment -> {
-                        //TODO: implement
-                        return null;
-                    }))
+                            .type(GraphQLNonNull.nonNull(GraphQLString))))
             .build();
 
+    public static FieldCoordinates thingCoordinates = FieldCoordinates.coordinates("RelayQuery", "thing");
+    public static DataFetcher<?> thingDataFetcher = environment -> null;
+
+    public static GraphQLCodeRegistry codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+            .dataFetcher(thingCoordinates, thingDataFetcher)
+            .build();
 
     public static GraphQLSchema Schema = GraphQLSchema.newSchema()
+            .codeRegistry(codeRegistry)
             .query(RelayQueryType)
             .additionalType(Relay.pageInfoType)
             .build();

--- a/src/test/groovy/graphql/ScalarsQuerySchema.java
+++ b/src/test/groovy/graphql/ScalarsQuerySchema.java
@@ -2,6 +2,8 @@ package graphql;
 
 
 import graphql.schema.DataFetcher;
+import graphql.schema.FieldCoordinates;
+import graphql.schema.GraphQLCodeRegistry;
 import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
@@ -12,53 +14,56 @@ import static graphql.schema.GraphQLObjectType.newObject;
 
 public class ScalarsQuerySchema {
 
-    public static final DataFetcher inputDF = environment -> environment.getArgument("input");
+    public static final DataFetcher<?> inputDF = environment -> environment.getArgument("input");
 
     public static final GraphQLObjectType queryType = newObject()
             .name("QueryType")
-            /** Static Scalars */
+            // Static scalars
             .field(newFieldDefinition()
                     .name("floatNaN")
                     .type(Scalars.GraphQLFloat)
                     .staticValue(Double.NaN))
-
-
-            /** Scalars with input of same type, value echoed back */
+            // Scalars with input of same type, value echoed back
             .field(newFieldDefinition()
                     .name("floatNaNInput")
                     .type(Scalars.GraphQLFloat)
                     .argument(newArgument()
                             .name("input")
-                            .type(GraphQLNonNull.nonNull(Scalars.GraphQLFloat)))
-                    .dataFetcher(inputDF))
+                            .type(GraphQLNonNull.nonNull(Scalars.GraphQLFloat))))
             .field(newFieldDefinition()
                     .name("stringInput")
                     .type(Scalars.GraphQLString)
                     .argument(newArgument()
                             .name("input")
-                            .type(GraphQLNonNull.nonNull(Scalars.GraphQLString)))
-                    .dataFetcher(inputDF))
-
-
-            /** Scalars with input of String, cast to scalar */
+                            .type(GraphQLNonNull.nonNull(Scalars.GraphQLString))))
+            // Scalars with input of String, cast to scalar
             .field(newFieldDefinition()
                     .name("floatString")
                     .type(Scalars.GraphQLFloat)
                     .argument(newArgument()
                             .name("input")
-                            .type(Scalars.GraphQLString))
-                    .dataFetcher(inputDF))
+                            .type(Scalars.GraphQLString)))
             .field(newFieldDefinition()
                     .name("intString")
                     .type(Scalars.GraphQLInt)
                     .argument(newArgument()
                             .name("input")
-                            .type(Scalars.GraphQLString))
-                    .dataFetcher(inputDF))
+                            .type(Scalars.GraphQLString)))
             .build();
 
+    static FieldCoordinates floatNaNCoordinates = FieldCoordinates.coordinates("QueryType", "floatNaNInput");
+    static FieldCoordinates stringInputCoordinates = FieldCoordinates.coordinates("QueryType", "stringInput");
+    static FieldCoordinates floatStringCoordinates = FieldCoordinates.coordinates("QueryType", "floatString");
+    static FieldCoordinates intStringCoordinates = FieldCoordinates.coordinates("QueryType", "intString");
+    static GraphQLCodeRegistry codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+            .dataFetcher(floatNaNCoordinates, inputDF)
+            .dataFetcher(stringInputCoordinates, inputDF)
+            .dataFetcher(floatStringCoordinates, inputDF)
+            .dataFetcher(intStringCoordinates, inputDF)
+            .build();
 
     public static final GraphQLSchema scalarsQuerySchema = GraphQLSchema.newSchema()
+            .codeRegistry(codeRegistry)
             .query(queryType)
             .build();
 }

--- a/src/test/groovy/graphql/StarWarsData.groovy
+++ b/src/test/groovy/graphql/StarWarsData.groovy
@@ -94,7 +94,6 @@ class StarWarsData {
         }
     }
 
-
     static DataFetcher droidDataFetcher = new DataFetcher() {
         @Override
         Object get(DataFetchingEnvironment environment) {

--- a/src/test/groovy/graphql/StarWarsSchema.java
+++ b/src/test/groovy/graphql/StarWarsSchema.java
@@ -1,12 +1,14 @@
 package graphql;
 
 
+import graphql.schema.DataFetcher;
+import graphql.schema.FieldCoordinates;
+import graphql.schema.GraphQLCodeRegistry;
 import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLInputObjectType;
 import graphql.schema.GraphQLInterfaceType;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
-import graphql.schema.GraphqlTypeComparatorRegistry;
 import graphql.schema.StaticDataFetcher;
 
 import static graphql.Scalars.GraphQLString;
@@ -23,7 +25,6 @@ import static graphql.schema.GraphQLTypeReference.typeRef;
 import static graphql.schema.GraphqlTypeComparatorRegistry.*;
 
 public class StarWarsSchema {
-
 
     public static GraphQLEnumType episodeEnum = newEnum()
             .name("Episode")
@@ -73,8 +74,7 @@ public class StarWarsSchema {
             .field(newFieldDefinition()
                     .name("friends")
                     .description("The friends of the human, or an empty list if they have none.")
-                    .type(list(characterInterface))
-                    .dataFetcher(StarWarsData.getFriendsDataFetcher()))
+                    .type(list(characterInterface)))
             .field(newFieldDefinition()
                     .name("appearsIn")
                     .description("Which movies they appear in.")
@@ -101,8 +101,7 @@ public class StarWarsSchema {
             .field(newFieldDefinition()
                     .name("friends")
                     .description("The friends of the droid, or an empty list if they have none.")
-                    .type(list(characterInterface))
-                    .dataFetcher(StarWarsData.getFriendsDataFetcher()))
+                    .type(list(characterInterface)))
             .field(newFieldDefinition()
                     .name("appearsIn")
                     .description("Which movies they appear in.")
@@ -132,24 +131,21 @@ public class StarWarsSchema {
                     .argument(newArgument()
                             .name("episode")
                             .description("If omitted, returns the hero of the whole saga. If provided, returns the hero of that particular episode.")
-                            .type(episodeEnum))
-                    .dataFetcher(new StaticDataFetcher(StarWarsData.getArtoo())))
+                            .type(episodeEnum)))
             .field(newFieldDefinition()
                     .name("human")
                     .type(humanType)
                     .argument(newArgument()
                             .name("id")
                             .description("id of the human")
-                            .type(nonNull(GraphQLString)))
-                    .dataFetcher(StarWarsData.getHumanDataFetcher()))
+                            .type(nonNull(GraphQLString))))
             .field(newFieldDefinition()
                     .name("droid")
                     .type(droidType)
                     .argument(newArgument()
                             .name("id")
                             .description("id of the droid")
-                            .type(nonNull(GraphQLString)))
-                    .dataFetcher(StarWarsData.getDroidDataFetcher()))
+                            .type(nonNull(GraphQLString))))
             .comparatorRegistry(BY_NAME_REGISTRY)
             .build();
 
@@ -160,12 +156,34 @@ public class StarWarsSchema {
                     .type(characterInterface)
                     .argument(newArgument()
                             .name("input")
-                            .type(inputHumanType))
-                    .dataFetcher(new StaticDataFetcher(StarWarsData.getArtoo())))
+                            .type(inputHumanType)))
             .comparatorRegistry(BY_NAME_REGISTRY)
             .build();
 
+    public static FieldCoordinates humanFriendsCoordinates = FieldCoordinates.coordinates("Human", "friends");
+    public static DataFetcher<?> humanFriendsDataFetcher = StarWarsData.getFriendsDataFetcher();
+    public static FieldCoordinates droidFriendsCoordinates = FieldCoordinates.coordinates("Droid", "friends");
+    public static DataFetcher<?> droidFriendsDataFetcher = StarWarsData.getFriendsDataFetcher();
+    public static FieldCoordinates heroCoordinates = FieldCoordinates.coordinates("QueryType", "hero");
+    public static DataFetcher<?> heroDataFetcher = new StaticDataFetcher(StarWarsData.getArtoo());
+    public static FieldCoordinates humanCoordinates = FieldCoordinates.coordinates("QueryType", "human");
+    public static DataFetcher<?> humanDataFetcher = StarWarsData.getHumanDataFetcher();
+    public static FieldCoordinates droidCoordinates = FieldCoordinates.coordinates("QueryType", "droid");
+    public static DataFetcher<?> droidDataFetcher = StarWarsData.getDroidDataFetcher();
+    public static FieldCoordinates createHumanCoordinates = FieldCoordinates.coordinates("MutationType", "createHuman");
+    public static DataFetcher<?> createHumanDataFetcher = new StaticDataFetcher(StarWarsData.getArtoo());
+
+    public static GraphQLCodeRegistry codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+            .dataFetcher(humanFriendsCoordinates, humanFriendsDataFetcher)
+            .dataFetcher(droidFriendsCoordinates, droidFriendsDataFetcher)
+            .dataFetcher(heroCoordinates, heroDataFetcher)
+            .dataFetcher(humanCoordinates, humanDataFetcher)
+            .dataFetcher(droidCoordinates, droidDataFetcher)
+            .dataFetcher(createHumanCoordinates, createHumanDataFetcher)
+            .build();
+
     public static GraphQLSchema starWarsSchema = GraphQLSchema.newSchema()
+            .codeRegistry(codeRegistry)
             .query(queryType)
             .mutation(mutationType)
             .build();

--- a/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy
@@ -10,6 +10,8 @@ import graphql.language.Field
 import graphql.language.OperationDefinition
 import graphql.parser.Parser
 import graphql.schema.DataFetcher
+import graphql.schema.FieldCoordinates
+import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLSchema
 import spock.lang.Specification
@@ -30,25 +32,37 @@ import static org.awaitility.Awaitility.await
 class AsyncExecutionStrategyTest extends Specification {
 
     GraphQLSchema schema(DataFetcher dataFetcher1, DataFetcher dataFetcher2) {
-        GraphQLFieldDefinition.Builder fieldDefinition = newFieldDefinition()
-                .name("hello")
-                .type(GraphQLString)
-                .dataFetcher(dataFetcher1)
-        GraphQLFieldDefinition.Builder fieldDefinition2 = newFieldDefinition()
-                .name("hello2")
-                .type(GraphQLString)
-                .dataFetcher(dataFetcher2)
+        def queryName = "RootQueryType"
+        def field1Name = "hello"
+        def field2Name = "hello2"
 
-        GraphQLSchema schema = newSchema().query(
-                newObject()
-                        .name("RootQueryType")
-                        .field(fieldDefinition)
+        GraphQLFieldDefinition.Builder fieldDefinition1 = newFieldDefinition()
+                .name(field1Name)
+                .type(GraphQLString)
+        GraphQLFieldDefinition.Builder fieldDefinition2 = newFieldDefinition()
+                .name(field2Name)
+                .type(GraphQLString)
+
+        def field1Coordinates = FieldCoordinates.coordinates(queryName, field1Name)
+        def field2Coordinates = FieldCoordinates.coordinates(queryName, field2Name)
+
+        GraphQLCodeRegistry codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .dataFetcher(field1Coordinates, dataFetcher1)
+                .dataFetcher(field2Coordinates, dataFetcher2)
+                .build()
+
+        GraphQLSchema schema = newSchema()
+                .codeRegistry(codeRegistry)
+                .query(newObject()
+                        .name(queryName)
+                        .field(fieldDefinition1)
                         .field(fieldDefinition2)
                         .build()
-        ).build()
+                )
+                .build()
+
         schema
     }
-
 
     def "execution is serial if the dataFetchers are blocking"() {
         given:

--- a/src/test/groovy/graphql/execution/AsyncSerialExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/AsyncSerialExecutionStrategyTest.groovy
@@ -6,6 +6,8 @@ import graphql.language.Field
 import graphql.language.OperationDefinition
 import graphql.parser.Parser
 import graphql.schema.DataFetcher
+import graphql.schema.FieldCoordinates
+import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLSchema
 import spock.lang.Specification
@@ -23,27 +25,42 @@ import static graphql.schema.GraphQLSchema.newSchema
 
 class AsyncSerialExecutionStrategyTest extends Specification {
     GraphQLSchema schema(DataFetcher dataFetcher1, DataFetcher dataFetcher2, DataFetcher dataFetcher3) {
-        GraphQLFieldDefinition.Builder fieldDefinition = newFieldDefinition()
-                .name("hello")
-                .type(GraphQLString)
-                .dataFetcher(dataFetcher1)
-        GraphQLFieldDefinition.Builder fieldDefinition2 = newFieldDefinition()
-                .name("hello2")
-                .type(GraphQLString)
-                .dataFetcher(dataFetcher2)
-        GraphQLFieldDefinition.Builder fieldDefinition3 = newFieldDefinition()
-                .name("hello3")
-                .type(GraphQLString)
-                .dataFetcher(dataFetcher3)
+        def queryName = "RootQueryType"
+        def field1Name = "hello"
+        def field2Name = "hello2"
+        def field3Name = "hello3"
 
-        GraphQLSchema schema = newSchema().query(
-                newObject()
-                        .name("RootQueryType")
-                        .field(fieldDefinition)
+        GraphQLFieldDefinition.Builder fieldDefinition1 = newFieldDefinition()
+                .name(field1Name)
+                .type(GraphQLString)
+        GraphQLFieldDefinition.Builder fieldDefinition2 = newFieldDefinition()
+                .name(field2Name)
+                .type(GraphQLString)
+        GraphQLFieldDefinition.Builder fieldDefinition3 = newFieldDefinition()
+                .name(field3Name)
+                .type(GraphQLString)
+
+        def field1Coordinates = FieldCoordinates.coordinates(queryName, field1Name)
+        def field2Coordinates = FieldCoordinates.coordinates(queryName, field2Name)
+        def field3Coordinates = FieldCoordinates.coordinates(queryName, field3Name)
+
+        GraphQLCodeRegistry codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .dataFetcher(field1Coordinates, dataFetcher1)
+                .dataFetcher(field2Coordinates, dataFetcher2)
+                .dataFetcher(field3Coordinates, dataFetcher3)
+                .build()
+
+        GraphQLSchema schema = newSchema()
+                .codeRegistry(codeRegistry)
+                .query(newObject()
+                        .name(queryName)
+                        .field(fieldDefinition1)
                         .field(fieldDefinition2)
                         .field(fieldDefinition3)
                         .build()
-        ).build()
+                )
+                .build()
+
         schema
     }
 

--- a/src/test/groovy/graphql/execution/instrumentation/dataloader/DeepDataFetchers.java
+++ b/src/test/groovy/graphql/execution/instrumentation/dataloader/DeepDataFetchers.java
@@ -5,68 +5,77 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
 import graphql.schema.DataFetcher;
+import graphql.schema.FieldCoordinates;
+import graphql.schema.GraphQLCodeRegistry;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLTypeReference;
 
 public class DeepDataFetchers {
-  private static <T> CompletableFuture<T> supplyAsyncWithSleep(Supplier<T> supplier) {
-    Supplier<T> sleepSome = sleepSome(supplier);
-    return CompletableFuture.supplyAsync(sleepSome);
-  }
-
-  private static <T> Supplier<T> sleepSome(Supplier<T> supplier) {
-    return () -> {
-      try {
-        Thread.sleep(10L);
-        return supplier.get();
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
-    };
-  }
-
-  public GraphQLSchema schema() {
-    DataFetcher<CompletableFuture<HashMap<String, Object>>> slowFetcher = environment ->
-        supplyAsyncWithSleep(HashMap::new);
-
-    GraphQLFieldDefinition selfField = GraphQLFieldDefinition.newFieldDefinition()
-        .name("self")
-        .type(GraphQLTypeReference.typeRef("Query"))
-        .dataFetcher(slowFetcher)
-        .build();
-
-    GraphQLObjectType query = GraphQLObjectType.newObject()
-        .name("Query")
-        .field(selfField)
-        .build();
-
-    return GraphQLSchema.newSchema().query(query).build();
-  }
-
-  public String buildQuery(Integer depth) {
-    StringBuilder sb = new StringBuilder();
-    sb.append("query {");
-    for (Integer i = 0; i < depth; i++) {
-      sb.append("self {");
+    private static <T> CompletableFuture<T> supplyAsyncWithSleep(Supplier<T> supplier) {
+        Supplier<T> sleepSome = sleepSome(supplier);
+        return CompletableFuture.supplyAsync(sleepSome);
     }
-    sb.append("__typename");
-    for (Integer i = 0; i < depth; i++) {
-      sb.append("}");
-    }
-    sb.append("}");
 
-    return sb.toString();
-  }
-
-  public HashMap<String, Object> buildResponse(Integer depth) {
-    HashMap<String, Object> level = new HashMap<>();
-    if (depth == 0) {
-      level.put("__typename", "Query");
-    } else {
-      level.put("self", buildResponse(depth - 1));
+    private static <T> Supplier<T> sleepSome(Supplier<T> supplier) {
+        return () -> {
+            try {
+                Thread.sleep(10L);
+                return supplier.get();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
     }
-    return level;
-  }
+
+    public GraphQLSchema schema() {
+        GraphQLFieldDefinition selfField = GraphQLFieldDefinition.newFieldDefinition()
+                .name("self")
+                .type(GraphQLTypeReference.typeRef("Query"))
+                .build();
+
+        GraphQLObjectType query = GraphQLObjectType.newObject()
+                .name("Query")
+                .field(selfField)
+                .build();
+
+        FieldCoordinates selfCoordinates = FieldCoordinates.coordinates("Query", "self");
+        DataFetcher<CompletableFuture<HashMap<String, Object>>> slowFetcher = environment ->
+                supplyAsyncWithSleep(HashMap::new);
+
+        GraphQLCodeRegistry codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .dataFetcher(selfCoordinates, slowFetcher)
+                .build();
+
+        return GraphQLSchema.newSchema()
+                .codeRegistry(codeRegistry)
+                .query(query)
+                .build();
+    }
+
+    public String buildQuery(Integer depth) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("query {");
+        for (Integer i = 0; i < depth; i++) {
+            sb.append("self {");
+        }
+        sb.append("__typename");
+        for (Integer i = 0; i < depth; i++) {
+            sb.append("}");
+        }
+        sb.append("}");
+
+        return sb.toString();
+    }
+
+    public HashMap<String, Object> buildResponse(Integer depth) {
+        HashMap<String, Object> level = new HashMap<>();
+        if (depth == 0) {
+            level.put("__typename", "Query");
+        } else {
+            level.put("self", buildResponse(depth - 1));
+        }
+        return level;
+    }
 }

--- a/src/test/groovy/graphql/schema/GraphQLCodeRegistryTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLCodeRegistryTest.groovy
@@ -230,7 +230,7 @@ class GraphQLCodeRegistryTest extends Specification {
                 .field(newFieldDefinition().name("codeRegistryField").type(Scalars.GraphQLString))
                 .field(newFieldDefinition().name("nonCodeRegistryField").type(Scalars.GraphQLString)
                 // df comes from the field itself here
-                        .dataFetcher(new NamedDF("nonCodeRegistryFieldValue")))
+                        .dataFetcher(new NamedDF("nonCodeRegistryFieldValue"))) // Retain to test Field Definition DataFetcher
                 .field(newFieldDefinition().name("neitherSpecified").type(Scalars.GraphQLString))
                 .build()
 

--- a/src/test/groovy/graphql/schema/GraphQLFieldDefinitionTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLFieldDefinitionTest.groovy
@@ -15,7 +15,7 @@ class GraphQLFieldDefinitionTest extends Specification {
 
     def "dataFetcher can't be null"() {
         when:
-        newFieldDefinition().dataFetcher(null)
+        newFieldDefinition().dataFetcher(null) // Retain for test coverage
         then:
         def exception = thrown(AssertException)
         exception.getMessage().contains("dataFetcher")

--- a/src/test/groovy/graphql/schema/SchemaTransformerTest.groovy
+++ b/src/test/groovy/graphql/schema/SchemaTransformerTest.groovy
@@ -28,7 +28,7 @@ class SchemaTransformerTest extends Specification {
            bar: String
        } 
         """)
-        schema.getQueryType();
+        schema.getQueryType()
         SchemaTransformer schemaTransformer = new SchemaTransformer()
         when:
         GraphQLSchema newSchema = schemaTransformer.transform(schema, new GraphQLTypeVisitorStub() {
@@ -39,7 +39,7 @@ class SchemaTransformerTest extends Specification {
                     def changedNode = fieldDefinition.transform({ builder -> builder.name("barChanged") })
                     return changeNode(context, changedNode)
                 }
-                return TraversalControl.CONTINUE;
+                return TraversalControl.CONTINUE
             }
         })
 
@@ -59,7 +59,7 @@ class SchemaTransformerTest extends Specification {
            baz: String
        } 
         """)
-        schema.getQueryType();
+        schema.getQueryType()
         SchemaTransformer schemaTransformer = new SchemaTransformer()
         when:
         GraphQLSchema newSchema = schemaTransformer.transform(schema, new GraphQLTypeVisitorStub() {
@@ -69,7 +69,7 @@ class SchemaTransformerTest extends Specification {
                 if (fieldDefinition.name == "baz") {
                     return deleteNode(context)
                 }
-                return TraversalControl.CONTINUE;
+                return TraversalControl.CONTINUE
             }
         })
 
@@ -133,7 +133,7 @@ class SchemaTransformerTest extends Specification {
            baz: String
         } 
         """)
-        schema.getQueryType();
+        schema.getQueryType()
         SchemaTransformer schemaTransformer = new SchemaTransformer()
         when:
         GraphQLSchema newSchema = schemaTransformer.transform(schema, new GraphQLTypeVisitorStub() {
@@ -143,7 +143,7 @@ class SchemaTransformerTest extends Specification {
                 if (fieldDefinition.name == "baz") {
                     return deleteNode(context)
                 }
-                return TraversalControl.CONTINUE;
+                return TraversalControl.CONTINUE
             }
         })
 
@@ -182,7 +182,7 @@ class SchemaTransformerTest extends Specification {
                     def changedNode = fieldDefinition.transform({ builder -> builder.name("helloChanged") })
                     return changeNode(context, changedNode)
                 }
-                return TraversalControl.CONTINUE;
+                return TraversalControl.CONTINUE
             }
 
             @Override
@@ -201,7 +201,7 @@ class SchemaTransformerTest extends Specification {
             @Override
             TraversalControl visitGraphQLTypeReference(GraphQLTypeReference node, TraverserContext<GraphQLSchemaElement> context) {
                 if (node.name == "Parent") {
-                    return changeNode(context, typeRef("ParentChanged"));
+                    return changeNode(context, typeRef("ParentChanged"))
                 }
                 return super.visitGraphQLTypeReference(node, context)
             }
@@ -303,21 +303,30 @@ type SubChildChanged {
         def queryObject = newObject()
                 .name("Query")
                 .field({ builder ->
-                    builder.name("foo").type(Scalars.GraphQLString).dataFetcher(new DataFetcher<Object>() {
-                        @Override
-                        Object get(DataFetchingEnvironment environment) throws Exception {
-                            return "bar";
-                        }
-                    })
-                }).build();
+                    builder.name("foo")
+                           .type(Scalars.GraphQLString)
+                }).build()
+
+        def fooCoordinates = FieldCoordinates.coordinates("Query", "foo")
+        DataFetcher<?> dataFetcher = new DataFetcher<Object>() {
+            @Override
+            Object get(DataFetchingEnvironment environment) throws Exception {
+                return "bar"
+            }
+        }
+        GraphQLCodeRegistry codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .dataFetcher(fooCoordinates, dataFetcher)
+                .build()
 
         def schemaObject = newSchema()
+                .codeRegistry(codeRegistry)
                 .query(queryObject)
                 .build()
 
         when:
         def result = GraphQL.newGraphQL(schemaObject)
-                .build().execute('''
+                .build()
+                .execute('''
             { foo } 
         ''').getData()
 
@@ -336,14 +345,20 @@ type SubChildChanged {
                 return TraversalControl.CONTINUE
             }
         })
+
+        def fooTransformedCoordinates = FieldCoordinates.coordinates("Query", "fooChanged")
+        codeRegistry = codeRegistry.transform({it.dataFetcher(fooTransformedCoordinates, dataFetcher)})
+        newSchema = newSchema.transform({
+            builder -> builder.codeRegistry(codeRegistry)
+        })
         result = GraphQL.newGraphQL(newSchema)
-                .build().execute('''
+                .build()
+                .execute('''
             { fooChanged }
         ''').getData()
 
         then:
         (result as Map)['fooChanged'] == 'bar'
-
     }
 
     def "transformed schema can be executed"() {
@@ -430,7 +445,7 @@ type SubChildChanged {
                 if (fieldDefinition.name == "billingStatus") {
                     return deleteNode(context)
                 }
-                return TraversalControl.CONTINUE;
+                return TraversalControl.CONTINUE
             }
         })
 
@@ -448,11 +463,11 @@ type SubChildChanged {
             @Override
             TraversalControl visitGraphQLDirective(GraphQLDirective node,
                                                    TraverserContext<GraphQLSchemaElement> context) {
-                if ("internalnote".equals(node.getName())) {
+                if ("internalnote" == node.getName()) {
                     // this deletes the declaration and the two usages of it
-                    deleteNode(context);
+                    deleteNode(context)
                 }
-                return TraversalControl.CONTINUE;
+                return TraversalControl.CONTINUE
             }
         }
 
@@ -628,7 +643,7 @@ type Query {
 
             @Override
             TraversalControl visitGraphQLObjectType(GraphQLObjectType node, TraverserContext<GraphQLSchemaElement> context) {
-                if (node.getName().startsWith("__")) return TraversalControl.ABORT;
+                if (node.getName().startsWith("__")) return TraversalControl.ABORT
                 node = node.transform({ b -> b.name(node.getName().toUpperCase()) })
                 return changeNode(context, node)
             }
@@ -716,7 +731,7 @@ type Query {
 
             @Override
             TraversalControl visitGraphQLObjectType(GraphQLObjectType node, TraverserContext<GraphQLSchemaElement> context) {
-                if (node.getName().equals('ToDel')) {
+                if (node.getName() == 'ToDel') {
                     return deleteNode(context)
                 }
                 return TraversalControl.CONTINUE
@@ -774,7 +789,7 @@ type Query {
                 if (node.name == "__Field") {
                     return changeNode(context, node.transform({ it.name("__FieldChanged") }))
                 }
-                return TraversalControl.CONTINUE;
+                return TraversalControl.CONTINUE
             }
         }
 
@@ -855,7 +870,7 @@ type Query {
 
             @Override
             TraversalControl visitGraphQLScalarType(GraphQLScalarType node, TraverserContext<GraphQLSchemaElement> context) {
-                if (node.getName().equals("Foo")) {
+                if (node.getName() == "Foo") {
                     GraphQLScalarType newNode = node.transform({sc -> sc.name("Bar")})
                     return changeNode(context, newNode)
                 }
@@ -885,7 +900,7 @@ type Query {
 
             @Override
             TraversalControl visitGraphQLScalarType(GraphQLScalarType node, TraverserContext<GraphQLSchemaElement> context) {
-                if (node.getName().equals("Foo")) {
+                if (node.getName() == "Foo") {
                     GraphQLScalarType newNode = node.transform({sc -> sc.name("Bar")})
                     return changeNode(context, newNode)
                 }


### PR DESCRIPTION
Cleaning up tests to use `GraphQLCodeRegistry` for datafetchers, rather than directly on the `GraphQLFieldDefinition`.

You might be thinking, that's so many lines of code for only one builder cleanup! We were using it everywhere.