### PR TITLE
Skip signing for local and upgrade to Gradle 8.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -348,7 +348,7 @@ nexusPublishing {
 }
 
 signing {
-    required { !project.hasProperty('publishToMavenLocal')  }
+    required { !project.hasProperty('publishToMavenLocal') }
     def signingKey = System.env.MAVEN_CENTRAL_PGP_KEY
     useInMemoryPgpKeys(signingKey, "")
     sign publishing.publications

--- a/build.gradle
+++ b/build.gradle
@@ -348,7 +348,7 @@ nexusPublishing {
 }
 
 signing {
-    required { !version.endsWith('-SNAPSHOT') }
+    required { !project.hasProperty('publishToMavenLocal')  }
     def signingKey = System.env.MAVEN_CENTRAL_PGP_KEY
     useInMemoryPgpKeys(signingKey, "")
     sign publishing.publications

--- a/build.gradle
+++ b/build.gradle
@@ -347,8 +347,8 @@ nexusPublishing {
     }
 }
 
-// to publish to local maven repo skip signing: ./gradlew publishToMavenLocal  -x signGraphqlJavaPublication
 signing {
+    required { !version.endsWith('-SNAPSHOT') }
     def signingKey = System.env.MAVEN_CENTRAL_PGP_KEY
     useInMemoryPgpKeys(signingKey, "")
     sign publishing.publications

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
We spotted a problem where the local Maven publish task fails on Gradle 8.5 and later. Something has changed with the signing plugin.

When running the publish locally task excluding signing on Gradle 8.5:
```
./gradlew publishToMavenLocal  -x signGraphqlJavaPublication
```

We got an invalid publication error

```
Invalid publication 'graphqlJava': artifact file does not exist: 'src/graphql-java/build/libs/graphql-java-0.0.0-defer-execution-2024-SNAPSHOT-sources.jar.asc'
```

It's a strange error because by skipping signing, we intentionally don't want this file there.

This PR fixes the problem by updating the signing task to only run when we're publishing (in other words, not a local SNAPSHOT version).

While I'm here I upgraded to Gradle 8.6. There are no accompanying gradlew etc file changes to check in.