### PR TITLE
parseValue coercion alignment for Boolean, Float, and Int

### DIFF
--- a/src/main/java/graphql/scalar/GraphqlBooleanCoercing.java
+++ b/src/main/java/graphql/scalar/GraphqlBooleanCoercing.java
@@ -68,13 +68,12 @@ public class GraphqlBooleanCoercing implements Coercing<Boolean, Boolean> {
 
     @NotNull
     private Boolean parseValueImpl(@NotNull Object input, @NotNull Locale locale) {
-        Boolean result = convertImpl(input);
-        if (result == null) {
+        if (!(input instanceof Boolean)) {
             throw new CoercingParseValueException(
-                    i18nMsg(locale, "Boolean.notBoolean", typeName(input))
+                    i18nMsg(locale, "Boolean.unexpectedRawValueType", typeName(input))
             );
         }
-        return result;
+        return (Boolean) input;
     }
 
     private static boolean parseLiteralImpl(@NotNull Object input, @NotNull Locale locale) {

--- a/src/main/java/graphql/scalar/GraphqlFloatCoercing.java
+++ b/src/main/java/graphql/scalar/GraphqlFloatCoercing.java
@@ -64,13 +64,20 @@ public class GraphqlFloatCoercing implements Coercing<Double, Double> {
     }
 
     @NotNull
-    private Double parseValueImpl(Object input, @NotNull Locale locale) {
+    private Double parseValueImpl(@NotNull Object input, @NotNull Locale locale) {
+        if (!(input instanceof Number)) {
+            throw new CoercingParseValueException(
+                    i18nMsg(locale, "Float.unexpectedRawValueType", typeName(input))
+            );
+        }
+
         Double result = convertImpl(input);
         if (result == null) {
             throw new CoercingParseValueException(
                     i18nMsg(locale, "Float.notFloat", typeName(input))
             );
         }
+
         return result;
     }
 

--- a/src/main/java/graphql/scalar/GraphqlIntCoercing.java
+++ b/src/main/java/graphql/scalar/GraphqlIntCoercing.java
@@ -63,7 +63,13 @@ public class GraphqlIntCoercing implements Coercing<Integer, Integer> {
     }
 
     @NotNull
-    private Integer parseValueImpl(Object input, @NotNull Locale locale) {
+    private Integer parseValueImpl(@NotNull Object input, @NotNull Locale locale) {
+        if (!(input instanceof Number)) {
+            throw new CoercingParseValueException(
+                    i18nMsg(locale, "Int.notInt", typeName(input))
+            );
+        }
+
         Integer result = convertImpl(input);
         if (result == null) {
             throw new CoercingParseValueException(

--- a/src/main/java/graphql/scalar/GraphqlIntCoercing.java
+++ b/src/main/java/graphql/scalar/GraphqlIntCoercing.java
@@ -64,19 +64,45 @@ public class GraphqlIntCoercing implements Coercing<Integer, Integer> {
 
     @NotNull
     private Integer parseValueImpl(@NotNull Object input, @NotNull Locale locale) {
+        if (input instanceof Integer) {
+            return (Integer) input;
+        }
+
         if (!(input instanceof Number)) {
             throw new CoercingParseValueException(
                     i18nMsg(locale, "Int.notInt", typeName(input))
             );
         }
 
-        Integer result = convertImpl(input);
+        BigInteger result = convertParseValueImpl(input);
         if (result == null) {
             throw new CoercingParseValueException(
                     i18nMsg(locale, "Int.notInt", typeName(input))
             );
         }
-        return result;
+
+        if (result.compareTo(INT_MIN) < 0 || result.compareTo(INT_MAX) > 0) {
+            throw new CoercingParseValueException(
+                    i18nMsg(locale, "Int.outsideRange", result.toString())
+            );
+        }
+        return result.intValueExact();
+    }
+
+    private BigInteger convertParseValueImpl(Object input) {
+        BigDecimal value;
+        try {
+            value = new BigDecimal(input.toString());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+
+        try {
+            return value.toBigIntegerExact();
+        } catch (ArithmeticException e) {
+            // Exception if number has non-zero fractional part
+            return null;
+        }
     }
 
     private static int parseLiteralImpl(Object input, @NotNull Locale locale) {

--- a/src/main/java/graphql/scalar/GraphqlIntCoercing.java
+++ b/src/main/java/graphql/scalar/GraphqlIntCoercing.java
@@ -64,14 +64,14 @@ public class GraphqlIntCoercing implements Coercing<Integer, Integer> {
 
     @NotNull
     private Integer parseValueImpl(@NotNull Object input, @NotNull Locale locale) {
-        if (input instanceof Integer) {
-            return (Integer) input;
-        }
-
         if (!(input instanceof Number)) {
             throw new CoercingParseValueException(
                     i18nMsg(locale, "Int.notInt", typeName(input))
             );
+        }
+
+        if (input instanceof Integer) {
+            return (Integer) input;
         }
 
         BigInteger result = convertParseValueImpl(input);

--- a/src/main/resources/i18n/Scalars.properties
+++ b/src/main/resources/i18n/Scalars.properties
@@ -27,5 +27,6 @@ Float.unexpectedAstType=Expected an AST type of ''IntValue'' or ''FloatValue'' b
 #
 Boolean.notBoolean=Expected a value that can be converted to type ''Boolean'' but it was a ''{0}''
 Boolean.unexpectedAstType=Expected an AST type of ''BooleanValue'' but it was a ''{0}''
+Boolean.unexpectedRawValueType=Expected a Boolean input, but it was a ''{0}''
 #
 String.unexpectedRawValueType=Expected a String input, but it was a ''{0}''

--- a/src/main/resources/i18n/Scalars.properties
+++ b/src/main/resources/i18n/Scalars.properties
@@ -24,6 +24,7 @@ ID.unexpectedAstType=Expected an AST type of ''IntValue'' or ''StringValue'' but
 #
 Float.notFloat=Expected a value that can be converted to type ''Float'' but it was a ''{0}''
 Float.unexpectedAstType=Expected an AST type of ''IntValue'' or ''FloatValue'' but it was a ''{0}''
+Float.unexpectedRawValueType=Expected a Number input, but it was a ''{0}''
 #
 Boolean.notBoolean=Expected a value that can be converted to type ''Boolean'' but it was a ''{0}''
 Boolean.unexpectedAstType=Expected an AST type of ''BooleanValue'' but it was a ''{0}''

--- a/src/main/resources/i18n/Scalars_de.properties
+++ b/src/main/resources/i18n/Scalars_de.properties
@@ -30,5 +30,6 @@ Float.unexpectedAstType=Erwartet wurde ein AST type von ''IntValue'' oder ''Floa
 #
 Boolean.notBoolean=Erwartet wurde ein Wert, der in den Typ ''Boolean'' konvertiert werden kann, aber es war ein ''{0}''
 Boolean.unexpectedAstType=Erwartet wurde ein AST type ''BooleanValue'', aber es war ein ''{0}''
+Boolean.unexpectedRawValueType=Erwartet wurde eine Boolean-Eingabe, aber es war ein ''{0}''
 #
 String.unexpectedRawValueType=Erwartet wurde eine String-Eingabe, aber es war ein ''{0}''

--- a/src/main/resources/i18n/Scalars_de.properties
+++ b/src/main/resources/i18n/Scalars_de.properties
@@ -27,6 +27,7 @@ ID.unexpectedAstType=Erwartet wurde ein AST type von ''IntValue'' oder ''StringV
 #
 Float.notFloat=Erwartet wurde ein Wert, der in den Typ ''Float'' konvertiert werden kann, aber es war ein ''{0}''
 Float.unexpectedAstType=Erwartet wurde ein AST type von ''IntValue'' oder ''FloatValue'', aber es war ein ''{0}''
+Float.unexpectedRawValueType=Erwartet wurde eine Number-Eingabe, aber es war ein ''{0}''
 #
 Boolean.notBoolean=Erwartet wurde ein Wert, der in den Typ ''Boolean'' konvertiert werden kann, aber es war ein ''{0}''
 Boolean.unexpectedAstType=Erwartet wurde ein AST type ''BooleanValue'', aber es war ein ''{0}''

--- a/src/test/groovy/graphql/ScalarsBooleanTest.groovy
+++ b/src/test/groovy/graphql/ScalarsBooleanTest.groovy
@@ -53,7 +53,6 @@ class ScalarsBooleanTest extends Specification {
     def "Boolean serialize #value into #result (#result.class)"() {
         expect:
         Scalars.GraphQLBoolean.getCoercing().serialize(value, GraphQLContext.default, Locale.default) == result
-        Scalars.GraphQLBoolean.getCoercing().parseValue(value, GraphQLContext.default, Locale.default) == result
 
         where:
         value                        | result
@@ -75,7 +74,6 @@ class ScalarsBooleanTest extends Specification {
     def "Boolean serialize #value into #result (#result.class) with deprecated methods"() {
         expect:
         Scalars.GraphQLBoolean.getCoercing().serialize(value) == result // Retain deprecated method for test coverage
-        Scalars.GraphQLBoolean.getCoercing().parseValue(value) == result // Retain deprecated method for test coverage
 
         where:
         value                        | result
@@ -112,6 +110,28 @@ class ScalarsBooleanTest extends Specification {
     }
 
     @Unroll
+    def "Boolean parseValue #value into #result (#result.class)"() {
+        expect:
+        Scalars.GraphQLBoolean.getCoercing().parseValue(value, GraphQLContext.default, Locale.default) == result
+
+        where:
+        value | result
+        true  | true
+        false | false
+    }
+
+    @Unroll
+    def "Boolean parseValue #value into #result (#result.class) with deprecated methods"() {
+        expect:
+        Scalars.GraphQLBoolean.getCoercing().parseValue(value) == result // Retain deprecated method for test coverage
+
+        where:
+        value | result
+        true  | true
+        false | false
+    }
+
+    @Unroll
     def "parseValue throws exception for invalid input #value"() {
         when:
         Scalars.GraphQLBoolean.getCoercing().parseValue(value, GraphQLContext.default, Locale.default)
@@ -119,8 +139,19 @@ class ScalarsBooleanTest extends Specification {
         thrown(CoercingParseValueException)
 
         where:
-        value        | _
-        new Object() | _
+        value                        | _
+        new Object()                 | _
+        "false"                      | _
+        "true"                       | _
+        "True"                       | _
+        0                            | _
+        1                            | _
+        -1                           | _
+        new Long(42345784398534785l) | _
+        new Double(42.3)             | _
+        new Float(42.3)              | _
+        Integer.MAX_VALUE + 1l       | _
+        Integer.MIN_VALUE - 1l       | _
     }
 
 }

--- a/src/test/groovy/graphql/ScalarsFloatTest.groovy
+++ b/src/test/groovy/graphql/ScalarsFloatTest.groovy
@@ -58,7 +58,6 @@ class ScalarsFloatTest extends Specification {
     def "Float serialize #value into #result (#result.class)"() {
         expect:
         Scalars.GraphQLFloat.getCoercing().serialize(value, GraphQLContext.default, Locale.default) == result
-        Scalars.GraphQLFloat.getCoercing().parseValue(value, GraphQLContext.default, Locale.default) == result
 
         where:
         value                 | result
@@ -84,7 +83,6 @@ class ScalarsFloatTest extends Specification {
     def "Float serialize #value into #result (#result.class) with deprecated methods"() {
         expect:
         Scalars.GraphQLFloat.getCoercing().serialize(value) == result // Retain deprecated method for coverage
-        Scalars.GraphQLFloat.getCoercing().parseValue(value) == result // Retain deprecated method for coverage
 
         where:
         value                 | result
@@ -132,6 +130,51 @@ class ScalarsFloatTest extends Specification {
     }
 
     @Unroll
+    def "Float parseValue #value into #result (#result.class)"() {
+        expect:
+        Scalars.GraphQLFloat.getCoercing().parseValue(value, GraphQLContext.default, Locale.default) == result
+
+        where:
+        value                 | result
+        42.0000d              | 42
+        new Integer(42)       | 42
+        new BigInteger("42")  | 42
+        new BigDecimal("42")  | 42
+        new BigDecimal("4.2") | 4.2d
+        42.3f                 | 42.3d
+        42.0d                 | 42d
+        new Byte("42")        | 42
+        new Short("42")       | 42
+        1234567l              | 1234567d
+        new AtomicInteger(42) | 42
+        Double.MAX_VALUE      | Double.MAX_VALUE
+        Double.MIN_VALUE      | Double.MIN_VALUE
+    }
+
+    @Unroll
+    def "Float parseValue #value into #result (#result.class) with deprecated methods"() {
+        expect:
+        Scalars.GraphQLFloat.getCoercing().parseValue(value) == result // Retain deprecated method for coverage
+
+        where:
+        value                 | result
+        42.0000d              | 42
+        new Integer(42)       | 42
+        new BigInteger("42")  | 42
+        new BigDecimal("42")  | 42
+        new BigDecimal("4.2") | 4.2d
+        42.3f                 | 42.3d
+        42.0d                 | 42d
+        new Byte("42")        | 42
+        new Short("42")       | 42
+        1234567l              | 1234567d
+        new AtomicInteger(42) | 42
+        Double.MAX_VALUE      | Double.MAX_VALUE
+        Double.MIN_VALUE      | Double.MIN_VALUE
+    }
+
+
+    @Unroll
     def "parseValue throws exception for invalid input #value"() {
         when:
         Scalars.GraphQLFloat.getCoercing().parseValue(value, GraphQLContext.default, Locale.default)
@@ -154,6 +197,9 @@ class ScalarsFloatTest extends Specification {
         Float.POSITIVE_INFINITY.toString()  | _
         Float.NEGATIVE_INFINITY             | _
         Float.NEGATIVE_INFINITY.toString()  | _
+        "42"                                | _
+        "42.123"                            | _
+        "-1"                                | _
     }
 
 }

--- a/src/test/groovy/graphql/ScalarsIntTest.groovy
+++ b/src/test/groovy/graphql/ScalarsIntTest.groovy
@@ -60,7 +60,6 @@ class ScalarsIntTest extends Specification {
     def "Int serialize #value into #result (#result.class)"() {
         expect:
         Scalars.GraphQLInt.getCoercing().serialize(value, GraphQLContext.default, Locale.default) == result
-        Scalars.GraphQLInt.getCoercing().parseValue(value, GraphQLContext.default, Locale.default) == result
 
         where:
         value                 | result
@@ -85,7 +84,6 @@ class ScalarsIntTest extends Specification {
     def "Int serialize #value into #result (#result.class) with deprecated methods"() {
         expect:
         Scalars.GraphQLInt.getCoercing().serialize(value) == result // Retain deprecated for test coverage
-        Scalars.GraphQLInt.getCoercing().parseValue(value) == result // Retain deprecated for test coverage
 
         where:
         value                 | result
@@ -127,6 +125,48 @@ class ScalarsIntTest extends Specification {
     }
 
     @Unroll
+    def "Int parseValue #value into #result (#result.class)"() {
+        expect:
+        Scalars.GraphQLInt.getCoercing().parseValue(value, GraphQLContext.default, Locale.default) == result
+
+        where:
+        value                 | result
+        new Integer(42)       | 42
+        new BigInteger("42")  | 42
+        new Byte("42")        | 42
+        new Short("42")       | 42
+        1234567l              | 1234567
+        new AtomicInteger(42) | 42
+        Integer.MAX_VALUE     | Integer.MAX_VALUE
+        Integer.MIN_VALUE     | Integer.MIN_VALUE
+        42.0000d              | 42
+        new BigDecimal("42")  | 42
+        42.0f                 | 42
+        42.0d                 | 42
+    }
+
+    @Unroll
+    def "Int parseValue #value into #result (#result.class) with deprecated methods"() {
+        expect:
+        Scalars.GraphQLInt.getCoercing().parseValue(value) == result // Retain deprecated for test coverage
+
+        where:
+        value                 | result
+        42.0000d              | 42
+        new Integer(42)       | 42
+        new BigInteger("42")  | 42
+        new BigDecimal("42")  | 42
+        42.0f                 | 42
+        42.0d                 | 42
+        new Byte("42")        | 42
+        new Short("42")       | 42
+        1234567l              | 1234567
+        new AtomicInteger(42) | 42
+        Integer.MAX_VALUE     | Integer.MAX_VALUE
+        Integer.MIN_VALUE     | Integer.MIN_VALUE
+    }
+
+    @Unroll
     def "parseValue throws exception for invalid input #value"() {
         when:
         Scalars.GraphQLInt.getCoercing().parseValue(value, GraphQLContext.default, Locale.default)
@@ -144,6 +184,9 @@ class ScalarsIntTest extends Specification {
         Integer.MAX_VALUE + 1l       | _
         Integer.MIN_VALUE - 1l       | _
         new Object()                 | _
+        "42"                         | _
+        "42.0000"                    | _
+        "-1"                         | _
     }
 
 }

--- a/src/test/groovy/graphql/execution/ValuesResolverTest.groovy
+++ b/src/test/groovy/graphql/execution/ValuesResolverTest.groovy
@@ -56,8 +56,8 @@ class ValuesResolverTest extends Specification {
         inputType      | variableType            | inputValue   || outputValue
         GraphQLInt     | new TypeName("Int")     | 100          || 100
         GraphQLString  | new TypeName("String")  | 'someString' || 'someString'
-        GraphQLBoolean | new TypeName("Boolean") | 'true'       || true
-        GraphQLFloat   | new TypeName("Float")   | '42.43'      || 42.43d
+        GraphQLBoolean | new TypeName("Boolean") | true         || true
+        GraphQLFloat   | new TypeName("Float")   | 42.43d       || 42.43d
     }
 
     def "getVariableValues: map object as variable input"() {
@@ -641,7 +641,7 @@ class ValuesResolverTest extends Specification {
         executionResult.data == null
         executionResult.errors.size() == 1
         executionResult.errors[0].errorType == ErrorType.ValidationError
-        executionResult.errors[0].message == "Variable 'input' has an invalid value: Expected a value that can be converted to type 'Boolean' but it was a 'String'"
+        executionResult.errors[0].message == "Variable 'input' has an invalid value: Expected a Boolean input, but it was a 'String'"
         executionResult.errors[0].locations == [new SourceLocation(2, 35)]
     }
 
@@ -679,7 +679,7 @@ class ValuesResolverTest extends Specification {
         executionResult.data == null
         executionResult.errors.size() == 1
         executionResult.errors[0].errorType == ErrorType.ValidationError
-        executionResult.errors[0].message == "Variable 'input' has an invalid value: Expected a value that can be converted to type 'Float' but it was a 'String'"
+        executionResult.errors[0].message == "Variable 'input' has an invalid value: Expected a Number input, but it was a 'String'"
         executionResult.errors[0].locations == [new SourceLocation(2, 35)]
     }
 }


### PR DESCRIPTION
Aligning `parseValue` coercion to be closer to the JavaScript reference implementation https://github.com/graphql/graphql-js/blob/main/src/type/scalars.ts

Key change is that a string will no longer be accepted as an input, e.g. `"true"` is no longer accepted as a `parseValue` input for Boolean.

There is no change corresponding change for ID as coercion for ID was already aligned.

I tried to make coercion as close as possible, keeping in mind that JavaScript uses the floating point `Number` type to represent integer values.