### PR TITLE
Does not allocate a default deferred context that is thrown away on transform

### DIFF
--- a/src/main/java/graphql/execution/ExecutionStrategyParameters.java
+++ b/src/main/java/graphql/execution/ExecutionStrategyParameters.java
@@ -114,7 +114,7 @@ public class ExecutionStrategyParameters {
         ResultPath path = ResultPath.rootPath();
         MergedField currentField;
         ExecutionStrategyParameters parent;
-        DeferredCallContext deferredCallContext = new DeferredCallContext();
+        DeferredCallContext deferredCallContext;
 
         /**
          * @see ExecutionStrategyParameters#newParameters()
@@ -188,6 +188,9 @@ public class ExecutionStrategyParameters {
         }
 
         public ExecutionStrategyParameters build() {
+            if (deferredCallContext == null) {
+                deferredCallContext = new DeferredCallContext();
+            }
             return new ExecutionStrategyParameters(executionStepInfo, source, localContext, fields, nonNullableFieldValidator, path, currentField, parent, deferredCallContext);
         }
     }


### PR DESCRIPTION
related to https://github.com/graphql-java/graphql-java/issues/3483

This is more memory efficient because the builder default is not thrown away