### PR TITLE
Ensured that the MANIFEST.MF files is the first entry in the JAR File

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -160,20 +160,27 @@ Import-Package: !com.google.*,!org.checkerframework.*,!javax.annotation.*,!graph
 }
 
 
-task removeNotNeededGuava(type: Zip) {
+task extractWithoutGuava(type: Copy) {
     from({ zipTree({ "build/libs/graphql-java-${project.version}.jar" }) }) {
         exclude('/com/**')
     }
+    into layout.buildDirectory.dir("extract")
+}
+
+task buildNewJar(type: Jar) {
+    from layout.buildDirectory.dir("extract")
     archiveFileName = "graphql-java-tmp.jar"
     destinationDirectory = file("${project.buildDir}/libs")
+    manifest {
+        from file("build/extract/META-INF/MANIFEST.MF")
+    }
     doLast {
         delete("build/libs/graphql-java-${project.version}.jar")
         file("build/libs/graphql-java-tmp.jar").renameTo(file("build/libs/graphql-java-${project.version}.jar"))
     }
 }
 
-
-shadowJar.finalizedBy removeNotNeededGuava
+shadowJar.finalizedBy extractWithoutGuava, buildNewJar
 
 
 task testng(type: Test) {


### PR DESCRIPTION
as it is required for java.util.jar.JarFile to obtain the manfiest entry which is essential for Sling to work as discussed in #3089. This will fail to work with Sling's bundle installer as it is using JarFile to obtain the manifest and that is not found if it is not the first entry.