### PR TITLE
add directiveName as property to AppliedDirectiveLocationDetail

### DIFF
--- a/src/main/java/graphql/schema/diffing/ana/EditOperationAnalyzer.java
+++ b/src/main/java/graphql/schema/diffing/ana/EditOperationAnalyzer.java
@@ -244,7 +244,7 @@ public class EditOperationAnalyzer {
             if (isObjectDeleted(object.getName())) {
                 return;
             }
-            AppliedDirectiveObjectLocation location = new AppliedDirectiveObjectLocation(object.getName());
+            AppliedDirectiveObjectLocation location = new AppliedDirectiveObjectLocation(object.getName(), appliedDirective.getName());
             AppliedDirectiveDeletion appliedDirectiveDeletion = new AppliedDirectiveDeletion(location, appliedDirective.getName());
             getObjectModification(object.getName()).getDetails().add(appliedDirectiveDeletion);
         } else if (container.isOfType(SchemaGraph.INTERFACE)) {
@@ -252,7 +252,7 @@ public class EditOperationAnalyzer {
             if (isInterfaceDeleted(interfaze.getName())) {
                 return;
             }
-            AppliedDirectiveInterfaceLocation location = new AppliedDirectiveInterfaceLocation(interfaze.getName());
+            AppliedDirectiveInterfaceLocation location = new AppliedDirectiveInterfaceLocation(interfaze.getName(), appliedDirective.getName());
             AppliedDirectiveDeletion appliedDirectiveDeletion = new AppliedDirectiveDeletion(location, appliedDirective.getName());
             getInterfaceModification(interfaze.getName()).getDetails().add(appliedDirectiveDeletion);
         } else if (container.isOfType(SchemaGraph.SCALAR)) {
@@ -260,7 +260,7 @@ public class EditOperationAnalyzer {
             if (isScalarDeleted(scalar.getName())) {
                 return;
             }
-            AppliedDirectiveScalarLocation location = new AppliedDirectiveScalarLocation(scalar.getName());
+            AppliedDirectiveScalarLocation location = new AppliedDirectiveScalarLocation(scalar.getName(), appliedDirective.getName());
             AppliedDirectiveDeletion appliedDirectiveDeletion = new AppliedDirectiveDeletion(location, appliedDirective.getName());
             getScalarModification(scalar.getName()).getDetails().add(appliedDirectiveDeletion);
         } else if (container.isOfType(SchemaGraph.ENUM)) {
@@ -268,7 +268,7 @@ public class EditOperationAnalyzer {
             if (isEnumDeleted(enumVertex.getName())) {
                 return;
             }
-            AppliedDirectiveEnumLocation location = new AppliedDirectiveEnumLocation(enumVertex.getName());
+            AppliedDirectiveEnumLocation location = new AppliedDirectiveEnumLocation(enumVertex.getName(), appliedDirective.getName());
             AppliedDirectiveDeletion appliedDirectiveDeletion = new AppliedDirectiveDeletion(location, appliedDirective.getName());
             getEnumModification(enumVertex.getName()).getDetails().add(appliedDirectiveDeletion);
         } else if (container.isOfType(SchemaGraph.ENUM_VALUE)) {
@@ -280,7 +280,7 @@ public class EditOperationAnalyzer {
             if (isEnumValueDeletedFromExistingEnum(enumVertex.getName(), enumValue.getName())) {
                 return;
             }
-            AppliedDirectiveEnumValueLocation location = new AppliedDirectiveEnumValueLocation(enumVertex.getName(), enumValue.getName());
+            AppliedDirectiveEnumValueLocation location = new AppliedDirectiveEnumValueLocation(enumVertex.getName(), enumValue.getName(), appliedDirective.getName());
             AppliedDirectiveDeletion appliedDirectiveDeletion = new AppliedDirectiveDeletion(location, appliedDirective.getName());
             getEnumModification(enumVertex.getName()).getDetails().add(appliedDirectiveDeletion);
         } else if (container.isOfType(SchemaGraph.INPUT_OBJECT)) {
@@ -288,7 +288,7 @@ public class EditOperationAnalyzer {
             if (isInputObjectDeleted(inputObject.getName())) {
                 return;
             }
-            AppliedDirectiveInputObjectLocation location = new AppliedDirectiveInputObjectLocation(inputObject.getName());
+            AppliedDirectiveInputObjectLocation location = new AppliedDirectiveInputObjectLocation(inputObject.getName(), appliedDirective.getName());
             AppliedDirectiveDeletion appliedDirectiveDeletion = new AppliedDirectiveDeletion(location, appliedDirective.getName());
             getInputObjectModification(inputObject.getName()).getDetails().add(appliedDirectiveDeletion);
         } else if (container.isOfType(SchemaGraph.INPUT_FIELD)) {
@@ -300,7 +300,7 @@ public class EditOperationAnalyzer {
             if (isInputFieldDeletedFromExistingInputObject(inputObject.getName(), inputField.getName())) {
                 return;
             }
-            AppliedDirectiveInputObjectFieldLocation location = new AppliedDirectiveInputObjectFieldLocation(inputObject.getName(), inputField.getName());
+            AppliedDirectiveInputObjectFieldLocation location = new AppliedDirectiveInputObjectFieldLocation(inputObject.getName(), inputField.getName(), appliedDirective.getName());
             AppliedDirectiveDeletion appliedDirectiveDeletion = new AppliedDirectiveDeletion(location, appliedDirective.getName());
             getInputObjectModification(inputObject.getName()).getDetails().add(appliedDirectiveDeletion);
         } else if (container.isOfType(SchemaGraph.UNION)) {
@@ -308,7 +308,7 @@ public class EditOperationAnalyzer {
             if (isUnionDeleted(union.getName())) {
                 return;
             }
-            AppliedDirectiveUnionLocation location = new AppliedDirectiveUnionLocation(union.getName());
+            AppliedDirectiveUnionLocation location = new AppliedDirectiveUnionLocation(union.getName(), appliedDirective.getName());
             AppliedDirectiveDeletion appliedDirectiveDeletion = new AppliedDirectiveDeletion(location, appliedDirective.getName());
             getUnionModification(union.getName()).getDetails().add(appliedDirectiveDeletion);
         }
@@ -327,7 +327,7 @@ public class EditOperationAnalyzer {
                 if (isObjectDeleted(object.getName())) {
                     return;
                 }
-                AppliedDirectiveObjectFieldLocation location = new AppliedDirectiveObjectFieldLocation(object.getName(), field.getName());
+                AppliedDirectiveObjectFieldLocation location = new AppliedDirectiveObjectFieldLocation(object.getName(), field.getName(), appliedDirective.getName());
                 getObjectModification(object.getName()).getDetails().add(new AppliedDirectiveArgumentDeletion(location, deletedArgument.getName()));
             } else {
                 assertTrue(interfaceOrObjective.isOfType(SchemaGraph.INTERFACE));
@@ -335,7 +335,7 @@ public class EditOperationAnalyzer {
                 if (isInterfaceDeleted(interfaze.getName())) {
                     return;
                 }
-                AppliedDirectiveInterfaceFieldLocation location = new AppliedDirectiveInterfaceFieldLocation(interfaze.getName(), field.getName());
+                AppliedDirectiveInterfaceFieldLocation location = new AppliedDirectiveInterfaceFieldLocation(interfaze.getName(), field.getName(), appliedDirective.getName());
                 getInterfaceModification(interfaze.getName()).getDetails().add(new AppliedDirectiveArgumentDeletion(location, deletedArgument.getName()));
             }
         }
@@ -359,7 +359,7 @@ public class EditOperationAnalyzer {
             Vertex interfaceOrObjective = newSchemaGraph.getFieldsContainerForField(field);
             if (interfaceOrObjective.isOfType(SchemaGraph.OBJECT)) {
                 Vertex object = interfaceOrObjective;
-                AppliedDirectiveObjectFieldLocation location = new AppliedDirectiveObjectFieldLocation(object.getName(), field.getName());
+                AppliedDirectiveObjectFieldLocation location = new AppliedDirectiveObjectFieldLocation(object.getName(), field.getName(), appliedDirective.getName());
                 if (valueChanged) {
                     AppliedDirectiveArgumentValueModification argumentValueModification = new AppliedDirectiveArgumentValueModification(location, newArgumentName, oldValue, newValue);
                     getObjectModification(object.getName()).getDetails().add(argumentValueModification);
@@ -385,7 +385,7 @@ public class EditOperationAnalyzer {
             if (isObjectAdded(object.getName())) {
                 return;
             }
-            AppliedDirectiveObjectLocation location = new AppliedDirectiveObjectLocation(object.getName());
+            AppliedDirectiveObjectLocation location = new AppliedDirectiveObjectLocation(object.getName(), appliedDirective.getName());
             AppliedDirectiveAddition appliedDirectiveAddition = new AppliedDirectiveAddition(location, appliedDirective.getName());
             getObjectModification(object.getName()).getDetails().add(appliedDirectiveAddition);
         } else if (container.isOfType(SchemaGraph.INTERFACE)) {
@@ -393,7 +393,7 @@ public class EditOperationAnalyzer {
             if (isInterfaceAdded(interfaze.getName())) {
                 return;
             }
-            AppliedDirectiveInterfaceLocation location = new AppliedDirectiveInterfaceLocation(interfaze.getName());
+            AppliedDirectiveInterfaceLocation location = new AppliedDirectiveInterfaceLocation(interfaze.getName(), appliedDirective.getName());
             AppliedDirectiveAddition appliedDirectiveAddition = new AppliedDirectiveAddition(location, appliedDirective.getName());
             getInterfaceModification(interfaze.getName()).getDetails().add(appliedDirectiveAddition);
         } else if (container.isOfType(SchemaGraph.SCALAR)) {
@@ -401,7 +401,7 @@ public class EditOperationAnalyzer {
             if (isScalarAdded(scalar.getName())) {
                 return;
             }
-            AppliedDirectiveScalarLocation location = new AppliedDirectiveScalarLocation(scalar.getName());
+            AppliedDirectiveScalarLocation location = new AppliedDirectiveScalarLocation(scalar.getName(), appliedDirective.getName());
             AppliedDirectiveAddition appliedDirectiveAddition = new AppliedDirectiveAddition(location, appliedDirective.getName());
             getScalarModification(scalar.getName()).getDetails().add(appliedDirectiveAddition);
         } else if (container.isOfType(SchemaGraph.ENUM)) {
@@ -409,7 +409,7 @@ public class EditOperationAnalyzer {
             if (isEnumAdded(enumVertex.getName())) {
                 return;
             }
-            AppliedDirectiveEnumLocation location = new AppliedDirectiveEnumLocation(enumVertex.getName());
+            AppliedDirectiveEnumLocation location = new AppliedDirectiveEnumLocation(enumVertex.getName(), appliedDirective.getName());
             AppliedDirectiveAddition appliedDirectiveAddition = new AppliedDirectiveAddition(location, appliedDirective.getName());
             getEnumModification(enumVertex.getName()).getDetails().add(appliedDirectiveAddition);
         } else if (container.isOfType(SchemaGraph.ENUM_VALUE)) {
@@ -421,7 +421,7 @@ public class EditOperationAnalyzer {
             if (isNewEnumValueForExistingEnum(enumVertex.getName(), enumValue.getName())) {
                 return;
             }
-            AppliedDirectiveEnumValueLocation location = new AppliedDirectiveEnumValueLocation(enumVertex.getName(), enumValue.getName());
+            AppliedDirectiveEnumValueLocation location = new AppliedDirectiveEnumValueLocation(enumVertex.getName(), enumValue.getName(), appliedDirective.getName());
             AppliedDirectiveAddition appliedDirectiveAddition = new AppliedDirectiveAddition(location, appliedDirective.getName());
             getEnumModification(enumVertex.getName()).getDetails().add(appliedDirectiveAddition);
         } else if (container.isOfType(SchemaGraph.INPUT_OBJECT)) {
@@ -429,7 +429,7 @@ public class EditOperationAnalyzer {
             if (isInputObjectAdded(inputObject.getName())) {
                 return;
             }
-            AppliedDirectiveInputObjectLocation location = new AppliedDirectiveInputObjectLocation(inputObject.getName());
+            AppliedDirectiveInputObjectLocation location = new AppliedDirectiveInputObjectLocation(inputObject.getName(), appliedDirective.getName());
             AppliedDirectiveAddition appliedDirectiveAddition = new AppliedDirectiveAddition(location, appliedDirective.getName());
             getInputObjectModification(inputObject.getName()).getDetails().add(appliedDirectiveAddition);
         } else if (container.isOfType(SchemaGraph.INPUT_FIELD)) {
@@ -441,7 +441,7 @@ public class EditOperationAnalyzer {
             if (isNewInputFieldExistingInputObject(inputObject.getName(), inputField.getName())) {
                 return;
             }
-            AppliedDirectiveInputObjectFieldLocation location = new AppliedDirectiveInputObjectFieldLocation(inputObject.getName(), inputField.getName());
+            AppliedDirectiveInputObjectFieldLocation location = new AppliedDirectiveInputObjectFieldLocation(inputObject.getName(), inputField.getName(), appliedDirective.getName());
             AppliedDirectiveAddition appliedDirectiveAddition = new AppliedDirectiveAddition(location, appliedDirective.getName());
             getInputObjectModification(inputObject.getName()).getDetails().add(appliedDirectiveAddition);
         } else if (container.isOfType(SchemaGraph.UNION)) {
@@ -449,7 +449,7 @@ public class EditOperationAnalyzer {
             if (isUnionAdded(union.getName())) {
                 return;
             }
-            AppliedDirectiveUnionLocation location = new AppliedDirectiveUnionLocation(union.getName());
+            AppliedDirectiveUnionLocation location = new AppliedDirectiveUnionLocation(union.getName(), appliedDirective.getName());
             AppliedDirectiveAddition appliedDirectiveAddition = new AppliedDirectiveAddition(location, appliedDirective.getName());
             getUnionModification(union.getName()).getDetails().add(appliedDirectiveAddition);
         }
@@ -467,7 +467,7 @@ public class EditOperationAnalyzer {
             if (isFieldDeletedFromExistingObject(object.getName(), field.getName())) {
                 return;
             }
-            AppliedDirectiveObjectFieldLocation location = new AppliedDirectiveObjectFieldLocation(object.getName(), field.getName());
+            AppliedDirectiveObjectFieldLocation location = new AppliedDirectiveObjectFieldLocation(object.getName(), field.getName(), appliedDirective.getName());
             AppliedDirectiveDeletion appliedDirectiveDeletion = new AppliedDirectiveDeletion(location, appliedDirective.getName());
             getObjectModification(object.getName()).getDetails().add(appliedDirectiveDeletion);
         }
@@ -485,7 +485,7 @@ public class EditOperationAnalyzer {
             if (isFieldNewForExistingObject(object.getName(), field.getName())) {
                 return;
             }
-            AppliedDirectiveObjectFieldLocation location = new AppliedDirectiveObjectFieldLocation(object.getName(), field.getName());
+            AppliedDirectiveObjectFieldLocation location = new AppliedDirectiveObjectFieldLocation(object.getName(), field.getName(), appliedDirective.getName());
             AppliedDirectiveAddition appliedDirectiveAddition = new AppliedDirectiveAddition(location, appliedDirective.getName());
             getObjectModification(object.getName()).getDetails().add(appliedDirectiveAddition);
         }
@@ -508,7 +508,7 @@ public class EditOperationAnalyzer {
                 if (isArgumentDeletedFromExistingObjectField(object.getName(), field.getName(), argument.getName())) {
                     return;
                 }
-                AppliedDirectiveObjectFieldArgumentLocation location = new AppliedDirectiveObjectFieldArgumentLocation(object.getName(), field.getName(), argument.getName());
+                AppliedDirectiveObjectFieldArgumentLocation location = new AppliedDirectiveObjectFieldArgumentLocation(object.getName(), field.getName(), argument.getName(), appliedDirective.getName());
                 AppliedDirectiveDeletion appliedDirectiveDeletion = new AppliedDirectiveDeletion(location, appliedDirective.getName());
                 getObjectModification(object.getName()).getDetails().add(appliedDirectiveDeletion);
             } else {
@@ -523,7 +523,7 @@ public class EditOperationAnalyzer {
                 if (isArgumentDeletedFromExistingInterfaceField(interfaze.getName(), field.getName(), argument.getName())) {
                     return;
                 }
-                AppliedDirectiveInterfaceFieldArgumentLocation location = new AppliedDirectiveInterfaceFieldArgumentLocation(interfaze.getName(), field.getName(), argument.getName());
+                AppliedDirectiveInterfaceFieldArgumentLocation location = new AppliedDirectiveInterfaceFieldArgumentLocation(interfaze.getName(), field.getName(), argument.getName(), appliedDirective.getName());
                 AppliedDirectiveDeletion appliedDirectiveDeletion = new AppliedDirectiveDeletion(location, appliedDirective.getName());
                 getInterfaceModification(interfaze.getName()).getDetails().add(appliedDirectiveDeletion);
             }
@@ -559,7 +559,7 @@ public class EditOperationAnalyzer {
                 if (isArgumentNewForExistingObjectField(object.getName(), field.getName(), argument.getName())) {
                     return;
                 }
-                AppliedDirectiveObjectFieldArgumentLocation location = new AppliedDirectiveObjectFieldArgumentLocation(object.getName(), field.getName(), argument.getName());
+                AppliedDirectiveObjectFieldArgumentLocation location = new AppliedDirectiveObjectFieldArgumentLocation(object.getName(), field.getName(), argument.getName(), appliedDirective.getName());
                 AppliedDirectiveAddition appliedDirectiveAddition = new AppliedDirectiveAddition(location, appliedDirective.getName());
                 getObjectModification(object.getName()).getDetails().add(appliedDirectiveAddition);
             } else {
@@ -574,7 +574,7 @@ public class EditOperationAnalyzer {
                 if (isArgumentNewForExistingInterfaceField(interfaze.getName(), field.getName(), argument.getName())) {
                     return;
                 }
-                AppliedDirectiveInterfaceFieldArgumentLocation location = new AppliedDirectiveInterfaceFieldArgumentLocation(interfaze.getName(), field.getName(), argument.getName());
+                AppliedDirectiveInterfaceFieldArgumentLocation location = new AppliedDirectiveInterfaceFieldArgumentLocation(interfaze.getName(), field.getName(), argument.getName(), appliedDirective.getName());
                 AppliedDirectiveAddition appliedDirectiveAddition = new AppliedDirectiveAddition(location, appliedDirective.getName());
                 getInterfaceModification(interfaze.getName()).getDetails().add(appliedDirectiveAddition);
             }

--- a/src/main/java/graphql/schema/diffing/ana/SchemaDifference.java
+++ b/src/main/java/graphql/schema/diffing/ana/SchemaDifference.java
@@ -1250,10 +1250,12 @@ public interface SchemaDifference {
     class AppliedDirectiveObjectFieldLocation implements AppliedDirectiveLocationDetail {
         private final String objectName;
         private final String fieldName;
+        private final String directiveName;
 
-        public AppliedDirectiveObjectFieldLocation(String objectName, String fieldName) {
+        public AppliedDirectiveObjectFieldLocation(String objectName, String fieldName, String directiveName) {
             this.objectName = objectName;
             this.fieldName = fieldName;
+            this.directiveName = directiveName;
         }
 
         public String getFieldName() {
@@ -1263,15 +1265,23 @@ public interface SchemaDifference {
         public String getObjectName() {
             return objectName;
         }
+
+        public String getDirectiveName() {
+            return directiveName;
+        }
     }
 
     class AppliedDirectiveInterfaceFieldLocation implements AppliedDirectiveLocationDetail {
         private final String interfaceName;
         private final String fieldName;
 
-        public AppliedDirectiveInterfaceFieldLocation(String interfaceName, String fieldName) {
+        private final String directiveName;
+
+
+        public AppliedDirectiveInterfaceFieldLocation(String interfaceName, String fieldName, String directiveName) {
             this.interfaceName = interfaceName;
             this.fieldName = fieldName;
+            this.directiveName = directiveName;
         }
 
         public String getFieldName() {
@@ -1281,17 +1291,28 @@ public interface SchemaDifference {
         public String getInterfaceName() {
             return interfaceName;
         }
+
+        public String getDirectiveName() {
+            return directiveName;
+        }
     }
 
     class AppliedDirectiveScalarLocation implements AppliedDirectiveLocationDetail {
         private final String name;
 
-        public AppliedDirectiveScalarLocation(String name) {
+        private final String directiveName;
+
+        public AppliedDirectiveScalarLocation(String name, String directiveName) {
             this.name = name;
+            this.directiveName = directiveName;
         }
 
         public String getName() {
             return name;
+        }
+
+        public String getDirectiveName() {
+            return directiveName;
         }
     }
 
@@ -1301,25 +1322,38 @@ public interface SchemaDifference {
 
     class AppliedDirectiveObjectLocation implements AppliedDirectiveLocationDetail {
         private final String name;
+        private final String directiveName;
 
-        public AppliedDirectiveObjectLocation(String name) {
+
+        public AppliedDirectiveObjectLocation(String name, String directiveName) {
             this.name = name;
+            this.directiveName = directiveName;
         }
 
         public String getName() {
             return name;
+        }
+
+        public String getDirectiveName() {
+            return directiveName;
         }
     }
 
     class AppliedDirectiveInterfaceLocation implements AppliedDirectiveLocationDetail {
         private final String name;
+        private final String directiveName;
 
-        public AppliedDirectiveInterfaceLocation(String name) {
+        public AppliedDirectiveInterfaceLocation(String name, String directiveName) {
             this.name = name;
+            this.directiveName = directiveName;
         }
 
         public String getName() {
             return name;
+        }
+
+        public String getDirectiveName() {
+            return directiveName;
         }
     }
 
@@ -1327,11 +1361,14 @@ public interface SchemaDifference {
         private final String objectName;
         private final String fieldName;
         private final String argumentName;
+        private final String directiveName;
 
-        public AppliedDirectiveObjectFieldArgumentLocation(String objectName, String fieldName, String argumentName) {
+
+        public AppliedDirectiveObjectFieldArgumentLocation(String objectName, String fieldName, String argumentName, String directiveName) {
             this.objectName = objectName;
             this.fieldName = fieldName;
             this.argumentName = argumentName;
+            this.directiveName = directiveName;
         }
 
         public String getObjectName() {
@@ -1344,6 +1381,10 @@ public interface SchemaDifference {
 
         public String getArgumentName() {
             return argumentName;
+        }
+
+        public String getDirectiveName() {
+            return directiveName;
         }
     }
 
@@ -1369,11 +1410,14 @@ public interface SchemaDifference {
         private final String interfaceName;
         private final String fieldName;
         private final String argumentName;
+        private final String directiveName;
 
-        public AppliedDirectiveInterfaceFieldArgumentLocation(String interfaceName, String fieldName, String argumentName) {
+
+        public AppliedDirectiveInterfaceFieldArgumentLocation(String interfaceName, String fieldName, String argumentName, String directiveName) {
             this.interfaceName = interfaceName;
             this.fieldName = fieldName;
             this.argumentName = argumentName;
+            this.directiveName = directiveName;
         }
 
         public String getInterfaceName() {
@@ -1387,13 +1431,20 @@ public interface SchemaDifference {
         public String getArgumentName() {
             return argumentName;
         }
+
+        public String getDirectiveName() {
+            return directiveName;
+        }
     }
 
     class AppliedDirectiveUnionLocation implements AppliedDirectiveLocationDetail {
         private final String name;
+        private final String directiveName;
 
-        public AppliedDirectiveUnionLocation(String name) {
+
+        public AppliedDirectiveUnionLocation(String name, String directiveName) {
             this.name = name;
+            this.directiveName = directiveName;
         }
 
         public String getName() {
@@ -1403,23 +1454,33 @@ public interface SchemaDifference {
 
     class AppliedDirectiveEnumLocation implements AppliedDirectiveLocationDetail {
         private final String name;
+        private final String directiveName;
 
-        public AppliedDirectiveEnumLocation(String name) {
+
+        public AppliedDirectiveEnumLocation(String name, String directiveName) {
             this.name = name;
+            this.directiveName = directiveName;
         }
 
         public String getName() {
             return name;
+        }
+
+        public String getDirectiveName() {
+            return directiveName;
         }
     }
 
     class AppliedDirectiveEnumValueLocation implements AppliedDirectiveLocationDetail {
         private final String enumName;
         private final String valueName;
+        private final String directiveName;
 
-        public AppliedDirectiveEnumValueLocation(String enumName, String valueName) {
+
+        public AppliedDirectiveEnumValueLocation(String enumName, String valueName, String directiveName) {
             this.enumName = enumName;
             this.valueName = valueName;
+            this.directiveName = directiveName;
         }
 
         public String getEnumName() {
@@ -1429,17 +1490,28 @@ public interface SchemaDifference {
         public String getValueName() {
             return valueName;
         }
+
+        public String getDirectiveName() {
+            return directiveName;
+        }
     }
 
     class AppliedDirectiveInputObjectLocation implements AppliedDirectiveLocationDetail {
         private final String name;
+        private final String directiveName;
 
-        public AppliedDirectiveInputObjectLocation(String name) {
+
+        public AppliedDirectiveInputObjectLocation(String name, String directiveName) {
             this.name = name;
+            this.directiveName = directiveName;
         }
 
         public String getName() {
             return name;
+        }
+
+        public String getDirectiveName() {
+            return directiveName;
         }
     }
 
@@ -1447,10 +1519,13 @@ public interface SchemaDifference {
     class AppliedDirectiveInputObjectFieldLocation implements AppliedDirectiveLocationDetail {
         private final String inputObjectName;
         private final String fieldName;
+        private final String directiveName;
 
-        public AppliedDirectiveInputObjectFieldLocation(String inputObjectName, String fieldName) {
+
+        public AppliedDirectiveInputObjectFieldLocation(String inputObjectName, String fieldName, String directiveName) {
             this.inputObjectName = inputObjectName;
             this.fieldName = fieldName;
+            this.directiveName = directiveName;
         }
 
         public String getInputObjectName() {
@@ -1459,6 +1534,10 @@ public interface SchemaDifference {
 
         public String getFieldName() {
             return fieldName;
+        }
+
+        public String getDirectiveName() {
+            return directiveName;
         }
     }
 


### PR DESCRIPTION
very thin change, when looking at `SchemaDifference`s one should be able to access the name of the directive for differences like `AppliedDirectiveArgumentValueModification` which currently don't give you that.

```
public AppliedDirectiveArgumentValueModification(AppliedDirectiveLocationDetail locationDetail, String argumentName, String oldValue, String newValue) {
            this.locationDetail = locationDetail;
            this.argumentName = argumentName;
            this.oldValue = oldValue;
            this.newValue = newValue;
        }
```
example the `AppliedDirectiveArgumentValueModification` only has the name of the argument, and the location detail only has the name of the object type and field name, but nothing about what the name of the directive is

This is useful for lets say if you want to analyse `AppliedDirectiveArgumentValueModification`s and have a custom logic on checking these modifications based of the name of the directive

