### PR TITLE
Bump up com.google.guava:guava version to 32.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ dependencies {
     api 'com.graphql-java:java-dataloader:3.1.0'
     api 'org.reactivestreams:reactive-streams:' + reactiveStreamsVersion
     antlr 'org.antlr:antlr4:' + antlrVersion
-    implementation 'com.google.guava:guava:30.0-jre'
+    implementation 'com.google.guava:guava:32.1.1-jre'
     testImplementation group: 'junit', name: 'junit', version: '4.12'
     testImplementation 'org.spockframework:spock-core:2.0-groovy-3.0'
     testImplementation 'org.codehaus.groovy:groovy:3.0.8'
@@ -125,7 +125,7 @@ shadowJar {
         include 'com.google.common.primitives.*'
     }
     dependencies {
-        include(dependency('com.google.guava:guava:30.0-jre'))
+        include(dependency('com.google.guava:guava:32.1.1-jre'))
     }
     from "LICENSE.md"
     from "src/main/antlr/Graphql.g4"


### PR DESCRIPTION
Bump up com.google.guava:guava version to 32.1.1 to fix vulnerabilities - https://nvd.nist.gov/vuln/detail/CVE-2023-2976