### PR TITLE
Add missing equals/hashcode methods to relay classes

### DIFF
--- a/src/main/java/graphql/relay/DefaultConnection.java
+++ b/src/main/java/graphql/relay/DefaultConnection.java
@@ -5,6 +5,7 @@ import graphql.PublicApi;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import static graphql.Assert.assertNotNull;
 
@@ -38,6 +39,23 @@ public class DefaultConnection<T> implements Connection<T> {
     @Override
     public PageInfo getPageInfo() {
         return pageInfo;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DefaultConnection that = (DefaultConnection) o;
+        return Objects.equals(edges, that.edges) && Objects.equals(pageInfo, that.pageInfo);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(edges, pageInfo);
     }
 
     @Override

--- a/src/main/java/graphql/relay/DefaultEdge.java
+++ b/src/main/java/graphql/relay/DefaultEdge.java
@@ -2,6 +2,8 @@ package graphql.relay;
 
 import graphql.PublicApi;
 
+import java.util.Objects;
+
 import static graphql.Assert.assertNotNull;
 
 @PublicApi
@@ -24,6 +26,23 @@ public class DefaultEdge<T> implements Edge<T> {
     @Override
     public ConnectionCursor getCursor() {
         return cursor;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DefaultEdge that = (DefaultEdge) o;
+        return Objects.equals(node, that.node) && Objects.equals(cursor, that.cursor);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(node, cursor);
     }
 
     @Override

--- a/src/main/java/graphql/relay/DefaultPageInfo.java
+++ b/src/main/java/graphql/relay/DefaultPageInfo.java
@@ -3,6 +3,8 @@ package graphql.relay;
 
 import graphql.PublicApi;
 
+import java.util.Objects;
+
 @PublicApi
 public class DefaultPageInfo implements PageInfo {
 
@@ -37,6 +39,26 @@ public class DefaultPageInfo implements PageInfo {
     @Override
     public boolean isHasNextPage() {
         return hasNextPage;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DefaultPageInfo that = (DefaultPageInfo) o;
+        return Objects.equals(startCursor, that.startCursor) &&
+                Objects.equals(endCursor, that.endCursor) &&
+                Objects.equals(hasPreviousPage, that.hasPreviousPage) &&
+                Objects.equals(hasNextPage, that.hasNextPage);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(startCursor, endCursor, hasPreviousPage, hasNextPage);
     }
 
     @Override

--- a/src/test/groovy/graphql/relay/DefaultConnectionTest.groovy
+++ b/src/test/groovy/graphql/relay/DefaultConnectionTest.groovy
@@ -1,0 +1,27 @@
+package graphql.relay
+
+import com.google.common.collect.ImmutableList
+import spock.lang.Specification
+
+class DefaultConnectionTest extends Specification {
+
+    def "test equality and hashcode"() {
+        def edges1 = ImmutableList.of(new DefaultEdge("a", new DefaultConnectionCursor("a")))
+        def edges2 = ImmutableList.of(new DefaultEdge("b", new DefaultConnectionCursor("b")))
+
+        def pageInfo1 = new DefaultPageInfo(new DefaultConnectionCursor("c"), new DefaultConnectionCursor("c"), true, false)
+        def pageInfo2 = new DefaultPageInfo(new DefaultConnectionCursor("d"), new DefaultConnectionCursor("d"), false, true)
+
+        expect:
+
+        assert new DefaultConnection(edges1, pageInfo1).equals(new DefaultConnection(edges1, pageInfo1))
+        assert !new DefaultConnection(edges1, pageInfo2).equals(new DefaultConnection(edges1, pageInfo1))
+        assert !new DefaultConnection(edges1, pageInfo1).equals(new DefaultConnection(edges2, pageInfo1))
+        assert !new DefaultConnection(edges1, pageInfo1).equals(new DefaultConnection(edges1, pageInfo2))
+
+        assert new DefaultConnection(edges1, pageInfo1).hashCode() == new DefaultConnection(edges1, pageInfo1).hashCode()
+        assert new DefaultConnection(edges1, pageInfo2).hashCode() != new DefaultConnection(edges1, pageInfo1).hashCode()
+        assert new DefaultConnection(edges1, pageInfo1).hashCode() != new DefaultConnection(edges2, pageInfo1).hashCode()
+        assert new DefaultConnection(edges1, pageInfo1).hashCode() != new DefaultConnection(edges1, pageInfo2).hashCode()
+    }
+}

--- a/src/test/groovy/graphql/relay/DefaultEdgeTest.groovy
+++ b/src/test/groovy/graphql/relay/DefaultEdgeTest.groovy
@@ -1,0 +1,25 @@
+package graphql.relay
+
+import spock.lang.Specification
+
+class DefaultEdgeTest extends Specification {
+
+    def "test equality and hashcode"() {
+        expect:
+
+        assert new DefaultEdge(leftNode, new DefaultConnectionCursor(leftConnectionCursor)).equals(
+                new DefaultEdge(rightNode, new DefaultConnectionCursor(rightConnectionCursor))) == isEqual
+
+        assert (new DefaultEdge(leftNode, new DefaultConnectionCursor(leftConnectionCursor)).hashCode() ==
+                new DefaultEdge(rightNode, new DefaultConnectionCursor(rightConnectionCursor)).hashCode()) == isEqual
+
+        where:
+
+        leftNode | leftConnectionCursor | rightNode | rightConnectionCursor || isEqual
+        "a"      | "b"                  | "a"       | "b"                   || true
+        "x"      | "b"                  | "a"       | "b"                   || false
+        "a"      | "x"                  | "a"       | "b"                   || false
+        "a"      | "b"                  | "x"       | "b"                   || false
+        "a"      | "b"                  | "a"       | "x"                   || false
+    }
+}

--- a/src/test/groovy/graphql/relay/DefaultPageInfoTest.groovy
+++ b/src/test/groovy/graphql/relay/DefaultPageInfoTest.groovy
@@ -1,0 +1,29 @@
+package graphql.relay
+
+import spock.lang.Specification
+
+class DefaultPageInfoTest extends Specification {
+
+    def "test equality and hashcode"() {
+        expect:
+
+        assert new DefaultPageInfo(new DefaultConnectionCursor(ls), new DefaultConnectionCursor(le), lp, ln).equals(
+                new DefaultPageInfo(new DefaultConnectionCursor(rs), new DefaultConnectionCursor(re), rp, rn)) == isEqual
+
+        assert (new DefaultPageInfo(new DefaultConnectionCursor(ls), new DefaultConnectionCursor(le), lp, ln).hashCode() ==
+                new DefaultPageInfo(new DefaultConnectionCursor(rs), new DefaultConnectionCursor(re), rp, rn).hashCode()) == isEqual
+
+        where:
+
+        ls  | le  | lp    | ln    | rs  | re  | rp    | rn    || isEqual
+        "a" | "b" | true  | true  | "a" | "b" | true  | true  || true
+        "x" | "b" | true  | true  | "a" | "b" | true  | true  || false
+        "a" | "x" | true  | true  | "a" | "b" | true  | true  || false
+        "a" | "b" | false | true  | "a" | "b" | true  | true  || false
+        "a" | "b" | true  | false | "a" | "b" | true  | true  || false
+        "a" | "b" | true  | true  | "x" | "b" | true  | true  || false
+        "a" | "b" | true  | true  | "a" | "x" | true  | true  || false
+        "a" | "b" | true  | true  | "a" | "b" | false | true  || false
+        "a" | "b" | true  | true  | "a" | "b" | true  | false || false
+    }
+}


### PR DESCRIPTION
Add equals/hashcode methods to DefaultConnection, DefaultEdge, DefaultPageInfo.

As discussed: https://github.com/graphql-java/graphql-java/discussions/2986

This is my first time using Spock, so please let me know if there's a different or better way to do this testing. I used the tables to try to reduce the test noise.