### PR TITLE
deprecated default value method produces bad results

### DIFF
--- a/src/main/java/graphql/execution/ValuesResolverConversion.java
+++ b/src/main/java/graphql/execution/ValuesResolverConversion.java
@@ -69,11 +69,17 @@ class ValuesResolverConversion {
             if (valueMode == NORMALIZED) {
                 return assertShouldNeverHappen("can't infer normalized structure");
             }
-            return ValuesResolverLegacy.valueToLiteralLegacy(
+            Value<?> value = ValuesResolverLegacy.valueToLiteralLegacy(
                     inputValueWithState.getValue(),
                     type,
                     graphqlContext,
                     locale);
+            //
+            // the valueToLiteralLegacy() nominally cant know if null means never set or is set to a null value
+            // but this code can know - its is SET to a value so, it MUST be a Null Literal
+            // this method would assert at the end of it if inputValueWithState.isNotSet() were true
+            //
+            return value == null ? NullValue.of() : value;
         }
         if (inputValueWithState.isLiteral()) {
             return inputValueWithState.getValue();

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -2250,7 +2250,7 @@ type TestObjectB {
 '''
     }
 
-    def "deprecated defaultValue on programmatic args prints as expected"() {
+    def "issue 3285 - deprecated defaultValue on programmatic args prints as expected"() {
         def queryObjType = newObject().name("Query")
                 .field(newFieldDefinition().name("f").type(GraphQLString)
                         .argument(newArgument().name("arg").type(GraphQLString).defaultValue(null)))
@@ -2262,8 +2262,7 @@ type TestObjectB {
         def options = defaultOptions().includeDirectiveDefinitions(false)
         def sdl = new SchemaPrinter(options).print(schema)
         then:
-        sdl == '''
-type Query {
+        sdl == '''type Query {
   f(arg: String = null): String
 }
 '''

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -2249,4 +2249,23 @@ type TestObjectB {
 }
 '''
     }
+
+    def "deprecated defaultValue on programmatic args prints as expected"() {
+        def queryObjType = newObject().name("Query")
+                .field(newFieldDefinition().name("f").type(GraphQLString)
+                        .argument(newArgument().name("arg").type(GraphQLString).defaultValue(null)))
+                .build()
+        def schema = GraphQLSchema.newSchema().query(queryObjType).build()
+
+
+        when:
+        def options = defaultOptions().includeDirectiveDefinitions(false)
+        def sdl = new SchemaPrinter(options).print(schema)
+        then:
+        sdl == '''
+type Query {
+  f(arg: String = null): String
+}
+'''
+    }
 }


### PR DESCRIPTION
This fixes the deprecated `defaultValue` input of null values when an AST literal is required - eg in schema printing and introspection.

see #3285 