### PR TITLE
Avoid allocating a type resolve env if the type is already an object type

### DIFF
--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -679,6 +679,18 @@ public abstract class ExecutionStrategy {
         return null;
     }
 
+    /**
+     * Converts an object that is known to should be an Iterable into one
+     *
+     * @param result the result object
+     *
+     * @return an Iterable from that object
+     *
+     * @throws java.lang.ClassCastException if it's not an Iterable
+     */
+    protected Iterable<Object> toIterable(Object result) {
+        return FpKit.toIterable(result);
+    }
 
     protected GraphQLObjectType resolveType(ExecutionContext executionContext, ExecutionStrategyParameters parameters, GraphQLType fieldType) {
         // we can avoid a method call and type resolver environment allocation if we know it's an object type

--- a/src/main/java/graphql/execution/ResolveType.java
+++ b/src/main/java/graphql/execution/ResolveType.java
@@ -1,5 +1,6 @@
 package graphql.execution;
 
+import graphql.Assert;
 import graphql.Internal;
 import graphql.TypeResolutionEnvironment;
 import graphql.normalized.ExecutableNormalizedField;
@@ -19,11 +20,20 @@ import java.util.function.Supplier;
 @Internal
 public class ResolveType {
 
-
     public GraphQLObjectType resolveType(ExecutionContext executionContext, MergedField field, Object source, ExecutionStepInfo executionStepInfo, GraphQLType fieldType, Object localContext) {
-        GraphQLObjectType resolvedType;
+        Assert.assertTrue(fieldType instanceof GraphQLInterfaceType || fieldType instanceof GraphQLUnionType,
+                () -> "The passed in fieldType MUST be an interface or union type : " + fieldType.getClass().getName());
+        TypeResolutionEnvironment env = buildEnv(executionContext, field, source, executionStepInfo, fieldType, localContext);
+        if (fieldType instanceof GraphQLInterfaceType) {
+            return resolveTypeForInterface(env, (GraphQLInterfaceType) fieldType);
+        } else {
+            return resolveTypeForUnion(env, (GraphQLUnionType) fieldType);
+        }
+    }
+
+    private TypeResolutionEnvironment buildEnv(ExecutionContext executionContext, MergedField field, Object source, ExecutionStepInfo executionStepInfo, GraphQLType fieldType, Object localContext) {
         DataFetchingFieldSelectionSet fieldSelectionSet = buildSelectionSet(executionContext, field, (GraphQLOutputType) fieldType, executionStepInfo);
-        TypeResolutionEnvironment env = TypeResolutionParameters.newParameters()
+        return TypeResolutionParameters.newParameters()
                 .field(field)
                 .fieldType(fieldType)
                 .value(source)
@@ -34,14 +44,6 @@ public class ResolveType {
                 .localContext(localContext)
                 .schema(executionContext.getGraphQLSchema())
                 .build();
-        if (fieldType instanceof GraphQLInterfaceType) {
-            resolvedType = resolveTypeForInterface(env, (GraphQLInterfaceType) fieldType);
-        } else if (fieldType instanceof GraphQLUnionType) {
-            resolvedType = resolveTypeForUnion(env, (GraphQLUnionType) fieldType);
-        } else {
-            resolvedType = (GraphQLObjectType) fieldType;
-        }
-        return resolvedType;
     }
 
     private DataFetchingFieldSelectionSet buildSelectionSet(ExecutionContext executionContext, MergedField field, GraphQLOutputType fieldType, ExecutionStepInfo executionStepInfo) {
@@ -65,11 +67,9 @@ public class ResolveType {
         if (result == null) {
             throw new UnresolvedTypeException(abstractType);
         }
-
         if (!env.getSchema().isPossibleType(abstractType, result)) {
             throw new UnresolvedTypeException(abstractType, result);
         }
-
         return result;
     }
 

--- a/src/main/java/graphql/execution/ResolveType.java
+++ b/src/main/java/graphql/execution/ResolveType.java
@@ -23,17 +23,8 @@ public class ResolveType {
     public GraphQLObjectType resolveType(ExecutionContext executionContext, MergedField field, Object source, ExecutionStepInfo executionStepInfo, GraphQLType fieldType, Object localContext) {
         Assert.assertTrue(fieldType instanceof GraphQLInterfaceType || fieldType instanceof GraphQLUnionType,
                 () -> "The passed in fieldType MUST be an interface or union type : " + fieldType.getClass().getName());
-        TypeResolutionEnvironment env = buildEnv(executionContext, field, source, executionStepInfo, fieldType, localContext);
-        if (fieldType instanceof GraphQLInterfaceType) {
-            return resolveTypeForInterface(env, (GraphQLInterfaceType) fieldType);
-        } else {
-            return resolveTypeForUnion(env, (GraphQLUnionType) fieldType);
-        }
-    }
-
-    private TypeResolutionEnvironment buildEnv(ExecutionContext executionContext, MergedField field, Object source, ExecutionStepInfo executionStepInfo, GraphQLType fieldType, Object localContext) {
         DataFetchingFieldSelectionSet fieldSelectionSet = buildSelectionSet(executionContext, field, (GraphQLOutputType) fieldType, executionStepInfo);
-        return TypeResolutionParameters.newParameters()
+        TypeResolutionEnvironment env = TypeResolutionParameters.newParameters()
                 .field(field)
                 .fieldType(fieldType)
                 .value(source)
@@ -44,6 +35,11 @@ public class ResolveType {
                 .localContext(localContext)
                 .schema(executionContext.getGraphQLSchema())
                 .build();
+        if (fieldType instanceof GraphQLInterfaceType) {
+            return resolveTypeForInterface(env, (GraphQLInterfaceType) fieldType);
+        } else {
+            return resolveTypeForUnion(env, (GraphQLUnionType) fieldType);
+        }
     }
 
     private DataFetchingFieldSelectionSet buildSelectionSet(ExecutionContext executionContext, MergedField field, GraphQLOutputType fieldType, ExecutionStepInfo executionStepInfo) {


### PR DESCRIPTION
This will improve the runtime for every object type encountered since the type env allocation (and indeed method call) is not needed