### PR TITLE
Update ValidationError#toString to print the extentions field 

### DIFF
--- a/src/main/java/graphql/validation/ValidationError.java
+++ b/src/main/java/graphql/validation/ValidationError.java
@@ -12,6 +12,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @PublicApi
 public class ValidationError implements GraphQLError {
@@ -113,12 +115,23 @@ public class ValidationError implements GraphQLError {
 
     @Override
     public String toString() {
+        String extensionsString = "";
+
+        if (Optional.ofNullable(extensions).isPresent() && extensions.size() > 0) {
+            extensionsString = extensions
+                    .keySet()
+                    .stream()
+                    .map(key -> key + "=" + extensions.get(key))
+                    .collect(Collectors.joining(", "));
+        }
+
         return "ValidationError{" +
                 "validationErrorType=" + validationErrorType +
                 ", queryPath=" + queryPath +
                 ", message=" + message +
                 ", locations=" + locations +
                 ", description='" + description + '\'' +
+                ", extensions=[" + extensionsString + ']' +
                 '}';
     }
 

--- a/src/main/java/graphql/validation/ValidationError.java
+++ b/src/main/java/graphql/validation/ValidationError.java
@@ -10,20 +10,19 @@ import graphql.language.SourceLocation;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @PublicApi
 public class ValidationError implements GraphQLError {
 
-    private final String message;
     private final List<SourceLocation> locations = new ArrayList<>();
     private final String description;
     private final ValidationErrorClassification validationErrorType;
-    private final List<String> queryPath;
-    private final Map<String, Object> extensions;
+    private final List<String> queryPath = new ArrayList<>();
+    private final Map<String, Object> extensions = new HashMap<>();
 
     @Deprecated
     @DeprecatedAt("2022-07-10")
@@ -72,13 +71,18 @@ public class ValidationError implements GraphQLError {
 
     private ValidationError(Builder builder) {
         this.validationErrorType = builder.validationErrorType;
+        this.description = builder.description;
         if (builder.sourceLocations != null) {
             this.locations.addAll(builder.sourceLocations);
         }
-        this.description = builder.description;
-        this.message = builder.description;
-        this.queryPath = builder.queryPath;
-        this.extensions = builder.extensions;
+
+        if (builder.queryPath != null) {
+            this.queryPath.addAll(builder.queryPath);
+        }
+
+        if (builder.extensions != null) {
+            this.extensions.putAll(builder.extensions);
+        }
     }
 
     public ValidationErrorClassification getValidationErrorType() {
@@ -87,7 +91,7 @@ public class ValidationError implements GraphQLError {
 
     @Override
     public String getMessage() {
-        return message;
+        return description;
     }
 
     public String getDescription() {
@@ -117,7 +121,7 @@ public class ValidationError implements GraphQLError {
     public String toString() {
         String extensionsString = "";
 
-        if (Optional.ofNullable(extensions).isPresent() && extensions.size() > 0) {
+        if (extensions.size() > 0) {
             extensionsString = extensions
                     .keySet()
                     .stream()
@@ -128,7 +132,7 @@ public class ValidationError implements GraphQLError {
         return "ValidationError{" +
                 "validationErrorType=" + validationErrorType +
                 ", queryPath=" + queryPath +
-                ", message=" + message +
+                ", message=" + description +
                 ", locations=" + locations +
                 ", description='" + description + '\'' +
                 ", extensions=[" + extensionsString + ']' +

--- a/src/main/java/graphql/validation/ValidationError.java
+++ b/src/main/java/graphql/validation/ValidationError.java
@@ -1,6 +1,7 @@
 package graphql.validation;
 
 
+import com.google.common.collect.ImmutableMap;
 import graphql.DeprecatedAt;
 import graphql.ErrorType;
 import graphql.GraphQLError;
@@ -10,7 +11,6 @@ import graphql.language.SourceLocation;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -22,7 +22,7 @@ public class ValidationError implements GraphQLError {
     private final String description;
     private final ValidationErrorClassification validationErrorType;
     private final List<String> queryPath = new ArrayList<>();
-    private final Map<String, Object> extensions = new HashMap<>();
+    private final ImmutableMap<String, Object> extensions;
 
     @Deprecated
     @DeprecatedAt("2022-07-10")
@@ -80,9 +80,7 @@ public class ValidationError implements GraphQLError {
             this.queryPath.addAll(builder.queryPath);
         }
 
-        if (builder.extensions != null) {
-            this.extensions.putAll(builder.extensions);
-        }
+        this.extensions = (builder.extensions != null) ? ImmutableMap.copyOf(builder.extensions) : ImmutableMap.of();
     }
 
     public ValidationErrorClassification getValidationErrorType() {

--- a/src/test/groovy/graphql/validation/ValidationErrorToString.groovy
+++ b/src/test/groovy/graphql/validation/ValidationErrorToString.groovy
@@ -1,0 +1,39 @@
+package graphql.validation
+
+import graphql.language.SourceLocation
+import spock.lang.Specification
+
+class ValidationErrorToString extends Specification {
+
+    def 'toString prints correctly ValidationError object when all fields are initialized'() {
+        given:
+        def sourceLocations = [new SourceLocation(5, 0), new SourceLocation(10, 1)]
+        def description = "Validation Error (UnknownType)"
+        def validationErrorClassification = ValidationErrorType.UnknownType
+        def queryPath = ["home", "address"]
+        def extensions = ["extension1": "first", "extension2": true, "extension3": 2]
+
+        when:
+        def validationError = ValidationError
+                .newValidationError()
+                .sourceLocations(sourceLocations)
+                .description(description)
+                .validationErrorType(validationErrorClassification)
+                .queryPath(queryPath)
+                .extensions(extensions)
+                .build()
+
+        then:
+        validationError.toString() == "ValidationError{validationErrorType=UnknownType, queryPath=[home, address], message=Validation Error (UnknownType), locations=[SourceLocation{line=5, column=0}, SourceLocation{line=10, column=1}], description='Validation Error (UnknownType)', extensions=[extension1=first, extension2=true, extension3=2]}"
+    }
+
+    def 'toString prints correctly ValidationError object when all fields are empty'() {
+       when:
+        def validationError = ValidationError
+                .newValidationError()
+                .build()
+
+        then:
+        validationError.toString() == "ValidationError{validationErrorType=null, queryPath=null, message=null, locations=[], description='null', extensions=[]}"
+    }
+}

--- a/src/test/groovy/graphql/validation/ValidationErrorToString.groovy
+++ b/src/test/groovy/graphql/validation/ValidationErrorToString.groovy
@@ -24,7 +24,7 @@ class ValidationErrorToString extends Specification {
                 .build()
 
         then:
-        validationError.toString() == "ValidationError{validationErrorType=UnknownType, queryPath=[home, address], message=Validation Error (UnknownType), locations=[SourceLocation{line=5, column=0}, SourceLocation{line=10, column=1}], description='Validation Error (UnknownType)', extensions=[extension3=2, extension1=first, extension2=true]}"
+        validationError.toString() == "ValidationError{validationErrorType=UnknownType, queryPath=[home, address], message=Validation Error (UnknownType), locations=[SourceLocation{line=5, column=0}, SourceLocation{line=10, column=1}], description='Validation Error (UnknownType)', extensions=[extension1=first, extension2=true, extension3=2]}"
     }
 
     def 'toString prints correctly ValidationError object when all fields are empty'() {

--- a/src/test/groovy/graphql/validation/ValidationErrorToString.groovy
+++ b/src/test/groovy/graphql/validation/ValidationErrorToString.groovy
@@ -24,7 +24,7 @@ class ValidationErrorToString extends Specification {
                 .build()
 
         then:
-        validationError.toString() == "ValidationError{validationErrorType=UnknownType, queryPath=[home, address], message=Validation Error (UnknownType), locations=[SourceLocation{line=5, column=0}, SourceLocation{line=10, column=1}], description='Validation Error (UnknownType)', extensions=[extension1=first, extension2=true, extension3=2]}"
+        validationError.toString() == "ValidationError{validationErrorType=UnknownType, queryPath=[home, address], message=Validation Error (UnknownType), locations=[SourceLocation{line=5, column=0}, SourceLocation{line=10, column=1}], description='Validation Error (UnknownType)', extensions=[extension3=2, extension1=first, extension2=true]}"
     }
 
     def 'toString prints correctly ValidationError object when all fields are empty'() {
@@ -34,6 +34,6 @@ class ValidationErrorToString extends Specification {
                 .build()
 
         then:
-        validationError.toString() == "ValidationError{validationErrorType=null, queryPath=null, message=null, locations=[], description='null', extensions=[]}"
+        validationError.toString() == "ValidationError{validationErrorType=null, queryPath=[], message=null, locations=[], description='null', extensions=[]}"
     }
 }


### PR DESCRIPTION
 - Updated `toString` method in `ValidationError` class to print the `extensions` field. If the field is null then an empty array will be printed `...extensions=[]`
 - Removed the `message` field because it was always initialized with the description but the getMessage() method is still there and returns the content of the description
 - Initialized the `extensions` and `queryPath` fields during their declaration to align with the `sourceLocations` field
 - Added a couple of UTs to test the ValidationError#toString method
 
 It resolves #3005