### PR TITLE
Schema Printer - add deprecation reason printing and fix missing deprecated directive on argument

### DIFF
--- a/src/test/groovy/graphql/schema/SchemaPrinterComparatorsTest.groovy
+++ b/src/test/groovy/graphql/schema/SchemaPrinterComparatorsTest.groovy
@@ -180,7 +180,7 @@ scalar TestScalar @a(a : 0, bb : 0) @bb(a : 0, bb : 0)
 
         when:
         def options = defaultOptions()
-        def result = new SchemaPrinter(options).directivesString(null, false, directives)
+        def result = new SchemaPrinter(options).directivesString(null, directives)
 
         then:
         result == ''' @a(a : 0, bb : 0) @bb(a : 0, bb : 0)'''


### PR DESCRIPTION
This PR addresses two schema printer items:
1. Adds deprecation reason printing to better support programmatically provided deprecation reason which is required by schema linters such as GraphQL-ESLint schema recommended rule [require-deprecation-reason](https://the-guild.dev/graphql/eslint/rules/require-deprecation-reason).
2. Fixes `@deprecated` directive missing from printed arguments.
