### PR TITLE
CVE-2022-37734 root cause fix

### DIFF
--- a/src/main/antlr/GraphqlSDL.g4
+++ b/src/main/antlr/GraphqlSDL.g4
@@ -16,7 +16,7 @@ schemaDefinition : description? SCHEMA directives? '{' operationTypeDefinition+ 
 
 schemaExtension :
     EXTEND SCHEMA directives? '{' operationTypeDefinition+ '}' |
-    EXTEND SCHEMA directives+
+    EXTEND SCHEMA directives
 ;
 
 operationTypeDefinition : description? operationType ':' typeName;

--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -407,10 +407,9 @@ public class GraphqlAntlrToLanguage {
         addCommonData(def, ctx);
 
         List<Directive> directives = new ArrayList<>();
-        List<GraphqlParser.DirectivesContext> directivesCtx = ctx.directives();
-        for (GraphqlParser.DirectivesContext directiveCtx : directivesCtx) {
-            directives.addAll(createDirectives(directiveCtx));
-        }
+        GraphqlParser.DirectivesContext directivesCtx = ctx.directives();
+        directives.addAll(createDirectives(directivesCtx));
+
         def.directives(directives);
 
         List<OperationTypeDefinition> operationTypeDefs = map(ctx.operationTypeDefinition(), this::createOperationTypeDefinition);


### PR DESCRIPTION
Hello @bbakerman,
This is the continuation of the [CVE-2022-37734](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-37734):
- https://github.com/graphql-java/graphql-java/issues/2888
- https://github.com/graphql-java/graphql-java/pull/2892

The fix you provided previously protects graphql-java server from the one-request DoS. But if an attacker sends malformed requests simultaneously (let’s say 50-100 threads) and don’t cross the number of allowed directives in each request – Distributed Denial of Service is still applicable.

## Root cause
My colleague, [Daniela](https://www.linkedin.com/in/daniela-morais-fonte/), figured out the root cause of the issue. The following rule is located in the [GraphqlSDL.g4](https://github.com/graphql-java/graphql-java/blob/v18.1/src/main/antlr/GraphqlSDL.g4) file:

```
...
schemaExtension :
    EXTEND SCHEMA directives? '{' operationTypeDefinition+ '}' |
    EXTEND SCHEMA directives+
;
```

And the directives rule is described in the file [GraphqlCommon.g4](https://github.com/graphql-java/graphql-java/blob/v18.1/src/main/antlr/GraphqlCommon.g4):

```
directives : directive+;

directive :'@' name arguments?;

```

The rule called *directives* is repetitive and itself applies repetition to the *directive* subrule. Nested repetition leads to Denial-of-Service. This issue can be compared with an “evil” regex.
How does it happen, since *schemaExtension* rule is not even used to recognise the attack input?
Daniela explains: ANTLR adaptivePredict algorithm is context-free by default – [but, in case of ambiguity, it falls back to a context-sensitive analysis](https://github.com/antlr/antlr4/blob/49b69bb31aa34654676a864b229a369680122470/runtime/Java/src/org/antlr/v4/runtime/atn/ParserATNSimulator.java#L43) to proceed the recognition. This seems especially relevant when a rule has a repetition operator, since ANTLR can only decide to which state transit after looking ahead until the end of repetition. This lookup wouldn’t be a problem for a single repetition, since ANTLR only performs this analysis once per loop. 

## The fix
Daniela has developed the fix. It passes all building tests and after applying the fix, we see a significant difference in execution time between the first and the second fixes:

![fix](https://user-images.githubusercontent.com/26700606/212013182-4dc3290e-ccde-4243-b24c-6ca5e597045a.png)