### PR TITLE
Intern field names

### DIFF
--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -420,17 +420,16 @@ public class GraphQL {
                 InstrumentationExecutionParameters inputInstrumentationParameters = new InstrumentationExecutionParameters(executionInputWithId, this.graphQLSchema, instrumentationState);
                 ExecutionInput instrumentedExecutionInput = instrumentation.instrumentExecutionInput(executionInputWithId, inputInstrumentationParameters, instrumentationState);
 
-                CompletableFuture<ExecutionResult> beginExecutionCF = new CompletableFuture<>();
                 InstrumentationExecutionParameters instrumentationParameters = new InstrumentationExecutionParameters(instrumentedExecutionInput, this.graphQLSchema, instrumentationState);
                 InstrumentationContext<ExecutionResult> executionInstrumentation = nonNullCtx(instrumentation.beginExecution(instrumentationParameters, instrumentationState));
-                executionInstrumentation.onDispatched(beginExecutionCF);
+                executionInstrumentation.onDispatched();
 
                 GraphQLSchema graphQLSchema = instrumentation.instrumentSchema(this.graphQLSchema, instrumentationParameters, instrumentationState);
 
                 CompletableFuture<ExecutionResult> executionResult = parseValidateAndExecute(instrumentedExecutionInput, graphQLSchema, instrumentationState);
                 //
                 // finish up instrumentation
-                executionResult = executionResult.whenComplete(completeInstrumentationCtxCF(executionInstrumentation, beginExecutionCF));
+                executionResult = executionResult.whenComplete(completeInstrumentationCtxCF(executionInstrumentation));
                 //
                 // allow instrumentation to tweak the result
                 executionResult = executionResult.thenCompose(result -> instrumentation.instrumentExecutionResult(result, instrumentationParameters, instrumentationState));
@@ -507,15 +506,13 @@ public class GraphQL {
     private ParseAndValidateResult parse(ExecutionInput executionInput, GraphQLSchema graphQLSchema, InstrumentationState instrumentationState) {
         InstrumentationExecutionParameters parameters = new InstrumentationExecutionParameters(executionInput, graphQLSchema, instrumentationState);
         InstrumentationContext<Document> parseInstrumentationCtx = nonNullCtx(instrumentation.beginParse(parameters, instrumentationState));
-        CompletableFuture<Document> documentCF = new CompletableFuture<>();
-        parseInstrumentationCtx.onDispatched(documentCF);
+        parseInstrumentationCtx.onDispatched();
 
         ParseAndValidateResult parseResult = ParseAndValidate.parse(executionInput);
         if (parseResult.isFailure()) {
             parseInstrumentationCtx.onCompleted(null, parseResult.getSyntaxException());
             return parseResult;
         } else {
-            documentCF.complete(parseResult.getDocument());
             parseInstrumentationCtx.onCompleted(parseResult.getDocument(), null);
 
             DocumentAndVariables documentAndVariables = parseResult.getDocumentAndVariables();
@@ -527,15 +524,13 @@ public class GraphQL {
 
     private List<ValidationError> validate(ExecutionInput executionInput, Document document, GraphQLSchema graphQLSchema, InstrumentationState instrumentationState) {
         InstrumentationContext<List<ValidationError>> validationCtx = nonNullCtx(instrumentation.beginValidation(new InstrumentationValidationParameters(executionInput, document, graphQLSchema, instrumentationState), instrumentationState));
-        CompletableFuture<List<ValidationError>> cf = new CompletableFuture<>();
-        validationCtx.onDispatched(cf);
+        validationCtx.onDispatched();
 
         Predicate<Class<?>> validationRulePredicate = executionInput.getGraphQLContext().getOrDefault(ParseAndValidate.INTERNAL_VALIDATION_PREDICATE_HINT, r -> true);
         Locale locale = executionInput.getLocale() != null ? executionInput.getLocale() : Locale.getDefault();
         List<ValidationError> validationErrors = ParseAndValidate.validate(graphQLSchema, document, validationRulePredicate, locale);
 
         validationCtx.onCompleted(validationErrors, null);
-        cf.complete(validationErrors);
         return validationErrors;
     }
 

--- a/src/main/java/graphql/execution/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncExecutionStrategy.java
@@ -50,7 +50,7 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
         Async.CombinedBuilder<FieldValueInfo> futures = getAsyncFieldValueInfo(executionContext, parameters, deferredExecutionSupport);
 
         CompletableFuture<ExecutionResult> overallResult = new CompletableFuture<>();
-        executionStrategyCtx.onDispatched(overallResult);
+        executionStrategyCtx.onDispatched();
 
         futures.await().whenComplete((completeValueInfos, throwable) -> {
             List<String> fieldsExecutedOnInitialResult = deferredExecutionSupport.getNonDeferredFieldNames(fieldNames);

--- a/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
@@ -49,7 +49,7 @@ public class AsyncSerialExecutionStrategy extends AbstractAsyncExecutionStrategy
         });
 
         CompletableFuture<ExecutionResult> overallResult = new CompletableFuture<>();
-        executionStrategyCtx.onDispatched(overallResult);
+        executionStrategyCtx.onDispatched();
 
         resultsFuture.whenComplete(handleResults(executionContext, fieldNames, overallResult));
         overallResult.whenComplete(executionStrategyCtx::onCompleted);

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -134,7 +134,7 @@ public class Execution {
                 ExecutionResult executionResult = new ExecutionResultImpl(Collections.singletonList((GraphQLError) rte));
                 CompletableFuture<ExecutionResult> resultCompletableFuture = completedFuture(executionResult);
 
-                executeOperationCtx.onDispatched(resultCompletableFuture);
+                executeOperationCtx.onDispatched();
                 executeOperationCtx.onCompleted(executionResult, rte);
                 return resultCompletableFuture;
             }
@@ -189,7 +189,7 @@ public class Execution {
         }
 
         // note this happens NOW - not when the result completes
-        executeOperationCtx.onDispatched(result);
+        executeOperationCtx.onDispatched();
 
         // fill out extensions if we have them
         result = result.thenApply(er -> mergeExtensionsBuilderIfPresent(er, graphQLContext));

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -211,7 +211,7 @@ public abstract class ExecutionStrategy {
         Async.CombinedBuilder<FieldValueInfo> resolvedFieldFutures = getAsyncFieldValueInfo(executionContext, parameters, deferredExecutionSupport);
 
         CompletableFuture<Map<String, Object>> overallResult = new CompletableFuture<>();
-        resolveObjectCtx.onDispatched(overallResult);
+        resolveObjectCtx.onDispatched();
 
         resolvedFieldFutures.await().whenComplete((completeValueInfos, throwable) -> {
             List<String> fieldsExecutedOnInitialResult = deferredExecutionSupport.getNonDeferredFieldNames(fieldNames);
@@ -354,7 +354,7 @@ public abstract class ExecutionStrategy {
 
         CompletableFuture<Object> fieldValueFuture = result.thenCompose(FieldValueInfo::getFieldValueFuture);
 
-        fieldCtx.onDispatched(fieldValueFuture);
+        fieldCtx.onDispatched();
         fieldValueFuture.whenComplete(fieldCtx::onCompleted);
         return result;
     }
@@ -425,7 +425,7 @@ public abstract class ExecutionStrategy {
         dataFetcher = executionContext.getDataLoaderDispatcherStrategy().modifyDataFetcher(dataFetcher);
         CompletableFuture<Object> fetchedValue = invokeDataFetcher(executionContext, parameters, fieldDef, dataFetchingEnvironment, dataFetcher);
         executionContext.getDataLoaderDispatcherStrategy().fieldFetched(executionContext, parameters, dataFetcher, fetchedValue);
-        fetchCtx.onDispatched(fetchedValue);
+        fetchCtx.onDispatched();
         return fetchedValue
                 .handle((result, exception) -> {
                     fetchCtx.onCompleted(result, exception);
@@ -568,7 +568,7 @@ public abstract class ExecutionStrategy {
         FieldValueInfo fieldValueInfo = completeValue(executionContext, newParameters);
 
         CompletableFuture<Object> executionResultFuture = fieldValueInfo.getFieldValueFuture();
-        ctxCompleteField.onDispatched(executionResultFuture);
+        ctxCompleteField.onDispatched();
         executionResultFuture.whenComplete(ctxCompleteField::onCompleted);
         return fieldValueInfo;
     }
@@ -722,7 +722,7 @@ public abstract class ExecutionStrategy {
         CompletableFuture<List<Object>> resultsFuture = Async.each(fieldValueInfos, FieldValueInfo::getFieldValueFuture);
 
         CompletableFuture<Object> overallResult = new CompletableFuture<>();
-        completeListCtx.onDispatched(overallResult);
+        completeListCtx.onDispatched();
         overallResult.whenComplete(completeListCtx::onCompleted);
 
         resultsFuture.whenComplete((results, exception) -> {

--- a/src/main/java/graphql/execution/FetchedValue.java
+++ b/src/main/java/graphql/execution/FetchedValue.java
@@ -6,7 +6,6 @@ import graphql.PublicApi;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldCompleteParameters;
 
 import java.util.List;
-import java.util.function.Consumer;
 
 /**
  * Note: This is returned by {@link InstrumentationFieldCompleteParameters#getFetchedValue()}
@@ -15,14 +14,12 @@ import java.util.function.Consumer;
 @PublicApi
 public class FetchedValue {
     private final Object fetchedValue;
-    private final Object rawFetchedValue;
     private final Object localContext;
     private final ImmutableList<GraphQLError> errors;
 
-    private FetchedValue(Object fetchedValue, Object rawFetchedValue, ImmutableList<GraphQLError> errors, Object localContext) {
+    FetchedValue(Object fetchedValue, List<GraphQLError> errors, Object localContext) {
         this.fetchedValue = fetchedValue;
-        this.rawFetchedValue = rawFetchedValue;
-        this.errors = errors;
+        this.errors = ImmutableList.copyOf(errors);
         this.localContext = localContext;
     }
 
@@ -33,10 +30,6 @@ public class FetchedValue {
         return fetchedValue;
     }
 
-    public Object getRawFetchedValue() {
-        return rawFetchedValue;
-    }
-
     public List<GraphQLError> getErrors() {
         return errors;
     }
@@ -45,64 +38,13 @@ public class FetchedValue {
         return localContext;
     }
 
-    public FetchedValue transform(Consumer<Builder> builderConsumer) {
-        Builder builder = newFetchedValue(this);
-        builderConsumer.accept(builder);
-        return builder.build();
-    }
-
     @Override
     public String toString() {
         return "FetchedValue{" +
                 "fetchedValue=" + fetchedValue +
-                ", rawFetchedValue=" + rawFetchedValue +
                 ", localContext=" + localContext +
                 ", errors=" + errors +
                 '}';
     }
 
-    public static Builder newFetchedValue() {
-        return new Builder();
-    }
-
-    public static Builder newFetchedValue(FetchedValue otherValue) {
-        return new Builder()
-                .fetchedValue(otherValue.getFetchedValue())
-                .rawFetchedValue(otherValue.getRawFetchedValue())
-                .errors(otherValue.getErrors())
-                .localContext(otherValue.getLocalContext())
-                ;
-    }
-
-    public static class Builder {
-
-        private Object fetchedValue;
-        private Object rawFetchedValue;
-        private Object localContext;
-        private ImmutableList<GraphQLError> errors = ImmutableList.of();
-
-        public Builder fetchedValue(Object fetchedValue) {
-            this.fetchedValue = fetchedValue;
-            return this;
-        }
-
-        public Builder rawFetchedValue(Object rawFetchedValue) {
-            this.rawFetchedValue = rawFetchedValue;
-            return this;
-        }
-
-        public Builder localContext(Object localContext) {
-            this.localContext = localContext;
-            return this;
-        }
-
-        public Builder errors(List<GraphQLError> errors) {
-            this.errors = ImmutableList.copyOf(errors);
-            return this;
-        }
-
-        public FetchedValue build() {
-            return new FetchedValue(fetchedValue, rawFetchedValue, errors, localContext);
-        }
-    }
 }

--- a/src/main/java/graphql/execution/FieldValueInfo.java
+++ b/src/main/java/graphql/execution/FieldValueInfo.java
@@ -1,10 +1,10 @@
 package graphql.execution;
 
+import com.google.common.collect.ImmutableList;
 import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.PublicApi;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -26,7 +26,11 @@ public class FieldValueInfo {
     private final CompletableFuture<Object> fieldValue;
     private final List<FieldValueInfo> fieldValueInfos;
 
-    private FieldValueInfo(CompleteValueType completeValueType, CompletableFuture<Object> fieldValue, List<FieldValueInfo> fieldValueInfos) {
+    FieldValueInfo(CompleteValueType completeValueType, CompletableFuture<Object> fieldValue) {
+        this(completeValueType, fieldValue, ImmutableList.of());
+    }
+
+    FieldValueInfo(CompleteValueType completeValueType, CompletableFuture<Object> fieldValue, List<FieldValueInfo> fieldValueInfos) {
         assertNotNull(fieldValueInfos, () -> "fieldValueInfos can't be null");
         this.completeValueType = completeValueType;
         this.fieldValue = fieldValue;
@@ -37,10 +41,11 @@ public class FieldValueInfo {
         return completeValueType;
     }
 
-    @Deprecated(since="2023-09-11" )
+    @Deprecated(since = "2023-09-11")
     public CompletableFuture<ExecutionResult> getFieldValue() {
         return fieldValue.thenApply(fv -> ExecutionResultImpl.newExecutionResult().data(fv).build());
     }
+
     public CompletableFuture<Object> getFieldValueFuture() {
         return fieldValue;
     }
@@ -49,9 +54,6 @@ public class FieldValueInfo {
         return fieldValueInfos;
     }
 
-    public static Builder newFieldValueInfo(CompleteValueType completeValueType) {
-        return new Builder(completeValueType);
-    }
 
     @Override
     public String toString() {
@@ -62,34 +64,4 @@ public class FieldValueInfo {
                 '}';
     }
 
-    @SuppressWarnings("unused")
-    public static class Builder {
-        private CompleteValueType completeValueType;
-        private CompletableFuture<Object> fieldValueFuture;
-        private List<FieldValueInfo> listInfos = new ArrayList<>();
-
-        public Builder(CompleteValueType completeValueType) {
-            this.completeValueType = completeValueType;
-        }
-
-        public Builder completeValueType(CompleteValueType completeValueType) {
-            this.completeValueType = completeValueType;
-            return this;
-        }
-
-        public Builder fieldValue(CompletableFuture<Object> executionResultFuture) {
-            this.fieldValueFuture = executionResultFuture;
-            return this;
-        }
-
-        public Builder fieldValueInfos(List<FieldValueInfo> listInfos) {
-            assertNotNull(listInfos, () -> "fieldValueInfos can't be null");
-            this.listInfos = listInfos;
-            return this;
-        }
-
-        public FieldValueInfo build() {
-            return new FieldValueInfo(completeValueType, fieldValueFuture, listInfos);
-        }
-    }
 }

--- a/src/main/java/graphql/execution/SubscriptionExecutionStrategy.java
+++ b/src/main/java/graphql/execution/SubscriptionExecutionStrategy.java
@@ -69,7 +69,7 @@ public class SubscriptionExecutionStrategy extends ExecutionStrategy {
         });
 
         // dispatched the subscription query
-        executionStrategyCtx.onDispatched(overallResult);
+        executionStrategyCtx.onDispatched();
         overallResult.whenComplete(executionStrategyCtx::onCompleted);
 
         return overallResult;
@@ -140,7 +140,7 @@ public class SubscriptionExecutionStrategy extends ExecutionStrategy {
                 .thenApply(executionResult -> wrapWithRootFieldName(newParameters, executionResult));
 
         // dispatch instrumentation so they can know about each subscription event
-        subscribedFieldCtx.onDispatched(overallResult);
+        subscribedFieldCtx.onDispatched();
         overallResult.whenComplete(subscribedFieldCtx::onCompleted);
 
         // allow them to instrument each ER should they want to

--- a/src/main/java/graphql/execution/instrumentation/ChainedInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/ChainedInstrumentation.java
@@ -397,8 +397,8 @@ public class ChainedInstrumentation implements Instrumentation {
         }
 
         @Override
-        public void onDispatched(CompletableFuture<T> result) {
-            contexts.forEach(context -> context.onDispatched(result));
+        public void onDispatched() {
+            contexts.forEach(InstrumentationContext::onDispatched);
         }
 
         @Override
@@ -416,8 +416,8 @@ public class ChainedInstrumentation implements Instrumentation {
         }
 
         @Override
-        public void onDispatched(CompletableFuture<ExecutionResult> result) {
-            contexts.forEach(context -> context.onDispatched(result));
+        public void onDispatched() {
+            contexts.forEach(InstrumentationContext::onDispatched);
         }
 
         @Override
@@ -445,8 +445,8 @@ public class ChainedInstrumentation implements Instrumentation {
         }
 
         @Override
-        public void onDispatched(CompletableFuture<Map<String, Object>> result) {
-            contexts.forEach(context -> context.onDispatched(result));
+        public void onDispatched() {
+            contexts.forEach(InstrumentationContext::onDispatched);
         }
 
         @Override
@@ -474,8 +474,8 @@ public class ChainedInstrumentation implements Instrumentation {
         }
 
         @Override
-        public void onDispatched(CompletableFuture<Object> result) {
-            contexts.forEach(context -> context.onDispatched(result));
+        public void onDispatched() {
+            contexts.forEach(InstrumentationContext::onDispatched);
         }
 
         @Override

--- a/src/main/java/graphql/execution/instrumentation/ExecuteObjectInstrumentationContext.java
+++ b/src/main/java/graphql/execution/instrumentation/ExecuteObjectInstrumentationContext.java
@@ -15,7 +15,7 @@ public interface ExecuteObjectInstrumentationContext extends InstrumentationCont
     @Internal
     ExecuteObjectInstrumentationContext NOOP = new ExecuteObjectInstrumentationContext() {
         @Override
-        public void onDispatched(CompletableFuture<Map<String, Object>> result) {
+        public void onDispatched() {
         }
 
         @Override

--- a/src/main/java/graphql/execution/instrumentation/ExecutionStrategyInstrumentationContext.java
+++ b/src/main/java/graphql/execution/instrumentation/ExecutionStrategyInstrumentationContext.java
@@ -36,7 +36,7 @@ public interface ExecutionStrategyInstrumentationContext extends Instrumentation
     @Internal
     ExecutionStrategyInstrumentationContext NOOP = new ExecutionStrategyInstrumentationContext() {
         @Override
-        public void onDispatched(CompletableFuture<ExecutionResult> result) {
+        public void onDispatched() {
         }
 
         @Override

--- a/src/main/java/graphql/execution/instrumentation/InstrumentationContext.java
+++ b/src/main/java/graphql/execution/instrumentation/InstrumentationContext.java
@@ -17,10 +17,8 @@ public interface InstrumentationContext<T> {
 
     /**
      * This is invoked when the instrumentation step is initially dispatched
-     *
-     * @param result the result of the step as a completable future
      */
-    void onDispatched(CompletableFuture<T> result);
+    void onDispatched();
 
     /**
      * This is invoked when the instrumentation step is fully completed

--- a/src/main/java/graphql/execution/instrumentation/SimpleInstrumentationContext.java
+++ b/src/main/java/graphql/execution/instrumentation/SimpleInstrumentationContext.java
@@ -15,7 +15,7 @@ public class SimpleInstrumentationContext<T> implements InstrumentationContext<T
 
     private static final InstrumentationContext<Object> NO_OP = new InstrumentationContext<Object>() {
         @Override
-        public void onDispatched(CompletableFuture<Object> result) {
+        public void onDispatched() {
         }
 
         @Override
@@ -49,21 +49,21 @@ public class SimpleInstrumentationContext<T> implements InstrumentationContext<T
     }
 
     private final BiConsumer<T, Throwable> codeToRunOnComplete;
-    private final Consumer<CompletableFuture<T>> codeToRunOnDispatch;
+    private final Runnable codeToRunOnDispatch;
 
     public SimpleInstrumentationContext() {
         this(null, null);
     }
 
-    private SimpleInstrumentationContext(Consumer<CompletableFuture<T>> codeToRunOnDispatch, BiConsumer<T, Throwable> codeToRunOnComplete) {
+    private SimpleInstrumentationContext(Runnable codeToRunOnDispatch, BiConsumer<T, Throwable> codeToRunOnComplete) {
         this.codeToRunOnComplete = codeToRunOnComplete;
         this.codeToRunOnDispatch = codeToRunOnDispatch;
     }
 
     @Override
-    public void onDispatched(CompletableFuture<T> result) {
+    public void onDispatched() {
         if (codeToRunOnDispatch != null) {
-            codeToRunOnDispatch.accept(result);
+            codeToRunOnDispatch.run();
         }
     }
 
@@ -83,7 +83,7 @@ public class SimpleInstrumentationContext<T> implements InstrumentationContext<T
      *
      * @return an instrumentation context
      */
-    public static <U> SimpleInstrumentationContext<U> whenDispatched(Consumer<CompletableFuture<U>> codeToRun) {
+    public static <U> SimpleInstrumentationContext<U> whenDispatched(Runnable codeToRun) {
         return new SimpleInstrumentationContext<>(codeToRun, null);
     }
 
@@ -101,13 +101,8 @@ public class SimpleInstrumentationContext<T> implements InstrumentationContext<T
     }
 
     public static <T> BiConsumer<? super T, ? super Throwable> completeInstrumentationCtxCF(
-            InstrumentationContext<T> instrumentationContext, CompletableFuture<T> targetCF) {
+            InstrumentationContext<T> instrumentationContext) {
         return (result, throwable) -> {
-            if (throwable != null) {
-                targetCF.completeExceptionally(throwable);
-            } else {
-                targetCF.complete(result);
-            }
             nonNullCtx(instrumentationContext).onCompleted(result, throwable);
         };
     }

--- a/src/main/java/graphql/execution/instrumentation/adapters/ExecuteObjectInstrumentationContextAdapter.java
+++ b/src/main/java/graphql/execution/instrumentation/adapters/ExecuteObjectInstrumentationContextAdapter.java
@@ -4,12 +4,11 @@ import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.Internal;
 import graphql.execution.FieldValueInfo;
-import graphql.execution.instrumentation.ExecutionStrategyInstrumentationContext;
 import graphql.execution.instrumentation.ExecuteObjectInstrumentationContext;
+import graphql.execution.instrumentation.ExecutionStrategyInstrumentationContext;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * A class to help adapt old {@link ExecutionResult} based ExecutionStrategyInstrumentationContext
@@ -25,16 +24,17 @@ public class ExecuteObjectInstrumentationContextAdapter implements ExecuteObject
     }
 
     @Override
-    public void onDispatched(CompletableFuture<Map<String, Object>> result) {
-        CompletableFuture<ExecutionResult> future = result.thenApply(r -> ExecutionResultImpl.newExecutionResult().data(r).build());
-        delegate.onDispatched(future);
-        //
-        // when the mapped future is completed, then call onCompleted on the delegate
-        future.whenComplete(delegate::onCompleted);
+    public void onDispatched() {
+        delegate.onDispatched();
     }
 
     @Override
     public void onCompleted(Map<String, Object> result, Throwable t) {
+        if (t != null) {
+            delegate.onCompleted(null, t);
+        } else {
+            delegate.onCompleted(ExecutionResultImpl.newExecutionResult().data(result).build(), null);
+        }
     }
 
     @Override

--- a/src/main/java/graphql/execution/instrumentation/adapters/ExecutionResultInstrumentationContextAdapter.java
+++ b/src/main/java/graphql/execution/instrumentation/adapters/ExecutionResultInstrumentationContextAdapter.java
@@ -5,8 +5,6 @@ import graphql.ExecutionResultImpl;
 import graphql.Internal;
 import graphql.execution.instrumentation.InstrumentationContext;
 
-import java.util.concurrent.CompletableFuture;
-
 /**
  * A class to help adapt old {@link ExecutionResult} based InstrumentationContext
  * from the newer {@link Object} based ones.
@@ -21,15 +19,16 @@ public class ExecutionResultInstrumentationContextAdapter implements Instrumenta
     }
 
     @Override
-    public void onDispatched(CompletableFuture<Object> result) {
-        CompletableFuture<ExecutionResult> future = result.thenApply(obj -> ExecutionResultImpl.newExecutionResult().data(obj).build());
-        delegate.onDispatched(future);
-        //
-        // when the mapped future is completed, then call onCompleted on the delegate
-        future.whenComplete(delegate::onCompleted);
+    public void onDispatched() {
+        delegate.onDispatched();
     }
 
     @Override
     public void onCompleted(Object result, Throwable t) {
+        if (t != null) {
+            delegate.onCompleted(null, t);
+        } else {
+            delegate.onCompleted(ExecutionResultImpl.newExecutionResult().data(result).build(), null);
+        }
     }
 }

--- a/src/main/java/graphql/language/Field.java
+++ b/src/main/java/graphql/language/Field.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableMap;
 import graphql.Internal;
 import graphql.PublicApi;
 import graphql.collect.ImmutableKit;
+import graphql.util.FieldNameInterner;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
@@ -50,8 +51,8 @@ public class Field extends AbstractNode<Field> implements Selection<Field>, Sele
                     IgnoredChars ignoredChars,
                     Map<String, String> additionalData) {
         super(sourceLocation, comments, ignoredChars, additionalData);
-        this.name = name;
-        this.alias = alias;
+        this.name = name == null ? null : FieldNameInterner.intern(name);
+        this.alias = alias == null ? null : FieldNameInterner.intern(alias);
         this.arguments = ImmutableList.copyOf(arguments);
         this.directives = ImmutableList.copyOf(directives);
         this.selectionSet = selectionSet;

--- a/src/main/java/graphql/schema/GraphQLFieldDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLFieldDefinition.java
@@ -6,6 +6,7 @@ import graphql.DirectivesUtil;
 import graphql.Internal;
 import graphql.PublicApi;
 import graphql.language.FieldDefinition;
+import graphql.util.FieldNameInterner;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
@@ -61,7 +62,7 @@ public class GraphQLFieldDefinition implements GraphQLNamedSchemaElement, GraphQ
         assertValidName(name);
         assertNotNull(type, () -> "type can't be null");
         assertNotNull(arguments, () -> "arguments can't be null");
-        this.name = name;
+        this.name = FieldNameInterner.intern(name);
         this.description = description;
         this.originalType = type;
         this.dataFetcherFactory = dataFetcherFactory;

--- a/src/main/java/graphql/schema/GraphQLInterfaceType.java
+++ b/src/main/java/graphql/schema/GraphQLInterfaceType.java
@@ -51,7 +51,6 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLCompositeT
     private final Comparator<? super GraphQLSchemaElement> interfaceComparator;
     private ImmutableList<GraphQLNamedOutputType> replacedInterfaces;
 
-
     public static final String CHILD_FIELD_DEFINITIONS = "fieldDefinitions";
     public static final String CHILD_INTERFACES = "interfaces";
 
@@ -95,7 +94,6 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLCompositeT
     public GraphQLFieldDefinition getFieldDefinition(String name) {
         return fieldDefinitionsByName.get(name);
     }
-
 
     @Override
     public List<GraphQLFieldDefinition> getFieldDefinitions() {
@@ -229,9 +227,9 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLCompositeT
     @Override
     public List<GraphQLNamedOutputType> getInterfaces() {
         if (replacedInterfaces != null) {
-            return ImmutableList.copyOf(replacedInterfaces);
+            return replacedInterfaces;
         }
-        return ImmutableList.copyOf(originalInterfaces);
+        return originalInterfaces;
     }
 
     void replaceInterfaces(List<GraphQLNamedOutputType> interfaces) {

--- a/src/main/java/graphql/schema/GraphQLObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLObjectType.java
@@ -40,7 +40,6 @@ import static graphql.util.FpKit.valuesToList;
 @PublicApi
 public class GraphQLObjectType implements GraphQLNamedOutputType, GraphQLCompositeType, GraphQLUnmodifiedType, GraphQLNullableType, GraphQLDirectiveContainer, GraphQLImplementingType {
 
-
     private final String name;
     private final String description;
     private final Comparator<? super GraphQLSchemaElement> interfaceComparator;
@@ -131,7 +130,6 @@ public class GraphQLObjectType implements GraphQLNamedOutputType, GraphQLComposi
     public List<GraphQLFieldDefinition> getFieldDefinitions() {
         return ImmutableList.copyOf(fieldDefinitionsByName.values());
     }
-
 
     @Override
     public List<GraphQLNamedOutputType> getInterfaces() {

--- a/src/main/java/graphql/schema/idl/SchemaPrinter.java
+++ b/src/main/java/graphql/schema/idl/SchemaPrinter.java
@@ -98,6 +98,8 @@ public class SchemaPrinter {
 
         private final boolean descriptionsAsHashComments;
 
+        private final Predicate<String> includeDirectiveDefinition;
+
         private final Predicate<String> includeDirective;
 
         private final Predicate<GraphQLSchemaElement> includeSchemaElement;
@@ -110,6 +112,7 @@ public class SchemaPrinter {
                         boolean includeScalars,
                         boolean includeSchemaDefinition,
                         boolean includeDirectiveDefinitions,
+                        Predicate<String> includeDirectiveDefinition,
                         boolean useAstDefinitions,
                         boolean descriptionsAsHashComments,
                         Predicate<String> includeDirective,
@@ -120,6 +123,7 @@ public class SchemaPrinter {
             this.includeScalars = includeScalars;
             this.includeSchemaDefinition = includeSchemaDefinition;
             this.includeDirectiveDefinitions = includeDirectiveDefinitions;
+            this.includeDirectiveDefinition = includeDirectiveDefinition;
             this.includeDirective = includeDirective;
             this.useAstDefinitions = useAstDefinitions;
             this.descriptionsAsHashComments = descriptionsAsHashComments;
@@ -144,6 +148,10 @@ public class SchemaPrinter {
             return includeDirectiveDefinitions;
         }
 
+        public Predicate<String> getIncludeDirectiveDefinition() {
+            return includeDirectiveDefinition;
+        }
+
         public Predicate<String> getIncludeDirective() {
             return includeDirective;
         }
@@ -164,14 +172,16 @@ public class SchemaPrinter {
             return useAstDefinitions;
         }
 
-        public boolean isIncludeAstDefinitionComments() { return includeAstDefinitionComments; }
+        public boolean isIncludeAstDefinitionComments() {
+            return includeAstDefinitionComments;
+        }
 
         public static Options defaultOptions() {
             return new Options(false,
                     true,
                     false,
                     true,
-                    false,
+                    directive -> true, false,
                     false,
                     directive -> true,
                     element -> true,
@@ -191,7 +201,7 @@ public class SchemaPrinter {
                     this.includeScalars,
                     this.includeSchemaDefinition,
                     this.includeDirectiveDefinitions,
-                    this.useAstDefinitions,
+                    this.includeDirectiveDefinition, this.useAstDefinitions,
                     this.descriptionsAsHashComments,
                     this.includeDirective,
                     this.includeSchemaElement,
@@ -211,7 +221,7 @@ public class SchemaPrinter {
                     flag,
                     this.includeSchemaDefinition,
                     this.includeDirectiveDefinitions,
-                    this.useAstDefinitions,
+                    this.includeDirectiveDefinition, this.useAstDefinitions,
                     this.descriptionsAsHashComments,
                     this.includeDirective,
                     this.includeSchemaElement,
@@ -234,6 +244,7 @@ public class SchemaPrinter {
                     this.includeScalars,
                     flag,
                     this.includeDirectiveDefinitions,
+                    this.includeDirectiveDefinition,
                     this.useAstDefinitions,
                     this.descriptionsAsHashComments,
                     this.includeDirective,
@@ -259,6 +270,29 @@ public class SchemaPrinter {
                     this.includeScalars,
                     this.includeSchemaDefinition,
                     flag,
+                    directive -> flag,
+                    this.useAstDefinitions,
+                    this.descriptionsAsHashComments,
+                    this.includeDirective,
+                    this.includeSchemaElement,
+                    this.comparatorRegistry,
+                    this.includeAstDefinitionComments);
+        }
+
+
+        /**
+         * This is a Predicate that decides whether a directive definition is printed.
+         *
+         * @param includeDirectiveDefinition the predicate to decide of a directive defintion is printed
+         *
+         * @return new instance of options
+         */
+        public Options includeDirectiveDefinition(Predicate<String> includeDirectiveDefinition) {
+            return new Options(this.includeIntrospectionTypes,
+                    this.includeScalars,
+                    this.includeSchemaDefinition,
+                    this.includeDirectiveDefinitions,
+                    includeDirectiveDefinition,
                     this.useAstDefinitions,
                     this.descriptionsAsHashComments,
                     this.includeDirective,
@@ -280,6 +314,7 @@ public class SchemaPrinter {
                     this.includeScalars,
                     this.includeSchemaDefinition,
                     this.includeDirectiveDefinitions,
+                    this.includeDirectiveDefinition,
                     this.useAstDefinitions,
                     this.descriptionsAsHashComments,
                     directive -> flag,
@@ -300,6 +335,7 @@ public class SchemaPrinter {
                     this.includeScalars,
                     this.includeSchemaDefinition,
                     this.includeDirectiveDefinitions,
+                    this.includeDirectiveDefinition,
                     this.useAstDefinitions,
                     this.descriptionsAsHashComments,
                     includeDirective,
@@ -307,6 +343,7 @@ public class SchemaPrinter {
                     this.comparatorRegistry,
                     this.includeAstDefinitionComments);
         }
+
 
         /**
          * This is a general purpose Predicate that decides whether a schema element is printed ever.
@@ -321,6 +358,7 @@ public class SchemaPrinter {
                     this.includeScalars,
                     this.includeSchemaDefinition,
                     this.includeDirectiveDefinitions,
+                    this.includeDirectiveDefinition,
                     this.useAstDefinitions,
                     this.descriptionsAsHashComments,
                     this.includeDirective,
@@ -342,6 +380,7 @@ public class SchemaPrinter {
                     this.includeScalars,
                     this.includeSchemaDefinition,
                     this.includeDirectiveDefinitions,
+                    this.includeDirectiveDefinition,
                     flag,
                     this.descriptionsAsHashComments,
                     this.includeDirective,
@@ -365,6 +404,7 @@ public class SchemaPrinter {
                     this.includeScalars,
                     this.includeSchemaDefinition,
                     this.includeDirectiveDefinitions,
+                    this.includeDirectiveDefinition,
                     this.useAstDefinitions,
                     flag,
                     this.includeDirective,
@@ -387,6 +427,7 @@ public class SchemaPrinter {
                     this.includeScalars,
                     this.includeSchemaDefinition,
                     this.includeDirectiveDefinitions,
+                    this.includeDirectiveDefinition,
                     this.useAstDefinitions,
                     this.descriptionsAsHashComments,
                     this.includeDirective,
@@ -409,6 +450,7 @@ public class SchemaPrinter {
                     this.includeScalars,
                     this.includeSchemaDefinition,
                     this.includeDirectiveDefinitions,
+                    this.includeDirectiveDefinition,
                     this.useAstDefinitions,
                     this.descriptionsAsHashComments,
                     this.includeDirective,
@@ -638,7 +680,9 @@ public class SchemaPrinter {
 
     private SchemaElementPrinter<GraphQLDirective> directivePrinter() {
         return (out, directive, visibility) -> {
-            if (options.isIncludeDirectiveDefinitions()) {
+            boolean isOnEver = options.isIncludeDirectiveDefinitions();
+            boolean specificTest = options.getIncludeDirectiveDefinition().test(directive.getName());
+            if (isOnEver && specificTest) {
                 String s = directiveDefinition(directive);
                 out.format("%s", s);
                 out.print("\n\n");
@@ -876,7 +920,7 @@ public class SchemaPrinter {
     private String directivesString(Class<? extends GraphQLSchemaElement> parentType, List<GraphQLAppliedDirective> directives) {
         directives = directives.stream()
                 // @deprecated is special - we always print it if something is deprecated
-                .filter(directive -> options.getIncludeDirective().test(directive.getName()) || isDeprecatedDirective(directive))
+                .filter(directive -> options.getIncludeDirective().test(directive.getName()))
                 .filter(options.getIncludeSchemaElement())
                 .collect(toList());
 
@@ -909,10 +953,7 @@ public class SchemaPrinter {
             return "";
         }
         if (!options.getIncludeDirective().test(directive.getName())) {
-            // @deprecated is special - we always print it if something is deprecated
-            if (!isDeprecatedDirective(directive)) {
-                return "";
-            }
+            return "";
         }
 
         StringBuilder sb = new StringBuilder();
@@ -948,6 +989,13 @@ public class SchemaPrinter {
         return sb.toString();
     }
 
+    private boolean isDeprecatedDirectiveAllowed() {
+        // we ask if the special deprecated directive,
+        // which can be programmatically on a type without an applied directive,
+        // should be printed or not
+        return options.getIncludeDirective().test(DeprecatedDirective.getName());
+    }
+
     private boolean isDeprecatedDirective(GraphQLAppliedDirective directive) {
         return directive.getName().equals(DeprecatedDirective.getName());
     }
@@ -960,14 +1008,14 @@ public class SchemaPrinter {
 
     private List<GraphQLAppliedDirective> addDeprecatedDirectiveIfNeeded(GraphQLDirectiveContainer directiveContainer) {
         List<GraphQLAppliedDirective> directives = DirectivesUtil.toAppliedDirectives(directiveContainer);
-        if (!hasDeprecatedDirective(directives)) {
+        if (!hasDeprecatedDirective(directives) && isDeprecatedDirectiveAllowed()) {
             directives = new ArrayList<>(directives);
-                    String reason = getDeprecationReason(directiveContainer);
-                    GraphQLAppliedDirectiveArgument arg = GraphQLAppliedDirectiveArgument.newArgument()
-                            .name("reason")
-                            .valueProgrammatic(reason)
-                            .type(GraphQLString)
-                            .build();
+            String reason = getDeprecationReason(directiveContainer);
+            GraphQLAppliedDirectiveArgument arg = GraphQLAppliedDirectiveArgument.newArgument()
+                    .name("reason")
+                    .valueProgrammatic(reason)
+                    .type(GraphQLString)
+                    .build();
             GraphQLAppliedDirective directive = GraphQLAppliedDirective.newDirective()
                     .name("deprecated")
                     .argument(arg)
@@ -1104,7 +1152,7 @@ public class SchemaPrinter {
         if (options.isIncludeAstDefinitionComments()) {
             String commentsText = getAstDefinitionComments(graphQLType);
             if (!isNullOrEmpty(commentsText)) {
-                List<String> lines = Arrays.asList(commentsText.split("\n") );
+                List<String> lines = Arrays.asList(commentsText.split("\n"));
                 if (!lines.isEmpty()) {
                     printMultiLineHashDescription(out, prefix, lines);
                 }
@@ -1179,7 +1227,7 @@ public class SchemaPrinter {
     }
 
     private String comments(List<Comment> comments) {
-        if ( comments == null || comments.isEmpty() ) {
+        if (comments == null || comments.isEmpty()) {
             return null;
         }
         String s = comments.stream().map(c -> c.getContent()).collect(joining("\n", "", "\n"));

--- a/src/main/java/graphql/util/FieldNameInterner.java
+++ b/src/main/java/graphql/util/FieldNameInterner.java
@@ -1,0 +1,22 @@
+package graphql.util;
+
+import com.google.common.collect.Interner;
+import com.google.common.collect.Interners;
+import graphql.Internal;
+
+/**
+ * Interner allowing object identity based comparison of field names.
+ */
+@Internal
+public class FieldNameInterner {
+
+    private FieldNameInterner() {
+    }
+
+    public static final Interner<String> INTERNER = Interners.newWeakInterner();
+
+    public static String intern(String name) {
+        return INTERNER.intern(name);
+    }
+
+}

--- a/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy
@@ -287,7 +287,7 @@ abstract class AsyncExecutionStrategyTest extends Specification {
                             }
 
                             @Override
-                            void onDispatched(CompletableFuture<ExecutionResult> result) {
+                            void onDispatched() {
                             }
 
                             @Override

--- a/src/test/groovy/graphql/execution/FieldValueInfoTest.groovy
+++ b/src/test/groovy/graphql/execution/FieldValueInfoTest.groovy
@@ -3,26 +3,26 @@ package graphql.execution
 import graphql.AssertException
 import spock.lang.Specification
 
+import java.util.concurrent.CompletableFuture
 
-class FieldValueInfoTest extends Specification{
+import static graphql.execution.FieldValueInfo.CompleteValueType.SCALAR
+
+
+class FieldValueInfoTest extends Specification {
 
     def "simple constructor test"() {
         when:
-        def fieldValueInfo = FieldValueInfo.newFieldValueInfo().build()
+        def fieldValueInfo = new FieldValueInfo(SCALAR, CompletableFuture.completedFuture("A"))
 
         then: "fieldValueInfos to be empty list"
         fieldValueInfo.fieldValueInfos == [] as List
-
-        and: "other fields to be null "
-        fieldValueInfo.fieldValueFuture == null
-        fieldValueInfo.completeValueType == null
+        fieldValueInfo.fieldValueFuture.join() == "A"
+        fieldValueInfo.completeValueType == SCALAR
     }
 
     def "negative constructor test"() {
         when:
-        FieldValueInfo.newFieldValueInfo()
-                .fieldValueInfos(null)
-                .build()
+        new FieldValueInfo(SCALAR, CompletableFuture.completedFuture("A"), null)
         then:
         def assEx = thrown(AssertException)
         assEx.message.contains("fieldValueInfos")

--- a/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
@@ -171,7 +171,7 @@ class InstrumentationTest extends Specification {
             return new ExecutionStrategyInstrumentationContext() {
 
                 @Override
-                void onDispatched(CompletableFuture<ExecutionResult> result) {
+                void onDispatched() {
                     System.out.println(String.format("t%s setting go signal on", Thread.currentThread().getId()))
                     goSignal.set(true)
                 }

--- a/src/test/groovy/graphql/execution/instrumentation/TestingInstrumentContext.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/TestingInstrumentContext.groovy
@@ -25,7 +25,7 @@ class TestingInstrumentContext<T> implements InstrumentationContext<T> {
     }
 
     @Override
-    void onDispatched(CompletableFuture<T> result) {
+    void onDispatched() {
         if (useOnDispatch) {
             this.executionList << "onDispatched:$op"
         }

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -1556,7 +1556,7 @@ extend type Query {
 '''
     }
 
-    def "@deprecated directives are always printed"() {
+    def "@deprecated directives are NOT always printed - they used to be"() {
         given:
         def idl = """
 
@@ -1588,7 +1588,7 @@ extend type Query {
 
         then:
         result == '''type Field {
-  deprecated: Enum @deprecated(reason : "No longer supported")
+  deprecated: Enum
 }
 
 type Query {
@@ -1596,11 +1596,11 @@ type Query {
 }
 
 enum Enum {
-  enumVal @deprecated(reason : "No longer supported")
+  enumVal
 }
 
 input Input {
-  deprecated: String @deprecated(reason : "custom reason")
+  deprecated: String
 }
 '''
     }
@@ -1641,7 +1641,7 @@ type Query {
 '''
     }
 
-    def "@deprecated directive are always printed regardless of options"() {
+    def "@deprecated directive are NOT always printed regardless of options"() {
         given:
         def idl = '''
 
@@ -1660,6 +1660,37 @@ type Query {
 
         then:
         result == '''type Query {
+  fieldX: String
+}
+'''
+    }
+
+    def "@deprecated directive are printed respecting options"() {
+        given:
+        def idl = '''
+
+            type Query {
+              fieldX : String @deprecated
+            }
+            
+        '''
+        def registry = new SchemaParser().parse(idl)
+        def runtimeWiring = newRuntimeWiring().build()
+        def options = SchemaGenerator.Options.defaultOptions()
+        def schema = new SchemaGenerator().makeExecutableSchema(options, registry, runtimeWiring)
+
+        when:
+        def printOptions = defaultOptions().includeDirectives({ dName -> (dName == "deprecated") })
+        def result = new SchemaPrinter(printOptions).print(schema)
+
+        then:
+        result == '''"Marks the field, argument, input field or enum value as deprecated"
+directive @deprecated(
+    "The reason for the deprecation"
+    reason: String = "No longer supported"
+  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+
+type Query {
   fieldX: String @deprecated(reason : "No longer supported")
 }
 '''
@@ -2678,7 +2709,10 @@ input Gun {
                 .query(queryType)
                 .build()
         when:
-        def result = "\n" + new SchemaPrinter(noDirectivesOption).print(schema)
+
+        def printOptions = defaultOptions().includeDirectiveDefinitions(false).includeDirectives({ d -> true })
+
+        def result = "\n" + new SchemaPrinter(printOptions).print(schema)
         println(result)
 
         then:
@@ -2700,4 +2734,49 @@ input Input {
 }
 """
     }
+
+    def "can use predicate for directive definitions"() {
+
+        def schema = TestUtil.schema("""
+            type Query {
+                field: String @deprecated
+            }
+        """)
+
+
+        def options = defaultOptions()
+                .includeDirectiveDefinitions(true)
+                .includeDirectiveDefinition({ it != "skip" })
+        def result = new SchemaPrinter(options).print(schema)
+
+        expect: "has no skip definition"
+
+        result == """"Marks the field, argument, input field or enum value as deprecated"
+directive @deprecated(
+    "The reason for the deprecation"
+    reason: String = "No longer supported"
+  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+
+"Directs the executor to include this field or fragment only when the `if` argument is true"
+directive @include(
+    "Included when true."
+    if: Boolean!
+  ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"Indicates an Input Object is a OneOf Input Object."
+directive @oneOf on INPUT_OBJECT
+
+"Exposes a URL that specifies the behaviour of this scalar."
+directive @specifiedBy(
+    "The URL that specifies the behaviour of this scalar."
+    url: String!
+  ) on SCALAR
+
+type Query {
+  field: String @deprecated(reason : "No longer supported")
 }
+"""
+    }
+}
+
+

--- a/src/test/groovy/graphql/util/AnonymizerTest.groovy
+++ b/src/test/groovy/graphql/util/AnonymizerTest.groovy
@@ -718,7 +718,7 @@ type Object1 {
         when:
         def result = Anonymizer.anonymizeSchema(schema)
         def newSchema = new SchemaPrinter(SchemaPrinter.Options.defaultOptions()
-                .includeDirectives({!DirectiveInfo.isGraphqlSpecifiedDirective(it)}))
+                .includeDirectives({!DirectiveInfo.isGraphqlSpecifiedDirective(it) || it == "deprecated"}))
                 .print(result)
 
         then:
@@ -729,6 +729,8 @@ type Object1 {
             
             directive @Directive1(argument1: String! = "stringValue4") repeatable on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
             
+            directive @deprecated(reason: String) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+
             interface Interface1 @Directive1(argument1 : "stringValue12") {
               field2: String
               field3: Enum1


### PR DESCRIPTION
Quick follow up from https://github.com/graphql-java/graphql-java/pull/3478 to intern field names which allows object identity equality checks for `String.equals` and when looking up field definitions by name. Benchmark result here:

https://github.com/graphql-java/graphql-java/pull/3478#issuecomment-1972649516
