### PR TITLE
Do NOT MERGE - Another POC PR to show removing ER allocation

### DIFF
--- a/src/main/java/graphql/ExecutionResultImpl.java
+++ b/src/main/java/graphql/ExecutionResultImpl.java
@@ -53,6 +53,10 @@ public class ExecutionResultImpl implements ExecutionResult {
         this.extensions = extensions;
     }
 
+    public static Builder newExecutionResult() {
+        return new Builder();
+    }
+
     public boolean isDataPresent() {
         return dataPresent;
     }
@@ -103,8 +107,11 @@ public class ExecutionResultImpl implements ExecutionResult {
                 '}';
     }
 
-    public static Builder newExecutionResult() {
-        return new Builder();
+    public static ExecutionResult asExecutionResult(Object dataOrER) {
+        if (dataOrER instanceof ExecutionResult) {
+            return (ExecutionResult) dataOrER;
+        }
+        return newExecutionResult().data(dataOrER).build();
     }
 
     public static class Builder implements ExecutionResult.Builder<Builder> {

--- a/src/main/java/graphql/execution/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncExecutionStrategy.java
@@ -95,6 +95,7 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
         // TODO - we need new instrumentation call here saying we entered a ES recursively
         // TODO - something like beginObjectExecution()
         //executionStrategyCtx.onDispatched(overallResult);
+        executionStrategyCtx.onDispatched(FAKE_ER_CF);
 
         Object awaitedFieldsWithInfo = futures.awaitPolymorphic();
         if (awaitedFieldsWithInfo instanceof CompletableFuture) {
@@ -153,7 +154,8 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
             //
             // TODO - we need new instrumentation call here saying we entered a ES recursively
             // TODO - something like beginObjectExecution() so we can complete it here
-            // overallResult.whenComplete(executionStrategyCtx::onCompleted);
+            //overallResult.whenComplete(executionStrategyCtx::onCompleted);
+            FAKE_ER_CF.whenComplete(executionStrategyCtx::onCompleted);
             return overallResult;
         } else {
             List<Object> completedValues = (List<Object>) awaitedValues;
@@ -162,6 +164,7 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
             // TODO - we need new instrumentation call here saying we entered a ES recursively
             // TODO - something like beginObjectExecution() so we can complete it here
             //executionStrategyCtx.onCompleted(resultMap, null);
+            executionStrategyCtx.onCompleted(FAKE_ER, null);
             return resultMap;
         }
     }

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -153,21 +153,6 @@ public abstract class ExecutionStrategy {
         this.dataFetcherExceptionHandler = dataFetcherExceptionHandler;
     }
 
-    @Internal
-    public static String mkNameForPath(Field currentField) {
-        return mkNameForPath(Collections.singletonList(currentField));
-    }
-
-    @Internal
-    public static String mkNameForPath(MergedField mergedField) {
-        return mkNameForPath(mergedField.getFields());
-    }
-
-    @Internal
-    public static String mkNameForPath(List<Field> currentField) {
-        Field field = currentField.get(0);
-        return field.getResultKey();
-    }
 
     /**
      * This is the entry point to an execution strategy.  It will be passed the fields to execute and get values for.
@@ -983,5 +968,21 @@ public abstract class ExecutionStrategy {
                 .parentInfo(parentStepInfo)
                 .arguments(argumentValues)
                 .build();
+    }
+
+    @Internal
+    public static String mkNameForPath(Field currentField) {
+        return mkNameForPath(Collections.singletonList(currentField));
+    }
+
+    @Internal
+    public static String mkNameForPath(MergedField mergedField) {
+        return mkNameForPath(mergedField.getFields());
+    }
+
+    @Internal
+    public static String mkNameForPath(List<Field> currentField) {
+        Field field = currentField.get(0);
+        return field.getResultKey();
     }
 }

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -653,6 +653,7 @@ public abstract class ExecutionStrategy {
             // TODO - we need new instrumentation call here saying we entered a ES recursively
             // TODO - something like beginList() so we can complete it here
             //completeListCtx.onDispatched(overallResult);
+            completeListCtx.onDispatched(FAKE_ER_CF);
             resultsFuture.whenComplete((results, exception) -> {
                 if (exception != null) {
                     Optional<Throwable> throwableOpt = handleNonNullExceptionForList(exception);
@@ -667,7 +668,7 @@ public abstract class ExecutionStrategy {
                         //
                         // TODO - we need new instrumentation call here saying we entered a ES recursively
                         // TODO - something like beginList() so we can complete it here
-                        //completeListCtx.onCompleted(null, null);
+                        completeListCtx.onCompleted(null, null);
                     }
                     return;
                 }
@@ -678,7 +679,8 @@ public abstract class ExecutionStrategy {
             //
             // TODO - we need new instrumentation call here saying we entered a ES recursively
             // TODO - something like beginList() so we can complete it here
-            // overallResult.whenComplete(completeListCtx::onCompleted);
+            //overallResult.whenComplete(completeListCtx::onCompleted);
+            FAKE_ER_CF.whenComplete(completeListCtx::onCompleted);
             fieldValueResult = overallResult;
         } else {
             @SuppressWarnings("unchecked")
@@ -687,6 +689,7 @@ public abstract class ExecutionStrategy {
             // TODO - we need new instrumentation call here saying we entered a ES recursively
             // TODO - something like beginList() so we can complete it here
             //completeListCtx.onDispatched(overallResult);
+            completeListCtx.onDispatched(FAKE_ER_CF);
 
             List<Object> completedResults = new ArrayList<>(results.size());
             completedResults.addAll(results);
@@ -696,6 +699,7 @@ public abstract class ExecutionStrategy {
             // TODO - we need new instrumentation call here saying we entered a ES recursively
             // TODO - something like beginList() so we can complete it here
             //overallResult.whenComplete(completeListCtx::onCompleted);
+            FAKE_ER_CF.whenComplete(completeListCtx::onCompleted);
 
             fieldValueResult = completedResults;
         }
@@ -985,4 +989,7 @@ public abstract class ExecutionStrategy {
         Field field = currentField.get(0);
         return field.getResultKey();
     }
+
+    static CompletableFuture<ExecutionResult> FAKE_ER_CF = CompletableFuture.completedFuture(null);
+    static ExecutionResult FAKE_ER = null;
 }


### PR DESCRIPTION
This is built on [support_objects_or_cfs](https://github.com/graphql-java/graphql-java/pull/3323) - it extends it by removing all the `ExecutionResult` wrapping that happends around objects, enums and scalars (and even nulls)

At present I dont fix up the Insturmentation calls which means it WONT pass the tests that rely on instrumentations calls

This is very POC - I am already rethinking its approach and will likely close it.

