### PR TITLE
EXAMINATION -  DO NOT MERGE -  An annotated examination of our allocations during field fetching

### DIFF
--- a/src/main/java/graphql/execution/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncExecutionStrategy.java
@@ -40,18 +40,50 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
     public CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) throws NonNullableFieldWasNullException {
 
         Instrumentation instrumentation = executionContext.getInstrumentation();
+        //
+        // Standard allocation of instrumentation parameters.  Not overly heavy weight since it's a holder of objects - debatable tomove to
+        // a supplier pattern since even a `() -> new InstrumentationExecutionStrategyParameters(...)` involves the allocation
+        // of a lambda object with parameter capture.
+        //
         InstrumentationExecutionStrategyParameters instrumentationParameters = new InstrumentationExecutionStrategyParameters(executionContext, parameters);
 
+        //
+        // This is smart - if the instrumentation returns null - then a static no op is used - no allocation
+        // This allows an Instrumentation to move to null contexts if they have none.
+        // However, since `ChainedInstrumentation` is the most common form here, then there will always
+        // be a graphql.execution.instrumentation.ChainedInstrumentation.ChainedInstrumentationContext allocated
+        // back.
+        //
+        // We could be smarted here - if there is 0 or 1 instrumentation in the chain, and they return null, so could the chained instrumentation
+        // code return a NOOP.
+        //
         ExecutionStrategyInstrumentationContext executionStrategyCtx = ExecutionStrategyInstrumentationContext.nonNullCtx(instrumentation.beginExecutionStrategy(instrumentationParameters, executionContext.getInstrumentationState()));
 
         MergedSelectionSet fields = parameters.getFields();
         Set<String> fieldNames = fields.keySet();
+        //
+        // Async.CombinedBuilder is an array of CompletableFutures.  It sized by the number of fields
+        // in the sub selection.  Since this method gets called back during object descending, we create onf of these for
+        // every object that has a field selection.
+        //
+        // It's quite a nice alternative to the rubbish java.util.concurrent.CompletableFuture.allOf()
+        //
+        //
         Async.CombinedBuilder<FieldValueInfo> futures = Async.ofExpectedSize(fields.size());
+        //
+        // a list of the names of the fields - it's really a copy of Set<String> fieldNames above - candidate
+        // to be removed honestly
+        //
         List<String> resolvedFields = new ArrayList<>(fieldNames.size());
         for (String fieldName : fieldNames) {
             MergedField currentField = fields.getSubField(fieldName);
 
+            //
+            // Creation of a field path for that field
             ResultPath fieldPath = parameters.getPath().segment(mkNameForPath(currentField));
+            //
+            // This takes the current ES parameters tweaks them and allows them to point upwards to the
+            // parent parameters.
             ExecutionStrategyParameters newParameters = parameters
                     .transform(builder -> builder.field(currentField).path(fieldPath).parent(parameters));
 
@@ -59,6 +91,14 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
             CompletableFuture<FieldValueInfo> future = resolveFieldWithInfo(executionContext, newParameters);
             futures.add(future);
         }
+        //
+        // CF of the execution result.  When this is the actual overall result (first entry) - then this makes sense
+        // as a returned value.  How-ever for inner calls to the ES (per object selection) we create a CF<ExecutionResult>
+        // only to unwrap them and stick them into a map as values.
+        //
+        // The calling of the ES again (copied form graphql-js) is a candidate for enhancement.  Have a new "executeInner"
+        // that returns a more specific and less heavy-weight value.
+        //
         CompletableFuture<ExecutionResult> overallResult = new CompletableFuture<>();
         executionStrategyCtx.onDispatched(overallResult);
 
@@ -68,6 +108,11 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
                 handleResultsConsumer.accept(null, throwable.getCause());
                 return;
             }
+            //
+            // Allocation again of an array of CFs that needs to all complete to combine them into one value
+            // This has a need trick where it optimised to returns zero / single or many version of itself
+            // to reduce memory usage - don't use a list if there is 1 field
+            //
             Async.CombinedBuilder<ExecutionResult> executionResultFutures = Async.ofExpectedSize(completeValueInfos.size());
             for (FieldValueInfo completeValueInfo : completeValueInfos) {
                 executionResultFutures.add(completeValueInfo.getFieldValue());

--- a/src/main/java/graphql/execution/ResolveType.java
+++ b/src/main/java/graphql/execution/ResolveType.java
@@ -22,6 +22,10 @@ public class ResolveType {
 
     public GraphQLObjectType resolveType(ExecutionContext executionContext, MergedField field, Object source, ExecutionStepInfo executionStepInfo, GraphQLType fieldType, Object localContext) {
         GraphQLObjectType resolvedType;
+        //
+        // We are building a DataFetchingFieldSelectionSet and a TypeResolutionEnvironment here ALWAYS
+        // but if it's an object type then its never needed.  This should be fixed
+        //
         DataFetchingFieldSelectionSet fieldSelectionSet = buildSelectionSet(executionContext, field, (GraphQLOutputType) fieldType, executionStepInfo);
         TypeResolutionEnvironment env = TypeResolutionParameters.newParameters()
                 .field(field)


### PR DESCRIPTION
This is just some comments on the code (in the code) about how we allocate objects during field fetches.  

It does not propose too many solutions per se (albeit hints at a few) but it was really an exercise for me to review the current code and see what we are doing.

The biggest areas I can see for discussion and improvemnt are

* FetchedValue versus FieldValueInfo - both contain values and ALL but 2 could be created up front at data fetch time
   *   OBJECT / SCALAR / ENUM could be all known upfront - no need for FetchValue say
   *   NULL is a special case but it could be a static FieldValueInfo value
   *  LIST is the special case

* The wrapping of data values in `ExecutionResult`s ONLY for them to be immediately unwrapped
