### PR TITLE
Adding builder for QueryDirectives

### DIFF
--- a/src/main/java/graphql/execution/directives/QueryDirectives.java
+++ b/src/main/java/graphql/execution/directives/QueryDirectives.java
@@ -1,11 +1,16 @@
 package graphql.execution.directives;
 
 import graphql.DeprecatedAt;
+import graphql.GraphQLContext;
 import graphql.PublicApi;
+import graphql.execution.CoercedVariables;
+import graphql.execution.MergedField;
 import graphql.language.Field;
 import graphql.schema.GraphQLDirective;
+import graphql.schema.GraphQLSchema;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -89,4 +94,28 @@ public interface QueryDirectives {
     @Deprecated
     @DeprecatedAt("2022-02-24")
     Map<Field, List<GraphQLDirective>> getImmediateDirectivesByField();
+
+    /**
+     * @return a builder of {@link QueryDirectives}
+     */
+    static Builder newQueryDirectives() {
+        return new QueryDirectivesBuilder();
+    }
+
+    interface Builder {
+
+        Builder schema(GraphQLSchema schema);
+
+        Builder mergedField(MergedField mergedField);
+
+        Builder field(Field field);
+
+        Builder coercedVariables(CoercedVariables coercedVariables);
+
+        Builder graphQLContext(GraphQLContext graphQLContext);
+
+        Builder locale(Locale locale);
+
+        QueryDirectives build();
+    }
 }

--- a/src/main/java/graphql/execution/directives/QueryDirectivesBuilder.java
+++ b/src/main/java/graphql/execution/directives/QueryDirectivesBuilder.java
@@ -1,0 +1,62 @@
+package graphql.execution.directives;
+
+import graphql.GraphQLContext;
+import graphql.Internal;
+import graphql.execution.CoercedVariables;
+import graphql.execution.MergedField;
+import graphql.language.Field;
+import graphql.schema.GraphQLSchema;
+
+import java.util.Locale;
+
+@Internal
+public class QueryDirectivesBuilder implements QueryDirectives.Builder {
+
+    private MergedField mergedField;
+    private GraphQLSchema schema;
+    private CoercedVariables coercedVariables = CoercedVariables.emptyVariables();
+    private GraphQLContext graphQLContext = GraphQLContext.getDefault();
+    private Locale locale = Locale.getDefault();
+
+    @Override
+    public QueryDirectives.Builder schema(GraphQLSchema schema) {
+        this.schema = schema;
+        return this;
+    }
+
+    @Override
+    public QueryDirectives.Builder mergedField(MergedField mergedField) {
+        this.mergedField = mergedField;
+        return this;
+    }
+
+    @Override
+    public QueryDirectives.Builder field(Field field) {
+        this.mergedField = MergedField.newMergedField(field).build();
+        return this;
+    }
+
+    @Override
+    public QueryDirectives.Builder coercedVariables(CoercedVariables coercedVariables) {
+        this.coercedVariables = coercedVariables;
+        return this;
+    }
+
+    @Override
+    public QueryDirectives.Builder graphQLContext(GraphQLContext graphQLContext) {
+        this.graphQLContext = graphQLContext;
+        return this;
+    }
+
+    @Override
+    public QueryDirectives.Builder locale(Locale locale) {
+        this.locale = locale;
+        return this;
+    }
+
+
+    @Override
+    public QueryDirectives build() {
+        return new QueryDirectivesImpl(mergedField, schema, coercedVariables.toMap(), graphQLContext, locale);
+    }
+}


### PR DESCRIPTION
The QueryDirecivesImpl is @internal API but there is not builder to make one if used outside the engine

So this adds one