### PR TITLE
ensure that instrumentations get an executionid

### DIFF
--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -415,7 +415,7 @@ public class GraphQL {
     public CompletableFuture<ExecutionResult> executeAsync(ExecutionInput executionInput) {
         ExecutionInput executionInputWithId = ensureInputHasId(executionInput);
 
-        CompletableFuture<InstrumentationState> instrumentationStateCF = instrumentation.createStateAsync(new InstrumentationCreateStateParameters(this.graphQLSchema, executionInput));
+        CompletableFuture<InstrumentationState> instrumentationStateCF = instrumentation.createStateAsync(new InstrumentationCreateStateParameters(this.graphQLSchema, executionInputWithId));
         return Async.orNullCompletedFuture(instrumentationStateCF).thenCompose(instrumentationState -> {
             try {
                 InstrumentationExecutionParameters inputInstrumentationParameters = new InstrumentationExecutionParameters(executionInputWithId, this.graphQLSchema, instrumentationState);

--- a/src/test/groovy/graphql/GraphQLTest.groovy
+++ b/src/test/groovy/graphql/GraphQLTest.groovy
@@ -17,8 +17,11 @@ import graphql.execution.SubscriptionExecutionStrategy
 import graphql.execution.ValueUnboxer
 import graphql.execution.instrumentation.ChainedInstrumentation
 import graphql.execution.instrumentation.Instrumentation
+import graphql.execution.instrumentation.InstrumentationState
+import graphql.execution.instrumentation.SimpleInstrumentation
 import graphql.execution.instrumentation.SimplePerformantInstrumentation
 import graphql.execution.instrumentation.dataloader.DataLoaderDispatcherInstrumentation
+import graphql.execution.instrumentation.parameters.InstrumentationCreateStateParameters
 import graphql.execution.preparsed.NoOpPreparsedDocumentProvider
 import graphql.language.SourceLocation
 import graphql.schema.DataFetcher
@@ -1061,6 +1064,26 @@ many lines""") }''')
         result.data == [hello: '''world
 over
 many lines''']
+    }
+
+    def "executionId is set before being passed to instrumentation"() {
+        InstrumentationCreateStateParameters seenParams
+
+        def instrumentation = new Instrumentation() {
+            @Override InstrumentationState createState(InstrumentationCreateStateParameters params) {
+                seenParams = params
+                null
+            }
+        }
+
+        when:
+            GraphQL.newGraphQL(StarWarsSchema.starWarsSchema)
+                .instrumentation(instrumentation)
+                .build()
+                .execute("{ __typename }")
+
+        then:
+            seenParams.executionInput.executionId != null
     }
 
     def "variables map can't be null via ExecutionInput"() {


### PR DESCRIPTION
👋  While migrating from v18 to v21.3, I noticed there was a regression where instrumentations would have `createState` called without an executionId.

I think this might have been introduced in ce83384b7ae682cc1eb099c10ef87e8a0daa938f. I added a fix and a test.