### PR TITLE
guava version fix for 19.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ def reactiveStreamsVersion = '1.0.3'
 def slf4jVersion = '1.7.35'
 def releaseVersion = System.env.RELEASE_VERSION
 def antlrVersion = '4.9.3' // https://mvnrepository.com/artifact/org.antlr/antlr4-runtime
+def guavaVersion = '32.1.1-jre'
 version = releaseVersion ? releaseVersion : getDevelopmentVersion()
 group = 'com.graphql-java'
 
@@ -91,7 +92,7 @@ dependencies {
     api 'com.graphql-java:java-dataloader:3.2.0'
     api 'org.reactivestreams:reactive-streams:' + reactiveStreamsVersion
     antlr 'org.antlr:antlr4:' + antlrVersion
-    implementation 'com.google.guava:guava:32.0.0-jre'
+    implementation 'com.google.guava:guava:' + guavaVersion
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation 'org.spockframework:spock-core:2.0-groovy-3.0'
     testImplementation 'org.codehaus.groovy:groovy:3.0.9'
@@ -127,7 +128,7 @@ shadowJar {
     }
     relocate('org.antlr.v4.runtime', 'graphql.org.antlr.v4.runtime')
     dependencies {
-        include(dependency('com.google.guava:guava:32.1.1-jre'))
+        include(dependency('com.google.guava:guava:' + guavaVersion))
         include(dependency('org.antlr:antlr4-runtime:' + antlrVersion))
     }
     from "LICENSE.md"


### PR DESCRIPTION
Related to #3318

the guava version declared as a dependency and the guava version declared to the shadow jar plugin were different and this cause the code not to be included.  This only happened in the latest bug versions released.


I have confirmed locally that when the shadowJar task runs it includes `graphql.com.google` classes when this is in place.   `gradle check` makes shadowJar run

