### PR TITLE
Deprecate getAppliedDirective in favor of getUniqueAppliedDirective

### DIFF
--- a/src/main/java/graphql/schema/GraphQLArgument.java
+++ b/src/main/java/graphql/schema/GraphQLArgument.java
@@ -227,6 +227,11 @@ public class GraphQLArgument implements GraphQLNamedSchemaElement, GraphQLInputV
     }
 
     @Override
+    public GraphQLAppliedDirective getUniqueAppliedDirective(String directiveName) {
+        return directivesHolder.getAppliedDirective(directiveName);
+    }
+
+    @Override
     public List<GraphQLSchemaElement> getChildren() {
         List<GraphQLSchemaElement> children = new ArrayList<>();
         children.add(getType());

--- a/src/main/java/graphql/schema/GraphQLDirectiveContainer.java
+++ b/src/main/java/graphql/schema/GraphQLDirectiveContainer.java
@@ -52,12 +52,25 @@ public interface GraphQLDirectiveContainer extends GraphQLNamedSchemaElement {
      * @param directiveName the name of the directive to retrieve
      *
      * @return the directive or null if there is not one with that name
+     *
+     * @deprecated use {@link #getUniqueAppliedDirective(String)} instead
      */
+    @Deprecated
+    @DeprecatedAt("2022-11-21")
     GraphQLAppliedDirective getAppliedDirective(String directiveName);
+
+    /**
+     * Returns a non-repeatable directive with the provided name.
+     *
+     * @param directiveName is a {@link String} representing the name of the directive to retrieve
+     *
+     * @return the {@link GraphQLAppliedDirective} or null if there is not one with that name
+     */
+    GraphQLAppliedDirective getUniqueAppliedDirective(String directiveName);
 
 
     /**
-     * Returns all of the directives with the provided name, including repeatable and non repeatable directives.
+     * Returns all the directives with the provided name, including repeatable and non-repeatable directives.
      *
      * @param directiveName the name of the directives to retrieve
      *
@@ -68,7 +81,7 @@ public interface GraphQLDirectiveContainer extends GraphQLNamedSchemaElement {
     }
 
     /**
-     * This will return true if the element has a directive (repeatable or non repeatable) with the specified name
+     * This will return true if the element has a directive (repeatable or non-repeatable) with the specified name
      *
      * @param directiveName the name of the directive
      *
@@ -83,7 +96,7 @@ public interface GraphQLDirectiveContainer extends GraphQLNamedSchemaElement {
     }
 
     /**
-     * This will return true if the element has a directive (repeatable or non repeatable) with the specified name
+     * This will return true if the element has a directive (repeatable or non-repeatable) with the specified name
      *
      * @param directiveName the name of the directive
      *
@@ -106,10 +119,10 @@ public interface GraphQLDirectiveContainer extends GraphQLNamedSchemaElement {
     List<GraphQLDirective> getDirectives();
 
     /**
-     * This will return a Map of the non repeatable directives that are associated with a {@link graphql.schema.GraphQLNamedSchemaElement}.  Any repeatable directives
+     * This will return a Map of the non-repeatable directives that are associated with a {@link graphql.schema.GraphQLNamedSchemaElement}.  Any repeatable directives
      * will be filtered out of this map.
      *
-     * @return a map of non repeatable directives by directive name.
+     * @return a map of non-repeatable directives by directive name.
      *
      * @deprecated - use the {@link GraphQLAppliedDirective} methods instead
      */
@@ -119,7 +132,7 @@ public interface GraphQLDirectiveContainer extends GraphQLNamedSchemaElement {
 
     /**
      * This will return a Map of the all directives that are associated with a {@link graphql.schema.GraphQLNamedSchemaElement}, including both
-     * repeatable and non repeatable directives.
+     * repeatable and non-repeatable directives.
      *
      * @return a map of all directives by directive name
      *
@@ -131,7 +144,7 @@ public interface GraphQLDirectiveContainer extends GraphQLNamedSchemaElement {
 
     /**
      * Returns a non-repeatable directive with the provided name.  This will throw a {@link graphql.AssertException} if
-     * the directive is a repeatable directive that has more then one instance.
+     * the directive is a repeatable directive that has more than one instance.
      *
      * @param directiveName the name of the directive to retrieve
      *
@@ -144,7 +157,7 @@ public interface GraphQLDirectiveContainer extends GraphQLNamedSchemaElement {
     GraphQLDirective getDirective(String directiveName);
 
     /**
-     * Returns all of the directives with the provided name, including repeatable and non repeatable directives.
+     * Returns all the directives with the provided name, including repeatable and non-repeatable directives.
      *
      * @param directiveName the name of the directives to retrieve
      *

--- a/src/main/java/graphql/schema/GraphQLEnumType.java
+++ b/src/main/java/graphql/schema/GraphQLEnumType.java
@@ -235,6 +235,11 @@ public class GraphQLEnumType implements GraphQLNamedInputType, GraphQLNamedOutpu
         return directivesHolder.getAppliedDirective(directiveName);
     }
 
+    @Override
+    public GraphQLAppliedDirective getUniqueAppliedDirective(String directiveName) {
+        return directivesHolder.getAppliedDirective(directiveName);
+    }
+
     /**
      * This helps you transform the current GraphQLEnumType into another one by starting a builder with all
      * the current values and allows you to transform it how you want.

--- a/src/main/java/graphql/schema/GraphQLEnumValueDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLEnumValueDefinition.java
@@ -112,6 +112,11 @@ public class GraphQLEnumValueDefinition implements GraphQLNamedSchemaElement, Gr
         return directivesHolder.getAppliedDirective(directiveName);
     }
 
+    @Override
+    public GraphQLAppliedDirective getUniqueAppliedDirective(String directiveName) {
+        return directivesHolder.getAppliedDirective(directiveName);
+    }
+
     /**
      * This helps you transform the current GraphQLEnumValueDefinition into another one by starting a builder with all
      * the current values and allows you to transform it how you want.

--- a/src/main/java/graphql/schema/GraphQLFieldDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLFieldDefinition.java
@@ -143,6 +143,11 @@ public class GraphQLFieldDefinition implements GraphQLNamedSchemaElement, GraphQ
         return directivesHolder.getAppliedDirective(directiveName);
     }
 
+    @Override
+    public GraphQLAppliedDirective getUniqueAppliedDirective(String directiveName) {
+        return directivesHolder.getAppliedDirective(directiveName);
+    }
+
     public List<GraphQLArgument> getArguments() {
         return arguments;
     }

--- a/src/main/java/graphql/schema/GraphQLInputObjectField.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectField.java
@@ -168,6 +168,11 @@ public class GraphQLInputObjectField implements GraphQLNamedSchemaElement, Graph
         return directivesHolder.getAppliedDirective(directiveName);
     }
 
+    @Override
+    public GraphQLAppliedDirective getUniqueAppliedDirective(String directiveName) {
+        return directivesHolder.getAppliedDirective(directiveName);
+    }
+
     /**
      * This helps you transform the current GraphQLInputObjectField into another one by starting a builder with all
      * the current values and allows you to transform it how you want.

--- a/src/main/java/graphql/schema/GraphQLInputObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectType.java
@@ -120,6 +120,11 @@ public class GraphQLInputObjectType implements GraphQLNamedInputType, GraphQLUnm
     }
 
     @Override
+    public GraphQLAppliedDirective getUniqueAppliedDirective(String directiveName) {
+        return directives.getAppliedDirective(directiveName);
+    }
+
+    @Override
     public GraphQLInputObjectField getFieldDefinition(String name) {
         return fieldMap.get(name);
     }

--- a/src/main/java/graphql/schema/GraphQLInterfaceType.java
+++ b/src/main/java/graphql/schema/GraphQLInterfaceType.java
@@ -164,6 +164,11 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLCompositeT
     }
 
     @Override
+    public GraphQLAppliedDirective getUniqueAppliedDirective(String directiveName) {
+        return directivesHolder.getAppliedDirective(directiveName);
+    }
+
+    @Override
     public String toString() {
         return "GraphQLInterfaceType{" +
                 "name='" + name + '\'' +

--- a/src/main/java/graphql/schema/GraphQLObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLObjectType.java
@@ -123,6 +123,11 @@ public class GraphQLObjectType implements GraphQLNamedOutputType, GraphQLComposi
     }
 
     @Override
+    public GraphQLAppliedDirective getUniqueAppliedDirective(String directiveName) {
+        return directivesHolder.getAppliedDirective(directiveName);
+    }
+
+    @Override
     public GraphQLFieldDefinition getFieldDefinition(String name) {
         return fieldDefinitionsByName.get(name);
     }

--- a/src/main/java/graphql/schema/GraphQLScalarType.java
+++ b/src/main/java/graphql/schema/GraphQLScalarType.java
@@ -131,6 +131,11 @@ GraphQLScalarType implements GraphQLNamedInputType, GraphQLNamedOutputType, Grap
     }
 
     @Override
+    public GraphQLAppliedDirective getUniqueAppliedDirective(String directiveName) {
+        return directivesHolder.getAppliedDirective(directiveName);
+    }
+
+    @Override
     public String toString() {
         return "GraphQLScalarType{" +
                 "name='" + name + '\'' +

--- a/src/main/java/graphql/schema/GraphQLUnionType.java
+++ b/src/main/java/graphql/schema/GraphQLUnionType.java
@@ -160,6 +160,11 @@ public class GraphQLUnionType implements GraphQLNamedOutputType, GraphQLComposit
         return directives.getAppliedDirective(directiveName);
     }
 
+    @Override
+    public GraphQLAppliedDirective getUniqueAppliedDirective(String directiveName) {
+        return directives.getAppliedDirective(directiveName);
+    }
+
     /**
      * This helps you transform the current GraphQLUnionType into another one by starting a builder with all
      * the current values and allows you to transform it how you want.

--- a/src/test/groovy/graphql/schema/GraphQLAppliedDirectiveArgumentTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLAppliedDirectiveArgumentTest.groovy
@@ -21,7 +21,7 @@ class GraphQLAppliedDirectiveArgumentTest extends Specification {
             '''
 
         def closure = {
-            def argument = it.fieldDefinition.getAppliedDirective("test").getArgument("value") as GraphQLAppliedDirectiveArgument
+            def argument = it.fieldDefinition.getUniqueAppliedDirective("test").getArgument("value") as GraphQLAppliedDirectiveArgument
             return ValuesResolver.valueToInternalValue(argument.getArgumentValue(), argument.getType(), GraphQLContext.getDefault(), Locale.getDefault())[0]
         }
         def graphql = TestUtil.graphQL(spec, RuntimeWiring.newRuntimeWiring()

--- a/src/test/groovy/graphql/schema/GraphQLDirectiveTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLDirectiveTest.groovy
@@ -178,7 +178,7 @@ class GraphQLDirectiveTest extends Specification {
         assert !container.hasAppliedDirective("non existent")
         assert container.getDirectives().collect({ it.name }) == ["d1", "dr", "dr"] // Retain for test coverage
         assert container.getAppliedDirectives().collect({ it.name }) == ["d1", "dr", "dr"]
-        assert container.getAppliedDirective("d1").name == "d1"
+        assert container.getUniqueAppliedDirective("d1").name == "d1"
         assert container.getDirectivesByName().keySet() == ["d1"] as Set // Retain for test coverage, there is no equivalent non-repeatable directive method
 
         assert container.getAllDirectivesByName().keySet() == ["d1", "dr"] as Set // Retain for test coverage

--- a/src/test/groovy/graphql/schema/SchemaTransformerTest.groovy
+++ b/src/test/groovy/graphql/schema/SchemaTransformerTest.groovy
@@ -913,7 +913,7 @@ type Query {
         then:
 
         def fieldDef = newSchema.getObjectType("Query").getFieldDefinition("foo")
-        def appliedDirective = fieldDef.getAppliedDirective("myDirective")
+        def appliedDirective = fieldDef.getUniqueAppliedDirective("myDirective")
         def oldSkoolDirective = fieldDef.getDirective("myDirective")
         def argument = fieldDef.getArgument("fooArgOnField")
         def directiveDecl = newSchema.getDirective("myDirective")

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorAppliedDirectiveHelperTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorAppliedDirectiveHelperTest.groovy
@@ -68,15 +68,15 @@ class SchemaGeneratorAppliedDirectiveHelperTest extends Specification {
         barType.directives.collect { it.name }.sort() == ["foo"]
         barType.appliedDirectives.collect { it.name }.sort() == ["foo"]
 
-        def fooAppliedDirective = field.getAppliedDirective("foo")
+        def fooAppliedDirective = field.getUniqueAppliedDirective("foo")
         fooAppliedDirective.arguments.collect { it.name }.sort() == ["arg1", "arg2"]
         fooAppliedDirective.arguments.collect { it.getValue() }.sort() == ["arg2Value", "fooArg1Value"]
 
-        def fooAppliedDirectiveOnType = barType.getAppliedDirective("foo")
+        def fooAppliedDirectiveOnType = barType.getUniqueAppliedDirective("foo")
         fooAppliedDirectiveOnType.arguments.collect { it.name }.sort() == ["arg1", "arg2"]
         fooAppliedDirectiveOnType.arguments.collect { it.getValue() }.sort() == ["BarTypeValue", "arg2Value",]
 
-        def complexAppliedDirective = complexField.getAppliedDirective("complex")
+        def complexAppliedDirective = complexField.getUniqueAppliedDirective("complex")
         GraphQLInputType complexInputType = schema.getTypeAs("ComplexInput")
         complexAppliedDirective.arguments.collect { it.name }.sort() == ["complexArg1"]
         complexAppliedDirective.arguments.collect { it.getValue() }.sort() == [
@@ -118,7 +118,7 @@ class SchemaGeneratorAppliedDirectiveHelperTest extends Specification {
         barType.appliedDirectives.collect { it.name }.sort() == ["foo"]
 
 
-        def fooAppliedDirective = field.getAppliedDirective("foo")
+        def fooAppliedDirective = field.getUniqueAppliedDirective("foo")
         fooAppliedDirective.arguments.collect { it.name }.sort() == ["arg1", "arg2"]
         fooAppliedDirective.arguments.collect { it.value }.sort() == ["arg2Value", "fooArg1Value"]
     }

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -1365,7 +1365,7 @@ class SchemaGeneratorTest extends Specification {
 
         expect:
 
-        container.getAppliedDirective(directiveName) != null
+        container.getUniqueAppliedDirective(directiveName) != null
 
         if (container instanceof GraphQLEnumType) {
             def evd = ((GraphQLEnumType) container).getValue("X").getDirective("EnumValueDirective")
@@ -1633,7 +1633,7 @@ class SchemaGeneratorTest extends Specification {
         argInt.getDirective("thirdDirective") != null
 
         def intDirective = argInt.getDirective("intDirective")
-        def intAppliedDirective = argInt.getAppliedDirective("intDirective")
+        def intAppliedDirective = argInt.getUniqueAppliedDirective("intDirective")
         intAppliedDirective.name == "intDirective"
         intAppliedDirective.arguments.size() == 1
         def directiveArg = intAppliedDirective.getArgument("inception")
@@ -1703,13 +1703,13 @@ class SchemaGeneratorTest extends Specification {
         def directiveTest1 = schema.getDirective("test1")
         GraphQLNonNull.nonNull(GraphQLBoolean).isEqualTo(directiveTest1.getArgument("include").type)
         directiveTest1.getArgument("include").argumentDefaultValue.value == null
-        def appliedDirective1 = schema.getObjectType("Query").getFieldDefinition("f1").getAppliedDirective("test1")
+        def appliedDirective1 = schema.getObjectType("Query").getFieldDefinition("f1").getUniqueAppliedDirective("test1")
         printAst(appliedDirective1.getArgument("include").argumentValue.value as Node) == "false"
 
         def directiveTest2 = schema.getDirective("test2")
         GraphQLNonNull.nonNull(GraphQLBoolean).isEqualTo(directiveTest2.getArgument("include").type)
         printAst(directiveTest2.getArgument("include").argumentDefaultValue.value as Node) == "true"
-        def appliedDirective2 = schema.getObjectType("Query").getFieldDefinition("f2").getAppliedDirective("test2")
+        def appliedDirective2 = schema.getObjectType("Query").getFieldDefinition("f2").getUniqueAppliedDirective("test2")
         printAst(appliedDirective2.getArgument("include").argumentValue.value as Node) == "true"
     }
 
@@ -1736,7 +1736,7 @@ class SchemaGeneratorTest extends Specification {
         def directive = schema.getObjectType("Query").getFieldDefinition("f").getDirective("testDirective")
         directive.getArgument("knownArg1").type == GraphQLString
         printAst(directive.getArgument("knownArg1").argumentDefaultValue.value as Node) == '"defaultValue1"'
-        def appliedDirective = schema.getObjectType("Query").getFieldDefinition("f").getAppliedDirective("testDirective")
+        def appliedDirective = schema.getObjectType("Query").getFieldDefinition("f").getUniqueAppliedDirective("testDirective")
         printAst(appliedDirective.getArgument("knownArg1").argumentValue.value as Node) == '"overrideVal1"'
 
         directive.getArgument("knownArg2").type == GraphQLInt
@@ -1771,7 +1771,7 @@ class SchemaGeneratorTest extends Specification {
         printAst(directive.getArgument("reason").argumentDefaultValue.value as Node) == '"No longer supported"'
         directive.validLocations().collect { it.name() } == [Introspection.DirectiveLocation.FIELD_DEFINITION.name()]
 
-        def appliedDirective = f1.getAppliedDirective("deprecated")
+        def appliedDirective = f1.getUniqueAppliedDirective("deprecated")
         appliedDirective.name == "deprecated"
         appliedDirective.getArgument("reason").type == GraphQLString
         printAst(appliedDirective.getArgument("reason").argumentValue.value as Node) == '"No longer supported"'
@@ -1782,7 +1782,7 @@ class SchemaGeneratorTest extends Specification {
         then:
         f2.getDeprecationReason() == "Just because"
 
-        def appliedDirective2 = f2.getAppliedDirective("deprecated")
+        def appliedDirective2 = f2.getUniqueAppliedDirective("deprecated")
         appliedDirective2.name == "deprecated"
         appliedDirective2.getArgument("reason").type == GraphQLString
         printAst(appliedDirective2.getArgument("reason").argumentValue.value as Node) == '"Just because"'


### PR DESCRIPTION
The `GraphQLDirectiveContainer#getAppliedDirective` returns a single `GraphQLAppliedDirective`.
To be more consistent and auto explanatory this method is deprecated in favor of `getUniqueAppliedDirective` one.
All the implementations and the related tests are updated so now there is no reference to the deprecated method.

It resolves #2810