### PR TITLE
Experimental - oneOf directive support

### DIFF
--- a/src/main/java/graphql/Directives.java
+++ b/src/main/java/graphql/Directives.java
@@ -37,6 +37,7 @@ public class Directives {
     public static final String NO_LONGER_SUPPORTED = "No longer supported";
     public static final DirectiveDefinition DEPRECATED_DIRECTIVE_DEFINITION;
     public static final DirectiveDefinition SPECIFIED_BY_DIRECTIVE_DEFINITION;
+    @ExperimentalApi
     public static final DirectiveDefinition ONE_OF_DIRECTIVE_DEFINITION;
 
 
@@ -128,6 +129,7 @@ public class Directives {
             .definition(SPECIFIED_BY_DIRECTIVE_DEFINITION)
             .build();
 
+    @ExperimentalApi
     public static final GraphQLDirective OneOfDirective = GraphQLDirective.newDirective()
             .name(ONE_OF)
             .description("Indicates an Input Object is a OneOf Input Object.")

--- a/src/main/java/graphql/Directives.java
+++ b/src/main/java/graphql/Directives.java
@@ -72,7 +72,7 @@ public class Directives {
         ONE_OF_DIRECTIVE_DEFINITION = DirectiveDefinition.newDirectiveDefinition()
                 .name(ONE_OF)
                 .directiveLocation(newDirectiveLocation().name(INPUT_OBJECT.name()).build())
-                .description(createDescription("This directive is used to indicate an Input Object is a OneOf Input Object."))
+                .description(createDescription("Indicates an Input Object is a OneOf Input Object."))
                 .build();
     }
 
@@ -130,7 +130,7 @@ public class Directives {
 
     public static final GraphQLDirective OneOfDirective = GraphQLDirective.newDirective()
             .name(ONE_OF)
-            .description("This directive is used to indicate an Input Object is a OneOf Input Object.")
+            .description("Indicates an Input Object is a OneOf Input Object.")
             .validLocations(INPUT_OBJECT)
             .definition(ONE_OF_DIRECTIVE_DEFINITION)
             .build();

--- a/src/main/java/graphql/Directives.java
+++ b/src/main/java/graphql/Directives.java
@@ -15,6 +15,7 @@ import static graphql.introspection.Introspection.DirectiveLocation.FIELD_DEFINI
 import static graphql.introspection.Introspection.DirectiveLocation.FRAGMENT_SPREAD;
 import static graphql.introspection.Introspection.DirectiveLocation.INLINE_FRAGMENT;
 import static graphql.introspection.Introspection.DirectiveLocation.INPUT_FIELD_DEFINITION;
+import static graphql.introspection.Introspection.DirectiveLocation.INPUT_OBJECT;
 import static graphql.introspection.Introspection.DirectiveLocation.SCALAR;
 import static graphql.language.DirectiveLocation.newDirectiveLocation;
 import static graphql.language.InputValueDefinition.newInputValueDefinition;
@@ -31,10 +32,12 @@ public class Directives {
 
     private static final String SPECIFIED_BY = "specifiedBy";
     private static final String DEPRECATED = "deprecated";
+    private static final String ONE_OF = "oneOf";
 
     public static final String NO_LONGER_SUPPORTED = "No longer supported";
     public static final DirectiveDefinition DEPRECATED_DIRECTIVE_DEFINITION;
     public static final DirectiveDefinition SPECIFIED_BY_DIRECTIVE_DEFINITION;
+    public static final DirectiveDefinition ONE_OF_DIRECTIVE_DEFINITION;
 
 
     static {
@@ -64,6 +67,12 @@ public class Directives {
                                 .description(createDescription("The URL that specifies the behaviour of this scalar."))
                                 .type(newNonNullType(newTypeName().name("String").build()).build())
                                 .build())
+                .build();
+
+        ONE_OF_DIRECTIVE_DEFINITION = DirectiveDefinition.newDirectiveDefinition()
+                .name(ONE_OF)
+                .directiveLocation(newDirectiveLocation().name(INPUT_OBJECT.name()).build())
+                .description(createDescription("This directive is used to indicate an Input Object is a OneOf Input Object."))
                 .build();
     }
 
@@ -117,6 +126,13 @@ public class Directives {
                     .description("The URL that specifies the behaviour of this scalar."))
             .validLocations(SCALAR)
             .definition(SPECIFIED_BY_DIRECTIVE_DEFINITION)
+            .build();
+
+    public static final GraphQLDirective OneOfDirective = GraphQLDirective.newDirective()
+            .name(ONE_OF)
+            .description("This directive is used to indicate an Input Object is a OneOf Input Object.")
+            .validLocations(INPUT_OBJECT)
+            .definition(ONE_OF_DIRECTIVE_DEFINITION)
             .build();
 
     private static Description createDescription(String s) {

--- a/src/main/java/graphql/execution/OneOfNullValueException.java
+++ b/src/main/java/graphql/execution/OneOfNullValueException.java
@@ -1,0 +1,30 @@
+package graphql.execution;
+
+import graphql.ErrorType;
+import graphql.GraphQLError;
+import graphql.GraphQLException;
+import graphql.PublicApi;
+import graphql.language.SourceLocation;
+
+import java.util.List;
+
+/**
+ * The input map to One Of Input Types MUST only have 1 entry with a non null value
+ */
+@PublicApi
+public class OneOfNullValueException extends GraphQLException implements GraphQLError {
+
+    public OneOfNullValueException(String message) {
+        super(message);
+    }
+
+    @Override
+    public List<SourceLocation> getLocations() {
+        return null;
+    }
+
+    @Override
+    public ErrorType getErrorType() {
+        return ErrorType.ValidationError;
+    }
+}

--- a/src/main/java/graphql/execution/OneOfTooManyKeysException.java
+++ b/src/main/java/graphql/execution/OneOfTooManyKeysException.java
@@ -1,0 +1,32 @@
+package graphql.execution;
+
+import graphql.ErrorType;
+import graphql.GraphQLError;
+import graphql.GraphQLException;
+import graphql.PublicApi;
+import graphql.language.SourceLocation;
+import graphql.schema.GraphQLType;
+import graphql.schema.GraphQLTypeUtil;
+
+import java.util.List;
+
+/**
+ * The input map to One Of Input Types MUST only have 1 entry
+ */
+@PublicApi
+public class OneOfTooManyKeysException extends GraphQLException implements GraphQLError {
+
+    public OneOfTooManyKeysException(String message) {
+        super(message);
+    }
+
+    @Override
+    public List<SourceLocation> getLocations() {
+        return null;
+    }
+
+    @Override
+    public ErrorType getErrorType() {
+        return ErrorType.ValidationError;
+    }
+}

--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -379,7 +379,7 @@ public class ValuesResolver {
                 if (argumentType instanceof GraphQLInputObjectType) {
                     GraphQLInputObjectType inputObjectType = (GraphQLInputObjectType) argumentType;
                     if (inputObjectType.isOneOf() && ! ValuesResolverConversion.isNullValue(value)) {
-                        validateOneOfInputTypes(inputObjectType, argumentName, value, locale);
+                        validateOneOfInputTypes(inputObjectType, argumentValue, argumentName, value, locale);
                     }
                 }
             }
@@ -389,18 +389,24 @@ public class ValuesResolver {
     }
 
     @SuppressWarnings("unchecked")
-    private static void validateOneOfInputTypes(GraphQLInputObjectType oneOfInputType, String argumentName, Object mapValue, Locale locale) {
-        Assert.assertTrue(mapValue instanceof Map, () -> String.format("The coerced argument %s GraphQLInputObjectType is unexpectedly not a map", argumentName));
-        Map<String, Object> objectMap = (Map<String, Object>) mapValue;
-        if (objectMap.size() != 1) {
+    private static void validateOneOfInputTypes(GraphQLInputObjectType oneOfInputType, Value argumentValue, String argumentName, Object inputValue, Locale locale) {
+        Assert.assertTrue(inputValue instanceof Map, () -> String.format("The coerced argument %s GraphQLInputObjectType is unexpectedly not a map", argumentName));
+        Map<String, Object> objectMap = (Map<String, Object>) inputValue;
+        int mapSize;
+        if (argumentValue instanceof ObjectValue) {
+            mapSize = ((ObjectValue) argumentValue).getObjectFields().size();
+        } else {
+            mapSize = objectMap.size();
+        }
+        if (mapSize != 1) {
             String msg = I18n.i18n(I18n.BundleType.Execution, locale)
-                    .msg("handleOneOfNotOneFieldError", oneOfInputType.getName());
+                    .msg("Execution.handleOneOfNotOneFieldError", oneOfInputType.getName());
             throw new OneOfTooManyKeysException(msg);
         }
         String fieldName = objectMap.keySet().iterator().next();
         if (objectMap.get(fieldName) == null) {
             String msg = I18n.i18n(I18n.BundleType.Execution, locale)
-                    .msg("handleOneOfValueIsNullError", oneOfInputType.getName() + "." + fieldName);
+                    .msg("Execution.handleOneOfValueIsNullError", oneOfInputType.getName() + "." + fieldName);
             throw new OneOfNullValueException(msg);
         }
     }

--- a/src/main/java/graphql/introspection/Introspection.java
+++ b/src/main/java/graphql/introspection/Introspection.java
@@ -450,6 +450,7 @@ public class Introspection {
                     .type(typeRef("__Type")))
             .field(newFieldDefinition()
                     .name("isOneOf")
+                    .description("This field is considered experimental because it has not yet been ratified in the graphql specification")
                     .type(GraphQLBoolean))
             .field(newFieldDefinition()
                     .name("specifiedByURL")

--- a/src/main/java/graphql/introspection/Introspection.java
+++ b/src/main/java/graphql/introspection/Introspection.java
@@ -399,6 +399,14 @@ public class Introspection {
         return null;
     };
 
+    private static final IntrospectionDataFetcher<?> isOneOfFetcher = environment -> {
+        Object type = environment.getSource();
+        if (type instanceof GraphQLInputObjectType) {
+            return ((GraphQLInputObjectType) type).isOneOf();
+        }
+        return null;
+    };
+
     public static final GraphQLObjectType __Type = newObject()
             .name("__Type")
             .field(newFieldDefinition()
@@ -441,6 +449,9 @@ public class Introspection {
                     .name("ofType")
                     .type(typeRef("__Type")))
             .field(newFieldDefinition()
+                    .name("isOneOf")
+                    .type(GraphQLBoolean))
+            .field(newFieldDefinition()
                     .name("specifiedByURL")
                     .type(GraphQLString))
             .field(newFieldDefinition()
@@ -460,6 +471,7 @@ public class Introspection {
         register(__Type, "enumValues", enumValuesTypesFetcher);
         register(__Type, "inputFields", inputFieldsFetcher);
         register(__Type, "ofType", OfTypeFetcher);
+        register(__Type, "isOneOf", isOneOfFetcher);
         register(__Type, "specifiedByURL", specifiedByUrlDataFetcher);
         register(__Type, "specifiedByUrl", specifiedByUrlDataFetcher); // note that this field is deprecated
     }

--- a/src/main/java/graphql/introspection/IntrospectionQueryBuilder.java
+++ b/src/main/java/graphql/introspection/IntrospectionQueryBuilder.java
@@ -90,8 +90,8 @@ public class IntrospectionQueryBuilder {
         public static Options defaultOptions() {
             return new Options(
                     true,
-                    true,
                     false,
+                    true,
                     true,
                     false,
                     true,

--- a/src/main/java/graphql/introspection/IntrospectionQueryBuilder.java
+++ b/src/main/java/graphql/introspection/IntrospectionQueryBuilder.java
@@ -33,6 +33,7 @@ public class IntrospectionQueryBuilder {
         private final boolean descriptions;
 
         private final boolean specifiedByUrl;
+        private final boolean isOneOf;
 
         private final boolean directiveIsRepeatable;
 
@@ -44,12 +45,14 @@ public class IntrospectionQueryBuilder {
 
         private Options(boolean descriptions,
                         boolean specifiedByUrl,
+                        boolean isOneOf,
                         boolean directiveIsRepeatable,
                         boolean schemaDescription,
                         boolean inputValueDeprecation,
                         int typeRefFragmentDepth) {
             this.descriptions = descriptions;
             this.specifiedByUrl = specifiedByUrl;
+            this.isOneOf = isOneOf;
             this.directiveIsRepeatable = directiveIsRepeatable;
             this.schemaDescription = schemaDescription;
             this.inputValueDeprecation = inputValueDeprecation;
@@ -62,6 +65,10 @@ public class IntrospectionQueryBuilder {
 
         public boolean isSpecifiedByUrl() {
             return specifiedByUrl;
+        }
+
+        public boolean isOneOf() {
+            return isOneOf;
         }
 
         public boolean isDirectiveIsRepeatable() {
@@ -83,6 +90,7 @@ public class IntrospectionQueryBuilder {
         public static Options defaultOptions() {
             return new Options(
                     true,
+                    true,
                     false,
                     true,
                     false,
@@ -101,6 +109,7 @@ public class IntrospectionQueryBuilder {
         public Options descriptions(boolean flag) {
             return new Options(flag,
                     this.specifiedByUrl,
+                    this.isOneOf,
                     this.directiveIsRepeatable,
                     this.schemaDescription,
                     this.inputValueDeprecation,
@@ -117,12 +126,32 @@ public class IntrospectionQueryBuilder {
         public Options specifiedByUrl(boolean flag) {
             return new Options(this.descriptions,
                     flag,
+                    this.isOneOf,
                     this.directiveIsRepeatable,
                     this.schemaDescription,
                     this.inputValueDeprecation,
                     this.typeRefFragmentDepth);
         }
 
+        /**
+         * This will allow you to include the `isOneOf` field for one of input types in the introspection query.
+         * <p>
+         * This option is only needed while `@oneOf` input types are new and in time the reason for this
+         * option will go away.
+         *
+         * @param flag whether to include them
+         *
+         * @return options
+         */
+        public Options isOneOf(boolean flag) {
+            return new Options(this.descriptions,
+                    this.specifiedByUrl,
+                    flag,
+                    this.directiveIsRepeatable,
+                    this.schemaDescription,
+                    this.inputValueDeprecation,
+                    this.typeRefFragmentDepth);
+        }
         /**
          * This will allow you to include the `isRepeatable` field for directives in the introspection query.
          *
@@ -133,6 +162,7 @@ public class IntrospectionQueryBuilder {
         public Options directiveIsRepeatable(boolean flag) {
             return new Options(this.descriptions,
                     this.specifiedByUrl,
+                    this.isOneOf,
                     flag,
                     this.schemaDescription,
                     this.inputValueDeprecation,
@@ -149,6 +179,7 @@ public class IntrospectionQueryBuilder {
         public Options schemaDescription(boolean flag) {
             return new Options(this.descriptions,
                     this.specifiedByUrl,
+                    this.isOneOf,
                     this.directiveIsRepeatable,
                     flag,
                     this.inputValueDeprecation,
@@ -165,6 +196,7 @@ public class IntrospectionQueryBuilder {
         public Options inputValueDeprecation(boolean flag) {
             return new Options(this.descriptions,
                     this.specifiedByUrl,
+                    this.isOneOf,
                     this.directiveIsRepeatable,
                     this.schemaDescription,
                     flag,
@@ -181,6 +213,7 @@ public class IntrospectionQueryBuilder {
         public Options typeRefFragmentDepth(int typeRefFragmentDepth) {
             return new Options(this.descriptions,
                     this.specifiedByUrl,
+                    this.isOneOf,
                     this.directiveIsRepeatable,
                     this.schemaDescription,
                     this.inputValueDeprecation,
@@ -249,6 +282,7 @@ public class IntrospectionQueryBuilder {
                 newField("name").build(),
                 options.descriptions ? newField("description").build() : null,
                 options.specifiedByUrl ? newField("specifiedByURL").build() : null,
+                options.isOneOf ? newField("isOneOf").build() : null,
                 newField("fields")
                         .arguments(ImmutableList.of(
                                 newArgument("includeDeprecated", BooleanValue.of(true)).build()

--- a/src/main/java/graphql/language/VariableReference.java
+++ b/src/main/java/graphql/language/VariableReference.java
@@ -91,6 +91,10 @@ public class VariableReference extends AbstractNode<VariableReference> implement
         return visitor.visitVariableReference(this, context);
     }
 
+    public static VariableReference of(String name) {
+        return newVariableReference().name(name).build();
+    }
+
     public static Builder newVariableReference() {
         return new Builder();
     }

--- a/src/main/java/graphql/schema/GraphQLInputObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectType.java
@@ -35,7 +35,6 @@ import static graphql.util.FpKit.getByName;
 public class GraphQLInputObjectType implements GraphQLNamedInputType, GraphQLUnmodifiedType, GraphQLNullableType, GraphQLInputFieldsContainer, GraphQLDirectiveContainer {
 
     private final String name;
-
     private final boolean isOneOf;
     private final String description;
     private final ImmutableMap<String, GraphQLInputObjectField> fieldMap;

--- a/src/main/java/graphql/schema/GraphQLInputObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectType.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import graphql.Directives;
 import graphql.DirectivesUtil;
+import graphql.ExperimentalApi;
 import graphql.Internal;
 import graphql.PublicApi;
 import graphql.language.InputObjectTypeDefinition;
@@ -86,9 +87,13 @@ public class GraphQLInputObjectType implements GraphQLNamedInputType, GraphQLUnm
 
     /**
      * An Input Object is considered a OneOf Input Object if it has the `@oneOf` directive applied to it.
+     * <p>
+     * This API is currently considered experimental since the graphql specification has not yet ratified
+     * this approach.
      *
      * @return true if it's a OneOf Input Object
      */
+    @ExperimentalApi
     public boolean isOneOf() {
         return isOneOf;
     }

--- a/src/main/java/graphql/schema/GraphQLInputObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectType.java
@@ -2,6 +2,7 @@ package graphql.schema;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import graphql.Directives;
 import graphql.DirectivesUtil;
 import graphql.Internal;
 import graphql.PublicApi;
@@ -34,6 +35,8 @@ import static graphql.util.FpKit.getByName;
 public class GraphQLInputObjectType implements GraphQLNamedInputType, GraphQLUnmodifiedType, GraphQLNullableType, GraphQLInputFieldsContainer, GraphQLDirectiveContainer {
 
     private final String name;
+
+    private final boolean isOneOf;
     private final String description;
     private final ImmutableMap<String, GraphQLInputObjectField> fieldMap;
     private final InputObjectTypeDefinition definition;
@@ -60,6 +63,7 @@ public class GraphQLInputObjectType implements GraphQLNamedInputType, GraphQLUnm
         this.extensionDefinitions = ImmutableList.copyOf(extensionDefinitions);
         this.directives = new DirectivesUtil.DirectivesHolder(directives, appliedDirectives);
         this.fieldMap = buildDefinitionMap(fields);
+        this.isOneOf = hasOneOf(directives, appliedDirectives);
     }
 
     private ImmutableMap<String, GraphQLInputObjectField> buildDefinitionMap(List<GraphQLInputObjectField> fieldDefinitions) {
@@ -67,9 +71,27 @@ public class GraphQLInputObjectType implements GraphQLNamedInputType, GraphQLUnm
                 (fld1, fld2) -> assertShouldNeverHappen("Duplicated definition for field '%s' in type '%s'", fld1.getName(), this.name)));
     }
 
+    private boolean hasOneOf(List<GraphQLDirective> directives, List<GraphQLAppliedDirective> appliedDirectives) {
+        if (appliedDirectives.stream().anyMatch(d -> Directives.OneOfDirective.getName().equals(d.getName()))) {
+            return true;
+        }
+        // eventually GraphQLDirective as applied directive goes away
+        return directives.stream().anyMatch(d -> Directives.OneOfDirective.getName().equals(d.getName()));
+    }
+
     @Override
     public String getName() {
         return name;
+    }
+
+
+    /**
+     * An Input Object is considered a OneOf Input Object if it has the `@oneOf` directive applied to it.
+     *
+     * @return true if it's a OneOf Input Object
+     */
+    public boolean isOneOf() {
+        return isOneOf;
     }
 
     public String getDescription() {

--- a/src/main/java/graphql/schema/GraphQLSchema.java
+++ b/src/main/java/graphql/schema/GraphQLSchema.java
@@ -917,6 +917,9 @@ public class GraphQLSchema {
             if (additionalDirectives.stream().noneMatch(d -> d.getName().equals(Directives.SpecifiedByDirective.getName()))) {
                 additionalDirectives.add(Directives.SpecifiedByDirective);
             }
+            if (additionalDirectives.stream().noneMatch(d -> d.getName().equals(Directives.OneOfDirective.getName()))) {
+                additionalDirectives.add(Directives.OneOfDirective);
+            }
 
             // quick build - no traversing
             final GraphQLSchema partiallyBuiltSchema = new GraphQLSchema(this);

--- a/src/main/java/graphql/schema/idl/DirectiveInfo.java
+++ b/src/main/java/graphql/schema/idl/DirectiveInfo.java
@@ -22,7 +22,9 @@ public class DirectiveInfo {
             Directives.IncludeDirective,
             Directives.SkipDirective,
             Directives.DeprecatedDirective,
-            Directives.SpecifiedByDirective);
+            Directives.SpecifiedByDirective,
+            Directives.OneOfDirective
+    );
 
     /**
      * A map from directive name to directive which provided by specification
@@ -31,7 +33,9 @@ public class DirectiveInfo {
             Directives.IncludeDirective.getName(), Directives.IncludeDirective,
             Directives.SkipDirective.getName(), Directives.SkipDirective,
             Directives.DeprecatedDirective.getName(), Directives.DeprecatedDirective,
-            Directives.SpecifiedByDirective.getName(), Directives.SpecifiedByDirective);
+            Directives.SpecifiedByDirective.getName(), Directives.SpecifiedByDirective,
+            Directives.OneOfDirective.getName(), Directives.OneOfDirective
+            );
 
     /**
      * Returns true if a directive with provided directiveName has been defined in graphql specification

--- a/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
+++ b/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
@@ -82,6 +82,7 @@ import static graphql.Assert.assertNotNull;
 import static graphql.Directives.DEPRECATED_DIRECTIVE_DEFINITION;
 import static graphql.Directives.IncludeDirective;
 import static graphql.Directives.NO_LONGER_SUPPORTED;
+import static graphql.Directives.ONE_OF_DIRECTIVE_DEFINITION;
 import static graphql.Directives.SPECIFIED_BY_DIRECTIVE_DEFINITION;
 import static graphql.Directives.SkipDirective;
 import static graphql.Directives.SpecifiedByDirective;
@@ -1079,6 +1080,7 @@ public class SchemaGeneratorHelper {
         // we synthesize this into the type registry - no need for them to add it
         typeRegistry.add(DEPRECATED_DIRECTIVE_DEFINITION);
         typeRegistry.add(SPECIFIED_BY_DIRECTIVE_DEFINITION);
+        typeRegistry.add(ONE_OF_DIRECTIVE_DEFINITION);
     }
 
     private Optional<OperationTypeDefinition> getOperationNamed(String name, Map<String, OperationTypeDefinition> operationTypeDefs) {

--- a/src/main/java/graphql/schema/validation/OneOfInputObjectRules.java
+++ b/src/main/java/graphql/schema/validation/OneOfInputObjectRules.java
@@ -1,0 +1,39 @@
+package graphql.schema.validation;
+
+import graphql.schema.GraphQLInputObjectField;
+import graphql.schema.GraphQLInputObjectType;
+import graphql.schema.GraphQLSchemaElement;
+import graphql.schema.GraphQLTypeUtil;
+import graphql.schema.GraphQLTypeVisitorStub;
+import graphql.util.TraversalControl;
+import graphql.util.TraverserContext;
+
+import static java.lang.String.format;
+
+/*
+ * Spec: If the Input Object is a OneOf Input Object then:
+ * The type of the input field must be nullable.
+ * The input field must not have a default value.
+ */
+public class OneOfInputObjectRules extends GraphQLTypeVisitorStub {
+
+    @Override
+    public TraversalControl visitGraphQLInputObjectField(GraphQLInputObjectField inputObjectField, TraverserContext<GraphQLSchemaElement> context) {
+        GraphQLInputObjectType inputObjectType = (GraphQLInputObjectType) context.getParentNode();
+        if (!inputObjectType.isOneOf()) {
+            return TraversalControl.CONTINUE;
+        }
+        SchemaValidationErrorCollector errorCollector = context.getVarFromParents(SchemaValidationErrorCollector.class);
+        // error messages take from the reference implementation
+        if (inputObjectField.hasSetDefaultValue()) {
+            String message = format("OneOf input field %s.%s cannot have a default value.", inputObjectType.getName(), inputObjectField.getName());
+            errorCollector.addError(new SchemaValidationError(SchemaValidationErrorType.OneOfDefaultValueOnField, message));
+        }
+
+        if (GraphQLTypeUtil.isNonNull(inputObjectField.getType())) {
+            String message = format("OneOf input field %s.%s must be nullable.", inputObjectType.getName(), inputObjectField.getName());
+            errorCollector.addError(new SchemaValidationError(SchemaValidationErrorType.OneOfNonNullableField, message));
+        }
+        return TraversalControl.CONTINUE;
+    }
+}

--- a/src/main/java/graphql/schema/validation/OneOfInputObjectRules.java
+++ b/src/main/java/graphql/schema/validation/OneOfInputObjectRules.java
@@ -1,5 +1,6 @@
 package graphql.schema.validation;
 
+import graphql.ExperimentalApi;
 import graphql.schema.GraphQLInputObjectField;
 import graphql.schema.GraphQLInputObjectType;
 import graphql.schema.GraphQLSchemaElement;
@@ -15,6 +16,7 @@ import static java.lang.String.format;
  * The type of the input field must be nullable.
  * The input field must not have a default value.
  */
+@ExperimentalApi
 public class OneOfInputObjectRules extends GraphQLTypeVisitorStub {
 
     @Override

--- a/src/main/java/graphql/schema/validation/SchemaValidationErrorType.java
+++ b/src/main/java/graphql/schema/validation/SchemaValidationErrorType.java
@@ -20,4 +20,6 @@ public enum SchemaValidationErrorType implements SchemaValidationErrorClassifica
     InvalidAppliedDirective,
     OutputTypeUsedInInputTypeContext,
     InputTypeUsedInOutputTypeContext,
+    OneOfDefaultValueOnField,
+    OneOfNonNullableField
 }

--- a/src/main/java/graphql/schema/validation/SchemaValidator.java
+++ b/src/main/java/graphql/schema/validation/SchemaValidator.java
@@ -25,6 +25,7 @@ public class SchemaValidator {
         rules.add(new AppliedDirectivesAreValid());
         rules.add(new AppliedDirectiveArgumentsAreValid());
         rules.add(new InputAndOutputTypesUsedAppropriately());
+        rules.add(new OneOfInputObjectRules());
     }
 
     public List<GraphQLTypeVisitor> getRules() {

--- a/src/main/java/graphql/validation/ArgumentValidationUtil.java
+++ b/src/main/java/graphql/validation/ArgumentValidationUtil.java
@@ -91,18 +91,6 @@ public class ArgumentValidationUtil extends ValidationUtil {
         argumentNames.add(0, String.format("[%s]", index));
     }
 
-    @Override
-    protected void handleOneOfNotOneFieldError(GraphQLInputObjectType type) {
-        errMsgKey = "ArgumentValidationUtil.handleOneOfNotOneFieldError";
-        arguments.add(type.getName());
-    }
-
-    @Override
-    protected void handleOneOfValueIsNullError(GraphQLInputObjectType type, ObjectField objectField) {
-        errMsgKey = "ArgumentValidationUtil.handleOneOfValueIsNullError";
-        arguments.add(type.getName() + "." + objectField.getName());
-    }
-
     public I18nMsg getMsgAndArgs() {
         StringBuilder argument = new StringBuilder(argumentName);
         for (String name : argumentNames) {

--- a/src/main/java/graphql/validation/ArgumentValidationUtil.java
+++ b/src/main/java/graphql/validation/ArgumentValidationUtil.java
@@ -91,6 +91,18 @@ public class ArgumentValidationUtil extends ValidationUtil {
         argumentNames.add(0, String.format("[%s]", index));
     }
 
+    @Override
+    protected void handleOneOfNotOneFieldError(GraphQLInputObjectType type) {
+        errMsgKey = "ArgumentValidationUtil.handleOneOfNotOneFieldError";
+        arguments.add(type.getName());
+    }
+
+    @Override
+    protected void handleOneOfValueIsNullError(GraphQLInputObjectType type, ObjectField objectField) {
+        errMsgKey = "ArgumentValidationUtil.handleOneOfValueIsNullError";
+        arguments.add(type.getName() + "." + objectField.getName());
+    }
+
     public I18nMsg getMsgAndArgs() {
         StringBuilder argument = new StringBuilder(argumentName);
         for (String name : argumentNames) {

--- a/src/main/java/graphql/validation/ValidationUtil.java
+++ b/src/main/java/graphql/validation/ValidationUtil.java
@@ -77,6 +77,12 @@ public class ValidationUtil {
     protected void handleFieldNotValidError(Value<?> value, GraphQLType type, int index) {
     }
 
+    protected void handleOneOfNotOneFieldError(GraphQLInputObjectType type) {
+    }
+
+    protected void handleOneOfValueIsNullError(GraphQLInputObjectType type, ObjectField objectField) {
+    }
+
     public boolean isValidLiteralValue(Value<?> value, GraphQLType type, GraphQLSchema schema, GraphQLContext graphQLContext, Locale locale) {
         if (value == null || value instanceof NullValue) {
             boolean valid = !(isNonNull(type));
@@ -154,10 +160,21 @@ public class ValidationUtil {
                 handleFieldNotValidError(objectField, type);
                 return false;
             }
-
+        }
+        if (type.isOneOf()) {
+            if (objectValue.getObjectFields().size() != 1) {
+                handleOneOfNotOneFieldError(type);
+                return false;
+            }
+            ObjectField objectField = objectValue.getObjectFields().get(0);
+            if (objectField.getValue() instanceof NullValue) {
+                handleOneOfValueIsNullError(type, objectField);
+                return false;
+            }
         }
         return true;
     }
+
 
     private Set<String> getMissingFields(GraphQLInputObjectType type, Map<String, ObjectField> objectFieldMap, GraphqlFieldVisibility fieldVisibility) {
         return fieldVisibility.getFieldDefinitions(type).stream()

--- a/src/main/java/graphql/validation/ValidationUtil.java
+++ b/src/main/java/graphql/validation/ValidationUtil.java
@@ -77,12 +77,6 @@ public class ValidationUtil {
     protected void handleFieldNotValidError(Value<?> value, GraphQLType type, int index) {
     }
 
-    protected void handleOneOfNotOneFieldError(GraphQLInputObjectType type) {
-    }
-
-    protected void handleOneOfValueIsNullError(GraphQLInputObjectType type, ObjectField objectField) {
-    }
-
     public boolean isValidLiteralValue(Value<?> value, GraphQLType type, GraphQLSchema schema, GraphQLContext graphQLContext, Locale locale) {
         if (value == null || value instanceof NullValue) {
             boolean valid = !(isNonNull(type));
@@ -160,21 +154,10 @@ public class ValidationUtil {
                 handleFieldNotValidError(objectField, type);
                 return false;
             }
-        }
-        if (type.isOneOf()) {
-            if (objectValue.getObjectFields().size() != 1) {
-                handleOneOfNotOneFieldError(type);
-                return false;
-            }
-            ObjectField objectField = objectValue.getObjectFields().get(0);
-            if (objectField.getValue() instanceof NullValue) {
-                handleOneOfValueIsNullError(type, objectField);
-                return false;
-            }
+
         }
         return true;
     }
-
 
     private Set<String> getMissingFields(GraphQLInputObjectType type, Map<String, ObjectField> objectFieldMap, GraphqlFieldVisibility fieldVisibility) {
         return fieldVisibility.getFieldDefinitions(type).stream()

--- a/src/main/resources/i18n/Execution.properties
+++ b/src/main/resources/i18n/Execution.properties
@@ -4,3 +4,5 @@
 # REMEMBER - a single quote ' in MessageFormat means things that are never replaced within them
 # so use 2 '' characters to make it one ' on output.  This will take for the form ''{0}''
 #
+Execution.handleOneOfNotOneFieldError=Exactly one key must be specified for OneOf type ''{0}''.
+Execution.handleOneOfValueIsNullError=OneOf type field ''{0}'' must be non-null.

--- a/src/main/resources/i18n/Validation.properties
+++ b/src/main/resources/i18n/Validation.properties
@@ -98,9 +98,3 @@ ArgumentValidationUtil.handleNotObjectError=Validation error ({0}) : argument ''
 ArgumentValidationUtil.handleMissingFieldsError=Validation error ({0}) : argument ''{1}'' with value ''{2}'' is missing required fields ''{3}''
 # suppress inspection "UnusedProperty"
 ArgumentValidationUtil.handleExtraFieldError=Validation error ({0}) : argument ''{1}'' with value ''{2}'' contains a field not in ''{3}'': ''{4}''
-# suppress inspection "UnusedProperty"
-# suppress inspection "UnusedMessageFormatParameter"
-ArgumentValidationUtil.handleOneOfNotOneFieldError=Validation error ({0}) : Exactly one key must be specified for OneOf type ''{3}''.
-# suppress inspection "UnusedProperty"
-# suppress inspection "UnusedMessageFormatParameter"
-ArgumentValidationUtil.handleOneOfValueIsNullError=Validation error ({0}) : OneOf type field ''{3}'' must be non-null.

--- a/src/main/resources/i18n/Validation.properties
+++ b/src/main/resources/i18n/Validation.properties
@@ -98,4 +98,9 @@ ArgumentValidationUtil.handleNotObjectError=Validation error ({0}) : argument ''
 ArgumentValidationUtil.handleMissingFieldsError=Validation error ({0}) : argument ''{1}'' with value ''{2}'' is missing required fields ''{3}''
 # suppress inspection "UnusedProperty"
 ArgumentValidationUtil.handleExtraFieldError=Validation error ({0}) : argument ''{1}'' with value ''{2}'' contains a field not in ''{3}'': ''{4}''
-#
+# suppress inspection "UnusedProperty"
+# suppress inspection "UnusedMessageFormatParameter"
+ArgumentValidationUtil.handleOneOfNotOneFieldError=Validation error ({0}) : Exactly one key must be specified for OneOf type ''{3}''.
+# suppress inspection "UnusedProperty"
+# suppress inspection "UnusedMessageFormatParameter"
+ArgumentValidationUtil.handleOneOfValueIsNullError=Validation error ({0}) : OneOf type field ''{3}'' must be non-null.

--- a/src/test/groovy/graphql/Issue2141.groovy
+++ b/src/test/groovy/graphql/Issue2141.groovy
@@ -36,6 +36,9 @@ directive @include(
     if: Boolean!
   ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
+"Indicates an Input Object is a OneOf Input Object."
+directive @oneOf on INPUT_OBJECT
+
 "Directs the executor to skip this field or fragment when the `if` argument is true."
 directive @skip(
     "Skipped when true."

--- a/src/test/groovy/graphql/StarWarsIntrospectionTests.groovy
+++ b/src/test/groovy/graphql/StarWarsIntrospectionTests.groovy
@@ -430,6 +430,6 @@ class StarWarsIntrospectionTests extends Specification {
         schemaParts.get('mutationType').size() == 1
         schemaParts.get('subscriptionType') == null
         schemaParts.get('types').size() == 17
-        schemaParts.get('directives').size() == 4
+        schemaParts.get('directives').size() == 5
     }
 }

--- a/src/test/groovy/graphql/introspection/IntrospectionTest.groovy
+++ b/src/test/groovy/graphql/introspection/IntrospectionTest.groovy
@@ -463,6 +463,7 @@ class IntrospectionTest extends Specification {
                 "    kind\n" +
                 "    name\n" +
                 "    description\n" +
+                "    isOneOf\n" +
                 "    fields(includeDeprecated: true) {\n" +
                 "      name\n" +
                 "      description\n" +
@@ -542,10 +543,11 @@ class IntrospectionTest extends Specification {
 
             def newIntrospectionQuery = IntrospectionQuery.INTROSPECTION_QUERY;
 
+
         then:
-            oldIntrospectionQuery.replaceAll("\\s+","").equals(
-                newIntrospectionQuery.replaceAll("\\s+","")
-            )
+        def oldQuery = oldIntrospectionQuery.replaceAll("\\s+", "")
+        def newQuery = newIntrospectionQuery.replaceAll("\\s+","")
+        oldQuery == newQuery
     }
 
     def "test parameterized introspection queries"() {
@@ -660,7 +662,7 @@ class IntrospectionTest extends Specification {
         oneOfInputType["isOneOf"] == true
 
         def queryType = types.find { it['name'] == 'Query' }
-        oneOfInputType["isOneOf"] == null
+        queryType["isOneOf"] == null
     }
 
 }

--- a/src/test/groovy/graphql/introspection/IntrospectionWithDirectivesSupportTest.groovy
+++ b/src/test/groovy/graphql/introspection/IntrospectionWithDirectivesSupportTest.groovy
@@ -89,7 +89,10 @@ class IntrospectionWithDirectivesSupportTest extends Specification {
 
         def schemaType = er.data["__schema"]
 
-        schemaType["directives"] == [[name: "include"], [name: "skip"], [name: "example"], [name: "secret"], [name: "noDefault"], [name: "deprecated"], [name: "specifiedBy"]]
+        schemaType["directives"] == [
+                [name: "include"], [name: "skip"], [name: "example"], [name: "secret"],
+                [name: "noDefault"], [name: "deprecated"], [name: "specifiedBy"], [name: "oneOf"]
+        ]
 
         schemaType["appliedDirectives"] == [[name: "example", args: [[name: "argName", value: '"onSchema"']]]]
 
@@ -170,7 +173,7 @@ class IntrospectionWithDirectivesSupportTest extends Specification {
 
         def definedDirectives = er.data["__schema"]["directives"]
         // secret is filter out
-        definedDirectives == [[name: "include"], [name: "skip"], [name: "example"], [name: "deprecated"], [name: "specifiedBy"]]
+        definedDirectives == [[name: "include"], [name: "skip"], [name: "example"], [name: "deprecated"], [name: "specifiedBy"], [name: "oneOf"]]
     }
 
     def "can set prefixes onto the Applied types"() {

--- a/src/test/groovy/graphql/schema/GraphQLInputObjectTypeTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLInputObjectTypeTest.groovy
@@ -1,8 +1,11 @@
 package graphql.schema
 
 import graphql.Directives
+import graphql.ExecutionInput
+import graphql.GraphQL
 import graphql.GraphQLContext
 import graphql.StarWarsSchema
+import graphql.TestUtil
 import graphql.language.ObjectValue
 import graphql.validation.ValidationUtil
 import spock.lang.Specification
@@ -104,5 +107,77 @@ class GraphQLInputObjectTypeTest extends Specification {
                 .build()
         then:
         inputObjectType.isOneOf()
+    }
+
+    def "e2e test of oneOf support"() {
+        def sdl = '''
+            type Query {
+                f(arg : OneOf) : [KV]
+            }
+            
+            type KV {
+                key : String
+                value : String
+            }
+            
+            input OneOf @oneOf {
+                a : String
+                b : Int
+            }
+        '''
+
+        DataFetcher df = { DataFetchingEnvironment env ->
+            Map<String, Object> arg = env.getArgument("arg")
+
+            def l = []
+            for (Map.Entry<String, Object> entry : arg.entrySet()) {
+                l.add(["key": entry.getKey(), "value": String.valueOf(entry.getValue())])
+            }
+            return l
+        }
+
+        def graphQLSchema = TestUtil.schema(sdl, [Query: [f: df]])
+        def graphQL = GraphQL.newGraphQL(graphQLSchema).build()
+
+        when:
+        def er = graphQL.execute('query q { f( arg : {a : "abc"}) { key value }}')
+        def l = (er.data["f"] as List)
+        then:
+        er.errors.isEmpty()
+        l.size() == 1
+        l[0]["key"] == "a"
+        l[0]["value"] == "abc"
+
+        when:
+        er = graphQL.execute('query q { f( arg : {b : 123}) { key value }}')
+        l = (er.data["f"] as List)
+
+        then:
+        er.errors.isEmpty()
+        l.size() == 1
+        l[0]["key"] == "b"
+        l[0]["value"] == "123"
+
+        when:
+        er = graphQL.execute('query q { f( arg : {a : "abc", b : 123}) { key value }}')
+        then:
+        !er.errors.isEmpty()
+        er.errors[0].message == "Exception while fetching data (/f) : Exactly one key must be specified for OneOf type 'OneOf'."
+
+        when:
+        def ei = ExecutionInput.newExecutionInput('query q($var : OneOf)  { f( arg : $var) { key value }}').variables([var: [a: "abc", b: 123]]).build()
+        er = graphQL.execute(ei)
+        then:
+        !er.errors.isEmpty()
+        er.errors[0].message == "Exception while fetching data (/f) : Exactly one key must be specified for OneOf type 'OneOf'."
+
+        when:
+        ei = ExecutionInput.newExecutionInput('query q($var : OneOf)  { f( arg : $var) { key value }}').variables([var: [a: null]]).build()
+        er = graphQL.execute(ei)
+        then:
+        !er.errors.isEmpty()
+        er.errors[0].message == "Exception while fetching data (/f) : OneOf type field 'OneOf.a' must be non-null."
+
+        // lots more covered in unit tests
     }
 }

--- a/src/test/groovy/graphql/schema/GraphQLInputObjectTypeTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLInputObjectTypeTest.groovy
@@ -1,5 +1,6 @@
 package graphql.schema
 
+import graphql.Directives
 import graphql.GraphQLContext
 import graphql.StarWarsSchema
 import graphql.language.ObjectValue
@@ -78,5 +79,30 @@ class GraphQLInputObjectTypeTest extends Specification {
 
         expect:
         validationUtil.isValidLiteralValue(objectValue.build(), inputObjectType, schema, graphQLContext, Locale.ENGLISH)
+    }
+
+    def "can detect one of support"() {
+        when:
+        def inputObjectType = newInputObject().name("TestInputObjectType")
+                .field(newInputObjectField().name("NAME").type(GraphQLInt))
+                .build()
+        then:
+        !inputObjectType.isOneOf()
+
+        when:
+        inputObjectType = newInputObject().name("TestInputObjectType")
+                .field(newInputObjectField().name("NAME").type(GraphQLInt))
+                .withDirective(Directives.OneOfDirective)
+                .build()
+        then:
+        inputObjectType.isOneOf()
+
+        when:
+        inputObjectType = newInputObject().name("TestInputObjectType")
+                .field(newInputObjectField().name("NAME").type(GraphQLInt))
+                .withAppliedDirective(Directives.OneOfDirective.toAppliedDirective())
+                .build()
+        then:
+        inputObjectType.isOneOf()
     }
 }

--- a/src/test/groovy/graphql/schema/GraphQLSchemaTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLSchemaTest.groovy
@@ -136,22 +136,22 @@ class GraphQLSchemaTest extends Specification {
         when: "no additional directives have been specified"
         def schema = schemaBuilder.build()
         then:
-        schema.directives.size() == 4
+        schema.directives.size() == 5
 
         when: "clear directives is called"
         schema = schemaBuilder.clearDirectives().build()
         then:
-        schema.directives.size() == 2 // @deprecated and @specifiedBy is ALWAYS added if missing
+        schema.directives.size() == 3 // @deprecated and @specifiedBy and @oneOf is ALWAYS added if missing
 
         when: "clear directives is called with more directives"
         schema = schemaBuilder.clearDirectives().additionalDirective(Directives.SkipDirective).build()
         then:
-        schema.directives.size() == 3
+        schema.directives.size() == 4
 
         when: "the schema is transformed, things are copied"
         schema = schema.transform({ builder -> builder.additionalDirective(Directives.IncludeDirective) })
         then:
-        schema.directives.size() == 4
+        schema.directives.size() == 5
     }
 
     def "clear additional types works as expected"() {

--- a/src/test/groovy/graphql/schema/diffing/SchemaDiffingTest.groovy
+++ b/src/test/groovy/graphql/schema/diffing/SchemaDiffingTest.groovy
@@ -34,14 +34,14 @@ class SchemaDiffingTest extends Specification {
         schemaGraph.getVerticesByType(SchemaGraph.INTERFACE).size() == 0
         schemaGraph.getVerticesByType(SchemaGraph.UNION).size() == 0
         schemaGraph.getVerticesByType(SchemaGraph.SCALAR).size() == 2
-        schemaGraph.getVerticesByType(SchemaGraph.FIELD).size() == 39
+        schemaGraph.getVerticesByType(SchemaGraph.FIELD).size() == 40
         schemaGraph.getVerticesByType(SchemaGraph.ARGUMENT).size() == 9
         schemaGraph.getVerticesByType(SchemaGraph.INPUT_FIELD).size() == 0
         schemaGraph.getVerticesByType(SchemaGraph.INPUT_OBJECT).size() == 0
-        schemaGraph.getVerticesByType(SchemaGraph.DIRECTIVE).size() == 4
+        schemaGraph.getVerticesByType(SchemaGraph.DIRECTIVE).size() == 5
         schemaGraph.getVerticesByType(SchemaGraph.APPLIED_ARGUMENT).size() == 0
         schemaGraph.getVerticesByType(SchemaGraph.APPLIED_DIRECTIVE).size() == 0
-        schemaGraph.size() == 91
+        schemaGraph.size() == 93
 
     }
 

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorAppliedDirectiveHelperTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorAppliedDirectiveHelperTest.groovy
@@ -58,6 +58,7 @@ class SchemaGeneratorAppliedDirectiveHelperTest extends Specification {
                 "deprecated",
                 "foo",
                 "include",
+                "oneOf",
                 "skip",
                 "specifiedBy",
         ]
@@ -107,6 +108,7 @@ class SchemaGeneratorAppliedDirectiveHelperTest extends Specification {
                 "deprecated",
                 "foo",
                 "include",
+                "oneOf",
                 "skip",
                 "specifiedBy",
         ]

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -2052,11 +2052,13 @@ class SchemaGeneratorTest extends Specification {
         directives = schema.getDirectives()
 
         then:
-        directives.size() == 7 // built in ones :  include / skip and deprecated
+        directives.size() == 8 // built in ones :  include / skip and deprecated
         def directiveNames = directives.collect { it.name }
         directiveNames.contains("include")
         directiveNames.contains("skip")
         directiveNames.contains("deprecated")
+        directiveNames.contains("specifiedBy")
+        directiveNames.contains("oneOf")
         directiveNames.contains("sd1")
         directiveNames.contains("sd2")
         directiveNames.contains("sd3")
@@ -2065,10 +2067,11 @@ class SchemaGeneratorTest extends Specification {
         directivesMap = schema.getDirectivesByName()
 
         then:
-        directivesMap.size() == 7 // built in ones
+        directivesMap.size() == 8 // built in ones
         directivesMap.containsKey("include")
         directivesMap.containsKey("skip")
         directivesMap.containsKey("deprecated")
+        directivesMap.containsKey("oneOf")
         directivesMap.containsKey("sd1")
         directivesMap.containsKey("sd2")
         directivesMap.containsKey("sd3")

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -2536,4 +2536,26 @@ class SchemaGeneratorTest extends Specification {
         newSchema.getDirectives().findAll { it.name == "skip" }.size() == 1
         newSchema.getDirectives().findAll { it.name == "include" }.size() == 1
     }
+
+    def "oneOf directive is available implicitly"() {
+        def sdl = '''
+            type Query {
+                f(arg : OneOfInputType) : String
+            }
+            
+            input OneOfInputType @oneOf {
+                a : String
+                b : String
+            }
+        '''
+
+        when:
+        def schema = TestUtil.schema(sdl)
+        then:
+        schema.getDirectives().findAll { it.name == "oneOf" }.size() == 1
+
+        GraphQLInputObjectType inputObjectType = schema.getTypeAs("OneOfInputType")
+        inputObjectType.isOneOf()
+        inputObjectType.hasAppliedDirective("oneOf")
+    }
 }

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -2311,6 +2311,9 @@ directive @include(
     if: Boolean!
   ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
+"Indicates an Input Object is a OneOf Input Object."
+directive @oneOf on INPUT_OBJECT
+
 "Directs the executor to skip this field or fragment when the `if` argument is true."
 directive @skip(
     "Skipped when true."
@@ -2543,6 +2546,9 @@ directive @include(
     "Included when true."
     if: Boolean!
   ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"Indicates an Input Object is a OneOf Input Object."
+directive @oneOf on INPUT_OBJECT
 
 "Directs the executor to skip this field or fragment when the `if` argument is true."
 directive @skip(

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -980,6 +980,9 @@ directive @interfaceImplementingTypeDirective on OBJECT
 
 directive @interfaceTypeDirective on INTERFACE
 
+"Indicates an Input Object is a OneOf Input Object."
+directive @oneOf on INPUT_OBJECT
+
 directive @query1 repeatable on OBJECT
 
 directive @query2(arg1: String) on OBJECT
@@ -1133,6 +1136,9 @@ directive @include(
     if: Boolean!
   ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
+"Indicates an Input Object is a OneOf Input Object."
+directive @oneOf on INPUT_OBJECT
+
 "Directs the executor to skip this field or fragment when the `if` argument is true."
 directive @skip(
     "Skipped when true."
@@ -1230,6 +1236,9 @@ directive @include(
 
 directive @moreComplex(arg1: String = "default", arg2: Int) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
+"Indicates an Input Object is a OneOf Input Object."
+directive @oneOf on INPUT_OBJECT
+
 "Directs the executor to skip this field or fragment when the `if` argument is true."
 directive @skip(
     "Skipped when true."
@@ -1294,6 +1303,9 @@ directive @include(
   ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
 directive @moreComplex(arg1: String = "default", arg2: Int) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+"Indicates an Input Object is a OneOf Input Object."
+directive @oneOf on INPUT_OBJECT
 
 "Directs the executor to skip this field or fragment when the `if` argument is true."
 directive @skip(
@@ -1426,6 +1438,9 @@ directive @include(
     "Included when true."
     if: Boolean!
   ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"Indicates an Input Object is a OneOf Input Object."
+directive @oneOf on INPUT_OBJECT
 
 "Directs the executor to skip this field or fragment when the `if` argument is true."
 directive @skip(
@@ -1929,6 +1944,9 @@ directive @include(
     if: Boolean!
   ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
+"Indicates an Input Object is a OneOf Input Object."
+directive @oneOf on INPUT_OBJECT
+
 "Directs the executor to skip this field or fragment when the `if` argument is true."
 directive @skip(
     "Skipped when true."
@@ -2134,6 +2152,9 @@ directive @skip(
     "Skipped when true."
     if: Boolean!
   ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"Indicates an Input Object is a OneOf Input Object."
+directive @oneOf on INPUT_OBJECT
 
 "Directs the executor to include this field or fragment only when the `if` argument is true"
 directive @include(

--- a/src/test/groovy/graphql/schema/validation/OneOfInputObjectRulesTest.groovy
+++ b/src/test/groovy/graphql/schema/validation/OneOfInputObjectRulesTest.groovy
@@ -1,0 +1,36 @@
+package graphql.schema.validation
+
+import graphql.TestUtil
+import graphql.schema.idl.SchemaGenerator
+import graphql.schema.idl.SchemaParser
+import spock.lang.Specification
+
+class OneOfInputObjectRulesTest extends Specification {
+
+    def "oneOf fields must be the right shape"() {
+
+        def sdl = """
+            type Query {
+                f(arg : OneOfInputType) : String
+            }
+            
+            input OneOfInputType @oneOf {
+                ok : String
+                badNonNull : String!
+                badDefaulted : String = "default"
+            }
+        """
+
+        when:
+        def registry = new SchemaParser().parse(sdl)
+        new SchemaGenerator().makeExecutableSchema(registry, TestUtil.getMockRuntimeWiring())
+
+        then:
+        def schemaProblem = thrown(InvalidSchemaException)
+        schemaProblem.errors.size() == 2
+        schemaProblem.errors[0].description == "OneOf input field OneOfInputType.badNonNull must be nullable."
+        schemaProblem.errors[0].classification == SchemaValidationErrorType.OneOfNonNullableField
+        schemaProblem.errors[1].description == "OneOf input field OneOfInputType.badDefaulted cannot have a default value."
+        schemaProblem.errors[1].classification == SchemaValidationErrorType.OneOfDefaultValueOnField
+    }
+}

--- a/src/test/groovy/graphql/schema/validation/SchemaValidatorTest.groovy
+++ b/src/test/groovy/graphql/schema/validation/SchemaValidatorTest.groovy
@@ -11,7 +11,7 @@ class SchemaValidatorTest extends Specification {
         def validator = new SchemaValidator()
         def rules = validator.rules
         then:
-        rules.size() == 7
+        rules.size() == 8
         rules[0] instanceof NoUnbrokenInputCycles
         rules[1] instanceof TypesImplementInterfaces
         rules[2] instanceof TypeAndFieldRule
@@ -19,6 +19,6 @@ class SchemaValidatorTest extends Specification {
         rules[4] instanceof AppliedDirectivesAreValid
         rules[5] instanceof AppliedDirectiveArgumentsAreValid
         rules[6] instanceof InputAndOutputTypesUsedAppropriately
+        rules[7] instanceof OneOfInputObjectRules
     }
-
 }

--- a/src/test/groovy/graphql/validation/SpecValidationSchema.java
+++ b/src/test/groovy/graphql/validation/SpecValidationSchema.java
@@ -1,5 +1,6 @@
 package graphql.validation;
 
+import graphql.Directives;
 import graphql.Scalars;
 import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLCodeRegistry;
@@ -184,6 +185,18 @@ public class SpecValidationSchema {
             .validLocations(FIELD, FRAGMENT_SPREAD, FRAGMENT_DEFINITION, INLINE_FRAGMENT, QUERY)
             .build();
 
+    public static final GraphQLInputObjectType oneOfInputType = GraphQLInputObjectType.newInputObject()
+            .name("oneOfInputType")
+            .withAppliedDirective(Directives.OneOfDirective.toAppliedDirective())
+            .field(GraphQLInputObjectField.newInputObjectField()
+                    .name("a")
+                    .type(GraphQLString))
+            .field(GraphQLInputObjectField.newInputObjectField()
+                    .name("b")
+                    .type(GraphQLString))
+            .build();
+
+
     public static final GraphQLObjectType queryRoot = GraphQLObjectType.newObject()
             .name("QueryRoot")
             .field(newFieldDefinition().name("dog").type(dog)
@@ -191,6 +204,9 @@ public class SpecValidationSchema {
                     .withDirective(dogDirective)
             )
             .field(newFieldDefinition().name("pet").type(pet))
+            .field(newFieldDefinition().name("oneOfField").type(GraphQLString)
+                    .argument(newArgument().name("oneOfArg").type(oneOfInputType).build())
+            )
             .build();
 
     public static final GraphQLObjectType subscriptionRoot = GraphQLObjectType.newObject()

--- a/src/test/groovy/graphql/validation/rules/ArgumentsOfCorrectTypeTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/ArgumentsOfCorrectTypeTest.groovy
@@ -335,51 +335,6 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         validationErrors.get(0).message == "Validation error (WrongType@[dog/doesKnowCommand]) : argument 'dogCommand' with value 'EnumValue{name='PRETTY'}' is not a valid 'DogCommand' - Literal value not in allowable values for enum 'DogCommand' - 'EnumValue{name='PRETTY'}'"
     }
 
-    def "invalid oneOf input because of two keys"() {
-        def query = """
-            query oneOF {
-                oneOfField(oneOfArg : { a : "x", b : "y" })
-            }
-        """
-        when:
-        def validationErrors = validate(query)
-
-        then:
-        !validationErrors.empty
-        validationErrors.size() == 1
-        validationErrors.get(0).getValidationErrorType() == ValidationErrorType.WrongType
-        validationErrors.get(0).message == "Validation error (WrongType@[oneOfField]) : Exactly one key must be specified for OneOf type 'oneOfInputType'."
-    }
-
-    def "invalid oneOf input because of null key"() {
-        def query = """
-            query oneOF {
-                oneOfField(oneOfArg : { a : null })
-            }
-        """
-        when:
-        def validationErrors = validate(query)
-
-        then:
-        !validationErrors.empty
-        validationErrors.size() == 1
-        validationErrors.get(0).getValidationErrorType() == ValidationErrorType.WrongType
-        validationErrors.get(0).message == "Validation error (WrongType@[oneOfField]) : OneOf type field 'oneOfInputType.a' must be non-null."
-    }
-
-    def "valid oneOf input"() {
-        def query = """
-            query oneOF {
-                oneOfField(oneOfArg : { a : "x" })
-            }
-        """
-        when:
-        def validationErrors = validate(query)
-
-        then:
-        validationErrors.empty
-    }
-
     static List<ValidationError> validate(String query) {
         def document = new Parser().parseDocument(query)
         return new Validator().validateDocument(SpecValidationSchema.specValidationSchema, document, Locale.ENGLISH)

--- a/src/test/groovy/graphql/validation/rules/ArgumentsOfCorrectTypeTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/ArgumentsOfCorrectTypeTest.groovy
@@ -335,6 +335,51 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         validationErrors.get(0).message == "Validation error (WrongType@[dog/doesKnowCommand]) : argument 'dogCommand' with value 'EnumValue{name='PRETTY'}' is not a valid 'DogCommand' - Literal value not in allowable values for enum 'DogCommand' - 'EnumValue{name='PRETTY'}'"
     }
 
+    def "invalid oneOf input because of two keys"() {
+        def query = """
+            query oneOF {
+                oneOfField(oneOfArg : { a : "x", b : "y" })
+            }
+        """
+        when:
+        def validationErrors = validate(query)
+
+        then:
+        !validationErrors.empty
+        validationErrors.size() == 1
+        validationErrors.get(0).getValidationErrorType() == ValidationErrorType.WrongType
+        validationErrors.get(0).message == "Validation error (WrongType@[oneOfField]) : Exactly one key must be specified for OneOf type 'oneOfInputType'."
+    }
+
+    def "invalid oneOf input because of null key"() {
+        def query = """
+            query oneOF {
+                oneOfField(oneOfArg : { a : null })
+            }
+        """
+        when:
+        def validationErrors = validate(query)
+
+        then:
+        !validationErrors.empty
+        validationErrors.size() == 1
+        validationErrors.get(0).getValidationErrorType() == ValidationErrorType.WrongType
+        validationErrors.get(0).message == "Validation error (WrongType@[oneOfField]) : OneOf type field 'oneOfInputType.a' must be non-null."
+    }
+
+    def "valid oneOf input"() {
+        def query = """
+            query oneOF {
+                oneOfField(oneOfArg : { a : "x" })
+            }
+        """
+        when:
+        def validationErrors = validate(query)
+
+        then:
+        validationErrors.empty
+    }
+
     static List<ValidationError> validate(String query) {
         def document = new Parser().parseDocument(query)
         return new Validator().validateDocument(SpecValidationSchema.specValidationSchema, document, Locale.ENGLISH)


### PR DESCRIPTION
This PR provides `@oneOf` support to graphql-java

related to https://github.com/graphql-java/graphql-java/issues/3266

This is now complete.  

The error messages here are inspired by the graphql-js versions.

I chose to add `isOneOf` into our pre built Introspection queries  by default and have an option to turn it off if it causes problems (I dont see how it would be just in case)

I am a fan of the directive based approach of this mechanism

This code is considered experimental namely because the spec has not been accepted.  The PR has been put into the reference implementation graphql-js however so its not pie in the sky stuff