### PR TITLE
Adding Entry Point for custom coercion on standard scalars

### DIFF
--- a/src/main/java/graphql/execution/ValueTransformer.java
+++ b/src/main/java/graphql/execution/ValueTransformer.java
@@ -1,0 +1,10 @@
+package graphql.execution;
+
+/**
+ * Overrideable class that allows transformation of values pre-coercion
+ *
+ */
+public abstract class ValueTransformer {
+
+  public abstract Object transformValue(Object value);
+}

--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -26,6 +26,7 @@ import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
 import graphql.schema.InputValueWithState;
 import graphql.schema.visibility.GraphqlFieldVisibility;
+import java.util.function.Function;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -78,9 +79,33 @@ public class ValuesResolver {
                                                         GraphQLContext graphqlContext,
                                                         Locale locale) throws CoercingParseValueException, NonNullableValueCoercedAsNullException {
 
-        return ValuesResolverConversion.externalValueToInternalValueForVariables(schema, variableDefinitions, rawVariables, graphqlContext, locale);
+        return ValuesResolverConversion.externalValueToInternalValueForVariables(schema, variableDefinitions, rawVariables, graphqlContext, locale, null);
     }
 
+    /**
+     * This method coerces the "raw" variables values provided to the engine. The coerced values will be used to
+     * provide arguments to {@link graphql.schema.DataFetchingEnvironment}. This function takes a callable pre-coercion
+     * function that allows users to inject custom coercion instead of needing to build new types.
+     *
+     * This method is called once per execution and also performs validation.
+     *
+     * @param schema              the schema
+     * @param variableDefinitions the variable definitions
+     * @param rawVariables        the supplied variables
+     * @param graphqlContext      the GraphqlContext to use
+     * @param locale              the Locale to use
+     * @param preCoercionFunction the function to pre-coerce values if non-null
+     *
+     * @return coerced variable values as a map
+     */
+    public static CoercedVariables coerceVariableValues(GraphQLSchema schema,
+        List<VariableDefinition> variableDefinitions,
+        RawVariables rawVariables,
+        GraphQLContext graphqlContext,
+        Locale locale,
+        Function<Object, Object> preCoercionFunction) throws CoercingParseValueException, NonNullableValueCoercedAsNullException {
+        return ValuesResolverConversion.externalValueToInternalValueForVariables(schema, variableDefinitions, rawVariables, graphqlContext, locale, preCoercionFunction);
+    }
 
     /**
      * Normalized variables values are Literals with type information. No validation here!

--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -26,7 +26,6 @@ import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
 import graphql.schema.InputValueWithState;
 import graphql.schema.visibility.GraphqlFieldVisibility;
-import java.util.function.Function;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -79,33 +78,9 @@ public class ValuesResolver {
                                                         GraphQLContext graphqlContext,
                                                         Locale locale) throws CoercingParseValueException, NonNullableValueCoercedAsNullException {
 
-        return ValuesResolverConversion.externalValueToInternalValueForVariables(schema, variableDefinitions, rawVariables, graphqlContext, locale, null);
+        return ValuesResolverConversion.externalValueToInternalValueForVariables(schema, variableDefinitions, rawVariables, graphqlContext, locale);
     }
 
-    /**
-     * This method coerces the "raw" variables values provided to the engine. The coerced values will be used to
-     * provide arguments to {@link graphql.schema.DataFetchingEnvironment}. This function takes a callable pre-coercion
-     * function that allows users to inject custom coercion instead of needing to build new types.
-     *
-     * This method is called once per execution and also performs validation.
-     *
-     * @param schema              the schema
-     * @param variableDefinitions the variable definitions
-     * @param rawVariables        the supplied variables
-     * @param graphqlContext      the GraphqlContext to use
-     * @param locale              the Locale to use
-     * @param preCoercionFunction the function to pre-coerce values if non-null
-     *
-     * @return coerced variable values as a map
-     */
-    public static CoercedVariables coerceVariableValues(GraphQLSchema schema,
-        List<VariableDefinition> variableDefinitions,
-        RawVariables rawVariables,
-        GraphQLContext graphqlContext,
-        Locale locale,
-        Function<Object, Object> preCoercionFunction) throws CoercingParseValueException, NonNullableValueCoercedAsNullException {
-        return ValuesResolverConversion.externalValueToInternalValueForVariables(schema, variableDefinitions, rawVariables, graphqlContext, locale, preCoercionFunction);
-    }
 
     /**
      * Normalized variables values are Literals with type information. No validation here!


### PR DESCRIPTION
I want to add an entry point for custom coercion in ValuesResolver.json

Essentially, I'd want to keep the current coerceVariableValues and add another flavor of it that takes a Function<Object, Object> preCoercionFunction.

This would get passed to ValuesResolverConversion.externalValueToInternalValueForVariables where if not-null, would translate the value right before this line [here](https://github.com/graphql-java/graphql-java/blob/09984d7c8b4b4a173a6f51df86634b1a70419046/src/main/java/graphql/execution/ValuesResolverConversion.java#L263)

At linkedIn, our APIs pass around a custom null class instance to represent null (say Data.NULL) instead of the java null. This is an issue for us even pre-v20 because this Data.null instance is converting to a string "null" instead of java null. To work around this we are rebuilding the entire rawVariables map to convert Data.NULL to null before parsing our raw input variables. However, we have found that this may be causing performance issues so we would like a way to be able to do our custom conversions while still using the grapql native scalars. 

Beyond that, migrating to v20 for us is a challenge because of the stricter string coercer. Ideally a new type would be made for non-strings that fail string coercion in v20. The reason we want to not build our own new scalars is because currently our APIs are using schemas with the native scalars and creating a new type would make all of our schema backwards incompatible which is not an option for us.
