### PR TITLE
Added a ValueTraverser allowing you to visit and optionally change input argument values

### DIFF
--- a/src/main/java/graphql/analysis/values/ValueTraverser.java
+++ b/src/main/java/graphql/analysis/values/ValueTraverser.java
@@ -124,16 +124,14 @@ public class ValueTraverser {
         for (GraphQLArgument fieldArgument : fieldArguments) {
             String key = fieldArgument.getName();
             Object argValue = coercedArgumentValues.get(key);
-            if (argValue != null) {
-                InputElements inputElements = new InputElements(fieldArgument);
-                Object newValue = visitPreOrderImpl(argValue, fieldArgument.getType(), inputElements, visitor);
-                if (hasChanged(newValue, argValue)) {
-                    if (!copied) {
-                        coercedArgumentValues = new LinkedHashMap<>(coercedArgumentValues);
-                        copied = true;
-                    }
-                    setNewValue(coercedArgumentValues, key, newValue);
+            InputElements inputElements = new InputElements(fieldArgument);
+            Object newValue = visitPreOrderImpl(argValue, fieldArgument.getType(), inputElements, visitor);
+            if (hasChanged(newValue, argValue)) {
+                if (!copied) {
+                    coercedArgumentValues = new LinkedHashMap<>(coercedArgumentValues);
+                    copied = true;
                 }
+                setNewValue(coercedArgumentValues, key, newValue);
             }
         }
         return coercedArgumentValues;

--- a/src/main/java/graphql/analysis/values/ValueTraverser.java
+++ b/src/main/java/graphql/analysis/values/ValueTraverser.java
@@ -1,0 +1,198 @@
+package graphql.analysis.values;
+
+import com.google.common.collect.ImmutableList;
+import graphql.Assert;
+import graphql.PublicApi;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingEnvironmentImpl;
+import graphql.schema.GraphQLArgument;
+import graphql.schema.GraphQLDirectiveContainer;
+import graphql.schema.GraphQLEnumType;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLInputObjectField;
+import graphql.schema.GraphQLInputObjectType;
+import graphql.schema.GraphQLInputType;
+import graphql.schema.GraphQLList;
+import graphql.schema.GraphQLScalarType;
+import graphql.schema.GraphQLTypeUtil;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class allows you to traverse a set of input values according to the type system and optional
+ * change the values present.
+ * <p>
+ * If you just want to traverse without changing anything, just return the value presented to you and nothing will change.
+ * <p>
+ * If you want to change a value, perhaps in the presence of a directive say on the containing element, then return
+ * a new value back in your visitor.
+ * <p>
+ * This class is intended to be used say inside a DataFetcher, allowing you to change the {@link DataFetchingEnvironment#getArguments()}
+ * say before further processing.
+ * <p>
+ * The values passed in are assumed to be valid and coerced.  This classes does not check for non nullness say or the right coerced objects given
+ * the type system.  This is assumed to have occurred earlier in the graphql validation phase.  This also means if you are not careful you can undo the
+ * validation that has gone before you.  For example, it would be possible to change values that are illegal according to the type system, such as
+ * null values for non-nullable types say, so you need to be careful.
+ */
+@PublicApi
+public class ValueTraverser {
+
+
+    /**
+     * This will visit the arguments of a {@link DataFetchingEnvironment} and if the values are changed by the visitor a new environment will be built
+     *
+     * @param environment the starting data fetching environment
+     * @param visitor     the visitor to use
+     *
+     * @return the same environment if nothing changes or a new one with the {@link DataFetchingEnvironment#getArguments()} changed
+     */
+    public static DataFetchingEnvironment visitPreOrder(DataFetchingEnvironment environment, ValueVisitor visitor) {
+        GraphQLFieldDefinition fieldDefinition = environment.getFieldDefinition();
+        Map<String, Object> originalArgs = environment.getArguments();
+        Map<String, Object> newArgs = visitPreOrder(originalArgs, fieldDefinition, visitor);
+        if (newArgs != originalArgs) {
+            return DataFetchingEnvironmentImpl.newDataFetchingEnvironment(environment).arguments(newArgs).build();
+        }
+        return environment;
+    }
+
+    /**
+     * This will visit the arguments of a {@link GraphQLFieldDefinition} and if the visitor changes the values, it will return a new set of arguments
+     *
+     * @param coercedArgumentValues the starting coerced arguments
+     * @param fieldDefinition       the field definition
+     * @param visitor               the visitor to use
+     *
+     * @return the same set of arguments if nothing changes or new ones if the visitor changes anything
+     */
+    public static Map<String, Object> visitPreOrder(Map<String, Object> coercedArgumentValues, GraphQLFieldDefinition fieldDefinition, ValueVisitor visitor) {
+        List<GraphQLArgument> fieldArguments = fieldDefinition.getArguments();
+        boolean copied = false;
+        for (GraphQLArgument fieldArgument : fieldArguments) {
+            String key = fieldArgument.getName();
+            Object argValue = coercedArgumentValues.get(key);
+            if (argValue != null) {
+                Object newValue = visitPreOrderImpl(argValue, fieldArgument.getType(), ImmutableList.of(fieldDefinition, fieldArgument), -1, visitor);
+                if (newValue != argValue) {
+                    if (!copied) {
+                        coercedArgumentValues = new LinkedHashMap<>(coercedArgumentValues);
+                        copied = true;
+                    }
+                    coercedArgumentValues.put(key, newValue);
+                }
+            }
+        }
+        return coercedArgumentValues;
+    }
+
+    /**
+     * This will visit a single argument of a {@link GraphQLArgument} and if the visitor changes the value, it will return a new argument
+     *
+     * @param coercedArgumentValue the starting coerced argument value
+     * @param argument             the argument definition
+     * @param visitor              the visitor to use
+     *
+     * @return the same value if nothing changes or a new value if the visitor changes anything
+     */
+    public static Object visitPreOrder(Object coercedArgumentValue, GraphQLArgument argument, ValueVisitor visitor) {
+        return visitPreOrderImpl(coercedArgumentValue, argument.getType(), ImmutableList.of(argument), -1, visitor);
+    }
+
+    private static Object visitPreOrderImpl(Object coercedValue, GraphQLInputType startingInputType, List<GraphQLDirectiveContainer> containingElements, int index, ValueVisitor visitor) {
+        GraphQLInputType inputType = GraphQLTypeUtil.unwrapNonNullAs(startingInputType);
+        if (inputType instanceof GraphQLList) {
+            return visitListValue(coercedValue, (GraphQLList) inputType, index, containingElements, visitor);
+        } else if (inputType instanceof GraphQLInputObjectType) {
+            GraphQLInputObjectType inputObjectType = (GraphQLInputObjectType) inputType;
+            return visitObjectValue(coercedValue, inputObjectType, index, containingElements, visitor);
+        } else if (inputType instanceof GraphQLScalarType) {
+            return visitor.visitScalarValue(coercedValue, (GraphQLScalarType) inputType, index, containingElements);
+        } else if (inputType instanceof GraphQLEnumType) {
+            return visitor.visitEnumValue(coercedValue, (GraphQLEnumType) inputType, index, containingElements);
+        } else {
+            return Assert.assertShouldNeverHappen("ValueTraverser can only be called on full materialised schemas");
+        }
+    }
+
+    private static Object visitObjectValue(Object coercedValue, GraphQLInputObjectType inputObjectType, int index, List<GraphQLDirectiveContainer> containingElements, ValueVisitor visitor) {
+        if (coercedValue != null) {
+            Assert.assertTrue(coercedValue instanceof Map, () -> "A input object type MUST have an Map<String,Object> value");
+        }
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map = (Map<String, Object>) coercedValue;
+        Map<String, Object> newMap = visitor.visitInputObjectValue(map, inputObjectType, index, containingElements);
+        if (newMap != null) {
+            List<GraphQLDirectiveContainer> containersWithObject = pushElement(containingElements, inputObjectType);
+            boolean copied = false;
+            for (Map.Entry<String, Object> entry : newMap.entrySet()) {
+                GraphQLInputObjectField inputField = inputObjectType.getField(entry.getKey());
+                /// should we assert if the map contain a key that's not a field ?
+                if (inputField != null) {
+                    Object newSubValue = visitor.visitInputObjectFieldValue(entry.getValue(), inputObjectType, inputField, index, containersWithObject);
+                    if (newSubValue != entry.getValue()) {
+                        if (!copied) {
+                            newMap = new LinkedHashMap<>(newMap);
+                            copied = true;
+                        }
+                        newMap.put(entry.getKey(), newSubValue);
+                    }
+                    List<GraphQLDirectiveContainer> containersWithField = pushElement(containingElements, inputField);
+                    newSubValue = visitPreOrderImpl(newSubValue, inputField.getType(), containersWithField, -1, visitor);
+                    if (newSubValue != entry.getValue()) {
+                        if (!copied) {
+                            newMap = new LinkedHashMap<>(newMap);
+                            copied = true;
+                        }
+                        newMap.put(entry.getKey(), newSubValue);
+                    }
+                }
+            }
+            return newMap;
+        } else {
+            return null;
+        }
+    }
+
+    private static Object visitListValue(Object coercedValue, GraphQLList listInputType, int index, List<GraphQLDirectiveContainer> containingElements, ValueVisitor visitor) {
+        if (coercedValue != null) {
+            Assert.assertTrue(coercedValue instanceof List, () -> "A list type MUST have an List value");
+        }
+        @SuppressWarnings("unchecked")
+        List<Object> list = (List<Object>) coercedValue;
+        List<Object> newList = visitor.visitListValue(list, listInputType, index, containingElements);
+        if (newList != null) {
+            GraphQLInputType inputType = GraphQLTypeUtil.unwrapOneAs(listInputType);
+            ImmutableList.Builder<Object> copiedList = null;
+            int i = 0;
+            for (Object subValue : newList) {
+                Object newSubValue = visitPreOrderImpl(subValue, inputType, containingElements, i, visitor);
+                if (copiedList != null) {
+                    copiedList.add(newSubValue);
+                } else if (newSubValue != subValue) {
+                    // go into copy mode because something has changed
+                    // copy previous values up to this point
+                    copiedList = ImmutableList.builder();
+                    for (int j = 0; j < i; j++) {
+                        copiedList.add(newList.get(j));
+                    }
+                    copiedList.add(newSubValue);
+                }
+                i++;
+            }
+            if (copiedList != null) {
+                return copiedList.build();
+            } else {
+                return newList;
+            }
+        } else {
+            return null;
+        }
+    }
+
+    private static List<GraphQLDirectiveContainer> pushElement(List<GraphQLDirectiveContainer> containingElements, GraphQLDirectiveContainer element) {
+        return ImmutableList.<GraphQLDirectiveContainer>builder().addAll(containingElements).add(element).build();
+    }
+}

--- a/src/main/java/graphql/analysis/values/ValueTraverser.java
+++ b/src/main/java/graphql/analysis/values/ValueTraverser.java
@@ -71,16 +71,16 @@ public class ValueTraverser {
         }
 
         @Override
-        public List<GraphQLInputSchemaElement> inputElements() {
+        public List<GraphQLInputSchemaElement> getInputElements() {
             return inputElements;
         }
 
-        public List<GraphQLInputValueDefinition> inputValueDefinitions() {
+        public List<GraphQLInputValueDefinition> getInputValueDefinitions() {
             return inputValueDefinitions;
         }
 
         @Override
-        public GraphQLInputValueDefinition lastInputValueDefinition() {
+        public GraphQLInputValueDefinition getLastInputValueDefinition() {
             return inputValueDefinitions.get(inputValueDefinitions.size() - 1);
         }
     }

--- a/src/main/java/graphql/analysis/values/ValueVisitor.java
+++ b/src/main/java/graphql/analysis/values/ValueVisitor.java
@@ -40,9 +40,12 @@ public interface ValueVisitor {
         List<GraphQLInputSchemaElement> getInputElements();
 
         /**
+         * This is the list of input schema elements that are unwrapped, e.g.
+         * {@link GraphQLList} and {@link graphql.schema.GraphQLNonNull} types have been removed
+         *
          * @return then list of {@link GraphQLInputValueDefinition} elements that lead to an input value.
          */
-        List<GraphQLInputValueDefinition> getInputValueDefinitions();
+        List<GraphQLInputSchemaElement> getUnwrappedInputElements();
 
         /**
          * This is the last {@link GraphQLInputValueDefinition} that pointed to the value during a callback.  This will

--- a/src/main/java/graphql/analysis/values/ValueVisitor.java
+++ b/src/main/java/graphql/analysis/values/ValueVisitor.java
@@ -1,10 +1,11 @@
 package graphql.analysis.values;
 
 import graphql.PublicSpi;
-import graphql.schema.GraphQLDirectiveContainer;
 import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLInputObjectField;
 import graphql.schema.GraphQLInputObjectType;
+import graphql.schema.GraphQLInputSchemaElement;
+import graphql.schema.GraphQLInputValueDefinition;
 import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLScalarType;
 
@@ -18,73 +19,103 @@ import java.util.Map;
 public interface ValueVisitor {
 
     /**
+     * This magic sentinel value indicates that a value should be removed from a list or object versus being set to null,
+     * that is the difference between a value not being present and a value being null
+     */
+    Object ABSENCE_SENTINEL = new Object() {
+        @Override
+        public String toString() {
+            return "ABSENCE_SENTINEL";
+        }
+    };
+
+    /**
+     * Represents the elements that leads to a value and type
+     */
+    interface InputElements {
+
+        /**
+         * @return then list of input schema elements that lead to an input value.
+         */
+        List<GraphQLInputSchemaElement> inputElements();
+
+        /**
+         * @return then list of {@link GraphQLInputValueDefinition} elements that lead to an input value.
+         */
+        List<GraphQLInputValueDefinition> inputValueDefinitions();
+
+        /**
+         * This is the last {@link GraphQLInputValueDefinition} that pointed to the value during a callback.  This will
+         * be either a {@link graphql.schema.GraphQLArgument} or a {@link GraphQLInputObjectField}
+         *
+         * @return the last {@link GraphQLInputValueDefinition} that contains this value
+         */
+        GraphQLInputValueDefinition lastInputValueDefinition();
+    }
+
+    /**
      * This is called when a scalar value is encountered
      *
-     * @param coercedValue       the value that is in coerced form
-     * @param inputType          the type of scalar
-     * @param index              if the container of this value was a list, this is the index into the list
-     * @param containingElements the elements that lead to this value and type
+     * @param coercedValue  the value that is in coerced form
+     * @param inputType     the type of scalar
+     * @param inputElements the elements that lead to this value and type
      *
      * @return the same value or a new value
      */
-    default Object visitScalarValue(Object coercedValue, GraphQLScalarType inputType, int index, List<GraphQLDirectiveContainer> containingElements) {
+    default Object visitScalarValue(Object coercedValue, GraphQLScalarType inputType, InputElements inputElements) {
         return coercedValue;
     }
 
     /**
      * This is called when an enum value is encountered
      *
-     * @param coercedValue       the value that is in coerced form
-     * @param inputType          the type of enum
-     * @param index              if the container of this value was a list, this is the index into the list
-     * @param containingElements the elements that lead to this value and type
+     * @param coercedValue  the value that is in coerced form
+     * @param inputType     the type of enum
+     * @param inputElements the elements that lead to this value and type
      *
      * @return the same value or a new value
      */
-    default Object visitEnumValue(Object coercedValue, GraphQLEnumType inputType, int index, List<GraphQLDirectiveContainer> containingElements) {
+    default Object visitEnumValue(Object coercedValue, GraphQLEnumType inputType, InputElements inputElements) {
         return coercedValue;
     }
 
     /**
      * This is called when an input object field value is encountered
      *
-     * @param coercedValue       the value that is in coerced form
-     * @param inputObjectType    the input object type containing the input field
-     * @param inputObjectField   the input object field
-     * @param index              if the container of this value was a list, this is the index into the list
-     * @param containingElements the elements that lead to this value and type
+     * @param coercedValue     the value that is in coerced form
+     * @param inputObjectType  the input object type containing the input field
+     * @param inputObjectField the input object field
+     * @param inputElements    the elements that lead to this value and type
      *
      * @return the same value or a new value
      */
-    default Object visitInputObjectFieldValue(Object coercedValue, GraphQLInputObjectType inputObjectType, GraphQLInputObjectField inputObjectField, int index, List<GraphQLDirectiveContainer> containingElements) {
+    default Object visitInputObjectFieldValue(Object coercedValue, GraphQLInputObjectType inputObjectType, GraphQLInputObjectField inputObjectField, InputElements inputElements) {
         return coercedValue;
     }
 
     /**
      * This is called when an input object value is encountered.
      *
-     * @param coercedValue       the value that is in coerced form
-     * @param inputObjectType    the input object type
-     * @param index              if the container of this value was a list, this is the index into the list
-     * @param containingElements the elements that lead to this value and type
+     * @param coercedValue    the value that is in coerced form
+     * @param inputObjectType the input object type
+     * @param inputElements   the elements that lead to this value and type
      *
      * @return the same value or a new value
      */
-    default Map<String, Object> visitInputObjectValue(Map<String, Object> coercedValue, GraphQLInputObjectType inputObjectType, int index, List<GraphQLDirectiveContainer> containingElements) {
+    default Map<String, Object> visitInputObjectValue(Map<String, Object> coercedValue, GraphQLInputObjectType inputObjectType, InputElements inputElements) {
         return coercedValue;
     }
 
     /**
      * This is called when an input list value is encountered.
      *
-     * @param coercedValue       the value that is in coerced form
-     * @param listInputType      the input list type
-     * @param index              if the container of this value was a list, this is the index into the list
-     * @param containingElements the elements that lead to this value and type
+     * @param coercedValue  the value that is in coerced form
+     * @param listInputType the input list type
+     * @param inputElements the elements that lead to this value and type
      *
      * @return the same value or a new value
      */
-    default List<Object> visitListValue(List<Object> coercedValue, GraphQLList listInputType, int index, List<GraphQLDirectiveContainer> containingElements) {
+    default List<Object> visitListValue(List<Object> coercedValue, GraphQLList listInputType, InputElements inputElements) {
         return coercedValue;
     }
 }

--- a/src/main/java/graphql/analysis/values/ValueVisitor.java
+++ b/src/main/java/graphql/analysis/values/ValueVisitor.java
@@ -1,0 +1,90 @@
+package graphql.analysis.values;
+
+import graphql.PublicSpi;
+import graphql.schema.GraphQLDirectiveContainer;
+import graphql.schema.GraphQLEnumType;
+import graphql.schema.GraphQLInputObjectField;
+import graphql.schema.GraphQLInputObjectType;
+import graphql.schema.GraphQLList;
+import graphql.schema.GraphQLScalarType;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A visitor callback used by {@link ValueTraverser}
+ */
+@PublicSpi
+public interface ValueVisitor {
+
+    /**
+     * This is called when a scalar value is encountered
+     *
+     * @param coercedValue       the value that is in coerced form
+     * @param inputType          the type of scalar
+     * @param index              if the container of this value was a list, this is the index into the list
+     * @param containingElements the elements that lead to this value and type
+     *
+     * @return the same value or a new value
+     */
+    default Object visitScalarValue(Object coercedValue, GraphQLScalarType inputType, int index, List<GraphQLDirectiveContainer> containingElements) {
+        return coercedValue;
+    }
+
+    /**
+     * This is called when an enum value is encountered
+     *
+     * @param coercedValue       the value that is in coerced form
+     * @param inputType          the type of enum
+     * @param index              if the container of this value was a list, this is the index into the list
+     * @param containingElements the elements that lead to this value and type
+     *
+     * @return the same value or a new value
+     */
+    default Object visitEnumValue(Object coercedValue, GraphQLEnumType inputType, int index, List<GraphQLDirectiveContainer> containingElements) {
+        return coercedValue;
+    }
+
+    /**
+     * This is called when an input object field value is encountered
+     *
+     * @param coercedValue       the value that is in coerced form
+     * @param inputObjectType    the input object type containing the input field
+     * @param inputObjectField   the input object field
+     * @param index              if the container of this value was a list, this is the index into the list
+     * @param containingElements the elements that lead to this value and type
+     *
+     * @return the same value or a new value
+     */
+    default Object visitInputObjectFieldValue(Object coercedValue, GraphQLInputObjectType inputObjectType, GraphQLInputObjectField inputObjectField, int index, List<GraphQLDirectiveContainer> containingElements) {
+        return coercedValue;
+    }
+
+    /**
+     * This is called when an input object value is encountered.
+     *
+     * @param coercedValue       the value that is in coerced form
+     * @param inputObjectType    the input object type
+     * @param index              if the container of this value was a list, this is the index into the list
+     * @param containingElements the elements that lead to this value and type
+     *
+     * @return the same value or a new value
+     */
+    default Map<String, Object> visitInputObjectValue(Map<String, Object> coercedValue, GraphQLInputObjectType inputObjectType, int index, List<GraphQLDirectiveContainer> containingElements) {
+        return coercedValue;
+    }
+
+    /**
+     * This is called when an input list value is encountered.
+     *
+     * @param coercedValue       the value that is in coerced form
+     * @param listInputType      the input list type
+     * @param index              if the container of this value was a list, this is the index into the list
+     * @param containingElements the elements that lead to this value and type
+     *
+     * @return the same value or a new value
+     */
+    default List<Object> visitListValue(List<Object> coercedValue, GraphQLList listInputType, int index, List<GraphQLDirectiveContainer> containingElements) {
+        return coercedValue;
+    }
+}

--- a/src/main/java/graphql/analysis/values/ValueVisitor.java
+++ b/src/main/java/graphql/analysis/values/ValueVisitor.java
@@ -37,12 +37,12 @@ public interface ValueVisitor {
         /**
          * @return then list of input schema elements that lead to an input value.
          */
-        List<GraphQLInputSchemaElement> inputElements();
+        List<GraphQLInputSchemaElement> getInputElements();
 
         /**
          * @return then list of {@link GraphQLInputValueDefinition} elements that lead to an input value.
          */
-        List<GraphQLInputValueDefinition> inputValueDefinitions();
+        List<GraphQLInputValueDefinition> getInputValueDefinitions();
 
         /**
          * This is the last {@link GraphQLInputValueDefinition} that pointed to the value during a callback.  This will
@@ -50,7 +50,7 @@ public interface ValueVisitor {
          *
          * @return the last {@link GraphQLInputValueDefinition} that contains this value
          */
-        GraphQLInputValueDefinition lastInputValueDefinition();
+        GraphQLInputValueDefinition getLastInputValueDefinition();
     }
 
     /**

--- a/src/main/java/graphql/analysis/values/ValueVisitor.java
+++ b/src/main/java/graphql/analysis/values/ValueVisitor.java
@@ -8,6 +8,7 @@ import graphql.schema.GraphQLInputSchemaElement;
 import graphql.schema.GraphQLInputValueDefinition;
 import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLScalarType;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.Map;
@@ -65,7 +66,7 @@ public interface ValueVisitor {
      *
      * @return the same value or a new value
      */
-    default Object visitScalarValue(Object coercedValue, GraphQLScalarType inputType, InputElements inputElements) {
+    default @Nullable Object visitScalarValue(@Nullable Object coercedValue, GraphQLScalarType inputType, InputElements inputElements) {
         return coercedValue;
     }
 
@@ -78,7 +79,7 @@ public interface ValueVisitor {
      *
      * @return the same value or a new value
      */
-    default Object visitEnumValue(Object coercedValue, GraphQLEnumType inputType, InputElements inputElements) {
+    default @Nullable Object visitEnumValue(@Nullable Object coercedValue, GraphQLEnumType inputType, InputElements inputElements) {
         return coercedValue;
     }
 
@@ -92,7 +93,7 @@ public interface ValueVisitor {
      *
      * @return the same value or a new value
      */
-    default Object visitInputObjectFieldValue(Object coercedValue, GraphQLInputObjectType inputObjectType, GraphQLInputObjectField inputObjectField, InputElements inputElements) {
+    default @Nullable Object visitInputObjectFieldValue(@Nullable Object coercedValue, GraphQLInputObjectType inputObjectType, GraphQLInputObjectField inputObjectField, InputElements inputElements) {
         return coercedValue;
     }
 
@@ -105,7 +106,7 @@ public interface ValueVisitor {
      *
      * @return the same value or a new value
      */
-    default Map<String, Object> visitInputObjectValue(Map<String, Object> coercedValue, GraphQLInputObjectType inputObjectType, InputElements inputElements) {
+    default @Nullable Map<String, Object> visitInputObjectValue(@Nullable Map<String, Object> coercedValue, GraphQLInputObjectType inputObjectType, InputElements inputElements) {
         return coercedValue;
     }
 
@@ -118,7 +119,7 @@ public interface ValueVisitor {
      *
      * @return the same value or a new value
      */
-    default List<Object> visitListValue(List<Object> coercedValue, GraphQLList listInputType, InputElements inputElements) {
+    default @Nullable List<Object> visitListValue(@Nullable List<Object> coercedValue, GraphQLList listInputType, InputElements inputElements) {
         return coercedValue;
     }
 }

--- a/src/main/java/graphql/schema/GraphQLInputSchemaElement.java
+++ b/src/main/java/graphql/schema/GraphQLInputSchemaElement.java
@@ -1,7 +1,10 @@
 package graphql.schema;
 
+import graphql.PublicApi;
+
 /**
  * A schema element that is concerned with input.
  */
+@PublicApi
 public interface GraphQLInputSchemaElement extends GraphQLSchemaElement {
 }

--- a/src/main/java/graphql/schema/GraphQLInputSchemaElement.java
+++ b/src/main/java/graphql/schema/GraphQLInputSchemaElement.java
@@ -1,0 +1,7 @@
+package graphql.schema;
+
+/**
+ * A schema element that is concerned with input.
+ */
+public interface GraphQLInputSchemaElement extends GraphQLSchemaElement {
+}

--- a/src/main/java/graphql/schema/GraphQLInputType.java
+++ b/src/main/java/graphql/schema/GraphQLInputType.java
@@ -8,5 +8,5 @@ import graphql.PublicApi;
  * to {@link graphql.schema.GraphQLOutputType}s which can only be used as graphql response output.
  */
 @PublicApi
-public interface GraphQLInputType extends GraphQLType {
+public interface GraphQLInputType extends GraphQLType, GraphQLInputSchemaElement {
 }

--- a/src/main/java/graphql/schema/GraphQLInputValueDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLInputValueDefinition.java
@@ -11,7 +11,7 @@ import graphql.PublicApi;
  * @see graphql.schema.GraphQLArgument
  */
 @PublicApi
-public interface GraphQLInputValueDefinition extends GraphQLDirectiveContainer {
+public interface GraphQLInputValueDefinition extends GraphQLDirectiveContainer, GraphQLInputSchemaElement {
 
     <T extends GraphQLInputType> T getType();
 }

--- a/src/test/groovy/graphql/analysis/values/ValueTraverserTest.groovy
+++ b/src/test/groovy/graphql/analysis/values/ValueTraverserTest.groovy
@@ -384,7 +384,7 @@ class ValueTraverserTest extends Specification {
         def visitor = new ValueVisitor() {
             @Override
             Object visitScalarValue(Object coercedValue, GraphQLScalarType inputType, ValueVisitor.InputElements inputElements) {
-                def fieldName = inputElements.lastInputValueDefinition().name
+                def fieldName = inputElements.getLastInputValueDefinition().name
                 if (fieldName == "age") {
                     return ABSENCE_SENTINEL
                 }
@@ -399,7 +399,7 @@ class ValueTraverserTest extends Specification {
 
             @Override
             Object visitInputObjectFieldValue(Object coercedValue, GraphQLInputObjectType inputObjectType, GraphQLInputObjectField inputObjectField, ValueVisitor.InputElements inputElements) {
-                def fieldName = inputElements.lastInputValueDefinition().name
+                def fieldName = inputElements.getLastInputValueDefinition().name
                 if (fieldName == "otherInput") {
                     return ABSENCE_SENTINEL
                 }
@@ -454,10 +454,10 @@ class ValueTraverserTest extends Specification {
 
 
             private void checkDirectives(ValueVisitor.InputElements inputElements) {
-                def lastElement = inputElements.lastInputValueDefinition()
+                def lastElement = inputElements.getLastInputValueDefinition()
                 def directive = lastElement.getAppliedDirective("d")
                 if (directive != null) {
-                    def elementNames = inputElements.inputElements().collect(
+                    def elementNames = inputElements.getInputElements().collect(
                             { it ->
                                 if (it instanceof GraphQLNamedSchemaElement) {
                                     return it.name
@@ -514,7 +514,7 @@ class ValueTraverserTest extends Specification {
         def visitor = new ValueVisitor() {
             @Override
             Object visitScalarValue(Object coercedValue, GraphQLScalarType inputType, ValueVisitor.InputElements inputElements) {
-                def lastElement = inputElements.lastInputValueDefinition()
+                def lastElement = inputElements.getLastInputValueDefinition()
                 def directive = lastElement.getAppliedDirective("stripHtml")
                 if (directive != null) {
                     def v = String.valueOf(coercedValue)
@@ -570,7 +570,7 @@ type Profile {
                     ValueVisitor visitor = new ValueVisitor() {
                         @Override
                         Object visitScalarValue(Object coercedValue, GraphQLScalarType inputType, ValueVisitor.InputElements inputElements) {
-                            def container = inputElements.lastInputValueDefinition()
+                            def container = inputElements.getLastInputValueDefinition()
                             if (container.hasAppliedDirective("stripHtml")) {
                                 return stripHtml(coercedValue)
                             }

--- a/src/test/groovy/graphql/analysis/values/ValueTraverserTest.groovy
+++ b/src/test/groovy/graphql/analysis/values/ValueTraverserTest.groovy
@@ -1,0 +1,446 @@
+package graphql.analysis.values
+
+import graphql.TestUtil
+import graphql.schema.DataFetchingEnvironmentImpl
+import graphql.schema.GraphQLDirectiveContainer
+import graphql.schema.GraphQLEnumType
+import graphql.schema.GraphQLInputObjectField
+import graphql.schema.GraphQLInputObjectType
+import graphql.schema.GraphQLList
+import graphql.schema.GraphQLScalarType
+import spock.lang.Specification
+
+class ValueTraverserTest extends Specification {
+
+    def sdl = """
+            type Query {
+                field(arg1 : ComplexInput, arg2 : ComplexInput, stringArg : String, enumArg : RGB) : String
+            } 
+            
+            input ComplexInput {
+                complexListField : [[ComplexInput!]]
+                objectField : InnerInput
+                listField : [Int!]
+                stringField : String
+                enumField : RGB
+            }
+
+            input InnerInput {
+                innerListField : [Int!]
+                innerStringField : String
+                innerEnumField : RGB
+            }
+                
+            
+            enum RGB {
+                RED,GREEN,BLUE
+            }
+        """
+
+    def schema = TestUtil.schema(sdl)
+
+    class CountingVisitor implements ValueVisitor {
+
+        Map<String, Integer> visits = [:]
+
+        private int bumpCount(String name) {
+            visits.compute(name, { k, v -> return v == null ? 0 : ++v })
+        }
+
+        @Override
+        Object visitScalarValue(Object coercedValue, GraphQLScalarType inputType, int index, List<GraphQLDirectiveContainer> containingElements) {
+            bumpCount("scalar")
+            return coercedValue
+        }
+
+        @Override
+        Object visitEnumValue(Object coercedValue, GraphQLEnumType inputType, int index, List<GraphQLDirectiveContainer> containingElements) {
+            bumpCount("enum")
+            return coercedValue
+        }
+
+        @Override
+        Object visitInputObjectFieldValue(Object coercedValue, GraphQLInputObjectType inputObjectType, GraphQLInputObjectField inputObjectField, int index, List<GraphQLDirectiveContainer> containingElements) {
+            bumpCount("objectField")
+            return coercedValue
+        }
+
+        @Override
+        Map<String, Object> visitInputObjectValue(Map<String, Object> coercedValue, GraphQLInputObjectType inputObjectType, int index, List<GraphQLDirectiveContainer> containingElements) {
+            bumpCount("object")
+            return coercedValue
+        }
+
+        @Override
+        List<Object> visitListValue(List<Object> coercedValue, GraphQLList listInputType, int index, List<GraphQLDirectiveContainer> containingElements) {
+            bumpCount("list")
+            return coercedValue
+        }
+    }
+
+    def "can traverse and changes nothing at all"() {
+
+        def fieldDef = this.schema.getObjectType("Query").getFieldDefinition("field")
+
+        def innerInput = [
+                innerListField  : [6, 7, 8],
+                innerStringField: "Inner",
+                innerEnumField  : "RED",
+        ]
+        def complexInput = [
+                complexListField: [[[objectField: innerInput, complexListField: [[]], stringField: "There", enumField: "GREEN"]]],
+                objectField     : [innerStringField: "World", innerEnumField: "BLUE"],
+                listField       : [1, 2, 3, 4, 5],
+                stringField     : "Hello",
+                enumField       : "RED",
+        ]
+        Map<String, Object> originalValues = [
+                arg1       : complexInput,
+                arg2       : null,
+                stringArg  : "Hello",
+                enumArg    : "RGB",
+                noFieldData: "wat",
+        ]
+        def visitor = new CountingVisitor()
+        when:
+        def newValues = ValueTraverser.visitPreOrder(originalValues, fieldDef, visitor)
+        then:
+        // nothing changed - its the same object
+        newValues === originalValues
+        visitor.visits == ["scalar": 12, "enum": 4, "list": 5, "object": 3, "objectField": 13]
+
+
+        when:
+        def originalDFE = DataFetchingEnvironmentImpl.newDataFetchingEnvironment().fieldDefinition(fieldDef).graphQLSchema(this.schema).arguments(originalValues).build()
+        def newDFE = ValueTraverser.visitPreOrder(originalDFE, visitor)
+
+        then:
+        newDFE === originalDFE
+
+        when:
+        def graphQLArgument = fieldDef.getArgument("arg1")
+        def newValue = ValueTraverser.visitPreOrder(complexInput, graphQLArgument, visitor)
+
+        then:
+        complexInput === newValue
+    }
+
+    def "can change simple values"() {
+        def fieldDef = this.schema.getObjectType("Query").getFieldDefinition("field")
+
+        def innerInput = [
+                innerListField  : [6, 7, 8],
+                innerStringField: "Inner",
+                innerEnumField  : "RED",
+        ]
+        def complexInput = [
+                complexListField: [[[objectField: innerInput, complexListField: [[]], stringField: "There", enumField: "GREEN"]]],
+                objectField     : [innerStringField: "World", innerEnumField: "BLUE"],
+                listField       : [1, 2, 3, 4, 5],
+                stringField     : "Hello",
+                enumField       : "RED",
+        ]
+        Map<String, Object> originalValues = [
+                arg1       : complexInput,
+                arg2       : null,
+                stringArg  : "Hello",
+                enumArg    : "BLUE",
+                noFieldData: "wat",
+        ]
+        def visitor = new ValueVisitor() {
+            @Override
+            Object visitScalarValue(Object coercedValue, GraphQLScalarType inputType, int index, List<GraphQLDirectiveContainer> containingElements) {
+                if (coercedValue instanceof String) {
+                    def val = coercedValue as String
+                    return val.toUpperCase().reverse()
+                }
+                if (coercedValue instanceof Number) {
+                    return coercedValue * 1000
+                }
+                return coercedValue;
+            }
+
+            @Override
+            Object visitEnumValue(Object coercedValue, GraphQLEnumType inputType, int index, List<GraphQLDirectiveContainer> containingElements) {
+                def val = coercedValue as String
+                return val.toLowerCase().reverse()
+            }
+        }
+        when:
+        def newValues = ValueTraverser.visitPreOrder(originalValues, fieldDef, visitor)
+        then:
+        // numbers are 1000 greater and strings are upper case reversed and enums are lower cased reversed
+        newValues == [
+                arg1       : [complexListField: [[[
+                                                          objectField     : [
+                                                                  innerListField  : [6000, 7000, 8000],
+                                                                  innerStringField: "RENNI",
+                                                                  innerEnumField  : "der"
+                                                          ],
+                                                          complexListField: [[]],
+                                                          stringField     : "EREHT",
+                                                          enumField       : "neerg"]]],
+                              objectField     : [innerStringField: "DLROW", innerEnumField: "eulb"],
+                              listField       : [1000, 2000, 3000, 4000, 5000],
+                              stringField     : "OLLEH",
+                              enumField       : "der"],
+                arg2       : null,
+                stringArg  : "OLLEH",
+                enumArg    : "eulb",
+                noFieldData: "wat"
+        ]
+    }
+
+    def "can change a list midway through "() {
+        def sdl = """
+            type Query {
+                field(arg : [Int]!) : String
+            }
+        """
+        def schema = TestUtil.schema(sdl)
+
+        def fieldDef = schema.getObjectType("Query").getFieldDefinition("field")
+        def argValues = [arg: [1, 2, 3, 4]]
+        def visitor = new ValueVisitor() {
+            @Override
+            Object visitScalarValue(Object coercedValue, GraphQLScalarType inputType, int index, List<GraphQLDirectiveContainer> containingElements) {
+                if (coercedValue == 3) {
+                    return 33
+                }
+                return coercedValue
+            }
+        }
+        when:
+        def newValues = ValueTraverser.visitPreOrder(argValues, fieldDef, visitor)
+        then:
+        newValues == [arg: [1, 2, 33, 4]]
+    }
+
+    def "can change an object midway through "() {
+        def sdl = """
+            type Query {
+                field(arg : Input!) : String
+            }
+            
+            input Input {
+                name : String
+                age : Int
+                input : Input
+            }
+        """
+        def schema = TestUtil.schema(sdl)
+
+        def fieldDef = schema.getObjectType("Query").getFieldDefinition("field")
+        def argValues = [arg:
+                                 [name: "Tess", age: 42, input:
+                                         [name: "Tom", age: 33, input:
+                                                 [name: "Ted", age: 42]]
+                                 ]
+        ]
+        def visitor = new ValueVisitor() {
+            @Override
+            Object visitScalarValue(Object coercedValue, GraphQLScalarType inputType, int index, List<GraphQLDirectiveContainer> containingElements) {
+                if (coercedValue == 42) {
+                    return 24
+                }
+                return coercedValue
+            }
+        }
+        when:
+        def actual = ValueTraverser.visitPreOrder(argValues, fieldDef, visitor)
+
+        def expected = [arg:
+                                [name: "Tess", age: 24, input:
+                                        [name: "Tom", age: 33, input:
+                                                [name: "Ted", age: 24]
+                                        ]
+                                ]
+        ]
+        then:
+        actual == expected
+
+
+        // can change a DFE arguments
+        when:
+        def startingDFE = DataFetchingEnvironmentImpl.newDataFetchingEnvironment().fieldDefinition(fieldDef).arguments(argValues).build()
+        def newDFE = ValueTraverser.visitPreOrder(startingDFE, visitor)
+
+        then:
+        newDFE.getArguments() == expected
+        newDFE.getFieldDefinition() == fieldDef
+
+        // can change a single arguments
+        when:
+        def newValues = ValueTraverser.visitPreOrder(argValues['arg'], fieldDef.getArgument("arg"), visitor)
+
+        then:
+        newValues == [name: "Tess", age: 24, input:
+                [name: "Tom", age: 33, input:
+                        [name: "Ted", age: 24]
+                ]
+        ]
+    }
+
+    def "can handle a null changes"() {
+        def sdl = """
+            type Query {
+                field(arg : Input!) : String
+            }
+            
+            input Input {
+                listField : [String!]
+                objectField : Input
+                stringField : String
+                leaveAloneField : String
+            }
+        """
+        def schema = TestUtil.schema(sdl)
+
+        def fieldDef = schema.getObjectType("Query").getFieldDefinition("field")
+        def argValues = [arg:
+                                 [
+                                         listField  : ["a", "b", "c"],
+                                         objectField: [listField: ["a", "b", "c"]],
+                                         stringField: "s",
+                                         leaveAloneField: "ok"
+                                 ]
+        ]
+        def visitor = new ValueVisitor() {
+
+            @Override
+            Object visitInputObjectFieldValue(Object coercedValue, GraphQLInputObjectType inputObjectType, GraphQLInputObjectField inputObjectField, int index, List<GraphQLDirectiveContainer> containingElements) {
+                if (inputObjectField.name == "leaveAloneField") {
+                    return coercedValue
+                }
+                return null
+            }
+
+        }
+        when:
+        def actual = ValueTraverser.visitPreOrder(argValues, fieldDef, visitor)
+
+        def expected = [arg:
+                                [
+                                        listField  : null,
+                                        objectField: null,
+                                        stringField: null,
+                                        leaveAloneField: "ok",
+                                ]
+        ]
+        then:
+        actual == expected
+    }
+
+    def "can get access to directives"() {
+        def sdl = """
+            directive @d(name : String!) on ARGUMENT_DEFINITION | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+            type Query {
+                field(arg : Input! @d(name :  "argDirective") ) : String
+            }
+            
+            input Input {
+                name : String @d(name : "nameDirective")
+                age : Int @d(name : "ageDirective")
+                input : Input @d(name : "inputDirective")
+            }
+        """
+        def schema = TestUtil.schema(sdl)
+
+        def fieldDef = schema.getObjectType("Query").getFieldDefinition("field")
+        def argValues = [arg:
+                                 [name: "Tess", age: 42, input:
+                                         [name: "Tom", age: 33, input:
+                                                 [name: "Ted", age: 42]]
+                                 ]
+        ]
+        def capture = []
+        def visitor = new ValueVisitor() {
+            @Override
+            Object visitScalarValue(Object coercedValue, GraphQLScalarType inputType, int index, List<GraphQLDirectiveContainer> containingElements) {
+                checkDirectives(containingElements)
+                return coercedValue
+            }
+
+            @Override
+            Object visitInputObjectFieldValue(Object coercedValue, GraphQLInputObjectType inputObjectType, GraphQLInputObjectField inputObjectField, int index, List<GraphQLDirectiveContainer> containingElements) {
+                checkDirectives(containingElements)
+                return coercedValue
+            }
+
+            private void checkDirectives(List<GraphQLDirectiveContainer> containingElements) {
+                def lastElement = containingElements.last()
+                def directive = lastElement.getAppliedDirective("d")
+                if (directive != null) {
+                    def elementNames = containingElements.collect({ it -> it.name }).join(":")
+                    def value = directive.getArgument("name").value
+                    capture.add(elementNames + "@" + value)
+                }
+            }
+        }
+        when:
+        def newValues = ValueTraverser.visitPreOrder(argValues, fieldDef, visitor)
+        then:
+        newValues == argValues
+        capture == ["field:arg:name@nameDirective",
+                    "field:arg:age@ageDirective",
+                    "field:arg:input:name@nameDirective",
+
+                    "field:arg:input:age@ageDirective",
+                    "field:arg:input:input:name@nameDirective",
+                    "field:arg:input:input:age@ageDirective"]
+    }
+
+    def "can follow directives and change input"() {
+        def sdl = """
+            directive @stripHtml on ARGUMENT_DEFINITION | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+            type Query {
+                field(arg : Input!) : String
+            }
+            
+            input Input {
+                name : String @stripHtml
+                age : Int
+                input : Input
+            }
+        """
+        def schema = TestUtil.schema(sdl)
+
+        def fieldDef = schema.getObjectType("Query").getFieldDefinition("field")
+        def argValues = [arg:
+                                 [name: "<b>Tess</b>", age: 42, input:
+                                         [name: "<u>Tom</u>", age: 33, input:
+                                                 [name: "<i>Ted</i>", age: 42]]
+                                 ]
+        ]
+
+        def visitor = new ValueVisitor() {
+            @Override
+            Object visitScalarValue(Object coercedValue, GraphQLScalarType inputType, int index, List<GraphQLDirectiveContainer> containingElements) {
+                def lastElement = containingElements.last()
+                def directive = lastElement.getAppliedDirective("stripHtml")
+                if (directive != null) {
+                    def v = String.valueOf(coercedValue)
+                    return v.replaceAll(/<!--.*?-->/, '').replaceAll(/<.*?>/, '')
+                }
+                return coercedValue
+            }
+
+            @Override
+            Object visitInputObjectFieldValue(Object coercedValue, GraphQLInputObjectType inputObjectType, GraphQLInputObjectField inputObjectField, int index, List<GraphQLDirectiveContainer> containingElements) {
+                return coercedValue
+            }
+
+        }
+        when:
+        def newValues = ValueTraverser.visitPreOrder(argValues, fieldDef, visitor)
+        then:
+        newValues == [arg:
+                              [name: "Tess", age: 42, input:
+                                      [name: "Tom", age: 33, input:
+                                              [name: "Ted", age: 42]]
+                              ]
+        ]
+    }
+}


### PR DESCRIPTION
This traverser allows you to change input values - eg arguments to fields.

It is intended to be used inside DataFetchers say to allow you to change the arguments after validation



Some design choices I made

* I looked at using the traverser code (versus a hand coded visitor) but this requires a `accept()` method on objects to traverse AND it can only traverse on a single set of values.  
   *  And we need two - the in memory value and the runtime input types involved
* This assumes coerced values - that is what gets passed to a DataFetcher
* This does NOT check for valid input - and it leaves alone any object values that have no corresponding fields
    * earlier validation should ensure that is never the case
* This does not check for valid output - eg it would be possible to put nullable values in place for non nullable types say
    *  with great power comes great responsibility