### PR TITLE
Upgrade ANTLR to 4.11.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ targetCompatibility = JavaVersion.VERSION_11.toString()
 def reactiveStreamsVersion = '1.0.3'
 def slf4jVersion = '1.7.35'
 def releaseVersion = System.env.RELEASE_VERSION
-def antlrVersion = '4.9.3' // https://mvnrepository.com/artifact/org.antlr/antlr4-runtime
+def antlrVersion = '4.11.1' // https://mvnrepository.com/artifact/org.antlr/antlr4-runtime
 version = releaseVersion ? releaseVersion : getDevelopmentVersion()
 group = 'com.graphql-java'
 


### PR DESCRIPTION
This PR upgrades ANTLR to 4.11.1, the latest version.

Note that v4.10 was a major change, and generated lexers and parsers are not backwards compatible. Not an issue for us as we always regenerate these files https://github.com/antlr/antlr4/releases/tag/4.10