### PR TITLE
Update aQute builder version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
     id 'antlr'
     id 'signing'
     id "com.github.johnrengelman.shadow" version "7.1.2"
-    id "biz.aQute.bnd.builder" version "6.1.0"
+    id "biz.aQute.bnd.builder" version "6.3.1"
     id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
     id "groovy"
     id "me.champeau.jmh" version "0.6.6"


### PR DESCRIPTION
Our builds are failing because the old builder version was referencing bintray, which was sunset ~11 months ago.

This PR bumps the aQute builder version.

We are using this builder to create OSGI compliant jars.