### PR TITLE
Test cleanup: typeResolver builder on unions and interfaces, applied directive tests, and more

### DIFF
--- a/src/main/java/graphql/schema/GraphQLDirectiveContainer.java
+++ b/src/main/java/graphql/schema/GraphQLDirectiveContainer.java
@@ -9,15 +9,15 @@ import java.util.Map;
 import static graphql.collect.ImmutableKit.emptyList;
 
 /**
- * Represents a graphql runtime type that can have {@link graphql.schema.GraphQLAppliedDirective}'s.
+ * Represents a graphql runtime type that can have {@link graphql.schema.GraphQLAppliedDirective}s.
  * <p>
  * Directives can be repeatable and (by default) non-repeatable.
  * <p>
  * There are access methods here that get the two different types.
  * <p>
  * The use of {@link GraphQLDirective} to represent a directive applied to an element is deprecated in favour of
- * {@link GraphQLAppliedDirective}.   A {@link GraphQLDirective} really should represent the definition of a directive in a schema not its use
- * on schema elements.  However, it has been left in place for legacy reasons and will be removed in a
+ * {@link GraphQLAppliedDirective}. A {@link GraphQLDirective} really should represent the definition of a directive in a schema, not its use
+ * on schema elements. However, it has been left in place for legacy reasons and will be removed in a
  * future version.
  *
  * @see graphql.language.DirectiveDefinition

--- a/src/main/java/graphql/schema/GraphQLInterfaceType.java
+++ b/src/main/java/graphql/schema/GraphQLInterfaceType.java
@@ -363,7 +363,13 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLCompositeT
             return this;
         }
 
-
+        /**
+         * @param typeResolver the type resolver
+         *
+         * @return this builder
+         *
+         * @deprecated use {@link graphql.schema.GraphQLCodeRegistry.Builder#typeResolver(GraphQLInterfaceType, TypeResolver)} instead
+         */
         @Deprecated
         @DeprecatedAt("2018-12-03")
         public Builder typeResolver(TypeResolver typeResolver) {

--- a/src/main/java/graphql/schema/GraphQLUnionType.java
+++ b/src/main/java/graphql/schema/GraphQLUnionType.java
@@ -275,6 +275,13 @@ public class GraphQLUnionType implements GraphQLNamedOutputType, GraphQLComposit
             return this;
         }
 
+        /**
+         * @param typeResolver the type resolver
+         *
+         * @return this builder
+         *
+         * @deprecated use {@link graphql.schema.GraphQLCodeRegistry.Builder#typeResolver(GraphQLUnionType, TypeResolver)} instead
+         */
         @Deprecated
         @DeprecatedAt("2018-12-03")
         public Builder typeResolver(TypeResolver typeResolver) {

--- a/src/test/groovy/graphql/GraphQLTest.groovy
+++ b/src/test/groovy/graphql/GraphQLTest.groovy
@@ -856,7 +856,6 @@ class GraphQLTest extends Specification {
                                     .name("id")
                                     .type(Scalars.GraphQLID)
                         } as UnaryOperator)
-                .typeResolver({ type -> foo })
                 .build()
 
         GraphQLObjectType query = newObject()
@@ -869,7 +868,12 @@ class GraphQLTest extends Specification {
                         } as UnaryOperator)
                 .build()
 
+        def codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .typeResolver(node, {type -> foo })
+                .build()
+
         GraphQLSchema schema = newSchema()
+                .codeRegistry(codeRegistry)
                 .query(query)
                 .build()
 

--- a/src/test/groovy/graphql/GraphQLTest.groovy
+++ b/src/test/groovy/graphql/GraphQLTest.groovy
@@ -2,7 +2,6 @@ package graphql
 
 import graphql.analysis.MaxQueryComplexityInstrumentation
 import graphql.analysis.MaxQueryDepthInstrumentation
-import graphql.collect.ImmutableKit
 import graphql.execution.AsyncExecutionStrategy
 import graphql.execution.AsyncSerialExecutionStrategy
 import graphql.execution.DataFetcherExceptionHandler
@@ -26,7 +25,6 @@ import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironment
 import graphql.schema.FieldCoordinates
 import graphql.schema.GraphQLCodeRegistry
-import graphql.schema.GraphQLDirective
 import graphql.schema.GraphQLEnumType
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLInterfaceType
@@ -1415,28 +1413,6 @@ many lines''']
         then:
         def e = thrown(SchemaProblem)
         e.message.contains("an illegal value for the argument ")
-    }
-
-    def "Applied schema directives arguments are validated for programmatic schemas"() {
-        given:
-        def arg = newArgument().name("arg").type(GraphQLInt).valueProgrammatic(ImmutableKit.emptyMap()).build()
-        def directive = GraphQLDirective.newDirective().name("cached").argument(arg).build()
-        def field = newFieldDefinition()
-                .name("hello")
-                .type(GraphQLString)
-                .argument(arg)
-                .withDirective(directive)
-                .build()
-        when:
-        newSchema().query(
-                newObject()
-                        .name("Query")
-                        .field(field)
-                        .build())
-                .build()
-        then:
-        def e = thrown(InvalidSchemaException)
-        e.message.contains("Invalid argument 'arg' for applied directive of name 'cached'")
     }
 
     def "getters work as expected"() {

--- a/src/test/groovy/graphql/InterfacesImplementingInterfacesTest.groovy
+++ b/src/test/groovy/graphql/InterfacesImplementingInterfacesTest.groovy
@@ -1,5 +1,6 @@
 package graphql
 
+import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLInterfaceType
 import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLSchema
@@ -970,14 +971,12 @@ class InterfacesImplementingInterfacesTest extends Specification {
         def node1Type = newInterface()
                 .name("Node1")
                 .field(newFieldDefinition().name("id1").type(GraphQLString).build())
-                .typeResolver({ env -> Assert.assertShouldNeverHappen() })
-                .build();
+                .build()
 
         def node2Type = newInterface()
                 .name("Node2")
                 .field(newFieldDefinition().name("id2").type(GraphQLString).build())
-                .typeResolver({ env -> Assert.assertShouldNeverHappen() })
-                .build();
+                .build()
 
         // references two interfaces: directly and via type ref
         def resource = newInterface()
@@ -986,8 +985,7 @@ class InterfacesImplementingInterfacesTest extends Specification {
                 .field(newFieldDefinition().name("id2").type(GraphQLString).build())
                 .withInterface(GraphQLTypeReference.typeRef("Node1"))
                 .withInterface(node2Type)
-                .typeResolver({ env -> Assert.assertShouldNeverHappen() })
-                .build();
+                .build()
         def image = newObject()
                 .name("Image")
                 .field(newFieldDefinition().name("id1").type(GraphQLString).build())
@@ -1000,7 +998,17 @@ class InterfacesImplementingInterfacesTest extends Specification {
                 .name("Query")
                 .field(newFieldDefinition().name("image").type(image).build())
                 .build()
-        def schema = GraphQLSchema.newSchema().query(query).additionalType(node1Type).build();
+
+        def codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .typeResolver(node1Type, { env -> Assert.assertShouldNeverHappen() })
+                .typeResolver(node2Type, { env -> Assert.assertShouldNeverHappen() })
+                .typeResolver(resource, { env -> Assert.assertShouldNeverHappen() })
+                .build()
+        def schema = GraphQLSchema.newSchema()
+                .codeRegistry(codeRegistry)
+                .query(query)
+                .additionalType(node1Type)
+                .build()
 
         when:
         def printedSchema = new SchemaPrinter().print(schema)
@@ -1045,7 +1053,6 @@ type Query {
                                 .argument(newArgument().name("arg3").type(GraphQLString))
                 )
                 .field(newFieldDefinition().name("field4").type(GraphQLString))
-                .typeResolver({ env -> Assert.assertShouldNeverHappen() })
                 .build()
 
         def interface2 = newInterface()
@@ -1057,7 +1064,6 @@ type Query {
                 .field(newFieldDefinition().name("field2").type(GraphQLInt))
                 .field(newFieldDefinition().name("field3").type(GraphQLString))
                 .withInterface(interface1)
-                .typeResolver({ env -> Assert.assertShouldNeverHappen() })
                 .build()
 
         def query = newObject()
@@ -1065,9 +1071,16 @@ type Query {
                 .field(newFieldDefinition().name("interface2").type(interface2).build())
                 .build()
 
+        def codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .typeResolver(interface1, { env -> Assert.assertShouldNeverHappen() })
+                .typeResolver(interface2, { env -> Assert.assertShouldNeverHappen() })
+                .build()
 
         when:
-        GraphQLSchema.newSchema().query(query).build()
+        GraphQLSchema.newSchema()
+                .codeRegistry(codeRegistry)
+                .query(query)
+                .build()
 
         then:
         def error = thrown(InvalidSchemaException)
@@ -1094,7 +1107,6 @@ type Query {
                                 .argument(newArgument().name("arg3").type(GraphQLString))
                 )
                 .field(newFieldDefinition().name("field4").type(GraphQLString))
-                .typeResolver({ env -> Assert.assertShouldNeverHappen() })
                 .build()
 
         def interface2 = newInterface()
@@ -1110,7 +1122,6 @@ type Query {
                 )
                 .field(newFieldDefinition().name("field4").type(GraphQLString))
                 .withInterface(interface1)
-                .typeResolver({ env -> Assert.assertShouldNeverHappen() })
                 .build()
 
         def query = newObject()
@@ -1118,9 +1129,16 @@ type Query {
                 .field(newFieldDefinition().name("interface2").type(interface2).build())
                 .build()
 
+        def codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .typeResolver(interface1, { env -> Assert.assertShouldNeverHappen() })
+                .typeResolver(interface2, { env -> Assert.assertShouldNeverHappen() })
+                .build()
 
         when:
-        GraphQLSchema.newSchema().query(query).build()
+        GraphQLSchema.newSchema()
+                .codeRegistry(codeRegistry)
+                .query(query)
+                .build()
 
         then:
         noExceptionThrown()
@@ -1131,7 +1149,6 @@ type Query {
         def interface1 = newInterface()
                 .name("Interface1")
                 .field(newFieldDefinition().name("field1").type(GraphQLString))
-                .typeResolver({ env -> Assert.assertShouldNeverHappen() })
                 .build()
 
         def interface2 = newInterface()
@@ -1139,7 +1156,6 @@ type Query {
                 .field(newFieldDefinition().name("field1").type(GraphQLString))
                 .field(newFieldDefinition().name("field2").type(GraphQLString))
                 .withInterface(interface1)
-                .typeResolver({ env -> Assert.assertShouldNeverHappen() })
                 .build()
 
         def type = newObject()
@@ -1154,9 +1170,16 @@ type Query {
                 .field(newFieldDefinition().name("find").type(type).build())
                 .build()
 
+        def codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .typeResolver(interface1, { env -> Assert.assertShouldNeverHappen() })
+                .typeResolver(interface2, { env -> Assert.assertShouldNeverHappen() })
+                .build()
 
         when:
-        GraphQLSchema.newSchema().query(query).build()
+        GraphQLSchema.newSchema()
+                .codeRegistry(codeRegistry)
+                .query(query)
+                .build()
 
         then:
         def error = thrown(InvalidSchemaException)
@@ -1169,7 +1192,6 @@ type Query {
         def interface1 = newInterface()
                 .name("Interface1")
                 .field(newFieldDefinition().name("field1").type(GraphQLString))
-                .typeResolver({ env -> Assert.assertShouldNeverHappen() })
                 .build()
 
         def interface2 = newInterface()
@@ -1177,7 +1199,6 @@ type Query {
                 .field(newFieldDefinition().name("field1").type(GraphQLString))
                 .field(newFieldDefinition().name("field2").type(GraphQLString))
                 .withInterface(interface1)
-                .typeResolver({ env -> Assert.assertShouldNeverHappen() })
                 .build()
 
         def type = newObject()
@@ -1193,9 +1214,16 @@ type Query {
                 .field(newFieldDefinition().name("find").type(type).build())
                 .build()
 
+        def codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .typeResolver(interface1, { env -> Assert.assertShouldNeverHappen() })
+                .typeResolver(interface2, { env -> Assert.assertShouldNeverHappen() })
+                .build()
 
         when:
-        GraphQLSchema.newSchema().query(query).build()
+        GraphQLSchema.newSchema()
+                .codeRegistry(codeRegistry)
+                .query(query)
+                .build()
 
         then:
         noExceptionThrown()
@@ -1208,7 +1236,6 @@ type Query {
                 .field(newFieldDefinition().name("field1").type(GraphQLString))
                 .withInterface(GraphQLTypeReference.typeRef("Interface3"))
                 .withInterface(GraphQLTypeReference.typeRef("Interface2"))
-                .typeResolver({ env -> Assert.assertShouldNeverHappen() })
                 .build()
 
         def interface2 = newInterface()
@@ -1216,7 +1243,6 @@ type Query {
                 .field(newFieldDefinition().name("field1").type(GraphQLString))
                 .withInterface(interface1)
                 .withInterface(GraphQLTypeReference.typeRef("Interface3"))
-                .typeResolver({ env -> Assert.assertShouldNeverHappen() })
                 .build()
 
         def interface3 = newInterface()
@@ -1224,7 +1250,6 @@ type Query {
                 .field(newFieldDefinition().name("field1").type(GraphQLString))
                 .withInterface(interface1)
                 .withInterface(interface2)
-                .typeResolver({ env -> Assert.assertShouldNeverHappen() })
                 .build()
 
         def query = newObject()
@@ -1232,9 +1257,17 @@ type Query {
                 .field(newFieldDefinition().name("find").type(interface3).build())
                 .build()
 
+        def codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .typeResolver(interface1, { env -> Assert.assertShouldNeverHappen() })
+                .typeResolver(interface2, { env -> Assert.assertShouldNeverHappen() })
+                .typeResolver(interface3, { env -> Assert.assertShouldNeverHappen() })
+                .build()
 
         when:
-        GraphQLSchema.newSchema().query(query).build()
+        GraphQLSchema.newSchema()
+                .codeRegistry(codeRegistry)
+                .query(query)
+                .build()
 
         then:
         def error = thrown(InvalidSchemaException)
@@ -1305,14 +1338,14 @@ type Query {
         def typeDefinitionRegistry = new SchemaParser().parse(sdl)
 
         TypeResolver typeResolver = { env ->
-            Map<String, Object> obj = env.getObject();
-            String id = (String) obj.get("id");
+            Map<String, Object> obj = env.getObject()
+            String id = (String) obj.get("id")
             GraphQLSchema schema = env.getSchema()
 
             if (id == "1") {
-                return (GraphQLObjectType) schema.getType("Image");
+                return (GraphQLObjectType) schema.getType("Image")
             } else {
-                return (GraphQLObjectType) schema.getType("File");
+                return (GraphQLObjectType) schema.getType("File")
             }
         }
 

--- a/src/test/groovy/graphql/TypeMismatchErrorTest.groovy
+++ b/src/test/groovy/graphql/TypeMismatchErrorTest.groovy
@@ -2,7 +2,6 @@ package graphql
 
 import graphql.introspection.Introspection
 import graphql.schema.GraphQLType
-import graphql.schema.TypeResolverProxy
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -22,14 +21,14 @@ class TypeMismatchErrorTest extends Specification {
         TypeMismatchError.GraphQLTypeToTypeKindMapping.getTypeKindFromGraphQLType(type) == typeKind
 
         where:
-        type                                                                                            || typeKind
-        list(Scalars.GraphQLInt)                                                                        || Introspection.TypeKind.LIST
-        Scalars.GraphQLInt                                                                              || Introspection.TypeKind.SCALAR
-        newObject().name("myObject").fields([]).build()                                                 || Introspection.TypeKind.OBJECT
-        newEnum().name("myEnum").values([]).build()                                                     || Introspection.TypeKind.ENUM
-        newInputObject().name("myInputType").fields([]).build()                                         || Introspection.TypeKind.INPUT_OBJECT
-        newInterface().name("myInterfaceType").fields([]).typeResolver(new TypeResolverProxy()).build() || Introspection.TypeKind.INTERFACE
-        nonNull(Scalars.GraphQLInt)                                                                     || Introspection.TypeKind.NON_NULL
-        newUnionType().name("myUnion").possibleType(newObject().name("test").build()).build()           || Introspection.TypeKind.UNION
+        type                                                                                   || typeKind
+        list(Scalars.GraphQLInt)                                                               || Introspection.TypeKind.LIST
+        Scalars.GraphQLInt                                                                     || Introspection.TypeKind.SCALAR
+        newObject().name("myObject").fields([]).build()                                        || Introspection.TypeKind.OBJECT
+        newEnum().name("myEnum").values([]).build()                                            || Introspection.TypeKind.ENUM
+        newInputObject().name("myInputType").fields([]).build()                                || Introspection.TypeKind.INPUT_OBJECT
+        newInterface().name("myInterfaceType").fields([]).build()                              || Introspection.TypeKind.INTERFACE
+        nonNull(Scalars.GraphQLInt)                                                            || Introspection.TypeKind.NON_NULL
+        newUnionType().name("myUnion").possibleType(newObject().name("test").build()).build()  || Introspection.TypeKind.UNION
     }
 }

--- a/src/test/groovy/graphql/TypeResolutionEnvironmentTest.groovy
+++ b/src/test/groovy/graphql/TypeResolutionEnvironmentTest.groovy
@@ -51,7 +51,7 @@ class TypeResolutionEnvironmentTest extends Specification {
                 .field(mergedField(new Field("field")))
                 .fieldType(interfaceType)
                 .schema(schema)
-                .context("FooBar")
+                .context("FooBar") // Retain for test coverage
                 .graphQLContext(graphqlContext)
                 .localContext("LocalContext")
         .build()
@@ -65,7 +65,7 @@ class TypeResolutionEnvironmentTest extends Specification {
                 assert source == "source"
                 assert env.getField().getName() == "field"
                 assert env.getFieldType() == interfaceType
-                assert env.getContext() == "FooBar"
+                assert env.getContext() == "FooBar" // Retain for test coverage
                 assert env.getLocalContext() == "LocalContext"
                 assert env.getGraphQLContext() == graphqlContext
                 assert env.getArguments() == [a: "b"]

--- a/src/test/groovy/graphql/TypeResolutionEnvironmentTest.groovy
+++ b/src/test/groovy/graphql/TypeResolutionEnvironmentTest.groovy
@@ -104,10 +104,10 @@ class TypeResolutionEnvironmentTest extends Specification {
                 String source = env.getObject()
                 assert source == "source"
                 assert env.getGraphQLContext().get("a") == "b"
-                if ("FooBar" == env.getContext()) {
+                if ("FooBar" == env.getContext()) { // Retain for test coverage
                     return schema.getObjectType("FooBar")
                 }
-                if ("Foo" == env.getContext()) {
+                if ("Foo" == env.getContext()) { // Retain for test coverage
                     return schema.getObjectType("FooImpl")
                 }
                 return null
@@ -121,7 +121,7 @@ class TypeResolutionEnvironmentTest extends Specification {
                 .field(mergedField(new Field("field")))
                 .fieldType(interfaceType)
                 .schema(schema)
-                .context("FooBar")
+                .context("FooBar") // Retain for test coverage
                 .graphQLContext(graphqlContext)
                 .build()
 
@@ -137,7 +137,7 @@ class TypeResolutionEnvironmentTest extends Specification {
                 .field(mergedField(new Field("field")))
                 .fieldType(interfaceType)
                 .schema(schema)
-                .context("Foo")
+                .context("Foo") // Retain for test coverage
                 .graphQLContext(graphqlContext)
                 .build()
 

--- a/src/test/groovy/graphql/analysis/MaxQueryDepthInstrumentationTest.groovy
+++ b/src/test/groovy/graphql/analysis/MaxQueryDepthInstrumentationTest.groovy
@@ -17,11 +17,10 @@ import java.util.function.Function
 
 class MaxQueryDepthInstrumentationTest extends Specification {
 
-    Document createQuery(String query) {
+    static Document createQuery(String query) {
         Parser parser = new Parser()
         parser.parseDocument(query)
     }
-
 
     def "throws exception if too deep"() {
         given:
@@ -68,8 +67,34 @@ class MaxQueryDepthInstrumentationTest extends Specification {
         ExecutionInput executionInput = Mock(ExecutionInput)
         def executionContext = executionCtx(executionInput, query, schema)
         def executeOperationParameters = new InstrumentationExecuteOperationParameters(executionContext)
+        def state = maximumQueryDepthInstrumentation.createState(null)
         when:
-        maximumQueryDepthInstrumentation.beginExecuteOperation(executeOperationParameters)
+        maximumQueryDepthInstrumentation.beginExecuteOperation(executeOperationParameters, state)
+        then:
+        notThrown(Exception)
+    }
+
+    def "doesn't throw exception if not deep enough with deprecated beginExecuteOperation"() {
+        given:
+        def schema = TestUtil.schema("""
+            type Query{
+                foo: Foo
+                bar: String
+            }
+            type Foo {
+                scalar: String  
+                foo: Foo
+            }
+        """)
+        def query = createQuery("""
+            {f1: foo {foo {foo {scalar}}} f2: foo { foo {foo {foo {foo{foo{scalar}}}}}} }
+            """)
+        MaxQueryDepthInstrumentation maximumQueryDepthInstrumentation = new MaxQueryDepthInstrumentation(7)
+        ExecutionInput executionInput = Mock(ExecutionInput)
+        def executionContext = executionCtx(executionInput, query, schema)
+        def executeOperationParameters = new InstrumentationExecuteOperationParameters(executionContext)
+        when:
+        maximumQueryDepthInstrumentation.beginExecuteOperation(executeOperationParameters) // Retain for test coverage
         then:
         notThrown(Exception)
     }
@@ -133,7 +158,7 @@ class MaxQueryDepthInstrumentationTest extends Specification {
         !er.errors.isEmpty()
     }
 
-    private ExecutionContext executionCtx(ExecutionInput executionInput, Document query, GraphQLSchema schema) {
+    static private ExecutionContext executionCtx(ExecutionInput executionInput, Document query, GraphQLSchema schema) {
         ExecutionContextBuilder.newExecutionContextBuilder()
                 .executionInput(executionInput).document(query).graphQLSchema(schema).executionId(ExecutionId.generate()).build()
     }

--- a/src/test/groovy/graphql/execution/ExecutionStepInfoTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStepInfoTest.groovy
@@ -37,7 +37,6 @@ class ExecutionStepInfoTest extends Specification {
 
     def interfaceType = GraphQLInterfaceType.newInterface().name("Interface")
             .field(field1Def)
-            .typeResolver({ env -> null })
             .build()
 
     def fieldType = GraphQLObjectType.newObject()
@@ -49,7 +48,6 @@ class ExecutionStepInfoTest extends Specification {
             .name("RootType")
             .field(newFieldDefinition().name("rootField1").type(fieldType))
             .build()
-
 
     def "basic hierarchy"() {
         given:

--- a/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
@@ -10,6 +10,7 @@ import graphql.SerializationError
 import graphql.StarWarsSchema
 import graphql.TypeMismatchError
 import graphql.execution.instrumentation.InstrumentationContext
+import graphql.execution.instrumentation.InstrumentationState
 import graphql.execution.instrumentation.SimpleInstrumentation
 import graphql.execution.instrumentation.parameters.InstrumentationFieldCompleteParameters
 import graphql.language.Argument
@@ -678,12 +679,12 @@ class ExecutionStrategyTest extends Specification {
             Map<String, FetchedValue> fetchedValues = [:]
 
             @Override
-            InstrumentationContext<ExecutionResult> beginFieldComplete(InstrumentationFieldCompleteParameters parameters) {
+            InstrumentationContext<ExecutionResult> beginFieldComplete(InstrumentationFieldCompleteParameters parameters, InstrumentationState state) {
                 if (parameters.fetchedValue instanceof FetchedValue) {
                     FetchedValue value = (FetchedValue) parameters.fetchedValue
                     fetchedValues.put(parameters.field.name, value)
                 }
-                return super.beginFieldComplete(parameters)
+                return super.beginFieldComplete(parameters, state)
             }
         }
         ExecutionContext instrumentedExecutionContext = executionContextBuilder.instrumentation(instrumentation).build()

--- a/src/test/groovy/graphql/execution/directives/QueryDirectivesIntegrationTest.groovy
+++ b/src/test/groovy/graphql/execution/directives/QueryDirectivesIntegrationTest.groovy
@@ -3,7 +3,6 @@ package graphql.execution.directives
 import graphql.GraphQL
 import graphql.TestUtil
 import graphql.schema.DataFetcher
-import graphql.schema.GraphQLDirective
 import spock.lang.Specification
 
 /**
@@ -74,7 +73,7 @@ class QueryDirectivesIntegrationTest extends Specification {
         graphql.execute({ input -> input.query(query).root(root) })
     }
 
-    def joinArgs(List<GraphQLDirective> timeoutDirectives) {
+    static def joinArgs(List<QueryAppliedDirective> timeoutDirectives) {
         timeoutDirectives.collect({
             def s = it.getName() + "("
             it.arguments.forEach({
@@ -95,7 +94,7 @@ class QueryDirectivesIntegrationTest extends Specification {
         then:
         er.errors.isEmpty()
 
-        Map<String, List<GraphQLDirective>> immediateMap = capturedDirectives["review"].getImmediateDirectivesByName()
+        def immediateMap = capturedDirectives["review"].getImmediateAppliedDirectivesByName()
         def entries = immediateMap.entrySet().collectEntries({
             [(it.getKey()): joinArgs(it.getValue())]
         })
@@ -103,7 +102,7 @@ class QueryDirectivesIntegrationTest extends Specification {
                     timeout: "timeout(afterMillis:5),timeout(afterMillis:28),timeout(afterMillis:10)"
         ]
 
-        def immediate = capturedDirectives["review"].getImmediateDirective("cached")
+        def immediate = capturedDirectives["review"].getImmediateAppliedDirective("cached")
         joinArgs(immediate) == "cached(forMillis:5),cached(forMillis:10)"
     }
 
@@ -123,7 +122,7 @@ class QueryDirectivesIntegrationTest extends Specification {
         then:
         er.errors.isEmpty()
 
-        Map<String, List<GraphQLDirective>> immediateMap = capturedDirectives["title"].getImmediateDirectivesByName()
+        def immediateMap = capturedDirectives["title"].getImmediateAppliedDirectivesByName()
         def entries = immediateMap.entrySet().collectEntries({
             [(it.getKey()): joinArgs(it.getValue())]
         })
@@ -131,7 +130,7 @@ class QueryDirectivesIntegrationTest extends Specification {
                     timeout: "timeout(afterMillis:99)"
         ]
 
-        def immediate = capturedDirectives["review"].getImmediateDirective("cached")
+        def immediate = capturedDirectives["review"].getImmediateAppliedDirective("cached")
         joinArgs(immediate) == "cached(forMillis:10)"
     }
 

--- a/src/test/groovy/graphql/execution/instrumentation/LegacyTestingInstrumentation.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/LegacyTestingInstrumentation.groovy
@@ -39,85 +39,85 @@ class LegacyTestingInstrumentation implements Instrumentation {
 
     @Override
     InstrumentationContext<ExecutionResult> beginExecution(InstrumentationExecutionParameters parameters) {
-        assert parameters.getInstrumentationState() == instrumentationState
+        assert parameters.getInstrumentationState() == instrumentationState // Retain for test coverage
         new TestingInstrumentContext("execution", executionList, throwableList, useOnDispatch)
     }
 
     @Override
     InstrumentationContext<Document> beginParse(InstrumentationExecutionParameters parameters) {
-        assert parameters.getInstrumentationState() == instrumentationState
+        assert parameters.getInstrumentationState() == instrumentationState // Retain for test coverage
         return new TestingInstrumentContext("parse", executionList, throwableList, useOnDispatch)
     }
 
     @Override
     InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters) {
-        assert parameters.getInstrumentationState() == instrumentationState
+        assert parameters.getInstrumentationState() == instrumentationState // Retain for test coverage
         return new TestingInstrumentContext("validation", executionList, throwableList, useOnDispatch)
     }
 
     @Override
     ExecutionStrategyInstrumentationContext beginExecutionStrategy(InstrumentationExecutionStrategyParameters parameters) {
-        assert parameters.getInstrumentationState() == instrumentationState
+        assert parameters.getInstrumentationState() == instrumentationState // Retain for test coverage
         return new TestingExecutionStrategyInstrumentationContext("execution-strategy", executionList, throwableList, useOnDispatch)
     }
 
     @Override
     InstrumentationContext<ExecutionResult> beginExecuteOperation(InstrumentationExecuteOperationParameters parameters) {
-        assert parameters.getInstrumentationState() == instrumentationState
+        assert parameters.getInstrumentationState() == instrumentationState // Retain for test coverage
         return new TestingInstrumentContext("execute-operation", executionList, throwableList, useOnDispatch)
     }
 
     @Override
     InstrumentationContext<ExecutionResult> beginSubscribedFieldEvent(InstrumentationFieldParameters parameters) {
-        assert parameters.getInstrumentationState() == instrumentationState
+        assert parameters.getInstrumentationState() == instrumentationState // Retain for test coverage
         return new TestingInstrumentContext("subscribed-field-event-$parameters.field.name", executionList, throwableList, useOnDispatch)
     }
 
     @Override
     InstrumentationContext<ExecutionResult> beginField(InstrumentationFieldParameters parameters) {
-        assert parameters.getInstrumentationState() == instrumentationState
+        assert parameters.getInstrumentationState() == instrumentationState // Retain for test coverage
         return new TestingInstrumentContext("field-$parameters.field.name", executionList, throwableList, useOnDispatch)
     }
 
     @Override
     InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters) {
-        assert parameters.getInstrumentationState() == instrumentationState
+        assert parameters.getInstrumentationState() == instrumentationState // Retain for test coverage
         return new TestingInstrumentContext("fetch-$parameters.field.name", executionList, throwableList, useOnDispatch)
     }
 
     @Override
     InstrumentationContext<CompletableFuture<ExecutionResult>> beginFieldComplete(InstrumentationFieldCompleteParameters parameters) {
-        assert parameters.getInstrumentationState() == instrumentationState
+        assert parameters.getInstrumentationState() == instrumentationState // Retain for test coverage
         return new TestingInstrumentContext("complete-$parameters.field.name", executionList, throwableList, useOnDispatch)
     }
 
     @Override
     InstrumentationContext<CompletableFuture<ExecutionResult>> beginFieldListComplete(InstrumentationFieldCompleteParameters parameters) {
-        assert parameters.getInstrumentationState() == instrumentationState
+        assert parameters.getInstrumentationState() == instrumentationState // Retain for test coverage
         return new TestingInstrumentContext("complete-list-$parameters.field.name", executionList, throwableList, useOnDispatch)
     }
 
     @Override
     GraphQLSchema instrumentSchema(GraphQLSchema schema, InstrumentationExecutionParameters parameters) {
-        assert parameters.getInstrumentationState() == instrumentationState
+        assert parameters.getInstrumentationState() == instrumentationState // Retain for test coverage
         return schema
     }
 
     @Override
     ExecutionInput instrumentExecutionInput(ExecutionInput executionInput, InstrumentationExecutionParameters parameters) {
-        assert parameters.getInstrumentationState() == instrumentationState
+        assert parameters.getInstrumentationState() == instrumentationState // Retain for test coverage
         return executionInput
     }
 
     @Override
     ExecutionContext instrumentExecutionContext(ExecutionContext executionContext, InstrumentationExecutionParameters parameters) {
-        assert parameters.getInstrumentationState() == instrumentationState
+        assert parameters.getInstrumentationState() == instrumentationState // Retain for test coverage
         return executionContext
     }
 
     @Override
     DataFetcher<?> instrumentDataFetcher(DataFetcher<?> dataFetcher, InstrumentationFieldFetchParameters parameters) {
-        assert parameters.getInstrumentationState() == instrumentationState
+        assert parameters.getInstrumentationState() == instrumentationState // Retain for test coverage
         dfClasses.add(dataFetcher.getClass())
         return new DataFetcher<Object>() {
             @Override
@@ -130,7 +130,7 @@ class LegacyTestingInstrumentation implements Instrumentation {
 
     @Override
     CompletableFuture<ExecutionResult> instrumentExecutionResult(ExecutionResult executionResult, InstrumentationExecutionParameters parameters) {
-        assert parameters.getInstrumentationState() == instrumentationState
+        assert parameters.getInstrumentationState() == instrumentationState // Retain for test coverage
         return CompletableFuture.completedFuture(executionResult)
     }
 }

--- a/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentationTest.groovy
@@ -14,7 +14,7 @@ import graphql.execution.instrumentation.SimpleInstrumentation
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters
 import graphql.schema.DataFetcher
 import org.dataloader.BatchLoader
-import org.dataloader.DataLoader
+import org.dataloader.DataLoaderFactory
 import org.dataloader.DataLoaderRegistry
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -38,7 +38,6 @@ class DataLoaderDispatcherInstrumentationTest extends Specification {
             return super.execute(executionContext, parameters)
         }
     }
-
 
     def query = """
         query {
@@ -104,7 +103,7 @@ class DataLoaderDispatcherInstrumentationTest extends Specification {
                 super.dispatchAll()
             }
         }
-        def dataLoader = DataLoader.newDataLoader(new BatchLoader() {
+        def dataLoader = DataLoaderFactory.newDataLoader(new BatchLoader() {
             @Override
             CompletionStage<List> load(List keys) {
                 return CompletableFuture.completedFuture(keys)
@@ -127,7 +126,7 @@ class DataLoaderDispatcherInstrumentationTest extends Specification {
         def starWarsWiring = new StarWarsDataLoaderWiring()
 
 
-        DataLoaderRegistry startingDataLoaderRegistry = new DataLoaderRegistry();
+        DataLoaderRegistry startingDataLoaderRegistry = new DataLoaderRegistry()
         def enhancedDataLoaderRegistry = starWarsWiring.newDataLoaderRegistry()
 
         def dlInstrumentation = new DataLoaderDispatcherInstrumentation()
@@ -274,7 +273,7 @@ class DataLoaderDispatcherInstrumentationTest extends Specification {
         BatchLoader batchLoader = { keys -> CompletableFuture.completedFuture(keys) }
 
         DataFetcher df = { env ->
-            def dataLoader = env.getDataLoaderRegistry().computeIfAbsent("key", { key -> DataLoader.newDataLoader(batchLoader) })
+            def dataLoader = env.getDataLoaderRegistry().computeIfAbsent("key", { key -> DataLoaderFactory.newDataLoader(batchLoader) })
 
             return dataLoader.load("working as expected")
         }

--- a/src/test/groovy/graphql/introspection/IntrospectionTest.groovy
+++ b/src/test/groovy/graphql/introspection/IntrospectionTest.groovy
@@ -421,7 +421,7 @@ class IntrospectionTest extends Specification {
                                                         .name("inputField")
                                                         .type(GraphQLString))
                                                 .build())
-                                        .defaultValue(new FooBar())
+                                        .defaultValue(new FooBar()) // Retain for test coverage. There is no alternative method that sets an internal value.
                                 )
                         )
                 )

--- a/src/test/groovy/graphql/schema/DataFetchingEnvironmentImplTest.groovy
+++ b/src/test/groovy/graphql/schema/DataFetchingEnvironmentImplTest.groovy
@@ -11,7 +11,7 @@ import graphql.language.OperationDefinition
 import graphql.language.StringValue
 import graphql.language.TypeName
 import org.dataloader.BatchLoader
-import org.dataloader.DataLoader
+import org.dataloader.DataLoaderFactory
 import org.dataloader.DataLoaderRegistry
 import spock.lang.Specification
 
@@ -27,7 +27,7 @@ class DataFetchingEnvironmentImplTest extends Specification {
 
     def frag = FragmentDefinition.newFragmentDefinition().name("frag").typeCondition(new TypeName("t")).build()
 
-    def dataLoader = DataLoader.newDataLoader({ keys -> CompletableFuture.completedFuture(keys) } as BatchLoader)
+    def dataLoader = DataLoaderFactory.newDataLoader({ keys -> CompletableFuture.completedFuture(keys) } as BatchLoader)
     def operationDefinition = new OperationDefinition("q")
     def document = toDocument("{ f }")
     def executionId = ExecutionId.from("123")

--- a/src/test/groovy/graphql/schema/GraphQLArgumentTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLArgumentTest.groovy
@@ -1,12 +1,18 @@
 package graphql.schema
 
+import graphql.collect.ImmutableKit
 import graphql.language.FloatValue
+import graphql.schema.validation.InvalidSchemaException
 import spock.lang.Specification
 
 import static graphql.Scalars.GraphQLFloat
 import static graphql.Scalars.GraphQLInt
 import static graphql.Scalars.GraphQLString
+import static graphql.schema.GraphQLArgument.newArgument
 import static graphql.schema.GraphQLDirective.newDirective
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
+import static graphql.schema.GraphQLObjectType.newObject
+import static graphql.schema.GraphQLSchema.newSchema
 
 class GraphQLArgumentTest extends Specification {
 
@@ -187,6 +193,28 @@ class GraphQLArgumentTest extends Specification {
         inputDefaultValue.isNotSet()
         inputDefaultValue.getValue() == null
         resolvedDefaultValue == null
+    }
+
+    def "Applied schema directives arguments are validated for programmatic schemas"() {
+        given:
+        def arg = newArgument().name("arg").type(GraphQLInt).valueProgrammatic(ImmutableKit.emptyMap()).build() // Retain for test coverage
+        def directive = GraphQLDirective.newDirective().name("cached").argument(arg).build()
+        def field = newFieldDefinition()
+                .name("hello")
+                .type(GraphQLString)
+                .argument(arg)
+                .withDirective(directive)
+                .build()
+        when:
+        newSchema().query(
+                newObject()
+                        .name("Query")
+                        .field(field)
+                        .build())
+                .build()
+        then:
+        def e = thrown(InvalidSchemaException)
+        e.message.contains("Invalid argument 'arg' for applied directive of name 'cached'")
     }
 
 }

--- a/src/test/groovy/graphql/schema/GraphQLFieldDefinitionTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLFieldDefinitionTest.groovy
@@ -1,15 +1,20 @@
 package graphql.schema
 
 import graphql.AssertException
+import graphql.TestUtil
+import graphql.schema.idl.SchemaPrinter
 import spock.lang.Specification
 
 import static graphql.Scalars.GraphQLBoolean
 import static graphql.Scalars.GraphQLFloat
 import static graphql.Scalars.GraphQLInt
 import static graphql.Scalars.GraphQLString
+import static graphql.TestUtil.mockArguments
+import static graphql.schema.DefaultGraphqlTypeComparatorRegistry.newComparators
 import static graphql.schema.GraphQLArgument.newArgument
 import static graphql.schema.GraphQLDirective.newDirective
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
+import static graphql.schema.idl.SchemaPrinter.Options.defaultOptions
 
 class GraphQLFieldDefinitionTest extends Specification {
 
@@ -76,5 +81,20 @@ class GraphQLFieldDefinitionTest extends Specification {
         transformedField.getDirective("directive1") != null
         transformedField.getDirective("directive2") != null
         transformedField.getDirective("directive3") != null
+    }
+
+    def "test deprecated argument builder for list"() {
+        given:
+        def field = newFieldDefinition().name("field").type(GraphQLInt).argument(mockArguments("a", "bb")).build() // Retain for test coverage
+
+        when:
+        def registry = newComparators()
+                .addComparator({ it.parentType(GraphQLFieldDefinition.class).elementType(GraphQLArgument.class) }, GraphQLArgument.class, TestUtil.byGreatestLength)
+                .build()
+        def options = defaultOptions().setComparators(registry)
+        def printer = new SchemaPrinter(options)
+
+        then:
+        printer.argsString(GraphQLFieldDefinition.class, field.arguments) == '''(bb: Int, a: Int)'''
     }
 }

--- a/src/test/groovy/graphql/schema/GraphQLInterfaceTypeTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLInterfaceTypeTest.groovy
@@ -24,7 +24,6 @@ class GraphQLInterfaceTypeTest extends Specification {
                         newFieldDefinition().name("NAME").type(GraphQLString).build(),
                         newFieldDefinition().name("NAME").type(GraphQLInt).build()
                 ])
-                .typeResolver(new TypeResolverProxy())
                 .build()
         then:
         interfaceType.getName() == "TestInterfaceType"
@@ -37,7 +36,6 @@ class GraphQLInterfaceTypeTest extends Specification {
                 .description("StartingDescription")
                 .field(newFieldDefinition().name("Str").type(GraphQLString))
                 .field(newFieldDefinition().name("Int").type(GraphQLInt))
-                .typeResolver(new TypeResolverProxy())
                 .build()
 
         when:
@@ -106,5 +104,20 @@ class GraphQLInterfaceTypeTest extends Specification {
 
         then:
         noExceptionThrown()
+    }
+
+    def "deprecated typeResolver builder works"() {
+        when:
+        def interfaceType = newInterface().name("TestInterfaceType")
+                .description("description")
+                .fields([
+                        newFieldDefinition().name("NAME").type(GraphQLString).build(),
+                        newFieldDefinition().name("NAME").type(GraphQLInt).build()
+                ])
+                .typeResolver(new TypeResolverProxy()) // Retain for test coverage
+                .build()
+        then:
+        interfaceType.getName() == "TestInterfaceType"
+        interfaceType.getFieldDefinition("NAME").getType() == GraphQLInt
     }
 }

--- a/src/test/groovy/graphql/schema/GraphQLUnionTypeTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLUnionTypeTest.groovy
@@ -14,7 +14,6 @@ class GraphQLUnionTypeTest extends Specification {
         when:
         newUnionType()
                 .name("TestUnionType")
-                .typeResolver(new TypeResolverProxy())
                 .build()
         then:
         thrown(AssertException)
@@ -38,7 +37,6 @@ class GraphQLUnionTypeTest extends Specification {
                 .description("StartingDescription")
                 .possibleType(objType1)
                 .possibleType(objType2)
-                .typeResolver(new TypeResolverProxy())
                 .build()
 
         when:
@@ -65,4 +63,13 @@ class GraphQLUnionTypeTest extends Specification {
         transformedUnion.isPossibleType(objType3)
     }
 
+    def "deprecated typeResolver builder works"() {
+        when:
+        newUnionType()
+                .name("TestUnionType")
+                .typeResolver(new TypeResolverProxy()) // Retain for test coverage
+                .build()
+        then:
+        thrown(AssertException)
+    }
 }

--- a/src/test/groovy/graphql/schema/SchemaPrinterComparatorsTest.groovy
+++ b/src/test/groovy/graphql/schema/SchemaPrinterComparatorsTest.groovy
@@ -534,7 +534,7 @@ scalar TestScalar @bb(bb : 0, a : 0) @a(bb : 0, a : 0)
 
     def "argsString uses most specific registered comparators"() {
         given:
-        def field = newFieldDefinition().name("field").type(GraphQLInt).argument(mockArguments("a", "bb")).build()
+        def field = newFieldDefinition().name("field").type(GraphQLInt).arguments(mockArguments("a", "bb")).build()
 
         when:
         def registry = newComparators()
@@ -549,7 +549,7 @@ scalar TestScalar @bb(bb : 0, a : 0) @a(bb : 0, a : 0)
 
     def "argsString uses least specific registered comparators"() {
         given:
-        def field = newFieldDefinition().name("field").type(GraphQLInt).argument(mockArguments("a", "bb")).build()
+        def field = newFieldDefinition().name("field").type(GraphQLInt).arguments(mockArguments("a", "bb")).build()
 
         when:
         def registry = newComparators()

--- a/src/test/groovy/graphql/schema/SchemaTraverserTest.groovy
+++ b/src/test/groovy/graphql/schema/SchemaTraverserTest.groovy
@@ -1,7 +1,6 @@
 package graphql.schema
 
 import graphql.Scalars
-import graphql.TypeResolutionEnvironment
 import graphql.util.TraversalControl
 import graphql.util.TraverserContext
 import spock.lang.Specification
@@ -117,7 +116,6 @@ class SchemaTraverserTest extends Specification {
                         .name("bar")
                         .type(Scalars.GraphQLString)
                         .build())
-                .typeResolver(NOOP_RESOLVER)
                 .build())
         then:
         visitor.getStack() == ["interface: foo", "fallback: foo",
@@ -155,7 +153,6 @@ class SchemaTraverserTest extends Specification {
                         .build())
                 .withInterface(GraphQLInterfaceType.newInterface()
                         .name("bar")
-                        .typeResolver(NOOP_RESOLVER)
                         .build())
                 .build())
         then:
@@ -181,7 +178,6 @@ class SchemaTraverserTest extends Specification {
                 .name("foo")
                 .possibleType(GraphQLObjectType.newObject().name("dummy").build())
                 .possibleType(typeRef("dummyRef"))
-                .typeResolver(NOOP_RESOLVER)
                 .build())
         then:
         visitor.getStack() == ["union: foo", "fallback: foo",
@@ -193,21 +189,21 @@ class SchemaTraverserTest extends Specification {
         when:
         def visitor = new GraphQLTestingVisitor()
         def coercing = new Coercing() {
-            private static final String TEST_ONLY = "For testing only";
+            private static final String TEST_ONLY = "For testing only"
 
             @Override
             Object serialize(Object dataFetcherResult) throws CoercingSerializeException {
-                throw new UnsupportedOperationException(TEST_ONLY);
+                throw new UnsupportedOperationException(TEST_ONLY)
             }
 
             @Override
             Object parseValue(Object input) throws CoercingParseValueException {
-                throw new UnsupportedOperationException(TEST_ONLY);
+                throw new UnsupportedOperationException(TEST_ONLY)
             }
 
             @Override
             Object parseLiteral(Object input) throws CoercingParseLiteralException {
-                throw new UnsupportedOperationException(TEST_ONLY);
+                throw new UnsupportedOperationException(TEST_ONLY)
             }
         }
         def scalarType = GraphQLScalarType.newScalar()
@@ -283,7 +279,6 @@ class SchemaTraverserTest extends Specification {
         def visitor = new GraphQLTestingVisitor()
         def interfaceType = GraphQLInterfaceType.newInterface()
                 .name("foo")
-                .typeResolver(NOOP_RESOLVER)
                 .withDirective(GraphQLDirective.newDirective()
                         .name("bar"))
                 .withAppliedDirective(GraphQLAppliedDirective.newDirective()
@@ -302,7 +297,6 @@ class SchemaTraverserTest extends Specification {
         def unionType = GraphQLUnionType.newUnionType()
                 .name("foo")
                 .possibleType(GraphQLObjectType.newObject().name("dummy").build())
-                .typeResolver(NOOP_RESOLVER)
                 .withDirective(GraphQLDirective.newDirective()
                         .name("bar"))
                 .build()
@@ -387,15 +381,6 @@ class SchemaTraverserTest extends Specification {
         ]
 
     }
-
-
-    def NOOP_RESOLVER = new TypeResolver() {
-        @Override
-        GraphQLObjectType getType(TypeResolutionEnvironment env) {
-            return null
-        }
-    }
-
 
     class GraphQLTestingVisitor extends GraphQLTypeVisitorStub {
 

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorDirectiveHelperTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorDirectiveHelperTest.groovy
@@ -11,9 +11,9 @@ import graphql.schema.CoercingSerializeException
 import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironment
 import graphql.schema.FieldCoordinates
+import graphql.schema.GraphQLAppliedDirective
 import graphql.schema.GraphQLArgument
 import graphql.schema.GraphQLCodeRegistry
-import graphql.schema.GraphQLDirective
 import graphql.schema.GraphQLEnumType
 import graphql.schema.GraphQLEnumValueDefinition
 import graphql.schema.GraphQLFieldDefinition
@@ -110,14 +110,12 @@ class SchemaGeneratorDirectiveHelperTest extends Specification {
                 indirectInputField1 : InputType @inputFieldDirective(target : "indirectInputField1")
             }
                 
-            
             enum EnumType @enumDirective(target:"EnumType") {
                 enumVal1 @enumValueDirective(target : "enumVal1")
                 enumVal2 @enumValueDirective(target : "enumVal2")
             }
             
             scalar ScalarType @scalarDirective(target:"ScalarType")
-            
         '''
 
         //`this contains the name of the element that was asked to be directive wired
@@ -142,8 +140,9 @@ class SchemaGeneratorDirectiveHelperTest extends Specification {
                 fieldsContainers[name] = environment.getFieldsContainer()?.getName()
                 fieldDefinitions[name] = environment.getFieldDefinition()?.getName()
 
-                GraphQLDirective directive = environment.getDirective()
-                def arg = directive.getArgument("target")
+                GraphQLAppliedDirective appliedDirective = environment.getAppliedDirective()
+                def arg = appliedDirective.getArgument("target")
+
                 String target = ValuesResolver.valueToInternalValue(arg.getArgumentValue(), arg.getType(), GraphQLContext.getDefault(), Locale.getDefault())
                 assert name == target, " The target $target is not equal to the object name $name"
                 return element
@@ -328,7 +327,7 @@ class SchemaGeneratorDirectiveHelperTest extends Specification {
                 // we use the non shortcut path to the data fetcher here so prove it still works
                 def fetcher = directiveEnv.getCodeRegistry().getDataFetcher(directiveEnv.fieldsContainer, field)
                 def newFetcher = wrapDataFetcher(fetcher, { dfEnv, value ->
-                    def directiveName = directiveEnv.directive.name
+                    def directiveName = directiveEnv.appliedDirective.name
                     if (directiveName == "uppercase") {
                         return String.valueOf(value).toUpperCase()
                     } else if (directiveName == "lowercase") {
@@ -620,7 +619,7 @@ class SchemaGeneratorDirectiveHelperTest extends Specification {
         def namedWiring = new SchemaDirectiveWiring() {
             @Override
             GraphQLFieldDefinition onField(SchemaDirectiveWiringEnvironment<GraphQLFieldDefinition> environment) {
-                GraphQLDirective directive = environment.getDirective()
+                GraphQLAppliedDirective directive = environment.getAppliedDirective()
                 DataFetcher existingFetcher = environment.getFieldDataFetcher()
 
                 DataFetcher newDF = new DataFetcher() {
@@ -684,7 +683,7 @@ class SchemaGeneratorDirectiveHelperTest extends Specification {
             @Override
             GraphQLFieldDefinition onField(SchemaDirectiveWiringEnvironment<GraphQLFieldDefinition> env) {
                 generalCount++
-                def directiveNames = env.getDirectives().values().collect { d -> d.getName() }.sort()
+                def directiveNames = env.getAppliedDirectives().values().collect { d -> d.getName() }.sort()
                 assert directiveNames == ["factoryDirective", "generalDirective", "namedDirective1", "namedDirective2"]
                 return env.getFieldDefinition()
             }
@@ -694,7 +693,7 @@ class SchemaGeneratorDirectiveHelperTest extends Specification {
             @Override
             GraphQLFieldDefinition onField(SchemaDirectiveWiringEnvironment<GraphQLFieldDefinition> env) {
                 factoryCount++
-                def directiveNames = env.getDirectives().values().collect { d -> d.getName() }.sort()
+                def directiveNames = env.getAppliedDirectives().values().collect { d -> d.getName() }.sort()
                 assert directiveNames == ["factoryDirective", "generalDirective", "namedDirective1", "namedDirective2"]
                 return env.getFieldDefinition()
             }
@@ -716,10 +715,10 @@ class SchemaGeneratorDirectiveHelperTest extends Specification {
             @Override
             GraphQLFieldDefinition onField(SchemaDirectiveWiringEnvironment<GraphQLFieldDefinition> env) {
                 namedCount++
-                def directiveNames = env.getDirectives().values().collect { d -> d.getName() }.sort()
+                def directiveNames = env.getAppliedDirectives().values().collect { d -> d.getName() }.sort()
                 assert directiveNames == ["factoryDirective", "generalDirective", "namedDirective1", "namedDirective2"]
 
-                assert env.getDirective("factoryDirective") != null
+                assert env.getAppliedDirective("factoryDirective") != null
                 assert env.containsDirective("factoryDirective")
                 return env.getFieldDefinition()
             }
@@ -776,11 +775,11 @@ class SchemaGeneratorDirectiveHelperTest extends Specification {
                 argCount++
                 def arg = env.getElement()
                 if (arg.getName() == "arg1") {
-                    assert env.getDirectives().keySet().sort() == ["argDirective1", "argDirective2"]
+                    assert env.getAppliedDirectives().keySet().sort() == ["argDirective1", "argDirective2"]
                     assert env.getAppliedDirectives().keySet().sort() == ["argDirective1", "argDirective2"]
                 }
                 if (arg.getName() == "arg2") {
-                    assert env.getDirectives().keySet().sort() == ["argDirective3"]
+                    assert env.getAppliedDirectives().keySet().sort() == ["argDirective3"]
                     assert env.getAppliedDirectives().keySet().sort() == ["argDirective3"]
                 }
                 def fieldDef = env.getFieldDefinition()
@@ -794,7 +793,7 @@ class SchemaGeneratorDirectiveHelperTest extends Specification {
             GraphQLFieldDefinition onField(SchemaDirectiveWiringEnvironment<GraphQLFieldDefinition> env) {
                 fieldCount++
 
-                assert env.getDirectives().keySet().sort() == ["fieldDirective"]
+                assert env.getAppliedDirectives().keySet().sort() == ["fieldDirective"]
 
                 def fieldDef = env.getFieldDefinition()
                 assert fieldDef.getDirectives().collect({ d -> d.getName() }) == ["fieldDirective"]

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -8,6 +8,7 @@ import graphql.schema.DataFetcher
 import graphql.schema.DataFetcherFactory
 import graphql.schema.DataFetcherFactoryEnvironment
 import graphql.schema.DataFetchingEnvironment
+import graphql.schema.GraphQLAppliedDirective
 import graphql.schema.GraphQLArgument
 import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLDirective
@@ -27,7 +28,6 @@ import graphql.schema.GraphQLType
 import graphql.schema.GraphQLTypeUtil
 import graphql.schema.GraphQLUnionType
 import graphql.schema.GraphqlTypeComparatorRegistry
-import graphql.schema.PropertyDataFetcher
 import graphql.schema.idl.errors.NotAnInputTypeError
 import graphql.schema.idl.errors.NotAnOutputTypeError
 import graphql.schema.idl.errors.SchemaProblem
@@ -1310,8 +1310,7 @@ class SchemaGeneratorTest extends Specification {
         def fieldDirective2 = field2.getDirectives()[0]
         fieldDirective2.getName() == "fieldDirective2"
 
-
-        def directive = type.getDirectives()[3] as GraphQLDirective
+        def directive = type.getAppliedDirectives()[3] as GraphQLAppliedDirective
         directive.name == "directiveWithArgs"
         directive.arguments.size() == 5
 
@@ -1634,13 +1633,14 @@ class SchemaGeneratorTest extends Specification {
         argInt.getDirective("thirdDirective") != null
 
         def intDirective = argInt.getDirective("intDirective")
-        intDirective.name == "intDirective"
-        intDirective.arguments.size() == 1
-        def directiveArg = intDirective.getArgument("inception")
+        def intAppliedDirective = argInt.getAppliedDirective("intDirective")
+        intAppliedDirective.name == "intDirective"
+        intAppliedDirective.arguments.size() == 1
+        def directiveArg = intAppliedDirective.getArgument("inception")
         directiveArg.name == "inception"
         directiveArg.type == GraphQLBoolean
         printAst(directiveArg.argumentValue.value as Node) == "true"
-        directiveArg.argumentDefaultValue.value == null
+        intDirective.getArgument("inception").argumentDefaultValue.value == null
     }
 
     def "directives definitions can be made"() {
@@ -1702,13 +1702,15 @@ class SchemaGeneratorTest extends Specification {
         then:
         def directiveTest1 = schema.getDirective("test1")
         GraphQLNonNull.nonNull(GraphQLBoolean).isEqualTo(directiveTest1.getArgument("include").type)
-        directiveTest1.getArgument("include").argumentValue.value == null
+        directiveTest1.getArgument("include").argumentDefaultValue.value == null
+        def appliedDirective1 = schema.getObjectType("Query").getFieldDefinition("f1").getAppliedDirective("test1")
+        printAst(appliedDirective1.getArgument("include").argumentValue.value as Node) == "false"
 
         def directiveTest2 = schema.getDirective("test2")
         GraphQLNonNull.nonNull(GraphQLBoolean).isEqualTo(directiveTest2.getArgument("include").type)
-        printAst(directiveTest2.getArgument("include").argumentValue.value as Node) == "true"
         printAst(directiveTest2.getArgument("include").argumentDefaultValue.value as Node) == "true"
-
+        def appliedDirective2 = schema.getObjectType("Query").getFieldDefinition("f2").getAppliedDirective("test2")
+        printAst(appliedDirective2.getArgument("include").argumentValue.value as Node) == "true"
     }
 
     def "missing directive arguments are transferred as are default values"() {
@@ -1733,16 +1735,17 @@ class SchemaGeneratorTest extends Specification {
         then:
         def directive = schema.getObjectType("Query").getFieldDefinition("f").getDirective("testDirective")
         directive.getArgument("knownArg1").type == GraphQLString
-        printAst(directive.getArgument("knownArg1").argumentValue.value as Node) == '"overrideVal1"'
         printAst(directive.getArgument("knownArg1").argumentDefaultValue.value as Node) == '"defaultValue1"'
+        def appliedDirective = schema.getObjectType("Query").getFieldDefinition("f").getAppliedDirective("testDirective")
+        printAst(appliedDirective.getArgument("knownArg1").argumentValue.value as Node) == '"overrideVal1"'
 
         directive.getArgument("knownArg2").type == GraphQLInt
-        printAst(directive.getArgument("knownArg2").argumentValue.value as Node) == "666"
         printAst(directive.getArgument("knownArg2").argumentDefaultValue.value as Node) == "666"
+        printAst(appliedDirective.getArgument("knownArg2").argumentValue.value as Node) == "666"
 
         directive.getArgument("knownArg3").type == GraphQLString
-        directive.getArgument("knownArg3").argumentValue.value == null
         directive.getArgument("knownArg3").argumentDefaultValue.value == null
+        appliedDirective.getArgument("knownArg3").argumentValue.value == null
     }
 
     def "deprecated directive is implicit"() {
@@ -1765,11 +1768,13 @@ class SchemaGeneratorTest extends Specification {
         f1.getDeprecationReason() == "No longer supported" // spec default text
 
         def directive = f1.getDirective("deprecated")
-        directive.name == "deprecated"
-        directive.getArgument("reason").type == GraphQLString
-        printAst(directive.getArgument("reason").argumentValue.value as Node) == '"No longer supported"'
         printAst(directive.getArgument("reason").argumentDefaultValue.value as Node) == '"No longer supported"'
         directive.validLocations().collect { it.name() } == [Introspection.DirectiveLocation.FIELD_DEFINITION.name()]
+
+        def appliedDirective = f1.getAppliedDirective("deprecated")
+        appliedDirective.name == "deprecated"
+        appliedDirective.getArgument("reason").type == GraphQLString
+        printAst(appliedDirective.getArgument("reason").argumentValue.value as Node) == '"No longer supported"'
 
         when:
         def f2 = schema.getObjectType("Query").getFieldDefinition("f2")
@@ -1777,13 +1782,13 @@ class SchemaGeneratorTest extends Specification {
         then:
         f2.getDeprecationReason() == "Just because"
 
+        def appliedDirective2 = f2.getAppliedDirective("deprecated")
+        appliedDirective2.name == "deprecated"
+        appliedDirective2.getArgument("reason").type == GraphQLString
+        printAst(appliedDirective2.getArgument("reason").argumentValue.value as Node) == '"Just because"'
         def directive2 = f2.getDirective("deprecated")
-        directive2.name == "deprecated"
-        directive2.getArgument("reason").type == GraphQLString
-        printAst(directive2.getArgument("reason").argumentValue.value as Node) == '"Just because"'
         printAst(directive2.getArgument("reason").argumentDefaultValue.value as Node) == '"No longer supported"'
         directive2.validLocations().collect { it.name() } == [Introspection.DirectiveLocation.FIELD_DEFINITION.name()]
-
     }
 
     def "does not break for circular references to interfaces"() {

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -1366,7 +1366,7 @@ class SchemaGeneratorTest extends Specification {
 
         expect:
 
-        container.getDirective(directiveName) != null
+        container.getAppliedDirective(directiveName) != null
 
         if (container instanceof GraphQLEnumType) {
             def evd = ((GraphQLEnumType) container).getValue("X").getDirective("EnumValueDirective")
@@ -2027,16 +2027,16 @@ class SchemaGeneratorTest extends Specification {
         schema.getMutationType().name == 'Mutation'
 
         when:
-        def directives = schema.getSchemaDirectives()
+        def directives = schema.getSchemaDirectives() // Retain for test coverage
 
         then:
         directives.size() == 3
-        schema.getSchemaDirective("sd1") != null
-        schema.getSchemaDirective("sd2") != null
-        schema.getSchemaDirective("sd3") != null
+        schema.getSchemaDirective("sd1") != null // Retain for test coverage
+        schema.getSchemaDirective("sd2") != null // Retain for test coverage
+        schema.getSchemaDirective("sd3") != null // Retain for test coverage
 
         when:
-        def directivesMap = schema.getSchemaDirectiveByName()
+        def directivesMap = schema.getSchemaDirectiveByName() // Retain for test coverage
         then:
         directives.size() == 3
         directivesMap["sd1"] != null

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -428,12 +428,19 @@ enum Enum {
                 .name("Union")
                 .description("About union")
                 .possibleType(possibleType)
-                .typeResolver({ it -> null })
                 .build()
         GraphQLFieldDefinition fieldDefinition2 = newFieldDefinition()
                 .name("field").type(unionType).build()
+
+        def codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .typeResolver(unionType, { it -> null })
+                .build()
         def queryType = newObject().name("Query").field(fieldDefinition2).build()
-        def schema = GraphQLSchema.newSchema().query(queryType).build()
+        def schema = GraphQLSchema.newSchema()
+                .codeRegistry(codeRegistry)
+                .query(queryType)
+                .build()
+
         when:
         def result = new SchemaPrinter(noDirectivesOption).print(schema)
 
@@ -463,12 +470,19 @@ type Query {
                 .name("Union")
                 .possibleType(possibleType1)
                 .possibleType(possibleType2)
-                .typeResolver({ it -> null })
                 .build()
         GraphQLFieldDefinition fieldDefinition2 = newFieldDefinition()
                 .name("field").type(unionType).build()
+
+        def codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .typeResolver(unionType, { it -> null })
+                .build()
         def queryType = newObject().name("Query").field(fieldDefinition2).build()
-        def schema = GraphQLSchema.newSchema().query(queryType).build()
+        def schema = GraphQLSchema.newSchema()
+                .codeRegistry(codeRegistry)
+                .query(queryType)
+                .build()
+
         when:
         def result = new SchemaPrinter(noDirectivesOption).print(schema)
 
@@ -526,12 +540,19 @@ input Input {
                 .name("Interface")
                 .description("about interface")
                 .field(newFieldDefinition().name("field").description("about field").type(GraphQLString).build())
-                .typeResolver({ it -> null })
                 .build()
         GraphQLFieldDefinition fieldDefinition = newFieldDefinition()
                 .name("field").type(graphQLInterfaceType).build()
+
+        def codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .typeResolver(graphQLInterfaceType, { it -> null })
+                .build()
         def queryType = newObject().name("Query").field(fieldDefinition).build()
-        def schema = GraphQLSchema.newSchema().query(queryType).build()
+        def schema = GraphQLSchema.newSchema()
+                .codeRegistry(codeRegistry)
+                .query(queryType)
+                .build()
+
         when:
         def result = new SchemaPrinter(noDirectivesOption).print(schema)
 
@@ -851,7 +872,6 @@ type Query {
 }
 '''
     }
-
 
     def idlWithDirectives() {
         return """

--- a/src/test/groovy/graphql/schema/transform/FieldVisibilitySchemaTransformationTest.groovy
+++ b/src/test/groovy/graphql/schema/transform/FieldVisibilitySchemaTransformationTest.groovy
@@ -2,7 +2,7 @@ package graphql.schema.transform
 
 import graphql.Scalars
 import graphql.TestUtil
-import graphql.introspection.Introspection
+import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLDirectiveContainer
 import graphql.schema.GraphQLInputObjectType
 import graphql.schema.GraphQLObjectType
@@ -957,10 +957,14 @@ class FieldVisibilitySchemaTransformationTest extends Specification {
         def secretData = newInterface()
                 .name("SuperSecretCustomerData")
                 .field(newFieldDefinition().name("id").type(Scalars.GraphQLString).build())
-                .typeResolver(Mock(TypeResolver))
+                .build()
+
+        def codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .typeResolver(secretData, Mock(TypeResolver))
                 .build()
 
         def schema = GraphQLSchema.newSchema()
+                .codeRegistry(codeRegistry)
                 .query(query)
                 .additionalType(billingStatus)
                 .additionalType(account)
@@ -1003,10 +1007,14 @@ class FieldVisibilitySchemaTransformationTest extends Specification {
         def secretData = newInterface()
                 .name("SuperSecretCustomerData")
                 .field(newFieldDefinition().name("id").type(Scalars.GraphQLString).build())
-                .typeResolver(Mock(TypeResolver))
+                .build()
+
+        def codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .typeResolver(secretData, Mock(TypeResolver))
                 .build()
 
         def schema = GraphQLSchema.newSchema()
+                .codeRegistry(codeRegistry)
                 .query(query)
                 .additionalType(billingStatus)
                 .additionalType(account)

--- a/src/test/groovy/graphql/schema/transform/FieldVisibilitySchemaTransformationTest.groovy
+++ b/src/test/groovy/graphql/schema/transform/FieldVisibilitySchemaTransformationTest.groovy
@@ -2,6 +2,7 @@ package graphql.schema.transform
 
 import graphql.Scalars
 import graphql.TestUtil
+import graphql.schema.GraphQLAppliedDirective
 import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLDirectiveContainer
 import graphql.schema.GraphQLInputObjectType
@@ -11,7 +12,6 @@ import graphql.schema.TypeResolver
 import graphql.schema.idl.SchemaPrinter
 import spock.lang.Specification
 
-import static graphql.schema.GraphQLDirective.newDirective
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
 import static graphql.schema.GraphQLInterfaceType.newInterface
 import static graphql.schema.GraphQLObjectType.newObject
@@ -20,7 +20,7 @@ import static graphql.schema.GraphQLTypeReference.typeRef
 class FieldVisibilitySchemaTransformationTest extends Specification {
 
     def visibilitySchemaTransformation = new FieldVisibilitySchemaTransformation({ environment ->
-        def directives = (environment.schemaElement as GraphQLDirectiveContainer).directives
+        def directives = (environment.schemaElement as GraphQLDirectiveContainer).appliedDirectives
         return directives.find({ directive -> directive.name == "private" }) == null
     })
 
@@ -941,11 +941,11 @@ class FieldVisibilitySchemaTransformationTest extends Specification {
                 .field(newFieldDefinition().name("account").type(typeRef("Account")).build())
                 .build()
 
-        def privateDirective = newDirective().name("private").build()
+        def privateDirective = GraphQLAppliedDirective.newDirective().name("private").build()
         def account = newObject()
                 .name("Account")
                 .field(newFieldDefinition().name("name").type(Scalars.GraphQLString).build())
-                .field(newFieldDefinition().name("billingStatus").type(typeRef("SuperSecretCustomerData")).withDirective(privateDirective).build())
+                .field(newFieldDefinition().name("billingStatus").type(typeRef("SuperSecretCustomerData")).withAppliedDirective(privateDirective).build())
                 .build()
 
         def billingStatus = newObject()
@@ -970,7 +970,6 @@ class FieldVisibilitySchemaTransformationTest extends Specification {
                 .additionalType(account)
                 .additionalType(billingStatus)
                 .additionalType(secretData)
-                .additionalDirective(privateDirective)
                 .build()
         when:
 
@@ -991,11 +990,11 @@ class FieldVisibilitySchemaTransformationTest extends Specification {
                 .field(newFieldDefinition().name("account").type(typeRef("Account")).build())
                 .build()
 
-        def privateDirective = newDirective().name("private").build()
+        def privateDirective = GraphQLAppliedDirective.newDirective().name("private").build()
         def account = newObject()
                 .name("Account")
                 .field(newFieldDefinition().name("name").type(Scalars.GraphQLString).build())
-                .field(newFieldDefinition().name("billingStatus").type(typeRef("BillingStatus")).withDirective(privateDirective).build())
+                .field(newFieldDefinition().name("billingStatus").type(typeRef("BillingStatus")).withAppliedDirective(privateDirective).build())
                 .build()
 
         def billingStatus = newObject()
@@ -1020,7 +1019,6 @@ class FieldVisibilitySchemaTransformationTest extends Specification {
                 .additionalType(account)
                 .additionalType(billingStatus)
                 .additionalType(secretData)
-                .additionalDirective(privateDirective)
                 .build()
         when:
 
@@ -1040,11 +1038,11 @@ class FieldVisibilitySchemaTransformationTest extends Specification {
                 .field(newFieldDefinition().name("account").type(typeRef("Account")).build())
                 .build()
 
-        def privateDirective = newDirective().name("private").build()
+        def privateDirective = GraphQLAppliedDirective.newDirective().name("private").build()
         def account = newObject()
                 .name("Account")
                 .field(newFieldDefinition().name("name").type(Scalars.GraphQLString).build())
-                .field(newFieldDefinition().name("billingStatus").type(typeRef("BillingStatus")).withDirective(privateDirective).build())
+                .field(newFieldDefinition().name("billingStatus").type(typeRef("BillingStatus")).withAppliedDirective(privateDirective).build())
                 .build()
 
         def billingStatus = newObject()
@@ -1056,7 +1054,6 @@ class FieldVisibilitySchemaTransformationTest extends Specification {
                 .query(query)
                 .additionalType(billingStatus)
                 .additionalType(account)
-                .additionalDirective(privateDirective)
                 .build()
         when:
 
@@ -1074,7 +1071,7 @@ class FieldVisibilitySchemaTransformationTest extends Specification {
         def callbacks = []
 
         def visibilitySchemaTransformation = new FieldVisibilitySchemaTransformation({ environment ->
-            def directives = (environment.schemaElement as GraphQLDirectiveContainer).directives
+            def directives = (environment.schemaElement as GraphQLDirectiveContainer).appliedDirectives
             return directives.find({ directive -> directive.name == "private" }) == null
         }, { -> callbacks << "before" }, { -> callbacks << "after"} )
 

--- a/src/test/groovy/graphql/schema/validation/TypeAndFieldRuleTest.groovy
+++ b/src/test/groovy/graphql/schema/validation/TypeAndFieldRuleTest.groovy
@@ -1,6 +1,7 @@
 package graphql.schema.validation
 
 import graphql.TestUtil
+import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLTypeReference
 import graphql.schema.TypeResolverProxy
@@ -9,7 +10,6 @@ import spock.lang.Specification
 import static graphql.schema.GraphQLUnionType.newUnionType
 
 class TypeAndFieldRuleTest extends Specification {
-
 
     def "type must define one or more fields."() {
         when:
@@ -55,7 +55,6 @@ class TypeAndFieldRuleTest extends Specification {
         e.message == "invalid schema:\n\"InputType\" must define one or more fields."
     }
 
-
     def "field name must not begin with \"__\""() {
         when:
         def sdl = '''
@@ -93,8 +92,6 @@ class TypeAndFieldRuleTest extends Specification {
         e.message == "invalid schema:\n\"Interface\" must define one or more fields."
     }
 
-
-
     def "union member types must be object types"() {
         def sdl = '''
         type Query { dummy: String }
@@ -108,7 +105,10 @@ class TypeAndFieldRuleTest extends Specification {
         }
         '''
         when:
-        def graphQLSchema = TestUtil.schema(sdl)
+        def codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .typeResolver("Interface", { null })
+                .build()
+        def graphQLSchema = TestUtil.schema(sdl).transform({it.codeRegistry(codeRegistry)})
 
         // this is a little convoluted, since this rule is repeated in the schemaChecker
         // we add the invalid union after schema creation so we can cover the validation from
@@ -116,10 +116,11 @@ class TypeAndFieldRuleTest extends Specification {
         def unionType = newUnionType().name("unionWithNonObjectTypes")
                 .possibleType(graphQLSchema.getObjectType("Object"))
                 .possibleType(GraphQLTypeReference.typeRef("Interface"))
-                .typeResolver(new TypeResolverProxy())
                 .build()
-
-        graphQLSchema.transform({ schema -> schema.additionalType(unionType) })
+        codeRegistry = codeRegistry.transform({it.typeResolver(unionType, new TypeResolverProxy())})
+        graphQLSchema.transform({ schema -> schema
+                .additionalType(unionType)
+                .codeRegistry(codeRegistry)})
 
         then:
         InvalidSchemaException e = thrown(InvalidSchemaException)
@@ -149,10 +150,15 @@ class TypeAndFieldRuleTest extends Specification {
         def unionType = newUnionType().name("unionWithNonObjectTypes")
                 .possibleType(graphQLSchema.getObjectType("Object"))
                 .possibleType(stubObjectType)
-                .typeResolver(new TypeResolverProxy())
                 .build()
 
-        graphQLSchema.transform({ schema -> schema.additionalType(unionType) })
+        def codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .typeResolver(unionType, new TypeResolverProxy())
+                .build()
+
+        graphQLSchema.transform({ schema -> schema
+                .additionalType(unionType)
+                .codeRegistry(codeRegistry) })
 
         then:
         InvalidSchemaException e = thrown(InvalidSchemaException)

--- a/src/test/groovy/graphql/schema/validation/TypesImplementInterfacesTest.groovy
+++ b/src/test/groovy/graphql/schema/validation/TypesImplementInterfacesTest.groovy
@@ -1,9 +1,7 @@
 package graphql.schema.validation
 
-import graphql.TypeResolutionEnvironment
 import graphql.schema.GraphQLInterfaceType
 import graphql.schema.GraphQLObjectType
-import graphql.schema.TypeResolver
 import spock.lang.Specification
 
 import static SchemaValidationErrorType.ObjectDoesNotImplementItsInterfaces
@@ -19,13 +17,6 @@ import static graphql.schema.GraphQLObjectType.newObject
 import static graphql.schema.GraphQLUnionType.newUnionType
 
 class TypesImplementInterfacesTest extends Specification {
-
-    TypeResolver typeResolver = new TypeResolver() {
-        @Override
-        GraphQLObjectType getType(TypeResolutionEnvironment env) {
-            null
-        }
-    }
 
     GraphQLInterfaceType InterfaceType = newInterface()
             .name("Interface")
@@ -47,7 +38,6 @@ class TypesImplementInterfacesTest extends Specification {
             .argument(newArgument().name("arg2").type(GraphQLInt))
             .argument(newArgument().name("arg3").type(GraphQLBoolean))
     )
-            .typeResolver(typeResolver)
             .build()
 
     def "objects implement interfaces"() {
@@ -102,7 +92,6 @@ class TypesImplementInterfacesTest extends Specification {
         def person = newInterface()
                 .name("Person")
                 .field(newFieldDefinition().name("name").type(GraphQLString).build())
-                .typeResolver({})
                 .build()
 
         def actor = newObject()
@@ -119,7 +108,6 @@ class TypesImplementInterfacesTest extends Specification {
         GraphQLInterfaceType interfaceType = newInterface()
                 .name("TestInterface")
                 .field(newFieldDefinition().name("field").type(person).build())
-                .typeResolver({})
                 .build()
 
         GraphQLObjectType goodImpl = newObject()
@@ -151,7 +139,6 @@ class TypesImplementInterfacesTest extends Specification {
         def person = newInterface()
                 .name("Person")
                 .field(newFieldDefinition().name("name").type(GraphQLString).build())
-                .typeResolver({})
                 .build()
 
         def actor = newObject()
@@ -168,7 +155,6 @@ class TypesImplementInterfacesTest extends Specification {
         GraphQLInterfaceType interfaceType = newInterface()
                 .name("TestInterface")
                 .field(newFieldDefinition().name("field").type(list(person)).build())
-                .typeResolver({})
                 .build()
 
         GraphQLObjectType goodImpl = newObject()
@@ -200,7 +186,6 @@ class TypesImplementInterfacesTest extends Specification {
         def person = newInterface()
                 .name("Person")
                 .field(newFieldDefinition().name("name").type(GraphQLString).build())
-                .typeResolver({})
                 .build()
 
         def actor = newInterface()
@@ -217,7 +202,6 @@ class TypesImplementInterfacesTest extends Specification {
         GraphQLInterfaceType interfaceType = newInterface()
                 .name("TestInterface")
                 .field(newFieldDefinition().name("field").type(list(person)).build())
-                .typeResolver({})
                 .build()
 
         GraphQLObjectType goodImpl = newObject()
@@ -260,7 +244,6 @@ class TypesImplementInterfacesTest extends Specification {
                 .name("Person")
                 .possibleType(actor)
                 .possibleType(director)
-                .typeResolver({})
                 .build()
 
         def prop = newObject()
@@ -271,7 +254,6 @@ class TypesImplementInterfacesTest extends Specification {
         GraphQLInterfaceType interfaceType = newInterface()
                 .name("TestInterface")
                 .field(newFieldDefinition().name("field").type(person).build())
-                .typeResolver({})
                 .build()
 
         GraphQLObjectType goodImpl = newObject()
@@ -303,7 +285,6 @@ class TypesImplementInterfacesTest extends Specification {
         GraphQLInterfaceType interfaceType = newInterface()
                 .name("TestInterface")
                 .field(newFieldDefinition().name("field").type(GraphQLString).build())
-                .typeResolver({})
                 .build()
 
         GraphQLObjectType goodImpl = newObject()
@@ -336,7 +317,6 @@ class TypesImplementInterfacesTest extends Specification {
         GraphQLInterfaceType memberInterface = newInterface()
                 .name("TestMemberInterface")
                 .field(newFieldDefinition().name("field").type(GraphQLString).build())
-                .typeResolver({})
                 .build()
 
         GraphQLObjectType memberInterfaceImpl = newObject()
@@ -348,7 +328,6 @@ class TypesImplementInterfacesTest extends Specification {
         GraphQLInterfaceType testInterface = newInterface()
                 .name("TestInterface")
                 .field(newFieldDefinition().name("field").type(nonNull(memberInterface)).build())
-                .typeResolver({})
                 .build()
 
         GraphQLObjectType testInterfaceImpl = newObject()


### PR DESCRIPTION
This PR fixes more tests with deprecated methods.

This is the last wave of Groovy test fixes. Next PR will fix deprecated usages in a few Java test/util files.