### PR TITLE
Upgrade to Java 11 (round 2)

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -15,9 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: '8.0.282'
+          java-version: '11.0.17'
       - name: build test and publish
         run: ./gradlew assemble && ./gradlew check --info && ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -x check --info --stacktrace

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - master
+      - 20.x
       - 19.x
       - 18.x
       - 17.x
@@ -16,9 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: '8.0.282'
+          java-version: '11.0.17'
       - name: build and test
         run: ./gradlew assemble && ./gradlew check --info --stacktrace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: '8.0.282'
+          java-version: '11.0.17'
       - name: build test and publish
         run: ./gradlew assemble && ./gradlew check --info && ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -x check --info --stacktrace

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(8)
+        languageVersion = JavaLanguageVersion.of(11)
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ def getDevelopmentVersion() {
 def reactiveStreamsVersion = '1.0.3'
 def slf4jVersion = '1.7.35'
 def releaseVersion = System.env.RELEASE_VERSION
-def antlrVersion = '4.9.3' // https://mvnrepository.com/artifact/org.antlr/antlr4-runtime
+def antlrVersion = '4.11.1' // https://mvnrepository.com/artifact/org.antlr/antlr4-runtime
 version = releaseVersion ? releaseVersion : getDevelopmentVersion()
 group = 'com.graphql-java'
 

--- a/src/main/resources/i18n/Parsing_de.properties
+++ b/src/main/resources/i18n/Parsing_de.properties
@@ -10,20 +10,17 @@
 # REMEMBER - a single quote ' in MessageFormat means things that are never replaced within them
 # so use 2 '' characters to make it one ' on output.  This will take for the form ''{0}''
 #
-# Prior to Java 9, properties files are encoded in ISO-8859-1.
-# We have to use \u00fc instead of the German ue character, \u00e4 for ae, \u00f6 for oe, \u00df for ss
-#
-InvalidSyntax.noMessage=Ung\u00fcltige Syntax in Zeile {0} Spalte {1}
-InvalidSyntax.full=Ung\u00fcltige Syntax, ANTLR-Fehler ''{0}'' in Zeile {1} Spalte {2}
+InvalidSyntax.noMessage=Ungültige Syntax in Zeile {0} Spalte {1}
+InvalidSyntax.full=Ungültige Syntax, ANTLR-Fehler ''{0}'' in Zeile {1} Spalte {2}
 
-InvalidSyntaxBail.noToken=Ung\u00fcltige Syntax in Zeile {0} Spalte {1}
-InvalidSyntaxBail.full=Ung\u00fcltige Syntax wegen des ung\u00fcltigen Tokens ''{0}'' in Zeile {1} Spalte {2}
+InvalidSyntaxBail.noToken=Ungültige Syntax in Zeile {0} Spalte {1}
+InvalidSyntaxBail.full=Ungültige Syntax wegen des ungültigen Tokens ''{0}'' in Zeile {1} Spalte {2}
 #
-InvalidSyntaxMoreTokens.full=Es wurde eine ung\u00fcltige Syntax festgestellt. Es gibt zus\u00e4tzliche Token im Text, die nicht konsumiert wurden. Ung\u00fcltiges Token ''{0}'' in Zeile {1} Spalte {2}
+InvalidSyntaxMoreTokens.full=Es wurde eine ungültige Syntax festgestellt. Es gibt zusätzliche Token im Text, die nicht konsumiert wurden. Ungültiges Token ''{0}'' in Zeile {1} Spalte {2}
 #
-ParseCancelled.full=Es wurden mehr als {0} ''{1}'' Token pr\u00e4sentiert. Um Denial-of-Service-Angriffe zu verhindern, wurde das Parsing abgebrochen
+ParseCancelled.full=Es wurden mehr als {0} ''{1}'' Token präsentiert. Um Denial-of-Service-Angriffe zu verhindern, wurde das Parsing abgebrochen
 #
-InvalidUnicode.trailingLeadingSurrogate=Ung\u00fcltiger Unicode gefunden. Trailing surrogate muss ein leading surrogate vorangestellt werden. Ung\u00fcltiges Token ''{0}'' in Zeile {1} Spalte {2}
-InvalidUnicode.leadingTrailingSurrogate=Ung\u00fcltiger Unicode gefunden. Auf ein leading surrogate muss ein trailing surrogate folgen. Ung\u00fcltiges Token ''{0}'' in Zeile {1} Spalte {2}
-InvalidUnicode.invalidCodePoint=Ung\u00fcltiger Unicode gefunden. Kein g\u00fcltiger code point. Ung\u00fcltiges Token ''{0}'' in Zeile {1} Spalte {2}
-InvalidUnicode.incorrectEscape=Ung\u00fcltiger Unicode gefunden. Falsch formatierte Escape-Sequenz. Ung\u00fcltiges Token ''{0}'' in Zeile {1} Spalte {2}
+InvalidUnicode.trailingLeadingSurrogate=Ungültiger Unicode gefunden. Trailing surrogate muss ein leading surrogate vorangestellt werden. Ungültiges Token ''{0}'' in Zeile {1} Spalte {2}
+InvalidUnicode.leadingTrailingSurrogate=Ungültiger Unicode gefunden. Auf ein leading surrogate muss ein trailing surrogate folgen. Ungültiges Token ''{0}'' in Zeile {1} Spalte {2}
+InvalidUnicode.invalidCodePoint=Ungültiger Unicode gefunden. Kein gültiger code point. Ungültiges Token ''{0}'' in Zeile {1} Spalte {2}
+InvalidUnicode.incorrectEscape=Ungültiger Unicode gefunden. Falsch formatierte Escape-Sequenz. Ungültiges Token ''{0}'' in Zeile {1} Spalte {2}

--- a/src/main/resources/i18n/Scalars_de.properties
+++ b/src/main/resources/i18n/Scalars_de.properties
@@ -10,14 +10,11 @@
 # REMEMBER - a single quote ' in MessageFormat means things that are never replaced within them
 # so use 2 '' characters to make it one ' on output.  This will take for the form ''{0}''
 #
-# Prior to Java 9, properties files are encoded in ISO-8859-1.
-# We have to use \u00fc instead of the German ue character, \u00e4 for ae, \u00f6 for oe, \u00df for ss
-#
 Scalar.unexpectedAstType=Erwartet wurde ein AST type von ''{0}'', aber es war ein ''{1}''
 #
-Enum.badInput=Ung\u00fcltige Eingabe f\u00fcr enum ''{0}''. Unbekannter Wert ''{1}''
-Enum.badName=Ung\u00fcltige Eingabe f\u00fcr enum ''{0}''. Kein Wert f\u00fcr den Namen ''{1}'' gefunden
-Enum.unallowableValue=Literal nicht in den zul\u00e4ssigen Werten f\u00fcr enum ''{0}'' - ''{1}''
+Enum.badInput=Ungültige Eingabe für enum ''{0}''. Unbekannter Wert ''{1}''
+Enum.badName=Ungültige Eingabe für enum ''{0}''. Kein Wert für den Namen ''{1}'' gefunden
+Enum.unallowableValue=Literal nicht in den zulässigen Werten für enum ''{0}'' - ''{1}''
 #
 Int.notInt=Erwartet wurde ein Wert, der in den Typ ''Int'' konvertiert werden kann, aber es war ein ''{0}''
 Int.outsideRange=Erwarteter Wert im Integer-Bereich, aber es war ein ''{0}''

--- a/src/main/resources/i18n/Validation_de.properties
+++ b/src/main/resources/i18n/Validation_de.properties
@@ -10,18 +10,15 @@
 # REMEMBER - a single quote ' in MessageFormat means things that are never replaced within them
 # so use 2 '' characters to make it one ' on output.  This will take for the form ''{0}''
 #
-# Prior to Java 9, properties files are encoded in ISO-8859-1.
-# We have to use \u00fc instead of the German ue character, \u00e4 for ae, \u00f6 for oe, \u00df for ss
-#
-ExecutableDefinitions.notExecutableType=Validierungsfehler ({0}) : Type definition ''{1}'' ist nicht ausf\u00fchrbar
-ExecutableDefinitions.notExecutableSchema=Validierungsfehler ({0}) : Schema definition ist nicht ausf\u00fchrbar
-ExecutableDefinitions.notExecutableDirective=Validierungsfehler ({0}) : Directive definition ''{1}'' ist nicht ausf\u00fchrbar
-ExecutableDefinitions.notExecutableDefinition=Validierungsfehler ({0}) : Die angegebene Definition ist nicht ausf\u00fchrbar
+ExecutableDefinitions.notExecutableType=Validierungsfehler ({0}) : Type definition ''{1}'' ist nicht ausführbar
+ExecutableDefinitions.notExecutableSchema=Validierungsfehler ({0}) : Schema definition ist nicht ausführbar
+ExecutableDefinitions.notExecutableDirective=Validierungsfehler ({0}) : Directive definition ''{1}'' ist nicht ausführbar
+ExecutableDefinitions.notExecutableDefinition=Validierungsfehler ({0}) : Die angegebene Definition ist nicht ausführbar
 #
 FieldsOnCorrectType.unknownField=Validierungsfehler ({0}) : Feld ''{1}'' vom Typ ''{2}'' ist nicht definiert
 #
-FragmentsOnCompositeType.invalidInlineTypeCondition=Validierungsfehler ({0}) : Inline fragment type condition ist ung\u00fcltig, muss auf Object/Interface/Union stehen
-FragmentsOnCompositeType.invalidFragmentTypeCondition=Validierungsfehler ({0}) : Fragment type condition ist ung\u00fcltig, muss auf Object/Interface/Union stehen
+FragmentsOnCompositeType.invalidInlineTypeCondition=Validierungsfehler ({0}) : Inline fragment type condition ist ungültig, muss auf Object/Interface/Union stehen
+FragmentsOnCompositeType.invalidFragmentTypeCondition=Validierungsfehler ({0}) : Fragment type condition ist ungültig, muss auf Object/Interface/Union stehen
 #
 KnownArgumentNames.unknownDirectiveArg=Validierungsfehler ({0}) : Unbekanntes directive argument ''{1}''
 KnownArgumentNames.unknownFieldArg=Validierungsfehler ({0}) : Unbekanntes field argument ''{1}''
@@ -48,17 +45,17 @@ OverlappingFieldsCanBeMerged.differentFields=Validierungsfehler ({0}) : ''{1}'' 
 OverlappingFieldsCanBeMerged.differentArgs=Validierungsfehler ({0}) : ''{1}'' : Felder haben unterschiedliche Argumente
 OverlappingFieldsCanBeMerged.differentNullability=Validierungsfehler ({0}) : ''{1}'' : Felder haben unterschiedliche nullability shapes
 OverlappingFieldsCanBeMerged.differentLists=Validierungsfehler ({0}) : ''{1}'' : Felder haben unterschiedliche list shapes
-OverlappingFieldsCanBeMerged.differentReturnTypes=Validierungsfehler ({0}) : ''{1}'' : gibt verschiedene Typen ''{2}'' und ''{3}'' zur\u00fcck
+OverlappingFieldsCanBeMerged.differentReturnTypes=Validierungsfehler ({0}) : ''{1}'' : gibt verschiedene Typen ''{2}'' und ''{3}'' zurück
 #
-PossibleFragmentSpreads.inlineIncompatibleTypes=Validierungsfehler ({0}) : Fragment kann hier nicht verbreitet werden, da object vom Typ ''{1}'' niemals vom Typ ''{2}'' sein k\u00f6nnen
-PossibleFragmentSpreads.fragmentIncompatibleTypes=Validierungsfehler ({0}) : Fragment ''{1}'' kann hier nicht verbreitet werden, da object vom Typ ''{2}'' niemals vom Typ ''{3}'' sein k\u00f6nnen
+PossibleFragmentSpreads.inlineIncompatibleTypes=Validierungsfehler ({0}) : Fragment kann hier nicht verbreitet werden, da object vom Typ ''{1}'' niemals vom Typ ''{2}'' sein können
+PossibleFragmentSpreads.fragmentIncompatibleTypes=Validierungsfehler ({0}) : Fragment ''{1}'' kann hier nicht verbreitet werden, da object vom Typ ''{2}'' niemals vom Typ ''{3}'' sein können
 #
 ProvidedNonNullArguments.missingFieldArg=Validierungsfehler ({0}) : Fehlendes field argument ''{1}''
 ProvidedNonNullArguments.missingDirectiveArg=Validierungsfehler ({0}) : Fehlendes directive argument ''{1}''
-ProvidedNonNullArguments.nullValue=Validierungsfehler ({0}) : Nullwert f\u00fcr non-null field argument ''{1}''
+ProvidedNonNullArguments.nullValue=Validierungsfehler ({0}) : Nullwert für non-null field argument ''{1}''
 #
-ScalarLeaves.subselectionOnLeaf=Validierungsfehler ({0}) : Unterauswahl f\u00fcr Blatttyp ''{1}'' von Feld ''{2}'' nicht zul\u00e4ssig
-ScalarLeaves.subselectionRequired=Validierungsfehler ({0}) : Unterauswahl erforderlich f\u00fcr Typ ''{1}'' des Feldes ''{2}''
+ScalarLeaves.subselectionOnLeaf=Validierungsfehler ({0}) : Unterauswahl für Blatttyp ''{1}'' von Feld ''{2}'' nicht zulässig
+ScalarLeaves.subselectionRequired=Validierungsfehler ({0}) : Unterauswahl erforderlich für Typ ''{1}'' des Feldes ''{2}''
 #
 SubscriptionUniqueRootField.multipleRootFields=Validierungsfehler ({0}) : Subscription operation ''{1}'' muss genau ein root field haben
 SubscriptionUniqueRootField.multipleRootFieldsWithFragment=Validierungsfehler ({0}) : Subscription operation ''{1}'' muss genau ein root field mit Fragmenten haben
@@ -67,7 +64,7 @@ SubscriptionIntrospectionRootField.introspectionRootFieldWithFragment=Validierun
 #
 UniqueArgumentNames.uniqueArgument=Validierungsfehler ({0}) : Es kann nur ein Argument namens ''{1}'' geben
 #
-UniqueDirectiveNamesPerLocation.uniqueDirectives=Validierungsfehler ({0}) : Nicht wiederholbare directive m\u00fcssen innerhalb einer Lokation eindeutig benannt werden. Directive ''{1}'', die auf einem ''{2}'' verwendet wird, ist nicht eindeutig
+UniqueDirectiveNamesPerLocation.uniqueDirectives=Validierungsfehler ({0}) : Nicht wiederholbare directive müssen innerhalb einer Lokation eindeutig benannt werden. Directive ''{1}'', die auf einem ''{2}'' verwendet wird, ist nicht eindeutig
 #
 UniqueFragmentNames.oneFragment=Validierungsfehler ({0}) : Es kann nur ein Fragment namens ''{1}'' geben
 #
@@ -75,28 +72,28 @@ UniqueOperationNames.oneOperation=Validierungsfehler ({0}) : Es kann nur eine Op
 #
 UniqueVariableNames.oneVariable=Validierungsfehler ({0}) : Es kann nur eine Variable namens ''{1}'' geben
 #
-VariableDefaultValuesOfCorrectType.badDefault=Validierungsfehler ({0}) : Ung\u00fcltiger Standardwert ''{1}'' f\u00fcr Typ ''{2}''
+VariableDefaultValuesOfCorrectType.badDefault=Validierungsfehler ({0}) : Ungültiger Standardwert ''{1}'' für Typ ''{2}''
 #
 VariablesAreInputTypes.wrongType=Validierungsfehler ({0}) : Eingabevariable ''{1}'' Typ ''{2}'' ist kein Eingabetyp
 #
-VariableTypesMatchRule.unexpectedType=Validierungsfehler ({0}) : Der Variablentyp ''{1}'' stimmt nicht mit dem erwarteten Typ ''{2}'' \u00fcberein
+VariableTypesMatchRule.unexpectedType=Validierungsfehler ({0}) : Der Variablentyp ''{1}'' stimmt nicht mit dem erwarteten Typ ''{2}'' überein
 #
 # These are used but IDEA cant find them easily as being called
 #
 # suppress inspection "UnusedProperty"
 ArgumentValidationUtil.handleNullError=Validierungsfehler ({0}) : Argument ''{1}'' mit Wert ''{2}'' darf nicht null sein
 # suppress inspection "UnusedProperty"
-ArgumentValidationUtil.handleScalarError=Validierungsfehler ({0}) : Argument ''{1}'' mit Wert ''{2}'' ist kein g\u00fcltiges ''{3}''
+ArgumentValidationUtil.handleScalarError=Validierungsfehler ({0}) : Argument ''{1}'' mit Wert ''{2}'' ist kein gültiges ''{3}''
 # suppress inspection "UnusedProperty"
-ArgumentValidationUtil.handleScalarErrorCustomMessage=Validierungsfehler ({0}) : Argument ''{1}'' mit Wert ''{2}'' ist kein g\u00fcltiges ''{3}'' - {4}
+ArgumentValidationUtil.handleScalarErrorCustomMessage=Validierungsfehler ({0}) : Argument ''{1}'' mit Wert ''{2}'' ist kein gültiges ''{3}'' - {4}
 # suppress inspection "UnusedProperty"
-ArgumentValidationUtil.handleEnumError=Validierungsfehler ({0}) : Argument ''{1}'' mit Wert ''{2}'' ist kein g\u00fcltiges ''{3}''
+ArgumentValidationUtil.handleEnumError=Validierungsfehler ({0}) : Argument ''{1}'' mit Wert ''{2}'' ist kein gültiges ''{3}''
 # suppress inspection "UnusedProperty"
-ArgumentValidationUtil.handleEnumErrorCustomMessage=Validierungsfehler ({0}) : Argument ''{1}'' mit Wert ''{2}'' ist kein g\u00fcltiges ''{3}'' - {4}
+ArgumentValidationUtil.handleEnumErrorCustomMessage=Validierungsfehler ({0}) : Argument ''{1}'' mit Wert ''{2}'' ist kein gültiges ''{3}'' - {4}
 # suppress inspection "UnusedProperty"
 ArgumentValidationUtil.handleNotObjectError=Validierungsfehler ({0}) : Argument ''{1}'' mit Wert ''{2}'' muss ein object type sein
 # suppress inspection "UnusedProperty"
 ArgumentValidationUtil.handleMissingFieldsError=Validierungsfehler ({0}) : Argument ''{1}'' mit Wert ''{2}'' fehlen Pflichtfelder ''{3}''
 # suppress inspection "UnusedProperty"
-ArgumentValidationUtil.handleExtraFieldError=Validierungsfehler ({0}) : Argument ''{1}'' mit Wert ''{2}'' enth\u00e4lt ein Feld nicht in ''{3}'': ''{4}''
+ArgumentValidationUtil.handleExtraFieldError=Validierungsfehler ({0}) : Argument ''{1}'' mit Wert ''{2}'' enthält ein Feld nicht in ''{3}'': ''{4}''
 #


### PR DESCRIPTION
Our next release will include breaking changes, including upgrading to Java 11!

Upgrading to Java 11 makes it easier to upgrade ANTLR and enables UTF-8 strings.

Note: The 20.1 release was a feature and bugfix release, without any breaking changes. Before the 20.1 release, I had to downgrade back to Java 8 to ensure no breaking changes. See https://github.com/graphql-java/graphql-java/pull/3110