### PR TITLE
EXPERIMENT - DO NOT MERGE - ability to stop path execution from a DataFetcher

### DIFF
--- a/src/main/java/graphql/execution/DataFetcherResult.java
+++ b/src/main/java/graphql/execution/DataFetcherResult.java
@@ -29,6 +29,7 @@ import static graphql.Assert.assertNotNull;
 public class DataFetcherResult<T> {
 
     private final T data;
+    private final boolean stopPathExecution;
     private final List<GraphQLError> errors;
     private final Object localContext;
 
@@ -44,13 +45,14 @@ public class DataFetcherResult<T> {
     @Deprecated
     @DeprecatedAt("2019-01-11")
     public DataFetcherResult(T data, List<GraphQLError> errors) {
-        this(data, errors, null);
+        this(data, errors, null, false);
     }
 
-    private DataFetcherResult(T data, List<GraphQLError> errors, Object localContext) {
+    private DataFetcherResult(T data, List<GraphQLError> errors, Object localContext, boolean stopPathExecution) {
         this.data = data;
         this.errors = ImmutableList.copyOf(assertNotNull(errors));
         this.localContext = localContext;
+        this.stopPathExecution = stopPathExecution;
     }
 
     /**
@@ -58,6 +60,15 @@ public class DataFetcherResult<T> {
      */
     public T getData() {
         return data;
+    }
+
+    /**
+     * if this is set then the graphql engine will stop executing any path under this value
+     *
+     * @return true if you want the engine to stop execution on this path and accept the value as is
+     */
+    public boolean isStopPathExecution() {
+        return stopPathExecution;
     }
 
     /**
@@ -110,11 +121,13 @@ public class DataFetcherResult<T> {
 
     public static class Builder<T> {
         private T data;
+        private boolean stopPathExecution  =false;
         private Object localContext;
         private final List<GraphQLError> errors = new ArrayList<>();
 
         public Builder(DataFetcherResult<T> existing) {
             data = existing.getData();
+            stopPathExecution = existing.isStopPathExecution();
             localContext = existing.getLocalContext();
             errors.addAll(existing.getErrors());
         }
@@ -128,6 +141,11 @@ public class DataFetcherResult<T> {
 
         public Builder<T> data(T data) {
             this.data = data;
+            return this;
+        }
+
+        public Builder<T> stopPathExecution(boolean stopPathExecution) {
+            this.stopPathExecution = stopPathExecution;
             return this;
         }
 
@@ -159,7 +177,7 @@ public class DataFetcherResult<T> {
         }
 
         public DataFetcherResult<T> build() {
-            return new DataFetcherResult<>(data, errors, localContext);
+            return new DataFetcherResult<>(data, errors, localContext, stopPathExecution);
         }
     }
 }

--- a/src/main/java/graphql/execution/ExecutionStrategyParameters.java
+++ b/src/main/java/graphql/execution/ExecutionStrategyParameters.java
@@ -23,6 +23,8 @@ public class ExecutionStrategyParameters {
     private final int currentListIndex;
     private final ExecutionStrategyParameters parent;
 
+    private final boolean stopPathExecution;
+
     private ExecutionStrategyParameters(ExecutionStepInfo executionStepInfo,
                                         Object source,
                                         Object localContext,
@@ -32,6 +34,7 @@ public class ExecutionStrategyParameters {
                                         MergedField currentField,
                                         int listSize,
                                         int currentListIndex,
+                                        boolean stopPathExecution,
                                         ExecutionStrategyParameters parent) {
 
         this.executionStepInfo = assertNotNull(executionStepInfo, () -> "executionStepInfo is null");
@@ -43,6 +46,7 @@ public class ExecutionStrategyParameters {
         this.currentField = currentField;
         this.listSize = listSize;
         this.currentListIndex = currentListIndex;
+        this.stopPathExecution = stopPathExecution;
         this.parent = parent;
     }
 
@@ -76,6 +80,10 @@ public class ExecutionStrategyParameters {
 
     public int getCurrentListIndex() {
         return currentListIndex;
+    }
+
+    public boolean isStopPathExecution() {
+        return stopPathExecution;
     }
 
     public ExecutionStrategyParameters getParent() {
@@ -121,6 +129,7 @@ public class ExecutionStrategyParameters {
         MergedField currentField;
         int listSize;
         int currentListIndex;
+        boolean stopPathExecution = false;
         ExecutionStrategyParameters parent;
 
         /**
@@ -143,6 +152,7 @@ public class ExecutionStrategyParameters {
             this.parent = oldParameters.parent;
             this.listSize = oldParameters.listSize;
             this.currentListIndex = oldParameters.currentListIndex;
+            this.stopPathExecution = oldParameters.stopPathExecution;
         }
 
         public Builder executionStepInfo(ExecutionStepInfo executionStepInfo) {
@@ -195,6 +205,11 @@ public class ExecutionStrategyParameters {
             return this;
         }
 
+        public Builder stopPathExecution(boolean stopPathExecution) {
+            this.stopPathExecution = stopPathExecution;
+            return this;
+        }
+
         public Builder parent(ExecutionStrategyParameters parent) {
             this.parent = parent;
             return this;
@@ -202,7 +217,7 @@ public class ExecutionStrategyParameters {
 
 
         public ExecutionStrategyParameters build() {
-            return new ExecutionStrategyParameters(executionStepInfo, source, localContext, fields, nonNullableFieldValidator, path, currentField, listSize, currentListIndex, parent);
+            return new ExecutionStrategyParameters(executionStepInfo, source, localContext, fields, nonNullableFieldValidator, path, currentField, listSize, currentListIndex, stopPathExecution, parent);
         }
     }
 }

--- a/src/main/java/graphql/execution/FetchedValue.java
+++ b/src/main/java/graphql/execution/FetchedValue.java
@@ -15,12 +15,15 @@ import java.util.function.Consumer;
 @PublicApi
 public class FetchedValue {
     private final Object fetchedValue;
+
+    private final boolean stopPathExecution;
     private final Object rawFetchedValue;
     private final Object localContext;
     private final ImmutableList<GraphQLError> errors;
 
-    private FetchedValue(Object fetchedValue, Object rawFetchedValue, ImmutableList<GraphQLError> errors, Object localContext) {
+    private FetchedValue(Object fetchedValue, Object rawFetchedValue, ImmutableList<GraphQLError> errors, Object localContext, boolean stopPathExecution) {
         this.fetchedValue = fetchedValue;
+        this.stopPathExecution = stopPathExecution;
         this.rawFetchedValue = rawFetchedValue;
         this.errors = errors;
         this.localContext = localContext;
@@ -43,6 +46,10 @@ public class FetchedValue {
 
     public Object getLocalContext() {
         return localContext;
+    }
+
+    public boolean isStopPathExecution() {
+        return stopPathExecution;
     }
 
     public FetchedValue transform(Consumer<Builder> builderConsumer) {
@@ -77,12 +84,18 @@ public class FetchedValue {
     public static class Builder {
 
         private Object fetchedValue;
+        private boolean stopPathExecution = false;
         private Object rawFetchedValue;
         private Object localContext;
         private ImmutableList<GraphQLError> errors = ImmutableList.of();
 
         public Builder fetchedValue(Object fetchedValue) {
             this.fetchedValue = fetchedValue;
+            return this;
+        }
+
+        public Builder stopPathExecution(boolean stopPathExecution) {
+            this.stopPathExecution = stopPathExecution;
             return this;
         }
 
@@ -102,7 +115,7 @@ public class FetchedValue {
         }
 
         public FetchedValue build() {
-            return new FetchedValue(fetchedValue, rawFetchedValue, errors, localContext);
+            return new FetchedValue(fetchedValue, rawFetchedValue, errors, localContext, stopPathExecution);
         }
     }
 }

--- a/src/test/groovy/graphql/execution/StopPathExecutionTest.groovy
+++ b/src/test/groovy/graphql/execution/StopPathExecutionTest.groovy
@@ -1,0 +1,104 @@
+package graphql.execution
+
+
+import graphql.GraphQL
+import graphql.TestUtil
+import graphql.schema.DataFetcher
+import graphql.schema.GraphQLSchema
+import graphql.schema.idl.RuntimeWiring
+import spock.lang.Specification
+
+import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring
+
+class StopPathExecutionTest extends Specification {
+
+    def sdl = """
+type Query {
+   longList : [Thing]
+   stopList : [Thing]
+   thing : Thing
+   stopThing : Thing
+}
+
+type Thing {
+    name : String
+    age : Int
+    active : Boolean
+}
+"""
+
+    def dataList = mkList()
+    def thingo = ["name": "Theo", "age": 42, "active": true]
+
+    DataFetcher<?> longListDF = env ->
+            dataList
+    DataFetcher<?> stopListDF = env ->
+            DataFetcherResult.newResult().data(dataList).stopPathExecution(true).build()
+
+    DataFetcher<?> thingDF = env -> thingo
+
+    DataFetcher<?> stopThingDF = env ->
+            DataFetcherResult.newResult().data(thingo).stopPathExecution(true).build()
+
+    RuntimeWiring runtimeWiring = RuntimeWiring.newRuntimeWiring()
+            .type(
+                    newTypeWiring("Query")
+                            .dataFetcher("longList", longListDF)
+                            .dataFetcher("stopList", stopListDF)
+                            .dataFetcher("thing", thingDF)
+                            .dataFetcher("stopThing", stopThingDF)
+            )
+            .build();
+    GraphQLSchema graphQLSchema = TestUtil.schema(sdl, runtimeWiring)
+
+    GraphQL graphQL = GraphQL.newGraphQL(graphQLSchema).build()
+
+    private static List<Object> mkList() {
+        List<Object> list = new ArrayList<>()
+        for (int i = 0; i < 200; i++) {
+            Map<String, Object> obj = new HashMap<>()
+            obj.put("name", "Name" + i)
+            obj.put("age", i)
+            obj.put("active", i % 2 == 0)
+            list.add(obj)
+        }
+        return list
+    }
+
+    def "can stop execution but get results"() {
+
+        when:
+        def er = graphQL.execute("""
+            query q { 
+                stopList { name age active }
+                longList { name age active }
+                thing { name age active }
+                stopThing { name age active }
+            }
+            """)
+
+        then:
+        er.errors.isEmpty()
+        def stopList = er.data["stopList"] as List
+        stopList.size() == 200
+        stopList[0]["name"] == "Name0"
+        stopList[0]["age"] == 0
+        stopList[0]["active"] == true
+
+        def longList = er.data["longList"] as List
+        longList.size() == 200
+        longList[0]["name"] == "Name0"
+        longList[0]["age"] == 0
+        longList[0]["active"] == true
+
+        def thing = er.data["thing"]
+        thing["name"] == "Theo"
+        thing["age"] == 42
+        thing["active"] == true
+
+        def stopThing = er.data["stopThing"]
+        stopThing["name"] == "Theo"
+        stopThing["age"] == 42
+        stopThing["active"] == true
+    }
+}

--- a/src/test/java/benchmark/StopQueryBenchMark.java
+++ b/src/test/java/benchmark/StopQueryBenchMark.java
@@ -1,0 +1,110 @@
+package benchmark;
+
+import graphql.GraphQL;
+import graphql.execution.DataFetcherResult;
+import graphql.schema.DataFetcher;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.idl.RuntimeWiring;
+import graphql.schema.idl.SchemaGenerator;
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.TypeDefinitionRegistry;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring;
+
+/**
+ * See <a href="https://github.com/openjdk/jmh/tree/master/jmh-samples/src/main/java/org/openjdk/jmh/samples/">...</a> for more samples
+ * on what you can do with JMH
+ * <p>
+ * You MUST have the JMH plugin for IDEA in place for this to work :  <a href="https://github.com/artyushov/idea-jmh-plugin">...</a>
+ * <p>
+ * Install it and then just hit "Run" on a certain benchmark method
+ */
+@Warmup(iterations = 2, time = 5, batchSize = 3)
+@Measurement(iterations = 3, time = 10, batchSize = 4)
+public class StopQueryBenchMark {
+
+    public static final String LONG_LIST = "query q { longList { name age active } }";
+    public static final String STOP_LIST = "query q { stopList { name age active } }";
+
+    static GraphQL graphQL = buildGraphQL();
+    static List<Object> list = mkList(1000);
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public void benchMarkLongListThroughput() {
+        executeQuery(LONG_LIST);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public void benchMarkLongListAvgTime() {
+        executeQuery(LONG_LIST);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public void benchMarkStopListThroughput() {
+        executeQuery(STOP_LIST);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public void benchMarkStopListAvgTime() {
+        executeQuery(STOP_LIST);
+    }
+
+    public static void executeQuery(String query) {
+        graphQL.execute(query);
+    }
+
+    private static GraphQL buildGraphQL() {
+        InputStream sdl = StopQueryBenchMark.class.getClassLoader().getResourceAsStream("large-list-schema.graphqls");
+        TypeDefinitionRegistry definitionRegistry = new SchemaParser().parse(new InputStreamReader(sdl));
+
+        DataFetcher<?> longListDF = env -> DataFetcherResult.newResult().data(list).build();
+        DataFetcher<?> stopListDF = env -> DataFetcherResult.newResult().data(list).stopPathExecution(true).build();
+
+        RuntimeWiring runtimeWiring = RuntimeWiring.newRuntimeWiring()
+                .type(
+                        newTypeWiring("Query")
+                                .dataFetcher("longList", longListDF)
+                                .dataFetcher("stopList", stopListDF)
+                )
+                .build();
+        GraphQLSchema graphQLSchema = new SchemaGenerator().makeExecutableSchema(definitionRegistry, runtimeWiring);
+
+        return GraphQL.newGraphQL(graphQLSchema)
+                .build();
+    }
+
+    private static List<Object> mkList(int howMany) {
+        List<Object> list = new ArrayList<>();
+        for (int i = 0; i < howMany; i++) {
+            Map<String, Object> obj = new HashMap<>();
+            obj.put("name", "Name" + i);
+            obj.put("age", i);
+            obj.put("active", i % 2 == 0);
+            list.add(obj);
+        }
+        return list;
+    }
+
+}

--- a/src/test/resources/large-list-schema.graphqls
+++ b/src/test/resources/large-list-schema.graphqls
@@ -1,0 +1,10 @@
+type Query {
+   longList : [Thing]
+   stopList : [Thing]
+}
+
+type Thing {
+    name : String
+    age : Int
+    active : Boolean
+}


### PR DESCRIPTION
This is an experiment  - this is not guaranteed to be merged as is IF at all.

I wanted to explore what it might take to allow a data fetcher to return a value and say "no more processing" from here

This I think is how it could be done.

I wrote a benchmark to demonstrate a completed long list versus a list that just stops.

```
Benchmark                                        Mode  Cnt     Score     Error  Units
StopQueryBenchMark.benchMarkLongListThroughput  thrpt   15   182.618 ±   7.967  ops/s
StopQueryBenchMark.benchMarkStopListThroughput  thrpt   15  9537.733 ± 193.399  ops/s
StopQueryBenchMark.benchMarkLongListAvgTime      avgt   15     5.655 ±   0.198  ms/op
StopQueryBenchMark.benchMarkStopListAvgTime      avgt   15     0.104 ±   0.003  ms/op
```

This has some trade offs of course

* leaf node coercing DOES it happen
   * the returned object better be correct to the schema type system
* sub selection reduction does not happen
   * the returned object should fit the sub selection (and fit the type system)
* the `__typename` sub selection can NEVER run - since we never ran the sub selection
* instrumentation does not run for the sub selection


