### PR TITLE
Don't build a builder object and then turn it into the actual object

### DIFF
--- a/src/main/java/graphql/execution/FetchedValue.java
+++ b/src/main/java/graphql/execution/FetchedValue.java
@@ -6,7 +6,6 @@ import graphql.PublicApi;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldCompleteParameters;
 
 import java.util.List;
-import java.util.function.Consumer;
 
 /**
  * Note: This is returned by {@link InstrumentationFieldCompleteParameters#getFetchedValue()}
@@ -15,14 +14,12 @@ import java.util.function.Consumer;
 @PublicApi
 public class FetchedValue {
     private final Object fetchedValue;
-    private final Object rawFetchedValue;
     private final Object localContext;
     private final ImmutableList<GraphQLError> errors;
 
-    private FetchedValue(Object fetchedValue, Object rawFetchedValue, ImmutableList<GraphQLError> errors, Object localContext) {
+    public FetchedValue(Object fetchedValue, List<GraphQLError> errors, Object localContext) {
         this.fetchedValue = fetchedValue;
-        this.rawFetchedValue = rawFetchedValue;
-        this.errors = errors;
+        this.errors = ImmutableList.copyOf(errors);
         this.localContext = localContext;
     }
 
@@ -33,10 +30,6 @@ public class FetchedValue {
         return fetchedValue;
     }
 
-    public Object getRawFetchedValue() {
-        return rawFetchedValue;
-    }
-
     public List<GraphQLError> getErrors() {
         return errors;
     }
@@ -45,64 +38,13 @@ public class FetchedValue {
         return localContext;
     }
 
-    public FetchedValue transform(Consumer<Builder> builderConsumer) {
-        Builder builder = newFetchedValue(this);
-        builderConsumer.accept(builder);
-        return builder.build();
-    }
-
     @Override
     public String toString() {
         return "FetchedValue{" +
                 "fetchedValue=" + fetchedValue +
-                ", rawFetchedValue=" + rawFetchedValue +
                 ", localContext=" + localContext +
                 ", errors=" + errors +
                 '}';
     }
 
-    public static Builder newFetchedValue() {
-        return new Builder();
-    }
-
-    public static Builder newFetchedValue(FetchedValue otherValue) {
-        return new Builder()
-                .fetchedValue(otherValue.getFetchedValue())
-                .rawFetchedValue(otherValue.getRawFetchedValue())
-                .errors(otherValue.getErrors())
-                .localContext(otherValue.getLocalContext())
-                ;
-    }
-
-    public static class Builder {
-
-        private Object fetchedValue;
-        private Object rawFetchedValue;
-        private Object localContext;
-        private ImmutableList<GraphQLError> errors = ImmutableList.of();
-
-        public Builder fetchedValue(Object fetchedValue) {
-            this.fetchedValue = fetchedValue;
-            return this;
-        }
-
-        public Builder rawFetchedValue(Object rawFetchedValue) {
-            this.rawFetchedValue = rawFetchedValue;
-            return this;
-        }
-
-        public Builder localContext(Object localContext) {
-            this.localContext = localContext;
-            return this;
-        }
-
-        public Builder errors(List<GraphQLError> errors) {
-            this.errors = ImmutableList.copyOf(errors);
-            return this;
-        }
-
-        public FetchedValue build() {
-            return new FetchedValue(fetchedValue, rawFetchedValue, errors, localContext);
-        }
-    }
 }

--- a/src/main/java/graphql/execution/FetchedValue.java
+++ b/src/main/java/graphql/execution/FetchedValue.java
@@ -17,7 +17,7 @@ public class FetchedValue {
     private final Object localContext;
     private final ImmutableList<GraphQLError> errors;
 
-    public FetchedValue(Object fetchedValue, List<GraphQLError> errors, Object localContext) {
+    FetchedValue(Object fetchedValue, List<GraphQLError> errors, Object localContext) {
         this.fetchedValue = fetchedValue;
         this.errors = ImmutableList.copyOf(errors);
         this.localContext = localContext;

--- a/src/main/java/graphql/execution/FieldValueInfo.java
+++ b/src/main/java/graphql/execution/FieldValueInfo.java
@@ -1,10 +1,10 @@
 package graphql.execution;
 
+import com.google.common.collect.ImmutableList;
 import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.PublicApi;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -26,7 +26,11 @@ public class FieldValueInfo {
     private final CompletableFuture<Object> fieldValue;
     private final List<FieldValueInfo> fieldValueInfos;
 
-    private FieldValueInfo(CompleteValueType completeValueType, CompletableFuture<Object> fieldValue, List<FieldValueInfo> fieldValueInfos) {
+    FieldValueInfo(CompleteValueType completeValueType, CompletableFuture<Object> fieldValue) {
+        this(completeValueType, fieldValue, ImmutableList.of());
+    }
+
+    FieldValueInfo(CompleteValueType completeValueType, CompletableFuture<Object> fieldValue, List<FieldValueInfo> fieldValueInfos) {
         assertNotNull(fieldValueInfos, () -> "fieldValueInfos can't be null");
         this.completeValueType = completeValueType;
         this.fieldValue = fieldValue;
@@ -37,10 +41,11 @@ public class FieldValueInfo {
         return completeValueType;
     }
 
-    @Deprecated(since="2023-09-11" )
+    @Deprecated(since = "2023-09-11")
     public CompletableFuture<ExecutionResult> getFieldValue() {
         return fieldValue.thenApply(fv -> ExecutionResultImpl.newExecutionResult().data(fv).build());
     }
+
     public CompletableFuture<Object> getFieldValueFuture() {
         return fieldValue;
     }
@@ -49,9 +54,6 @@ public class FieldValueInfo {
         return fieldValueInfos;
     }
 
-    public static Builder newFieldValueInfo(CompleteValueType completeValueType) {
-        return new Builder(completeValueType);
-    }
 
     @Override
     public String toString() {
@@ -62,34 +64,4 @@ public class FieldValueInfo {
                 '}';
     }
 
-    @SuppressWarnings("unused")
-    public static class Builder {
-        private CompleteValueType completeValueType;
-        private CompletableFuture<Object> fieldValueFuture;
-        private List<FieldValueInfo> listInfos = new ArrayList<>();
-
-        public Builder(CompleteValueType completeValueType) {
-            this.completeValueType = completeValueType;
-        }
-
-        public Builder completeValueType(CompleteValueType completeValueType) {
-            this.completeValueType = completeValueType;
-            return this;
-        }
-
-        public Builder fieldValue(CompletableFuture<Object> executionResultFuture) {
-            this.fieldValueFuture = executionResultFuture;
-            return this;
-        }
-
-        public Builder fieldValueInfos(List<FieldValueInfo> listInfos) {
-            assertNotNull(listInfos, () -> "fieldValueInfos can't be null");
-            this.listInfos = listInfos;
-            return this;
-        }
-
-        public FieldValueInfo build() {
-            return new FieldValueInfo(completeValueType, fieldValueFuture, listInfos);
-        }
-    }
 }

--- a/src/test/groovy/graphql/execution/FieldValueInfoTest.groovy
+++ b/src/test/groovy/graphql/execution/FieldValueInfoTest.groovy
@@ -3,26 +3,26 @@ package graphql.execution
 import graphql.AssertException
 import spock.lang.Specification
 
+import java.util.concurrent.CompletableFuture
 
-class FieldValueInfoTest extends Specification{
+import static graphql.execution.FieldValueInfo.CompleteValueType.SCALAR
+
+
+class FieldValueInfoTest extends Specification {
 
     def "simple constructor test"() {
         when:
-        def fieldValueInfo = FieldValueInfo.newFieldValueInfo().build()
+        def fieldValueInfo = new FieldValueInfo(SCALAR, CompletableFuture.completedFuture("A"))
 
         then: "fieldValueInfos to be empty list"
         fieldValueInfo.fieldValueInfos == [] as List
-
-        and: "other fields to be null "
-        fieldValueInfo.fieldValueFuture == null
-        fieldValueInfo.completeValueType == null
+        fieldValueInfo.fieldValueFuture.join() == "A"
+        fieldValueInfo.completeValueType == SCALAR
     }
 
     def "negative constructor test"() {
         when:
-        FieldValueInfo.newFieldValueInfo()
-                .fieldValueInfos(null)
-                .build()
+        new FieldValueInfo(SCALAR, CompletableFuture.completedFuture("A"), null)
         then:
         def assEx = thrown(AssertException)
         assEx.message.contains("fieldValueInfos")


### PR DESCRIPTION
FetchValue and FieldValueInfo are data classes that are needed to hold state about what has been fetched and what has been completed as objects.

Currently they use the code best practice of a builder however this induces memory pressure - we create a FetchValue.Builder object only to turn it immediately into a FetchValue object.

In the name of performance and reduced memory pressure, lets just have a direct constructor.

While builder pattern is nicer for future extension, lets trade off code maintenance for performance here.

Also these probably should not have been public API say - but here we are