### PR TITLE
Removed deprecated methods from fields / unions and interfaces

### DIFF
--- a/src/main/java/graphql/execution/ExecutionContext.java
+++ b/src/main/java/graphql/execution/ExecutionContext.java
@@ -120,16 +120,6 @@ public class ExecutionContext {
         return operationDefinition;
     }
 
-    /**
-     * @return map of coerced variables
-     *
-     * @deprecated use {@link #getCoercedVariables()} instead
-     */
-    @Deprecated(since = "2022-05-24")
-    public Map<String, Object> getVariables() {
-        return coercedVariables.toMap();
-    }
-
     public CoercedVariables getCoercedVariables() {
         return coercedVariables;
     }

--- a/src/main/java/graphql/relay/Relay.java
+++ b/src/main/java/graphql/relay/Relay.java
@@ -32,7 +32,7 @@ import static graphql.schema.GraphQLTypeReference.typeRef;
 /**
  * This can be used to compose graphql runtime types that implement
  * that Relay specification.
- *
+ * <p>
  * See <a href="https://facebook.github.io/relay/graphql/connections.htm">https://facebook.github.io/relay/graphql/connections.htm</a>
  */
 @PublicApi
@@ -61,11 +61,10 @@ public class Relay {
                     .description("When paginating forwards, the cursor to continue."))
             .build();
 
-    public GraphQLInterfaceType nodeInterface(TypeResolver typeResolver) {
+    public GraphQLInterfaceType nodeInterface() {
         return newInterface()
                 .name(NODE)
                 .description("An object with an ID")
-                .typeResolver(typeResolver)
                 .field(newFieldDefinition()
                         .name("id")
                         .description("The ID of an object")
@@ -73,12 +72,11 @@ public class Relay {
                 .build();
     }
 
-    public GraphQLFieldDefinition nodeField(GraphQLInterfaceType nodeInterface, DataFetcher nodeDataFetcher) {
+    public GraphQLFieldDefinition nodeField(GraphQLInterfaceType nodeInterface) {
         return newFieldDefinition()
                 .name("node")
                 .description("Fetches an object given its ID")
                 .type(nodeInterface)
-                .dataFetcher(nodeDataFetcher)
                 .argument(newArgument()
                         .name("id")
                         .description("The ID of an object")
@@ -175,8 +173,8 @@ public class Relay {
 
     public GraphQLFieldDefinition mutationWithClientMutationId(String name, String fieldName,
                                                                List<GraphQLInputObjectField> inputFields,
-                                                               List<GraphQLFieldDefinition> outputFields,
-                                                               DataFetcher dataFetcher) {
+                                                               List<GraphQLFieldDefinition> outputFields
+                                                               ) {
         GraphQLInputObjectField clientMutationIdInputField = newInputObjectField()
                 .name("clientMutationId")
                 .type(GraphQLString)
@@ -187,7 +185,7 @@ public class Relay {
                 .build();
 
         return mutation(name, fieldName, addElementToList(inputFields, clientMutationIdInputField),
-                addElementToList(outputFields, clientMutationIdPayloadField), dataFetcher);
+                addElementToList(outputFields, clientMutationIdPayloadField));
     }
 
     private static <T> List<T> addElementToList(List<T> list, T element) {
@@ -198,8 +196,7 @@ public class Relay {
 
     public GraphQLFieldDefinition mutation(String name, String fieldName,
                                            List<GraphQLInputObjectField> inputFields,
-                                           List<GraphQLFieldDefinition> outputFields,
-                                           DataFetcher dataFetcher) {
+                                           List<GraphQLFieldDefinition> outputFields) {
         GraphQLInputObjectType inputObjectType = newInputObject()
                 .name(name + "Input")
                 .fields(inputFields)
@@ -215,7 +212,6 @@ public class Relay {
                 .argument(newArgument()
                         .name("input")
                         .type(nonNull(inputObjectType)))
-                .dataFetcher(dataFetcher)
                 .build();
     }
 

--- a/src/main/java/graphql/schema/CodeRegistryVisitor.java
+++ b/src/main/java/graphql/schema/CodeRegistryVisitor.java
@@ -23,22 +23,11 @@ public class CodeRegistryVisitor extends GraphQLTypeVisitorStub {
 
     @Override
     public TraversalControl visitGraphQLFieldDefinition(GraphQLFieldDefinition node, TraverserContext<GraphQLSchemaElement> context) {
-        GraphQLFieldsContainer parentContainerType = (GraphQLFieldsContainer) context.getParentContext().thisNode();
-        DataFetcher<?> dataFetcher = node.getDataFetcher();
-        if (dataFetcher != null) {
-            FieldCoordinates coordinates = coordinates(parentContainerType, node);
-            codeRegistry.dataFetcherIfAbsent(coordinates, dataFetcher);
-        }
-
         return CONTINUE;
     }
 
     @Override
     public TraversalControl visitGraphQLInterfaceType(GraphQLInterfaceType node, TraverserContext<GraphQLSchemaElement> context) {
-        TypeResolver typeResolver = node.getTypeResolver();
-        if (typeResolver != null) {
-            codeRegistry.typeResolverIfAbsent(node, typeResolver);
-        }
         assertTrue(codeRegistry.getTypeResolver(node) != null,
                 () -> String.format("You MUST provide a type resolver for the interface type '%s'", node.getName()));
         return CONTINUE;
@@ -46,10 +35,6 @@ public class CodeRegistryVisitor extends GraphQLTypeVisitorStub {
 
     @Override
     public TraversalControl visitGraphQLUnionType(GraphQLUnionType node, TraverserContext<GraphQLSchemaElement> context) {
-        TypeResolver typeResolver = node.getTypeResolver();
-        if (typeResolver != null) {
-            codeRegistry.typeResolverIfAbsent(node, typeResolver);
-        }
         assertTrue(codeRegistry.getTypeResolver(node) != null,
                 () -> String.format("You MUST provide a type resolver for the union type '%s'", node.getName()));
         return CONTINUE;

--- a/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
@@ -94,7 +94,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
                 .locale(executionContext.getLocale())
                 .document(executionContext.getDocument())
                 .operationDefinition(executionContext.getOperationDefinition())
-                .variables(executionContext.getVariables())
+                .variables(executionContext.getCoercedVariables().toMap())
                 .executionId(executionContext.getExecutionId());
     }
 

--- a/src/main/java/graphql/schema/GraphQLCodeRegistry.java
+++ b/src/main/java/graphql/schema/GraphQLCodeRegistry.java
@@ -154,18 +154,12 @@ public class GraphQLCodeRegistry {
     private static TypeResolver getTypeResolverForInterface(GraphQLInterfaceType parentType, Map<String, TypeResolver> typeResolverMap) {
         assertNotNull(parentType);
         TypeResolver typeResolver = typeResolverMap.get(parentType.getName());
-        if (typeResolver == null) {
-            typeResolver = parentType.getTypeResolver();
-        }
         return assertNotNull(typeResolver, () -> "There must be a type resolver for interface " + parentType.getName());
     }
 
     private static TypeResolver getTypeResolverForUnion(GraphQLUnionType parentType, Map<String, TypeResolver> typeResolverMap) {
         assertNotNull(parentType);
         TypeResolver typeResolver = typeResolverMap.get(parentType.getName());
-        if (typeResolver == null) {
-            typeResolver = parentType.getTypeResolver();
-        }
         return assertNotNull(typeResolver, () -> "There must be a type resolver for union " + parentType.getName());
     }
 

--- a/src/main/java/graphql/schema/GraphQLInterfaceType.java
+++ b/src/main/java/graphql/schema/GraphQLInterfaceType.java
@@ -42,7 +42,6 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLCompositeT
     private final String name;
     private final String description;
     private final Map<String, GraphQLFieldDefinition> fieldDefinitionsByName;
-    private final TypeResolver typeResolver;
     private final InterfaceTypeDefinition definition;
     private final ImmutableList<InterfaceTypeExtensionDefinition> extensionDefinitions;
     private final DirectivesUtil.DirectivesHolder directivesHolder;
@@ -59,7 +58,6 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLCompositeT
     private GraphQLInterfaceType(String name,
                                  String description,
                                  List<GraphQLFieldDefinition> fieldDefinitions,
-                                 TypeResolver typeResolver,
                                  List<GraphQLDirective> directives,
                                  List<GraphQLAppliedDirective> appliedDirectives,
                                  InterfaceTypeDefinition definition,
@@ -72,7 +70,6 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLCompositeT
 
         this.name = name;
         this.description = description;
-        this.typeResolver = typeResolver;
         this.definition = definition;
         this.interfaceComparator = interfaceComparator;
         this.originalInterfaces = ImmutableList.copyOf(sortTypes(interfaceComparator, interfaces));
@@ -104,13 +101,6 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLCompositeT
 
     public String getDescription() {
         return description;
-    }
-
-    // to be removed in a future version when all code is in the code registry
-    @Internal
-    @Deprecated(since = "2018-12-03")
-    TypeResolver getTypeResolver() {
-        return typeResolver;
     }
 
     public InterfaceTypeDefinition getDefinition() {
@@ -162,7 +152,6 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLCompositeT
                 "name='" + name + '\'' +
                 ", description='" + description + '\'' +
                 ", fieldDefinitionsByName=" + fieldDefinitionsByName.keySet() +
-                ", typeResolver=" + typeResolver +
                 '}';
     }
 
@@ -261,7 +250,6 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLCompositeT
 
     @PublicApi
     public static class Builder extends GraphqlDirectivesContainerTypeBuilder<Builder, Builder> {
-        private TypeResolver typeResolver;
         private InterfaceTypeDefinition definition;
         private List<InterfaceTypeExtensionDefinition> extensionDefinitions = emptyList();
         private final Map<String, GraphQLFieldDefinition> fields = new LinkedHashMap<>();
@@ -273,7 +261,6 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLCompositeT
         public Builder(GraphQLInterfaceType existing) {
             this.name = existing.getName();
             this.description = existing.getDescription();
-            this.typeResolver = existing.getTypeResolver();
             this.definition = existing.getDefinition();
             this.extensionDefinitions = existing.getExtensionDefinitions();
             this.fields.putAll(getByName(existing.getFieldDefinitions(), GraphQLFieldDefinition::getName));
@@ -353,19 +340,6 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLCompositeT
          */
         public Builder clearFields() {
             fields.clear();
-            return this;
-        }
-
-        /**
-         * @param typeResolver the type resolver
-         *
-         * @return this builder
-         *
-         * @deprecated use {@link graphql.schema.GraphQLCodeRegistry.Builder#typeResolver(GraphQLInterfaceType, TypeResolver)} instead
-         */
-        @Deprecated(since = "2018-12-03")
-        public Builder typeResolver(TypeResolver typeResolver) {
-            this.typeResolver = typeResolver;
             return this;
         }
 
@@ -455,7 +429,6 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLCompositeT
                     name,
                     description,
                     sort(fields, GraphQLInterfaceType.class, GraphQLFieldDefinition.class),
-                    typeResolver,
                     sort(directives, GraphQLInterfaceType.class, GraphQLDirective.class),
                     sort(appliedDirectives, GraphQLScalarType.class, GraphQLAppliedDirective.class),
                     definition,

--- a/src/main/java/graphql/schema/GraphQLUnionType.java
+++ b/src/main/java/graphql/schema/GraphQLUnionType.java
@@ -40,7 +40,6 @@ public class GraphQLUnionType implements GraphQLNamedOutputType, GraphQLComposit
     private final String name;
     private final String description;
     private final ImmutableList<GraphQLNamedOutputType> originalTypes;
-    private final TypeResolver typeResolver;
     private final UnionTypeDefinition definition;
     private final ImmutableList<UnionTypeExtensionDefinition> extensionDefinitions;
     private final DirectivesUtil.DirectivesHolder directives;
@@ -53,7 +52,6 @@ public class GraphQLUnionType implements GraphQLNamedOutputType, GraphQLComposit
     private GraphQLUnionType(String name,
                              String description,
                              List<GraphQLNamedOutputType> types,
-                             TypeResolver typeResolver,
                              List<GraphQLDirective> directives,
                              List<GraphQLAppliedDirective> appliedDirectives,
                              UnionTypeDefinition definition,
@@ -66,7 +64,6 @@ public class GraphQLUnionType implements GraphQLNamedOutputType, GraphQLComposit
         this.name = name;
         this.description = description;
         this.originalTypes = ImmutableList.copyOf(types);
-        this.typeResolver = typeResolver;
         this.definition = definition;
         this.extensionDefinitions = ImmutableList.copyOf(extensionDefinitions);
         this.directives = new DirectivesUtil.DirectivesHolder(directives, appliedDirectives);
@@ -97,13 +94,6 @@ public class GraphQLUnionType implements GraphQLNamedOutputType, GraphQLComposit
      */
     public boolean isPossibleType(GraphQLObjectType graphQLObjectType) {
         return getTypes().stream().anyMatch(nt -> nt.getName().equals(graphQLObjectType.getName()));
-    }
-
-    // to be removed in a future version when all code is in the code registry
-    @Internal
-    @Deprecated(since = "2018-12-03")
-    TypeResolver getTypeResolver() {
-        return typeResolver;
     }
 
     @Override
@@ -245,7 +235,6 @@ public class GraphQLUnionType implements GraphQLNamedOutputType, GraphQLComposit
 
     @PublicApi
     public static class Builder extends GraphqlDirectivesContainerTypeBuilder<Builder, Builder> {
-        private TypeResolver typeResolver;
         private UnionTypeDefinition definition;
         private List<UnionTypeExtensionDefinition> extensionDefinitions = emptyList();
         private final Map<String, GraphQLNamedOutputType> types = new LinkedHashMap<>();
@@ -256,7 +245,6 @@ public class GraphQLUnionType implements GraphQLNamedOutputType, GraphQLComposit
         public Builder(GraphQLUnionType existing) {
             this.name = existing.getName();
             this.description = existing.getDescription();
-            this.typeResolver = existing.getTypeResolver();
             this.definition = existing.getDefinition();
             this.extensionDefinitions = existing.getExtensionDefinitions();
             this.types.putAll(getByName(existing.originalTypes, GraphQLNamedType::getName));
@@ -270,19 +258,6 @@ public class GraphQLUnionType implements GraphQLNamedOutputType, GraphQLComposit
 
         public Builder extensionDefinitions(List<UnionTypeExtensionDefinition> extensionDefinitions) {
             this.extensionDefinitions = extensionDefinitions;
-            return this;
-        }
-
-        /**
-         * @param typeResolver the type resolver
-         *
-         * @return this builder
-         *
-         * @deprecated use {@link graphql.schema.GraphQLCodeRegistry.Builder#typeResolver(GraphQLUnionType, TypeResolver)} instead
-         */
-        @Deprecated(since = "2018-12-03")
-        public Builder typeResolver(TypeResolver typeResolver) {
-            this.typeResolver = typeResolver;
             return this;
         }
 
@@ -382,7 +357,6 @@ public class GraphQLUnionType implements GraphQLNamedOutputType, GraphQLComposit
                     name,
                     description,
                     sort(types, GraphQLUnionType.class, GraphQLOutputType.class),
-                    typeResolver,
                     sort(directives, GraphQLUnionType.class, GraphQLDirective.class),
                     sort(appliedDirectives, GraphQLUnionType.class, GraphQLAppliedDirective.class),
                     definition,

--- a/src/test/groovy/graphql/HelloWorld.java
+++ b/src/test/groovy/graphql/HelloWorld.java
@@ -20,7 +20,7 @@ public class HelloWorld {
                 .field(newFieldDefinition()
                         .type(GraphQLString)
                         .name("hello")
-                        .staticValue("world"))
+                )
                 .build();
 
         GraphQLSchema schema = GraphQLSchema.newSchema()
@@ -29,7 +29,10 @@ public class HelloWorld {
 
         GraphQL graphQL = GraphQL.newGraphQL(schema).build();
 
-        Map<String, Object> result = graphQL.execute("{hello}").getData();
+
+        Map<String, String> rootObject = Map.of("hello", "world");
+        ExecutionInput executionInput = ExecutionInput.newExecutionInput().query("{hello}").root(rootObject).build();
+        Map<String, Object> result = graphQL.execute(executionInput).getData();
         System.out.println(result);
         // Prints: {hello=world}
     }
@@ -41,14 +44,17 @@ public class HelloWorld {
                 .field(newFieldDefinition()
                         .type(GraphQLString)
                         .name("hello")
-                        .staticValue("world"))
+                )
                 .build();
 
         GraphQLSchema schema = GraphQLSchema.newSchema()
                 .query(queryType)
                 .build();
         GraphQL graphQL = GraphQL.newGraphQL(schema).build();
-        Map<String, Object> result = graphQL.execute("{hello}").getData();
+        Map<String, String> rootObject = Map.of("hello", "world");
+        ExecutionInput executionInput = ExecutionInput.newExecutionInput().query("{hello}").root(rootObject).build();
+
+        Map<String, Object> result = graphQL.execute(executionInput).getData();
         assertEquals("world", result.get("hello"));
     }
 }

--- a/src/test/groovy/graphql/RelaySchema.java
+++ b/src/test/groovy/graphql/RelaySchema.java
@@ -27,11 +27,7 @@ public class RelaySchema {
             )
             .build();
 
-    public static GraphQLInterfaceType NodeInterface = relay.nodeInterface(env -> {
-        Relay.ResolvedGlobalId resolvedGlobalId = relay.fromGlobalId((String) env.getObject());
-        //TODO: implement
-        return null;
-    });
+    public static GraphQLInterfaceType NodeInterface = relay.nodeInterface();
 
     public static GraphQLObjectType StuffEdgeType = relay.edgeType("Stuff", StuffType, NodeInterface, new ArrayList<>());
 
@@ -50,10 +46,7 @@ public class RelaySchema {
 
     public static GraphQLObjectType RelayQueryType = newObject()
             .name("RelayQuery")
-            .field(relay.nodeField(NodeInterface, environment -> {
-                //TODO: implement
-                return null;
-            }))
+            .field(relay.nodeField(NodeInterface))
             .field(newFieldDefinition()
                     .name("thing")
                     .type(ThingType)
@@ -68,6 +61,7 @@ public class RelaySchema {
 
     public static GraphQLCodeRegistry codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
             .dataFetcher(thingCoordinates, thingDataFetcher)
+            .typeResolver("Node", env -> null)
             .build();
 
     public static GraphQLSchema Schema = GraphQLSchema.newSchema()

--- a/src/test/groovy/graphql/RelaySchemaTest.groovy
+++ b/src/test/groovy/graphql/RelaySchemaTest.groovy
@@ -1,5 +1,6 @@
 package graphql
 
+import graphql.schema.GraphQLCodeRegistry
 import spock.lang.Specification
 
 class RelaySchemaTest extends Specification {

--- a/src/test/groovy/graphql/execution/ExecutionContextBuilderTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionContextBuilderTest.groovy
@@ -54,7 +54,7 @@ class ExecutionContextBuilderTest extends Specification {
         executionContext.root == root
         executionContext.context == context // Retain deprecated method for test coverage
         executionContext.graphQLContext == graphQLContext
-        executionContext.variables == [var: 'value'] // Retain deprecated method for test coverage
+        executionContext.getCoercedVariables().toMap() == [var: 'value']
         executionContext.getFragmentsByName() == [MyFragment: fragment]
         executionContext.operationDefinition == operation
         executionContext.dataLoaderRegistry == dataLoaderRegistry

--- a/src/test/groovy/graphql/schema/GraphQLCodeRegistryTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLCodeRegistryTest.groovy
@@ -227,11 +227,8 @@ class GraphQLCodeRegistryTest extends Specification {
     def "integration test that code registry gets asked for data fetchers"() {
 
         def queryType = newObject().name("Query")
-                .field(newFieldDefinition().name("codeRegistryField").type(Scalars.GraphQLString))
-                .field(newFieldDefinition().name("nonCodeRegistryField").type(Scalars.GraphQLString)
-                // df comes from the field itself here
-                        .dataFetcher(new NamedDF("nonCodeRegistryFieldValue"))) // Retain to test Field Definition DataFetcher
-                .field(newFieldDefinition().name("neitherSpecified").type(Scalars.GraphQLString))
+                .field(newFieldDefinition().name("codeRegistryField").type(GraphQLString))
+                .field(newFieldDefinition().name("neitherSpecified").type(GraphQLString))
                 .build()
 
         // here we wire in a specific data fetcher via the code registry
@@ -244,12 +241,12 @@ class GraphQLCodeRegistryTest extends Specification {
         when:
         def er = graphQL.execute(ExecutionInput.newExecutionInput().query('''
             query {
-                codeRegistryField, nonCodeRegistryField,neitherSpecified
+                codeRegistryField, neitherSpecified
             }
             ''').root([neitherSpecified: "neitherSpecifiedValue"]).build())
         then:
         er.errors.isEmpty()
-        er.data == [codeRegistryField: "codeRegistryFieldValue", nonCodeRegistryField: "nonCodeRegistryFieldValue", neitherSpecified: "neitherSpecifiedValue"]
+        er.data == [codeRegistryField: "codeRegistryFieldValue", neitherSpecified: "neitherSpecifiedValue"]
 
         // when nothing is specified then its a plain old PropertyDataFetcher
         schema.getCodeRegistry().getDataFetcher(queryType, queryType.getFieldDefinition("neitherSpecified")) instanceof PropertyDataFetcher

--- a/src/test/groovy/graphql/schema/GraphQLFieldDefinitionTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLFieldDefinitionTest.groovy
@@ -18,14 +18,6 @@ import static graphql.schema.idl.SchemaPrinter.Options.defaultOptions
 
 class GraphQLFieldDefinitionTest extends Specification {
 
-    def "dataFetcher can't be null"() {
-        when:
-        newFieldDefinition().dataFetcher(null) // Retain for test coverage
-        then:
-        def exception = thrown(AssertException)
-        exception.getMessage().contains("dataFetcher")
-    }
-
     def "object can be transformed"() {
         given:
         def startingField = newFieldDefinition()
@@ -83,18 +75,4 @@ class GraphQLFieldDefinitionTest extends Specification {
         transformedField.getDirective("directive3") != null
     }
 
-    def "test deprecated argument builder for list"() {
-        given:
-        def field = newFieldDefinition().name("field").type(GraphQLInt).argument(mockArguments("a", "bb")).build() // Retain for test coverage
-
-        when:
-        def registry = newComparators()
-                .addComparator({ it.parentType(GraphQLFieldDefinition.class).elementType(GraphQLArgument.class) }, GraphQLArgument.class, TestUtil.byGreatestLength)
-                .build()
-        def options = defaultOptions().setComparators(registry)
-        def printer = new SchemaPrinter(options)
-
-        then:
-        printer.argsString(GraphQLFieldDefinition.class, field.arguments) == '''(bb: Int, a: Int)'''
-    }
 }

--- a/src/test/groovy/graphql/schema/GraphQLInterfaceTypeTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLInterfaceTypeTest.groovy
@@ -114,7 +114,6 @@ class GraphQLInterfaceTypeTest extends Specification {
                         newFieldDefinition().name("NAME").type(GraphQLString).build(),
                         newFieldDefinition().name("NAME").type(GraphQLInt).build()
                 ])
-                .typeResolver(new TypeResolverProxy()) // Retain for test coverage
                 .build()
         then:
         interfaceType.getName() == "TestInterfaceType"

--- a/src/test/groovy/graphql/schema/GraphQLUnionTypeTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLUnionTypeTest.groovy
@@ -63,13 +63,4 @@ class GraphQLUnionTypeTest extends Specification {
         transformedUnion.isPossibleType(objType3)
     }
 
-    def "deprecated typeResolver builder works"() {
-        when:
-        newUnionType()
-                .name("TestUnionType")
-                .typeResolver(new TypeResolverProxy()) // Retain for test coverage
-                .build()
-        then:
-        thrown(AssertException)
-    }
 }

--- a/src/test/groovy/graphql/validation/rules/Harness.java
+++ b/src/test/groovy/graphql/validation/rules/Harness.java
@@ -1,5 +1,6 @@
 package graphql.validation.rules;
 
+import graphql.schema.GraphQLCodeRegistry;
 import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLInputObjectType;
 import graphql.schema.GraphQLInterfaceType;
@@ -33,7 +34,6 @@ public class Harness {
             .field(newFieldDefinition()
                     .name("name")
                     .type(GraphQLString))
-            .typeResolver(dummyTypeResolve)
             .build();
 
     public static GraphQLInterfaceType Pet = newInterface()
@@ -41,7 +41,6 @@ public class Harness {
             .field(newFieldDefinition()
                     .name("name")
                     .type(GraphQLString))
-            .typeResolver(dummyTypeResolve)
             .build();
 
     public static GraphQLEnumType DogCommand = newEnum()
@@ -123,7 +122,6 @@ public class Harness {
     public static GraphQLUnionType CatOrDog = newUnionType()
             .name("CatOrDog")
             .possibleTypes(Dog, Cat)
-            .typeResolver(env -> null)
             .build();
 
     public static GraphQLInterfaceType Intelligent = newInterface()
@@ -131,7 +129,6 @@ public class Harness {
             .field(newFieldDefinition()
                     .name("iq")
                     .type(GraphQLInt))
-            .typeResolver(dummyTypeResolve)
             .build();
 
     public static GraphQLObjectType Human = newObject()
@@ -168,13 +165,11 @@ public class Harness {
     public static GraphQLUnionType DogOrHuman = newUnionType()
             .name("DogOrHuman")
             .possibleTypes(Dog, Human)
-            .typeResolver(dummyTypeResolve)
             .build();
 
     public static GraphQLUnionType HumanOrAlien = newUnionType()
             .name("HumanOrAlien")
             .possibleTypes(Alien, Human)
-            .typeResolver(dummyTypeResolve)
             .build();
 
     public static GraphQLInputObjectType Leash = GraphQLInputObjectType.newInputObject()
@@ -216,8 +211,19 @@ public class Harness {
                     .type(HumanOrAlien))
             .build();
 
+    private static final GraphQLCodeRegistry codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+            .typeResolver("Being", dummyTypeResolve)
+            .typeResolver("Pet", dummyTypeResolve)
+            .typeResolver("CatOrDog", dummyTypeResolve)
+            .typeResolver("Intelligent", dummyTypeResolve)
+            .typeResolver("DogOrHuman", dummyTypeResolve)
+            .typeResolver("HumanOrAlien", dummyTypeResolve)
+            .build();
+
+
     public static GraphQLSchema Schema = newSchema()
             .query(QueryRoot)
+            .codeRegistry(codeRegistry)
             .build();
 }
 


### PR DESCRIPTION
> Now is the winter of our discontent and also the time to remove deprecated methods
>    - Richard III by William Shakespeare

This finally removes the ability to specify code on type objects.  You can not longer put a DataFetcher on a field or a type resolve on the Union / Interface

You must use `GraphQLCodeRegistry` now for this.  This has deprecation been in place for 5 years - its time!