### PR TITLE
The ability to get the source location of a schema element

### DIFF
--- a/src/main/java/graphql/language/SourceLocation.java
+++ b/src/main/java/graphql/language/SourceLocation.java
@@ -2,8 +2,10 @@ package graphql.language;
 
 
 import graphql.PublicApi;
+import graphql.schema.GraphQLModifiedType;
 import graphql.schema.GraphQLNamedSchemaElement;
 import graphql.schema.GraphQLSchemaElement;
+import graphql.schema.GraphQLTypeUtil;
 import graphql.schema.idl.SchemaGenerator;
 
 import java.io.Serializable;
@@ -90,6 +92,9 @@ public class SourceLocation implements Serializable {
      * @return the source location if available or null if it's not.
      */
     public static SourceLocation getLocation(GraphQLSchemaElement schemaElement) {
+        if (schemaElement instanceof GraphQLModifiedType) {
+            schemaElement = GraphQLTypeUtil.unwrapAllAs((GraphQLModifiedType) schemaElement);
+        }
         if (schemaElement instanceof GraphQLNamedSchemaElement) {
             Node<?> node = ((GraphQLNamedSchemaElement) schemaElement).getDefinition();
             return node != null ? node.getSourceLocation() : null;

--- a/src/main/java/graphql/language/SourceLocation.java
+++ b/src/main/java/graphql/language/SourceLocation.java
@@ -2,6 +2,9 @@ package graphql.language;
 
 
 import graphql.PublicApi;
+import graphql.schema.GraphQLNamedSchemaElement;
+import graphql.schema.GraphQLSchemaElement;
+import graphql.schema.idl.SchemaGenerator;
 
 import java.io.Serializable;
 import java.util.Objects;
@@ -74,4 +77,24 @@ public class SourceLocation implements Serializable {
                 (sourceName != null ? ", sourceName=" + sourceName : "") +
                 '}';
     }
+
+
+    /**
+     * This method can return {@link SourceLocation} that help create the given schema element.  If the
+     * schema is created from input files and {@link SchemaGenerator.Options#isCaptureAstDefinitions()}
+     * is set to true then schema elements contain a reference to the {@link SourceLocation} that helped
+     * create that runtime schema element.
+     *
+     * @param schemaElement the schema element
+     *
+     * @return the source location if available or null if it's not.
+     */
+    public static SourceLocation getLocation(GraphQLSchemaElement schemaElement) {
+        if (schemaElement instanceof GraphQLNamedSchemaElement) {
+            Node<?> node = ((GraphQLNamedSchemaElement) schemaElement).getDefinition();
+            return node != null ? node.getSourceLocation() : null;
+        }
+        return null;
+    }
+
 }

--- a/src/test/groovy/graphql/language/SourceLocationTest.groovy
+++ b/src/test/groovy/graphql/language/SourceLocationTest.groovy
@@ -1,0 +1,61 @@
+package graphql.language
+
+import graphql.parser.MultiSourceReader
+import graphql.schema.idl.RuntimeWiring
+import graphql.schema.idl.SchemaGenerator
+import graphql.schema.idl.SchemaParser
+import spock.lang.Specification
+
+import static graphql.schema.FieldCoordinates.coordinates
+
+class SourceLocationTest extends Specification {
+
+    def "can get source location"() {
+        def sdl = """
+            type Query {
+                a : A
+            }
+            
+            type A {
+                b : B
+            }
+            
+            type B {
+                c : String
+            } 
+        """
+
+        def sourceReader = MultiSourceReader.newMultiSourceReader().string(sdl, "sourceName").build()
+
+        def definitionRegistry = new SchemaParser().parse(sourceReader)
+        when:
+        def schema = new SchemaGenerator().makeExecutableSchema(definitionRegistry, RuntimeWiring.MOCKED_WIRING)
+        def schemaElement = schema.getType("Query")
+        def location = SourceLocation.getLocation(schemaElement)
+
+        then:
+        location.sourceName == "sourceName"
+        location.line == 2
+        location.column == 13
+
+        when:
+        schemaElement = schema.getFieldDefinition(coordinates("Query", "a"))
+        location = SourceLocation.getLocation(schemaElement)
+
+        then:
+        location.sourceName == "sourceName"
+        location.line == 3
+        location.column == 17
+
+        when:
+        schemaElement = schema.getType("A")
+        location = SourceLocation.getLocation(schemaElement)
+
+        then:
+        location.sourceName == "sourceName"
+        location.line == 6
+        location.column == 13
+
+
+    }
+}

--- a/src/test/groovy/graphql/language/SourceLocationTest.groovy
+++ b/src/test/groovy/graphql/language/SourceLocationTest.groovy
@@ -13,7 +13,7 @@ class SourceLocationTest extends Specification {
     def "can get source location"() {
         def sdl = """
             type Query {
-                a : A
+                a : A!
             }
             
             type A {
@@ -46,6 +46,16 @@ class SourceLocationTest extends Specification {
         location.sourceName == "sourceName"
         location.line == 3
         location.column == 17
+
+        when:
+        schemaElement = schema.getFieldDefinition(coordinates("Query", "a")).getType()
+        // unwrapped
+        location = SourceLocation.getLocation(schemaElement)
+
+        then:
+        location.sourceName == "sourceName"
+        location.line == 6
+        location.column == 13
 
         when:
         schemaElement = schema.getType("A")


### PR DESCRIPTION
I have need of this a few times inside Atlassian and so I though graphql-java should natively have it