### PR TITLE
19.x fix - use class loader on i18n

### DIFF
--- a/src/main/java/graphql/i18n/I18n.java
+++ b/src/main/java/graphql/i18n/I18n.java
@@ -35,7 +35,9 @@ public class I18n {
     protected I18n(BundleType bundleType, Locale locale) {
         assertNotNull(bundleType);
         assertNotNull(locale);
-        this.resourceBundle = ResourceBundle.getBundle(bundleType.baseName, locale);
+        // load the resource bundle with this classes class loader - to help avoid confusion in complicated worlds
+        // like OSGI
+        this.resourceBundle = ResourceBundle.getBundle(bundleType.baseName, locale, I18n.class.getClassLoader());
     }
 
     public ResourceBundle getResourceBundle() {


### PR DESCRIPTION
This is a small improvement to see if this reduces the confusion on where a resource bundle is used

See https://stackoverflow.com/questions/13598351/loading-a-resourcebundle-within-an-osgi-bundle

This is intended for 19.x and then we will port it to master