### PR TITLE
18.x Guava Updated to 32.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ dependencies {
     api 'com.graphql-java:java-dataloader:3.1.2'
     api 'org.reactivestreams:reactive-streams:' + reactiveStreamsVersion
     antlr 'org.antlr:antlr4:' + antlrVersion
-    implementation 'com.google.guava:guava:32.0.0-jre'
+    implementation 'com.google.guava:guava:32.1.1-jre'
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation 'org.spockframework:spock-core:2.0-groovy-3.0'
     testImplementation 'org.codehaus.groovy:groovy:3.0.9'

--- a/build.gradle
+++ b/build.gradle
@@ -123,7 +123,7 @@ shadowJar {
         include 'com.google.common.primitives.*'
     }
     dependencies {
-        include(dependency('com.google.guava:guava:32.0.0-jre'))
+        include(dependency('com.google.guava:guava:32.1.1-jre'))
     }
     from "LICENSE.md"
     from "src/main/antlr/Graphql.g4"


### PR DESCRIPTION
Updating guava version to 32.1.1

Some security scanners incorrectly flagged the older version as vulnerable https://github.com/graphql-java/graphql-java/issues/3263

Note that the graphql-java was never vulnerable. It shades in selected classes which are not related to the vulnerability. This is an update to keep security scanners happy.