### PR TITLE
Preventing stack overflow exceptions via limiting the depth of the parser rules

### DIFF
--- a/src/main/java/graphql/parser/ParserOptions.java
+++ b/src/main/java/graphql/parser/ParserOptions.java
@@ -35,12 +35,12 @@ public class ParserOptions {
     /**
      * A graphql hacking vector is to send nonsensical queries that have lots of grammar rule depth to them which
      * can cause stack overflow exceptions during the query parsing.  To prevent this for most users, graphql-java
-     * sets this value to 1000.
+     * sets this value to 500 grammar rules deep.
      * <p>
      * If you want to allow more, then {@link #setDefaultParserOptions(ParserOptions)} allows you to change this
      * JVM wide.
      */
-    public static final int MAX_RULE_DEPTH = 1_000;
+    public static final int MAX_RULE_DEPTH = 500;
 
     private static ParserOptions defaultJvmParserOptions = newParserOptions()
             .captureIgnoredChars(false)

--- a/src/main/java/graphql/parser/ParserOptions.java
+++ b/src/main/java/graphql/parser/ParserOptions.java
@@ -15,9 +15,9 @@ public class ParserOptions {
     /**
      * A graphql hacking vector is to send nonsensical queries that burn lots of parsing CPU time and burn
      * memory representing a document that won't ever execute.  To prevent this for most users, graphql-java
-     * set this value to 15000.  ANTLR parsing time is linear to the number of tokens presented.  The more you
+     * sets this value to 15000.  ANTLR parsing time is linear to the number of tokens presented.  The more you
      * allow the longer it takes.
-     *
+     * <p>
      * If you want to allow more, then {@link #setDefaultParserOptions(ParserOptions)} allows you to change this
      * JVM wide.
      */
@@ -26,11 +26,21 @@ public class ParserOptions {
      * Another graphql hacking vector is to send large amounts of whitespace in operations that burn lots of parsing CPU time and burn
      * memory representing a document.  Whitespace token processing in ANTLR is 2 orders of magnitude faster than grammar token processing
      * however it still takes some time to happen.
-     *
+     * <p>
      * If you want to allow more, then {@link #setDefaultParserOptions(ParserOptions)} allows you to change this
      * JVM wide.
      */
     public static final int MAX_WHITESPACE_TOKENS = 200_000;
+
+    /**
+     * A graphql hacking vector is to send nonsensical queries that have lots of grammar rule depth to them which
+     * can cause stack overflow exceptions during the query parsing.  To prevent this for most users, graphql-java
+     * sets this value to 1000.
+     * <p>
+     * If you want to allow more, then {@link #setDefaultParserOptions(ParserOptions)} allows you to change this
+     * JVM wide.
+     */
+    public static final int MAX_RULE_DEPTH = 1_000;
 
     private static ParserOptions defaultJvmParserOptions = newParserOptions()
             .captureIgnoredChars(false)
@@ -39,6 +49,7 @@ public class ParserOptions {
             .readerTrackData(true)
             .maxTokens(MAX_QUERY_TOKENS) // to prevent a billion laughs style attacks, we set a default for graphql-java
             .maxWhitespaceTokens(MAX_WHITESPACE_TOKENS)
+            .maxRuleDepth(MAX_RULE_DEPTH)
             .build();
 
     private static ParserOptions defaultJvmOperationParserOptions = newParserOptions()
@@ -48,6 +59,7 @@ public class ParserOptions {
             .readerTrackData(true)
             .maxTokens(MAX_QUERY_TOKENS) // to prevent a billion laughs style attacks, we set a default for graphql-java
             .maxWhitespaceTokens(MAX_WHITESPACE_TOKENS)
+            .maxRuleDepth(MAX_RULE_DEPTH)
             .build();
 
     private static ParserOptions defaultJvmSdlParserOptions = newParserOptions()
@@ -57,6 +69,7 @@ public class ParserOptions {
             .readerTrackData(true)
             .maxTokens(Integer.MAX_VALUE) // we are less worried about a billion laughs with SDL parsing since the call path is not facing attackers
             .maxWhitespaceTokens(Integer.MAX_VALUE)
+            .maxRuleDepth(Integer.MAX_VALUE)
             .build();
 
     /**
@@ -160,6 +173,7 @@ public class ParserOptions {
     private final boolean readerTrackData;
     private final int maxTokens;
     private final int maxWhitespaceTokens;
+    private final int maxRuleDepth;
     private final ParsingListener parsingListener;
 
     private ParserOptions(Builder builder) {
@@ -169,6 +183,7 @@ public class ParserOptions {
         this.readerTrackData = builder.readerTrackData;
         this.maxTokens = builder.maxTokens;
         this.maxWhitespaceTokens = builder.maxWhitespaceTokens;
+        this.maxRuleDepth = builder.maxRuleDepth;
         this.parsingListener = builder.parsingListener;
     }
 
@@ -240,6 +255,17 @@ public class ParserOptions {
         return maxWhitespaceTokens;
     }
 
+    /**
+     * A graphql hacking vector is to send nonsensical queries that have lots of rule depth to them which
+     * can cause stack overflow exceptions during the query parsing.  To prevent this you can set a value
+     * that is the maximum depth allowed before an exception is thrown and the parsing is stopped.
+     *
+     * @return the maximum token depth the parser will accept, after which an exception will be thrown.
+     */
+    public int getMaxRuleDepth() {
+        return maxRuleDepth;
+    }
+
     public ParsingListener getParsingListener() {
         return parsingListener;
     }
@@ -260,9 +286,10 @@ public class ParserOptions {
         private boolean captureSourceLocation = true;
         private boolean captureLineComments = true;
         private boolean readerTrackData = true;
-        private int maxTokens = MAX_QUERY_TOKENS;
         private ParsingListener parsingListener = ParsingListener.NOOP;
+        private int maxTokens = MAX_QUERY_TOKENS;
         private int maxWhitespaceTokens = MAX_WHITESPACE_TOKENS;
+        private int maxRuleDepth = MAX_RULE_DEPTH;
 
         Builder() {
         }
@@ -273,6 +300,7 @@ public class ParserOptions {
             this.captureLineComments = parserOptions.captureLineComments;
             this.maxTokens = parserOptions.maxTokens;
             this.maxWhitespaceTokens = parserOptions.maxWhitespaceTokens;
+            this.maxRuleDepth = parserOptions.maxRuleDepth;
             this.parsingListener = parserOptions.parsingListener;
         }
 
@@ -303,6 +331,11 @@ public class ParserOptions {
 
         public Builder maxWhitespaceTokens(int maxWhitespaceTokens) {
             this.maxWhitespaceTokens = maxWhitespaceTokens;
+            return this;
+        }
+
+        public Builder maxRuleDepth(int maxRuleDepth) {
+            this.maxRuleDepth = maxRuleDepth;
             return this;
         }
 

--- a/src/main/java/graphql/parser/exceptions/ParseCancelledTooDeepException.java
+++ b/src/main/java/graphql/parser/exceptions/ParseCancelledTooDeepException.java
@@ -1,0 +1,18 @@
+package graphql.parser.exceptions;
+
+import graphql.Internal;
+import graphql.i18n.I18n;
+import graphql.language.SourceLocation;
+import graphql.parser.InvalidSyntaxException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@Internal
+public class ParseCancelledTooDeepException extends InvalidSyntaxException {
+
+    @Internal
+    public ParseCancelledTooDeepException(@NotNull I18n i18N, @Nullable SourceLocation sourceLocation, @Nullable String offendingToken, int maxTokens, @NotNull String tokenType) {
+        super(i18N.msg("ParseCancelled.tooDeep", maxTokens, tokenType),
+                sourceLocation, offendingToken, null, null);
+    }
+}

--- a/src/main/resources/i18n/Parsing.properties
+++ b/src/main/resources/i18n/Parsing.properties
@@ -19,6 +19,7 @@ InvalidSyntaxBail.full=Invalid syntax with offending token ''{0}'' at line {1} c
 InvalidSyntaxMoreTokens.full=Invalid syntax encountered. There are extra tokens in the text that have not been consumed. Offending token ''{0}'' at line {1} column {2}
 #
 ParseCancelled.full=More than {0} ''{1}'' tokens have been presented. To prevent Denial Of Service attacks, parsing has been cancelled.
+ParseCancelled.tooDeep=More than {0} deep ''{1}'' rules have been entered. To prevent Denial Of Service attacks, parsing has been cancelled.
 #
 InvalidUnicode.trailingLeadingSurrogate=Invalid unicode encountered. Trailing surrogate must be preceded with a leading surrogate. Offending token ''{0}'' at line {1} column {2}
 InvalidUnicode.leadingTrailingSurrogate=Invalid unicode encountered. Leading surrogate must be followed by a trailing surrogate. Offending token ''{0}'' at line {1} column {2}

--- a/src/test/groovy/graphql/parser/ParserStressTest.groovy
+++ b/src/test/groovy/graphql/parser/ParserStressTest.groovy
@@ -1,0 +1,185 @@
+package graphql.parser
+
+import graphql.ExecutionInput
+import graphql.TestUtil
+import graphql.parser.exceptions.ParseCancelledException
+import graphql.parser.exceptions.ParseCancelledTooDeepException
+import spock.lang.Specification
+
+import static graphql.parser.ParserEnvironment.newParserEnvironment
+
+/**
+ * Tests related to how the Parser can be stress tested
+ */
+class ParserStressTest extends Specification {
+    static defaultOptions = ParserOptions.getDefaultParserOptions()
+    static defaultOperationOptions = ParserOptions.getDefaultOperationParserOptions()
+    static defaultSdlOptions = ParserOptions.getDefaultSdlParserOptions()
+
+    void setup() {
+        ParserOptions.setDefaultParserOptions(defaultOptions)
+        ParserOptions.setDefaultOperationParserOptions(defaultOperationOptions)
+        ParserOptions.setDefaultSdlParserOptions(defaultSdlOptions)
+    }
+
+    void cleanup() {
+        ParserOptions.setDefaultParserOptions(defaultOptions)
+        ParserOptions.setDefaultOperationParserOptions(defaultOperationOptions)
+        ParserOptions.setDefaultSdlParserOptions(defaultSdlOptions)
+    }
+
+
+    def "a billion laughs attack will be prevented by default"() {
+        def lol = "@lol" * 10000 // two tokens = 20000+ tokens
+        def text = "query { f $lol }"
+        when:
+        Parser.parse(text)
+
+        then:
+        def e = thrown(ParseCancelledException)
+        e.getMessage().contains("parsing has been cancelled")
+
+        when: "integration test to prove it cancels by default"
+
+        def sdl = """type Query { f : ID} """
+        def graphQL = TestUtil.graphQL(sdl).build()
+        def er = graphQL.execute(text)
+        then:
+        er.errors.size() == 1
+        er.errors[0].message.contains("parsing has been cancelled")
+    }
+
+    def "a large whitespace laughs attack will be prevented by default"() {
+        def spaces = " " * 300_000
+        def text = "query { f $spaces }"
+        when:
+        Parser.parse(text)
+
+        then:
+        def e = thrown(ParseCancelledException)
+        e.getMessage().contains("parsing has been cancelled")
+
+        when: "integration test to prove it cancels by default"
+
+        def sdl = """type Query { f : ID} """
+        def graphQL = TestUtil.graphQL(sdl).build()
+        def er = graphQL.execute(text)
+        then:
+        er.errors.size() == 1
+        er.errors[0].message.contains("parsing has been cancelled")
+    }
+
+    def "they can shoot themselves if they want to with large documents"() {
+        def lol = "@lol" * 10000 // two tokens = 20000+ tokens
+        def text = "query { f $lol }"
+
+        def options = ParserOptions.newParserOptions().maxTokens(30000).build()
+        def parserEnvironment = newParserEnvironment().document(text).parserOptions(options).build()
+
+        when:
+        def doc = new Parser().parseDocument(parserEnvironment)
+
+        then:
+        doc != null
+    }
+
+    def "they can shoot themselves if they want to with large documents with lots of whitespace"() {
+        def spaces = " " * 300_000
+        def text = "query { f $spaces }"
+
+        def options = ParserOptions.newParserOptions().maxWhitespaceTokens(Integer.MAX_VALUE).build()
+        def parserEnvironment = newParserEnvironment().document(text).parserOptions(options).build()
+        when:
+        def doc = new Parser().parseDocument(parserEnvironment)
+
+        then:
+        doc != null
+    }
+
+    def "they can set their own listener into action"() {
+        def queryText = "query { f(arg : 1) }"
+
+        def count = 0
+        def tokens = []
+        ParsingListener listener = { count++; tokens.add(it.getText()) }
+        def parserOptions = ParserOptions.newParserOptions().parsingListener(listener).build()
+        def parserEnvironment = newParserEnvironment().document(queryText).parserOptions(parserOptions).build()
+
+        when:
+        def doc = new Parser().parseDocument(parserEnvironment)
+
+        then:
+        doc != null
+        count == 9
+        tokens == ["query", "{", "f", "(", "arg", ":", "1", ")", "}"]
+
+        when: "integration test to prove it be supplied via EI"
+
+        def sdl = """type Query { f(arg : Int) : ID} """
+        def graphQL = TestUtil.graphQL(sdl).build()
+
+
+        def context = [:]
+        context.put(ParserOptions.class, parserOptions)
+        def executionInput = ExecutionInput.newExecutionInput()
+                .query(queryText)
+                .graphQLContext(context).build()
+
+        count = 0
+        tokens = []
+        def er = graphQL.execute(executionInput)
+        then:
+        er.errors.size() == 0
+        count == 9
+        tokens == ["query", "{", "f", "(", "arg", ":", "1", ")", "}"]
+
+    }
+
+    def "deep query stack overflows are prevented by limiting the depth of rules"() {
+        String text = mkDeepQuery(10000)
+
+        when:
+        def parserEnvironment = newParserEnvironment().document(text).parserOptions(defaultOperationOptions).build()
+        Parser.parse(parserEnvironment)
+
+        then:
+        thrown(ParseCancelledTooDeepException)
+    }
+
+    def "wide queries are prevented by max token counts"() {
+        String text = mkWideQuery(10000)
+
+        when:
+
+        def parserEnvironment = newParserEnvironment().document(text).parserOptions(defaultOperationOptions).build()
+        Parser.parse(parserEnvironment)
+
+        then:
+        thrown(ParseCancelledException) // too many tokens will catch this wide queries
+    }
+
+    String mkDeepQuery(int howMany) {
+        def field = 'f(a:"")'
+        StringBuilder sb = new StringBuilder("query q{")
+        for (int i = 0; i < howMany; i++) {
+            sb.append(field)
+            if (i < howMany - 1) {
+                sb.append("{")
+            }
+        }
+        for (int i = 0; i < howMany - 1; i++) {
+            sb.append("}")
+        }
+        sb.append("}")
+        return sb.toString()
+    }
+
+    String mkWideQuery(int howMany) {
+        StringBuilder sb = new StringBuilder("query q{f(")
+        for (int i = 0; i < howMany; i++) {
+            sb.append('a:1,')
+        }
+        sb.append(")}")
+        return sb.toString()
+    }
+}

--- a/src/test/groovy/graphql/parser/ParserTest.groovy
+++ b/src/test/groovy/graphql/parser/ParserTest.groovy
@@ -1,7 +1,6 @@
 package graphql.parser
 
-import graphql.ExecutionInput
-import graphql.TestUtil
+
 import graphql.language.Argument
 import graphql.language.ArrayValue
 import graphql.language.AstComparator
@@ -40,31 +39,15 @@ import graphql.language.TypeName
 import graphql.language.UnionTypeDefinition
 import graphql.language.VariableDefinition
 import graphql.language.VariableReference
-import graphql.parser.exceptions.ParseCancelledException
 import org.antlr.v4.runtime.CommonTokenStream
 import org.antlr.v4.runtime.ParserRuleContext
 import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import static graphql.parser.ParserEnvironment.*
+
 class ParserTest extends Specification {
-
-    static defaultOptions = ParserOptions.getDefaultParserOptions()
-    static defaultOperationOptions = ParserOptions.getDefaultOperationParserOptions()
-    static defaultSdlOptions = ParserOptions.getDefaultSdlParserOptions()
-
-    void setup() {
-        ParserOptions.setDefaultParserOptions(defaultOptions)
-        ParserOptions.setDefaultOperationParserOptions(defaultOperationOptions)
-        ParserOptions.setDefaultSdlParserOptions(defaultSdlOptions)
-    }
-
-    void cleanup() {
-        ParserOptions.setDefaultParserOptions(defaultOptions)
-        ParserOptions.setDefaultOperationParserOptions(defaultOperationOptions)
-        ParserOptions.setDefaultSdlParserOptions(defaultSdlOptions)
-    }
-
 
     def "parse anonymous simple query"() {
         given:
@@ -90,10 +73,6 @@ class ParserTest extends Specification {
 
 
     boolean isEqual(Node node1, Node node2) {
-        return AstComparator.isEqual(node1, node2)
-    }
-
-    boolean isEqual(List<Node> node1, List<Node> node2) {
         return AstComparator.isEqual(node1, node2)
     }
 
@@ -404,7 +383,8 @@ class ParserTest extends Specification {
                 .build()
 
         when:
-        def document = new Parser().parseDocument(input, parserOptionsWithoutCaptureLineComments)
+        def parserEnvironment = newParserEnvironment().document(input).parserOptions(parserOptionsWithoutCaptureLineComments).build()
+        def document = new Parser().parseDocument(parserEnvironment)
         Field helloField = (document.definitions[0] as OperationDefinition).selectionSet.selections[0] as Field
 
         then:
@@ -772,7 +752,9 @@ triple3 : """edge cases \\""" "" " \\"" \\" edge cases"""
         when:
         def captureIgnoredCharsTRUE = ParserOptions.newParserOptions().captureIgnoredChars(true).build()
 
-        Document document = new Parser().parseDocument(input, captureIgnoredCharsTRUE)
+        def parserEnvironment = newParserEnvironment().document(input).parserOptions(captureIgnoredCharsTRUE).build()
+
+        Document document = new Parser().parseDocument(parserEnvironment)
         def field = (document.definitions[0] as OperationDefinition).selectionSet.selections[0]
         then:
         field.getIgnoredChars().getLeft().size() == 3
@@ -868,7 +850,7 @@ triple3 : """edge cases \\""" "" " \\"" \\" edge cases"""
                }
     '''
         when:
-        def parserEnvironment = ParserEnvironment.newParserEnvironment().document(input).build()
+        def parserEnvironment = newParserEnvironment().document(input).build()
 
         Document document = Parser.parse(parserEnvironment)
         OperationDefinition operationDefinition = (document.definitions[0] as OperationDefinition)
@@ -1043,7 +1025,8 @@ triple3 : """edge cases \\""" "" " \\"" \\" edge cases"""
         def captureIgnoredCharsTRUE = ParserOptions.newParserOptions().captureIgnoredChars(true).build()
 
         when: "explicitly off"
-        def doc = new Parser().parseDocument(s, captureIgnoredCharsFALSE)
+        def parserEnvironment = newParserEnvironment().document(s).parserOptions(captureIgnoredCharsFALSE).build()
+        def doc = new Parser().parseDocument(parserEnvironment)
         def type = doc.getDefinitionsOfType(ObjectTypeDefinition)[0]
         then:
         type.getIgnoredChars() == IgnoredChars.EMPTY
@@ -1058,7 +1041,8 @@ triple3 : """edge cases \\""" "" " \\"" \\" edge cases"""
 
         when: "explicitly on"
 
-        doc = new Parser().parseDocument(s, captureIgnoredCharsTRUE)
+        parserEnvironment = newParserEnvironment().document(s).parserOptions(captureIgnoredCharsTRUE).build()
+        doc = new Parser().parseDocument(parserEnvironment)
         type = doc.getDefinitionsOfType(ObjectTypeDefinition)[0]
 
         then:
@@ -1158,7 +1142,8 @@ triple3 : """edge cases \\""" "" " \\"" \\" edge cases"""
 
         when:
         options = ParserOptions.newParserOptions().captureSourceLocation(false).build()
-        document = new Parser().parseDocument("{ f }", options)
+        def parserEnvironment = newParserEnvironment().document("{ f }").parserOptions(options).build()
+        document = new Parser().parseDocument(parserEnvironment)
 
         then:
         !options.isCaptureSourceLocation()
@@ -1166,104 +1151,5 @@ triple3 : """edge cases \\""" "" " \\"" \\" edge cases"""
         document.getDefinitions()[0].getSourceLocation() == SourceLocation.EMPTY
     }
 
-    def "a billion laughs attack will be prevented by default"() {
-        def lol = "@lol" * 10000 // two tokens = 20000+ tokens
-        def text = "query { f $lol }"
-        when:
-        Parser.parse(text)
 
-        then:
-        def e = thrown(ParseCancelledException)
-        e.getMessage().contains("parsing has been cancelled")
-
-        when: "integration test to prove it cancels by default"
-
-        def sdl = """type Query { f : ID} """
-        def graphQL = TestUtil.graphQL(sdl).build()
-        def er = graphQL.execute(text)
-        then:
-        er.errors.size() == 1
-        er.errors[0].message.contains("parsing has been cancelled")
-    }
-
-    def "a large whitespace laughs attack will be prevented by default"() {
-        def spaces = " " * 300_000
-        def text = "query { f $spaces }"
-        when:
-        Parser.parse(text)
-
-        then:
-        def e = thrown(ParseCancelledException)
-        e.getMessage().contains("parsing has been cancelled")
-
-        when: "integration test to prove it cancels by default"
-
-        def sdl = """type Query { f : ID} """
-        def graphQL = TestUtil.graphQL(sdl).build()
-        def er = graphQL.execute(text)
-        then:
-        er.errors.size() == 1
-        er.errors[0].message.contains("parsing has been cancelled")
-    }
-
-    def "they can shoot themselves if they want to with large documents"() {
-        def lol = "@lol" * 10000 // two tokens = 20000+ tokens
-        def text = "query { f $lol }"
-
-        def options = ParserOptions.newParserOptions().maxTokens(30000).build()
-        when:
-        def doc = new Parser().parseDocument(text, options)
-
-        then:
-        doc != null
-    }
-
-    def "they can shoot themselves if they want to with large documents with lots of whitespace"() {
-        def spaces = " " * 300_000
-        def text = "query { f $spaces }"
-
-        def options = ParserOptions.newParserOptions().maxWhitespaceTokens(Integer.MAX_VALUE).build()
-        when:
-        def doc = new Parser().parseDocument(text, options)
-
-        then:
-        doc != null
-    }
-
-    def "they can set their own listener into action"() {
-        def queryText = "query { f(arg : 1) }"
-
-        def count = 0
-        def tokens = []
-        ParsingListener listener = { count++; tokens.add(it.getText()) }
-        def parserOptions = ParserOptions.newParserOptions().parsingListener(listener).build()
-        when:
-        def doc = new Parser().parseDocument(queryText, parserOptions)
-
-        then:
-        doc != null
-        count == 9
-        tokens == ["query", "{", "f", "(", "arg", ":", "1", ")", "}"]
-
-        when: "integration test to prove it be supplied via EI"
-
-        def sdl = """type Query { f(arg : Int) : ID} """
-        def graphQL = TestUtil.graphQL(sdl).build()
-
-
-        def context = [:]
-        context.put(ParserOptions.class, parserOptions)
-        def executionInput = ExecutionInput.newExecutionInput()
-                .query(queryText)
-                .graphQLContext(context).build()
-
-        count = 0
-        tokens = []
-        def er = graphQL.execute(executionInput)
-        then:
-        er.errors.size() == 0
-        count == 9
-        tokens == ["query", "{", "f", "(", "arg", ":", "1", ")", "}"]
-
-    }
 }


### PR DESCRIPTION
This puts in a limit on how deep grammar rules can get.  

As ANLTR is a **recursive-descent parser** it will build up a call stack as it moves along.  This stack is limited and can blow up with just the wrong input.  Even if the max tokens checking is in place, it can still blow the JVM stack before the max tokens are reached.

Right now it's 500 deep as presented here.  Is this the right value?  More?? Less ??  I changed it from 1000