### PR TITLE
Deprecate FieldsContainer on code registry

### DIFF
--- a/src/main/java/graphql/schema/GraphQLCodeRegistry.java
+++ b/src/main/java/graphql/schema/GraphQLCodeRegistry.java
@@ -1,6 +1,7 @@
 package graphql.schema;
 
 import graphql.Assert;
+import graphql.DeprecatedAt;
 import graphql.Internal;
 import graphql.PublicApi;
 import graphql.schema.visibility.GraphqlFieldVisibility;
@@ -56,8 +57,26 @@ public class GraphQLCodeRegistry {
      * @param fieldDefinition the field definition
      *
      * @return the DataFetcher associated with this field.  All fields have data fetchers
+     *
+     * @see #getDataFetcher(GraphQLObjectType, GraphQLFieldDefinition)
+     * @deprecated This is confusing because {@link GraphQLInterfaceType}s cant have data fetchers.  At runtime only a {@link GraphQLObjectType}
+     * can be used to fetch a field.  This method allows the mapping to be made, but it is never useful if an interface is passed in.
      */
+    @Deprecated
+    @DeprecatedAt("2023-05-13")
     public DataFetcher<?> getDataFetcher(GraphQLFieldsContainer parentType, GraphQLFieldDefinition fieldDefinition) {
+        return getDataFetcherImpl(FieldCoordinates.coordinates(parentType, fieldDefinition), fieldDefinition, dataFetcherMap, systemDataFetcherMap, defaultDataFetcherFactory);
+    }
+
+    /**
+     * Returns a data fetcher associated with a field within an object type
+     *
+     * @param parentType      the container type
+     * @param fieldDefinition the field definition
+     *
+     * @return the DataFetcher associated with this field.  All fields have data fetchers
+     */
+    public DataFetcher<?> getDataFetcher(GraphQLObjectType parentType, GraphQLFieldDefinition fieldDefinition) {
         return getDataFetcherImpl(FieldCoordinates.coordinates(parentType, fieldDefinition), fieldDefinition, dataFetcherMap, systemDataFetcherMap, defaultDataFetcherFactory);
     }
 
@@ -242,8 +261,26 @@ public class GraphQLCodeRegistry {
          * @param fieldDefinition the field definition
          *
          * @return the DataFetcher associated with this field.  All fields have data fetchers
+         *
+         * @see #getDataFetcher(GraphQLObjectType, GraphQLFieldDefinition)
+         * @deprecated This is confusing because {@link GraphQLInterfaceType}s cant have data fetchers.  At runtime only a {@link GraphQLObjectType}
+         * can be used to fetch a field.  This method allows the mapping to be made, but it is never useful if an interface is passed in.
          */
+        @Deprecated
+        @DeprecatedAt("2023-05-13")
         public DataFetcher<?> getDataFetcher(GraphQLFieldsContainer parentType, GraphQLFieldDefinition fieldDefinition) {
+            return getDataFetcherImpl(FieldCoordinates.coordinates(parentType, fieldDefinition), fieldDefinition, dataFetcherMap, systemDataFetcherMap, defaultDataFetcherFactory);
+        }
+
+        /**
+         * Returns a data fetcher associated with a field within an object type
+         *
+         * @param parentType      the container type
+         * @param fieldDefinition the field definition
+         *
+         * @return the DataFetcher associated with this field.  All fields have data fetchers
+         */
+        public DataFetcher<?> getDataFetcher(GraphQLObjectType parentType, GraphQLFieldDefinition fieldDefinition) {
             return getDataFetcherImpl(FieldCoordinates.coordinates(parentType, fieldDefinition), fieldDefinition, dataFetcherMap, systemDataFetcherMap, defaultDataFetcherFactory);
         }
 
@@ -331,8 +368,28 @@ public class GraphQLCodeRegistry {
          * @param dataFetcher     the data fetcher code for that field
          *
          * @return this builder
+         *
+         * @see #dataFetcher(GraphQLObjectType, GraphQLFieldDefinition, DataFetcher)
+         * @deprecated This is confusing because {@link GraphQLInterfaceType}s cant have data fetchers.  At runtime only a {@link GraphQLObjectType}
+         * can be used to fetch a field.  This method allows the mapping to be made, but it is never useful if an interface is passed in.
          */
+        @Deprecated
+        @DeprecatedAt("2023-05-13")
         public Builder dataFetcher(GraphQLFieldsContainer parentType, GraphQLFieldDefinition fieldDefinition, DataFetcher<?> dataFetcher) {
+            return dataFetcher(FieldCoordinates.coordinates(parentType.getName(), fieldDefinition.getName()), dataFetcher);
+        }
+
+
+        /**
+         * Sets the data fetcher for a specific field inside an object type
+         *
+         * @param parentType      the object type
+         * @param fieldDefinition the field definition
+         * @param dataFetcher     the data fetcher code for that field
+         *
+         * @return this builder
+         */
+        public Builder dataFetcher(GraphQLObjectType parentType, GraphQLFieldDefinition fieldDefinition, DataFetcher<?> dataFetcher) {
             return dataFetcher(FieldCoordinates.coordinates(parentType.getName(), fieldDefinition.getName()), dataFetcher);
         }
 

--- a/src/main/java/graphql/schema/idl/SchemaDirectiveWiringEnvironmentImpl.java
+++ b/src/main/java/graphql/schema/idl/SchemaDirectiveWiringEnvironmentImpl.java
@@ -130,7 +130,7 @@ public class SchemaDirectiveWiringEnvironmentImpl<T extends GraphQLDirectiveCont
     public DataFetcher<?> getFieldDataFetcher() {
         assertNotNull(fieldDefinition, () -> "An output field must be in context to call this method");
         assertNotNull(fieldsContainer, () -> "An output field container must be in context to call this method");
-        return codeRegistry.getDataFetcher(fieldsContainer, fieldDefinition);
+        return codeRegistry.getDataFetcher(FieldCoordinates.coordinates(fieldsContainer, fieldDefinition), fieldDefinition);
     }
 
     @Override

--- a/src/test/groovy/graphql/analysis/values/ValueTraverserTest.groovy
+++ b/src/test/groovy/graphql/analysis/values/ValueTraverserTest.groovy
@@ -17,6 +17,7 @@ import graphql.schema.GraphQLInputObjectType
 import graphql.schema.GraphQLInputSchemaElement
 import graphql.schema.GraphQLList
 import graphql.schema.GraphQLNamedSchemaElement
+import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLScalarType
 import graphql.schema.idl.SchemaDirectiveWiring
 import graphql.schema.idl.SchemaDirectiveWiringEnvironment
@@ -861,8 +862,12 @@ type Profile {
             GraphQLFieldDefinition onField(SchemaDirectiveWiringEnvironment<GraphQLFieldDefinition> env) {
                 GraphQLFieldsContainer fieldsContainer = env.getFieldsContainer()
                 GraphQLFieldDefinition fieldDefinition = env.getFieldDefinition()
+                if (! fieldsContainer instanceof GraphQLObjectType) {
+                    return fieldDefinition
+                }
+                GraphQLObjectType containingObjectType = env.getFieldsContainer() as GraphQLObjectType
 
-                final DataFetcher<?> originalDF = env.getCodeRegistry().getDataFetcher(fieldsContainer, fieldDefinition)
+                final DataFetcher<?> originalDF = env.getCodeRegistry().getDataFetcher(containingObjectType, fieldDefinition)
                 final DataFetcher<?> newDF = { DataFetchingEnvironment originalEnv ->
                     ValueVisitor visitor = new ValueVisitor() {
                         @Override
@@ -884,7 +889,7 @@ type Profile {
                     return originalDF.get(newEnv);
                 }
 
-                env.getCodeRegistry().dataFetcher(fieldsContainer, fieldDefinition, newDF)
+                env.getCodeRegistry().dataFetcher(containingObjectType, fieldDefinition, newDF)
 
                 return fieldDefinition
             }


### PR DESCRIPTION
The current coed registry allows you to map data fetchers on GraphqlFieldsContainers - hence interfaces and object types

But this is wrong.  Interfaces never have data fetchers - only object types.

So this deprecates the old method and introduces a more specific new one