### PR TITLE
Avoid repeated calls to getFieldDef and unnecessary immutable builders/collections

### DIFF
--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -348,9 +348,9 @@ public abstract class ExecutionStrategy {
                 new InstrumentationFieldParameters(executionContext, executionStepInfo), executionContext.getInstrumentationState()
         ));
 
-        CompletableFuture<FetchedValue> fetchFieldFuture = fetchField(executionContext, parameters);
+        CompletableFuture<FetchedValue> fetchFieldFuture = fetchField(fieldDef, executionContext, parameters);
         CompletableFuture<FieldValueInfo> result = fetchFieldFuture.thenApply((fetchedValue) ->
-                completeField(executionContext, parameters, fetchedValue));
+                completeField(fieldDef, executionContext, parameters, fetchedValue));
 
         CompletableFuture<Object> fieldValueFuture = result.thenCompose(FieldValueInfo::getFieldValueFuture);
 
@@ -377,7 +377,12 @@ public abstract class ExecutionStrategy {
         MergedField field = parameters.getField();
         GraphQLObjectType parentType = (GraphQLObjectType) parameters.getExecutionStepInfo().getUnwrappedNonNullType();
         GraphQLFieldDefinition fieldDef = getFieldDef(executionContext.getGraphQLSchema(), parentType, field.getSingleField());
-        GraphQLCodeRegistry codeRegistry = executionContext.getGraphQLSchema().getCodeRegistry();
+        return fetchField(fieldDef, executionContext, parameters);
+    }
+
+    private CompletableFuture<FetchedValue> fetchField(GraphQLFieldDefinition fieldDef, ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
+        MergedField field = parameters.getField();
+        GraphQLObjectType parentType = (GraphQLObjectType) parameters.getExecutionStepInfo().getUnwrappedNonNullType();
 
         // if the DF (like PropertyDataFetcher) does not use the arguments or execution step info then dont build any
 
@@ -412,6 +417,8 @@ public abstract class ExecutionStrategy {
                     .queryDirectives(queryDirectives)
                     .build();
         });
+
+        GraphQLCodeRegistry codeRegistry = executionContext.getGraphQLSchema().getCodeRegistry();
         DataFetcher<?> dataFetcher = codeRegistry.getDataFetcher(parentType, fieldDef);
 
         Instrumentation instrumentation = executionContext.getInstrumentation();
@@ -555,6 +562,11 @@ public abstract class ExecutionStrategy {
         Field field = parameters.getField().getSingleField();
         GraphQLObjectType parentType = (GraphQLObjectType) parameters.getExecutionStepInfo().getUnwrappedNonNullType();
         GraphQLFieldDefinition fieldDef = getFieldDef(executionContext.getGraphQLSchema(), parentType, field);
+        return completeField(fieldDef, executionContext, parameters, fetchedValue);
+    }
+
+    private FieldValueInfo completeField(GraphQLFieldDefinition fieldDef, ExecutionContext executionContext, ExecutionStrategyParameters parameters, FetchedValue fetchedValue) {
+        GraphQLObjectType parentType = (GraphQLObjectType) parameters.getExecutionStepInfo().getUnwrappedNonNullType();
         ExecutionStepInfo executionStepInfo = createExecutionStepInfo(executionContext, parameters, fieldDef, parentType);
 
         Instrumentation instrumentation = executionContext.getInstrumentation();

--- a/src/main/java/graphql/execution/ExecutionStrategyParameters.java
+++ b/src/main/java/graphql/execution/ExecutionStrategyParameters.java
@@ -114,7 +114,7 @@ public class ExecutionStrategyParameters {
         ResultPath path = ResultPath.rootPath();
         MergedField currentField;
         ExecutionStrategyParameters parent;
-        DeferredCallContext deferredCallContext = new DeferredCallContext();
+        DeferredCallContext deferredCallContext;
 
         /**
          * @see ExecutionStrategyParameters#newParameters()
@@ -188,6 +188,9 @@ public class ExecutionStrategyParameters {
         }
 
         public ExecutionStrategyParameters build() {
+            if (deferredCallContext == null) {
+                deferredCallContext = new DeferredCallContext();
+            }
             return new ExecutionStrategyParameters(executionStepInfo, source, localContext, fields, nonNullableFieldValidator, path, currentField, parent, deferredCallContext);
         }
     }

--- a/src/main/java/graphql/execution/FieldCollector.java
+++ b/src/main/java/graphql/execution/FieldCollector.java
@@ -148,10 +148,7 @@ public class FieldCollector {
                     .addDeferredExecution(deferredExecution))
             );
         } else {
-            fields.put(name, MergedField
-                    .newMergedField(field)
-                    .addDeferredExecution(deferredExecution).build()
-            );
+            fields.put(name, MergedField.newSingletonMergedField(field, deferredExecution));
         }
     }
 

--- a/src/main/java/graphql/execution/FieldValueInfo.java
+++ b/src/main/java/graphql/execution/FieldValueInfo.java
@@ -1,5 +1,6 @@
 package graphql.execution;
 
+import com.google.common.collect.ImmutableList;
 import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.PublicApi;
@@ -66,7 +67,7 @@ public class FieldValueInfo {
     public static class Builder {
         private CompleteValueType completeValueType;
         private CompletableFuture<Object> fieldValueFuture;
-        private List<FieldValueInfo> listInfos = new ArrayList<>();
+        private List<FieldValueInfo> listInfos = ImmutableList.of();
 
         public Builder(CompleteValueType completeValueType) {
             this.completeValueType = completeValueType;

--- a/src/main/java/graphql/execution/MergedField.java
+++ b/src/main/java/graphql/execution/MergedField.java
@@ -73,6 +73,10 @@ public class MergedField {
         this.deferredExecutions = deferredExecutions;
     }
 
+    private MergedField(Field field, DeferredExecution deferredExecution) {
+        this(ImmutableList.of(field), deferredExecution == null ? ImmutableList.of() : ImmutableList.of(deferredExecution));
+    }
+
     /**
      * All merged fields have the same name.
      *
@@ -131,10 +135,9 @@ public class MergedField {
      * @return all defer executions.
      */
     @ExperimentalApi
-    public ImmutableList<DeferredExecution> getDeferredExecutions() {
+    public List<DeferredExecution> getDeferredExecutions() {
         return deferredExecutions;
     }
-
 
     public static Builder newMergedField() {
         return new Builder();
@@ -146,6 +149,10 @@ public class MergedField {
 
     public static Builder newMergedField(List<Field> fields) {
         return new Builder().fields(fields);
+    }
+
+    static MergedField newSingletonMergedField(Field field, DeferredExecution deferredExecution) {
+        return new MergedField(field, deferredExecution);
     }
 
     public MergedField transform(Consumer<Builder> builderConsumer) {

--- a/src/main/java/graphql/execution/MergedSelectionSet.java
+++ b/src/main/java/graphql/execution/MergedSelectionSet.java
@@ -13,10 +13,12 @@ import java.util.Set;
 @PublicApi
 public class MergedSelectionSet {
 
-    private final ImmutableMap<String, MergedField> subFields;
+    private final Map<String, MergedField> subFields;
+    private final List<String> keys;
 
     protected MergedSelectionSet(Map<String, MergedField> subFields) {
-        this.subFields = ImmutableMap.copyOf(Assert.assertNotNull(subFields));
+        this.subFields = subFields == null ? ImmutableMap.of() : subFields;
+        this.keys =  ImmutableList.copyOf(this.subFields.keySet());
     }
 
     public Map<String, MergedField> getSubFields() {
@@ -40,7 +42,7 @@ public class MergedSelectionSet {
     }
 
     public List<String> getKeys() {
-        return ImmutableList.copyOf(keySet());
+        return keys;
     }
 
     public boolean isEmpty() {
@@ -52,10 +54,10 @@ public class MergedSelectionSet {
     }
 
     public static class Builder {
-        private Map<String, MergedField> subFields = ImmutableMap.of();
+
+        private Map<String, MergedField> subFields;
 
         private Builder() {
-
         }
 
         public Builder subFields(Map<String, MergedField> subFields) {

--- a/src/main/java/graphql/schema/GraphQLInterfaceType.java
+++ b/src/main/java/graphql/schema/GraphQLInterfaceType.java
@@ -2,12 +2,12 @@ package graphql.schema;
 
 import com.google.common.collect.ImmutableList;
 import graphql.Assert;
-import graphql.AssertException;
 import graphql.DirectivesUtil;
 import graphql.Internal;
 import graphql.PublicApi;
 import graphql.language.InterfaceTypeDefinition;
 import graphql.language.InterfaceTypeExtensionDefinition;
+import graphql.util.FpKit;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
@@ -20,12 +20,12 @@ import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 
 import static graphql.Assert.assertNotNull;
+import static graphql.Assert.assertShouldNeverHappen;
 import static graphql.Assert.assertValidName;
 import static graphql.collect.ImmutableKit.emptyList;
 import static graphql.schema.GraphqlTypeComparators.sortTypes;
 import static graphql.util.FpKit.getByName;
 import static graphql.util.FpKit.valuesToList;
-import static java.lang.String.format;
 
 /**
  * In graphql, an interface is an abstract type that defines the set of fields that a type must include to
@@ -41,7 +41,7 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLCompositeT
 
     private final String name;
     private final String description;
-    private final Map<String, GraphQLFieldDefinition> fieldDefinitionsByName = new LinkedHashMap<>();
+    private final Map<String, GraphQLFieldDefinition> fieldDefinitionsByName;
     private final TypeResolver typeResolver;
     private final InterfaceTypeDefinition definition;
     private final ImmutableList<InterfaceTypeExtensionDefinition> extensionDefinitions;
@@ -78,17 +78,12 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLCompositeT
         this.originalInterfaces = ImmutableList.copyOf(sortTypes(interfaceComparator, interfaces));
         this.extensionDefinitions = ImmutableList.copyOf(extensionDefinitions);
         this.directivesHolder = new DirectivesUtil.DirectivesHolder(directives, appliedDirectives);
-        buildDefinitionMap(fieldDefinitions);
+        this.fieldDefinitionsByName = buildDefinitionMap(fieldDefinitions);
     }
 
-    private void buildDefinitionMap(List<GraphQLFieldDefinition> fieldDefinitions) {
-        for (GraphQLFieldDefinition fieldDefinition : fieldDefinitions) {
-            String name = fieldDefinition.getName();
-            if (fieldDefinitionsByName.containsKey(name)) {
-                throw new AssertException(format("Duplicated definition for field '%s' in interface '%s'", name, this.name));
-            }
-            fieldDefinitionsByName.put(name, fieldDefinition);
-        }
+    private Map<String, GraphQLFieldDefinition> buildDefinitionMap(List<GraphQLFieldDefinition> fieldDefinitions) {
+        return FpKit.getByName(fieldDefinitions, GraphQLFieldDefinition::getName,
+                (fld1, fld2) -> assertShouldNeverHappen("Duplicated definition for field '%s' in interface '%s'", fld1.getName(), this.name));
     }
 
     @Override

--- a/src/main/java/graphql/schema/GraphQLObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLObjectType.java
@@ -44,7 +44,7 @@ public class GraphQLObjectType implements GraphQLNamedOutputType, GraphQLComposi
     private final String name;
     private final String description;
     private final Comparator<? super GraphQLSchemaElement> interfaceComparator;
-    private final ImmutableMap<String, GraphQLFieldDefinition> fieldDefinitionsByName;
+    private final Map<String, GraphQLFieldDefinition> fieldDefinitionsByName;
     private final ImmutableList<GraphQLNamedOutputType> originalInterfaces;
     private final DirectivesUtil.DirectivesHolder directivesHolder;
     private final ObjectTypeDefinition definition;
@@ -82,9 +82,9 @@ public class GraphQLObjectType implements GraphQLNamedOutputType, GraphQLComposi
         this.replacedInterfaces = ImmutableList.copyOf(sortTypes(interfaceComparator, interfaces));
     }
 
-    private ImmutableMap<String, GraphQLFieldDefinition> buildDefinitionMap(List<GraphQLFieldDefinition> fieldDefinitions) {
-        return ImmutableMap.copyOf(FpKit.getByName(fieldDefinitions, GraphQLFieldDefinition::getName,
-                (fld1, fld2) -> assertShouldNeverHappen("Duplicated definition for field '%s' in type '%s'", fld1.getName(), this.name)));
+    private Map<String, GraphQLFieldDefinition> buildDefinitionMap(List<GraphQLFieldDefinition> fieldDefinitions) {
+        return FpKit.getByName(fieldDefinitions, GraphQLFieldDefinition::getName,
+                (fld1, fld2) -> assertShouldNeverHappen("Duplicated definition for field '%s' in type '%s'", fld1.getName(), this.name));
     }
 
     @Override

--- a/src/test/java/benchmark/TwitterBenchmark.java
+++ b/src/test/java/benchmark/TwitterBenchmark.java
@@ -21,6 +21,10 @@ import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -128,8 +132,14 @@ public class TwitterBenchmark {
         }
     }
 
-    public static void main(String[] args) {
-        ExecutionResult result = execute();
-        System.out.println(result);
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include("benchmark.TwitterBenchmark")
+                .forks(1)
+                .warmupIterations(5)
+                .measurementIterations(10)
+                .build();
+
+        new Runner(opt).run();
     }
 }


### PR DESCRIPTION
Avoid additional calls to `getFieldDef` in `ExecutionStrategy` and avoid immutable builder/collections where they're unnecessary  on hot paths.

This improves the throughput of `TwitterBenchmark` by about 15%:

```
Benchmark                  Mode  Cnt    Score   Error  Units
TwitterBenchmark.execute  thrpt   10  105.571 ± 0.367  ops/s
```

```
Benchmark                  Mode  Cnt    Score   Error  Units
TwitterBenchmark.execute  thrpt   10  123.840 ± 1.492  ops/s
```