### PR TITLE
Use the non deprecated method in InstrumentationExamples.java

### DIFF
--- a/src/test/groovy/readme/InstrumentationExamples.java
+++ b/src/test/groovy/readme/InstrumentationExamples.java
@@ -15,6 +15,7 @@ import graphql.execution.instrumentation.fieldvalidation.FieldValidation;
 import graphql.execution.instrumentation.fieldvalidation.FieldValidationEnvironment;
 import graphql.execution.instrumentation.fieldvalidation.FieldValidationInstrumentation;
 import graphql.execution.instrumentation.fieldvalidation.SimpleFieldValidation;
+import graphql.execution.instrumentation.parameters.InstrumentationCreateStateParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
 import graphql.execution.instrumentation.tracing.TracingInstrumentation;

--- a/src/test/groovy/readme/InstrumentationExamples.java
+++ b/src/test/groovy/readme/InstrumentationExamples.java
@@ -64,7 +64,7 @@ public class InstrumentationExamples {
 
     class CustomInstrumentation extends SimplePerformantInstrumentation {
         @Override
-        public InstrumentationState createState() {
+        public @Nullable InstrumentationState createState(InstrumentationCreateStateParameters parameters) {
             //
             // instrumentation state is passed during each invocation of an Instrumentation method
             // and allows you to put stateful data away and reference it during the query execution


### PR DESCRIPTION
Currently, a deprecated method is still being used in InstrumentationExamples.java. This causes an NPE during the execution of `beginExecution`. Instead, use the non deprecated method in the example.