### PR TITLE
Adding in Java 9+ support for lookup across class loaders

### DIFF
--- a/src/main/java/graphql/schema/fetching/LambdaFetchingSupport.java
+++ b/src/main/java/graphql/schema/fetching/LambdaFetchingSupport.java
@@ -204,14 +204,16 @@ public class LambdaFetchingSupport {
         return getterFunction;
     }
 
-    private static MethodHandles.Lookup getLookup(Class<?> targetClass) throws IllegalAccessException {
+    private static MethodHandles.Lookup getLookup(Class<?> targetClass) {
         MethodHandles.Lookup lookupMe = MethodHandles.lookup();
         //
-        // This is a Java 9 approach to method look up allowing private access
-        // which we don't want to use yet until we get to Java 11
+        // This is a Java 9+ approach to method look up allowing private access
         //
-        //lookupMe = MethodHandles.privateLookupIn(targetClass, lookupMe);
-        return lookupMe;
+        try {
+            return MethodHandles.privateLookupIn(targetClass, lookupMe);
+        } catch (IllegalAccessException e) {
+            return lookupMe;
+        }
     }
 
 }

--- a/src/test/groovy/graphql/schema/fetching/LambdaFetchingSupportTest.groovy
+++ b/src/test/groovy/graphql/schema/fetching/LambdaFetchingSupportTest.groovy
@@ -182,18 +182,15 @@ class LambdaFetchingSupportTest extends Specification {
         def getter = LambdaFetchingSupport.createGetter(customClass, "hello")
         then:
 
+        // with Java 9+ we can get access to methods across class loaders
         getter.isPresent()
-        try {
-            getter.get().apply(targetObject)
-            assert false, "We expect this to fail on Java 8 without access to MethodHandles.privateLookupIn"
-        } catch (LinkageError | ClassCastException ignored) {
-        }
+        def value = getter.get().apply(targetObject)
+        value == "world"
 
-        // show that a DF can still be used access this because of the reflection fallback
-        // in the future it will work via MethodHandles.privateLookupIn
+        // show that a DF can be used
         when:
         def ageDF = PropertyDataFetcher.fetching("hello")
-        def value = ageDF.get(fld("hello"), targetObject, { -> null })
+        value = ageDF.get(fld("hello"), targetObject, { -> null })
         then:
         value == "world"
     }


### PR DESCRIPTION
This fix could not be done in the old version because it was not Java9+

Now that we are Java 11 - we can!