### PR TITLE
Deprecation cleanout - programmatic schemas

### DIFF
--- a/src/main/java/graphql/execution/instrumentation/Instrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/Instrumentation.java
@@ -468,7 +468,7 @@ public interface Instrumentation {
      *
      * @return a non null instrumented ExecutionContext, the default is to return to the same object
      *
-     * @deprecated use {@link #instrumentExecutionContext(ExecutionContext, InstrumentationExecutionParameters)} instead
+     * @deprecated use {@link #instrumentExecutionContext(ExecutionContext, InstrumentationExecutionParameters, InstrumentationState)} instead
      */
     @Deprecated
     @DeprecatedAt("2022-07-26")

--- a/src/test/groovy/example/http/ExecutionResultJSONTesting.java
+++ b/src/test/groovy/example/http/ExecutionResultJSONTesting.java
@@ -70,7 +70,7 @@ public class ExecutionResultJSONTesting {
     private ExecutionResult createER() {
         List<GraphQLError> errors = new ArrayList<>();
 
-        errors.add(new ValidationError(ValidationErrorType.UnknownType, mkLocations(), "Test ValidationError"));
+        errors.add(new ValidationError(ValidationErrorType.UnknownType, mkLocations(), "Test ValidationError")); // Retain as there is no alternative constructor for ValidationError
         errors.add(new MissingRootTypeException("Mutations are not supported.", null));
         errors.add(new InvalidSyntaxError(mkLocations(), "Not good syntax m'kay"));
         errors.add(new NonNullableFieldWasNullError(new NonNullableFieldWasNullException(mkExecutionInfo(), mkPath())));

--- a/src/test/groovy/example/http/HttpMain.java
+++ b/src/test/groovy/example/http/HttpMain.java
@@ -18,6 +18,7 @@ import graphql.schema.idl.SchemaParser;
 import graphql.schema.idl.TypeDefinitionRegistry;
 import org.dataloader.BatchLoader;
 import org.dataloader.DataLoader;
+import org.dataloader.DataLoaderFactory;
 import org.dataloader.DataLoaderRegistry;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
@@ -46,7 +47,7 @@ import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring;
 import static java.util.Arrays.asList;
 
 /**
- * An very simple example of serving a qraphql schema over http.
+ * A very simple example of serving a graphql schema over http.
  * <p>
  * More info can be found here : http://graphql.org/learn/serving-over-http/
  */
@@ -178,7 +179,7 @@ public class HttpMain extends AbstractHandler {
                 CompletableFuture.supplyAsync(() ->
                         loadCharactersViaHTTP(keys));
 
-        DataLoader<String, Object> friendsDataLoader = new DataLoader<>(friendsBatchLoader);
+        DataLoader<String, Object> friendsDataLoader = DataLoaderFactory.newDataLoader(friendsBatchLoader);
 
         DataLoaderRegistry dataLoaderRegistry = new DataLoaderRegistry();
         //
@@ -275,7 +276,7 @@ public class HttpMain extends AbstractHandler {
     }
 
     // Lots of the data happens to be maps of objects and this allows us to get back into type safety land
-    // with less boiler plate and casts
+    // with less boilerplate and casts
     //
     @SuppressWarnings("TypeParameterUnusedInFormals")
     private <T> T asMapGet(Object mapObj, Object mapKey) {

--- a/src/test/groovy/graphql/NestedInputSchema.java
+++ b/src/test/groovy/graphql/NestedInputSchema.java
@@ -63,7 +63,7 @@ public class NestedInputSchema {
                         .argument(GraphQLArgument.newArgument()
                                 .name("intialValue")
                                 .type(GraphQLInt)
-                                .defaultValue(5))
+                                .defaultValueProgrammatic(5))
                         .argument(GraphQLArgument.newArgument()
                                 .name("filter")
                                 .type(filterType())))

--- a/src/test/groovy/graphql/ScalarsQuerySchema.java
+++ b/src/test/groovy/graphql/ScalarsQuerySchema.java
@@ -22,7 +22,7 @@ public class ScalarsQuerySchema {
             .field(newFieldDefinition()
                     .name("floatNaN")
                     .type(Scalars.GraphQLFloat)
-                    .staticValue(Double.NaN))
+                    .staticValue(Double.NaN)) // Retain for test coverage
             // Scalars with input of same type, value echoed back
             .field(newFieldDefinition()
                     .name("floatNaNInput")

--- a/src/test/groovy/graphql/StarWarsSchema.java
+++ b/src/test/groovy/graphql/StarWarsSchema.java
@@ -55,7 +55,6 @@ public class StarWarsSchema {
                     .name("appearsIn")
                     .description("Which movies they appear in.")
                     .type(list(episodeEnum)))
-            .typeResolver(StarWarsData.getCharacterTypeResolver())
             .comparatorRegistry(BY_NAME_REGISTRY)
             .build();
 
@@ -180,6 +179,7 @@ public class StarWarsSchema {
             .dataFetcher(humanCoordinates, humanDataFetcher)
             .dataFetcher(droidCoordinates, droidDataFetcher)
             .dataFetcher(createHumanCoordinates, createHumanDataFetcher)
+            .typeResolver("Character", StarWarsData.getCharacterTypeResolver())
             .build();
 
     public static GraphQLSchema starWarsSchema = GraphQLSchema.newSchema()

--- a/src/test/groovy/graphql/TypeReferenceSchema.java
+++ b/src/test/groovy/graphql/TypeReferenceSchema.java
@@ -2,6 +2,7 @@ package graphql;
 
 import graphql.schema.Coercing;
 import graphql.schema.GraphQLArgument;
+import graphql.schema.GraphQLCodeRegistry;
 import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLFieldDefinition;
@@ -148,7 +149,6 @@ public class TypeReferenceSchema {
                 .name("Pet")
                 .possibleType(GraphQLTypeReference.typeRef(CatType.getName()))
                 .possibleType(GraphQLTypeReference.typeRef(DogType.getName()))
-                .typeResolver(new TypeResolverProxy())
                 .withDirective(unionDirective)
                 .build();
     }
@@ -171,7 +171,6 @@ public class TypeReferenceSchema {
 
         Addressable = GraphQLInterfaceType.newInterface()
                 .name("Addressable")
-                .typeResolver(new TypeResolverProxy())
                 .field(GraphQLFieldDefinition.newFieldDefinition()
                         .name("address")
                         .type(GraphQLString))
@@ -316,6 +315,11 @@ public class TypeReferenceSchema {
                     .type(QueryDirectiveInput))
             .build();
 
+    public static GraphQLCodeRegistry codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+            .typeResolver("Pet", new TypeResolverProxy())
+            .typeResolver("Addressable", new TypeResolverProxy())
+            .build();
+
     public static GraphQLSchema SchemaWithReferences = GraphQLSchema.newSchema()
             .query(PersonService)
             .additionalTypes(new HashSet<>(Arrays.asList(PersonType, PersonInputType, PetType, CatType, DogType, NamedType, HairStyle, OnOff)))
@@ -330,6 +334,6 @@ public class TypeReferenceSchema {
             .additionalDirective(enumDirective)
             .additionalDirective(enumValueDirective)
             .additionalDirective(interfaceDirective)
-
+            .codeRegistry(codeRegistry)
             .build();
 }

--- a/src/test/groovy/graphql/TypeReferenceSchema.java
+++ b/src/test/groovy/graphql/TypeReferenceSchema.java
@@ -318,6 +318,7 @@ public class TypeReferenceSchema {
     public static GraphQLCodeRegistry codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
             .typeResolver("Pet", new TypeResolverProxy())
             .typeResolver("Addressable", new TypeResolverProxy())
+            .typeResolver("Named", GarfieldSchema.namedTypeResolver)
             .build();
 
     public static GraphQLSchema SchemaWithReferences = GraphQLSchema.newSchema()

--- a/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy
@@ -4,6 +4,7 @@ import graphql.ErrorType
 import graphql.ExecutionResult
 import graphql.GraphQLContext
 import graphql.execution.instrumentation.ExecutionStrategyInstrumentationContext
+import graphql.execution.instrumentation.InstrumentationState
 import graphql.execution.instrumentation.SimpleInstrumentation
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionStrategyParameters
 import graphql.language.Field
@@ -267,7 +268,7 @@ class AsyncExecutionStrategyTest extends Specification {
                 .locale(Locale.getDefault())
                 .instrumentation(new SimpleInstrumentation() {
                     @Override
-                    ExecutionStrategyInstrumentationContext beginExecutionStrategy(InstrumentationExecutionStrategyParameters parameters) {
+                    ExecutionStrategyInstrumentationContext beginExecutionStrategy(InstrumentationExecutionStrategyParameters parameters, InstrumentationState state) {
                         return new ExecutionStrategyInstrumentationContext() {
 
                             @Override

--- a/src/test/groovy/graphql/execution/DataFetcherExceptionHandlerTest.groovy
+++ b/src/test/groovy/graphql/execution/DataFetcherExceptionHandlerTest.groovy
@@ -77,11 +77,6 @@ class DataFetcherExceptionHandlerTest extends Specification {
     def "integration test to prove an async custom error handle can be made"() {
         DataFetcherExceptionHandler handler = new DataFetcherExceptionHandler() {
             @Override
-            DataFetcherExceptionHandlerResult onException(DataFetcherExceptionHandlerParameters handlerParameters) {
-                return null
-            }
-
-            @Override
             CompletableFuture<DataFetcherExceptionHandlerResult> handleException(DataFetcherExceptionHandlerParameters params) {
                 def msg = "The thing went " + params.getException().getMessage()
                 def result = DataFetcherExceptionHandlerResult.newResult().error(new CustomError(msg, params.getSourceLocation())).build()
@@ -118,11 +113,6 @@ class DataFetcherExceptionHandlerTest extends Specification {
     def "if an async exception handler itself throws an exception than that is handled"() {
         DataFetcherExceptionHandler handler = new DataFetcherExceptionHandler() {
             @Override
-            DataFetcherExceptionHandlerResult onException(DataFetcherExceptionHandlerParameters handlerParameters) {
-                return null
-            }
-
-            @Override
             CompletableFuture<DataFetcherExceptionHandlerResult> handleException(DataFetcherExceptionHandlerParameters handlerParameters) {
                 throw new RuntimeException("The handler itself went BANG!")
             }
@@ -140,11 +130,6 @@ class DataFetcherExceptionHandlerTest extends Specification {
 
     def "multiple errors can be returned in a handler"() {
         DataFetcherExceptionHandler handler = new DataFetcherExceptionHandler() {
-            @Override
-            DataFetcherExceptionHandlerResult onException(DataFetcherExceptionHandlerParameters handlerParameters) {
-                return null
-            }
-
             @Override
             CompletableFuture<DataFetcherExceptionHandlerResult> handleException(DataFetcherExceptionHandlerParameters params) {
                 def result = DataFetcherExceptionHandlerResult.newResult()

--- a/src/test/groovy/graphql/execution/ExecutionStrategyExceptionHandlingEquivalenceTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategyExceptionHandlingEquivalenceTest.groovy
@@ -4,6 +4,7 @@ import graphql.ExecutionInput
 import graphql.GraphQL
 import graphql.StarWarsSchema
 import graphql.execution.instrumentation.InstrumentationContext
+import graphql.execution.instrumentation.InstrumentationState
 import graphql.execution.instrumentation.SimpleInstrumentation
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters
 import graphql.validation.ValidationError
@@ -16,8 +17,8 @@ class ExecutionStrategyExceptionHandlingEquivalenceTest extends Specification {
     class TestInstrumentation extends SimpleInstrumentation {
 
         @Override
-        InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters) {
-            throw new AbortExecutionException([new ValidationError(ValidationErrorType.UnknownType)])
+        InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters, InstrumentationState state) {
+            throw new AbortExecutionException([new ValidationError(ValidationErrorType.UnknownType)]) // Retain as there is no alternative constructor for ValidationError
         }
     }
 

--- a/src/test/groovy/graphql/execution/ExecutionTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionTest.groovy
@@ -115,7 +115,8 @@ class ExecutionTest extends Specification {
 
 			@Override
             ExecutionContext instrumentExecutionContext(ExecutionContext executionContext,
-                                                        InstrumentationExecutionParameters parameters) {
+                                                        InstrumentationExecutionParameters parameters,
+                                                        InstrumentationState state) {
 					
 					return ExecutionContextBuilder.newExecutionContextBuilder(executionContext)
 					.queryStrategy(queryStrategyUpdatedToDuringExecutionContextInstrument)

--- a/src/test/groovy/graphql/execution/instrumentation/dataloader/BatchCompareDataFetchers.java
+++ b/src/test/groovy/graphql/execution/instrumentation/dataloader/BatchCompareDataFetchers.java
@@ -6,6 +6,7 @@ import graphql.execution.instrumentation.dataloader.models.Shop;
 import graphql.schema.DataFetcher;
 import org.dataloader.BatchLoader;
 import org.dataloader.DataLoader;
+import org.dataloader.DataLoaderFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -99,7 +100,7 @@ public class BatchCompareDataFetchers {
         return completedFuture(getDepartmentsForShops(shopList));
     });
 
-    public DataLoader<String, List<Department>> departmentsForShopDataLoader = new DataLoader<>(departmentsForShopsBatchLoader);
+    public DataLoader<String, List<Department>> departmentsForShopDataLoader = DataLoaderFactory.newDataLoader(departmentsForShopsBatchLoader);
 
     public DataFetcher<CompletableFuture<List<Department>>> departmentsForShopDataLoaderDataFetcher = environment -> {
         Shop shop = environment.getSource();
@@ -136,7 +137,7 @@ public class BatchCompareDataFetchers {
         return completedFuture(getProductsForDepartments(d));
     });
 
-    public DataLoader<String, List<Product>> productsForDepartmentDataLoader = new DataLoader<>(productsForDepartmentsBatchLoader);
+    public DataLoader<String, List<Product>> productsForDepartmentDataLoader = DataLoaderFactory.newDataLoader(productsForDepartmentsBatchLoader);
 
     public DataFetcher<CompletableFuture<List<Product>>> productsForDepartmentDataLoaderDataFetcher = environment -> {
         Department department = environment.getSource();

--- a/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderCompanyProductBackend.java
+++ b/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderCompanyProductBackend.java
@@ -3,9 +3,8 @@ package graphql.execution.instrumentation.dataloader;
 
 import com.google.common.collect.ImmutableList;
 import org.dataloader.DataLoader;
+import org.dataloader.DataLoaderFactory;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -27,7 +26,7 @@ public class DataLoaderCompanyProductBackend {
             mkCompany(projectCount);
         }
 
-        projectsLoader = new DataLoader<>(keys -> getProjectsForCompanies(keys).thenApply(projects -> keys
+        projectsLoader = DataLoaderFactory.newDataLoader(keys -> getProjectsForCompanies(keys).thenApply(projects -> keys
                 .stream()
                 .map(companyId -> projects.stream()
                         .filter(project -> project.getCompanyId().equals(companyId))

--- a/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherInstrumentationTest.groovy
@@ -10,6 +10,7 @@ import graphql.execution.ExecutionContext
 import graphql.execution.ExecutionStrategyParameters
 import graphql.execution.instrumentation.ChainedInstrumentation
 import graphql.execution.instrumentation.Instrumentation
+import graphql.execution.instrumentation.InstrumentationState
 import graphql.execution.instrumentation.SimpleInstrumentation
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters
 import graphql.schema.DataFetcher
@@ -132,7 +133,7 @@ class DataLoaderDispatcherInstrumentationTest extends Specification {
         def dlInstrumentation = new DataLoaderDispatcherInstrumentation()
         def enhancingInstrumentation = new SimpleInstrumentation() {
             @Override
-            ExecutionInput instrumentExecutionInput(ExecutionInput executionInput, InstrumentationExecutionParameters parameters) {
+            ExecutionInput instrumentExecutionInput(ExecutionInput executionInput, InstrumentationExecutionParameters parameters, InstrumentationState state) {
                 assert executionInput.getDataLoaderRegistry() == startingDataLoaderRegistry
                 return executionInput.transform({ builder -> builder.dataLoaderRegistry(enhancedDataLoaderRegistry) })
             }

--- a/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderHangingTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderHangingTest.groovy
@@ -19,6 +19,7 @@ import graphql.schema.idl.RuntimeWiring
 import org.apache.commons.lang3.concurrent.BasicThreadFactory
 import org.dataloader.BatchLoader
 import org.dataloader.DataLoader
+import org.dataloader.DataLoaderFactory
 import org.dataloader.DataLoaderOptions
 import org.dataloader.DataLoaderRegistry
 import spock.lang.Specification
@@ -178,7 +179,7 @@ class DataLoaderHangingTest extends Specification {
     }
 
     private DataLoaderRegistry mkNewDataLoaderRegistry(executor) {
-        def dataLoaderAlbums = new DataLoader<Object, Object>(new BatchLoader<DataFetchingEnvironment, List<Object>>() {
+        def dataLoaderAlbums = DataLoaderFactory.newDataLoader(new BatchLoader<DataFetchingEnvironment, List<Object>>() {
             @Override
             CompletionStage<List<List<Object>>> load(List<DataFetchingEnvironment> keys) {
                 return CompletableFuture.supplyAsync({
@@ -195,7 +196,7 @@ class DataLoaderHangingTest extends Specification {
             }
         }, DataLoaderOptions.newOptions().setMaxBatchSize(5))
 
-        def dataLoaderSongs = new DataLoader<Object, Object>(new BatchLoader<DataFetchingEnvironment, List<Object>>() {
+        def dataLoaderSongs = DataLoaderFactory.newDataLoader(new BatchLoader<DataFetchingEnvironment, List<Object>>() {
             @Override
             CompletionStage<List<List<Object>>> load(List<DataFetchingEnvironment> keys) {
                 return CompletableFuture.supplyAsync({
@@ -242,7 +243,7 @@ class DataLoaderHangingTest extends Specification {
 
     DataFetcherExceptionHandler customExceptionHandlerThatThrows = new DataFetcherExceptionHandler() {
         @Override
-        DataFetcherExceptionHandlerResult onException(DataFetcherExceptionHandlerParameters handlerParameters) {
+        DataFetcherExceptionHandlerResult onException(DataFetcherExceptionHandlerParameters handlerParameters) { // Retain for test coverage, intentionally using sync version.
             throw handlerParameters.exception
         }
     }
@@ -332,8 +333,8 @@ class DataLoaderHangingTest extends Specification {
         """
 
     private DataLoaderRegistry buildRegistry() {
-        DataLoader<Integer, Person> personDataLoader = new DataLoader<>(personBatchLoader)
-        DataLoader<Integer, Company> companyDataLoader = new DataLoader<>(companyBatchLoader)
+        DataLoader<Integer, Person> personDataLoader = DataLoaderFactory.newDataLoader(personBatchLoader)
+        DataLoader<Integer, Company> companyDataLoader = DataLoaderFactory.newDataLoader(companyBatchLoader)
 
         DataLoaderRegistry registry = new DataLoaderRegistry()
         registry.register("person", personDataLoader)

--- a/src/test/groovy/graphql/parser/ParserTest.groovy
+++ b/src/test/groovy/graphql/parser/ParserTest.groovy
@@ -886,7 +886,7 @@ triple3 : """edge cases \\""" "" " \\"" \\" edge cases"""
         when:
         Parser parser = new Parser() {
             @Override
-            protected GraphqlAntlrToLanguage getAntlrToLanguage(CommonTokenStream tokens, MultiSourceReader multiSourceReader) {
+            protected GraphqlAntlrToLanguage getAntlrToLanguage(CommonTokenStream tokens, MultiSourceReader multiSourceReader, ParserOptions parserOptions) {
                 // this pattern is used in Nadel - its backdoor but needed
                 return new GraphqlAntlrToLanguage(tokens, multiSourceReader) {
                     @Override

--- a/src/test/groovy/graphql/schema/DelegatingDataFetchingEnvironmentTest.groovy
+++ b/src/test/groovy/graphql/schema/DelegatingDataFetchingEnvironmentTest.groovy
@@ -28,7 +28,7 @@ class DelegatingDataFetchingEnvironmentTest extends Specification {
             }
 
             @Override
-            def getContext() {
+            def getContext() { // Retain for test coverage
                 return "overriddenContext"
             }
         }

--- a/src/test/groovy/graphql/schema/GraphQLInputObjectTypeTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLInputObjectTypeTest.groovy
@@ -62,7 +62,10 @@ class GraphQLInputObjectTypeTest extends Specification {
     def "deprecated default value builder works"() {
         given:
         def graphQLContext = GraphQLContext.getDefault()
-        def schema = GraphQLSchema.newSchema().query(StarWarsSchema.queryType).build()
+        def schema = GraphQLSchema.newSchema()
+                .query(StarWarsSchema.queryType)
+                .codeRegistry(StarWarsSchema.codeRegistry)
+                .build()
         def validationUtil = new ValidationUtil()
         def inputObjectType = GraphQLInputObjectType.newInputObject()
                 .name("inputObjectType")

--- a/src/test/groovy/graphql/schema/visibility/GraphqlFieldVisibilityTest.groovy
+++ b/src/test/groovy/graphql/schema/visibility/GraphqlFieldVisibilityTest.groovy
@@ -30,6 +30,7 @@ class GraphqlFieldVisibilityTest extends Specification {
         GraphqlFieldVisibility banNameVisibility = newBlock().addPattern(".*\\.name").build()
         def schema = GraphQLSchema.newSchema()
                 .query(StarWarsSchema.queryType)
+                .codeRegistry(StarWarsSchema.codeRegistry)
                 .fieldVisibility(banNameVisibility) // Retain deprecated builder for test coverage
                 .build()
 
@@ -58,9 +59,9 @@ class GraphqlFieldVisibilityTest extends Specification {
 
     def "introspection visibility is enforced"() {
         given:
-        GraphQLCodeRegistry codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
-                .fieldVisibility(fieldVisibility)
-                .build()
+        GraphQLCodeRegistry codeRegistry = StarWarsSchema.codeRegistry.transform(builder -> {
+            builder.fieldVisibility(fieldVisibility)
+        })
         def schema = GraphQLSchema.newSchema()
                 .query(StarWarsSchema.queryType)
                 .codeRegistry(codeRegistry)
@@ -94,9 +95,9 @@ class GraphqlFieldVisibilityTest extends Specification {
 
     def "introspection turned off via field visibility"() {
         given:
-        GraphQLCodeRegistry codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
-                .fieldVisibility(NO_INTROSPECTION_FIELD_VISIBILITY)
-                .build()
+        GraphQLCodeRegistry codeRegistry = StarWarsSchema.codeRegistry.transform(builder -> {
+            builder.fieldVisibility(NO_INTROSPECTION_FIELD_VISIBILITY)
+        })
         def schema = GraphQLSchema.newSchema()
                 .query(StarWarsSchema.queryType)
                 .codeRegistry(codeRegistry)
@@ -118,7 +119,9 @@ class GraphqlFieldVisibilityTest extends Specification {
     def "schema printing filters on visibility"() {
 
         when:
-        def codeRegistry = GraphQLCodeRegistry.newCodeRegistry().fieldVisibility(DEFAULT_FIELD_VISIBILITY).build()
+        def codeRegistry = StarWarsSchema.codeRegistry.transform(builder -> {
+            builder.fieldVisibility(DEFAULT_FIELD_VISIBILITY)
+        })
         def schema = GraphQLSchema.newSchema()
                 .query(StarWarsSchema.queryType)
                 .codeRegistry(codeRegistry)
@@ -200,7 +203,9 @@ enum Episode {
         // and with specific bans
 
         when:
-        codeRegistry = GraphQLCodeRegistry.newCodeRegistry().fieldVisibility(ban(['Droid.id', 'Character.name', "QueryType.hero"])).build()
+        codeRegistry = StarWarsSchema.codeRegistry.transform(builder -> {
+            builder.fieldVisibility(ban(['Droid.id', 'Character.name', "QueryType.hero"]))
+        })
         schema = GraphQLSchema.newSchema()
                 .query(StarWarsSchema.queryType)
                 .codeRegistry(codeRegistry)

--- a/src/test/groovy/graphql/validation/SpecValidationSchema.java
+++ b/src/test/groovy/graphql/validation/SpecValidationSchema.java
@@ -112,9 +112,9 @@ public class SpecValidationSchema {
             .field(newFieldDefinition().name("nickname").type(Scalars.GraphQLString))
             .field(newFieldDefinition().name("barkVolume").type(Scalars.GraphQLInt))
             .field(newFieldDefinition().name("doesKnowCommand").type(nonNull(Scalars.GraphQLBoolean))
-                    .argument(singletonList(dogCommandArg)))
+                    .arguments(singletonList(dogCommandArg)))
             .field(newFieldDefinition().name("isHousetrained").type(Scalars.GraphQLBoolean)
-                    .argument(singletonList(atOtherHomesArg)))
+                    .arguments(singletonList(atOtherHomesArg)))
             .field(newFieldDefinition().name("owner").type(human))
             .withInterface(SpecValidationSchema.pet)
             .build();
@@ -125,7 +125,7 @@ public class SpecValidationSchema {
             .field(newFieldDefinition().name("nickname").type(Scalars.GraphQLString))
             .field(newFieldDefinition().name("meowVolume").type(Scalars.GraphQLInt))
             .field(newFieldDefinition().name("doesKnowCommand").type(nonNull(Scalars.GraphQLBoolean))
-                    .argument(singletonList(catCommandArg)))
+                    .arguments(singletonList(catCommandArg)))
             .withInterface(SpecValidationSchema.pet)
             .build();
 
@@ -237,6 +237,7 @@ public class SpecValidationSchema {
             .additionalDirective(dogDirective)
             .additionalDirective(nonNullDirective)
             .additionalDirective(objectArgumentDirective)
-            .build(specValidationDictionary);
+            .additionalTypes(specValidationDictionary)
+            .build();
 
 }

--- a/src/test/groovy/graphql/validation/SpecValidationSchema.java
+++ b/src/test/groovy/graphql/validation/SpecValidationSchema.java
@@ -1,8 +1,8 @@
 package graphql.validation;
 
 import graphql.Scalars;
-import graphql.TypeResolutionEnvironment;
 import graphql.schema.GraphQLArgument;
+import graphql.schema.GraphQLCodeRegistry;
 import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLInputObjectField;
@@ -55,27 +55,6 @@ public class SpecValidationSchema {
     public static final GraphQLInterfaceType sentient = GraphQLInterfaceType.newInterface()
             .name("Sentient")
             .field(newFieldDefinition().name("name").type(nonNull(Scalars.GraphQLString)))
-            .typeResolver(new TypeResolver() {
-                @Override
-                public GraphQLObjectType getType(TypeResolutionEnvironment env) {
-                    if (env.getObject() instanceof Human) return human;
-                    if (env.getObject() instanceof Alien) return alien;
-                    return null;
-                }
-            })
-            .build();
-
-    public static final GraphQLInterfaceType pet = GraphQLInterfaceType.newInterface()
-            .name("Pet")
-            .field(newFieldDefinition().name("name").type(nonNull(Scalars.GraphQLString)))
-            .typeResolver(new TypeResolver() {
-                @Override
-                public GraphQLObjectType getType(TypeResolutionEnvironment env) {
-                    if (env.getObject() instanceof Dog) return dog;
-                    if (env.getObject() instanceof Cat) return cat;
-                    return null;
-                }
-            })
             .build();
 
     public static final GraphQLObjectType human = GraphQLObjectType.newObject()
@@ -91,6 +70,21 @@ public class SpecValidationSchema {
             .withInterface(SpecValidationSchema.sentient)
             .build();
 
+    public static final TypeResolver sentientTypeResolver = env -> {
+        if (env.getObject() instanceof Human) {
+            return human;
+        }
+        if (env.getObject() instanceof Alien) {
+            return alien;
+        }
+        return null;
+    };
+
+    public static final GraphQLArgument catCommandArg = GraphQLArgument.newArgument()
+            .name("catCommand")
+            .type(nonNull(catCommand))
+            .build();
+
     public static final GraphQLArgument dogCommandArg = GraphQLArgument.newArgument()
             .name("dogCommand")
             .type(nonNull(dogCommand))
@@ -101,9 +95,9 @@ public class SpecValidationSchema {
             .type(Scalars.GraphQLBoolean)
             .build();
 
-    public static final GraphQLArgument catCommandArg = GraphQLArgument.newArgument()
-            .name("catCommand")
-            .type(nonNull(catCommand))
+    public static final GraphQLInterfaceType pet = GraphQLInterfaceType.newInterface()
+            .name("Pet")
+            .field(newFieldDefinition().name("name").type(nonNull(Scalars.GraphQLString)))
             .build();
 
     public static final GraphQLObjectType dog = GraphQLObjectType.newObject()
@@ -129,35 +123,60 @@ public class SpecValidationSchema {
             .withInterface(SpecValidationSchema.pet)
             .build();
 
+    public static final TypeResolver petTypeResolver = env -> {
+        if (env.getObject() instanceof Dog) {
+            return dog;
+        }
+        if (env.getObject() instanceof Cat) {
+            return cat;
+        }
+        return null;
+    };
+
     public static final GraphQLUnionType catOrDog = GraphQLUnionType.newUnionType()
             .name("CatOrDog")
             .possibleTypes(cat, dog)
-            .typeResolver(env -> {
-                if (env.getObject() instanceof Cat) return cat;
-                if (env.getObject() instanceof Dog) return dog;
-                return null;
-            })
             .build();
+
+    public static final TypeResolver catOrDogTypeResolver = env -> {
+        if (env.getObject() instanceof Cat) {
+            return cat;
+        }
+        if (env.getObject() instanceof Dog) {
+            return dog;
+        }
+        return null;
+    };
 
     public static final GraphQLUnionType dogOrHuman = GraphQLUnionType.newUnionType()
             .name("DogOrHuman")
             .possibleTypes(dog, human)
-            .typeResolver(env -> {
-                if (env.getObject() instanceof Human) return human;
-                if (env.getObject() instanceof Dog) return dog;
-                return null;
-            })
             .build();
+
+    public static final TypeResolver dogOrHumanTypeResolver = env -> {
+        if (env.getObject() instanceof Human) {
+            return human;
+        }
+        if (env.getObject() instanceof Dog) {
+            return dog;
+        }
+        return null;
+    };
 
     public static final GraphQLUnionType humanOrAlien = GraphQLUnionType.newUnionType()
             .name("HumanOrAlien")
             .possibleTypes(human, alien)
-            .typeResolver(env -> {
-                if (env.getObject() instanceof Human) return human;
-                if (env.getObject() instanceof Alien) return alien;
-                return null;
-            })
             .build();
+
+    public static final TypeResolver humanOrAlienTypeResolver = env -> {
+        if (env.getObject() instanceof Human) {
+            return human;
+        }
+        if (env.getObject() instanceof Alien) {
+            return alien;
+        }
+        return null;
+    };
 
     public static final GraphQLDirective dogDirective = GraphQLDirective.newDirective()
             .name("dogDirective")
@@ -180,7 +199,6 @@ public class SpecValidationSchema {
             .field(newFieldDefinition().name("cat").type(cat))
             .build();
 
-    @SuppressWarnings("serial")
     public static final Set<GraphQLType> specValidationDictionary = new HashSet<GraphQLType>() {{
         add(dogCommand);
         add(catCommand);
@@ -229,8 +247,17 @@ public class SpecValidationSchema {
             .validLocations(FIELD, FRAGMENT_SPREAD, FRAGMENT_DEFINITION, INLINE_FRAGMENT, QUERY)
             .build();
 
+    public static final GraphQLCodeRegistry codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+            .typeResolver("Sentient", sentientTypeResolver)
+            .typeResolver("Pet", petTypeResolver)
+            .typeResolver("CatOrDog", catOrDogTypeResolver)
+            .typeResolver("DogOrHuman", dogOrHumanTypeResolver)
+            .typeResolver("HumanOrAlien", humanOrAlienTypeResolver)
+            .build();
+
     public static final GraphQLSchema specValidationSchema = GraphQLSchema.newSchema()
             .query(queryRoot)
+            .codeRegistry(codeRegistry)
             .subscription(subscriptionRoot)
             .additionalDirective(upperDirective)
             .additionalDirective(lowerDirective)

--- a/src/test/groovy/graphql/validation/ValidateCustomDirectives.groovy
+++ b/src/test/groovy/graphql/validation/ValidateCustomDirectives.groovy
@@ -19,6 +19,7 @@ class ValidateCustomDirectives extends Specification {
 
     GraphQLSchema customDirectiveSchema = GraphQLSchema.newSchema()
             .query(SpecValidationSchema.queryRoot)
+            .codeRegistry(SpecValidationSchema.codeRegistry)
             .additionalDirective(SpecValidationSchema.dogDirective)
             .additionalDirective(customDirective)
             .additionalTypes(SpecValidationSchema.specValidationDictionary)

--- a/src/test/groovy/graphql/validation/ValidationUtilTest.groovy
+++ b/src/test/groovy/graphql/validation/ValidationUtilTest.groovy
@@ -26,7 +26,10 @@ import static graphql.schema.GraphQLNonNull.nonNull
 
 class ValidationUtilTest extends Specification {
 
-    def schema = GraphQLSchema.newSchema().query(StarWarsSchema.queryType).build()
+    def schema = GraphQLSchema.newSchema()
+            .query(StarWarsSchema.queryType)
+            .codeRegistry(StarWarsSchema.codeRegistry)
+            .build()
     def validationUtil = new ValidationUtil()
     def graphQLContext = GraphQLContext.getDefault()
     def locale = Locale.getDefault()

--- a/src/test/groovy/graphql/validation/rules/Harness.java
+++ b/src/test/groovy/graphql/validation/rules/Harness.java
@@ -77,7 +77,7 @@ public class Harness {
                     .argument(newArgument()
                             .name("atOtherHomes")
                             .type(GraphQLBoolean)
-                            .defaultValue(true)))
+                            .defaultValueProgrammatic(true)))
             .field(newFieldDefinition()
                     .name("isAtLocation")
                     .type(GraphQLBoolean)


### PR DESCRIPTION
Fixing up deprecated API usages in programmatic test schemas, fix last few remaining Java deprecated method overrides

This is the last deprecation fix PR for tests. Next PR will fix deprecated usages in documentation examples