### PR TITLE
Remove sun.misc.* from MANIFEST.MF

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,11 +14,9 @@ plugins {
     id "me.champeau.jmh" version "0.6.6"
 }
 
-
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(11)
-
     }
 }
 
@@ -150,12 +148,14 @@ shadowJar {
     // -removeheaders:  Private-Package Removes the MANIFEST.MF header Private-Package, which contains all the internal packages and 
     //                                  also the repackaged packages like guava, which would be wrong after repackaging.
     // Import-Package:  Changes the imported packages header, to exclude guava and dependencies from the import list (! excludes packages)
-    //                  Guava was repackaged and included inside the jar, so we need remove it.
+    //                  Guava was repackaged and included inside the jar, so we need to remove it.
+    //                  ANTLR was shaded, so we need to remove it.
+    //                  sun.misc is a JRE internal-only class that is not directly used by graphql-java. It was causing problems in libraries using graphql-java.
     //                  The last ,* copies all the existing imports from the other dependencies, which is required.
     bnd('''
 -exportcontents: graphql.*
 -removeheaders: Private-Package
-Import-Package: !com.google.*,!org.checkerframework.*,!javax.annotation.*,!graphql.com.google.*,!org.antlr.*,!graphql.org.antlr.*,*
+Import-Package: !com.google.*,!org.checkerframework.*,!javax.annotation.*,!graphql.com.google.*,!org.antlr.*,!graphql.org.antlr.*,!sun.misc.*,*
 ''')
 }
 


### PR DESCRIPTION
Addresses issue raised in this discussion thread https://github.com/graphql-java/graphql-java/discussions/3089. Thanks @schaefa for reporting!

From https://github.com/diffplug/osgiX
> The cause of the problem is that OSGi doesn't supply the entire JRE to its bundles - it only provides the most standardized packages. This means that non-standard packages like sun.misc and sun.reflect aren't available to your bundles, even though they are in common usage.

graphql-java does not directly use anything from `sun.misc`, but it still is turning up in the `MANIFEST.MF` file generated by the plugin `biz.aQute.bnd.builder`.

This PR removes `sun.misc.*` from the Import-Package header.