### PR TITLE
Make String parseValue coercion consistent with JS implementation & Gradle JCenter fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
     id "biz.aQute.bnd.builder" version "6.3.1"
     id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
     id "groovy"
-    id "me.champeau.jmh" version "0.6.6"
+    id "me.champeau.jmh" version "0.6.8"
 }
 
 def getDevelopmentVersion() {

--- a/build.gradle
+++ b/build.gradle
@@ -70,8 +70,14 @@ gradle.buildFinished { buildResult ->
 
 repositories {
     mavenCentral()
-    gradlePluginPortal()
     mavenLocal()
+}
+
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -73,13 +73,6 @@ repositories {
     mavenLocal()
 }
 
-pluginManagement {
-    repositories {
-        mavenCentral()
-        gradlePluginPortal()
-    }
-}
-
 jar {
     from "LICENSE.md"
     from "src/main/antlr/Graphql.g4"

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
     id "biz.aQute.bnd.builder" version "6.3.1"
     id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
     id "groovy"
-    id "me.champeau.jmh" version "0.6.8"
+    id "me.champeau.jmh" version "0.6.6"
 }
 
 def getDevelopmentVersion() {

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,7 @@ gradle.buildFinished { buildResult ->
 
 repositories {
     mavenCentral()
+    gradlePluginPortal()
     mavenLocal()
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,6 +4,7 @@ pluginManagement {
         maven {
             url 'https://plugins.gradle.org/m2'
             metadataSources {
+                // Avoid redirection to defunct JCenter when Gradle module metadata is not published by a plugin (e.g. JMH plugin)
                 ignoreGradleMetadataRedirection()
                 mavenPom()
                 artifact()

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,8 +1,8 @@
-rootProject.name = 'graphql-java'
-
 pluginManagement {
     repositories {
         gradlePluginPortal()
         mavenCentral()
     }
 }
+
+rootProject.name = 'graphql-java'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,14 @@
 pluginManagement {
     repositories {
-        gradlePluginPortal()
         mavenCentral()
+        maven {
+            url 'https://plugins.gradle.org/m2'
+            metadataSources {
+                ignoreGradleMetadataRedirection()
+                mavenPom()
+                artifact()
+            }
+        }
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,8 @@
 rootProject.name = 'graphql-java'
 
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}

--- a/src/main/java/graphql/scalar/GraphqlStringCoercing.java
+++ b/src/main/java/graphql/scalar/GraphqlStringCoercing.java
@@ -24,9 +24,17 @@ import static graphql.scalar.CoercingUtil.typeName;
 @Internal
 public class GraphqlStringCoercing implements Coercing<String, String> {
 
-
     private String toStringImpl(Object input) {
         return String.valueOf(input);
+    }
+
+    private String parseValueImpl(@NotNull Object input, Locale locale) {
+        if (!(input instanceof String)) {
+            throw new CoercingParseValueException(
+                    i18nMsg(locale, "String.unexpectedRawValueType", typeName(input))
+            );
+        }
+        return (String) input;
     }
 
     private String parseLiteralImpl(@NotNull Object input, Locale locale) {
@@ -56,12 +64,12 @@ public class GraphqlStringCoercing implements Coercing<String, String> {
     @Override
     @Deprecated
     public String parseValue(@NotNull Object input) {
-        return toStringImpl(input);
+        return parseValueImpl(input, Locale.getDefault());
     }
 
     @Override
     public String parseValue(@NotNull Object input, @NotNull GraphQLContext graphQLContext, @NotNull Locale locale) throws CoercingParseValueException {
-        return toStringImpl(input);
+        return parseValueImpl(input, locale);
     }
 
     @Override

--- a/src/main/java/graphql/scalar/GraphqlStringCoercing.java
+++ b/src/main/java/graphql/scalar/GraphqlStringCoercing.java
@@ -28,7 +28,7 @@ public class GraphqlStringCoercing implements Coercing<String, String> {
         return String.valueOf(input);
     }
 
-    private String parseValueImpl(@NotNull Object input, Locale locale) {
+    private String parseValueImpl(@NotNull Object input, @NotNull Locale locale) {
         if (!(input instanceof String)) {
             throw new CoercingParseValueException(
                     i18nMsg(locale, "String.unexpectedRawValueType", typeName(input))

--- a/src/main/resources/i18n/Scalars.properties
+++ b/src/main/resources/i18n/Scalars.properties
@@ -27,3 +27,5 @@ Float.unexpectedAstType=Expected an AST type of ''IntValue'' or ''FloatValue'' b
 #
 Boolean.notBoolean=Expected a value that can be converted to type ''Boolean'' but it was a ''{0}''
 Boolean.unexpectedAstType=Expected an AST type of ''BooleanValue'' but it was a ''{0}''
+#
+String.unexpectedRawValueType=Expected a String input, but it was a ''{0}''

--- a/src/main/resources/i18n/Scalars_de.properties
+++ b/src/main/resources/i18n/Scalars_de.properties
@@ -30,3 +30,5 @@ Float.unexpectedAstType=Erwartet wurde ein AST type von ''IntValue'' oder ''Floa
 #
 Boolean.notBoolean=Erwartet wurde ein Wert, der in den Typ ''Boolean'' konvertiert werden kann, aber es war ein ''{0}''
 Boolean.unexpectedAstType=Erwartet wurde ein AST type ''BooleanValue'', aber es war ein ''{0}''
+#
+String.unexpectedRawValueType=Erwartet wurde eine String-Eingabe, aber es war ein ''{0}''

--- a/src/test/groovy/graphql/ScalarsStringTest.groovy
+++ b/src/test/groovy/graphql/ScalarsStringTest.groovy
@@ -75,14 +75,12 @@ class ScalarsStringTest extends Specification {
         customObject | "foo"
     }
 
-    @Unroll
-    def "String parseValue #value into #result"() {
+    def "String parseValue value into result"() {
         expect:
         Scalars.GraphQLString.getCoercing().parseValue("123ab", GraphQLContext.default, Locale.default) == "123ab"
     }
 
-    @Unroll
-    def "String parseValue #value into #result with deprecated method"() {
+    def "String parseValue value into result with deprecated method"() {
         expect:
         Scalars.GraphQLString.getCoercing().parseValue("123ab") == "123ab" // Retain deprecated method for test coverage
     }


### PR DESCRIPTION
This PR makes String `parseValue` coercion consistent with the JS reference implementation, by only allowing String input values. Fixes #2990.

Consistent implementation of String coercion is particularly important for [String-based custom scalars](https://scalars.graphql.org/template-string.html).

Note that this is a breaking change.

`parseValue` in JS implementation: https://github.com/graphql/graphql-js/blob/main/src/type/scalars.ts#L156

----
This PR also fixes the Gradle settings to avoid redirecting to the defunct JCenter when the Gradle module metadata is not published by a plugin (in our case, the jmh plugin). https://github.com/gradle/gradle/issues/22864#issuecomment-1327978524

There was a problem with a JCenter SSL certificate expiring earlier today.