### PR TITLE
Patch SchemaDiff to apply respective nullability change validation for input vs. output types

### DIFF
--- a/src/main/java/graphql/schema/diff/SchemaDiff.java
+++ b/src/main/java/graphql/schema/diff/SchemaDiff.java
@@ -854,7 +854,7 @@ public class SchemaDiff {
                     // if they're both lists, compare the unwrapped types
                     oldTypeInfo = oldTypeInfo.unwrapOne();
                     newTypeInfo = newTypeInfo.unwrapOne();
-                } else if (newTypeInfo.isNonNull()){
+                } else if (newTypeInfo.isNonNull()) {
                     // nullable to non-null creates a stricter input requirement for clients to specify
                     return DiffCategory.STRICTER;
                 } else {
@@ -869,7 +869,7 @@ public class SchemaDiff {
                     // non-list to list is not valid
                     return DiffCategory.INVALID;
                 } else {
-                   return null;
+                    return null;
                 }
             }
         }
@@ -898,7 +898,7 @@ public class SchemaDiff {
                     // if they're both lists, compare the unwrapped types
                     oldTypeInfo = oldTypeInfo.unwrapOne();
                     newTypeInfo = newTypeInfo.unwrapOne();
-                } else if (newTypeInfo.isNonNull()){
+                } else if (newTypeInfo.isNonNull()) {
                     // nullable to non-null is valid, as long as the underlying types are also valid
                     newTypeInfo = newTypeInfo.unwrapOne();
                 } else {

--- a/src/main/java/graphql/schema/diff/SchemaDiff.java
+++ b/src/main/java/graphql/schema/diff/SchemaDiff.java
@@ -397,7 +397,7 @@ public class SchemaDiff {
                         .reasonMsg(message, mkDotName(old.getName(), oldField.getName()))
                         .build());
             } else {
-                DiffCategory category = checkTypeWithNonNullAndList(oldField.getType(), newField.get().getType());
+                DiffCategory category = checkTypeWithNonNullAndListOnInputOrArg(oldField.getType(), newField.get().getType());
                 if (category != null) {
                     ctx.report(DiffEvent.apiBreakage()
                             .category(category)
@@ -612,7 +612,7 @@ public class SchemaDiff {
         Type oldFieldType = oldField.getType();
         Type newFieldType = newField.getType();
 
-        DiffCategory category = checkTypeWithNonNullAndList(oldFieldType, newFieldType);
+        DiffCategory category = checkTypeWithNonNullAndListOnObjectOrInterface(oldFieldType, newFieldType);
         if (category != null) {
             ctx.report(DiffEvent.apiBreakage()
                     .category(category)
@@ -701,7 +701,7 @@ public class SchemaDiff {
         Type oldArgType = oldArg.getType();
         Type newArgType = newArg.getType();
 
-        DiffCategory category = checkTypeWithNonNullAndList(oldArgType, newArgType);
+        DiffCategory category = checkTypeWithNonNullAndListOnInputOrArg(oldArgType, newArgType);
         if (category != null) {
             ctx.report(DiffEvent.apiBreakage()
                     .category(category)
@@ -831,7 +831,7 @@ public class SchemaDiff {
         }
     }
 
-    DiffCategory checkTypeWithNonNullAndList(Type oldType, Type newType) {
+    DiffCategory checkTypeWithNonNullAndListOnInputOrArg(Type oldType, Type newType) {
         TypeInfo oldTypeInfo = typeInfo(oldType);
         TypeInfo newTypeInfo = typeInfo(newType);
 
@@ -840,29 +840,71 @@ public class SchemaDiff {
         }
 
         while (true) {
-            //
-            // its allowed to get more less strict in the new but not more strict
             if (oldTypeInfo.isNonNull() && newTypeInfo.isNonNull()) {
+                // if they're both non-null, compare the unwrapped types
                 oldTypeInfo = oldTypeInfo.unwrapOne();
                 newTypeInfo = newTypeInfo.unwrapOne();
             } else if (oldTypeInfo.isNonNull() && !newTypeInfo.isNonNull()) {
+                // inputs and arguments are allowed to become less strict (go from non-null to nullable)
                 oldTypeInfo = oldTypeInfo.unwrapOne();
             } else if (!oldTypeInfo.isNonNull() && newTypeInfo.isNonNull()) {
+                // nullable to non-null creates a stricter requirement for clients to specify
                 return DiffCategory.STRICTER;
-            }
-            // lists
-            if (oldTypeInfo.isList() && !newTypeInfo.isList()) {
+            } else if (oldTypeInfo.isList() && newTypeInfo.isList()) {
+                // if they're both list, compare the unwrapped types
+                oldTypeInfo = oldTypeInfo.unwrapOne();
+                newTypeInfo = newTypeInfo.unwrapOne();
+            } else if (oldTypeInfo.isList() && !newTypeInfo.isList()) {
                 return DiffCategory.INVALID;
+            } else if (oldTypeInfo.isPlain()) {
+                // we've unwrapped all the types of `old`
+                if (newTypeInfo.isList()) {
+                    return DiffCategory.INVALID;
+                } else if (newTypeInfo.isNonNull()) {
+                    // nullable to non-null creates a stricter requirement for clients to specify
+                    return DiffCategory.STRICTER;
+                }
+                break;
             }
-            // plain
-            if (oldTypeInfo.isPlain()) {
-                if (!newTypeInfo.isPlain()) {
+        }
+        return null;
+    }
+
+    DiffCategory checkTypeWithNonNullAndListOnObjectOrInterface(Type oldType, Type newType) {
+        TypeInfo oldTypeInfo = typeInfo(oldType);
+        TypeInfo newTypeInfo = typeInfo(newType);
+
+        if (!oldTypeInfo.getName().equals(newTypeInfo.getName())) {
+            return DiffCategory.INVALID;
+        }
+
+        while (true) {
+            if (oldTypeInfo.isNonNull() && newTypeInfo.isNonNull()) {
+                // if they're both non-null, compare the unwrapped types
+                oldTypeInfo = oldTypeInfo.unwrapOne();
+                newTypeInfo = newTypeInfo.unwrapOne();
+            } else if (!oldTypeInfo.isNonNull() && newTypeInfo.isNonNull()) {
+                // objects and interfaces are allowed to add more guarantees (go from nullable to non-null)
+                newTypeInfo = newTypeInfo.unwrapOne();
+            } else if (oldTypeInfo.isNonNull() && !newTypeInfo.isNonNull()) {
+                // non-null to nullable revokes a previous guarantee and unguarded client code may try to access null
+                return DiffCategory.STRICTER;
+            } else if (oldTypeInfo.isList() && newTypeInfo.isList()) {
+                // if they're both list, compare the unwrapped types
+                oldTypeInfo = oldTypeInfo.unwrapOne();
+                newTypeInfo = newTypeInfo.unwrapOne();
+            } else if (oldTypeInfo.isList() && newTypeInfo.isNonNull()) {
+                // objects and interfaces are allowed to add more guarantees (go from nullable to non-null)
+                newTypeInfo = newTypeInfo.unwrapOne();
+            } else if (oldTypeInfo.isList() && !newTypeInfo.isList()) {
+                return DiffCategory.INVALID;
+            } else if (oldTypeInfo.isPlain()) {
+                // we've unwrapped all the types of `old`
+                if (newTypeInfo.isList()) {
                     return DiffCategory.INVALID;
                 }
                 break;
             }
-            oldTypeInfo = oldTypeInfo.unwrapOne();
-            newTypeInfo = newTypeInfo.unwrapOne();
         }
         return null;
     }

--- a/src/test/groovy/graphql/schema/diff/SchemaDiffTest.groovy
+++ b/src/test/groovy/graphql/schema/diff/SchemaDiffTest.groovy
@@ -157,29 +157,33 @@ class SchemaDiffTest extends Specification {
     def "change_in_list_ness_input_or_arg"() {
 
         given:
-        Type baseLine = new NonNullType(new ListType(new TypeName("foo")))
+        Type list = new NonNullType(new ListType(new TypeName("foo")))
         Type notList = new NonNullType(new TypeName("foo"))
 
         def diff = new SchemaDiff()
 
-        def noLongerList = diff.checkTypeWithNonNullAndListOnInputOrArg(baseLine, notList)
+        def noLongerList = diff.checkTypeWithNonNullAndListOnInputOrArg(list, notList)
+        def nowList = diff.checkTypeWithNonNullAndListOnInputOrArg(notList, list)
 
         expect:
         noLongerList == DiffCategory.INVALID
+        nowList == DiffCategory.INVALID
     }
 
     def "change_in_list_ness_object_or_interface"() {
 
         given:
-        Type baseLine = new NonNullType(new ListType(new TypeName("foo")))
+        Type list = new NonNullType(new ListType(new TypeName("foo")))
         Type notList = new NonNullType(new TypeName("foo"))
 
         def diff = new SchemaDiff()
 
-        def noLongerList = diff.checkTypeWithNonNullAndListOnObjectOrInterface(baseLine, notList)
+        def noLongerList = diff.checkTypeWithNonNullAndListOnObjectOrInterface(list, notList)
+        def nowList = diff.checkTypeWithNonNullAndListOnObjectOrInterface(list, notList)
 
         expect:
         noLongerList == DiffCategory.INVALID
+        nowList == DiffCategory.INVALID
     }
 
     DiffEvent lastBreakage(CapturingReporter capturingReporter) {
@@ -382,21 +386,26 @@ class SchemaDiffTest extends Specification {
         diff.diffSchema(diffSet, chainedReporter)
 
         expect:
-        reporter.breakageCount == 3
+        reporter.breakageCount == 4
         reporter.breakages[0].category == DiffCategory.STRICTER
-        reporter.breakages[0].typeName == 'Questor'
-        reporter.breakages[0].typeKind == TypeKind.InputObject
-        reporter.breakages[0].fieldName == 'nestedInput'
+        reporter.breakages[0].typeName == 'Query'
+        reporter.breakages[0].typeKind == TypeKind.Object
+        reporter.breakages[0].fieldName == 'being'
 
-        reporter.breakages[1].category == DiffCategory.INVALID
+        reporter.breakages[1].category == DiffCategory.STRICTER
         reporter.breakages[1].typeName == 'Questor'
         reporter.breakages[1].typeKind == TypeKind.InputObject
-        reporter.breakages[1].fieldName == 'queryTarget'
+        reporter.breakages[1].fieldName == 'nestedInput'
 
-        reporter.breakages[2].category == DiffCategory.STRICTER
+        reporter.breakages[2].category == DiffCategory.INVALID
         reporter.breakages[2].typeName == 'Questor'
         reporter.breakages[2].typeKind == TypeKind.InputObject
-        reporter.breakages[2].fieldName == 'newMandatoryField'
+        reporter.breakages[2].fieldName == 'queryTarget'
+
+        reporter.breakages[3].category == DiffCategory.STRICTER
+        reporter.breakages[3].typeName == 'Questor'
+        reporter.breakages[3].typeKind == TypeKind.InputObject
+        reporter.breakages[3].fieldName == 'newMandatoryField'
 
     }
 
@@ -478,9 +487,9 @@ class SchemaDiffTest extends Specification {
         expect:
         reporter.breakageCount == 3
         reporter.breakages[0].category == DiffCategory.STRICTER
-        reporter.breakages[0].typeName == 'Query'
+        reporter.breakages[0].typeName == 'Istari'
         reporter.breakages[0].typeKind == TypeKind.Object
-        reporter.breakages[0].fieldName == 'being'
+        reporter.breakages[0].fieldName == 'temperament'
 
         reporter.breakages[1].category == DiffCategory.INVALID
         reporter.breakages[1].typeName == 'Query'

--- a/src/test/resources/diff/schema_ABaseLine.graphqls
+++ b/src/test/resources/diff/schema_ABaseLine.graphqls
@@ -12,6 +12,7 @@ type Query {
     deities : [Deity]
 
     allCharacters : [Character!] @deprecated(reason: "no longer supported")
+    allCharactersByTemperament : [[Character]]
 
     customScalar : CustomScalar
 }
@@ -22,7 +23,7 @@ type Mutation {
 }
 
 input Questor {
-    beingID : ID
+    beingID : ID!
     queryTarget : String
     nestedInput : NestedInput
 }

--- a/src/test/resources/diff/schema_changed_field_arguments.graphqls
+++ b/src/test/resources/diff/schema_changed_field_arguments.graphqls
@@ -12,6 +12,7 @@ type Query {
     deities : [Deity]
 
     allCharacters : [Character!] @deprecated(reason: "no longer supported")
+    allCharactersByTemperament : [[Character]]
 
     customScalar : CustomScalar
 }
@@ -23,7 +24,7 @@ type Mutation {
 }
 
 input Questor {
-    beingID : ID
+    beingID : ID!
     queryTarget : String
     nestedInput : NestedInput
 }

--- a/src/test/resources/diff/schema_changed_input_object_fields.graphqls
+++ b/src/test/resources/diff/schema_changed_input_object_fields.graphqls
@@ -4,7 +4,8 @@ schema {
 }
 
 type Query {
-    being(id : ID, type : String = "wizard") : Being
+    #being(id : ID, type : String = "wizard") : Being
+    being(id : ID, type : String, newArg : String!) : Being
     beings(type : String) : [Being]
 
     wizards : [Istari]

--- a/src/test/resources/diff/schema_changed_input_object_fields.graphqls
+++ b/src/test/resources/diff/schema_changed_input_object_fields.graphqls
@@ -12,6 +12,7 @@ type Query {
     deities : [Deity]
 
     allCharacters : [Character!] @deprecated(reason: "no longer supported")
+    allCharactersByTemperament : [[Character]]
 
     customScalar : CustomScalar
 }
@@ -22,9 +23,14 @@ type Mutation {
 }
 
 input Questor {
+    #beingID : ID!
     beingID : ID
+
+    #queryTarget : String
     queryTarget : Int
-    nestedInput : NestedInput
+
+    #nestedInput : NestedInput
+    nestedInput : NestedInput!
     newMandatoryField : String!
 }
 

--- a/src/test/resources/diff/schema_changed_nested_input_object_fields.graphqls
+++ b/src/test/resources/diff/schema_changed_nested_input_object_fields.graphqls
@@ -12,6 +12,7 @@ type Query {
     deities : [Deity]
 
     allCharacters : [Character!] @deprecated(reason: "no longer supported")
+    allCharactersByTemperament : [[Character]]
 
     customScalar : CustomScalar
 }
@@ -22,7 +23,7 @@ type Mutation {
 }
 
 input Questor {
-    beingID : ID
+    beingID : ID!
     queryTarget : String
     nestedInput : NestedInput
 }

--- a/src/test/resources/diff/schema_changed_object_fields.graphqls
+++ b/src/test/resources/diff/schema_changed_object_fields.graphqls
@@ -18,6 +18,9 @@ type Query {
     #allCharacters : [Character!] @deprecated(reason: "no longer supported")
     allCharacters : [Character!]
 
+    #allCharactersByTemperament : [[Character]]
+    allCharactersByTemperament : [[Character!]]!
+
     #customScalar : CustomScalar
     customScalar : [CustomScalar]!
 }
@@ -28,7 +31,7 @@ type Mutation {
 }
 
 input Questor {
-    beingID : ID
+    beingID : ID!
     queryTarget : String
     nestedInput : NestedInput
 }
@@ -41,7 +44,8 @@ scalar CustomScalar
 
 
 interface Being {
-    id : ID
+    #id : ID
+    id : ID!
     name : String
     nameInQuenyan : String
     invitedBy(id : ID) : Being
@@ -49,7 +53,8 @@ interface Being {
 
 
 type Ainur implements Being {
-    id : ID
+    #id : ID
+    id : ID!
     name : String
     nameInQuenyan : String
     invitedBy(id : ID) : Being
@@ -58,7 +63,8 @@ type Ainur implements Being {
 
 
 type Istari implements Being {
-    id : ID
+    #id : ID
+    id : ID!
     name : String
     nameInQuenyan : String
     invitedBy(id : ID) : Being
@@ -68,7 +74,8 @@ type Istari implements Being {
 }
 
 type Deity implements Being {
-    id : ID
+    #id : ID
+    id : ID!
     name : String
     nameInQuenyan : String
     invitedBy(id : ID) : Being

--- a/src/test/resources/diff/schema_changed_object_fields.graphqls
+++ b/src/test/resources/diff/schema_changed_object_fields.graphqls
@@ -4,8 +4,7 @@ schema {
 }
 
 type Query {
-    #being(id : ID, type : String = "wizard") : Being
-    being(id : ID, type : String, newArg : String!) : Being
+    being(id : ID, type : String = "wizard") : Being
 
     #beings(type : String) : [Being]
     beings(type : String) : Being
@@ -69,7 +68,9 @@ type Istari implements Being {
     nameInQuenyan : String
     invitedBy(id : ID) : Being
     colour : String
-    temperament : Temperament!
+
+    #temperament : Temperament!
+    temperament : Temperament
 
 }
 

--- a/src/test/resources/diff/schema_changed_type_kind.graphqls
+++ b/src/test/resources/diff/schema_changed_type_kind.graphqls
@@ -12,6 +12,7 @@ type Query {
     deities : [Deity]
 
     allCharacters : [Character!] @deprecated(reason: "no longer supported")
+    allCharactersByTemperament : [[Character]]
 
     customScalar : CustomScalar
 }
@@ -22,7 +23,7 @@ type Mutation {
 }
 
 input Questor {
-    beingID : ID
+    beingID : ID!
     queryTarget : String
     nestedInput : NestedInput
 }

--- a/src/test/resources/diff/schema_dangerous_changes.graphqls
+++ b/src/test/resources/diff/schema_dangerous_changes.graphqls
@@ -12,6 +12,7 @@ type Query {
     deities : [Deity]
 
     allCharacters : [Character!] @deprecated(reason: "no longer supported")
+    allCharactersByTemperament : [[Character]]
 
     customScalar : CustomScalar
 }
@@ -22,7 +23,7 @@ type Mutation {
 }
 
 input Questor {
-    beingID : ID
+    beingID : ID!
     queryTarget : String
     nestedInput : NestedInput
 }

--- a/src/test/resources/diff/schema_deprecated_fields_new.graphqls
+++ b/src/test/resources/diff/schema_deprecated_fields_new.graphqls
@@ -12,6 +12,7 @@ type Query {
     deities : [Deity] @deprecated
 
     allCharacters : [Character!] @deprecated(reason: "no longer supported")
+    allCharactersByTemperament : [[Character]] @deprecated(reason: "remove all Character references")
 
     customScalar : CustomScalar @deprecated(reason: "because")
 }

--- a/src/test/resources/diff/schema_interface_fields_missing.graphqls
+++ b/src/test/resources/diff/schema_interface_fields_missing.graphqls
@@ -12,6 +12,7 @@ type Query {
     deities : [Deity]
 
     allCharacters : [Character!] @deprecated(reason: "no longer supported")
+    allCharactersByTemperament : [[Character]]
 
     customScalar : CustomScalar
 }
@@ -22,7 +23,7 @@ type Mutation {
 }
 
 input Questor {
-    beingID : ID
+    beingID : ID!
     queryTarget : String
     nestedInput : NestedInput
 }

--- a/src/test/resources/diff/schema_missing_enum_value.graphqls
+++ b/src/test/resources/diff/schema_missing_enum_value.graphqls
@@ -12,6 +12,7 @@ type Query {
     deities : [Deity]
 
     allCharacters : [Character!] @deprecated(reason: "no longer supported")
+    allCharactersByTemperament : [[Character]]
 
     customScalar : CustomScalar
 }
@@ -22,7 +23,7 @@ type Mutation {
 }
 
 input Questor {
-    beingID : ID
+    beingID : ID!
     queryTarget : String
     nestedInput : NestedInput
 }

--- a/src/test/resources/diff/schema_missing_field_arguments.graphqls
+++ b/src/test/resources/diff/schema_missing_field_arguments.graphqls
@@ -12,6 +12,7 @@ type Query {
     deities : [Deity]
 
     allCharacters : [Character!] @deprecated(reason: "no longer supported")
+    allCharactersByTemperament : [[Character]]
 
     customScalar : CustomScalar
 }
@@ -24,7 +25,7 @@ type Mutation {
 }
 
 input Questor {
-    beingID : ID
+    beingID : ID!
     queryTarget : String
     nestedInput : NestedInput
 }

--- a/src/test/resources/diff/schema_missing_input_object_fields.graphqls
+++ b/src/test/resources/diff/schema_missing_input_object_fields.graphqls
@@ -12,6 +12,7 @@ type Query {
     deities : [Deity]
 
     allCharacters : [Character!] @deprecated(reason: "no longer supported")
+    allCharactersByTemperament : [[Character]]
 
     customScalar : CustomScalar
 }
@@ -22,7 +23,7 @@ type Mutation {
 }
 
 input Questor {
-    beingID : ID
+    beingID : ID!
     #queryTarget : String
     nestedInput : NestedInput
 }

--- a/src/test/resources/diff/schema_missing_object_fields.graphqls
+++ b/src/test/resources/diff/schema_missing_object_fields.graphqls
@@ -12,6 +12,7 @@ type Query {
     deities : [Deity]
 
     allCharacters : [Character!] @deprecated(reason: "no longer supported")
+    allCharactersByTemperament : [[Character]]
 
     customScalar : CustomScalar
 }
@@ -22,7 +23,7 @@ type Mutation {
 }
 
 input Questor {
-    beingID : ID
+    beingID : ID!
     queryTarget : String
     nestedInput : NestedInput
 }

--- a/src/test/resources/diff/schema_missing_operation.graphqls
+++ b/src/test/resources/diff/schema_missing_operation.graphqls
@@ -11,12 +11,13 @@ type Query {
     deities : [Deity]
 
     allCharacters : [Character!] @deprecated(reason: "no longer supported")
+    allCharactersByTemperament : [[Character]]
 
     customScalar : CustomScalar
 }
 
 input Questor {
-    beingID : ID
+    beingID : ID!
     queryTarget : String
     nestedInput : NestedInput
 }

--- a/src/test/resources/diff/schema_missing_union_members.graphqls
+++ b/src/test/resources/diff/schema_missing_union_members.graphqls
@@ -12,6 +12,7 @@ type Query {
     deities : [Deity]
 
     allCharacters : [Character!] @deprecated(reason: "no longer supported")
+    allCharactersByTemperament : [[Character]]
 
     customScalar : CustomScalar
 }
@@ -22,7 +23,7 @@ type Mutation {
 }
 
 input Questor {
-    beingID : ID
+    beingID : ID!
     queryTarget : String
     nestedInput : NestedInput
 }

--- a/src/test/resources/diff/schema_with_additional_field.graphqls
+++ b/src/test/resources/diff/schema_with_additional_field.graphqls
@@ -12,6 +12,7 @@ type Query {
     deities : [Deity]
 
     allCharacters : [Character!] @deprecated(reason: "no longer supported")
+    allCharactersByTemperament : [[Character]]
 
     customScalar : CustomScalar
 }
@@ -22,7 +23,7 @@ type Mutation {
 }
 
 input Questor {
-    beingID : ID
+    beingID : ID!
     queryTarget : String
     nestedInput : NestedInput
 }


### PR DESCRIPTION
## Description
SchemaDiff had a single method `checkTypeWithNonNullAndList` that always applied the rule "non-null to nullable is safe; nullable to non-null is breaking."
This is true for input types and arguments, but the opposite should be true for fields on output types -- "nullable to non-null is safe; non-null to nullable is breaking."
A consumer operating on a nullable field should already be checking for presence, and adding an additional guarantee of non-null is safe.
A consumer operating on a non-null field may not be checking for presence, and removing the guarantee of non-null may break when that field is null.

## Implementation
Two methods are defined -- one for input and argument types, and one for output types.
The methods are rewritten in a style of handling three top-level cases for the old type (non-null, list, and neither), and within each case handling the cases for the new type.
Calls to the previous method are updated to their respective new versions.

graphql-js implementation for reference:
[isChangeSafeForObjectOrInterfaceField](https://github.com/graphql/graphql-js/blob/a24a9f35b876bdd0d5050eca34d3020bd0db9a29/src/utilities/findBreakingChanges.ts#L445)
[isChangeSafeForInputObjectFieldOrFieldArg](https://github.com/graphql/graphql-js/blob/a24a9f35b876bdd0d5050eca34d3020bd0db9a29/src/utilities/findBreakingChanges.ts#L480)

## Testing
Unit tests for the new methods are updated and added:
- change_in_null_ness_object_or_interface
- change_in_null_ness_input_or_arg
- change_in_list_ness_object_or_interface
- change_in_list_ness_input_or_arg

schema_ABaseLine:
- Added Query.allCharactersByTemperament : [[Character]] to test a complex wrapped type.
- Made Questor.beingID non-null to be able to test "non-null to nullable" for input.

schema_changed_input_object_fields:
- Added case Query.being( .. , newArg: String!) -> stricter (moved from schema_changed_object_fields to here)
- Added case Questor.beingID "required to optional" -> safe
- Added case Questor.nestedInput "optional to required" -> stricter


schema_changed_object_fields:
- Moved case Query.being( .. , newArg: String!) to schema_changed_object_fields
- Added case Query.allCharactersByTemperament : [[Character!]]! to test complex wrapped type "optional to required" -> safe
- Added case Being.ID "optional to required" -> safe
- Added case Istari.temperament "required to optional" -> stricter