### PR TITLE
WIP - Bytecode based data fetchers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,7 @@ dependencies {
     api 'org.reactivestreams:reactive-streams:' + reactiveStreamsVersion
     antlr 'org.antlr:antlr4:' + antlrVersion
     implementation 'com.google.guava:guava:31.0.1-jre'
+    implementation('org.javassist:javassist:3.29.2-GA')
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation 'org.spockframework:spock-core:2.0-groovy-3.0'
     testImplementation 'org.codehaus.groovy:groovy:3.0.9'

--- a/src/main/java/graphql/schema/bytecode/ByteCodeException.java
+++ b/src/main/java/graphql/schema/bytecode/ByteCodeException.java
@@ -1,0 +1,15 @@
+package graphql.schema.bytecode;
+
+import graphql.GraphQLException;
+
+public class ByteCodeException extends GraphQLException {
+    public ByteCodeException(String message) {
+        super(message);
+    }
+
+    public ByteCodeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+
+}

--- a/src/main/java/graphql/schema/bytecode/ByteCodeFetcher.java
+++ b/src/main/java/graphql/schema/bytecode/ByteCodeFetcher.java
@@ -1,0 +1,8 @@
+package graphql.schema.bytecode;
+
+import graphql.Internal;
+
+@Internal
+public interface ByteCodeFetcher {
+    Object fetch(Object sourceObject, String propertyName);
+}

--- a/src/main/java/graphql/schema/bytecode/ByteCodePojoFetchingGenerator.java
+++ b/src/main/java/graphql/schema/bytecode/ByteCodePojoFetchingGenerator.java
@@ -1,0 +1,181 @@
+package graphql.schema.bytecode;
+
+import graphql.Internal;
+import javassist.ClassPool;
+import javassist.CtClass;
+import javassist.CtMethod;
+import javassist.CtNewMethod;
+import javassist.LoaderClassPath;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Internal
+public class ByteCodePojoFetchingGenerator {
+
+    public static class DualPropertyException extends ByteCodeException {
+        public DualPropertyException(String property) {
+            super("The property '" + property + "' has two definitions");
+        }
+    }
+
+    public static class NoMethodsException extends ByteCodeException {
+        public NoMethodsException(Class<?> clazz) {
+            super("There are no publicly accessible methods on " + clazz.getName());
+        }
+    }
+
+    public static class CantGenerateClassException extends ByteCodeException {
+        public CantGenerateClassException(Class<?> clazz, Exception e) {
+            super("Unable to use Javassist to generate class for " + clazz.getName(), e);
+        }
+    }
+
+
+    public static Class<ByteCodeFetcher> generateClassFor(Class<?> sourceClass) {
+        try {
+            ClassPool pool = ClassPool.getDefault();
+
+            pool.insertClassPath(new LoaderClassPath(ByteCodePojoFetchingGenerator.class.getClassLoader()));
+            CtClass cc = pool.makeClass("graphql.schema.bytecode." + mkClassName(sourceClass));
+            CtClass ci = pool.get("graphql.schema.bytecode.ByteCodeFetcher");
+            cc.setSuperclass(pool.get("java.lang.Object"));
+            cc.addInterface(ci);
+
+            String methodBody = generateMethodBody(sourceClass);
+            CtMethod m = CtNewMethod.make(
+                    methodBody,
+                    cc);
+            cc.addMethod(m);
+            //noinspection unchecked
+            return (Class<ByteCodeFetcher>) cc.toClass();
+        } catch (Exception e) {
+            throw new CantGenerateClassException(sourceClass, e);
+        }
+    }
+
+    private static String mkClassName(Class<?> sourceClass) {
+        return ByteCodePojoFetchingGenerator.class.getPackage().getName() + ".Fetcher4" + sourceClass.getCanonicalName() + "Gen";
+    }
+
+    public static String generateMethodBody(Class<?> sourceClass) {
+        StringWriter sw = new StringWriter();
+        PrintWriter out = new PrintWriter(sw);
+
+        String canonicalName = sourceClass.getCanonicalName();
+
+
+        out.println("public Object fetch(Object sourceObject, String propertyName) {");
+        out.println("   if (sourceObject == null) { return null; }");
+        out.printf("   %s source = (%s) sourceObject;\n", canonicalName, canonicalName);
+
+        Set<String> properties = new HashSet<>();
+        List<Method> methods = Arrays.stream(sourceClass.getMethods())
+                .sorted(Comparator.comparing(Method::getName))
+                .collect(Collectors.toList());
+        for (Method method : methods) {
+            if (isPojoMethod(method)) {
+                String propertyName = mkPropertyName(method);
+                if (properties.contains(propertyName)) {
+                    throw new DualPropertyException(propertyName);
+                }
+
+                String returnStatement = mkMethodCall(method);
+
+                String ifOrElseIf = "} else if";
+                if (properties.isEmpty()) {
+                    ifOrElseIf = "if";
+                }
+                out.printf("" +
+                        "   %s(\"%s\".equals(propertyName)) {\n" +
+                        "      return %s;\n" +
+                        "", ifOrElseIf, propertyName, returnStatement);
+
+                properties.add(propertyName);
+            }
+        }
+        if (properties.isEmpty()) {
+            throw new NoMethodsException(sourceClass);
+        }
+        out.println("" +
+                "   } else {\n" +
+                "      return null;\n" +
+                "   }");
+
+        out.println("}");
+        return sw.toString();
+    }
+
+    private static String mkPropertyName(Method method) {
+        //
+        // getFooName becomes fooName
+        // isFoo becomes foo
+        //
+        String name = method.getName();
+        if (name.startsWith("get")) {
+            name = name.substring(3);
+        } else if (name.startsWith("is")) {
+            name = name.substring(2);
+        }
+        return name.substring(0, 1).toLowerCase() + name.substring(1);
+    }
+
+    private static String mkMethodCall(Method method) {
+        Class<?> returnType = method.getReturnType();
+        String methodCall = "source." + method.getName() + "()";
+        if (returnType.isPrimitive()) {
+            if (returnType.equals(Byte.TYPE)) {
+                return "Integer.valueOf(" + methodCall + ")";
+            } else if (returnType.equals(Short.TYPE)) {
+                return "Integer.valueOf(" + methodCall + ")";
+            } else if (returnType.equals(Integer.TYPE)) {
+                return "Integer.valueOf(" + methodCall + ")";
+            } else if (returnType.equals(Long.TYPE)) {
+                return "Integer.valueOf(" + methodCall + ")";
+            } else if (returnType.equals(Float.TYPE)) {
+                return "Float.valueOf(" + methodCall + ")";
+            } else if (returnType.equals(Double.TYPE)) {
+                return "Double.valueOf(" + methodCall + ")";
+            } else if (returnType.equals(Character.TYPE)) {
+                return "Character.valueOf(" + methodCall + ")";
+            } else {
+                return "Boolean.valueOf(" + methodCall + ")";
+            }
+        } else {
+            return methodCall;
+        }
+    }
+
+    private static boolean isPojoMethod(Method method) {
+        return isPublic(method) &&
+                !isObjectMethod(method) &&
+                returnsSomething(method) &&
+                isGetter(method);
+    }
+
+    private static boolean isGetter(Method method) {
+        String name = method.getName();
+        return method.getParameterCount() == 0 &&
+                ((name.startsWith("get") && name.length() > 4) || (name.startsWith("is") && name.length() > 3));
+    }
+
+    private static boolean returnsSomething(Method method) {
+        return !method.getReturnType().equals(Void.class);
+    }
+
+    private static boolean isPublic(Method method) {
+        return Modifier.isPublic(method.getModifiers()) && Modifier.isPublic(method.getDeclaringClass().getModifiers());
+    }
+
+    private static boolean isObjectMethod(Method method) {
+        return method.getDeclaringClass().equals(Object.class);
+    }
+}

--- a/src/test/groovy/graphql/schema/bytecode/ByteCodePojoFetchingGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/bytecode/ByteCodePojoFetchingGeneratorTest.groovy
@@ -9,7 +9,7 @@ class ByteCodePojoFetchingGeneratorTest extends Specification {
 
     def "can handle simple pojo"() {
         when:
-        def body = ByteCodePojoFetchingGenerator.generateMethodBody(SimplePojo.class)
+        def body = ByteCodePojoFetchingGenerator.generateFetchMethodBody(SimplePojo.class)
         then:
         body == """public Object fetch(Object sourceObject, String propertyName) {
    if (sourceObject == null) { return null; }
@@ -30,7 +30,7 @@ class ByteCodePojoFetchingGeneratorTest extends Specification {
     def "can generate method body for primitive methods"() {
 
         when:
-        def body = ByteCodePojoFetchingGenerator.generateMethodBody(PrimitivePojo.class)
+        def body = ByteCodePojoFetchingGenerator.generateFetchMethodBody(PrimitivePojo.class)
         then:
         body == """public Object fetch(Object sourceObject, String propertyName) {
    if (sourceObject == null) { return null; }
@@ -60,7 +60,7 @@ class ByteCodePojoFetchingGeneratorTest extends Specification {
 
     def "can handle single method pojo"() {
         when:
-        def body = ByteCodePojoFetchingGenerator.generateMethodBody(SinglePropertyPojo.class)
+        def body = ByteCodePojoFetchingGenerator.generateFetchMethodBody(SinglePropertyPojo.class)
         then:
         body == """public Object fetch(Object sourceObject, String propertyName) {
    if (sourceObject == null) { return null; }
@@ -76,7 +76,7 @@ class ByteCodePojoFetchingGeneratorTest extends Specification {
 
     def "can handle setter methods and void pojo"() {
         when:
-        def body = ByteCodePojoFetchingGenerator.generateMethodBody(SettersAndVoidPojo.class)
+        def body = ByteCodePojoFetchingGenerator.generateFetchMethodBody(SettersAndVoidPojo.class)
         then:
         body == """public Object fetch(Object sourceObject, String propertyName) {
    if (sourceObject == null) { return null; }
@@ -92,7 +92,7 @@ class ByteCodePojoFetchingGeneratorTest extends Specification {
 
     def "can handle inheritance of public methods"() {
         when:
-        def body = ByteCodePojoFetchingGenerator.generateMethodBody(DerivedPojo.class)
+        def body = ByteCodePojoFetchingGenerator.generateFetchMethodBody(DerivedPojo.class)
         then:
         body == """public Object fetch(Object sourceObject, String propertyName) {
    if (sourceObject == null) { return null; }
@@ -108,21 +108,21 @@ class ByteCodePojoFetchingGeneratorTest extends Specification {
 
     def "can handle empty method pojo"() {
         when:
-        ByteCodePojoFetchingGenerator.generateMethodBody(EmptyPropertyPojo.class)
+        ByteCodePojoFetchingGenerator.generateFetchMethodBody(EmptyPropertyPojo.class)
         then:
         thrown(ByteCodePojoFetchingGenerator.NoMethodsException)
     }
 
     def "can handle non accessible class pojo"() {
         when:
-        ByteCodePojoFetchingGenerator.generateMethodBody(NotOpenPojo.class)
+        ByteCodePojoFetchingGenerator.generateFetchMethodBody(NotOpenPojo.class)
         then:
         thrown(ByteCodePojoFetchingGenerator.NoMethodsException)
     }
 
     def "can handle non accessible methods pojo"() {
         when:
-        ByteCodePojoFetchingGenerator.generateMethodBody(NotAccessibleMethodsPojo.class)
+        ByteCodePojoFetchingGenerator.generateFetchMethodBody(NotAccessibleMethodsPojo.class)
         then:
         thrown(ByteCodePojoFetchingGenerator.NoMethodsException)
     }
@@ -131,7 +131,7 @@ class ByteCodePojoFetchingGeneratorTest extends Specification {
         when:
         def result = ByteCodePojoFetchingGenerator.generateClassFor(SimplePojo.class)
         then:
-        result.fetcher.class.getName() == "graphql.schema.bytecode.graphql.schema.bytecode.Fetcher4graphql.schema.bytecode.SimplePojoGen"
+        result.fetcher.class.getName() == "graphql.schema.bytecode.Fetcher_4_graphql.schema.bytecode.SimplePojoGen0"
 
         when:
         ByteCodeFetcher byteCodeFetcher = result.fetcher

--- a/src/test/groovy/graphql/schema/bytecode/ByteCodePojoFetchingGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/bytecode/ByteCodePojoFetchingGeneratorTest.groovy
@@ -1,0 +1,159 @@
+package graphql.schema.bytecode
+
+import graphql.ExecutionInput
+import graphql.TestUtil
+import spock.lang.Specification
+
+class ByteCodePojoFetchingGeneratorTest extends Specification {
+
+    def "can handle simple pojo"() {
+        when:
+        def body = ByteCodePojoFetchingGenerator.generateMethodBody(SimplePojo.class)
+        then:
+        body == """public Object fetch(Object sourceObject, String propertyName) {
+   if (sourceObject == null) { return null; }
+   graphql.schema.bytecode.SimplePojo source = (graphql.schema.bytecode.SimplePojo) sourceObject;
+   if("age".equals(propertyName)) {
+      return Integer.valueOf(source.getAge());
+   } else if("interesting".equals(propertyName)) {
+      return source.getInteresting();
+   } else if("names".equals(propertyName)) {
+      return source.getNames();
+   } else {
+      return null;
+   }
+}
+"""
+    }
+
+    def "can generate method body for primitive methods"() {
+
+        when:
+        def body = ByteCodePojoFetchingGenerator.generateMethodBody(PrimitivePojo.class)
+        then:
+        body == """public Object fetch(Object sourceObject, String propertyName) {
+   if (sourceObject == null) { return null; }
+   graphql.schema.bytecode.PrimitivePojo source = (graphql.schema.bytecode.PrimitivePojo) sourceObject;
+   if("pbyte".equals(propertyName)) {
+      return Integer.valueOf(source.getPbyte());
+   } else if("pchar".equals(propertyName)) {
+      return Character.valueOf(source.getPchar());
+   } else if("pdouble".equals(propertyName)) {
+      return Double.valueOf(source.getPdouble());
+   } else if("pfloat".equals(propertyName)) {
+      return Float.valueOf(source.getPfloat());
+   } else if("pint".equals(propertyName)) {
+      return Integer.valueOf(source.getPint());
+   } else if("plong".equals(propertyName)) {
+      return Integer.valueOf(source.getPlong());
+   } else if("pshort".equals(propertyName)) {
+      return Integer.valueOf(source.getPshort());
+   } else if("pbool".equals(propertyName)) {
+      return Boolean.valueOf(source.isPbool());
+   } else {
+      return null;
+   }
+}
+"""
+    }
+
+    def "can handle single method pojo"() {
+        when:
+        def body = ByteCodePojoFetchingGenerator.generateMethodBody(SinglePropertyPojo.class)
+        then:
+        body == """public Object fetch(Object sourceObject, String propertyName) {
+   if (sourceObject == null) { return null; }
+   graphql.schema.bytecode.SinglePropertyPojo source = (graphql.schema.bytecode.SinglePropertyPojo) sourceObject;
+   if("single".equals(propertyName)) {
+      return source.getSingle();
+   } else {
+      return null;
+   }
+}
+"""
+    }
+
+    def "can handle setter methods and void pojo"() {
+        when:
+        def body = ByteCodePojoFetchingGenerator.generateMethodBody(SettersAndVoidPojo.class)
+        then:
+        body == """public Object fetch(Object sourceObject, String propertyName) {
+   if (sourceObject == null) { return null; }
+   graphql.schema.bytecode.SettersAndVoidPojo source = (graphql.schema.bytecode.SettersAndVoidPojo) sourceObject;
+   if("name".equals(propertyName)) {
+      return source.getName();
+   } else {
+      return null;
+   }
+}
+"""
+    }
+
+    def "can handle empty method pojo"() {
+        when:
+        ByteCodePojoFetchingGenerator.generateMethodBody(EmptyPropertyPojo.class)
+        then:
+        thrown(ByteCodePojoFetchingGenerator.NoMethodsException)
+    }
+
+    def "can handle non accessible class pojo"() {
+        when:
+        ByteCodePojoFetchingGenerator.generateMethodBody(NotOpenPojo.class)
+        then:
+        thrown(ByteCodePojoFetchingGenerator.NoMethodsException)
+    }
+
+    def "can handle non accessible methods pojo"() {
+        when:
+        ByteCodePojoFetchingGenerator.generateMethodBody(NotAccessibleMethodsPojo.class)
+        then:
+        thrown(ByteCodePojoFetchingGenerator.NoMethodsException)
+    }
+
+    def "can generate class for simple pojo"() {
+        when:
+        def generatedClass = ByteCodePojoFetchingGenerator.generateClassFor(SimplePojo.class)
+        then:
+        generatedClass.getName() == "graphql.schema.bytecode.graphql.schema.bytecode.Fetcher4graphql.schema.bytecode.SimplePojoGen"
+        ByteCodeFetcher.class.isAssignableFrom(generatedClass)
+
+        when:
+        // it can be created
+        ByteCodeFetcher byteCodeFetcher = generatedClass.newInstance()
+        def simplePojo = new SimplePojo(["name1"], 42, false)
+
+        then:
+
+        byteCodeFetcher.fetch(simplePojo, "names") == ["name1"]
+        byteCodeFetcher.fetch(simplePojo, "age") == 42
+        byteCodeFetcher.fetch(simplePojo, "interesting") == false
+        byteCodeFetcher.fetch(simplePojo, "foo") == null
+        byteCodeFetcher.fetch(simplePojo, "bar") == null
+    }
+
+    def "integration test on a POJO class"() {
+        def sdl = """
+            type Query {
+                simplePojo : SimplePojo
+            }
+            
+            type SimplePojo {
+                names : [String]
+                age : Int
+                interesting: Boolean
+                foo : ID
+            }
+                    
+        """
+
+        def graphQL = TestUtil.graphQL(sdl).build()
+        when:
+        def er = graphQL.execute(ExecutionInput.newExecutionInput("query q { simplePojo {names age interesting foo }}")
+                .root([simplePojo: new SimplePojo(["brad"], 42, true)]))
+
+        then:
+        er.errors.isEmpty()
+        er.data == [simplePojo: [names: ["brad"], age: 42, interesting: true, foo: null]]
+
+    }
+}

--- a/src/test/groovy/graphql/schema/bytecode/ByteCodePojoFetchingGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/bytecode/ByteCodePojoFetchingGeneratorTest.groovy
@@ -129,14 +129,12 @@ class ByteCodePojoFetchingGeneratorTest extends Specification {
 
     def "can generate class for simple pojo"() {
         when:
-        def generatedClass = ByteCodePojoFetchingGenerator.generateClassFor(SimplePojo.class)
+        def result = ByteCodePojoFetchingGenerator.generateClassFor(SimplePojo.class)
         then:
-        generatedClass.getName() == "graphql.schema.bytecode.graphql.schema.bytecode.Fetcher4graphql.schema.bytecode.SimplePojoGen"
-        ByteCodeFetcher.class.isAssignableFrom(generatedClass)
+        result.fetcher.class.getName() == "graphql.schema.bytecode.graphql.schema.bytecode.Fetcher4graphql.schema.bytecode.SimplePojoGen"
 
         when:
-        // it can be created
-        ByteCodeFetcher byteCodeFetcher = generatedClass.newInstance()
+        ByteCodeFetcher byteCodeFetcher = result.fetcher
         def simplePojo = new SimplePojo(["name1"], 42, false)
 
         then:

--- a/src/test/groovy/graphql/schema/bytecode/DerivedFromPojo.java
+++ b/src/test/groovy/graphql/schema/bytecode/DerivedFromPojo.java
@@ -1,0 +1,10 @@
+package graphql.schema.bytecode;
+
+public class DerivedFromPojo {
+
+    String name;
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/test/groovy/graphql/schema/bytecode/DerivedPojo.java
+++ b/src/test/groovy/graphql/schema/bytecode/DerivedPojo.java
@@ -1,0 +1,8 @@
+package graphql.schema.bytecode;
+
+public class DerivedPojo extends DerivedFromPojo {
+    @Override
+    public String getName() {
+        return super.getName();
+    }
+}

--- a/src/test/groovy/graphql/schema/bytecode/DualMethodsPojo.java
+++ b/src/test/groovy/graphql/schema/bytecode/DualMethodsPojo.java
@@ -1,0 +1,14 @@
+package graphql.schema.bytecode;
+
+public class DualMethodsPojo {
+
+    String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public Boolean isName() {
+        return false;
+    }
+}

--- a/src/test/groovy/graphql/schema/bytecode/EmptyPropertyPojo.java
+++ b/src/test/groovy/graphql/schema/bytecode/EmptyPropertyPojo.java
@@ -1,0 +1,4 @@
+package graphql.schema.bytecode;
+
+public class EmptyPropertyPojo {
+}

--- a/src/test/groovy/graphql/schema/bytecode/NotAccessibleMethodsPojo.java
+++ b/src/test/groovy/graphql/schema/bytecode/NotAccessibleMethodsPojo.java
@@ -1,0 +1,10 @@
+package graphql.schema.bytecode;
+
+public class NotAccessibleMethodsPojo {
+
+    String name;
+
+    String getName() {
+        return name;
+    }
+}

--- a/src/test/groovy/graphql/schema/bytecode/NotOpenPojo.java
+++ b/src/test/groovy/graphql/schema/bytecode/NotOpenPojo.java
@@ -1,0 +1,10 @@
+package graphql.schema.bytecode;
+
+class NotOpenPojo {
+
+    String name;
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/test/groovy/graphql/schema/bytecode/PrimitivePojo.java
+++ b/src/test/groovy/graphql/schema/bytecode/PrimitivePojo.java
@@ -1,0 +1,57 @@
+package graphql.schema.bytecode;
+
+@SuppressWarnings({"unused", "SpellCheckingInspection"})
+public class PrimitivePojo {
+
+    private final byte pbyte;
+    private final short pshort;
+    private final int pint;
+    private final long plong;
+    private final float pfloat;
+    private final double pdouble;
+    private final char pchar;
+    private final boolean pbool;
+
+    public PrimitivePojo(byte pbyte, short pshort, int pint, long plong, float pfloat, double pdouble, char pchar, boolean pbool) {
+        this.pbyte = pbyte;
+        this.pshort = pshort;
+        this.pint = pint;
+        this.plong = plong;
+        this.pfloat = pfloat;
+        this.pdouble = pdouble;
+        this.pchar = pchar;
+        this.pbool = pbool;
+    }
+
+    public byte getPbyte() {
+        return pbyte;
+    }
+
+    public short getPshort() {
+        return pshort;
+    }
+
+    public int getPint() {
+        return pint;
+    }
+
+    public long getPlong() {
+        return plong;
+    }
+
+    public float getPfloat() {
+        return pfloat;
+    }
+
+    public double getPdouble() {
+        return pdouble;
+    }
+
+    public char getPchar() {
+        return pchar;
+    }
+
+    public boolean isPbool() {
+        return pbool;
+    }
+}

--- a/src/test/groovy/graphql/schema/bytecode/SettersAndVoidPojo.java
+++ b/src/test/groovy/graphql/schema/bytecode/SettersAndVoidPojo.java
@@ -1,0 +1,20 @@
+package graphql.schema.bytecode;
+
+public class SettersAndVoidPojo {
+    String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public String getName(int arg) {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    void getSomething() {
+    }
+}

--- a/src/test/groovy/graphql/schema/bytecode/SimplePojo.java
+++ b/src/test/groovy/graphql/schema/bytecode/SimplePojo.java
@@ -1,0 +1,32 @@
+package graphql.schema.bytecode;
+
+import java.util.List;
+
+public class SimplePojo {
+
+    public SimplePojo(List<String> names, int age, Boolean interesting) {
+        this.names = names;
+        this.age = age;
+        this.interesting = interesting;
+    }
+
+    List<String> names;
+
+    int age;
+
+    Boolean interesting;
+
+    public List<String> getNames() {
+        return names;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public Boolean getInteresting() {
+        return interesting;
+    }
+
+
+}

--- a/src/test/groovy/graphql/schema/bytecode/SinglePropertyPojo.java
+++ b/src/test/groovy/graphql/schema/bytecode/SinglePropertyPojo.java
@@ -1,0 +1,9 @@
+package graphql.schema.bytecode;
+
+public class SinglePropertyPojo {
+    String single;
+
+    public String getSingle() {
+        return single;
+    }
+}

--- a/src/test/java/benchmark/ByteCodeGen.java
+++ b/src/test/java/benchmark/ByteCodeGen.java
@@ -1,0 +1,136 @@
+package benchmark;
+
+import javassist.CannotCompileException;
+import javassist.ClassPool;
+import javassist.CtClass;
+import javassist.CtMethod;
+import javassist.CtNewMethod;
+import javassist.LoaderClassPath;
+import javassist.NotFoundException;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+@Warmup(iterations = 2, time = 2, batchSize = 3)
+@Measurement(iterations = 3, time = 5, batchSize = 4)
+public class ByteCodeGen {
+
+
+    static public class Customer {
+        final String name;
+        final int age;
+
+        Customer(String name, int age) {
+            this.name = name;
+            this.age = age;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getAge() {
+            return age;
+        }
+    }
+
+    static class DFInterceptor implements DFFetcher {
+        public Object fetchImpl(Customer source, String propertyName) {
+            if ("name".equals(propertyName)) {
+                return source.getName();
+            }
+            if ("age".equals(propertyName)) {
+                return Integer.valueOf(source.getAge());
+            }
+            return null;
+        }
+
+        @Override
+        public Object fetch(Object source, String propertyName) {
+            return fetchImpl((Customer) source, propertyName);
+        }
+    }
+
+    interface DFFetcher {
+        Object fetch(Object source, String propertyName);
+
+    }
+
+
+    static Class<?> generatedClass;
+    static Customer customer1;
+
+    static DFFetcher fetcher;
+
+    static Method ageMethod;
+
+    static {
+        generatedClass = defineClass();
+        customer1 = new Customer("Brad", 53);
+        try {
+            ageMethod = Customer.class.getDeclaredMethod("getAge");
+            fetcher = (DFFetcher) generatedClass.newInstance();
+        } catch (InstantiationException | IllegalAccessException | NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    @Benchmark
+    public void measureViaReflectedMethod(Blackhole bh) throws InvocationTargetException, IllegalAccessException {
+        Object value = ageMethod.invoke(customer1);
+        bh.consume(value);
+    }
+    @Benchmark
+    public void measureViaGeneratedClass(Blackhole bh) throws InvocationTargetException, IllegalAccessException {
+        Object value = fetcher.fetch(customer1,"age");
+        bh.consume(value);
+    }
+
+    private static Class<?> defineClass() {
+        try {
+            ClassPool pool = ClassPool.getDefault();
+
+            pool.insertClassPath(new LoaderClassPath(ByteCodeGen.class.getClassLoader()));
+            CtClass cc = pool.makeClass("benchmark.DF");
+            CtClass ci = pool.get("benchmark.ByteCodeGen$DFFetcher");
+            cc.setSuperclass(pool.get("java.lang.Object"));
+            cc.addInterface(ci);
+
+            String methodBody = "" +
+                    "        public Object fetch(Object sourceObj, String propertyName) {\n" +
+                    "            benchmark.ByteCodeGen.Customer source = (benchmark.ByteCodeGen.Customer) sourceObj;\n" +
+                    "            if (\"name\".equals(propertyName)) {\n" +
+                    "                return source.getName();\n" +
+                    "            }\n" +
+                    "            if (\"age\".equals(propertyName)) {\n" +
+                    "                return Integer.valueOf(source.getAge());\n" +
+                    "            }\n" +
+                    "            return null;\n" +
+                    "        }\n";
+            CtMethod m = CtNewMethod.make(
+                    methodBody,
+                    cc);
+            cc.addMethod(m);
+
+            return cc.toClass();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void mainX(String[] args) throws NotFoundException, CannotCompileException, NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException, IOException {
+
+        Object value1 = fetcher.fetch(customer1,"age");
+        Object value2 = ageMethod.invoke(customer1);
+
+
+
+
+    }
+}


### PR DESCRIPTION
This PR is was inspired from some work done on https://github.com/jord1e/graphql-java-asm-datafetcher

While it does not use any of the code, it uses the some of the idea.  

That is could you dynamically generate a class that helps you fetch directly via method calls instead of reflection `Method.invoke()` calls

This uses JavaAssist to generate a peer class for each source class.  

The generated class looks much like this

```
public class GeneratedUniqueName implements ByteCodeFetcher {

public Object fetch(Object sourceObject, String propertyName) {
   if (sourceObject == null) { return null; }
   graphql.schema.bytecode.SettersAndVoidPojo source = (graphql.schema.bytecode.SettersAndVoidPojo) sourceObject;
   if("name".equals(propertyName)) {
      return source.getName();
   } else {
      return null;
   }
}
}
```

Calling a method directly is 1.7 times after than use the same `method.invoke`.  That sounds like a lot however its very quick so in the schema of all graphql processing its not a lot.

```
Benchmark                               Mode  Cnt         Score         Error  Units
ByteCodeGen.measureViaGeneratedClass   thrpt   15  67263591.084 ± 1577315.087  ops/s
ByteCodeGen.measureViaReflectedMethod  thrpt   15  39037523.623 ±  975625.383  ops/s
```

However we do get some improvements in object heavy benchmarks like the introspection one

```

Benchmark                                      Mode  Cnt  Score   Error  Units
IntrospectionBenchmark.benchMarkIntrospection  avgt   15  0.668 ± 0.069   s/op

```

vs master

```
Benchmark                                      Mode  Cnt  Score   Error  Units
IntrospectionBenchmark.benchMarkIntrospection  avgt   15  0.708 ± 0.078   s/op
```

This needs a few things to be ready.

We would need to shade Java assist - we dont want to expose this out to others.

We need a JVM wide switch to turn this on or off.  Like the `graphql.schema.PropertyDataFetcherHelper#setUseSetAccessible` flag we have today.

I think we might turn if off in a release and let people opt in and then maybe invert that on another release.

