### PR TITLE
Float coercion tidy up

### DIFF
--- a/src/main/java/graphql/execution/ValuesResolverLegacy.java
+++ b/src/main/java/graphql/execution/ValuesResolverLegacy.java
@@ -77,9 +77,6 @@ class ValuesResolverLegacy {
         // Since value is an internally represented value, it must be serialized
         // to an externally represented value before converting into an AST.
         final Object serialized = serializeLegacy(type, value, graphqlContext, locale);
-        if (isNullishLegacy(serialized)) {
-            return null;
-        }
 
         // Others serialize based on their corresponding JavaScript scalar types.
         if (serialized instanceof Boolean) {
@@ -156,12 +153,5 @@ class ValuesResolverLegacy {
         } else {
             return ((GraphQLEnumType) type).serialize(value, graphqlContext, locale);
         }
-    }
-
-    private static boolean isNullishLegacy(Object serialized) {
-        if (serialized instanceof Number) {
-            return Double.isNaN(((Number) serialized).doubleValue());
-        }
-        return serialized == null;
     }
 }

--- a/src/main/java/graphql/scalar/GraphqlFloatCoercing.java
+++ b/src/main/java/graphql/scalar/GraphqlFloatCoercing.java
@@ -31,12 +31,9 @@ public class GraphqlFloatCoercing implements Coercing<Double, Double> {
     private Double convertImpl(Object input) {
         // From the GraphQL Float spec, non-finite floating-point internal values (NaN and Infinity)
         // must raise a field error on both result and input coercion
+        Double doubleInput;
         if (input instanceof Double) {
-            Double doubleInput = (Double) input;
-            if (Double.isNaN(doubleInput) || Double.isInfinite(doubleInput)) {
-                return null;
-            }
-            return doubleInput;
+            doubleInput = (Double) input;
         } else if (isNumberIsh(input)) {
             BigDecimal value;
             try {
@@ -44,10 +41,15 @@ public class GraphqlFloatCoercing implements Coercing<Double, Double> {
             } catch (NumberFormatException e) {
                 return null;
             }
-            return value.doubleValue();
+            doubleInput = value.doubleValue();
         } else {
             return null;
         }
+
+        if (Double.isNaN(doubleInput) || Double.isInfinite(doubleInput)) {
+            return null;
+        }
+        return doubleInput;
     }
 
     @NotNull

--- a/src/main/java/graphql/scalar/GraphqlFloatCoercing.java
+++ b/src/main/java/graphql/scalar/GraphqlFloatCoercing.java
@@ -29,7 +29,15 @@ import static graphql.scalar.CoercingUtil.typeName;
 public class GraphqlFloatCoercing implements Coercing<Double, Double> {
 
     private Double convertImpl(Object input) {
-        if (isNumberIsh(input)) {
+        // From the GraphQL Float spec, non-finite floating-point internal values (NaN and Infinity)
+        // must raise a field error on both result and input coercion
+        if (input instanceof Double) {
+            Double doubleInput = (Double) input;
+            if (Double.isNaN(doubleInput) || Double.isInfinite(doubleInput)) {
+                return null;
+            }
+            return doubleInput;
+        } else if (isNumberIsh(input)) {
             BigDecimal value;
             try {
                 value = new BigDecimal(input.toString());
@@ -40,7 +48,6 @@ public class GraphqlFloatCoercing implements Coercing<Double, Double> {
         } else {
             return null;
         }
-
     }
 
     @NotNull

--- a/src/test/groovy/graphql/ScalarsFloatTest.groovy
+++ b/src/test/groovy/graphql/ScalarsFloatTest.groovy
@@ -114,10 +114,15 @@ class ScalarsFloatTest extends Specification {
         thrown(CoercingSerializeException)
 
         where:
-        value           | _
-        ""              | _
-        "not a number " | _
-        Double.NaN      | _
+        value                    | _
+        ""                       | _
+        "not a number "          | _
+        Double.NaN               | _
+        Double.POSITIVE_INFINITY | _
+        Double.NEGATIVE_INFINITY | _
+        Float.NaN                | _
+        Float.POSITIVE_INFINITY  | _
+        Float.NEGATIVE_INFINITY  | _
     }
 
     @Unroll
@@ -128,10 +133,15 @@ class ScalarsFloatTest extends Specification {
         thrown(CoercingParseValueException)
 
         where:
-        value           | _
-        ""              | _
-        "not a number " | _
-        Double.NaN      | _
+        value                    | _
+        ""                       | _
+        "not a number "          | _
+        Double.NaN               | _
+        Double.POSITIVE_INFINITY | _
+        Double.NEGATIVE_INFINITY | _
+        Float.NaN                | _
+        Float.POSITIVE_INFINITY  | _
+        Float.NEGATIVE_INFINITY  | _
     }
 
 }

--- a/src/test/groovy/graphql/ScalarsFloatTest.groovy
+++ b/src/test/groovy/graphql/ScalarsFloatTest.groovy
@@ -114,34 +114,46 @@ class ScalarsFloatTest extends Specification {
         thrown(CoercingSerializeException)
 
         where:
-        value                    | _
-        ""                       | _
-        "not a number "          | _
-        Double.NaN               | _
-        Double.POSITIVE_INFINITY | _
-        Double.NEGATIVE_INFINITY | _
-        Float.NaN                | _
-        Float.POSITIVE_INFINITY  | _
-        Float.NEGATIVE_INFINITY  | _
+        value                               | _
+        ""                                  | _
+        "not a number "                     | _
+        Double.NaN                          | _
+        Double.NaN.toString()               | _
+        Double.POSITIVE_INFINITY            | _
+        Double.POSITIVE_INFINITY.toString() | _
+        Double.NEGATIVE_INFINITY            | _
+        Double.NEGATIVE_INFINITY.toString() | _
+        Float.NaN                           | _
+        Float.NaN.toString()                | _
+        Float.POSITIVE_INFINITY             | _
+        Float.POSITIVE_INFINITY.toString()  | _
+        Float.NEGATIVE_INFINITY             | _
+        Float.NEGATIVE_INFINITY.toString()  | _
     }
 
     @Unroll
-    def "serialize/parseValue throws exception for invalid input #value"() {
+    def "parseValue throws exception for invalid input #value"() {
         when:
         Scalars.GraphQLFloat.getCoercing().parseValue(value, GraphQLContext.default, Locale.default)
         then:
         thrown(CoercingParseValueException)
 
         where:
-        value                    | _
-        ""                       | _
-        "not a number "          | _
-        Double.NaN               | _
-        Double.POSITIVE_INFINITY | _
-        Double.NEGATIVE_INFINITY | _
-        Float.NaN                | _
-        Float.POSITIVE_INFINITY  | _
-        Float.NEGATIVE_INFINITY  | _
+        value                               | _
+        ""                                  | _
+        "not a number "                     | _
+        Double.NaN                          | _
+        Double.NaN.toString()               | _
+        Double.POSITIVE_INFINITY            | _
+        Double.POSITIVE_INFINITY.toString() | _
+        Double.NEGATIVE_INFINITY            | _
+        Double.NEGATIVE_INFINITY.toString() | _
+        Float.NaN                           | _
+        Float.NaN.toString()                | _
+        Float.POSITIVE_INFINITY             | _
+        Float.POSITIVE_INFINITY.toString()  | _
+        Float.NEGATIVE_INFINITY             | _
+        Float.NEGATIVE_INFINITY.toString()  | _
     }
 
 }

--- a/src/test/groovy/graphql/ScalarsQuerySchema.java
+++ b/src/test/groovy/graphql/ScalarsQuerySchema.java
@@ -18,18 +18,6 @@ public class ScalarsQuerySchema {
 
     public static final GraphQLObjectType queryType = newObject()
             .name("QueryType")
-            // Static scalars
-            .field(newFieldDefinition()
-                    .name("floatNaN")
-                    .type(Scalars.GraphQLFloat)
-                    .staticValue(Double.NaN)) // Retain for test coverage
-            // Scalars with input of same type, value echoed back
-            .field(newFieldDefinition()
-                    .name("floatNaNInput")
-                    .type(Scalars.GraphQLFloat)
-                    .argument(newArgument()
-                            .name("input")
-                            .type(GraphQLNonNull.nonNull(Scalars.GraphQLFloat))))
             .field(newFieldDefinition()
                     .name("stringInput")
                     .type(Scalars.GraphQLString)
@@ -51,12 +39,10 @@ public class ScalarsQuerySchema {
                             .type(Scalars.GraphQLString)))
             .build();
 
-    static FieldCoordinates floatNaNCoordinates = FieldCoordinates.coordinates("QueryType", "floatNaNInput");
     static FieldCoordinates stringInputCoordinates = FieldCoordinates.coordinates("QueryType", "stringInput");
     static FieldCoordinates floatStringCoordinates = FieldCoordinates.coordinates("QueryType", "floatString");
     static FieldCoordinates intStringCoordinates = FieldCoordinates.coordinates("QueryType", "intString");
     static GraphQLCodeRegistry codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
-            .dataFetcher(floatNaNCoordinates, inputDF)
             .dataFetcher(stringInputCoordinates, inputDF)
             .dataFetcher(floatStringCoordinates, inputDF)
             .dataFetcher(intStringCoordinates, inputDF)

--- a/src/test/groovy/graphql/execution/ValuesResolverTestLegacy.groovy
+++ b/src/test/groovy/graphql/execution/ValuesResolverTestLegacy.groovy
@@ -1,6 +1,13 @@
-package graphql.language
+package graphql.execution
 
 import graphql.GraphQLContext
+import graphql.language.ArrayValue
+import graphql.language.EnumValue
+import graphql.language.FloatValue
+import graphql.language.IntValue
+import graphql.language.ObjectField
+import graphql.language.ObjectValue
+import graphql.language.StringValue
 import graphql.schema.GraphQLEnumType
 import graphql.schema.GraphQLInputObjectType
 import spock.lang.Ignore

--- a/src/test/groovy/graphql/execution/ValuesResolverTestLegacy.groovy
+++ b/src/test/groovy/graphql/execution/ValuesResolverTestLegacy.groovy
@@ -144,7 +144,7 @@ class ValuesResolverTestLegacy extends Specification {
     def 'converts list to lists'() {
         expect:
         valueToLiteralLegacy(['hello', 'world'], list(GraphQLString), graphQLContext, locale).isEqualTo(
-                new ArrayValue(['hello', 'world'])
+                new ArrayValue([new StringValue('hello'), new StringValue('world')])
         )
     }
 
@@ -152,7 +152,7 @@ class ValuesResolverTestLegacy extends Specification {
         String[] sArr = ['hello', 'world'] as String[]
         expect:
         valueToLiteralLegacy(sArr, list(GraphQLString), graphQLContext, locale).isEqualTo(
-                new ArrayValue(['hello', 'world'])
+                new ArrayValue([new StringValue('hello'), new StringValue('world')])
         )
     }
 


### PR DESCRIPTION
The GraphQL Float spec was updated a year ago to specifically not allow NaN and positive/negative infinity in both result coercion and input coercion 

https://spec.graphql.org/draft/#sec-Float
https://github.com/graphql/graphql-spec/issues/778

The float coercing was mostly compliant with this spec update, as NaN and positive/negative infinity are not allowed in the BigDecimal String constructor used in `GraphqlFloatCoercing`, specifically the line `value = new BigDecimal(input.toString());`.

I say mostly, there was one uncaught case. It's possible for the old `convertImpl` method to return a Double value that is later converted to positive infinity with `BigDecimal.valueOf`, such as in the `valueToLiteralImpl`

```
private FloatValue valueToLiteralImpl(Object input, @NotNull Locale locale) {
    Double result = assertNotNull(convertImpl(input), () -> i18nMsg(locale, "Float.notFloat", typeName(input)));
        return FloatValue.newFloatValue(BigDecimal.valueOf(result)).build();
}
```

This PR introduces an explicit check for positive/negative infinity and NaN to address this problem. This PR cleans up NaN and infinity tests.