### PR TITLE
WIP Schema definition ambiguity RFC

### DIFF
--- a/src/test/groovy/graphql/schema/idl/SchemaParserTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaParserTest.groovy
@@ -1,5 +1,6 @@
 package graphql.schema.idl
 
+import graphql.TestUtil
 import graphql.language.EnumTypeDefinition
 import graphql.language.InterfaceTypeDefinition
 import graphql.language.ObjectTypeDefinition
@@ -360,5 +361,32 @@ class SchemaParserTest extends Specification {
         def e = thrown(SchemaProblem)
         e.errors[0].message.contains("parsing has been cancelled")
 
+    }
+
+    def "correctly parses schema keyword block"() {
+        // From RFC to clarify spec https://github.com/graphql/graphql-spec/pull/987
+        when:
+        def graphQL = TestUtil.graphQL("""
+            schema {
+              query: Query
+            }
+            type Query {
+              viruses: [Virus!]
+            }
+            type Virus {
+              name: String!
+              knownMutations: [Mutation!]!
+            }
+            type Mutation {
+              name: String!
+              geneSequence: String!
+            }
+        """).build()
+
+        then:
+        graphQL.graphQLSchema.definition.operationTypeDefinitions.size() == 1
+        graphQL.graphQLSchema.definition.operationTypeDefinitions.first().name == "query"
+        graphQL.graphQLSchema.queryType != null
+        graphQL.graphQLSchema.mutationType == null
     }
 }


### PR DESCRIPTION
Following on from this proposed spec improvement https://github.com/graphql/graphql-spec/pull/987

Pasting Benjie's virus schema example
```graphql
type Query {
  viruses: [Virus!]
}
type Virus {
  name: String!
  knownMutations: [Mutation!]!
}
type Mutation {
  name: String!
  geneSequence: String!
}
schema {
  query: Query
}
```
The `schema` keyword defines query as the only operation in this schema. We have a `type Mutation` but that's referring to a virus, not the GraphQL operation. Health warning: the word schema is terribly overloaded.

Current behaviour is
* Operation type definitions only recognise query as an operation - this is correct
* Generated GraphQLSchema reads `type Mutation` and sets the `mutationType` - this is not correct

This PR is WIP