### PR TITLE
Removing the deprecated DataFetcherExceptionHandler sync method

### DIFF
--- a/src/main/java/graphql/execution/DataFetcherExceptionHandler.java
+++ b/src/main/java/graphql/execution/DataFetcherExceptionHandler.java
@@ -23,7 +23,5 @@ public interface DataFetcherExceptionHandler {
      *
      * @return a result that can contain custom formatted {@link graphql.GraphQLError}s
      */
-    default CompletableFuture<DataFetcherExceptionHandlerResult> handleException(DataFetcherExceptionHandlerParameters handlerParameters) {
-        return SimpleDataFetcherExceptionHandler.defaultImpl.handleException(handlerParameters);
-    }
+    CompletableFuture<DataFetcherExceptionHandlerResult> handleException(DataFetcherExceptionHandlerParameters handlerParameters);
 }

--- a/src/main/java/graphql/execution/DataFetcherExceptionHandler.java
+++ b/src/main/java/graphql/execution/DataFetcherExceptionHandler.java
@@ -22,27 +22,8 @@ public interface DataFetcherExceptionHandler {
      * @param handlerParameters the parameters to this callback
      *
      * @return a result that can contain custom formatted {@link graphql.GraphQLError}s
-     *
-     * @deprecated use {@link #handleException(DataFetcherExceptionHandlerParameters)} instead which as an asynchronous
-     * version
-     */
-    @Deprecated
-    @DeprecatedAt("2021-06-23")
-    default DataFetcherExceptionHandlerResult onException(DataFetcherExceptionHandlerParameters handlerParameters) {
-        return SimpleDataFetcherExceptionHandler.defaultImpl.onException(handlerParameters);
-    }
-
-    /**
-     * When an exception occurs during a call to a {@link DataFetcher} then this handler
-     * is called to shape the errors that should be placed in the {@link ExecutionResult#getErrors()}
-     * list of errors.
-     *
-     * @param handlerParameters the parameters to this callback
-     *
-     * @return a result that can contain custom formatted {@link graphql.GraphQLError}s
      */
     default CompletableFuture<DataFetcherExceptionHandlerResult> handleException(DataFetcherExceptionHandlerParameters handlerParameters) {
-        DataFetcherExceptionHandlerResult result = onException(handlerParameters);
-        return CompletableFuture.completedFuture(result);
+        return SimpleDataFetcherExceptionHandler.defaultImpl.handleException(handlerParameters);
     }
 }

--- a/src/main/java/graphql/execution/SimpleDataFetcherExceptionHandler.java
+++ b/src/main/java/graphql/execution/SimpleDataFetcherExceptionHandler.java
@@ -20,8 +20,7 @@ public class SimpleDataFetcherExceptionHandler implements DataFetcherExceptionHa
 
     static final SimpleDataFetcherExceptionHandler defaultImpl = new SimpleDataFetcherExceptionHandler();
 
-    @Override
-    public DataFetcherExceptionHandlerResult onException(DataFetcherExceptionHandlerParameters handlerParameters) {
+    private DataFetcherExceptionHandlerResult handleExceptionImpl(DataFetcherExceptionHandlerParameters handlerParameters) {
         Throwable exception = unwrap(handlerParameters.getException());
         SourceLocation sourceLocation = handlerParameters.getSourceLocation();
         ResultPath path = handlerParameters.getPath();
@@ -34,7 +33,7 @@ public class SimpleDataFetcherExceptionHandler implements DataFetcherExceptionHa
 
     @Override
     public CompletableFuture<DataFetcherExceptionHandlerResult> handleException(DataFetcherExceptionHandlerParameters handlerParameters) {
-        return CompletableFuture.completedFuture(onException(handlerParameters));
+        return CompletableFuture.completedFuture(handleExceptionImpl(handlerParameters));
     }
 
     /**

--- a/src/test/groovy/graphql/execution/SimpleDataFetcherExceptionHandlerTest.groovy
+++ b/src/test/groovy/graphql/execution/SimpleDataFetcherExceptionHandlerTest.groovy
@@ -21,29 +21,29 @@ class SimpleDataFetcherExceptionHandlerTest extends Specification {
     def "will wrap general exceptions"() {
         when:
         def handlerParameters = mkParams(new RuntimeException("RTE"))
-        def result = handler.onException(handlerParameters)
+        def result = handler.handleException(handlerParameters)
 
         then:
-        result.errors[0] instanceof ExceptionWhileDataFetching
-        result.errors[0].getMessage().contains("RTE")
+        result.join().errors[0] instanceof ExceptionWhileDataFetching
+        result.join().errors[0].getMessage().contains("RTE")
     }
 
     def "can unwrap certain exceptions"() {
         when:
-        def result = handler.onException(mkParams(new CompletionException(new RuntimeException("RTE"))))
+        def result = handler.handleException(mkParams(new CompletionException(new RuntimeException("RTE"))))
 
         then:
-        result.errors[0] instanceof ExceptionWhileDataFetching
-        result.errors[0].getMessage().contains("RTE")
+        result.join().errors[0] instanceof ExceptionWhileDataFetching
+        result.join().errors[0].getMessage().contains("RTE")
     }
 
     def "wont unwrap other exceptions"() {
         when:
-        def result = handler.onException(mkParams(new RuntimeException("RTE",new RuntimeException("BANG"))))
+        def result = handler.handleException(mkParams(new RuntimeException("RTE",new RuntimeException("BANG"))))
 
         then:
-        result.errors[0] instanceof ExceptionWhileDataFetching
-        ! result.errors[0].getMessage().contains("BANG")
+        result.join().errors[0] instanceof ExceptionWhileDataFetching
+        ! result.join().errors[0].getMessage().contains("BANG")
     }
 
     static class MyHandler implements DataFetcherExceptionHandler {}
@@ -52,18 +52,11 @@ class SimpleDataFetcherExceptionHandlerTest extends Specification {
         when:
         DataFetcherExceptionHandler handler = new MyHandler()
         def handlerParameters = mkParams(new RuntimeException("RTE"))
-        def result = handler.onException(handlerParameters) // Retain deprecated method for test coverage
+        def result = handler.handleException(handlerParameters) // Retain deprecated method for test coverage
 
         then:
-        result.errors[0] instanceof ExceptionWhileDataFetching
-        result.errors[0].getMessage().contains("RTE")
-
-        when:
-        def resultCF = handler.handleException(handlerParameters)
-
-        then:
-        resultCF.join().errors[0] instanceof ExceptionWhileDataFetching
-        resultCF.join().errors[0].getMessage().contains("RTE")
+        result.join().errors[0] instanceof ExceptionWhileDataFetching
+        result.join().errors[0].getMessage().contains("RTE")
     }
 
     private static DataFetcherExceptionHandlerParameters mkParams(Exception exception) {

--- a/src/test/groovy/graphql/execution/SimpleDataFetcherExceptionHandlerTest.groovy
+++ b/src/test/groovy/graphql/execution/SimpleDataFetcherExceptionHandlerTest.groovy
@@ -46,19 +46,6 @@ class SimpleDataFetcherExceptionHandlerTest extends Specification {
         ! result.join().errors[0].getMessage().contains("BANG")
     }
 
-    static class MyHandler implements DataFetcherExceptionHandler {}
-
-    def "a class can work without implementing anything"() {
-        when:
-        DataFetcherExceptionHandler handler = new MyHandler()
-        def handlerParameters = mkParams(new RuntimeException("RTE"))
-        def result = handler.handleException(handlerParameters) // Retain deprecated method for test coverage
-
-        then:
-        result.join().errors[0] instanceof ExceptionWhileDataFetching
-        result.join().errors[0].getMessage().contains("RTE")
-    }
-
     private static DataFetcherExceptionHandlerParameters mkParams(Exception exception) {
         def mergedField = newMergedField(newField("f").build()).build()
         def esi = newExecutionStepInfo()

--- a/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderHangingTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderHangingTest.groovy
@@ -241,8 +241,13 @@ class DataLoaderHangingTest extends Specification {
         """
 
     DataFetcherExceptionHandler customExceptionHandlerThatThrows = new DataFetcherExceptionHandler() {
+
         @Override
-        DataFetcherExceptionHandlerResult onException(DataFetcherExceptionHandlerParameters handlerParameters) { // Retain for test coverage, intentionally using sync version.
+        CompletableFuture<DataFetcherExceptionHandlerResult> handleException(DataFetcherExceptionHandlerParameters handlerParameters) {
+            //
+            // this is a weird test case - its not actually handling the exception - its a test
+            // case where the handler code itself throws an exception during the handling
+            // and that will not stop the DataLoader from being dispatched
             throw handlerParameters.exception
         }
     }

--- a/src/test/groovy/readme/ExecutionExamples.java
+++ b/src/test/groovy/readme/ExecutionExamples.java
@@ -141,13 +141,16 @@ public class ExecutionExamples {
         DataFetcherExceptionHandler handler = new DataFetcherExceptionHandler() {
 
             @Override
-            public DataFetcherExceptionHandlerResult onException(DataFetcherExceptionHandlerParameters handlerParameters) {
+            public CompletableFuture<DataFetcherExceptionHandlerResult> handleException(DataFetcherExceptionHandlerParameters handlerParameters) {
                 //
                 // do your custom handling here.  The parameters have all you need
                 GraphQLError buildCustomError = buildCustomError(handlerParameters);
 
-                return DataFetcherExceptionHandlerResult.newResult()
-                        .error(buildCustomError).build();
+                DataFetcherExceptionHandlerResult exceptionResult = DataFetcherExceptionHandlerResult
+                        .newResult()
+                        .error(buildCustomError)
+                        .build();
+                return CompletableFuture.completedFuture(exceptionResult);
             }
         };
         ExecutionStrategy executionStrategy = new AsyncExecutionStrategy(handler);


### PR DESCRIPTION
This has been deprecated since 2021-06-23

This was previously a sync value and its now required to be async.  It used to default but now it will not