### PR TITLE
Allow users to disable MultiSourceReader trackData through ParserOptions

### DIFF
--- a/src/main/java/graphql/parser/Parser.java
+++ b/src/main/java/graphql/parser/Parser.java
@@ -254,13 +254,19 @@ public class Parser {
     }
 
     private Node<?> parseImpl(ParserEnvironment environment, BiFunction<GraphqlParser, GraphqlAntlrToLanguage, Object[]> nodeFunction) throws InvalidSyntaxException {
+        // default in the parser options if they are not set
+        ParserOptions parserOptions = environment.getParserOptions();
+        parserOptions = Optional.ofNullable(parserOptions).orElse(ParserOptions.getDefaultParserOptions());
+
         MultiSourceReader multiSourceReader;
         Reader reader = environment.getDocument();
         if (reader instanceof MultiSourceReader) {
             multiSourceReader = (MultiSourceReader) reader;
         } else {
             multiSourceReader = MultiSourceReader.newMultiSourceReader()
-                    .reader(reader, null).build();
+                    .reader(reader, null)
+                    .trackData(parserOptions.isReaderTrackData())
+                    .build();
         }
         CodePointCharStream charStream;
         try {
@@ -289,10 +295,6 @@ public class Parser {
                 throw new InvalidSyntaxException(msg, sourceLocation, null, preview, null);
             }
         });
-
-        // default in the parser options if they are not set
-        ParserOptions parserOptions = environment.getParserOptions();
-        parserOptions = Optional.ofNullable(parserOptions).orElse(ParserOptions.getDefaultParserOptions());
 
         // this lexer wrapper allows us to stop lexing when too many tokens are in place.  This prevents DOS attacks.
         int maxTokens = parserOptions.getMaxTokens();

--- a/src/main/java/graphql/parser/ParserOptions.java
+++ b/src/main/java/graphql/parser/ParserOptions.java
@@ -36,6 +36,7 @@ public class ParserOptions {
             .captureIgnoredChars(false)
             .captureSourceLocation(true)
             .captureLineComments(true)
+            .readerTrackData(true)
             .maxTokens(MAX_QUERY_TOKENS) // to prevent a billion laughs style attacks, we set a default for graphql-java
             .maxWhitespaceTokens(MAX_WHITESPACE_TOKENS)
             .build();
@@ -44,6 +45,7 @@ public class ParserOptions {
             .captureIgnoredChars(false)
             .captureSourceLocation(true)
             .captureLineComments(false) // #comments are not useful in query parsing
+            .readerTrackData(true)
             .maxTokens(MAX_QUERY_TOKENS) // to prevent a billion laughs style attacks, we set a default for graphql-java
             .maxWhitespaceTokens(MAX_WHITESPACE_TOKENS)
             .build();
@@ -52,6 +54,7 @@ public class ParserOptions {
             .captureIgnoredChars(false)
             .captureSourceLocation(true)
             .captureLineComments(true) // #comments are useful in SDL parsing
+            .readerTrackData(true)
             .maxTokens(Integer.MAX_VALUE) // we are less worried about a billion laughs with SDL parsing since the call path is not facing attackers
             .maxWhitespaceTokens(Integer.MAX_VALUE)
             .build();
@@ -154,6 +157,7 @@ public class ParserOptions {
     private final boolean captureIgnoredChars;
     private final boolean captureSourceLocation;
     private final boolean captureLineComments;
+    private final boolean readerTrackData;
     private final int maxTokens;
     private final int maxWhitespaceTokens;
     private final ParsingListener parsingListener;
@@ -162,6 +166,7 @@ public class ParserOptions {
         this.captureIgnoredChars = builder.captureIgnoredChars;
         this.captureSourceLocation = builder.captureSourceLocation;
         this.captureLineComments = builder.captureLineComments;
+        this.readerTrackData = builder.readerTrackData;
         this.maxTokens = builder.maxTokens;
         this.maxWhitespaceTokens = builder.maxWhitespaceTokens;
         this.parsingListener = builder.parsingListener;
@@ -205,6 +210,15 @@ public class ParserOptions {
     }
 
     /**
+     * Controls whether the underlying {@link MultiSourceReader} should track previously read data or not.
+     *
+     * @return true if {@link MultiSourceReader} should track data in memory.
+     */
+    public boolean isReaderTrackData() {
+        return readerTrackData;
+    }
+
+    /**
      * A graphql hacking vector is to send nonsensical queries that burn lots of parsing CPU time and burns
      * memory representing a document that won't ever execute.  To prevent this you can set a maximum number of parse
      * tokens that will be accepted before an exception is thrown and the parsing is stopped.
@@ -245,6 +259,7 @@ public class ParserOptions {
         private boolean captureIgnoredChars = false;
         private boolean captureSourceLocation = true;
         private boolean captureLineComments = true;
+        private boolean readerTrackData = true;
         private int maxTokens = MAX_QUERY_TOKENS;
         private ParsingListener parsingListener = ParsingListener.NOOP;
         private int maxWhitespaceTokens = MAX_WHITESPACE_TOKENS;
@@ -273,6 +288,11 @@ public class ParserOptions {
 
         public Builder captureLineComments(boolean captureLineComments) {
             this.captureLineComments = captureLineComments;
+            return this;
+        }
+
+        public Builder readerTrackData(boolean readerTrackData) {
+            this.readerTrackData = readerTrackData;
             return this;
         }
 

--- a/src/test/groovy/graphql/parser/ParserOptionsTest.groovy
+++ b/src/test/groovy/graphql/parser/ParserOptionsTest.groovy
@@ -26,22 +26,25 @@ class ParserOptionsTest extends Specification {
         defaultOptions.isCaptureSourceLocation()
         defaultOptions.isCaptureLineComments()
         !defaultOptions.isCaptureIgnoredChars()
+        defaultOptions.isReaderTrackData()
 
         defaultOperationOptions.getMaxTokens() == 15_000
         defaultOperationOptions.getMaxWhitespaceTokens() == 200_000
         defaultOperationOptions.isCaptureSourceLocation()
         !defaultOperationOptions.isCaptureLineComments()
         !defaultOperationOptions.isCaptureIgnoredChars()
+        defaultOptions.isReaderTrackData()
 
         defaultSdlOptions.getMaxTokens() == Integer.MAX_VALUE
         defaultSdlOptions.getMaxWhitespaceTokens() == Integer.MAX_VALUE
         defaultSdlOptions.isCaptureSourceLocation()
         defaultSdlOptions.isCaptureLineComments()
         !defaultSdlOptions.isCaptureIgnoredChars()
+        defaultOptions.isReaderTrackData()
     }
 
     def "can set in new option JVM wide"() {
-        def newDefaultOptions = defaultOptions.transform({ it.captureIgnoredChars(true) })
+        def newDefaultOptions = defaultOptions.transform({ it.captureIgnoredChars(true).readerTrackData(false) })
         def newDefaultOperationOptions = defaultOperationOptions.transform(
                 { it.captureIgnoredChars(true).captureLineComments(true).maxWhitespaceTokens(300_000) })
         def newDefaultSDlOptions = defaultSdlOptions.transform(
@@ -63,17 +66,20 @@ class ParserOptionsTest extends Specification {
         currentDefaultOptions.isCaptureSourceLocation()
         currentDefaultOptions.isCaptureLineComments()
         currentDefaultOptions.isCaptureIgnoredChars()
+        !currentDefaultOptions.isReaderTrackData()
 
         currentDefaultOperationOptions.getMaxTokens() == 15_000
         currentDefaultOperationOptions.getMaxWhitespaceTokens() == 300_000
         currentDefaultOperationOptions.isCaptureSourceLocation()
         currentDefaultOperationOptions.isCaptureLineComments()
         currentDefaultOperationOptions.isCaptureIgnoredChars()
+        currentDefaultOperationOptions.isReaderTrackData()
 
         currentDefaultSdlOptions.getMaxTokens() == Integer.MAX_VALUE
         currentDefaultSdlOptions.getMaxWhitespaceTokens() == 300_000
         currentDefaultSdlOptions.isCaptureSourceLocation()
         currentDefaultSdlOptions.isCaptureLineComments()
         currentDefaultSdlOptions.isCaptureIgnoredChars()
+        currentDefaultSdlOptions.isReaderTrackData()
     }
 }


### PR DESCRIPTION
PR for #3061 

This change adds a new option into `ParserOptions` which is configurable by users so that we can pass it down to the underlying `MultiSourceReader` to control whether to enable `trackData` or not.