### PR TITLE
Adding ExtensionsBuilder in the graphql context by default

### DIFF
--- a/src/main/java/graphql/extensions/ExtensionsBuilder.java
+++ b/src/main/java/graphql/extensions/ExtensionsBuilder.java
@@ -18,6 +18,12 @@ import static graphql.Assert.assertNotNull;
  * This class can be used to help build the graphql `extensions` map.  A series of changes to the extensions can
  * be added and these will be merged together via a {@link ExtensionsMerger} implementation and that resultant
  * map can be used as the `extensions`
+ * <p>
+ * The engine will place a {@link ExtensionsBuilder} into the {@link graphql.GraphQLContext} (if one is not manually placed there)
+ * and hence {@link graphql.schema.DataFetcher}s can use it to build up extensions progressively.
+ * <p>
+ * At the end of the execution, the {@link ExtensionsBuilder} will be used to build a graphql `extensions` map that
+ * is placed in the {@link ExecutionResult}
  */
 @PublicApi
 public class ExtensionsBuilder {
@@ -100,6 +106,8 @@ public class ExtensionsBuilder {
 
     /**
      * This sets new  extensions into the provided {@link ExecutionResult}, overwriting any previous values
+     *
+     * @param executionResult the result to set these extensions into
      *
      * @return a new ExecutionResult with the extensions values in this builder
      */

--- a/src/main/java/graphql/extensions/ExtensionsBuilder.java
+++ b/src/main/java/graphql/extensions/ExtensionsBuilder.java
@@ -113,6 +113,13 @@ public class ExtensionsBuilder {
      */
     public ExecutionResult setExtensions(ExecutionResult executionResult) {
         assertNotNull(executionResult);
-        return executionResult.transform(builder -> builder.extensions(buildExtensions()));
+        Map<Object, Object> currentExtensions = executionResult.getExtensions();
+        Map<Object, Object> builderExtensions = buildExtensions();
+        // if there was no extensions map before, and we are not adding anything new
+        // then leave it null
+        if (currentExtensions == null && builderExtensions.isEmpty()) {
+            return executionResult;
+        }
+        return executionResult.transform(builder -> builder.extensions(builderExtensions));
     }
 }

--- a/src/test/groovy/graphql/extensions/ExtensionsBuilderTest.groovy
+++ b/src/test/groovy/graphql/extensions/ExtensionsBuilderTest.groovy
@@ -193,4 +193,27 @@ class ExtensionsBuilderTest extends Specification {
                 id    : "ID!",
         ]
     }
+
+    def "integration test showing it leaves extensions null if they are empty"() {
+        def sdl = """
+        type Query {
+            name : String!
+            street : String
+            id : ID!
+        }
+        """
+
+        def ei = ExecutionInput.newExecutionInput("query q { name street id }")
+                .root(["name" : "Brad", "id" :1234])
+                .build()
+
+
+        def graphQL = TestUtil.graphQL(sdl, newRuntimeWiring().build()).build()
+
+        when:
+        def er = graphQL.execute(ei)
+        then:
+        er.errors.isEmpty()
+        er.extensions == null
+    }
 }

--- a/src/test/groovy/graphql/extensions/ExtensionsBuilderTest.groovy
+++ b/src/test/groovy/graphql/extensions/ExtensionsBuilderTest.groovy
@@ -3,17 +3,11 @@ package graphql.extensions
 import graphql.ExecutionInput
 import graphql.ExecutionResult
 import graphql.TestUtil
-import graphql.execution.instrumentation.Instrumentation
-import graphql.execution.instrumentation.InstrumentationState
-import graphql.execution.instrumentation.SimplePerformantInstrumentation
-import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters
 import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironment
 import graphql.schema.GraphQLTypeUtil
 import org.jetbrains.annotations.NotNull
 import spock.lang.Specification
-
-import java.util.concurrent.CompletableFuture
 
 import static graphql.extensions.ExtensionsBuilder.newExtensionsBuilder
 import static graphql.schema.idl.RuntimeWiring.newRuntimeWiring
@@ -105,7 +99,20 @@ class ExtensionsBuilderTest extends Specification {
         extensions == [the: "end"]
     }
 
-    def "integration test that shows it working"() {
+    DataFetcher extensionDF = new DataFetcher() {
+        @Override
+        Object get(DataFetchingEnvironment env) throws Exception {
+            ExtensionsBuilder extensionsBuilder = env.getGraphQlContext().get(ExtensionsBuilder.class)
+            def fieldMap = [:]
+            fieldMap.put(env.getFieldDefinition().name, GraphQLTypeUtil.simplePrint(env.getFieldDefinition().type))
+            extensionsBuilder.addValues([common: fieldMap])
+            extensionsBuilder.addValues(fieldMap)
+            return "ignored"
+        }
+    }
+
+
+    def "integration test that shows it working when they put in a builder"() {
         def sdl = """
         type Query {
             name : String!
@@ -114,39 +121,60 @@ class ExtensionsBuilderTest extends Specification {
         }
         """
 
-        Instrumentation contextInstrumentation = new SimplePerformantInstrumentation() {
-            @Override
-            CompletableFuture<ExecutionResult> instrumentExecutionResult(ExecutionResult executionResult, InstrumentationExecutionParameters parameters, InstrumentationState state) {
-                ExtensionsBuilder extensionsBuilder = parameters.getGraphQLContext().get(ExtensionsBuilder.class)
-                def newEr = extensionsBuilder.setExtensions(executionResult)
-                return CompletableFuture.completedFuture(newEr)
-            }
-        }
-
-        DataFetcher df = new DataFetcher() {
-            @Override
-            Object get(DataFetchingEnvironment env) throws Exception {
-                ExtensionsBuilder extensionsBuilder = env.getGraphQlContext().get(ExtensionsBuilder.class)
-                def fieldMap = [:]
-                fieldMap.put(env.getFieldDefinition().name, GraphQLTypeUtil.simplePrint(env.getFieldDefinition().type))
-                extensionsBuilder.addValues([common: fieldMap])
-                extensionsBuilder.addValues(fieldMap)
-                return "ignored"
-            }
-        }
+        def extensionsBuilder = newExtensionsBuilder()
+        extensionsBuilder.addValue("added","explicitly")
 
         def ei = ExecutionInput.newExecutionInput("query q { name street id }")
-                .graphQLContext({ ctx -> ctx.put(ExtensionsBuilder.class, newExtensionsBuilder()) })
+                .graphQLContext({ ctx ->
+                    ctx.put(ExtensionsBuilder.class, extensionsBuilder) })
                 .build()
 
 
         def graphQL = TestUtil.graphQL(sdl, newRuntimeWiring()
                 .type(newTypeWiring("Query").dataFetchers([
-                        name  : df,
-                        street: df,
-                        id    : df,
+                        name  : extensionDF,
+                        street: extensionDF,
+                        id    : extensionDF,
                 ])))
-                .instrumentation(contextInstrumentation)
+                .build()
+
+        when:
+        def er = graphQL.execute(ei)
+        then:
+        er.errors.isEmpty()
+        er.extensions == [
+                "added": "explicitly",
+                common: [
+                        name  : "String!",
+                        street: "String",
+                        id    : "ID!",
+                ],
+                // we break them out so we have common and not common entries
+                name  : "String!",
+                street: "String",
+                id    : "ID!",
+        ]
+    }
+
+    def "integration test that shows it working when they DONT put in a builder"() {
+        def sdl = """
+        type Query {
+            name : String!
+            street : String
+            id : ID!
+        }
+        """
+
+        def ei = ExecutionInput.newExecutionInput("query q { name street id }")
+                .build()
+
+
+        def graphQL = TestUtil.graphQL(sdl, newRuntimeWiring()
+                .type(newTypeWiring("Query").dataFetchers([
+                        name  : extensionDF,
+                        street: extensionDF,
+                        id    : extensionDF,
+                ])))
                 .build()
 
         when:


### PR DESCRIPTION
This will be an `graphql.extensions.ExtensionsBuilder` into the graphql context if its not already present  and then used it later to build extensions on the way out of the engine