### PR TITLE
Update Guava version for v20

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,7 +89,7 @@ dependencies {
     api 'com.graphql-java:java-dataloader:3.2.0'
     api 'org.reactivestreams:reactive-streams:' + reactiveStreamsVersion
     antlr 'org.antlr:antlr4:' + antlrVersion
-    implementation 'com.google.guava:guava:31.0.1-jre'
+    implementation 'com.google.guava:guava:32.0.0-jre'
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation 'org.spockframework:spock-core:2.0-groovy-3.0'
     testImplementation 'org.codehaus.groovy:groovy:3.0.16'
@@ -123,7 +123,7 @@ shadowJar {
     }
     relocate('org.antlr.v4.runtime', 'graphql.org.antlr.v4.runtime')
     dependencies {
-        include(dependency('com.google.guava:guava:31.0.1-jre'))
+        include(dependency('com.google.guava:guava:32.0.0-jre'))
         include(dependency('org.antlr:antlr4-runtime:' + antlrVersion))
     }
     from "LICENSE.md"


### PR DESCRIPTION
**This PR will update the version of Guava to a patched version (32.0.0) so that security scanners do not mistakenly flag graphql-java as vulnerable. graphql-java never used the affected classes, this PR is only to make your security scanner happy.**

In graphql-java we shade selected classes from Guava. We don't actually use the affected classes in CVE-2023-2976, so this library was never vulnerable to CVE-2023-2976. However, in https://github.com/graphql-java/graphql-java/issues/3239 we received reports that security scanners have mistakenly flagged graphql-java as vulnerable because we do still include the Guava POM inside the META-INF directory of our jar. We still want to include the Guava POM in the jar, as a record of the version we shaded classes from.

Further explanation of exploit: https://github.com/advisories/GHSA-5mg8-w23w-74h3