### PR TITLE
Add map function to DataFetcherResult 

### DIFF
--- a/src/main/java/graphql/execution/DataFetcherResult.java
+++ b/src/main/java/graphql/execution/DataFetcherResult.java
@@ -127,14 +127,15 @@ public class DataFetcherResult<T> {
      * All other values are left unmodified.
      *
      * @param transformation the transformation that should be applied to the data
+     *
      * @return a new instance with where the data value has been transformed
      */
-    public <R> DataFetcherResult<R> map(Function<T,R> transformation) {
+    public <R> DataFetcherResult<R> map(Function<T, R> transformation) {
         return new Builder<>(transformation.apply(this.data))
-            .errors(this.errors)
-            .extensions(this.extensions)
-            .localContext(this.localContext)
-            .build();
+                .errors(this.errors)
+                .extensions(this.extensions)
+                .localContext(this.localContext)
+                .build();
     }
 
     /**

--- a/src/main/java/graphql/execution/DataFetcherResult.java
+++ b/src/main/java/graphql/execution/DataFetcherResult.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import static graphql.Assert.assertNotNull;
 
@@ -119,6 +120,21 @@ public class DataFetcherResult<T> {
         Builder<T> builder = new Builder<>(this);
         builderConsumer.accept(builder);
         return builder.build();
+    }
+
+    /**
+     * Transforms the data of the current DataFetcherResult using the provided function.
+     * All other values are left unmodified.
+     *
+     * @param transformation the transformation that should be applied to the data
+     * @return a new instance with where the data value has been transformed
+     */
+    public <R> DataFetcherResult<R> map(Function<T,R> transformation) {
+        return new Builder<>(transformation.apply(this.data))
+            .errors(this.errors)
+            .extensions(this.extensions)
+            .localContext(this.localContext)
+            .build();
     }
 
     /**

--- a/src/test/groovy/graphql/execution/DataFetcherResultTest.groovy
+++ b/src/test/groovy/graphql/execution/DataFetcherResultTest.groovy
@@ -74,6 +74,19 @@ class DataFetcherResultTest extends Specification {
 
     }
 
+    def "mapping works"() {
+        when:
+        def original = DataFetcherResult.newResult().data("hello")
+                .errors([error1]).localContext("world")
+                .extensions([x: "y"]).build()
+        def result = original.map({ data -> data.length()})
+        then:
+        result.getData() == 5
+        result.getLocalContext() == "world"
+        result.getExtensions() == [x : "y"]
+        result.getErrors() == [error1]
+    }
+
     def "transforming works"() {
         when:
         def original = DataFetcherResult.newResult().data("hello")

--- a/src/test/groovy/graphql/execution/DataFetcherResultTest.groovy
+++ b/src/test/groovy/graphql/execution/DataFetcherResultTest.groovy
@@ -79,11 +79,11 @@ class DataFetcherResultTest extends Specification {
         def original = DataFetcherResult.newResult().data("hello")
                 .errors([error1]).localContext("world")
                 .extensions([x: "y"]).build()
-        def result = original.map({ data -> data.length()})
+        def result = original.map({ data -> data.length() })
         then:
         result.getData() == 5
         result.getLocalContext() == "world"
-        result.getExtensions() == [x : "y"]
+        result.getExtensions() == [x: "y"]
         result.getErrors() == [error1]
     }
 


### PR DESCRIPTION
This PR adds a map function to DataFetcherResult (i.e. makes it a functor) to support a functional style of programming.