### PR TITLE
Droppinf some CompletableFuture allocations

### DIFF
--- a/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
@@ -39,7 +39,7 @@ public class AsyncSerialExecutionStrategy extends AbstractAsyncExecutionStrategy
         MergedSelectionSet fields = parameters.getFields();
         ImmutableList<String> fieldNames = ImmutableList.copyOf(fields.keySet());
 
-        CompletableFuture<List<ExecutionResult>> resultsFuture = Async.eachSequentially(fieldNames, (fieldName, index, prevResults) -> {
+        CompletableFuture<List<ExecutionResult>> resultsFuture = Async.eachSequentially(fieldNames, (fieldName, prevResults) -> {
             MergedField currentField = fields.getSubField(fieldName);
             ResultPath fieldPath = parameters.getPath().segment(mkNameForPath(currentField));
             ExecutionStrategyParameters newParameters = parameters

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -589,7 +589,7 @@ public abstract class ExecutionStrategy {
             index++;
         }
 
-        CompletableFuture<List<ExecutionResult>> resultsFuture = Async.each(fieldValueInfos, (item, i) -> item.getFieldValue());
+        CompletableFuture<List<ExecutionResult>> resultsFuture = Async.each(fieldValueInfos, FieldValueInfo::getFieldValue);
 
         CompletableFuture<ExecutionResult> overallResult = new CompletableFuture<>();
         completeListCtx.onDispatched(overallResult);

--- a/src/main/java/graphql/execution/instrumentation/ChainedInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/ChainedInstrumentation.java
@@ -340,7 +340,7 @@ public class ChainedInstrumentation implements Instrumentation {
     @NotNull
     @Override
     public CompletableFuture<ExecutionResult> instrumentExecutionResult(ExecutionResult executionResult, InstrumentationExecutionParameters parameters, InstrumentationState state) {
-        CompletableFuture<List<ExecutionResult>> resultsFuture = Async.eachSequentially(instrumentations, (instrumentation, index, prevResults) -> {
+        CompletableFuture<List<ExecutionResult>> resultsFuture = Async.eachSequentially(instrumentations, (instrumentation, prevResults) -> {
             InstrumentationState specificState = getSpecificState(instrumentation, state);
             ExecutionResult lastResult = prevResults.size() > 0 ? prevResults.get(prevResults.size() - 1) : executionResult;
             return instrumentation.instrumentExecutionResult(lastResult, parameters, specificState);

--- a/src/test/groovy/graphql/execution/AsyncTest.groovy
+++ b/src/test/groovy/graphql/execution/AsyncTest.groovy
@@ -4,6 +4,7 @@ import spock.lang.Specification
 
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
+import java.util.function.Function
 import java.util.function.BiFunction
 
 import static java.util.concurrent.CompletableFuture.completedFuture
@@ -13,7 +14,7 @@ class AsyncTest extends Specification {
     def "eachSequentially test"() {
         given:
         def input = ['a', 'b', 'c']
-        def cfFactory = Mock(Async.CFFactory)
+        def cfFactory = Mock(BiFunction)
         def cf1 = new CompletableFuture()
         def cf2 = new CompletableFuture()
         def cf3 = new CompletableFuture()
@@ -23,21 +24,21 @@ class AsyncTest extends Specification {
 
         then:
         !result.isDone()
-        1 * cfFactory.apply('a', 0, []) >> cf1
+        1 * cfFactory.apply('a', []) >> cf1
 
         when:
         cf1.complete('x')
 
         then:
         !result.isDone()
-        1 * cfFactory.apply('b', 1, ['x']) >> cf2
+        1 * cfFactory.apply('b', ['x']) >> cf2
 
         when:
         cf2.complete('y')
 
         then:
         !result.isDone()
-        1 * cfFactory.apply('c', 2, ['x', 'y']) >> cf3
+        1 * cfFactory.apply('c', ['x', 'y']) >> cf3
 
         when:
         cf3.complete('z')
@@ -50,9 +51,9 @@ class AsyncTest extends Specification {
     def "eachSequentially propagates exception"() {
         given:
         def input = ['a', 'b', 'c']
-        def cfFactory = Mock(Async.CFFactory)
-        cfFactory.apply('a', 0, _) >> completedFuture("x")
-        cfFactory.apply('b', 1, _) >> {
+        def cfFactory = Mock(BiFunction)
+        cfFactory.apply('a', _) >> completedFuture("x")
+        cfFactory.apply('b', _) >> {
             def cf = new CompletableFuture<>()
             cf.completeExceptionally(new RuntimeException("some error"))
             cf
@@ -74,9 +75,9 @@ class AsyncTest extends Specification {
     def "eachSequentially catches factory exception"() {
         given:
         def input = ['a', 'b', 'c']
-        def cfFactory = Mock(Async.CFFactory)
-        cfFactory.apply('a', 0, _) >> completedFuture("x")
-        cfFactory.apply('b', 1, _) >> { throw new RuntimeException("some error") }
+        def cfFactory = Mock(BiFunction)
+        cfFactory.apply('a', _) >> completedFuture("x")
+        cfFactory.apply('b', _) >> { throw new RuntimeException("some error") }
 
         when:
         def result = Async.eachSequentially(input, cfFactory)
@@ -94,10 +95,10 @@ class AsyncTest extends Specification {
     def "each works for mapping function"() {
         given:
         def input = ['a', 'b', 'c']
-        def cfFactory = Mock(BiFunction)
-        cfFactory.apply('a', 0) >> completedFuture('x')
-        cfFactory.apply('b', 1) >> completedFuture('y')
-        cfFactory.apply('c', 2) >> completedFuture('z')
+        def cfFactory = Mock(Function)
+        cfFactory.apply('a') >> completedFuture('x')
+        cfFactory.apply('b') >> completedFuture('y')
+        cfFactory.apply('c') >> completedFuture('z')
 
 
         when:
@@ -111,16 +112,15 @@ class AsyncTest extends Specification {
     def "each with mapping function propagates factory exception"() {
         given:
         def input = ['a', 'b', 'c']
-        def cfFactory = Mock(BiFunction)
-
+        def cfFactory = Mock(Function)
 
         when:
         def result = Async.each(input, cfFactory)
 
         then:
-        1 * cfFactory.apply('a', 0) >> completedFuture('x')
-        1 * cfFactory.apply('b', 1) >> { throw new RuntimeException('some error') }
-        1 * cfFactory.apply('c', 2) >> completedFuture('z')
+        1 * cfFactory.apply('a') >> completedFuture('x')
+        1 * cfFactory.apply('b') >> { throw new RuntimeException('some error') }
+        1 * cfFactory.apply('c') >> completedFuture('z')
         result.isCompletedExceptionally()
         Throwable exception
         result.exceptionally({ e ->


### PR DESCRIPTION
Hello @bbakerman @andimarek 

just trying to improve the allocation rate (see the discussion in https://github.com/graphql-java/graphql-java/discussions/3175).

There are 3 commits:
- first one is to drop TracingInstrumentation from BenchMark (to better understand the numbers from the profiler);
- second one is about to allocate less CompletableFuture in the Async class;
- third one is about removing the unused `index` parameter from Async CF factory functions: this will drop the allocations of `java.lang.Integer`.

On my machine, I get the following numbers. 

Baseline:

```
Result "benchmark.BenchMark.benchMarkSimpleQueriesThroughput":
  62.101 ±(99.9%) 2.006 ops/s [Average]
  (min, avg, max) = (59.572, 62.101, 65.441), stdev = 1.877
  CI (99.9%): [60.095, 64.108] (assumes normal distribution)
```

With this PR:
```
Result "benchmark.BenchMark.benchMarkSimpleQueriesThroughput":
  65.212 ±(99.9%) 2.302 ops/s [Average]
  (min, avg, max) = (61.499, 65.212, 68.287), stdev = 2.154
  CI (99.9%): [62.910, 67.515] (assumes normal distribution)
```
I see also that the allocation rate of `CompletableFuture` is dropping a bit. 

Please have a look :)


