### PR TITLE
Return empty singleton DirectivesHolder if directives are empty

### DIFF
--- a/src/main/java/graphql/DirectivesUtil.java
+++ b/src/main/java/graphql/DirectivesUtil.java
@@ -9,6 +9,7 @@ import graphql.schema.GraphQLDirectiveContainer;
 import graphql.util.FpKit;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -125,7 +126,7 @@ public class DirectivesUtil {
      * A holder class that breaks a list of directives into maps to be more easily accessible in using classes
      */
     public static class DirectivesHolder {
-        private static final DirectivesHolder EMPTY_HOLDER = new DirectivesHolder();
+        private static final DirectivesHolder EMPTY_HOLDER = new DirectivesHolder(Collections.emptyList(), Collections.emptyList());
 
         private final ImmutableMap<String, List<GraphQLDirective>> allDirectivesByName;
         private final ImmutableMap<String, GraphQLDirective> nonRepeatableDirectivesByName;

--- a/src/main/java/graphql/DirectivesUtil.java
+++ b/src/main/java/graphql/DirectivesUtil.java
@@ -91,7 +91,6 @@ public class DirectivesUtil {
      * directives collection takes precedence.
      *
      * @param directiveContainer the schema element holding applied directives
-     *
      * @return a combined list unique by name
      */
     public static List<GraphQLAppliedDirective> toAppliedDirectives(GraphQLDirectiveContainer directiveContainer) {
@@ -104,7 +103,6 @@ public class DirectivesUtil {
      *
      * @param appliedDirectives the applied directives to use
      * @param directives        the legacy directives to use
-     *
      * @return a combined list unique by name
      */
     public static List<GraphQLAppliedDirective> toAppliedDirectives(Collection<GraphQLAppliedDirective> appliedDirectives, Collection<GraphQLDirective> directives) {
@@ -127,6 +125,7 @@ public class DirectivesUtil {
      * A holder class that breaks a list of directives into maps to be more easily accessible in using classes
      */
     public static class DirectivesHolder {
+        private static final DirectivesHolder EMPTY_HOLDER = new DirectivesHolder();
 
         private final ImmutableMap<String, List<GraphQLDirective>> allDirectivesByName;
         private final ImmutableMap<String, GraphQLDirective> nonRepeatableDirectivesByName;
@@ -145,7 +144,14 @@ public class DirectivesUtil {
 
             this.allAppliedDirectives = ImmutableList.copyOf(allAppliedDirectives);
             this.allAppliedDirectivesByName = ImmutableMap.copyOf(FpKit.groupingBy(allAppliedDirectives, GraphQLAppliedDirective::getName));
+        }
 
+        public static DirectivesHolder create(List<GraphQLDirective> directives, List<GraphQLAppliedDirective> appliedDirectives) {
+            if (directives.isEmpty() && appliedDirectives.isEmpty()) {
+                return EMPTY_HOLDER;
+            }
+
+            return new DirectivesHolder(directives, appliedDirectives);
         }
 
         public ImmutableMap<String, List<GraphQLDirective>> getAllDirectivesByName() {

--- a/src/main/java/graphql/schema/GraphQLArgument.java
+++ b/src/main/java/graphql/schema/GraphQLArgument.java
@@ -82,7 +82,7 @@ public class GraphQLArgument implements GraphQLNamedSchemaElement, GraphQLInputV
         this.value = value;
         this.definition = definition;
         this.deprecationReason = deprecationReason;
-        this.directivesHolder = new DirectivesUtil.DirectivesHolder(directives, appliedDirectives);
+        this.directivesHolder = DirectivesUtil.DirectivesHolder.create(directives, appliedDirectives);
     }
 
 

--- a/src/main/java/graphql/schema/GraphQLEnumType.java
+++ b/src/main/java/graphql/schema/GraphQLEnumType.java
@@ -66,7 +66,7 @@ public class GraphQLEnumType implements GraphQLNamedInputType, GraphQLNamedOutpu
         this.description = description;
         this.definition = definition;
         this.extensionDefinitions = ImmutableList.copyOf(extensionDefinitions);
-        this.directivesHolder = new DirectivesUtil.DirectivesHolder(directives, appliedDirectives);
+        this.directivesHolder = DirectivesUtil.DirectivesHolder.create(directives, appliedDirectives);
         this.valueDefinitionMap = buildMap(values);
     }
 

--- a/src/main/java/graphql/schema/GraphQLEnumValueDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLEnumValueDefinition.java
@@ -48,7 +48,7 @@ public class GraphQLEnumValueDefinition implements GraphQLNamedSchemaElement, Gr
         this.description = description;
         this.value = value;
         this.deprecationReason = deprecationReason;
-        this.directivesHolder = new DirectivesUtil.DirectivesHolder(directives, appliedDirectives);
+        this.directivesHolder = DirectivesUtil.DirectivesHolder.create(directives, appliedDirectives);
         this.definition = definition;
     }
 

--- a/src/main/java/graphql/schema/GraphQLFieldDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLFieldDefinition.java
@@ -66,7 +66,7 @@ public class GraphQLFieldDefinition implements GraphQLNamedSchemaElement, GraphQ
         this.originalType = type;
         this.dataFetcherFactory = dataFetcherFactory;
         this.arguments = ImmutableList.copyOf(arguments);
-        this.directivesHolder = new DirectivesUtil.DirectivesHolder(directives, appliedDirectives);
+        this.directivesHolder = DirectivesUtil.DirectivesHolder.create(directives, appliedDirectives);
         this.deprecationReason = deprecationReason;
         this.definition = definition;
     }

--- a/src/main/java/graphql/schema/GraphQLInputObjectField.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectField.java
@@ -62,7 +62,7 @@ public class GraphQLInputObjectField implements GraphQLNamedSchemaElement, Graph
         this.originalType = type;
         this.defaultValue = defaultValue;
         this.description = description;
-        this.directivesHolder = new DirectivesUtil.DirectivesHolder(directives, appliedDirectives);
+        this.directivesHolder = DirectivesUtil.DirectivesHolder.create(directives, appliedDirectives);
         this.definition = definition;
         this.deprecationReason = deprecationReason;
     }

--- a/src/main/java/graphql/schema/GraphQLInputObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectType.java
@@ -61,7 +61,7 @@ public class GraphQLInputObjectType implements GraphQLNamedInputType, GraphQLUnm
         this.description = description;
         this.definition = definition;
         this.extensionDefinitions = ImmutableList.copyOf(extensionDefinitions);
-        this.directives = new DirectivesUtil.DirectivesHolder(directives, appliedDirectives);
+        this.directives = DirectivesUtil.DirectivesHolder.create(directives, appliedDirectives);
         this.fieldMap = buildDefinitionMap(fields);
         this.isOneOf = hasOneOf(directives, appliedDirectives);
     }

--- a/src/main/java/graphql/schema/GraphQLInterfaceType.java
+++ b/src/main/java/graphql/schema/GraphQLInterfaceType.java
@@ -77,7 +77,7 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLCompositeT
         this.interfaceComparator = interfaceComparator;
         this.originalInterfaces = ImmutableList.copyOf(sortTypes(interfaceComparator, interfaces));
         this.extensionDefinitions = ImmutableList.copyOf(extensionDefinitions);
-        this.directivesHolder = new DirectivesUtil.DirectivesHolder(directives, appliedDirectives);
+        this.directivesHolder = DirectivesUtil.DirectivesHolder.create(directives, appliedDirectives);
         this.fieldDefinitionsByName = buildDefinitionMap(fieldDefinitions);
     }
 

--- a/src/main/java/graphql/schema/GraphQLObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLObjectType.java
@@ -74,7 +74,7 @@ public class GraphQLObjectType implements GraphQLNamedOutputType, GraphQLComposi
         this.originalInterfaces = ImmutableList.copyOf(sortTypes(interfaceComparator, interfaces));
         this.definition = definition;
         this.extensionDefinitions = ImmutableList.copyOf(extensionDefinitions);
-        this.directivesHolder = new DirectivesUtil.DirectivesHolder(directives, appliedDirectives);
+        this.directivesHolder = DirectivesUtil.DirectivesHolder.create(directives, appliedDirectives);
         this.fieldDefinitionsByName = buildDefinitionMap(fieldDefinitions);
     }
 

--- a/src/main/java/graphql/schema/GraphQLScalarType.java
+++ b/src/main/java/graphql/schema/GraphQLScalarType.java
@@ -64,7 +64,7 @@ GraphQLScalarType implements GraphQLNamedInputType, GraphQLNamedOutputType, Grap
         this.description = description;
         this.coercing = coercing;
         this.definition = definition;
-        this.directivesHolder = new DirectivesUtil.DirectivesHolder(directives, appliedDirectives);
+        this.directivesHolder = DirectivesUtil.DirectivesHolder.create(directives, appliedDirectives);
         this.extensionDefinitions = ImmutableList.copyOf(extensionDefinitions);
         this.specifiedByUrl = specifiedByUrl;
     }

--- a/src/main/java/graphql/schema/GraphQLUnionType.java
+++ b/src/main/java/graphql/schema/GraphQLUnionType.java
@@ -69,7 +69,7 @@ public class GraphQLUnionType implements GraphQLNamedOutputType, GraphQLComposit
         this.typeResolver = typeResolver;
         this.definition = definition;
         this.extensionDefinitions = ImmutableList.copyOf(extensionDefinitions);
-        this.directives = new DirectivesUtil.DirectivesHolder(directives, appliedDirectives);
+        this.directives = DirectivesUtil.DirectivesHolder.create(directives, appliedDirectives);
     }
 
     void replaceTypes(List<GraphQLNamedOutputType> types) {


### PR DESCRIPTION
This PR is aimed at memory performance - every schema element that has zero directives gets the same empty object as a value.

Current memory dumps of large schemas show repeated instances of these empty holders