### PR TITLE
This removes the CompletableFuture signature from InstrumentationContext

### DIFF
--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -421,17 +421,16 @@ public class GraphQL {
                 InstrumentationExecutionParameters inputInstrumentationParameters = new InstrumentationExecutionParameters(executionInputWithId, this.graphQLSchema, instrumentationState);
                 ExecutionInput instrumentedExecutionInput = instrumentation.instrumentExecutionInput(executionInputWithId, inputInstrumentationParameters, instrumentationState);
 
-                CompletableFuture<ExecutionResult> beginExecutionCF = new CompletableFuture<>();
                 InstrumentationExecutionParameters instrumentationParameters = new InstrumentationExecutionParameters(instrumentedExecutionInput, this.graphQLSchema, instrumentationState);
                 InstrumentationContext<ExecutionResult> executionInstrumentation = nonNullCtx(instrumentation.beginExecution(instrumentationParameters, instrumentationState));
-                executionInstrumentation.onDispatched(beginExecutionCF);
+                executionInstrumentation.onDispatched();
 
                 GraphQLSchema graphQLSchema = instrumentation.instrumentSchema(this.graphQLSchema, instrumentationParameters, instrumentationState);
 
                 CompletableFuture<ExecutionResult> executionResult = parseValidateAndExecute(instrumentedExecutionInput, graphQLSchema, instrumentationState);
                 //
                 // finish up instrumentation
-                executionResult = executionResult.whenComplete(completeInstrumentationCtxCF(executionInstrumentation, beginExecutionCF));
+                executionResult = executionResult.whenComplete(completeInstrumentationCtxCF(executionInstrumentation));
                 //
                 // allow instrumentation to tweak the result
                 executionResult = executionResult.thenCompose(result -> instrumentation.instrumentExecutionResult(result, instrumentationParameters, instrumentationState));
@@ -508,15 +507,13 @@ public class GraphQL {
     private ParseAndValidateResult parse(ExecutionInput executionInput, GraphQLSchema graphQLSchema, InstrumentationState instrumentationState) {
         InstrumentationExecutionParameters parameters = new InstrumentationExecutionParameters(executionInput, graphQLSchema, instrumentationState);
         InstrumentationContext<Document> parseInstrumentationCtx = nonNullCtx(instrumentation.beginParse(parameters, instrumentationState));
-        CompletableFuture<Document> documentCF = new CompletableFuture<>();
-        parseInstrumentationCtx.onDispatched(documentCF);
+        parseInstrumentationCtx.onDispatched();
 
         ParseAndValidateResult parseResult = ParseAndValidate.parse(executionInput);
         if (parseResult.isFailure()) {
             parseInstrumentationCtx.onCompleted(null, parseResult.getSyntaxException());
             return parseResult;
         } else {
-            documentCF.complete(parseResult.getDocument());
             parseInstrumentationCtx.onCompleted(parseResult.getDocument(), null);
 
             DocumentAndVariables documentAndVariables = parseResult.getDocumentAndVariables();
@@ -528,15 +525,13 @@ public class GraphQL {
 
     private List<ValidationError> validate(ExecutionInput executionInput, Document document, GraphQLSchema graphQLSchema, InstrumentationState instrumentationState) {
         InstrumentationContext<List<ValidationError>> validationCtx = nonNullCtx(instrumentation.beginValidation(new InstrumentationValidationParameters(executionInput, document, graphQLSchema, instrumentationState), instrumentationState));
-        CompletableFuture<List<ValidationError>> cf = new CompletableFuture<>();
-        validationCtx.onDispatched(cf);
+        validationCtx.onDispatched();
 
         Predicate<Class<?>> validationRulePredicate = executionInput.getGraphQLContext().getOrDefault(ParseAndValidate.INTERNAL_VALIDATION_PREDICATE_HINT, r -> true);
         Locale locale = executionInput.getLocale() != null ? executionInput.getLocale() : Locale.getDefault();
         List<ValidationError> validationErrors = ParseAndValidate.validate(graphQLSchema, document, validationRulePredicate, locale);
 
         validationCtx.onCompleted(validationErrors, null);
-        cf.complete(validationErrors);
         return validationErrors;
     }
 

--- a/src/main/java/graphql/execution/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncExecutionStrategy.java
@@ -48,7 +48,7 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
         Async.CombinedBuilder<FieldValueInfo> futures = getAsyncFieldValueInfo(executionContext, parameters, deferredExecutionSupport);
 
         CompletableFuture<ExecutionResult> overallResult = new CompletableFuture<>();
-        executionStrategyCtx.onDispatched(overallResult);
+        executionStrategyCtx.onDispatched();
 
         futures.await().whenComplete((completeValueInfos, throwable) -> {
             List<String> fieldsExecutedOnInitialResult = deferredExecutionSupport.getNonDeferredFieldNames(fieldNames);

--- a/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
@@ -48,7 +48,7 @@ public class AsyncSerialExecutionStrategy extends AbstractAsyncExecutionStrategy
         });
 
         CompletableFuture<ExecutionResult> overallResult = new CompletableFuture<>();
-        executionStrategyCtx.onDispatched(overallResult);
+        executionStrategyCtx.onDispatched();
 
         resultsFuture.whenComplete(handleResults(executionContext, fieldNames, overallResult));
         overallResult.whenComplete(executionStrategyCtx::onCompleted);

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -124,7 +124,7 @@ public class Execution {
                 ExecutionResult executionResult = new ExecutionResultImpl(Collections.singletonList((GraphQLError) rte));
                 CompletableFuture<ExecutionResult> resultCompletableFuture = completedFuture(executionResult);
 
-                executeOperationCtx.onDispatched(resultCompletableFuture);
+                executeOperationCtx.onDispatched();
                 executeOperationCtx.onCompleted(executionResult, rte);
                 return resultCompletableFuture;
             }
@@ -176,7 +176,7 @@ public class Execution {
         }
 
         // note this happens NOW - not when the result completes
-        executeOperationCtx.onDispatched(result);
+        executeOperationCtx.onDispatched();
 
         // fill out extensions if we have them
         result = result.thenApply(er -> mergeExtensionsBuilderIfPresent(er, graphQLContext));

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -206,7 +206,7 @@ public abstract class ExecutionStrategy {
         Async.CombinedBuilder<FieldValueInfo> resolvedFieldFutures = getAsyncFieldValueInfo(executionContext, parameters, deferredExecutionSupport);
 
         CompletableFuture<Map<String, Object>> overallResult = new CompletableFuture<>();
-        resolveObjectCtx.onDispatched(overallResult);
+        resolveObjectCtx.onDispatched();
 
         resolvedFieldFutures.await().whenComplete((completeValueInfos, throwable) -> {
             List<String> fieldsExecutedOnInitialResult = deferredExecutionSupport.getNonDeferredFieldNames(fieldNames);
@@ -347,7 +347,7 @@ public abstract class ExecutionStrategy {
 
         CompletableFuture<Object> fieldValueFuture = result.thenCompose(FieldValueInfo::getFieldValueFuture);
 
-        fieldCtx.onDispatched(fieldValueFuture);
+        fieldCtx.onDispatched();
         fieldValueFuture.whenComplete(fieldCtx::onCompleted);
         return result;
     }
@@ -417,7 +417,7 @@ public abstract class ExecutionStrategy {
         dataFetcher = instrumentation.instrumentDataFetcher(dataFetcher, instrumentationFieldFetchParams, executionContext.getInstrumentationState());
         CompletableFuture<Object> fetchedValue = invokeDataFetcher(executionContext, parameters, fieldDef, dataFetchingEnvironment, dataFetcher);
 
-        fetchCtx.onDispatched(fetchedValue);
+        fetchCtx.onDispatched();
         return fetchedValue
                 .handle((result, exception) -> {
                     fetchCtx.onCompleted(result, exception);
@@ -567,7 +567,7 @@ public abstract class ExecutionStrategy {
         FieldValueInfo fieldValueInfo = completeValue(executionContext, newParameters);
 
         CompletableFuture<Object> executionResultFuture = fieldValueInfo.getFieldValueFuture();
-        ctxCompleteField.onDispatched(executionResultFuture);
+        ctxCompleteField.onDispatched();
         executionResultFuture.whenComplete(ctxCompleteField::onCompleted);
         return fieldValueInfo;
     }
@@ -721,7 +721,7 @@ public abstract class ExecutionStrategy {
         CompletableFuture<List<Object>> resultsFuture = Async.each(fieldValueInfos, FieldValueInfo::getFieldValueFuture);
 
         CompletableFuture<Object> overallResult = new CompletableFuture<>();
-        completeListCtx.onDispatched(overallResult);
+        completeListCtx.onDispatched();
         overallResult.whenComplete(completeListCtx::onCompleted);
 
         resultsFuture.whenComplete((results, exception) -> {

--- a/src/main/java/graphql/execution/SubscriptionExecutionStrategy.java
+++ b/src/main/java/graphql/execution/SubscriptionExecutionStrategy.java
@@ -69,7 +69,7 @@ public class SubscriptionExecutionStrategy extends ExecutionStrategy {
         });
 
         // dispatched the subscription query
-        executionStrategyCtx.onDispatched(overallResult);
+        executionStrategyCtx.onDispatched();
         overallResult.whenComplete(executionStrategyCtx::onCompleted);
 
         return overallResult;
@@ -140,7 +140,7 @@ public class SubscriptionExecutionStrategy extends ExecutionStrategy {
                 .thenApply(executionResult -> wrapWithRootFieldName(newParameters, executionResult));
 
         // dispatch instrumentation so they can know about each subscription event
-        subscribedFieldCtx.onDispatched(overallResult);
+        subscribedFieldCtx.onDispatched();
         overallResult.whenComplete(subscribedFieldCtx::onCompleted);
 
         // allow them to instrument each ER should they want to

--- a/src/main/java/graphql/execution/instrumentation/ChainedInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/ChainedInstrumentation.java
@@ -443,8 +443,8 @@ public class ChainedInstrumentation implements Instrumentation {
         }
 
         @Override
-        public void onDispatched(CompletableFuture<T> result) {
-            contexts.forEach(context -> context.onDispatched(result));
+        public void onDispatched() {
+            contexts.forEach(InstrumentationContext::onDispatched);
         }
 
         @Override
@@ -462,8 +462,8 @@ public class ChainedInstrumentation implements Instrumentation {
         }
 
         @Override
-        public void onDispatched(CompletableFuture<ExecutionResult> result) {
-            contexts.forEach(context -> context.onDispatched(result));
+        public void onDispatched() {
+            contexts.forEach(InstrumentationContext::onDispatched);
         }
 
         @Override
@@ -491,8 +491,8 @@ public class ChainedInstrumentation implements Instrumentation {
         }
 
         @Override
-        public void onDispatched(CompletableFuture<Map<String, Object>> result) {
-            contexts.forEach(context -> context.onDispatched(result));
+        public void onDispatched() {
+            contexts.forEach(InstrumentationContext::onDispatched);
         }
 
         @Override
@@ -520,8 +520,8 @@ public class ChainedInstrumentation implements Instrumentation {
         }
 
         @Override
-        public void onDispatched(CompletableFuture<Object> result) {
-            contexts.forEach(context -> context.onDispatched(result));
+        public void onDispatched() {
+            contexts.forEach(InstrumentationContext::onDispatched);
         }
 
         @Override

--- a/src/main/java/graphql/execution/instrumentation/ExecuteObjectInstrumentationContext.java
+++ b/src/main/java/graphql/execution/instrumentation/ExecuteObjectInstrumentationContext.java
@@ -15,7 +15,7 @@ public interface ExecuteObjectInstrumentationContext extends InstrumentationCont
     @Internal
     ExecuteObjectInstrumentationContext NOOP = new ExecuteObjectInstrumentationContext() {
         @Override
-        public void onDispatched(CompletableFuture<Map<String, Object>> result) {
+        public void onDispatched() {
         }
 
         @Override

--- a/src/main/java/graphql/execution/instrumentation/ExecutionStrategyInstrumentationContext.java
+++ b/src/main/java/graphql/execution/instrumentation/ExecutionStrategyInstrumentationContext.java
@@ -36,7 +36,7 @@ public interface ExecutionStrategyInstrumentationContext extends Instrumentation
     @Internal
     ExecutionStrategyInstrumentationContext NOOP = new ExecutionStrategyInstrumentationContext() {
         @Override
-        public void onDispatched(CompletableFuture<ExecutionResult> result) {
+        public void onDispatched() {
         }
 
         @Override

--- a/src/main/java/graphql/execution/instrumentation/InstrumentationContext.java
+++ b/src/main/java/graphql/execution/instrumentation/InstrumentationContext.java
@@ -20,7 +20,7 @@ public interface InstrumentationContext<T> {
      *
      * @param result the result of the step as a completable future
      */
-    void onDispatched(CompletableFuture<T> result);
+    void onDispatched();
 
     /**
      * This is invoked when the instrumentation step is fully completed

--- a/src/main/java/graphql/execution/instrumentation/SimpleInstrumentationContext.java
+++ b/src/main/java/graphql/execution/instrumentation/SimpleInstrumentationContext.java
@@ -15,7 +15,7 @@ public class SimpleInstrumentationContext<T> implements InstrumentationContext<T
 
     private static final InstrumentationContext<Object> NO_OP = new InstrumentationContext<Object>() {
         @Override
-        public void onDispatched(CompletableFuture<Object> result) {
+        public void onDispatched() {
         }
 
         @Override
@@ -49,21 +49,21 @@ public class SimpleInstrumentationContext<T> implements InstrumentationContext<T
     }
 
     private final BiConsumer<T, Throwable> codeToRunOnComplete;
-    private final Consumer<CompletableFuture<T>> codeToRunOnDispatch;
+    private final Runnable codeToRunOnDispatch;
 
     public SimpleInstrumentationContext() {
         this(null, null);
     }
 
-    private SimpleInstrumentationContext(Consumer<CompletableFuture<T>> codeToRunOnDispatch, BiConsumer<T, Throwable> codeToRunOnComplete) {
+    private SimpleInstrumentationContext(Runnable codeToRunOnDispatch, BiConsumer<T, Throwable> codeToRunOnComplete) {
         this.codeToRunOnComplete = codeToRunOnComplete;
         this.codeToRunOnDispatch = codeToRunOnDispatch;
     }
 
     @Override
-    public void onDispatched(CompletableFuture<T> result) {
+    public void onDispatched() {
         if (codeToRunOnDispatch != null) {
-            codeToRunOnDispatch.accept(result);
+            codeToRunOnDispatch.run();
         }
     }
 
@@ -83,7 +83,7 @@ public class SimpleInstrumentationContext<T> implements InstrumentationContext<T
      *
      * @return an instrumentation context
      */
-    public static <U> SimpleInstrumentationContext<U> whenDispatched(Consumer<CompletableFuture<U>> codeToRun) {
+    public static <U> SimpleInstrumentationContext<U> whenDispatched(Runnable codeToRun) {
         return new SimpleInstrumentationContext<>(codeToRun, null);
     }
 
@@ -101,13 +101,8 @@ public class SimpleInstrumentationContext<T> implements InstrumentationContext<T
     }
 
     public static <T> BiConsumer<? super T, ? super Throwable> completeInstrumentationCtxCF(
-            InstrumentationContext<T> instrumentationContext, CompletableFuture<T> targetCF) {
+            InstrumentationContext<T> instrumentationContext) {
         return (result, throwable) -> {
-            if (throwable != null) {
-                targetCF.completeExceptionally(throwable);
-            } else {
-                targetCF.complete(result);
-            }
             nonNullCtx(instrumentationContext).onCompleted(result, throwable);
         };
     }

--- a/src/main/java/graphql/execution/instrumentation/adapters/ExecuteObjectInstrumentationContextAdapter.java
+++ b/src/main/java/graphql/execution/instrumentation/adapters/ExecuteObjectInstrumentationContextAdapter.java
@@ -4,12 +4,11 @@ import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.Internal;
 import graphql.execution.FieldValueInfo;
-import graphql.execution.instrumentation.ExecutionStrategyInstrumentationContext;
 import graphql.execution.instrumentation.ExecuteObjectInstrumentationContext;
+import graphql.execution.instrumentation.ExecutionStrategyInstrumentationContext;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * A class to help adapt old {@link ExecutionResult} based ExecutionStrategyInstrumentationContext
@@ -25,16 +24,17 @@ public class ExecuteObjectInstrumentationContextAdapter implements ExecuteObject
     }
 
     @Override
-    public void onDispatched(CompletableFuture<Map<String, Object>> result) {
-        CompletableFuture<ExecutionResult> future = result.thenApply(r -> ExecutionResultImpl.newExecutionResult().data(r).build());
-        delegate.onDispatched(future);
-        //
-        // when the mapped future is completed, then call onCompleted on the delegate
-        future.whenComplete(delegate::onCompleted);
+    public void onDispatched() {
+        delegate.onDispatched();
     }
 
     @Override
     public void onCompleted(Map<String, Object> result, Throwable t) {
+        if (t != null) {
+            delegate.onCompleted(null, t);
+        } else {
+            delegate.onCompleted(ExecutionResultImpl.newExecutionResult().data(result).build(), null);
+        }
     }
 
     @Override

--- a/src/main/java/graphql/execution/instrumentation/adapters/ExecutionResultInstrumentationContextAdapter.java
+++ b/src/main/java/graphql/execution/instrumentation/adapters/ExecutionResultInstrumentationContextAdapter.java
@@ -5,8 +5,6 @@ import graphql.ExecutionResultImpl;
 import graphql.Internal;
 import graphql.execution.instrumentation.InstrumentationContext;
 
-import java.util.concurrent.CompletableFuture;
-
 /**
  * A class to help adapt old {@link ExecutionResult} based InstrumentationContext
  * from the newer {@link Object} based ones.
@@ -21,15 +19,16 @@ public class ExecutionResultInstrumentationContextAdapter implements Instrumenta
     }
 
     @Override
-    public void onDispatched(CompletableFuture<Object> result) {
-        CompletableFuture<ExecutionResult> future = result.thenApply(obj -> ExecutionResultImpl.newExecutionResult().data(obj).build());
-        delegate.onDispatched(future);
-        //
-        // when the mapped future is completed, then call onCompleted on the delegate
-        future.whenComplete(delegate::onCompleted);
+    public void onDispatched() {
+        delegate.onDispatched();
     }
 
     @Override
     public void onCompleted(Object result, Throwable t) {
+        if (t != null) {
+            delegate.onCompleted(null, t);
+        } else {
+            delegate.onCompleted(ExecutionResultImpl.newExecutionResult().data(result).build(), null);
+        }
     }
 }

--- a/src/main/java/graphql/execution/instrumentation/dataloader/FieldLevelTrackingApproach.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/FieldLevelTrackingApproach.java
@@ -123,7 +123,7 @@ public class FieldLevelTrackingApproach {
 
         return new ExecutionStrategyInstrumentationContext() {
             @Override
-            public void onDispatched(CompletableFuture<ExecutionResult> result) {
+            public void onDispatched() {
 
             }
 
@@ -154,7 +154,7 @@ public class FieldLevelTrackingApproach {
         return new ExecuteObjectInstrumentationContext() {
 
             @Override
-            public void onDispatched(CompletableFuture<Map<String, Object>> result) {
+            public void onDispatched() {
             }
 
             @Override
@@ -229,7 +229,7 @@ public class FieldLevelTrackingApproach {
         return new InstrumentationContext<Object>() {
 
             @Override
-            public void onDispatched(CompletableFuture<Object> result) {
+            public void onDispatched() {
                 boolean dispatchNeeded;
                 synchronized (callStack) {
                     callStack.increaseFetchCount(level);

--- a/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy
@@ -287,7 +287,7 @@ abstract class AsyncExecutionStrategyTest extends Specification {
                             }
 
                             @Override
-                            void onDispatched(CompletableFuture<ExecutionResult> result) {
+                            void onDispatched() {
                             }
 
                             @Override

--- a/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
@@ -171,7 +171,7 @@ class InstrumentationTest extends Specification {
             return new ExecutionStrategyInstrumentationContext() {
 
                 @Override
-                void onDispatched(CompletableFuture<ExecutionResult> result) {
+                void onDispatched() {
                     System.out.println(String.format("t%s setting go signal on", Thread.currentThread().getId()))
                     goSignal.set(true)
                 }

--- a/src/test/groovy/graphql/execution/instrumentation/TestingInstrumentContext.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/TestingInstrumentContext.groovy
@@ -25,7 +25,7 @@ class TestingInstrumentContext<T> implements InstrumentationContext<T> {
     }
 
     @Override
-    void onDispatched(CompletableFuture<T> result) {
+    void onDispatched() {
         if (useOnDispatch) {
             this.executionList << "onDispatched:$op"
         }


### PR DESCRIPTION
**This is a future setup PR** - it allows future work to be done where a CF does not have to be the returned value from fetching a field say or some other such change.

Currently the signature is

```
public interface InstrumentationContext<T> {

    void onDispatched(CompleteableFuture<T> result);

    void onCompleted(T result, Throwable t);
}
```

but this makes it

```
public interface InstrumentationContext<T> {

    void onDispatched();

    void onCompleted(T result, Throwable t);
}
```

So technically today some one could attach to the CF and do work on it rather than via waiting for `onCompleted` but conversely the semantics are the same - there will be a `onDispatched` followed by a call to `onCompleted` whether its exceptionally completed or not.  So the CF is technically not needed

if today some one was using the CF - then they can change their code so that they create the CF internally and hold it and complete it during `onCompleted` - so while its a breaking change, it allows them to achieve the same result if they desire.

