### PR TITLE
Only run GCP tests on main graphql-java repo (skip on forks).

### DIFF
--- a/.github/workflows/invoke_test_runner.yml
+++ b/.github/workflows/invoke_test_runner.yml
@@ -31,6 +31,7 @@ env:
 
 jobs:
   execute_workflow:
+    if: github.repository == 'graphql-java/graphql-java'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
# Problem
We only want this action to run on the main repository. Right now it attempts to execute on all the forks as well – e.g. see failed actions on my fork: https://github.com/folone/graphql-java/actions.

# Solution
This PR makes use of the syntax described in https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idif to skip GCP-based tests for all the forks and only run them on main repo.