### PR TITLE
A CompleteableFuture benchmark

### DIFF
--- a/src/test/java/benchmark/CompletableFuturesBenchmark.java
+++ b/src/test/java/benchmark/CompletableFuturesBenchmark.java
@@ -100,7 +100,6 @@ public class CompletableFuturesBenchmark {
     public static void main(String[] args) throws Exception {
         Options opt = new OptionsBuilder()
                 .include("benchmark.CompletableFuturesBenchmark")
-                .forks(1)
                 .build();
 
         new Runner(opt).run();

--- a/src/test/java/benchmark/CompletableFuturesBenchmark.java
+++ b/src/test/java/benchmark/CompletableFuturesBenchmark.java
@@ -1,7 +1,6 @@
 package benchmark;
 
 import com.google.common.collect.ImmutableList;
-import graphql.execution.Async;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -31,6 +30,7 @@ public class CompletableFuturesBenchmark {
     @Param({"2", "5"})
     public int depth;
     public int howMany = 10;
+
     @Setup(Level.Trial)
     public void setUp() {
     }

--- a/src/test/java/benchmark/CompletableFuturesBenchmark.java
+++ b/src/test/java/benchmark/CompletableFuturesBenchmark.java
@@ -1,0 +1,109 @@
+package benchmark;
+
+import com.google.common.collect.ImmutableList;
+import graphql.execution.Async;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+@State(Scope.Benchmark)
+@Warmup(iterations = 2, time = 1)
+@Measurement(iterations = 3, time = 10, batchSize = 10)
+@Fork(3)
+public class CompletableFuturesBenchmark {
+
+
+    @Param({"2", "5"})
+    public int depth;
+    public int howMany = 10;
+    @Setup(Level.Trial)
+    public void setUp() {
+    }
+
+    private List<CompletableFuture<Object>> mkCFObjects(int howMany, int depth) {
+        if (depth <= 0) {
+            return Collections.emptyList();
+        }
+        ImmutableList.Builder<CompletableFuture<Object>> builder = ImmutableList.builder();
+        for (int i = 0; i < howMany; i++) {
+            CompletableFuture<Object> cf = CompletableFuture.completedFuture(mkCFObjects(howMany, depth - 1));
+            builder.add(cf);
+        }
+        return builder.build();
+    }
+
+    private List<Object> mkObjects(int howMany, int depth) {
+        if (depth <= 0) {
+            return Collections.emptyList();
+        }
+        ImmutableList.Builder<Object> builder = ImmutableList.builder();
+        for (int i = 0; i < howMany; i++) {
+            Object obj = mkObjects(howMany, depth - 1);
+            builder.add(obj);
+        }
+        return builder.build();
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public void benchmarkCFApproach() {
+        // make results
+        List<CompletableFuture<Object>> completableFutures = mkCFObjects(howMany, depth);
+        // traverse results
+        traverseCFS(completableFutures);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public void benchmarkMaterializedApproach() {
+        // make results
+        List<Object> objects = mkObjects(howMany, depth);
+        // traverse results
+        traverseObjects(objects);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void traverseCFS(List<CompletableFuture<Object>> completableFutures) {
+        for (CompletableFuture<Object> completableFuture : completableFutures) {
+            // and when it's done - visit its child results - which are always immediate on completed CFs
+            // so this whenComplete executed now
+            completableFuture.whenComplete((list, t) -> {
+                List<CompletableFuture<Object>> cfs = (List<CompletableFuture<Object>>) list;
+                traverseCFS(cfs);
+            });
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void traverseObjects(List<Object> objects) {
+        for (Object object : objects) {
+            List<Object> list = (List<Object>) object;
+            traverseObjects(list);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        Options opt = new OptionsBuilder()
+                .include("benchmark.CompletableFuturesBenchmark")
+                .forks(1)
+                .build();
+
+        new Runner(opt).run();
+    }
+
+}


### PR DESCRIPTION
This bench mark makes a tree of objects and then traverses that tree if objects.

10 objects per level of either 2 or 5 in depth

One approach is that all objects are completed CFs to objects and the other approach is just a list of materialized objects.

We would always expect materialised object creation and traversal to be faster - but how much faster.

Well that is what this benchmark tried to find out

```
Benchmark                                                  (depth)   Mode  Cnt      Score      Error  Units
CompletableFuturesBenchmark.benchmarkCFApproach                  2  thrpt    3  27343.594 ± 3539.780  ops/s
CompletableFuturesBenchmark.benchmarkCFApproach                  5  thrpt    3     41.339 ±    9.774  ops/s

CompletableFuturesBenchmark.benchmarkMaterializedApproach        2  thrpt    3  87115.179 ± 8502.169  ops/s
CompletableFuturesBenchmark.benchmarkMaterializedApproach        5  thrpt    3    109.370 ±    3.277  ops/s
```