### PR TITLE
Add tag to exempt PRs and issues from the stale bot

### DIFF
--- a/.github/workflows/stale-pr-issue.yml
+++ b/.github/workflows/stale-pr-issue.yml
@@ -32,6 +32,7 @@ jobs:
           close-issue-message: >
             Hello, as this issue has been inactive for 90 days, we're closing the issue.
             If you would like to resume the discussion, please create a new issue.
+          exempt-issue-labels: keep-open
 
           # PULL REQUESTS -----------------------------------------------------
           # PRs will be closed after 90 days of inactive (60 to mark as stale + 30 to close)
@@ -42,3 +43,4 @@ jobs:
           close-pr-message: >
             Hello, as this pull request has been inactive for 90 days, we're closing this pull request.
             We always welcome contributions, and if you would like to continue, please open a new pull request.
+          exempt-pr-labels: keep-open


### PR DESCRIPTION
Tag PRs and issues as `keep-open` if you want to prevent the Stale Bot from closing what you're already working on

Note, any issues or PRs with a milestone label are also exempted from the Stale Bot.