### PR TITLE
Fix OSGi bundle manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -154,7 +154,7 @@ shadowJar {
     bnd('''
 -exportcontents: graphql.*
 -removeheaders: Private-Package
-Import-Package: !com.google.*,!org.checkerframework.*,!javax.annotation.*,!graphql.com.google.*,!org.antlr.*,!graphql.org.antlr.*,!sun.misc.*,*
+Import-Package: !android.os.*,!com.google.*,!org.checkerframework.*,!javax.annotation.*,!graphql.com.google.*,!org.antlr.*,!graphql.org.antlr.*,!sun.misc.*,*
 ''')
 }
 


### PR DESCRIPTION
Exclude the `android.os` package from the Import-Package header.

Fixes https://github.com/graphql-java/graphql-java/issues/3271


