### PR TITLE
Use String concatenation instead of StringBuilder

### DIFF
--- a/src/main/java/graphql/execution/preparsed/persisted/PersistedQuerySupport.java
+++ b/src/main/java/graphql/execution/preparsed/persisted/PersistedQuerySupport.java
@@ -45,7 +45,7 @@ public abstract class PersistedQuerySupport implements PreparsedDocumentProvider
                 Object persistedQueryId = queryIdOption.get();
                 return persistedQueryCache.getPersistedQueryDocument(persistedQueryId, executionInput, (queryText) -> {
                     // we have a miss and they gave us nothing - bah!
-                    if (queryText == null || queryText.trim().length() == 0) {
+                    if (queryText == null || queryText.isBlank()) {
                         throw new PersistedQueryNotFound(persistedQueryId);
                     }
                     // validate the queryText hash before returning to the cache which we assume will set it

--- a/src/main/java/graphql/language/AstPrinter.java
+++ b/src/main/java/graphql/language/AstPrinter.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.StringJoiner;
 
 import static graphql.Assert.assertTrue;
 import static graphql.util.EscapeUtil.escapeJsonString;
@@ -489,7 +490,7 @@ public class AstPrinter {
     }
 
     private boolean isEmpty(String s) {
-        return s == null || s.trim().length() == 0;
+        return s == null || s.isBlank();
     }
 
     private <T> List<T> nvl(List<T> list) {
@@ -525,7 +526,7 @@ public class AstPrinter {
     }
 
     private String description(Node<?> node) {
-        Description description = ((AbstractDescribedNode) node).getDescription();
+        Description description = ((AbstractDescribedNode<?>) node).getDescription();
         if (description == null || description.getContent() == null || compactMode) {
             return "";
         }
@@ -577,21 +578,13 @@ public class AstPrinter {
     }
 
     private <T extends Node> String join(List<T> nodes, String delim, String prefix, String suffix) {
-        StringBuilder joined = new StringBuilder();
-        joined.append(prefix);
+        StringJoiner joiner = new StringJoiner(delim, prefix, suffix);
 
-        boolean first = true;
         for (T node : nodes) {
-            if (first) {
-                first = false;
-            } else {
-                joined.append(delim);
-            }
-            joined.append(this.node(node));
+            joiner.add(node(node));
         }
 
-        joined.append(suffix);
-        return joined.toString();
+        return joiner.toString();
     }
 
     private String spaced(String... args) {
@@ -603,22 +596,15 @@ public class AstPrinter {
     }
 
     private String join(String delim, String... args) {
-        StringBuilder builder = new StringBuilder();
+        StringJoiner joiner = new StringJoiner(delim);
 
-        boolean first = true;
         for (final String arg : args) {
-            if (isEmpty(arg)) {
-                continue;
+            if (!isEmpty(arg)) {
+                joiner.add(arg);
             }
-            if (first) {
-                first = false;
-            } else {
-                builder.append(delim);
-            }
-            builder.append(arg);
         }
 
-        return builder.toString();
+        return joiner.toString();
     }
 
     String wrap(String start, String maybeString, String end) {
@@ -628,7 +614,7 @@ public class AstPrinter {
             }
             return "";
         }
-        return new StringBuilder().append(start).append(maybeString).append(!isEmpty(end) ? end : "").toString();
+        return start + maybeString + (!isEmpty(end) ? end : "");
     }
 
     private <T extends Node> String block(List<T> nodes) {
@@ -637,7 +623,7 @@ public class AstPrinter {
         }
         if (compactMode) {
             String joinedNodes = joinTight(nodes, " ", "", "");
-            return new StringBuilder().append("{").append(joinedNodes).append("}").toString();
+            return "{" + joinedNodes + "}";
         }
         return indent(new StringBuilder().append("{\n").append(join(nodes, "\n")))
                 + "\n}";
@@ -659,7 +645,7 @@ public class AstPrinter {
         if (maybeNode == null) {
             return "";
         }
-        return new StringBuilder().append(start).append(node(maybeNode)).append(isEmpty(end) ? "" : end).toString();
+        return start + node(maybeNode) + (isEmpty(end) ? "" : end);
     }
 
     /**

--- a/src/main/java/graphql/language/PrettyAstPrinter.java
+++ b/src/main/java/graphql/language/PrettyAstPrinter.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.StringJoiner;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -242,7 +243,7 @@ public class PrettyAstPrinter extends AstPrinter {
     }
 
     private boolean isEmpty(String s) {
-        return s == null || s.trim().length() == 0;
+        return s == null || s.isBlank();
     }
 
     private <T> List<T> nvl(List<T> list) {
@@ -258,7 +259,7 @@ public class PrettyAstPrinter extends AstPrinter {
     }
 
     private String description(Node<?> node) {
-        Description description = ((AbstractDescribedNode) node).getDescription();
+        Description description = ((AbstractDescribedNode<?>) node).getDescription();
         if (description == null || description.getContent() == null) {
             return "";
         }
@@ -304,21 +305,13 @@ public class PrettyAstPrinter extends AstPrinter {
     }
 
     private <T extends Node> String join(List<T> nodes, String delim, String prefix, String suffix) {
-        StringBuilder joined = new StringBuilder();
+        StringJoiner joiner = new StringJoiner(delim, prefix, suffix);
 
-        joined.append(prefix);
-        boolean first = true;
         for (T node : nodes) {
-            if (first) {
-                first = false;
-            } else {
-                joined.append(delim);
-            }
-            joined.append(node(node));
+            joiner.add(node(node));
         }
 
-        joined.append(suffix);
-        return joined.toString();
+        return joiner.toString();
     }
 
     private String node(Node node) {
@@ -338,22 +331,15 @@ public class PrettyAstPrinter extends AstPrinter {
     }
 
     private String join(String delim, String... args) {
-        StringBuilder builder = new StringBuilder();
+        StringJoiner joiner = new StringJoiner(delim);
 
-        boolean first = true;
         for (final String arg : args) {
-            if (isEmpty(arg)) {
-                continue;
+            if (!isEmpty(arg)) {
+                joiner.add(arg);
             }
-            if (first) {
-                first = false;
-            } else {
-                builder.append(delim);
-            }
-            builder.append(arg);
         }
 
-        return builder.toString();
+        return joiner.toString();
     }
 
     private <T extends Node> String block(List<T> nodes, Node parentNode, String prefix, String suffix, String separatorMultiline, String separatorSingleLine, String whenEmpty) {
@@ -381,8 +367,8 @@ public class PrettyAstPrinter extends AstPrinter {
 
         String blockStart = commentParser.getBeginningOfBlockComment(parentNode, prefix)
                 .map(this::comment)
-                .map(commentText -> String.format("%s %s\n", prefix, commentText))
-                .orElse(String.format("%s%s", prefix, (isMultiline ? "\n" : "")));
+                .map(commentText -> prefix + " " + commentText + "\n")
+                .orElseGet(() -> prefix + (isMultiline ? "\n" : ""));
 
         String blockEndComments = comments(commentParser.getEndOfBlockComments(parentNode, suffix), "\n", "");
         String blockEnd = (isMultiline ? "\n" : "") + suffix;

--- a/src/main/java/graphql/schema/GraphQLTypeUtil.java
+++ b/src/main/java/graphql/schema/GraphQLTypeUtil.java
@@ -27,18 +27,12 @@ public class GraphQLTypeUtil {
      */
     public static String simplePrint(GraphQLType type) {
         Assert.assertNotNull(type, () -> "type can't be null");
-        StringBuilder sb = new StringBuilder();
         if (isNonNull(type)) {
-            sb.append(simplePrint(unwrapOne(type)));
-            sb.append("!");
+            return simplePrint(unwrapOne(type)) + "!";
         } else if (isList(type)) {
-            sb.append("[");
-            sb.append(simplePrint(unwrapOne(type)));
-            sb.append("]");
-        } else {
-            sb.append(((GraphQLNamedType) type).getName());
+            return "[" + simplePrint(unwrapOne(type)) + "]";
         }
-        return sb.toString();
+        return ((GraphQLNamedType) type).getName();
     }
 
     public static String simplePrint(GraphQLSchemaElement schemaElement) {

--- a/src/main/java/graphql/schema/idl/TypeUtil.java
+++ b/src/main/java/graphql/schema/idl/TypeUtil.java
@@ -17,18 +17,12 @@ public class TypeUtil {
      * @return the type in graphql SDL format, eg [typeName!]!
      */
     public static String simplePrint(Type type) {
-        StringBuilder sb = new StringBuilder();
         if (isNonNull(type)) {
-            sb.append(simplePrint(unwrapOne(type)));
-            sb.append("!");
+            return simplePrint(unwrapOne(type)) + "!";
         } else if (isList(type)) {
-            sb.append("[");
-            sb.append(simplePrint(unwrapOne(type)));
-            sb.append("]");
-        } else {
-            sb.append(((TypeName) type).getName());
+            return "[" + simplePrint(unwrapOne(type)) + "]";
         }
-        return sb.toString();
+        return ((TypeName) type).getName();
     }
 
     /**


### PR DESCRIPTION
Change some places to use simple String concatenation instead of a StringBuilder, since JDK9+ has additional optimizations added as part of JEP280. Additionally, switch to the StringJoiner class and String.isBlank method in a few places.