### PR TITLE
Cleanup: Remove deprecated typeResolver builder for unions and interfaces

### DIFF
--- a/src/main/java/graphql/schema/GraphQLInterfaceType.java
+++ b/src/main/java/graphql/schema/GraphQLInterfaceType.java
@@ -363,7 +363,13 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLCompositeT
             return this;
         }
 
-
+        /**
+         * @param typeResolver the type resolver
+         *
+         * @return this builder
+         *
+         * @deprecated use {@link graphql.schema.GraphQLCodeRegistry.Builder#typeResolver(GraphQLInterfaceType, TypeResolver)} instead
+         */
         @Deprecated
         @DeprecatedAt("2018-12-03")
         public Builder typeResolver(TypeResolver typeResolver) {

--- a/src/main/java/graphql/schema/GraphQLUnionType.java
+++ b/src/main/java/graphql/schema/GraphQLUnionType.java
@@ -275,6 +275,13 @@ public class GraphQLUnionType implements GraphQLNamedOutputType, GraphQLComposit
             return this;
         }
 
+        /**
+         * @param typeResolver the type resolver
+         *
+         * @return this builder
+         *
+         * @deprecated use {@link graphql.schema.GraphQLCodeRegistry.Builder#typeResolver(GraphQLUnionType, TypeResolver)} instead
+         */
         @Deprecated
         @DeprecatedAt("2018-12-03")
         public Builder typeResolver(TypeResolver typeResolver) {

--- a/src/test/groovy/graphql/GraphQLTest.groovy
+++ b/src/test/groovy/graphql/GraphQLTest.groovy
@@ -856,7 +856,6 @@ class GraphQLTest extends Specification {
                                     .name("id")
                                     .type(Scalars.GraphQLID)
                         } as UnaryOperator)
-                .typeResolver({ type -> foo })
                 .build()
 
         GraphQLObjectType query = newObject()
@@ -869,7 +868,12 @@ class GraphQLTest extends Specification {
                         } as UnaryOperator)
                 .build()
 
+        def codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .typeResolver(node, {type -> foo })
+                .build()
+
         GraphQLSchema schema = newSchema()
+                .codeRegistry(codeRegistry)
                 .query(query)
                 .build()
 

--- a/src/test/groovy/graphql/InterfacesImplementingInterfacesTest.groovy
+++ b/src/test/groovy/graphql/InterfacesImplementingInterfacesTest.groovy
@@ -1,5 +1,6 @@
 package graphql
 
+import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLInterfaceType
 import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLSchema
@@ -970,14 +971,12 @@ class InterfacesImplementingInterfacesTest extends Specification {
         def node1Type = newInterface()
                 .name("Node1")
                 .field(newFieldDefinition().name("id1").type(GraphQLString).build())
-                .typeResolver({ env -> Assert.assertShouldNeverHappen() })
-                .build();
+                .build()
 
         def node2Type = newInterface()
                 .name("Node2")
                 .field(newFieldDefinition().name("id2").type(GraphQLString).build())
-                .typeResolver({ env -> Assert.assertShouldNeverHappen() })
-                .build();
+                .build()
 
         // references two interfaces: directly and via type ref
         def resource = newInterface()
@@ -986,8 +985,7 @@ class InterfacesImplementingInterfacesTest extends Specification {
                 .field(newFieldDefinition().name("id2").type(GraphQLString).build())
                 .withInterface(GraphQLTypeReference.typeRef("Node1"))
                 .withInterface(node2Type)
-                .typeResolver({ env -> Assert.assertShouldNeverHappen() })
-                .build();
+                .build()
         def image = newObject()
                 .name("Image")
                 .field(newFieldDefinition().name("id1").type(GraphQLString).build())
@@ -1000,7 +998,17 @@ class InterfacesImplementingInterfacesTest extends Specification {
                 .name("Query")
                 .field(newFieldDefinition().name("image").type(image).build())
                 .build()
-        def schema = GraphQLSchema.newSchema().query(query).additionalType(node1Type).build();
+
+        def codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .typeResolver(node1Type, { env -> Assert.assertShouldNeverHappen() })
+                .typeResolver(node2Type, { env -> Assert.assertShouldNeverHappen() })
+                .typeResolver(resource, { env -> Assert.assertShouldNeverHappen() })
+                .build()
+        def schema = GraphQLSchema.newSchema()
+                .codeRegistry(codeRegistry)
+                .query(query)
+                .additionalType(node1Type)
+                .build()
 
         when:
         def printedSchema = new SchemaPrinter().print(schema)
@@ -1045,7 +1053,6 @@ type Query {
                                 .argument(newArgument().name("arg3").type(GraphQLString))
                 )
                 .field(newFieldDefinition().name("field4").type(GraphQLString))
-                .typeResolver({ env -> Assert.assertShouldNeverHappen() })
                 .build()
 
         def interface2 = newInterface()
@@ -1057,7 +1064,6 @@ type Query {
                 .field(newFieldDefinition().name("field2").type(GraphQLInt))
                 .field(newFieldDefinition().name("field3").type(GraphQLString))
                 .withInterface(interface1)
-                .typeResolver({ env -> Assert.assertShouldNeverHappen() })
                 .build()
 
         def query = newObject()
@@ -1065,9 +1071,16 @@ type Query {
                 .field(newFieldDefinition().name("interface2").type(interface2).build())
                 .build()
 
+        def codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .typeResolver(interface1, { env -> Assert.assertShouldNeverHappen() })
+                .typeResolver(interface2, { env -> Assert.assertShouldNeverHappen() })
+                .build()
 
         when:
-        GraphQLSchema.newSchema().query(query).build()
+        GraphQLSchema.newSchema()
+                .codeRegistry(codeRegistry)
+                .query(query)
+                .build()
 
         then:
         def error = thrown(InvalidSchemaException)
@@ -1094,7 +1107,6 @@ type Query {
                                 .argument(newArgument().name("arg3").type(GraphQLString))
                 )
                 .field(newFieldDefinition().name("field4").type(GraphQLString))
-                .typeResolver({ env -> Assert.assertShouldNeverHappen() })
                 .build()
 
         def interface2 = newInterface()
@@ -1110,7 +1122,6 @@ type Query {
                 )
                 .field(newFieldDefinition().name("field4").type(GraphQLString))
                 .withInterface(interface1)
-                .typeResolver({ env -> Assert.assertShouldNeverHappen() })
                 .build()
 
         def query = newObject()
@@ -1118,9 +1129,16 @@ type Query {
                 .field(newFieldDefinition().name("interface2").type(interface2).build())
                 .build()
 
+        def codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .typeResolver(interface1, { env -> Assert.assertShouldNeverHappen() })
+                .typeResolver(interface2, { env -> Assert.assertShouldNeverHappen() })
+                .build()
 
         when:
-        GraphQLSchema.newSchema().query(query).build()
+        GraphQLSchema.newSchema()
+                .codeRegistry(codeRegistry)
+                .query(query)
+                .build()
 
         then:
         noExceptionThrown()
@@ -1131,7 +1149,6 @@ type Query {
         def interface1 = newInterface()
                 .name("Interface1")
                 .field(newFieldDefinition().name("field1").type(GraphQLString))
-                .typeResolver({ env -> Assert.assertShouldNeverHappen() })
                 .build()
 
         def interface2 = newInterface()
@@ -1139,7 +1156,6 @@ type Query {
                 .field(newFieldDefinition().name("field1").type(GraphQLString))
                 .field(newFieldDefinition().name("field2").type(GraphQLString))
                 .withInterface(interface1)
-                .typeResolver({ env -> Assert.assertShouldNeverHappen() })
                 .build()
 
         def type = newObject()
@@ -1154,9 +1170,16 @@ type Query {
                 .field(newFieldDefinition().name("find").type(type).build())
                 .build()
 
+        def codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .typeResolver(interface1, { env -> Assert.assertShouldNeverHappen() })
+                .typeResolver(interface2, { env -> Assert.assertShouldNeverHappen() })
+                .build()
 
         when:
-        GraphQLSchema.newSchema().query(query).build()
+        GraphQLSchema.newSchema()
+                .codeRegistry(codeRegistry)
+                .query(query)
+                .build()
 
         then:
         def error = thrown(InvalidSchemaException)
@@ -1169,7 +1192,6 @@ type Query {
         def interface1 = newInterface()
                 .name("Interface1")
                 .field(newFieldDefinition().name("field1").type(GraphQLString))
-                .typeResolver({ env -> Assert.assertShouldNeverHappen() })
                 .build()
 
         def interface2 = newInterface()
@@ -1177,7 +1199,6 @@ type Query {
                 .field(newFieldDefinition().name("field1").type(GraphQLString))
                 .field(newFieldDefinition().name("field2").type(GraphQLString))
                 .withInterface(interface1)
-                .typeResolver({ env -> Assert.assertShouldNeverHappen() })
                 .build()
 
         def type = newObject()
@@ -1193,9 +1214,16 @@ type Query {
                 .field(newFieldDefinition().name("find").type(type).build())
                 .build()
 
+        def codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .typeResolver(interface1, { env -> Assert.assertShouldNeverHappen() })
+                .typeResolver(interface2, { env -> Assert.assertShouldNeverHappen() })
+                .build()
 
         when:
-        GraphQLSchema.newSchema().query(query).build()
+        GraphQLSchema.newSchema()
+                .codeRegistry(codeRegistry)
+                .query(query)
+                .build()
 
         then:
         noExceptionThrown()
@@ -1208,7 +1236,6 @@ type Query {
                 .field(newFieldDefinition().name("field1").type(GraphQLString))
                 .withInterface(GraphQLTypeReference.typeRef("Interface3"))
                 .withInterface(GraphQLTypeReference.typeRef("Interface2"))
-                .typeResolver({ env -> Assert.assertShouldNeverHappen() })
                 .build()
 
         def interface2 = newInterface()
@@ -1216,7 +1243,6 @@ type Query {
                 .field(newFieldDefinition().name("field1").type(GraphQLString))
                 .withInterface(interface1)
                 .withInterface(GraphQLTypeReference.typeRef("Interface3"))
-                .typeResolver({ env -> Assert.assertShouldNeverHappen() })
                 .build()
 
         def interface3 = newInterface()
@@ -1224,7 +1250,6 @@ type Query {
                 .field(newFieldDefinition().name("field1").type(GraphQLString))
                 .withInterface(interface1)
                 .withInterface(interface2)
-                .typeResolver({ env -> Assert.assertShouldNeverHappen() })
                 .build()
 
         def query = newObject()
@@ -1232,9 +1257,17 @@ type Query {
                 .field(newFieldDefinition().name("find").type(interface3).build())
                 .build()
 
+        def codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .typeResolver(interface1, { env -> Assert.assertShouldNeverHappen() })
+                .typeResolver(interface2, { env -> Assert.assertShouldNeverHappen() })
+                .typeResolver(interface3, { env -> Assert.assertShouldNeverHappen() })
+                .build()
 
         when:
-        GraphQLSchema.newSchema().query(query).build()
+        GraphQLSchema.newSchema()
+                .codeRegistry(codeRegistry)
+                .query(query)
+                .build()
 
         then:
         def error = thrown(InvalidSchemaException)
@@ -1305,14 +1338,14 @@ type Query {
         def typeDefinitionRegistry = new SchemaParser().parse(sdl)
 
         TypeResolver typeResolver = { env ->
-            Map<String, Object> obj = env.getObject();
-            String id = (String) obj.get("id");
+            Map<String, Object> obj = env.getObject()
+            String id = (String) obj.get("id")
             GraphQLSchema schema = env.getSchema()
 
             if (id == "1") {
-                return (GraphQLObjectType) schema.getType("Image");
+                return (GraphQLObjectType) schema.getType("Image")
             } else {
-                return (GraphQLObjectType) schema.getType("File");
+                return (GraphQLObjectType) schema.getType("File")
             }
         }
 

--- a/src/test/groovy/graphql/TypeMismatchErrorTest.groovy
+++ b/src/test/groovy/graphql/TypeMismatchErrorTest.groovy
@@ -2,7 +2,6 @@ package graphql
 
 import graphql.introspection.Introspection
 import graphql.schema.GraphQLType
-import graphql.schema.TypeResolverProxy
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -22,14 +21,14 @@ class TypeMismatchErrorTest extends Specification {
         TypeMismatchError.GraphQLTypeToTypeKindMapping.getTypeKindFromGraphQLType(type) == typeKind
 
         where:
-        type                                                                                            || typeKind
-        list(Scalars.GraphQLInt)                                                                        || Introspection.TypeKind.LIST
-        Scalars.GraphQLInt                                                                              || Introspection.TypeKind.SCALAR
-        newObject().name("myObject").fields([]).build()                                                 || Introspection.TypeKind.OBJECT
-        newEnum().name("myEnum").values([]).build()                                                     || Introspection.TypeKind.ENUM
-        newInputObject().name("myInputType").fields([]).build()                                         || Introspection.TypeKind.INPUT_OBJECT
-        newInterface().name("myInterfaceType").fields([]).typeResolver(new TypeResolverProxy()).build() || Introspection.TypeKind.INTERFACE
-        nonNull(Scalars.GraphQLInt)                                                                     || Introspection.TypeKind.NON_NULL
-        newUnionType().name("myUnion").possibleType(newObject().name("test").build()).build()           || Introspection.TypeKind.UNION
+        type                                                                                   || typeKind
+        list(Scalars.GraphQLInt)                                                               || Introspection.TypeKind.LIST
+        Scalars.GraphQLInt                                                                     || Introspection.TypeKind.SCALAR
+        newObject().name("myObject").fields([]).build()                                        || Introspection.TypeKind.OBJECT
+        newEnum().name("myEnum").values([]).build()                                            || Introspection.TypeKind.ENUM
+        newInputObject().name("myInputType").fields([]).build()                                || Introspection.TypeKind.INPUT_OBJECT
+        newInterface().name("myInterfaceType").fields([]).build()                              || Introspection.TypeKind.INTERFACE
+        nonNull(Scalars.GraphQLInt)                                                            || Introspection.TypeKind.NON_NULL
+        newUnionType().name("myUnion").possibleType(newObject().name("test").build()).build()  || Introspection.TypeKind.UNION
     }
 }

--- a/src/test/groovy/graphql/TypeResolutionEnvironmentTest.groovy
+++ b/src/test/groovy/graphql/TypeResolutionEnvironmentTest.groovy
@@ -51,7 +51,7 @@ class TypeResolutionEnvironmentTest extends Specification {
                 .field(mergedField(new Field("field")))
                 .fieldType(interfaceType)
                 .schema(schema)
-                .context("FooBar")
+                .context("FooBar") // Retain for test coverage
                 .graphQLContext(graphqlContext)
                 .localContext("LocalContext")
         .build()
@@ -65,7 +65,7 @@ class TypeResolutionEnvironmentTest extends Specification {
                 assert source == "source"
                 assert env.getField().getName() == "field"
                 assert env.getFieldType() == interfaceType
-                assert env.getContext() == "FooBar"
+                assert env.getContext() == "FooBar" // Retain for test coverage
                 assert env.getLocalContext() == "LocalContext"
                 assert env.getGraphQLContext() == graphqlContext
                 assert env.getArguments() == [a: "b"]

--- a/src/test/groovy/graphql/execution/ExecutionStepInfoTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStepInfoTest.groovy
@@ -37,7 +37,6 @@ class ExecutionStepInfoTest extends Specification {
 
     def interfaceType = GraphQLInterfaceType.newInterface().name("Interface")
             .field(field1Def)
-            .typeResolver({ env -> null })
             .build()
 
     def fieldType = GraphQLObjectType.newObject()
@@ -49,7 +48,6 @@ class ExecutionStepInfoTest extends Specification {
             .name("RootType")
             .field(newFieldDefinition().name("rootField1").type(fieldType))
             .build()
-
 
     def "basic hierarchy"() {
         given:

--- a/src/test/groovy/graphql/schema/GraphQLFieldDefinitionTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLFieldDefinitionTest.groovy
@@ -1,15 +1,20 @@
 package graphql.schema
 
 import graphql.AssertException
+import graphql.TestUtil
+import graphql.schema.idl.SchemaPrinter
 import spock.lang.Specification
 
 import static graphql.Scalars.GraphQLBoolean
 import static graphql.Scalars.GraphQLFloat
 import static graphql.Scalars.GraphQLInt
 import static graphql.Scalars.GraphQLString
+import static graphql.TestUtil.mockArguments
+import static graphql.schema.DefaultGraphqlTypeComparatorRegistry.newComparators
 import static graphql.schema.GraphQLArgument.newArgument
 import static graphql.schema.GraphQLDirective.newDirective
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
+import static graphql.schema.idl.SchemaPrinter.Options.defaultOptions
 
 class GraphQLFieldDefinitionTest extends Specification {
 
@@ -76,5 +81,20 @@ class GraphQLFieldDefinitionTest extends Specification {
         transformedField.getDirective("directive1") != null
         transformedField.getDirective("directive2") != null
         transformedField.getDirective("directive3") != null
+    }
+
+    def "test deprecated argument builder for list"() {
+        given:
+        def field = newFieldDefinition().name("field").type(GraphQLInt).argument(mockArguments("a", "bb")).build() // Retain for test coverage
+
+        when:
+        def registry = newComparators()
+                .addComparator({ it.parentType(GraphQLFieldDefinition.class).elementType(GraphQLArgument.class) }, GraphQLArgument.class, TestUtil.byGreatestLength)
+                .build()
+        def options = defaultOptions().setComparators(registry)
+        def printer = new SchemaPrinter(options)
+
+        then:
+        printer.argsString(GraphQLFieldDefinition.class, field.arguments) == '''(bb: Int, a: Int)'''
     }
 }

--- a/src/test/groovy/graphql/schema/GraphQLInterfaceTypeTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLInterfaceTypeTest.groovy
@@ -24,7 +24,6 @@ class GraphQLInterfaceTypeTest extends Specification {
                         newFieldDefinition().name("NAME").type(GraphQLString).build(),
                         newFieldDefinition().name("NAME").type(GraphQLInt).build()
                 ])
-                .typeResolver(new TypeResolverProxy())
                 .build()
         then:
         interfaceType.getName() == "TestInterfaceType"
@@ -37,7 +36,6 @@ class GraphQLInterfaceTypeTest extends Specification {
                 .description("StartingDescription")
                 .field(newFieldDefinition().name("Str").type(GraphQLString))
                 .field(newFieldDefinition().name("Int").type(GraphQLInt))
-                .typeResolver(new TypeResolverProxy())
                 .build()
 
         when:
@@ -106,5 +104,20 @@ class GraphQLInterfaceTypeTest extends Specification {
 
         then:
         noExceptionThrown()
+    }
+
+    def "deprecated typeResolver builder works"() {
+        when:
+        def interfaceType = newInterface().name("TestInterfaceType")
+                .description("description")
+                .fields([
+                        newFieldDefinition().name("NAME").type(GraphQLString).build(),
+                        newFieldDefinition().name("NAME").type(GraphQLInt).build()
+                ])
+                .typeResolver(new TypeResolverProxy()) // Retain for test coverage
+                .build()
+        then:
+        interfaceType.getName() == "TestInterfaceType"
+        interfaceType.getFieldDefinition("NAME").getType() == GraphQLInt
     }
 }

--- a/src/test/groovy/graphql/schema/GraphQLUnionTypeTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLUnionTypeTest.groovy
@@ -14,7 +14,6 @@ class GraphQLUnionTypeTest extends Specification {
         when:
         newUnionType()
                 .name("TestUnionType")
-                .typeResolver(new TypeResolverProxy())
                 .build()
         then:
         thrown(AssertException)
@@ -38,7 +37,6 @@ class GraphQLUnionTypeTest extends Specification {
                 .description("StartingDescription")
                 .possibleType(objType1)
                 .possibleType(objType2)
-                .typeResolver(new TypeResolverProxy())
                 .build()
 
         when:
@@ -65,4 +63,13 @@ class GraphQLUnionTypeTest extends Specification {
         transformedUnion.isPossibleType(objType3)
     }
 
+    def "deprecated typeResolver builder works"() {
+        when:
+        newUnionType()
+                .name("TestUnionType")
+                .typeResolver(new TypeResolverProxy()) // Retain for test coverage
+                .build()
+        then:
+        thrown(AssertException)
+    }
 }

--- a/src/test/groovy/graphql/schema/SchemaPrinterComparatorsTest.groovy
+++ b/src/test/groovy/graphql/schema/SchemaPrinterComparatorsTest.groovy
@@ -534,7 +534,7 @@ scalar TestScalar @bb(bb : 0, a : 0) @a(bb : 0, a : 0)
 
     def "argsString uses most specific registered comparators"() {
         given:
-        def field = newFieldDefinition().name("field").type(GraphQLInt).argument(mockArguments("a", "bb")).build()
+        def field = newFieldDefinition().name("field").type(GraphQLInt).arguments(mockArguments("a", "bb")).build()
 
         when:
         def registry = newComparators()
@@ -549,7 +549,7 @@ scalar TestScalar @bb(bb : 0, a : 0) @a(bb : 0, a : 0)
 
     def "argsString uses least specific registered comparators"() {
         given:
-        def field = newFieldDefinition().name("field").type(GraphQLInt).argument(mockArguments("a", "bb")).build()
+        def field = newFieldDefinition().name("field").type(GraphQLInt).arguments(mockArguments("a", "bb")).build()
 
         when:
         def registry = newComparators()

--- a/src/test/groovy/graphql/schema/SchemaTraverserTest.groovy
+++ b/src/test/groovy/graphql/schema/SchemaTraverserTest.groovy
@@ -1,7 +1,6 @@
 package graphql.schema
 
 import graphql.Scalars
-import graphql.TypeResolutionEnvironment
 import graphql.util.TraversalControl
 import graphql.util.TraverserContext
 import spock.lang.Specification
@@ -117,7 +116,6 @@ class SchemaTraverserTest extends Specification {
                         .name("bar")
                         .type(Scalars.GraphQLString)
                         .build())
-                .typeResolver(NOOP_RESOLVER)
                 .build())
         then:
         visitor.getStack() == ["interface: foo", "fallback: foo",
@@ -155,7 +153,6 @@ class SchemaTraverserTest extends Specification {
                         .build())
                 .withInterface(GraphQLInterfaceType.newInterface()
                         .name("bar")
-                        .typeResolver(NOOP_RESOLVER)
                         .build())
                 .build())
         then:
@@ -181,7 +178,6 @@ class SchemaTraverserTest extends Specification {
                 .name("foo")
                 .possibleType(GraphQLObjectType.newObject().name("dummy").build())
                 .possibleType(typeRef("dummyRef"))
-                .typeResolver(NOOP_RESOLVER)
                 .build())
         then:
         visitor.getStack() == ["union: foo", "fallback: foo",
@@ -193,21 +189,21 @@ class SchemaTraverserTest extends Specification {
         when:
         def visitor = new GraphQLTestingVisitor()
         def coercing = new Coercing() {
-            private static final String TEST_ONLY = "For testing only";
+            private static final String TEST_ONLY = "For testing only"
 
             @Override
             Object serialize(Object dataFetcherResult) throws CoercingSerializeException {
-                throw new UnsupportedOperationException(TEST_ONLY);
+                throw new UnsupportedOperationException(TEST_ONLY)
             }
 
             @Override
             Object parseValue(Object input) throws CoercingParseValueException {
-                throw new UnsupportedOperationException(TEST_ONLY);
+                throw new UnsupportedOperationException(TEST_ONLY)
             }
 
             @Override
             Object parseLiteral(Object input) throws CoercingParseLiteralException {
-                throw new UnsupportedOperationException(TEST_ONLY);
+                throw new UnsupportedOperationException(TEST_ONLY)
             }
         }
         def scalarType = GraphQLScalarType.newScalar()
@@ -283,7 +279,6 @@ class SchemaTraverserTest extends Specification {
         def visitor = new GraphQLTestingVisitor()
         def interfaceType = GraphQLInterfaceType.newInterface()
                 .name("foo")
-                .typeResolver(NOOP_RESOLVER)
                 .withDirective(GraphQLDirective.newDirective()
                         .name("bar"))
                 .withAppliedDirective(GraphQLAppliedDirective.newDirective()
@@ -302,7 +297,6 @@ class SchemaTraverserTest extends Specification {
         def unionType = GraphQLUnionType.newUnionType()
                 .name("foo")
                 .possibleType(GraphQLObjectType.newObject().name("dummy").build())
-                .typeResolver(NOOP_RESOLVER)
                 .withDirective(GraphQLDirective.newDirective()
                         .name("bar"))
                 .build()
@@ -387,15 +381,6 @@ class SchemaTraverserTest extends Specification {
         ]
 
     }
-
-
-    def NOOP_RESOLVER = new TypeResolver() {
-        @Override
-        GraphQLObjectType getType(TypeResolutionEnvironment env) {
-            return null
-        }
-    }
-
 
     class GraphQLTestingVisitor extends GraphQLTypeVisitorStub {
 

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -428,12 +428,19 @@ enum Enum {
                 .name("Union")
                 .description("About union")
                 .possibleType(possibleType)
-                .typeResolver({ it -> null })
                 .build()
         GraphQLFieldDefinition fieldDefinition2 = newFieldDefinition()
                 .name("field").type(unionType).build()
+
+        def codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .typeResolver(unionType, { it -> null })
+                .build()
         def queryType = newObject().name("Query").field(fieldDefinition2).build()
-        def schema = GraphQLSchema.newSchema().query(queryType).build()
+        def schema = GraphQLSchema.newSchema()
+                .codeRegistry(codeRegistry)
+                .query(queryType)
+                .build()
+
         when:
         def result = new SchemaPrinter(noDirectivesOption).print(schema)
 
@@ -463,12 +470,19 @@ type Query {
                 .name("Union")
                 .possibleType(possibleType1)
                 .possibleType(possibleType2)
-                .typeResolver({ it -> null })
                 .build()
         GraphQLFieldDefinition fieldDefinition2 = newFieldDefinition()
                 .name("field").type(unionType).build()
+
+        def codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .typeResolver(unionType, { it -> null })
+                .build()
         def queryType = newObject().name("Query").field(fieldDefinition2).build()
-        def schema = GraphQLSchema.newSchema().query(queryType).build()
+        def schema = GraphQLSchema.newSchema()
+                .codeRegistry(codeRegistry)
+                .query(queryType)
+                .build()
+
         when:
         def result = new SchemaPrinter(noDirectivesOption).print(schema)
 
@@ -526,12 +540,19 @@ input Input {
                 .name("Interface")
                 .description("about interface")
                 .field(newFieldDefinition().name("field").description("about field").type(GraphQLString).build())
-                .typeResolver({ it -> null })
                 .build()
         GraphQLFieldDefinition fieldDefinition = newFieldDefinition()
                 .name("field").type(graphQLInterfaceType).build()
+
+        def codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .typeResolver(graphQLInterfaceType, { it -> null })
+                .build()
         def queryType = newObject().name("Query").field(fieldDefinition).build()
-        def schema = GraphQLSchema.newSchema().query(queryType).build()
+        def schema = GraphQLSchema.newSchema()
+                .codeRegistry(codeRegistry)
+                .query(queryType)
+                .build()
+
         when:
         def result = new SchemaPrinter(noDirectivesOption).print(schema)
 
@@ -851,7 +872,6 @@ type Query {
 }
 '''
     }
-
 
     def idlWithDirectives() {
         return """

--- a/src/test/groovy/graphql/schema/transform/FieldVisibilitySchemaTransformationTest.groovy
+++ b/src/test/groovy/graphql/schema/transform/FieldVisibilitySchemaTransformationTest.groovy
@@ -2,7 +2,7 @@ package graphql.schema.transform
 
 import graphql.Scalars
 import graphql.TestUtil
-import graphql.introspection.Introspection
+import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLDirectiveContainer
 import graphql.schema.GraphQLInputObjectType
 import graphql.schema.GraphQLObjectType
@@ -957,10 +957,14 @@ class FieldVisibilitySchemaTransformationTest extends Specification {
         def secretData = newInterface()
                 .name("SuperSecretCustomerData")
                 .field(newFieldDefinition().name("id").type(Scalars.GraphQLString).build())
-                .typeResolver(Mock(TypeResolver))
+                .build()
+
+        def codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .typeResolver(secretData, Mock(TypeResolver))
                 .build()
 
         def schema = GraphQLSchema.newSchema()
+                .codeRegistry(codeRegistry)
                 .query(query)
                 .additionalType(billingStatus)
                 .additionalType(account)
@@ -1003,10 +1007,14 @@ class FieldVisibilitySchemaTransformationTest extends Specification {
         def secretData = newInterface()
                 .name("SuperSecretCustomerData")
                 .field(newFieldDefinition().name("id").type(Scalars.GraphQLString).build())
-                .typeResolver(Mock(TypeResolver))
+                .build()
+
+        def codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .typeResolver(secretData, Mock(TypeResolver))
                 .build()
 
         def schema = GraphQLSchema.newSchema()
+                .codeRegistry(codeRegistry)
                 .query(query)
                 .additionalType(billingStatus)
                 .additionalType(account)

--- a/src/test/groovy/graphql/schema/validation/TypeAndFieldRuleTest.groovy
+++ b/src/test/groovy/graphql/schema/validation/TypeAndFieldRuleTest.groovy
@@ -1,6 +1,7 @@
 package graphql.schema.validation
 
 import graphql.TestUtil
+import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLTypeReference
 import graphql.schema.TypeResolverProxy
@@ -9,7 +10,6 @@ import spock.lang.Specification
 import static graphql.schema.GraphQLUnionType.newUnionType
 
 class TypeAndFieldRuleTest extends Specification {
-
 
     def "type must define one or more fields."() {
         when:
@@ -55,7 +55,6 @@ class TypeAndFieldRuleTest extends Specification {
         e.message == "invalid schema:\n\"InputType\" must define one or more fields."
     }
 
-
     def "field name must not begin with \"__\""() {
         when:
         def sdl = '''
@@ -93,8 +92,6 @@ class TypeAndFieldRuleTest extends Specification {
         e.message == "invalid schema:\n\"Interface\" must define one or more fields."
     }
 
-
-
     def "union member types must be object types"() {
         def sdl = '''
         type Query { dummy: String }
@@ -108,7 +105,10 @@ class TypeAndFieldRuleTest extends Specification {
         }
         '''
         when:
-        def graphQLSchema = TestUtil.schema(sdl)
+        def codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .typeResolver("Interface", { null })
+                .build()
+        def graphQLSchema = TestUtil.schema(sdl).transform({it.codeRegistry(codeRegistry)})
 
         // this is a little convoluted, since this rule is repeated in the schemaChecker
         // we add the invalid union after schema creation so we can cover the validation from
@@ -116,10 +116,11 @@ class TypeAndFieldRuleTest extends Specification {
         def unionType = newUnionType().name("unionWithNonObjectTypes")
                 .possibleType(graphQLSchema.getObjectType("Object"))
                 .possibleType(GraphQLTypeReference.typeRef("Interface"))
-                .typeResolver(new TypeResolverProxy())
                 .build()
-
-        graphQLSchema.transform({ schema -> schema.additionalType(unionType) })
+        codeRegistry = codeRegistry.transform({it.typeResolver(unionType, new TypeResolverProxy())})
+        graphQLSchema.transform({ schema -> schema
+                .additionalType(unionType)
+                .codeRegistry(codeRegistry)})
 
         then:
         InvalidSchemaException e = thrown(InvalidSchemaException)
@@ -149,10 +150,15 @@ class TypeAndFieldRuleTest extends Specification {
         def unionType = newUnionType().name("unionWithNonObjectTypes")
                 .possibleType(graphQLSchema.getObjectType("Object"))
                 .possibleType(stubObjectType)
-                .typeResolver(new TypeResolverProxy())
                 .build()
 
-        graphQLSchema.transform({ schema -> schema.additionalType(unionType) })
+        def codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .typeResolver(unionType, new TypeResolverProxy())
+                .build()
+
+        graphQLSchema.transform({ schema -> schema
+                .additionalType(unionType)
+                .codeRegistry(codeRegistry) })
 
         then:
         InvalidSchemaException e = thrown(InvalidSchemaException)

--- a/src/test/groovy/graphql/schema/validation/TypesImplementInterfacesTest.groovy
+++ b/src/test/groovy/graphql/schema/validation/TypesImplementInterfacesTest.groovy
@@ -1,9 +1,7 @@
 package graphql.schema.validation
 
-import graphql.TypeResolutionEnvironment
 import graphql.schema.GraphQLInterfaceType
 import graphql.schema.GraphQLObjectType
-import graphql.schema.TypeResolver
 import spock.lang.Specification
 
 import static SchemaValidationErrorType.ObjectDoesNotImplementItsInterfaces
@@ -19,13 +17,6 @@ import static graphql.schema.GraphQLObjectType.newObject
 import static graphql.schema.GraphQLUnionType.newUnionType
 
 class TypesImplementInterfacesTest extends Specification {
-
-    TypeResolver typeResolver = new TypeResolver() {
-        @Override
-        GraphQLObjectType getType(TypeResolutionEnvironment env) {
-            null
-        }
-    }
 
     GraphQLInterfaceType InterfaceType = newInterface()
             .name("Interface")
@@ -47,7 +38,6 @@ class TypesImplementInterfacesTest extends Specification {
             .argument(newArgument().name("arg2").type(GraphQLInt))
             .argument(newArgument().name("arg3").type(GraphQLBoolean))
     )
-            .typeResolver(typeResolver)
             .build()
 
     def "objects implement interfaces"() {
@@ -102,7 +92,6 @@ class TypesImplementInterfacesTest extends Specification {
         def person = newInterface()
                 .name("Person")
                 .field(newFieldDefinition().name("name").type(GraphQLString).build())
-                .typeResolver({})
                 .build()
 
         def actor = newObject()
@@ -119,7 +108,6 @@ class TypesImplementInterfacesTest extends Specification {
         GraphQLInterfaceType interfaceType = newInterface()
                 .name("TestInterface")
                 .field(newFieldDefinition().name("field").type(person).build())
-                .typeResolver({})
                 .build()
 
         GraphQLObjectType goodImpl = newObject()
@@ -151,7 +139,6 @@ class TypesImplementInterfacesTest extends Specification {
         def person = newInterface()
                 .name("Person")
                 .field(newFieldDefinition().name("name").type(GraphQLString).build())
-                .typeResolver({})
                 .build()
 
         def actor = newObject()
@@ -168,7 +155,6 @@ class TypesImplementInterfacesTest extends Specification {
         GraphQLInterfaceType interfaceType = newInterface()
                 .name("TestInterface")
                 .field(newFieldDefinition().name("field").type(list(person)).build())
-                .typeResolver({})
                 .build()
 
         GraphQLObjectType goodImpl = newObject()
@@ -200,7 +186,6 @@ class TypesImplementInterfacesTest extends Specification {
         def person = newInterface()
                 .name("Person")
                 .field(newFieldDefinition().name("name").type(GraphQLString).build())
-                .typeResolver({})
                 .build()
 
         def actor = newInterface()
@@ -217,7 +202,6 @@ class TypesImplementInterfacesTest extends Specification {
         GraphQLInterfaceType interfaceType = newInterface()
                 .name("TestInterface")
                 .field(newFieldDefinition().name("field").type(list(person)).build())
-                .typeResolver({})
                 .build()
 
         GraphQLObjectType goodImpl = newObject()
@@ -260,7 +244,6 @@ class TypesImplementInterfacesTest extends Specification {
                 .name("Person")
                 .possibleType(actor)
                 .possibleType(director)
-                .typeResolver({})
                 .build()
 
         def prop = newObject()
@@ -271,7 +254,6 @@ class TypesImplementInterfacesTest extends Specification {
         GraphQLInterfaceType interfaceType = newInterface()
                 .name("TestInterface")
                 .field(newFieldDefinition().name("field").type(person).build())
-                .typeResolver({})
                 .build()
 
         GraphQLObjectType goodImpl = newObject()
@@ -303,7 +285,6 @@ class TypesImplementInterfacesTest extends Specification {
         GraphQLInterfaceType interfaceType = newInterface()
                 .name("TestInterface")
                 .field(newFieldDefinition().name("field").type(GraphQLString).build())
-                .typeResolver({})
                 .build()
 
         GraphQLObjectType goodImpl = newObject()
@@ -336,7 +317,6 @@ class TypesImplementInterfacesTest extends Specification {
         GraphQLInterfaceType memberInterface = newInterface()
                 .name("TestMemberInterface")
                 .field(newFieldDefinition().name("field").type(GraphQLString).build())
-                .typeResolver({})
                 .build()
 
         GraphQLObjectType memberInterfaceImpl = newObject()
@@ -348,7 +328,6 @@ class TypesImplementInterfacesTest extends Specification {
         GraphQLInterfaceType testInterface = newInterface()
                 .name("TestInterface")
                 .field(newFieldDefinition().name("field").type(nonNull(memberInterface)).build())
-                .typeResolver({})
                 .build()
 
         GraphQLObjectType testInterfaceImpl = newObject()


### PR DESCRIPTION
Test cleanup PR to remove deprecated `typeResolver` builder for unions and interfaces. They belong in the `GraphQLCodeRegistry` now.

This PR seems large considering how tiny the change is. We had many deprecated usages in old tests.