### PR TITLE
Wrap NumberFormatException

### DIFF
--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -669,7 +669,12 @@ public class GraphqlAntlrToLanguage {
             addCommonData(intValue, ctx);
             return captureRuleContext(intValue.build(), ctx);
         } else if (ctx.FloatValue() != null) {
-            FloatValue.Builder floatValue = FloatValue.newFloatValue().value(new BigDecimal(ctx.FloatValue().getText()));
+            FloatValue.Builder floatValue;
+            try {
+                floatValue = FloatValue.newFloatValue().value(new BigDecimal(ctx.FloatValue().getText()));
+            } catch (NumberFormatException e) {
+                throw new InvalidSyntaxException("Invalid floating point value", null, ctx.FloatValue().getText(), null, e);
+            }
             addCommonData(floatValue, ctx);
             return captureRuleContext(floatValue.build(), ctx);
         } else if (ctx.BooleanValue() != null) {

--- a/src/main/java/graphql/parser/UnicodeUtil.java
+++ b/src/main/java/graphql/parser/UnicodeUtil.java
@@ -33,7 +33,12 @@ public class UnicodeUtil {
         int continueIndex = isBracedEscape(string, i) ? endIndexExclusive : endIndexExclusive - 1;
 
         String hexStr = string.substring(startIndex, endIndexExclusive);
-        int codePoint = Integer.parseInt(hexStr, 16);
+        int codePoint;
+        try {
+            codePoint = Integer.parseInt(hexStr, 16);
+        } catch (NumberFormatException e) {
+            throw new InvalidUnicodeSyntaxException(i18n, "InvalidUnicode.invalidHexString", sourceLocation, offendingToken(string, i, continueIndex));
+        }
 
         if (isTrailingSurrogateValue(codePoint)) {
             throw new InvalidUnicodeSyntaxException(i18n, "InvalidUnicode.trailingLeadingSurrogate", sourceLocation, offendingToken(string, i, continueIndex));

--- a/src/test/java/graphql/schema/idl/SchemaParserTest.java
+++ b/src/test/java/graphql/schema/idl/SchemaParserTest.java
@@ -1,0 +1,23 @@
+package graphql.schema.idl;
+
+import org.testng.annotations.Test;
+import graphql.GraphQLException;
+
+public class SchemaParserTest {
+
+    @Test
+    public void testNumberFormatException() {
+      String[] malformedStrings = {
+        "{B(t:66E3333333320,t:#\n66666666660)},622»» »»»6666662}}6666660t:z6666"
+      };
+
+      for (String malformed : malformedStrings) {
+        try {
+          SchemaParser parser = new SchemaParser();
+          parser.parse(malformed);
+        } catch (GraphQLException e) {
+          // Known exception
+        }
+      }
+    }
+}


### PR DESCRIPTION
This fixes a possible unwrapped NumberFormatException in src/main/java/graphql/parser/UnicodeUtil.java and src/main/java/graphql/parser/GraphqlAntlrToLanguage.java while parsing possibly malformed schema.


There are some places in the parser that require parsing numeric values from string to different numeric class types. When some of the text values contain invalid number representation, NumberFormatException are thrown. For example in [Line 672](https://github.com/graphql-java/graphql-java/blob/master/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java#L672) of GraphqlAntlrToLanguage class, the constructor call to the BigDecimal object will throw a NumberFormatException if the float value text has a long exponent which overflows the variable. This internal NumberFormatException is not wrapped or handled and thrown directly to the user and crashes the program. It is better to capture and handle it or wrap it with a project defined exception and error message. 


This PR adds an additional try catch block to capture and wrap the NumberFormatException with the InvalidSyntaxException to indicate there is some invalid syntax in the provided schema.


We found this bug using fuzzing by way of OSS-Fuzz, where we recently integrated graphql-java (https://github.com/google/oss-fuzz/pull/10748). OSS-Fuzz is a free service run by Google for fuzzing important open source software. If you'd like to know more about this then I'm happy to go into detail and also set up things so you can receive emails and detailed reports when bugs are found.
