### PR TITLE
Show test failures in builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -220,12 +220,40 @@ artifacts {
     archives javadocJar
 }
 
+List<TestDescriptor> failedTests = []
+
 test {
     testLogging {
         events "FAILED", "SKIPPED"
         exceptionFormat = "FULL"
     }
+
+    afterTest { TestDescriptor descriptor, result ->
+        if (result.getFailedTestCount() > 0) {
+            failedTests.add(descriptor)
+        }
+    }
 }
+
+/*
+ * The gradle.buildFinished callback is deprecated BUT there does not seem to be a decent alternative in gradle 7
+ * So progress over perfection here
+ *
+ * See https://github.com/gradle/gradle/issues/20151
+ */
+gradle. buildFinished {
+    if (!failedTests.isEmpty()) {
+        println "\n\n"
+        println "============================"
+        println "These are the test failures"
+        println "============================"
+        for (td in failedTests) {
+            println "${td.getClassName()}.${td.getDisplayName()}"
+        }
+        println "============================"
+    }
+}
+
 
 allprojects {
     tasks.withType(Javadoc) {

--- a/build.gradle
+++ b/build.gradle
@@ -228,7 +228,7 @@ test {
         exceptionFormat = "FULL"
     }
 
-    afterTest { TestDescriptor descriptor, result ->
+    afterTest { TestDescriptor descriptor, TestResult result ->
         if (result.getFailedTestCount() > 0) {
             failedTests.add(descriptor)
         }

--- a/src/test/groovy/graphql/AlwaysFailsTest.groovy
+++ b/src/test/groovy/graphql/AlwaysFailsTest.groovy
@@ -1,0 +1,25 @@
+package graphql
+
+import spock.lang.Specification
+
+/**
+ * This is only really useful for testing the gradle builds etc...
+ * and in general would not be needed to test graphql-java
+ */
+class AlwaysFailsTest extends Specification{
+
+    def "this test fails"() {
+        when:
+        true
+        then:
+        assert false
+    }
+
+    def "and this test always fails"() {
+        when:
+        true
+        then:
+        assert false
+    }
+
+}

--- a/src/test/groovy/graphql/AlwaysFailsTest.groovy
+++ b/src/test/groovy/graphql/AlwaysFailsTest.groovy
@@ -1,11 +1,13 @@
 package graphql
 
+import spock.lang.Ignore
 import spock.lang.Specification
 
 /**
  * This is only really useful for testing the gradle builds etc...
  * and in general would not be needed to test graphql-java
  */
+@Ignore
 class AlwaysFailsTest extends Specification{
 
     def "this test fails"() {


### PR DESCRIPTION
Its VERY annoying to scroll through the build logs to try and find failed tests

This adds a listener so that we can print a summary at the end of the build

```

============================
These are the test failures
============================
graphql.AlwaysFailsTest.this test fails
graphql.AlwaysFailsTest.and this test always fails
============================
```

That way its easier to work out what tests have failed