### PR TITLE
Bugfix for SDL check if an Interface is implemented correctly

### DIFF
--- a/src/main/java/graphql/schema/idl/ImplementingTypesChecker.java
+++ b/src/main/java/graphql/schema/idl/ImplementingTypesChecker.java
@@ -186,8 +186,9 @@ class ImplementingTypesChecker {
             if (objectArg == null) {
                 errors.add(new MissingInterfaceFieldArgumentsError(typeOfType, objectTypeDef, interfaceTypeDef, objectFieldDef));
             } else {
-                String interfaceArgStr = AstPrinter.printAstCompact(interfaceArg);
-                String objectArgStr = AstPrinter.printAstCompact(objectArg);
+                // we need to remove the not relevant  applied directives on the argument definitions to compare
+                String interfaceArgStr = AstPrinter.printAstCompact(interfaceArg.transform(builder -> builder.directives(emptyList())));
+                String objectArgStr = AstPrinter.printAstCompact(objectArg.transform(builder -> builder.directives(emptyList())));
                 if (!interfaceArgStr.equals(objectArgStr)) {
                     errors.add(new InterfaceFieldArgumentRedefinitionError(typeOfType, objectTypeDef, interfaceTypeDef, objectFieldDef, objectArgStr, interfaceArgStr));
                 }

--- a/src/test/groovy/graphql/schema/idl/SchemaTypeCheckerTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaTypeCheckerTest.groovy
@@ -708,6 +708,35 @@ class SchemaTypeCheckerTest extends Specification {
 
     }
 
+    def "directives on arguments are not relevant"() {
+        def spec = """    
+            directive @d on ARGUMENT_DEFINITION
+            interface InterfaceType {
+                fieldB(arg1 : String = "defaultVal", arg2 : String @d, arg3 : Int @d) : String 
+            }
+
+            type BaseType {
+                fieldX : Int
+            }
+
+            extend type BaseType implements InterfaceType {
+                fieldB(arg1 : String = "defaultVal" @d, arg2 : String, arg3 : Int)  : String 
+            }
+
+            schema {
+              query : BaseType
+            }
+        """
+
+        def result = check(spec)
+
+        expect:
+        result.isEmpty()
+
+    }
+
+
+
     def "test field arguments on object can contain additional optional arguments"() {
         def spec = """
             interface InterfaceType {


### PR DESCRIPTION
Applied directives on arguments are not relevant when checked if an interface is implemented correctly.

For example this SDL should be valid, but it was rejected:
```graphql
directive @d on ARGUMENT_DEFINITION
type Query implements I {
  foo(arg: String @d): String
}
interface I {
  foo(arg: String): String
}
```
This fixes this bug.