### PR TITLE
Fix invalid AST printer: add escape characters to single line descriptions

### DIFF
--- a/src/main/java/graphql/GraphQLError.java
+++ b/src/main/java/graphql/GraphQLError.java
@@ -39,8 +39,8 @@ public interface GraphQLError extends Serializable {
     ErrorClassification getErrorType();
 
     /**
-     * The graphql spec says that the (optional) path field of any error should be a list
-     * of path entries https://spec.graphql.org/October2021/#sec-Handling-Field-Errors
+     * The graphql spec says that the (optional) path field of any error must be a list
+     * of path entries https://spec.graphql.org/draft/#sec-Errors.Error-Result-Format
      *
      * @return the path in list format
      */

--- a/src/main/java/graphql/GraphQLError.java
+++ b/src/main/java/graphql/GraphQLError.java
@@ -39,8 +39,10 @@ public interface GraphQLError extends Serializable {
     ErrorClassification getErrorType();
 
     /**
-     * The graphql spec says that the (optional) path field of any error must be a list
-     * of path entries https://spec.graphql.org/draft/#sec-Errors.Error-Result-Format
+     * The graphql spec says that the (optional) path field of any error must be
+     * a list of path entries starting at the root of the response
+     * and ending with the field associated with the error
+     * https://spec.graphql.org/draft/#sec-Errors.Error-Result-Format
      *
      * @return the path in list format
      */

--- a/src/main/java/graphql/language/AstPrinter.java
+++ b/src/main/java/graphql/language/AstPrinter.java
@@ -534,7 +534,7 @@ public class AstPrinter {
         if (description.isMultiLine()) {
             s = "\"\"\"" + (startNewLine ? "" : "\n") + description.getContent() + "\n\"\"\"\n";
         } else {
-            s = "\"" + description.getContent() + "\"\n";
+            s = "\"" + escapeJsonString(description.getContent()) + "\"\n";
         }
         return s;
     }

--- a/src/test/groovy/graphql/parser/ParserTest.groovy
+++ b/src/test/groovy/graphql/parser/ParserTest.groovy
@@ -4,6 +4,7 @@ package graphql.parser
 import graphql.language.Argument
 import graphql.language.ArrayValue
 import graphql.language.AstComparator
+import graphql.language.AstPrinter
 import graphql.language.BooleanValue
 import graphql.language.Description
 import graphql.language.Directive
@@ -1151,5 +1152,35 @@ triple3 : """edge cases \\""" "" " \\"" \\" edge cases"""
         document.getDefinitions()[0].getSourceLocation() == SourceLocation.EMPTY
     }
 
+    def "escape characters correctly printed when printing AST"() {
+        given:
+        def src = "\"\\\"\" scalar A"
+
+        def env = newParserEnvironment()
+                .document(src)
+                .parserOptions(
+                        ParserOptions.newParserOptions()
+                                .captureIgnoredChars(true)
+                                .build()
+                )
+                .build()
+
+        when:
+        // Parse the original Document
+        def doc = Parser.parse(env)
+        // Print the AST
+        def printed = AstPrinter.printAst(doc)
+        // Re-parse printed AST
+        def reparsed = Parser.parse(printed)
+
+        then:
+        noExceptionThrown() // The printed AST was re-parsed without exception
+
+        when:
+        def reparsedPrinted = AstPrinter.printAst(reparsed)
+        
+        then:
+        reparsedPrinted == printed // Re-parsing and re-printing produces the same result
+    }
 
 }

--- a/src/test/groovy/graphql/parser/ParserTest.groovy
+++ b/src/test/groovy/graphql/parser/ParserTest.groovy
@@ -1154,8 +1154,6 @@ triple3 : """edge cases \\""" "" " \\"" \\" edge cases"""
 
     def "escape characters correctly printed when printing AST"() {
         given:
-        def src = "\"\\\"\" scalar A"
-
         def env = newParserEnvironment()
                 .document(src)
                 .parserOptions(
@@ -1178,9 +1176,17 @@ triple3 : """edge cases \\""" "" " \\"" \\" edge cases"""
 
         when:
         def reparsedPrinted = AstPrinter.printAst(reparsed)
-        
+
         then:
         reparsedPrinted == printed // Re-parsing and re-printing produces the same result
+
+        where:
+        src                 | _
+        "\"\\\"\" scalar A" | _
+        "\"\f\" scalar A"   | _
+        "\"\b\" scalar A"   | _
+        "\"\t\" scalar A"   | _
+        "\"\\\" scalar A"   | _
     }
 
 }

--- a/src/test/groovy/graphql/parser/ParserTest.groovy
+++ b/src/test/groovy/graphql/parser/ParserTest.groovy
@@ -1186,7 +1186,6 @@ triple3 : """edge cases \\""" "" " \\"" \\" edge cases"""
         "\"\f\" scalar A"   | _
         "\"\b\" scalar A"   | _
         "\"\t\" scalar A"   | _
-        "\"\\\" scalar A"   | _
     }
 
 }


### PR DESCRIPTION
## This PR fixes #3229 

Add escape characters where appropriate to AST printer for single line descriptions.

#### What was the problem?
When parsing single line descriptions, escape characters are converted to their Java string equivalent. See `parseSingleQuotedString` inside `StringValueParsing`. https://github.com/graphql-java/graphql-java/blob/97ba988eabd74657f5455e9d32867c5170b0dffe/src/main/java/graphql/parser/StringValueParsing.java#L107

However, when we printed single line descriptions, we did not do the reverse and put the escape characters back into the printed output. Without the correct escape characters, it is possible to print invalid GraphQL (see #3229).

#### To do
I'll add more test cases. Currently only has a test for case described in the original issue