### PR TITLE
19.x backport of #3286 null default value bugfix

### DIFF
--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -220,7 +220,15 @@ public class ValuesResolver {
             if (valueMode == NORMALIZED) {
                 return assertShouldNeverHappen("can't infer normalized structure");
             }
-            return valueToLiteralLegacy(inputValueWithState.getValue(), type);
+            Value<?> value = valueToLiteralLegacy(
+                    inputValueWithState.getValue(),
+                    type);
+            //
+            // the valueToLiteralLegacy() nominally cant know if null means never set or is set to a null value
+            // but this code can know - its is SET to a value so, it MUST be a Null Literal
+            // this method would assert at the end of it if inputValueWithState.isNotSet() were true
+            //
+            return value == null ? NullValue.of() : value;
         }
         if (inputValueWithState.isLiteral()) {
             return inputValueWithState.getValue();

--- a/src/main/java/graphql/util/FpKit.java
+++ b/src/main/java/graphql/util/FpKit.java
@@ -335,6 +335,7 @@ public class FpKit {
      *
      * @param set1 first set
      * @param set2 second set
+     * @param <T>      for two
      * @return intersection set
      */
     public static <T> Set<T> intersection(Set<T> set1, Set<T> set2) {

--- a/src/test/groovy/graphql/introspection/IntrospectionTest.groovy
+++ b/src/test/groovy/graphql/introspection/IntrospectionTest.groovy
@@ -7,6 +7,7 @@ import graphql.schema.FieldCoordinates
 import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLFieldsContainer
 import graphql.schema.GraphQLNamedType
+import graphql.schema.GraphQLObjectType
 import spock.lang.Issue
 import spock.lang.See
 import spock.lang.Specification

--- a/src/test/groovy/graphql/introspection/IntrospectionTest.groovy
+++ b/src/test/groovy/graphql/introspection/IntrospectionTest.groovy
@@ -1,5 +1,6 @@
 package graphql.introspection
 
+
 import graphql.TestUtil
 import graphql.schema.DataFetcher
 import graphql.schema.FieldCoordinates
@@ -352,5 +353,27 @@ class IntrospectionTest extends Specification {
 
         then:
         queryTypeFields == [[name: "inA"], [name: "inB"], [name: "inC"]]
+    }
+
+    def "issue 3285 - deprecated defaultValue on programmatic args prints AST literal as expected"() {
+        def queryObjType = GraphQLObjectType.newObject().name("Query")
+                .field(newFieldDefinition().name("f").type(GraphQLString)
+                        .argument(newArgument().name("arg").type(GraphQLString).defaultValue(null)))
+                .build()
+        def schema = newSchema().query(queryObjType).build()
+        def graphQL = newGraphQL(schema).build()
+
+
+        when:
+        def executionResult = graphQL.execute(IntrospectionQuery.INTROSPECTION_QUERY)
+        then:
+        executionResult.errors.isEmpty()
+
+        def types = executionResult.data['__schema']['types'] as List
+        def queryType = types.find { it['name'] == 'Query' }
+        def fField = (queryType['fields'] as List)[0]
+        def arg = (fField['args'] as List)[0]
+        arg['name'] == "arg"
+        arg['defaultValue'] == "null" // printed AST
     }
 }

--- a/src/test/groovy/graphql/introspection/IntrospectionTest.groovy
+++ b/src/test/groovy/graphql/introspection/IntrospectionTest.groovy
@@ -16,6 +16,7 @@ import static graphql.Scalars.GraphQLString
 import static graphql.schema.GraphQLArgument.newArgument
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
 import static graphql.schema.GraphQLObjectType.newObject
+import static graphql.schema.GraphQLSchema.newSchema
 
 class IntrospectionTest extends Specification {
 

--- a/src/test/groovy/graphql/introspection/IntrospectionTest.groovy
+++ b/src/test/groovy/graphql/introspection/IntrospectionTest.groovy
@@ -7,12 +7,15 @@ import graphql.schema.FieldCoordinates
 import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLFieldsContainer
 import graphql.schema.GraphQLNamedType
-import graphql.schema.GraphQLObjectType
 import spock.lang.Issue
 import spock.lang.See
 import spock.lang.Specification
 
 import static graphql.GraphQL.newGraphQL
+import static graphql.Scalars.GraphQLString
+import static graphql.schema.GraphQLArgument.newArgument
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
+import static graphql.schema.GraphQLObjectType.newObject
 
 class IntrospectionTest extends Specification {
 
@@ -357,7 +360,7 @@ class IntrospectionTest extends Specification {
     }
 
     def "issue 3285 - deprecated defaultValue on programmatic args prints AST literal as expected"() {
-        def queryObjType = GraphQLObjectType.newObject().name("Query")
+        def queryObjType = newObject().name("Query")
                 .field(newFieldDefinition().name("f").type(GraphQLString)
                         .argument(newArgument().name("arg").type(GraphQLString).defaultValue(null)))
                 .build()

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -2195,4 +2195,22 @@ type TestObjectB {
 }
 '''
     }
+
+    def "issue 3285 - deprecated defaultValue on programmatic args prints as expected"() {
+        def queryObjType = newObject().name("Query")
+                .field(newFieldDefinition().name("f").type(GraphQLString)
+                        .argument(newArgument().name("arg").type(GraphQLString).defaultValue(null)))
+                .build()
+        def schema = GraphQLSchema.newSchema().query(queryObjType).build()
+
+
+        when:
+        def options = defaultOptions().includeDirectiveDefinitions(false)
+        def sdl = new SchemaPrinter(options).print(schema)
+        then:
+        sdl == '''type Query {
+  f(arg: String = null): String
+}
+'''
+    }
 }


### PR DESCRIPTION
This PR backports null value default value bugfix https://github.com/graphql-java/graphql-java/pull/3286 to v19.

Keep in mind, back in v19 we had not yet split up ValuesResolver, so methods are in different places.