### PR TITLE
SchemaGeneratorPostProcessing should be deprecated

### DIFF
--- a/src/main/java/graphql/schema/idl/RuntimeWiring.java
+++ b/src/main/java/graphql/schema/idl/RuntimeWiring.java
@@ -1,5 +1,6 @@
 package graphql.schema.idl;
 
+import graphql.DeprecatedAt;
 import graphql.PublicApi;
 import graphql.schema.DataFetcher;
 import graphql.schema.GraphQLCodeRegistry;
@@ -352,7 +353,11 @@ public class RuntimeWiring {
          * @param schemaGeneratorPostProcessing the non null schema transformer to add
          *
          * @return the runtime wiring builder
+         * @deprecated This mechanism can be achieved in a better way via {@link graphql.schema.SchemaTransformer}
+         * after the schema is built
          */
+        @Deprecated
+        @DeprecatedAt(value = "2012-10-29")
         public Builder transformer(SchemaGeneratorPostProcessing schemaGeneratorPostProcessing) {
             this.schemaGeneratorPostProcessings.add(assertNotNull(schemaGeneratorPostProcessing));
             return this;

--- a/src/main/java/graphql/schema/idl/RuntimeWiring.java
+++ b/src/main/java/graphql/schema/idl/RuntimeWiring.java
@@ -357,7 +357,7 @@ public class RuntimeWiring {
          * after the schema is built
          */
         @Deprecated
-        @DeprecatedAt(value = "2012-10-29")
+        @DeprecatedAt(value = "2022-10-29")
         public Builder transformer(SchemaGeneratorPostProcessing schemaGeneratorPostProcessing) {
             this.schemaGeneratorPostProcessings.add(assertNotNull(schemaGeneratorPostProcessing));
             return this;

--- a/src/main/java/graphql/schema/idl/SchemaDirectiveWiringSchemaGeneratorPostProcessing.java
+++ b/src/main/java/graphql/schema/idl/SchemaDirectiveWiringSchemaGeneratorPostProcessing.java
@@ -25,7 +25,7 @@ import java.util.function.Function;
 import static graphql.util.TraversalControl.CONTINUE;
 
 @Internal
-class SchemaDirectiveWiringSchemaGeneratorPostProcessing implements SchemaGeneratorPostProcessing {
+class SchemaDirectiveWiringSchemaGeneratorPostProcessing {
 
     private final SchemaGeneratorDirectiveHelper generatorDirectiveHelper = new SchemaGeneratorDirectiveHelper();
     private final TypeDefinitionRegistry typeRegistry;
@@ -41,7 +41,6 @@ class SchemaDirectiveWiringSchemaGeneratorPostProcessing implements SchemaGenera
     }
 
 
-    @Override
     public GraphQLSchema process(GraphQLSchema originalSchema) {
         codeRegistryBuilder.trackChanges();
         Visitor visitor = new Visitor();

--- a/src/main/java/graphql/schema/idl/SchemaGeneratorPostProcessing.java
+++ b/src/main/java/graphql/schema/idl/SchemaGeneratorPostProcessing.java
@@ -1,13 +1,19 @@
 package graphql.schema.idl;
 
+import graphql.DeprecatedAt;
 import graphql.PublicSpi;
 import graphql.schema.GraphQLSchema;
 
 /**
  * These are called by the {@link SchemaGenerator} after a valid schema has been built
  * and they can then adjust it accordingly with some sort of post processing.
+ *
+ * @deprecated This mechanism can be achieved in a better way via {@link graphql.schema.SchemaTransformer}
+ * after the schema is built
  */
 @PublicSpi
+@Deprecated
+@DeprecatedAt(value = "2012-10-29")
 public interface SchemaGeneratorPostProcessing {
 
     /**

--- a/src/main/java/graphql/schema/idl/SchemaGeneratorPostProcessing.java
+++ b/src/main/java/graphql/schema/idl/SchemaGeneratorPostProcessing.java
@@ -13,7 +13,7 @@ import graphql.schema.GraphQLSchema;
  */
 @PublicSpi
 @Deprecated
-@DeprecatedAt(value = "2012-10-29")
+@DeprecatedAt(value = "2022-10-29")
 public interface SchemaGeneratorPostProcessing {
 
     /**

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -1831,14 +1831,14 @@ class SchemaGeneratorTest extends Specification {
 
         def extraDirective = (GraphQLDirective.newDirective()).name("extra")
                 .argument(GraphQLArgument.newArgument().name("value").type(GraphQLString)).build()
-        def transformer = new SchemaGeneratorPostProcessing() {
+        def transformer = new SchemaGeneratorPostProcessing() {  // Retained to show deprecated code is still run
             @Override
             GraphQLSchema process(GraphQLSchema originalSchema) {
                 originalSchema.transform({ builder -> builder.additionalDirective(extraDirective) })
             }
         }
         def wiring = RuntimeWiring.newRuntimeWiring()
-                .transformer(transformer)
+                .transformer(transformer) // Retained to show deprecated code is still run
                 .build()
         GraphQLSchema schema = new SchemaGenerator().makeExecutableSchema(types, wiring)
         expect:


### PR DESCRIPTION
SchemaGeneratorPostProcessing was a previous mechanism that `graphql.schema.SchemaTransformer` is better suited to

We should not have two mechanisms for the same thing

I propose we deprecated it and remove at a later date