### PR TITLE
Make QueryTraverser work for queries with non-nullable variables.

### DIFF
--- a/src/main/java/graphql/analysis/NodeVisitorWithTypeTracking.java
+++ b/src/main/java/graphql/analysis/NodeVisitorWithTypeTracking.java
@@ -30,6 +30,7 @@ import graphql.schema.GraphQLUnmodifiedType;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
@@ -153,12 +154,12 @@ public class NodeVisitorWithTypeTracking extends NodeVisitorStub {
         boolean isTypeNameIntrospectionField = fieldDefinition == schema.getIntrospectionTypenameFieldDefinition();
         GraphQLFieldsContainer fieldsContainer = !isTypeNameIntrospectionField ? (GraphQLFieldsContainer) unwrapAll(parentEnv.getOutputType()) : null;
         GraphQLCodeRegistry codeRegistry = schema.getCodeRegistry();
-        Map<String, Object> argumentValues = ValuesResolver.getArgumentValues(codeRegistry,
+        Map<String, Object> argumentValues = !variables.isEmpty() ? ValuesResolver.getArgumentValues(codeRegistry,
                 fieldDefinition.getArguments(),
                 field.getArguments(),
                 CoercedVariables.of(variables),
                 GraphQLContext.getDefault(),
-                Locale.getDefault());
+                Locale.getDefault()) : new HashMap<>();
         QueryVisitorFieldEnvironment environment = new QueryVisitorFieldEnvironmentImpl(isTypeNameIntrospectionField,
                 field,
                 fieldDefinition,

--- a/src/main/java/graphql/analysis/NodeVisitorWithTypeTracking.java
+++ b/src/main/java/graphql/analysis/NodeVisitorWithTypeTracking.java
@@ -30,7 +30,7 @@ import graphql.schema.GraphQLUnmodifiedType;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
 
@@ -159,7 +159,7 @@ public class NodeVisitorWithTypeTracking extends NodeVisitorStub {
                 field.getArguments(),
                 CoercedVariables.of(variables),
                 GraphQLContext.getDefault(),
-                Locale.getDefault()) : new HashMap<>();
+                Locale.getDefault()) : Collections.emptyMap();
         QueryVisitorFieldEnvironment environment = new QueryVisitorFieldEnvironmentImpl(isTypeNameIntrospectionField,
                 field,
                 fieldDefinition,


### PR DESCRIPTION
# Problem

Currently, `QueryTraverser` does not work for queries with non-nullable arguments. The added unit test illustrates the problem – without the fix it fails like so:

```
QueryTraverserTest > test visitField for non-nullable variables FAILED
    graphql.execution.NonNullableValueCoercedAsNullException: Argument 'id' has coerced Null value for NonNull type 'ID!'
        at app//graphql.execution.ValuesResolver.getArgumentValuesImpl(ValuesResolver.java:298)
        at app//graphql.execution.ValuesResolver.getArgumentValues(ValuesResolver.java:192)
        at app//graphql.analysis.NodeVisitorWithTypeTracking.visitField(NodeVisitorWithTypeTracking.java:156)
        at app//graphql.language.Field.accept(Field.java:199)
        at app//graphql.language.NodeTraverser$1.enter(NodeTraverser.java:62)
        at app//graphql.util.Traverser.traverse(Traverser.java:144)
        at app//graphql.language.NodeTraverser.doTraverse(NodeTraverser.java:150)
        at app//graphql.language.NodeTraverser.depthFirst(NodeTraverser.java:70)
        at app//graphql.analysis.QueryTraverser.visitImpl(QueryTraverser.java:195)
        at app//graphql.analysis.QueryTraverser.visitPreOrder(QueryTraverser.java:109)
        at graphql.analysis.QueryTraverserTest.test visitField for non-nullable variables(QueryTraverserTest.groovy:555)
```

# Solution

Skip constructing and coercing variables/arguments in `NodeVisitorWithTypeTracking` if no variables have been provided. This allows using `QueryTraverser` for queries with non-nullable arguments by just not providing the variables in the builder (again, see unit test for an example).

# Discussion

This solution feels quite hacky to me, so I'd appreciate if owners shared their ideas for how this could be improved.

**Note:** here's a related pull request with likely a better solution – https://github.com/graphql-java/graphql-java/pull/2585