### PR TITLE
Handle list of @oneOf input objects

### DIFF
--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -27,7 +27,6 @@ import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLScalarType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
-import graphql.schema.GraphQLTypeUtil;
 import graphql.schema.InputValueWithState;
 import graphql.schema.visibility.GraphqlFieldVisibility;
 import org.jetbrains.annotations.NotNull;

--- a/src/test/groovy/graphql/execution/ValuesResolverTest.groovy
+++ b/src/test/groovy/graphql/execution/ValuesResolverTest.groovy
@@ -645,8 +645,8 @@ class ValuesResolverTest extends Specification {
                                 a: StringValue.of("abc")
                             ]),
                             buildObjectLiteral([
-                                    a: StringValue.of("xyz"),
-                                    b: IntValue.of(789)
+                                a: StringValue.of("xyz"),
+                                b: IntValue.of(789)
                             ]),
                         ]).build()
                                     | CoercedVariables.emptyVariables()
@@ -655,7 +655,7 @@ class ValuesResolverTest extends Specification {
                     | ArrayValue.newArrayValue()
                         .values([
                             buildObjectLiteral([
-                                    a: StringValue.of("abc")
+                                a: StringValue.of("abc")
                             ]),
                             VariableReference.of("var")
                         ]).build()
@@ -695,10 +695,10 @@ class ValuesResolverTest extends Specification {
                     | ArrayValue.newArrayValue()
                         .values([
                             buildObjectLiteral([
-                                    a: StringValue.of("abc")
+                                a: StringValue.of("abc")
                             ]),
                             buildObjectLiteral([
-                                    a: NullValue.of()
+                                a: NullValue.of()
                             ]),
                         ]).build()
                                     | CoercedVariables.emptyVariables()
@@ -707,10 +707,10 @@ class ValuesResolverTest extends Specification {
                     | ArrayValue.newArrayValue()
                         .values([
                             buildObjectLiteral([
-                                    a: StringValue.of("abc")
+                                a: StringValue.of("abc")
                             ]),
                             buildObjectLiteral([
-                                    a: VariableReference.of("var")
+                                a: VariableReference.of("var")
                             ]),
                         ]).build()
                                     | CoercedVariables.of("var": null)
@@ -757,11 +757,11 @@ class ValuesResolverTest extends Specification {
                     | ArrayValue.newArrayValue()
                         .values([
                             buildObjectLiteral([
-                                    a: StringValue.of("abc")
+                                a: StringValue.of("abc")
                             ]),
                             buildObjectLiteral([
-                                    a: StringValue.of("xyz"),
-                                    b: IntValue.of(789)
+                                a: StringValue.of("xyz"),
+                                b: IntValue.of(789)
                             ]),
                         ]).build()
                                     | CoercedVariables.emptyVariables()
@@ -770,7 +770,7 @@ class ValuesResolverTest extends Specification {
                     | ArrayValue.newArrayValue()
                         .values([
                             buildObjectLiteral([
-                                    a: StringValue.of("abc")
+                                a: StringValue.of("abc")
                             ]),
                             VariableReference.of("var")
                         ]).build()
@@ -818,11 +818,11 @@ class ValuesResolverTest extends Specification {
                     | ArrayValue.newArrayValue()
                         .values([
                             buildObjectLiteral([
-                                    a: StringValue.of("abc")
+                                a: StringValue.of("abc")
                             ]),
                             buildObjectLiteral([
-                                    a: StringValue.of("xyz"),
-                                    b: IntValue.of(789)
+                                a: StringValue.of("xyz"),
+                                b: IntValue.of(789)
                             ]),
                         ]).build()
                                     | CoercedVariables.emptyVariables()
@@ -831,7 +831,7 @@ class ValuesResolverTest extends Specification {
                     | ArrayValue.newArrayValue()
                         .values([
                             buildObjectLiteral([
-                                    a: StringValue.of("abc")
+                                a: StringValue.of("abc")
                             ]),
                             VariableReference.of("var")
                         ]).build()

--- a/src/test/groovy/graphql/execution/ValuesResolverTest.groovy
+++ b/src/test/groovy/graphql/execution/ValuesResolverTest.groovy
@@ -23,7 +23,6 @@ import graphql.language.Value
 import graphql.language.VariableDefinition
 import graphql.language.VariableReference
 import graphql.schema.CoercingParseValueException
-import graphql.schema.GraphQLNonNull
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -373,7 +372,7 @@ class ValuesResolverTest extends Specification {
         e.message == "Exactly one key must be specified for OneOf type 'oneOfInputObject'."
 
         when: "input type is wrapped in non-null"
-        def nonNullInputObjectType = GraphQLNonNull.nonNull(inputObjectType)
+        def nonNullInputObjectType = nonNull(inputObjectType)
         def fieldArgumentNonNull = newArgument().name("arg").type(nonNullInputObjectType).build()
         ValuesResolver.getArgumentValues([fieldArgumentNonNull], [argument], variables, graphQLContext, locale)
 
@@ -603,7 +602,7 @@ class ValuesResolverTest extends Specification {
 
     }
 
-    def "getArgumentValues: invalid oneOf input validation applied with list of input type"() {
+    def "getArgumentValues: invalid oneOf list input because element contains duplicate key - #testCase"() {
         given: "schema defining input object"
         def inputObjectType = newInputObject()
                 .name("oneOfInputObject")
@@ -618,23 +617,226 @@ class ValuesResolverTest extends Specification {
                         .build())
                 .build()
 
-        def inputValue = buildObjectLiteral([
-                oneOfField: [
-                        a: StringValue.of("abc"),
-                        b: IntValue.of(123)
-                ]
-        ])
-        def inputArray = ArrayValue.newArrayValue().value(inputValue).build()
-
-        def argument = new Argument("arg", inputArray)
-
         when:
+        def argument = new Argument("arg", inputArray)
         def fieldArgumentList = newArgument().name("arg").type(list(inputObjectType)).build()
-        ValuesResolver.getArgumentValues([fieldArgumentList], [argument], CoercedVariables.emptyVariables(), graphQLContext, locale)
+        ValuesResolver.getArgumentValues([fieldArgumentList], [argument], variables, graphQLContext, locale)
 
         then:
         def e = thrown(OneOfTooManyKeysException)
         e.message == "Exactly one key must be specified for OneOf type 'oneOfInputObject'."
+
+        where:
+
+        testCase    | inputArray    | variables
+
+        '[{ a: "abc", b: 123 }]'
+                    | ArrayValue.newArrayValue()
+                        .value(buildObjectLiteral([
+                            a: StringValue.of("abc"),
+                            b: IntValue.of(123)
+                        ])).build()
+                                    | CoercedVariables.emptyVariables()
+
+        '[{ a: "abc" }, { a: "xyz", b: 789 }]'
+                    | ArrayValue.newArrayValue()
+                        .values([
+                            buildObjectLiteral([
+                                a: StringValue.of("abc")
+                            ]),
+                            buildObjectLiteral([
+                                    a: StringValue.of("xyz"),
+                                    b: IntValue.of(789)
+                            ]),
+                        ]).build()
+                                    | CoercedVariables.emptyVariables()
+
+        '[{ a: "abc" }, $var ] [{ a: "abc" }, { a: "xyz", b: 789 }]'
+                    | ArrayValue.newArrayValue()
+                        .values([
+                            buildObjectLiteral([
+                                    a: StringValue.of("abc")
+                            ]),
+                            VariableReference.of("var")
+                        ]).build()
+                                    | CoercedVariables.of("var": [a: "xyz", b: 789])
+
+    }
+
+    def "getArgumentValues: invalid oneOf list input because element contains null value - #testCase"() {
+        given: "schema defining input object"
+        def inputObjectType = newInputObject()
+                .name("oneOfInputObject")
+                .withAppliedDirective(Directives.OneOfDirective.toAppliedDirective())
+                .field(newInputObjectField()
+                        .name("a")
+                        .type(GraphQLString)
+                        .build())
+                .field(newInputObjectField()
+                        .name("b")
+                        .type(GraphQLInt)
+                        .build())
+                .build()
+
+        when:
+        def argument = new Argument("arg", inputArray)
+        def fieldArgumentList = newArgument().name("arg").type(list(inputObjectType)).build()
+        ValuesResolver.getArgumentValues([fieldArgumentList], [argument], variables, graphQLContext, locale)
+
+        then:
+        def e = thrown(OneOfNullValueException)
+        e.message == "OneOf type field 'oneOfInputObject.a' must be non-null."
+
+        where:
+
+        testCase    | inputArray    | variables
+
+        '[{ a: "abc" }, { a: null }]'
+                    | ArrayValue.newArrayValue()
+                        .values([
+                            buildObjectLiteral([
+                                    a: StringValue.of("abc")
+                            ]),
+                            buildObjectLiteral([
+                                    a: NullValue.of()
+                            ]),
+                        ]).build()
+                                    | CoercedVariables.emptyVariables()
+
+        '[{ a: "abc" }, { a: $var }] [{ a: "abc" }, { a: null }]'
+                    | ArrayValue.newArrayValue()
+                        .values([
+                            buildObjectLiteral([
+                                    a: StringValue.of("abc")
+                            ]),
+                            buildObjectLiteral([
+                                    a: VariableReference.of("var")
+                            ]),
+                        ]).build()
+                                    | CoercedVariables.of("var": null)
+
+    }
+
+    def "getArgumentValues: invalid oneOf non-null list input because element contains duplicate key - #testCase"() {
+        given: "schema defining input object"
+        def inputObjectType = newInputObject()
+                .name("oneOfInputObject")
+                .withAppliedDirective(Directives.OneOfDirective.toAppliedDirective())
+                .field(newInputObjectField()
+                        .name("a")
+                        .type(GraphQLString)
+                        .build())
+                .field(newInputObjectField()
+                        .name("b")
+                        .type(GraphQLInt)
+                        .build())
+                .build()
+
+        when:
+        def argument = new Argument("arg", inputArray)
+        def fieldArgumentList = newArgument().name("arg").type(nonNull(list(inputObjectType))).build()
+        ValuesResolver.getArgumentValues([fieldArgumentList], [argument], variables, graphQLContext, locale)
+
+        then:
+        def e = thrown(OneOfTooManyKeysException)
+        e.message == "Exactly one key must be specified for OneOf type 'oneOfInputObject'."
+
+        where:
+
+        testCase    | inputArray    | variables
+
+        '[{ a: "abc", b: 123 }]'
+                    | ArrayValue.newArrayValue()
+                        .value(buildObjectLiteral([
+                            a: StringValue.of("abc"),
+                            b: IntValue.of(123)
+                        ])).build()
+                                    | CoercedVariables.emptyVariables()
+
+        '[{ a: "abc" }, { a: "xyz", b: 789 }]'
+                    | ArrayValue.newArrayValue()
+                        .values([
+                            buildObjectLiteral([
+                                    a: StringValue.of("abc")
+                            ]),
+                            buildObjectLiteral([
+                                    a: StringValue.of("xyz"),
+                                    b: IntValue.of(789)
+                            ]),
+                        ]).build()
+                                    | CoercedVariables.emptyVariables()
+
+        '[{ a: "abc" }, $var ] [{ a: "abc" }, { a: "xyz", b: 789 }]'
+                    | ArrayValue.newArrayValue()
+                        .values([
+                            buildObjectLiteral([
+                                    a: StringValue.of("abc")
+                            ]),
+                            VariableReference.of("var")
+                        ]).build()
+                                    | CoercedVariables.of("var": [a: "xyz", b: 789])
+
+    }
+
+    def "getArgumentValues: invalid oneOf list input with non-nullable elements, because element contains duplicate key - #testCase"() {
+        given: "schema defining input object"
+        def inputObjectType = newInputObject()
+                .name("oneOfInputObject")
+                .withAppliedDirective(Directives.OneOfDirective.toAppliedDirective())
+                .field(newInputObjectField()
+                        .name("a")
+                        .type(GraphQLString)
+                        .build())
+                .field(newInputObjectField()
+                        .name("b")
+                        .type(GraphQLInt)
+                        .build())
+                .build()
+
+        when:
+        def argument = new Argument("arg", inputArray)
+        def fieldArgumentList = newArgument().name("arg").type(list(nonNull(inputObjectType))).build()
+        ValuesResolver.getArgumentValues([fieldArgumentList], [argument], variables, graphQLContext, locale)
+
+        then:
+        def e = thrown(OneOfTooManyKeysException)
+        e.message == "Exactly one key must be specified for OneOf type 'oneOfInputObject'."
+
+        where:
+
+        testCase    | inputArray    | variables
+
+        '[{ a: "abc", b: 123 }]'
+                    | ArrayValue.newArrayValue()
+                        .value(buildObjectLiteral([
+                            a: StringValue.of("abc"),
+                            b: IntValue.of(123)
+                        ])).build()
+                                    | CoercedVariables.emptyVariables()
+
+        '[{ a: "abc" }, { a: "xyz", b: 789 }]'
+                    | ArrayValue.newArrayValue()
+                        .values([
+                            buildObjectLiteral([
+                                    a: StringValue.of("abc")
+                            ]),
+                            buildObjectLiteral([
+                                    a: StringValue.of("xyz"),
+                                    b: IntValue.of(789)
+                            ]),
+                        ]).build()
+                                    | CoercedVariables.emptyVariables()
+
+        '[{ a: "abc" }, $var ] [{ a: "abc" }, { a: "xyz", b: 789 }]'
+                    | ArrayValue.newArrayValue()
+                        .values([
+                            buildObjectLiteral([
+                                    a: StringValue.of("abc")
+                            ]),
+                            VariableReference.of("var")
+                        ]).build()
+                                    | CoercedVariables.of("var": [a: "xyz", b: 789])
+
     }
 
     def "getArgumentValues: valid oneOf input - #testCase"() {


### PR DESCRIPTION
Update: This PR adds handling of arguments with a list of `@oneOf` input objects

Fixes https://github.com/graphql-java/graphql-java/issues/3366

Confirmed that graphql-js validates elements of a list