### PR TITLE
EXPERIMENT - Unwrapping the ER from around fetched values

### DIFF
--- a/src/main/java/graphql/execution/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncExecutionStrategy.java
@@ -6,9 +6,7 @@ import graphql.execution.instrumentation.ExecutionStrategyInstrumentationContext
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionStrategyParameters;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 
@@ -45,31 +43,21 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
         ExecutionStrategyInstrumentationContext executionStrategyCtx = ExecutionStrategyInstrumentationContext.nonNullCtx(instrumentation.beginExecutionStrategy(instrumentationParameters, executionContext.getInstrumentationState()));
 
         MergedSelectionSet fields = parameters.getFields();
-        Set<String> fieldNames = fields.keySet();
-        Async.CombinedBuilder<FieldValueInfo> futures = Async.ofExpectedSize(fields.size());
-        List<String> resolvedFields = new ArrayList<>(fieldNames.size());
-        for (String fieldName : fieldNames) {
-            MergedField currentField = fields.getSubField(fieldName);
-
-            ResultPath fieldPath = parameters.getPath().segment(mkNameForPath(currentField));
-            ExecutionStrategyParameters newParameters = parameters
-                    .transform(builder -> builder.field(currentField).path(fieldPath).parent(parameters));
-
-            resolvedFields.add(fieldName);
-            CompletableFuture<FieldValueInfo> future = resolveFieldWithInfo(executionContext, newParameters);
-            futures.add(future);
-        }
+        List<String> fieldNames = fields.getKeys();
+        Async.CombinedBuilder<FieldValueInfo> futures = resolveFieldsWithInfo(executionContext, parameters, fields, fieldNames);
         CompletableFuture<ExecutionResult> overallResult = new CompletableFuture<>();
         executionStrategyCtx.onDispatched(overallResult);
 
         futures.await().whenComplete((completeValueInfos, throwable) -> {
-            BiConsumer<List<ExecutionResult>, Throwable> handleResultsConsumer = handleResults(executionContext, resolvedFields, overallResult);
+            BiConsumer<List<ExecutionResult>, Throwable> handleResultsConsumer = handleResults(executionContext, fieldNames, overallResult);
             if (throwable != null) {
                 handleResultsConsumer.accept(null, throwable.getCause());
                 return;
             }
             Async.CombinedBuilder<ExecutionResult> executionResultFutures = Async.ofExpectedSize(completeValueInfos.size());
             for (FieldValueInfo completeValueInfo : completeValueInfos) {
+                // tweak here since most of this is NOT needed in practice since
+                // handleResults unwraps and throws away the ER objects
                 executionResultFutures.add(completeValueInfo.getFieldValue());
             }
             executionStrategyCtx.onFieldValuesInfo(completeValueInfos);

--- a/src/main/java/graphql/execution/FieldValueInfo.java
+++ b/src/main/java/graphql/execution/FieldValueInfo.java
@@ -1,5 +1,6 @@
 package graphql.execution;
 
+import graphql.DeprecatedAt;
 import graphql.ExecutionResult;
 import graphql.PublicApi;
 
@@ -22,10 +23,10 @@ public class FieldValueInfo {
     }
 
     private final CompleteValueType completeValueType;
-    private final CompletableFuture<ExecutionResult> fieldValue;
+    private final CompletableFuture<Object> fieldValue;
     private final List<FieldValueInfo> fieldValueInfos;
 
-    private FieldValueInfo(CompleteValueType completeValueType, CompletableFuture<ExecutionResult> fieldValue, List<FieldValueInfo> fieldValueInfos) {
+    private FieldValueInfo(CompleteValueType completeValueType, CompletableFuture<Object> fieldValue, List<FieldValueInfo> fieldValueInfos) {
         assertNotNull(fieldValueInfos, () -> "fieldValueInfos can't be null");
         this.completeValueType = completeValueType;
         this.fieldValue = fieldValue;
@@ -36,8 +37,19 @@ public class FieldValueInfo {
         return completeValueType;
     }
 
-    public CompletableFuture<ExecutionResult> getFieldValue() {
+    public CompletableFuture<Object> getValue() {
         return fieldValue;
+    }
+
+    /**
+     * @return a promise to the value wrapped in an execution result
+     *
+     * @deprecated use {@link #getValue()} instead
+     */
+    @Deprecated
+    @DeprecatedAt(value = "2022-10-03")
+    public CompletableFuture<ExecutionResult> getFieldValue() {
+        return fieldValue.thenApply(value -> ExecutionResult.newExecutionResult().data(value).build());
     }
 
     public List<FieldValueInfo> getFieldValueInfos() {
@@ -60,7 +72,7 @@ public class FieldValueInfo {
     @SuppressWarnings("unused")
     public static class Builder {
         private CompleteValueType completeValueType;
-        private CompletableFuture<ExecutionResult> executionResultFuture;
+        private CompletableFuture<Object> valueFuture;
         private List<FieldValueInfo> listInfos = new ArrayList<>();
 
         public Builder(CompleteValueType completeValueType) {
@@ -72,8 +84,8 @@ public class FieldValueInfo {
             return this;
         }
 
-        public Builder fieldValue(CompletableFuture<ExecutionResult> executionResultFuture) {
-            this.executionResultFuture = executionResultFuture;
+        public Builder fieldValue(CompletableFuture<Object> executionResultFuture) {
+            this.valueFuture = executionResultFuture;
             return this;
         }
 
@@ -84,7 +96,7 @@ public class FieldValueInfo {
         }
 
         public FieldValueInfo build() {
-            return new FieldValueInfo(completeValueType, executionResultFuture, listInfos);
+            return new FieldValueInfo(completeValueType, valueFuture, listInfos);
         }
     }
 }

--- a/src/main/java/graphql/execution/SubscriptionExecutionStrategy.java
+++ b/src/main/java/graphql/execution/SubscriptionExecutionStrategy.java
@@ -133,6 +133,7 @@ public class SubscriptionExecutionStrategy extends ExecutionStrategy {
 
         FetchedValue fetchedValue = unboxPossibleDataFetcherResult(newExecutionContext, parameters, eventPayload);
         FieldValueInfo fieldValueInfo = completeField(newExecutionContext, newParameters, fetchedValue);
+        // potential change here
         CompletableFuture<ExecutionResult> overallResult = fieldValueInfo
                 .getFieldValue()
                 .thenApply(executionResult -> wrapWithRootFieldName(newParameters, executionResult));


### PR DESCRIPTION
This is a SPIKE of what it would take to not wrap values in `ExecutionResult` objects and rather just use plain objects.

The friction points are

* MOSTLY in Instrumentation - this would need to go from `InstrumentationContext<ExecutionResult>` to `InstrumentationContext<Object>`  in a  fair few call back methods.

* Some of the protected methods in ExecutionStrategy code would change

The branch marks I ran did not seem to show any great improvement BUT there must be some in a memory pressure sense since we are allocated a `ER` for every field value fetch including scalars and enums and nulls