### PR TITLE
Build cache fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,37 +20,45 @@ java {
     }
 }
 
+def makeDevelopmentVersion(parts) {
+    def version = String.join("-", parts)
+    println "created development version: $version"
+    return version
+}
+
 def getDevelopmentVersion() {
     def dateTime = new SimpleDateFormat('yyyy-MM-dd\'T\'HH-mm-ss').format(new Date())
     def gitCheckOutput = new StringBuilder()
     def gitCheckError = new StringBuilder()
-    def gitCheck = ["git", "rev-parse", "--is-inside-work-tree"].execute()
+    def gitCheck = ["git", "-C", projectDir.toString(), "rev-parse", "--is-inside-work-tree"].execute()
     gitCheck.waitForProcessOutput(gitCheckOutput, gitCheckError)
     def isGit = gitCheckOutput.toString().trim()
     if (isGit != "true") {
-        def version = "0.0.0-" + dateTime + "-no-git"
-        println "created development version: $version"
-        return version
+        return makeDevelopmentVersion(["0.0.0", dateTime, "no-git"])
     }
 
-    def gitStatusOutput = new StringBuilder()
-    def gitStatusError = new StringBuilder()
-    def gitStatus = ["git", "-C", projectDir.toString(), "status", "--porcelain"].execute()
-    gitStatus.waitForProcessOutput(gitStatusOutput, gitStatusError)
-    def gitIsDirty = !gitStatusOutput.toString().trim().isEmpty()
+    def isCi = Boolean.parseBoolean(System.env.CI)
+    if (isCi) {
+        def gitHashOutput = new StringBuilder()
+        def gitHashError = new StringBuilder()
+        def gitShortHash = ["git", "-C", projectDir.toString(), "rev-parse", "--short", "HEAD"].execute()
+        gitShortHash.waitForProcessOutput(gitHashOutput, gitHashError)
+        def gitHash = gitHashOutput.toString().trim()
+        if (gitHash.isEmpty()) {
+            println "git hash is empty: error: ${gitHashError.toString()}"
+            throw new IllegalStateException("git hash could not be determined")
+        }
 
-    def gitHashOutput = new StringBuilder()
-    def gitHashError = new StringBuilder()
-    def gitShortHash = ["git", "-C", projectDir.toString(), "rev-parse", "--short", "HEAD"].execute()
-    gitShortHash.waitForProcessOutput(gitHashOutput, gitHashError)
-    def gitHash = gitHashOutput.toString().trim()
-    if (gitHash.isEmpty()) {
-        println "git hash is empty: error: ${error.toString()}"
-        throw new IllegalStateException("git hash could not be determined")
+        return makeDevelopmentVersion(["0.0.0", dateTime, gitHash])
     }
-    def version = "0.0.0-" + (gitIsDirty ? "${dateTime}-" : "") + gitHash
-    println "created development version: $version"
-    version
+
+    def gitRevParseOutput = new StringBuilder()
+    def gitRevParseError = new StringBuilder()
+    def gitRevParse = ["git", "-C", projectDir.toString(), "rev-parse", "--abbrev-ref", "HEAD"].execute()
+    gitRevParse.waitForProcessOutput(gitRevParseOutput, gitRevParseError)
+    def branchName = gitRevParseOutput.toString().trim()
+
+    return makeDevelopmentVersion(["0.0.0", branchName, "SNAPSHOT"])
 }
 
 def reactiveStreamsVersion = '1.0.3'

--- a/build.gradle
+++ b/build.gradle
@@ -21,16 +21,23 @@ java {
 }
 
 def getDevelopmentVersion() {
+    def dateTime = new SimpleDateFormat('yyyy-MM-dd\'T\'HH-mm-ss').format(new Date())
     def gitCheckOutput = new StringBuilder()
     def gitCheckError = new StringBuilder()
     def gitCheck = ["git", "rev-parse", "--is-inside-work-tree"].execute()
     gitCheck.waitForProcessOutput(gitCheckOutput, gitCheckError)
     def isGit = gitCheckOutput.toString().trim()
     if (isGit != "true") {
-        def version = "0.0.0-" + new SimpleDateFormat('yyyy-MM-dd\'T\'HH-mm-ss').format(new Date()) + "-no-git"
+        def version = "0.0.0-" + dateTime + "-no-git"
         println "created development version: $version"
         return version
     }
+
+    def gitStatusOutput = new StringBuilder()
+    def gitStatusError = new StringBuilder()
+    def gitStatus = ["git", "-C", projectDir.toString(), "status", "--porcelain"].execute()
+    gitStatus.waitForProcessOutput(gitStatusOutput, gitStatusError)
+    def gitIsDirty = !gitStatusOutput.toString().trim().isEmpty()
 
     def gitHashOutput = new StringBuilder()
     def gitHashError = new StringBuilder()
@@ -41,7 +48,7 @@ def getDevelopmentVersion() {
         println "git hash is empty: error: ${error.toString()}"
         throw new IllegalStateException("git hash could not be determined")
     }
-    def version = "0.0.0-" + new SimpleDateFormat('yyyy-MM-dd\'T\'HH-mm-ss').format(new Date()) + "-" + gitHash
+    def version = "0.0.0-" + (gitIsDirty ? "${dateTime}-" : "") + gitHash
     println "created development version: $version"
     version
 }

--- a/build.gradle
+++ b/build.gradle
@@ -210,7 +210,10 @@ generateGrammarSource {
     arguments += ["-visitor"]
     outputDirectory = file("${project.buildDir}/generated-src/antlr/main/graphql/parser/antlr")
 }
-generateGrammarSource.inputs.dir('src/main/antlr')
+generateGrammarSource.inputs
+    .dir('src/main/antlr')
+    .withPropertyName('sourceDir')
+    .withPathSensitivity(PathSensitivity.RELATIVE)
 
 
 task sourcesJar(type: Jar) {


### PR DESCRIPTION
### Use stable version number on clean workspace
Previously, the graphql-java build would always produce a new version
number based on the current date and time in local development. Because
the version number would always be different between 2 Gradle
invocations, some tasks, such as `javadoc` or `jar` could never be
cached because they depend on the version number.

With this patch, the version number will no longer include the date and
time when the Git workspace is clean, because the commit hash is
sufficient to uniquely identify the state of the workspace. This allows
the tasks that depend on the version number to be properly cached.

### Relativize Antlr sources in cache key
Previously, the cache key of the antlr task would be computed using
(among other things) the absolute paths of its input files. Because the
absolute paths were part of the cache key, the build cache would rarely
be hit.

With this patch, the task is configured to use relative paths
when computing the cache key.