### PR TITLE
Replace javax nullable annotations with JetBrains equivalent

### DIFF
--- a/src/main/java/graphql/execution/instrumentation/ExecutionStrategyInstrumentationContext.java
+++ b/src/main/java/graphql/execution/instrumentation/ExecutionStrategyInstrumentationContext.java
@@ -4,8 +4,8 @@ import graphql.ExecutionResult;
 import graphql.Internal;
 import graphql.PublicSpi;
 import graphql.execution.FieldValueInfo;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -27,7 +27,7 @@ public interface ExecutionStrategyInstrumentationContext extends Instrumentation
      *
      * @return a non null {@link InstrumentationContext} that maybe a no-op
      */
-    @Nonnull
+    @NotNull
     @Internal
     static ExecutionStrategyInstrumentationContext nonNullCtx(ExecutionStrategyInstrumentationContext nullableContext) {
         return nullableContext == null ? NOOP : nullableContext;

--- a/src/main/java/graphql/execution/instrumentation/SimpleInstrumentationContext.java
+++ b/src/main/java/graphql/execution/instrumentation/SimpleInstrumentationContext.java
@@ -1,8 +1,8 @@
 package graphql.execution.instrumentation;
 
 import graphql.PublicApi;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -43,7 +43,7 @@ public class SimpleInstrumentationContext<T> implements InstrumentationContext<T
      *
      * @return a non null {@link InstrumentationContext} that maybe a no-op
      */
-    @Nonnull
+    @NotNull
     public static <T> InstrumentationContext<T> nonNullCtx(InstrumentationContext<T> nullableContext) {
         return nullableContext == null ? noOp() : nullableContext;
     }

--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -1,6 +1,5 @@
 package graphql.parser;
 
-
 import com.google.common.collect.ImmutableList;
 import graphql.Assert;
 import graphql.Internal;
@@ -68,8 +67,8 @@ import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.TerminalNode;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;

--- a/src/main/java/graphql/schema/GraphQLEnumType.java
+++ b/src/main/java/graphql/schema/GraphQLEnumType.java
@@ -1,6 +1,5 @@
 package graphql.schema;
 
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import graphql.DirectivesUtil;
@@ -14,8 +13,8 @@ import graphql.language.Value;
 import graphql.util.FpKit;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -149,7 +148,7 @@ public class GraphQLEnumType implements GraphQLNamedInputType, GraphQLNamedOutpu
                 (fld1, fld2) -> assertShouldNeverHappen("Duplicated definition for field '%s' in type '%s'", fld1.getName(), this.name)));
     }
 
-    private Object getValueByName(@Nonnull Object value, GraphQLContext graphQLContext, Locale locale) {
+    private Object getValueByName(@NotNull Object value, GraphQLContext graphQLContext, Locale locale) {
         GraphQLEnumValueDefinition enumValueDefinition = valueDefinitionMap.get(value.toString());
         if (enumValueDefinition != null) {
             return enumValueDefinition.getValue();


### PR DESCRIPTION
Whoops we were using javax `@Nullable` and `@Nonnull` annotations in a few places when we should have used the JetBrains equivalent annotation.

This PR fixes up and removes all usages of javax.annotation.*