### PR TITLE
19.x Guava update again

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,7 +127,7 @@ shadowJar {
     }
     relocate('org.antlr.v4.runtime', 'graphql.org.antlr.v4.runtime')
     dependencies {
-        include(dependency('com.google.guava:guava:32.0.0-jre'))
+        include(dependency('com.google.guava:guava:32.1.1-jre'))
         include(dependency('org.antlr:antlr4-runtime:' + antlrVersion))
     }
     from "LICENSE.md"


### PR DESCRIPTION
Update Guava ahead of patch release

Some security scanners incorrectly flagged the older version as vulnerable https://github.com/graphql-java/graphql-java/issues/3263

Note that the graphql-java was never vulnerable. We shade in selected classes which are not related to the vulnerability. This is an update to keep security scanners happy.