### PR TITLE
Avoid repeated Map lookups in SimpleFieldValidation

### DIFF
--- a/src/main/java/graphql/execution/instrumentation/fieldvalidation/SimpleFieldValidation.java
+++ b/src/main/java/graphql/execution/instrumentation/fieldvalidation/SimpleFieldValidation.java
@@ -40,11 +40,12 @@ public class SimpleFieldValidation implements FieldValidation {
     @Override
     public List<GraphQLError> validateFields(FieldValidationEnvironment validationEnvironment) {
         List<GraphQLError> errors = new ArrayList<>();
-        for (ResultPath fieldPath : rules.keySet()) {
+        for (Map.Entry<ResultPath, BiFunction<FieldAndArguments, FieldValidationEnvironment, Optional<GraphQLError>>> entry : rules.entrySet()) {
+            ResultPath fieldPath = entry.getKey();
+            BiFunction<FieldAndArguments, FieldValidationEnvironment, Optional<GraphQLError>> ruleFunction = entry.getValue();
+
             List<FieldAndArguments> fieldAndArguments = validationEnvironment.getFieldsByPath().get(fieldPath);
             if (fieldAndArguments != null) {
-                BiFunction<FieldAndArguments, FieldValidationEnvironment, Optional<GraphQLError>> ruleFunction = rules.get(fieldPath);
-
                 for (FieldAndArguments fieldAndArgument : fieldAndArguments) {
                     Optional<GraphQLError> graphQLError = ruleFunction.apply(fieldAndArgument, validationEnvironment);
                     graphQLError.ifPresent(errors::add);


### PR DESCRIPTION
The validateFields method in SimpleFieldValidation would iterate over the keySet of the rules Map and then subsequently use the key to look up the value; switch to iterating over the entrySet.