### PR TITLE
ci: use temurin

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -19,6 +19,6 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '8'
-          distribution: 'corretto'
+          distribution: 'temurin'
       - name: build test and publish
         run: ./gradlew assemble && ./gradlew check --info && ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -x check --info --stacktrace

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,6 +20,6 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '8'
-          distribution: 'corretto'
+          distribution: 'temurin'
       - name: build and test
         run: ./gradlew assemble && ./gradlew check --info --stacktrace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,6 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '8'
-          distribution: 'corretto'
+          distribution: 'temurin'
       - name: build test and publish
         run: ./gradlew assemble && ./gradlew check --info && ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -x check --info --stacktrace


### PR DESCRIPTION
Host runners include Temurin by default as part of the [hosted tool cache](https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#hosted-tool-cache). Using Temurin speeds up builds as there is no need to download and configure the Java SDK with every build.


Before: 

![image](https://user-images.githubusercontent.com/8935151/229593247-205e4ed9-0137-41cd-bf57-7d26a3d11344.png)



After : 


![image](https://user-images.githubusercontent.com/8935151/229593080-84035631-5832-4943-9333-a9d5118e40d5.png)
