### PR TITLE
WIP - no instrumentation during execution

### DIFF
--- a/src/main/java/graphql/execution/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncExecutionStrategy.java
@@ -40,9 +40,11 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
     public CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) throws NonNullableFieldWasNullException {
 
         Instrumentation instrumentation = executionContext.getInstrumentation();
-        InstrumentationExecutionStrategyParameters instrumentationParameters = new InstrumentationExecutionStrategyParameters(executionContext, parameters);
 
-        ExecutionStrategyInstrumentationContext executionStrategyCtx = ExecutionStrategyInstrumentationContext.nonNullCtx(instrumentation.beginExecutionStrategy(instrumentationParameters, executionContext.getInstrumentationState()));
+        ExecutionStrategyInstrumentationContext executionStrategyCtx = ExecutionStrategyInstrumentationContext.nonNullCtx(() -> {
+            InstrumentationExecutionStrategyParameters instrumentationParameters = new InstrumentationExecutionStrategyParameters(executionContext, parameters);
+            return instrumentation.beginExecutionStrategy(instrumentationParameters, executionContext.getInstrumentationState());
+        });
 
         MergedSelectionSet fields = parameters.getFields();
         Set<String> fieldNames = fields.keySet();

--- a/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
@@ -32,9 +32,11 @@ public class AsyncSerialExecutionStrategy extends AbstractAsyncExecutionStrategy
     public CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) throws NonNullableFieldWasNullException {
 
         Instrumentation instrumentation = executionContext.getInstrumentation();
-        InstrumentationExecutionStrategyParameters instrumentationParameters = new InstrumentationExecutionStrategyParameters(executionContext, parameters);
-        InstrumentationContext<ExecutionResult> executionStrategyCtx = nonNullCtx(instrumentation.beginExecutionStrategy(instrumentationParameters,
-                executionContext.getInstrumentationState())
+        InstrumentationContext<ExecutionResult> executionStrategyCtx = nonNullCtx(() -> {
+                    InstrumentationExecutionStrategyParameters instrumentationParameters = new InstrumentationExecutionStrategyParameters(executionContext, parameters);
+                    return instrumentation.beginExecutionStrategy(instrumentationParameters,
+                            executionContext.getInstrumentationState());
+                }
         );
         MergedSelectionSet fields = parameters.getFields();
         ImmutableList<String> fieldNames = ImmutableList.copyOf(fields.keySet());

--- a/src/main/java/graphql/execution/Backdoor.java
+++ b/src/main/java/graphql/execution/Backdoor.java
@@ -1,0 +1,26 @@
+package graphql.execution;
+
+import graphql.Internal;
+import graphql.execution.instrumentation.Instrumentation;
+import graphql.execution.instrumentation.SimpleInstrumentation;
+
+@Internal
+public class Backdoor {
+
+    private static boolean useInstrumentation = true;
+
+    public static boolean isUseInstrumentation() {
+        return useInstrumentation;
+    }
+
+    public static void setUseInstrumentation(boolean flag) {
+        useInstrumentation = flag;
+    }
+
+    public static Instrumentation instrumentationToUse(Instrumentation instrumentation) {
+        if (isUseInstrumentation()) {
+            return instrumentation;
+        }
+        return SimpleInstrumentation.INSTANCE; // a no op
+    }
+}

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -71,8 +71,9 @@ public class Execution {
             throw rte;
         }
 
+        Instrumentation instrumentationToUse = Backdoor.instrumentationToUse(instrumentation);
         ExecutionContext executionContext = newExecutionContextBuilder()
-                .instrumentation(instrumentation)
+                .instrumentation(instrumentationToUse)
                 .instrumentationState(instrumentationState)
                 .executionId(executionId)
                 .graphQLSchema(graphQLSchema)

--- a/src/main/java/graphql/execution/instrumentation/ExecutionStrategyInstrumentationContext.java
+++ b/src/main/java/graphql/execution/instrumentation/ExecutionStrategyInstrumentationContext.java
@@ -3,11 +3,13 @@ package graphql.execution.instrumentation;
 import graphql.ExecutionResult;
 import graphql.Internal;
 import graphql.PublicSpi;
+import graphql.execution.Backdoor;
 import graphql.execution.FieldValueInfo;
 
 import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 
 @PublicSpi
 public interface ExecutionStrategyInstrumentationContext extends InstrumentationContext<ExecutionResult> {
@@ -31,6 +33,13 @@ public interface ExecutionStrategyInstrumentationContext extends Instrumentation
     @Internal
     static ExecutionStrategyInstrumentationContext nonNullCtx(ExecutionStrategyInstrumentationContext nullableContext) {
         return nullableContext == null ? NOOP : nullableContext;
+    }
+
+    static ExecutionStrategyInstrumentationContext nonNullCtx(Supplier<ExecutionStrategyInstrumentationContext> nullableContext) {
+        if (Backdoor.isUseInstrumentation()) {
+            return nonNullCtx(nullableContext.get());
+        }
+        return NOOP;
     }
 
     @Internal

--- a/src/main/java/graphql/execution/instrumentation/SimpleInstrumentationContext.java
+++ b/src/main/java/graphql/execution/instrumentation/SimpleInstrumentationContext.java
@@ -1,11 +1,13 @@
 package graphql.execution.instrumentation;
 
 import graphql.PublicApi;
+import graphql.execution.Backdoor;
 
 import javax.annotation.Nonnull;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * A simple implementation of {@link InstrumentationContext}
@@ -46,6 +48,15 @@ public class SimpleInstrumentationContext<T> implements InstrumentationContext<T
     @Nonnull
     public static <T> InstrumentationContext<T> nonNullCtx(InstrumentationContext<T> nullableContext) {
         return nullableContext == null ? noOp() : nullableContext;
+    }
+
+    @Nonnull
+    public static <T> InstrumentationContext<T> nonNullCtx(Supplier<InstrumentationContext<T>> nullableContext) {
+        if (Backdoor.isUseInstrumentation()) {
+            return nonNullCtx(nullableContext.get());
+        } else {
+            return noOp();
+        }
     }
 
     private final BiConsumer<T, Throwable> codeToRunOnComplete;

--- a/src/test/java/benchmark/NoInstrumentationBenchmark.java
+++ b/src/test/java/benchmark/NoInstrumentationBenchmark.java
@@ -1,0 +1,48 @@
+package benchmark;
+
+import graphql.ExecutionResult;
+import graphql.GraphQL;
+import graphql.execution.Backdoor;
+import graphql.introspection.IntrospectionQuery;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.idl.SchemaGenerator;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import static benchmark.BenchmarkUtils.loadResource;
+
+@State(Scope.Benchmark)
+@Warmup(iterations = 2)
+@Measurement(iterations = 3)
+
+public class NoInstrumentationBenchmark {
+
+    private final GraphQL graphQL;
+
+    public NoInstrumentationBenchmark() {
+        String largeSchema = loadResource("large-schema-4.graphqls");
+        GraphQLSchema graphQLSchema = SchemaGenerator.createdMockedSchema(largeSchema);
+        graphQL = GraphQL.newGraphQL(graphQLSchema)
+                //.instrumentation(countingInstrumentation)
+                .build();
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    public ExecutionResult benchMarkNormalIntrospection() {
+        Backdoor.setUseInstrumentation(true);
+        return graphQL.execute(IntrospectionQuery.INTROSPECTION_QUERY);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    public ExecutionResult benchMarkNoInstrumentationIntrospection() {
+        Backdoor.setUseInstrumentation(false);
+        return graphQL.execute(IntrospectionQuery.INTROSPECTION_QUERY);
+    }
+}


### PR DESCRIPTION
This is another experiment to see if there is some savings to be made if instrumentation was turned off

This avoids the allocation of parameters AND also makes the callback context a no op.

So its slightly faster (at the expense of no instrummentation) but not much


```
Benchmark                                                           Mode  Cnt  Score   Error  Units
NoInstrumentationBenchmark.benchMarkNoInstrumentationIntrospection  avgt   15  0.573 ± 0.016   s/op
NoInstrumentationBenchmark.benchMarkNormalIntrospection             avgt   15  0.618 ± 0.038   s/op
```
