### PR TITLE
Consider union containers when checking if type is referenced

### DIFF
--- a/src/main/java/graphql/schema/usage/SchemaUsage.java
+++ b/src/main/java/graphql/schema/usage/SchemaUsage.java
@@ -47,6 +47,8 @@ public class SchemaUsage {
     private final Map<String, Set<String>> interfaceImplementors;
     private final Map<String, Set<String>> elementBackReferences;
 
+    private final Map<String, Set<String>> unionReferences;
+
     private SchemaUsage(Builder builder) {
         this.fieldReferenceCounts = ImmutableMap.copyOf(builder.fieldReferenceCounts);
         this.inputFieldReferenceCounts = ImmutableMap.copyOf(builder.inputFieldReferenceCounts);
@@ -57,6 +59,7 @@ public class SchemaUsage {
         this.directiveReferenceCount = ImmutableMap.copyOf(builder.directiveReferenceCount);
         this.interfaceImplementors = ImmutableMap.copyOf(builder.interfaceImplementors);
         this.elementBackReferences = ImmutableMap.copyOf(builder.elementBackReferences);
+        this.unionReferences = ImmutableMap.copyOf(builder.unionReferences);
     }
 
     /**
@@ -225,6 +228,13 @@ public class SchemaUsage {
                     }
                 }
             }
+
+            Set<String> unionContainers = unionReferences.getOrDefault(type.getName(), emptySet());
+            for (String unionContainer : unionContainers) {
+                if (isReferencedImpl(schema, unionContainer, pathSoFar)) {
+                    return true;
+                }
+            }
         }
         return false;
     }
@@ -249,6 +259,8 @@ public class SchemaUsage {
         Map<String, Integer> unionReferenceCount = new LinkedHashMap<>();
         Map<String, Integer> directiveReferenceCount = new LinkedHashMap<>();
         Map<String, Set<String>> interfaceImplementors = new LinkedHashMap<>();
+
+        Map<String, Set<String>> unionReferences = new LinkedHashMap<>();
         Map<String, Set<String>> elementBackReferences = new LinkedHashMap<>();
 
         SchemaUsage build() {

--- a/src/main/java/graphql/schema/usage/SchemaUsageSupport.java
+++ b/src/main/java/graphql/schema/usage/SchemaUsageSupport.java
@@ -135,6 +135,7 @@ public class SchemaUsageSupport {
                 List<GraphQLNamedOutputType> members = unionType.getTypes();
                 for (GraphQLNamedOutputType member : members) {
                     builder.unionReferenceCount.compute(member.getName(), incCount());
+                    builder.unionReferences.computeIfAbsent(member.getName(), k -> new HashSet<>()).add(unionType.getName());
 
                     recordBackReference(unionType, member);
                 }

--- a/src/test/groovy/graphql/schema/usage/SchemaUsageSupportTest.groovy
+++ b/src/test/groovy/graphql/schema/usage/SchemaUsageSupportTest.groovy
@@ -16,6 +16,7 @@ class SchemaUsageSupportTest extends Specification {
                 f3 : RefUnion1
                 f4 : RefEnum1
                 f5 : String
+                f6 : RefUnion2
                 
                 f_arg1( arg : RefInput1) : String
                 f_arg2( arg : [RefInput2]) : String
@@ -52,6 +53,12 @@ class SchemaUsageSupportTest extends Specification {
             }
                          
             union RefUnion1 = Ref1 | Ref2
+            
+            
+            type RefByUnionOnly1 { f : ID}
+            type RefByUnionOnly2 { f : ID}
+            
+            union RefUnion2 = RefByUnionOnly1 | RefByUnionOnly2
             
             enum RefEnum1 { A, B }
             
@@ -153,6 +160,10 @@ class SchemaUsageSupportTest extends Specification {
         schemaUsage.isStronglyReferenced(schema, "Floating3")
 
         schemaUsage.isStronglyReferenced(schema, "RefUnion1")
+
+        schemaUsage.isStronglyReferenced(schema, "RefUnion2")
+        schemaUsage.isStronglyReferenced(schema, "RefByUnionOnly1")
+        schemaUsage.isStronglyReferenced(schema, "RefByUnionOnly2")
 
         schemaUsage.isStronglyReferenced(schema, "RefInput1")
         schemaUsage.isStronglyReferenced(schema, "RefInput2")


### PR DESCRIPTION
Fix a bug where `SchemaUsage#isStronglyReferenced` returns `false` for object types that are only referenced via unions.