### PR TITLE
Propagate GraphQLContext when completing fields - fix missing ConditionalNodesDecision issue

### DIFF
--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -683,6 +683,7 @@ public abstract class ExecutionStrategy {
                 .objectType(resolvedObjectType)
                 .fragments(executionContext.getFragmentsByName())
                 .variables(executionContext.getCoercedVariables().toMap())
+                .graphQLContext(executionContext.getGraphQLContext())
                 .build();
 
         MergedSelectionSet subFields = fieldCollector.collectFields(collectorParameters, parameters.getField());

--- a/src/test/groovy/graphql/execution/ConditionalNodesTest.groovy
+++ b/src/test/groovy/graphql/execution/ConditionalNodesTest.groovy
@@ -192,8 +192,7 @@ class ConditionalNodesTest extends Specification {
         then:
         er["data"] == ["in": "in", "out": "out"]
 
-        // TODO: this test demonstrates that the GraphQLContext is missing for Pet
-        // and therefore, fields are being incorrectly included
+        // A test for fields below the top level
         when:
         ei = ExecutionInput.newExecutionInput()
                 .graphQLContext(contextMap)
@@ -210,7 +209,6 @@ class ConditionalNodesTest extends Specification {
         er = graphQL.execute(ei)
 
         then:
-        // TODO: favouriteSnack should not appear in the data
         er["data"] == ["in": "in", "pet": ["name": "name"]]
     }
 


### PR DESCRIPTION
This PR fixes issue #3409. As @dfa1 wrote, when evaluating nodes at least 1 level lower than the top level field, the GraphQLContext is for some reason wiped out, which means a custom ConditionalNodesDecision is not applied.

The problem was the GraphQLContext was there when evaluating whether a top level field should be included, but any fields below top level is evaluated for inclusion when completing values. In this separate method, the GraphQLContext was not propagated in the parameters.

In case you're wondering, this bug did not affect `@include`/`@skip`, it only affected decisions stored in `GraphQLContext`.