### PR TITLE
Use string concat instead of string builder when building field glob name

### DIFF
--- a/src/main/java/graphql/schema/DataFetchingFieldSelectionSetImpl.java
+++ b/src/main/java/graphql/schema/DataFetchingFieldSelectionSetImpl.java
@@ -264,7 +264,11 @@ public class DataFetchingFieldSelectionSetImpl implements DataFetchingFieldSelec
     }
 
     private static String mkFieldGlobName(String fieldPrefix, String fieldName) {
-        return (!fieldPrefix.isEmpty() ? fieldPrefix + SEP : "") + fieldName;
+        if (fieldPrefix.isEmpty()) {
+            return fieldName;
+        }
+
+        return fieldPrefix.concat(SEP).concat(fieldName);
     }
 
     private static PathMatcher globMatcher(String fieldGlobPattern) {


### PR DESCRIPTION
Using `+` can be expensive with a sufficiently large schema and query. This is a micro-optimization to swap `+`/`StringBuilder` for `.concat`