### PR TITLE
This changes onDispatched so it no longer takes a CF

### DIFF
--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -430,17 +430,16 @@ public class GraphQL {
                 InstrumentationExecutionParameters inputInstrumentationParameters = new InstrumentationExecutionParameters(executionInputWithId, this.graphQLSchema, instrumentationState);
                 ExecutionInput instrumentedExecutionInput = instrumentation.instrumentExecutionInput(executionInputWithId, inputInstrumentationParameters, instrumentationState);
 
-                CompletableFuture<ExecutionResult> beginExecutionCF = new CompletableFuture<>();
                 InstrumentationExecutionParameters instrumentationParameters = new InstrumentationExecutionParameters(instrumentedExecutionInput, this.graphQLSchema, instrumentationState);
                 InstrumentationContext<ExecutionResult> executionInstrumentation = nonNullCtx(instrumentation.beginExecution(instrumentationParameters, instrumentationState));
-                executionInstrumentation.onDispatched(beginExecutionCF);
+                executionInstrumentation.onDispatched();
 
                 GraphQLSchema graphQLSchema = instrumentation.instrumentSchema(this.graphQLSchema, instrumentationParameters, instrumentationState);
 
                 CompletableFuture<ExecutionResult> executionResult = parseValidateAndExecute(instrumentedExecutionInput, graphQLSchema, instrumentationState);
                 //
                 // finish up instrumentation
-                executionResult = executionResult.whenComplete(completeInstrumentationCtxCF(executionInstrumentation, beginExecutionCF));
+                executionResult = executionResult.whenComplete(completeInstrumentationCtxCF(executionInstrumentation));
                 //
                 // allow instrumentation to tweak the result
                 executionResult = executionResult.thenCompose(result -> instrumentation.instrumentExecutionResult(result, instrumentationParameters, instrumentationState));
@@ -525,15 +524,13 @@ public class GraphQL {
     private ParseAndValidateResult parse(ExecutionInput executionInput, GraphQLSchema graphQLSchema, InstrumentationState instrumentationState) {
         InstrumentationExecutionParameters parameters = new InstrumentationExecutionParameters(executionInput, graphQLSchema, instrumentationState);
         InstrumentationContext<Document> parseInstrumentationCtx = nonNullCtx(instrumentation.beginParse(parameters, instrumentationState));
-        CompletableFuture<Document> documentCF = new CompletableFuture<>();
-        parseInstrumentationCtx.onDispatched(documentCF);
+        parseInstrumentationCtx.onDispatched();
 
         ParseAndValidateResult parseResult = ParseAndValidate.parse(executionInput);
         if (parseResult.isFailure()) {
             parseInstrumentationCtx.onCompleted(null, parseResult.getSyntaxException());
             return parseResult;
         } else {
-            documentCF.complete(parseResult.getDocument());
             parseInstrumentationCtx.onCompleted(parseResult.getDocument(), null);
 
             DocumentAndVariables documentAndVariables = parseResult.getDocumentAndVariables();
@@ -545,15 +542,13 @@ public class GraphQL {
 
     private List<ValidationError> validate(ExecutionInput executionInput, Document document, GraphQLSchema graphQLSchema, InstrumentationState instrumentationState) {
         InstrumentationContext<List<ValidationError>> validationCtx = nonNullCtx(instrumentation.beginValidation(new InstrumentationValidationParameters(executionInput, document, graphQLSchema, instrumentationState), instrumentationState));
-        CompletableFuture<List<ValidationError>> cf = new CompletableFuture<>();
-        validationCtx.onDispatched(cf);
+        validationCtx.onDispatched();
 
         Predicate<Class<?>> validationRulePredicate = executionInput.getGraphQLContext().getOrDefault(ParseAndValidate.INTERNAL_VALIDATION_PREDICATE_HINT, r -> true);
         Locale locale = executionInput.getLocale() != null ? executionInput.getLocale() : Locale.getDefault();
         List<ValidationError> validationErrors = ParseAndValidate.validate(graphQLSchema, document, validationRulePredicate, locale);
 
         validationCtx.onCompleted(validationErrors, null);
-        cf.complete(validationErrors);
         return validationErrors;
     }
 

--- a/src/main/java/graphql/execution/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncExecutionStrategy.java
@@ -56,7 +56,7 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
             futures.add(future);
         }
         CompletableFuture<ExecutionResult> overallResult = new CompletableFuture<>();
-        executionStrategyCtx.onDispatched(overallResult);
+        executionStrategyCtx.onDispatched();
 
         futures.await().whenComplete((completeValueInfos, throwable) -> {
             BiConsumer<List<ExecutionResult>, Throwable> handleResultsConsumer = handleResults(executionContext, fieldNames, overallResult);

--- a/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
@@ -48,7 +48,7 @@ public class AsyncSerialExecutionStrategy extends AbstractAsyncExecutionStrategy
         });
 
         CompletableFuture<ExecutionResult> overallResult = new CompletableFuture<>();
-        executionStrategyCtx.onDispatched(overallResult);
+        executionStrategyCtx.onDispatched();
 
         resultsFuture.whenComplete(handleResults(executionContext, fieldNames, overallResult));
         overallResult.whenComplete(executionStrategyCtx::onCompleted);

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -122,7 +122,7 @@ public class Execution {
                 ExecutionResult executionResult = new ExecutionResultImpl(Collections.singletonList((GraphQLError) rte));
                 CompletableFuture<ExecutionResult> resultCompletableFuture = completedFuture(executionResult);
 
-                executeOperationCtx.onDispatched(resultCompletableFuture);
+                executeOperationCtx.onDispatched();
                 executeOperationCtx.onCompleted(executionResult, rte);
                 return resultCompletableFuture;
             }
@@ -171,7 +171,7 @@ public class Execution {
         }
 
         // note this happens NOW - not when the result completes
-        executeOperationCtx.onDispatched(result);
+        executeOperationCtx.onDispatched();
 
         // fill out extensions if we have them
         result = result.thenApply(er -> mergeExtensionsBuilderIfPresent(er, graphQLContext));

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -216,7 +216,7 @@ public abstract class ExecutionStrategy {
 
         CompletableFuture<ExecutionResult> executionResultFuture = result.thenCompose(FieldValueInfo::getFieldValue);
 
-        fieldCtx.onDispatched(executionResultFuture);
+        fieldCtx.onDispatched();
         executionResultFuture.whenComplete(fieldCtx::onCompleted);
         return result;
     }
@@ -286,7 +286,7 @@ public abstract class ExecutionStrategy {
         dataFetcher = instrumentation.instrumentDataFetcher(dataFetcher, instrumentationFieldFetchParams, executionContext.getInstrumentationState());
         CompletableFuture<Object> fetchedValue = invokeDataFetcher(executionContext, parameters, fieldDef, dataFetchingEnvironment, dataFetcher);
 
-        fetchCtx.onDispatched(fetchedValue);
+        fetchCtx.onDispatched();
         return fetchedValue
                 .handle((result, exception) -> {
                     fetchCtx.onCompleted(result, exception);
@@ -435,7 +435,7 @@ public abstract class ExecutionStrategy {
         FieldValueInfo fieldValueInfo = completeValue(executionContext, newParameters);
 
         CompletableFuture<ExecutionResult> executionResultFuture = fieldValueInfo.getFieldValue();
-        ctxCompleteField.onDispatched(executionResultFuture);
+        ctxCompleteField.onDispatched();
         executionResultFuture.whenComplete(ctxCompleteField::onCompleted);
         return fieldValueInfo;
     }
@@ -590,7 +590,7 @@ public abstract class ExecutionStrategy {
         CompletableFuture<List<ExecutionResult>> resultsFuture = Async.each(fieldValueInfos, FieldValueInfo::getFieldValue);
 
         CompletableFuture<ExecutionResult> overallResult = new CompletableFuture<>();
-        completeListCtx.onDispatched(overallResult);
+        completeListCtx.onDispatched();
 
         resultsFuture.whenComplete((results, exception) -> {
             if (exception != null) {

--- a/src/main/java/graphql/execution/SubscriptionExecutionStrategy.java
+++ b/src/main/java/graphql/execution/SubscriptionExecutionStrategy.java
@@ -69,7 +69,7 @@ public class SubscriptionExecutionStrategy extends ExecutionStrategy {
         });
 
         // dispatched the subscription query
-        executionStrategyCtx.onDispatched(overallResult);
+        executionStrategyCtx.onDispatched();
         overallResult.whenComplete(executionStrategyCtx::onCompleted);
 
         return overallResult;
@@ -139,7 +139,7 @@ public class SubscriptionExecutionStrategy extends ExecutionStrategy {
                 .thenApply(executionResult -> wrapWithRootFieldName(newParameters, executionResult));
 
         // dispatch instrumentation so they can know about each subscription event
-        subscribedFieldCtx.onDispatched(overallResult);
+        subscribedFieldCtx.onDispatched();
         overallResult.whenComplete(subscribedFieldCtx::onCompleted);
 
         // allow them to instrument each ER should they want to

--- a/src/main/java/graphql/execution/instrumentation/ChainedInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/ChainedInstrumentation.java
@@ -395,8 +395,8 @@ public class ChainedInstrumentation implements Instrumentation {
         }
 
         @Override
-        public void onDispatched(CompletableFuture<T> result) {
-            contexts.forEach(context -> context.onDispatched(result));
+        public void onDispatched() {
+            contexts.forEach(InstrumentationContext::onDispatched);
         }
 
         @Override
@@ -414,8 +414,8 @@ public class ChainedInstrumentation implements Instrumentation {
         }
 
         @Override
-        public void onDispatched(CompletableFuture<ExecutionResult> result) {
-            contexts.forEach(context -> context.onDispatched(result));
+        public void onDispatched() {
+            contexts.forEach(InstrumentationContext::onDispatched);
         }
 
         @Override

--- a/src/main/java/graphql/execution/instrumentation/ExecutionStrategyInstrumentationContext.java
+++ b/src/main/java/graphql/execution/instrumentation/ExecutionStrategyInstrumentationContext.java
@@ -36,7 +36,7 @@ public interface ExecutionStrategyInstrumentationContext extends Instrumentation
     @Internal
     ExecutionStrategyInstrumentationContext NOOP = new ExecutionStrategyInstrumentationContext() {
         @Override
-        public void onDispatched(CompletableFuture<ExecutionResult> result) {
+        public void onDispatched() {
         }
 
         @Override

--- a/src/main/java/graphql/execution/instrumentation/InstrumentationContext.java
+++ b/src/main/java/graphql/execution/instrumentation/InstrumentationContext.java
@@ -7,8 +7,8 @@ import java.util.concurrent.CompletableFuture;
 /**
  * When a {@link Instrumentation}.'beginXXX()' method is called then it must return a non null InstrumentationContext
  * that will be invoked when the step is first dispatched and then when it completes.  Sometimes this is effectively the same time
- * whereas at other times its when an asynchronous {@link java.util.concurrent.CompletableFuture} completes.
- *
+ * whereas at other times it's when an asynchronous {@link java.util.concurrent.CompletableFuture} completes.
+ * <p>
  * This pattern of construction of an object then call back is intended to allow "timers" to be created that can instrument what has
  * just happened or "loggers" to be called to record what has happened.
  */
@@ -17,10 +17,8 @@ public interface InstrumentationContext<T> {
 
     /**
      * This is invoked when the instrumentation step is initially dispatched
-     *
-     * @param result the result of the step as a completable future
      */
-    void onDispatched(CompletableFuture<T> result);
+    void onDispatched();
 
     /**
      * This is invoked when the instrumentation step is fully completed

--- a/src/main/java/graphql/execution/instrumentation/SimpleInstrumentationContext.java
+++ b/src/main/java/graphql/execution/instrumentation/SimpleInstrumentationContext.java
@@ -5,7 +5,6 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 
 /**
  * A simple implementation of {@link InstrumentationContext}
@@ -15,7 +14,7 @@ public class SimpleInstrumentationContext<T> implements InstrumentationContext<T
 
     private static final InstrumentationContext<Object> NO_OP = new InstrumentationContext<Object>() {
         @Override
-        public void onDispatched(CompletableFuture<Object> result) {
+        public void onDispatched() {
         }
 
         @Override
@@ -49,21 +48,21 @@ public class SimpleInstrumentationContext<T> implements InstrumentationContext<T
     }
 
     private final BiConsumer<T, Throwable> codeToRunOnComplete;
-    private final Consumer<CompletableFuture<T>> codeToRunOnDispatch;
+    private final Runnable codeToRunOnDispatch;
 
     public SimpleInstrumentationContext() {
         this(null, null);
     }
 
-    private SimpleInstrumentationContext(Consumer<CompletableFuture<T>> codeToRunOnDispatch, BiConsumer<T, Throwable> codeToRunOnComplete) {
+    private SimpleInstrumentationContext(Runnable codeToRunOnDispatch, BiConsumer<T, Throwable> codeToRunOnComplete) {
         this.codeToRunOnComplete = codeToRunOnComplete;
         this.codeToRunOnDispatch = codeToRunOnDispatch;
     }
 
     @Override
-    public void onDispatched(CompletableFuture<T> result) {
+    public void onDispatched() {
         if (codeToRunOnDispatch != null) {
-            codeToRunOnDispatch.accept(result);
+            codeToRunOnDispatch.run();
         }
     }
 
@@ -83,7 +82,7 @@ public class SimpleInstrumentationContext<T> implements InstrumentationContext<T
      *
      * @return an instrumentation context
      */
-    public static <U> SimpleInstrumentationContext<U> whenDispatched(Consumer<CompletableFuture<U>> codeToRun) {
+    public static <U> SimpleInstrumentationContext<U> whenDispatched(Runnable codeToRun) {
         return new SimpleInstrumentationContext<>(codeToRun, null);
     }
 
@@ -101,13 +100,8 @@ public class SimpleInstrumentationContext<T> implements InstrumentationContext<T
     }
 
     public static <T> BiConsumer<? super T, ? super Throwable> completeInstrumentationCtxCF(
-            InstrumentationContext<T> instrumentationContext, CompletableFuture<T> targetCF) {
+            InstrumentationContext<T> instrumentationContext) {
         return (result, throwable) -> {
-            if (throwable != null) {
-                targetCF.completeExceptionally(throwable);
-            } else {
-                targetCF.complete(result);
-            }
             nonNullCtx(instrumentationContext).onCompleted(result, throwable);
         };
     }

--- a/src/main/java/graphql/execution/instrumentation/dataloader/FieldLevelTrackingApproach.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/FieldLevelTrackingApproach.java
@@ -134,8 +134,7 @@ public class FieldLevelTrackingApproach {
 
         return new ExecutionStrategyInstrumentationContext() {
             @Override
-            public void onDispatched(CompletableFuture<ExecutionResult> result) {
-
+            public void onDispatched() {
             }
 
             @Override
@@ -192,7 +191,7 @@ public class FieldLevelTrackingApproach {
         return new InstrumentationContext<>() {
 
             @Override
-            public void onDispatched(CompletableFuture<Object> result) {
+            public void onDispatched() {
                 boolean dispatchNeeded = callStack.lock.callLocked(() -> {
                     callStack.increaseFetchCount(level);
                     return dispatchIfNeeded(callStack, level);

--- a/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy
@@ -278,7 +278,7 @@ class AsyncExecutionStrategyTest extends Specification {
                             }
 
                             @Override
-                            void onDispatched(CompletableFuture<ExecutionResult> result) {
+                            void onDispatched() {
                             }
 
                             @Override

--- a/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
@@ -171,7 +171,7 @@ class InstrumentationTest extends Specification {
             return new ExecutionStrategyInstrumentationContext() {
 
                 @Override
-                void onDispatched(CompletableFuture<ExecutionResult> result) {
+                void onDispatched() {
                     System.out.println(String.format("t%s setting go signal on", Thread.currentThread().getId()))
                     goSignal.set(true)
                 }

--- a/src/test/groovy/graphql/execution/instrumentation/TestingInstrumentContext.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/TestingInstrumentContext.groovy
@@ -25,7 +25,7 @@ class TestingInstrumentContext<T> implements InstrumentationContext<T> {
     }
 
     @Override
-    void onDispatched(CompletableFuture<T> result) {
+    void onDispatched() {
         if (useOnDispatch) {
             this.executionList << "onDispatched:$op"
         }


### PR DESCRIPTION
In order to allow new engines to NOT always returns a CF for a value, this changes the InstrumentationContext such that the onDispatch is not passed a CF.  The onCompleted will be called back just like CF semantics however to if any one was doing work when the CF completed - then they still can, just not from the CF passed in