### PR TITLE
This provides and ability to disable Introspection

### DIFF
--- a/src/main/java/graphql/ErrorType.java
+++ b/src/main/java/graphql/ErrorType.java
@@ -11,5 +11,6 @@ public enum ErrorType implements ErrorClassification {
     DataFetchingException,
     NullValueInNonNullableField,
     OperationNotSupported,
+    IntrospectionDisabled,
     ExecutionAborted
 }

--- a/src/main/java/graphql/ErrorType.java
+++ b/src/main/java/graphql/ErrorType.java
@@ -11,6 +11,5 @@ public enum ErrorType implements ErrorClassification {
     DataFetchingException,
     NullValueInNonNullableField,
     OperationNotSupported,
-    IntrospectionDisabled,
     ExecutionAborted
 }

--- a/src/main/java/graphql/execution/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncExecutionStrategy.java
@@ -6,8 +6,10 @@ import graphql.execution.incremental.DeferredExecutionSupport;
 import graphql.execution.instrumentation.ExecutionStrategyInstrumentationContext;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionStrategyParameters;
+import graphql.introspection.Introspection;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 
@@ -45,6 +47,11 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
 
         MergedSelectionSet fields = parameters.getFields();
         List<String> fieldNames = fields.getKeys();
+
+        Optional<ExecutionResult> isDisabled = Introspection.isIntrospectionSensible(executionContext.getGraphQLContext(),fields);
+        if (isDisabled.isPresent()) {
+            return CompletableFuture.completedFuture(isDisabled.get());
+        }
 
         DeferredExecutionSupport deferredExecutionSupport = createDeferredExecutionSupport(executionContext, parameters);
         Async.CombinedBuilder<FieldValueInfo> futures = getAsyncFieldValueInfo(executionContext, parameters, deferredExecutionSupport);

--- a/src/main/java/graphql/execution/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncExecutionStrategy.java
@@ -48,9 +48,9 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
         MergedSelectionSet fields = parameters.getFields();
         List<String> fieldNames = fields.getKeys();
 
-        Optional<ExecutionResult> isDisabled = Introspection.isIntrospectionSensible(executionContext.getGraphQLContext(),fields);
-        if (isDisabled.isPresent()) {
-            return CompletableFuture.completedFuture(isDisabled.get());
+        Optional<ExecutionResult> isNotSensible = Introspection.isIntrospectionSensible(executionContext.getGraphQLContext(),fields);
+        if (isNotSensible.isPresent()) {
+            return CompletableFuture.completedFuture(isNotSensible.get());
         }
 
         DeferredExecutionSupport deferredExecutionSupport = createDeferredExecutionSupport(executionContext, parameters);

--- a/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
@@ -44,9 +44,9 @@ public class AsyncSerialExecutionStrategy extends AbstractAsyncExecutionStrategy
 
         // this is highly unlikely since Mutations cant do introspection BUT in theory someone could make the query strategy this code
         // so belts and braces
-        Optional<ExecutionResult> isDisabled = Introspection.isIntrospectionSensible(executionContext.getGraphQLContext(), fields);
-        if (isDisabled.isPresent()) {
-            return CompletableFuture.completedFuture(isDisabled.get());
+        Optional<ExecutionResult> isNotSensible = Introspection.isIntrospectionSensible(executionContext.getGraphQLContext(), fields);
+        if (isNotSensible.isPresent()) {
+            return CompletableFuture.completedFuture(isNotSensible.get());
         }
 
         CompletableFuture<List<Object>> resultsFuture = Async.eachSequentially(fieldNames, (fieldName, prevResults) -> {

--- a/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
@@ -6,8 +6,10 @@ import graphql.PublicApi;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionStrategyParameters;
+import graphql.introspection.Introspection;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import static graphql.execution.instrumentation.SimpleInstrumentationContext.nonNullCtx;
@@ -39,6 +41,13 @@ public class AsyncSerialExecutionStrategy extends AbstractAsyncExecutionStrategy
         );
         MergedSelectionSet fields = parameters.getFields();
         ImmutableList<String> fieldNames = ImmutableList.copyOf(fields.keySet());
+
+        // this is highly unlikely since Mutations cant do introspection BUT in theory someone could make the query strategy this code
+        // so belts and braces
+        Optional<ExecutionResult> isDisabled = Introspection.isIntrospectionSensible(executionContext.getGraphQLContext(), fields);
+        if (isDisabled.isPresent()) {
+            return CompletableFuture.completedFuture(isDisabled.get());
+        }
 
         CompletableFuture<List<Object>> resultsFuture = Async.eachSequentially(fieldNames, (fieldName, prevResults) -> {
             MergedField currentField = fields.getSubField(fieldName);

--- a/src/main/java/graphql/introspection/IntrospectionDisabledError.java
+++ b/src/main/java/graphql/introspection/IntrospectionDisabledError.java
@@ -30,6 +30,6 @@ public class IntrospectionDisabledError implements GraphQLError {
 
     @Override
     public ErrorClassification getErrorType() {
-        return ErrorType.IntrospectionDisabled;
+        return ErrorClassification.errorClassification("IntrospectionDisabled");
     }
 }

--- a/src/main/java/graphql/introspection/IntrospectionDisabledError.java
+++ b/src/main/java/graphql/introspection/IntrospectionDisabledError.java
@@ -1,0 +1,35 @@
+package graphql.introspection;
+
+import graphql.ErrorClassification;
+import graphql.ErrorType;
+import graphql.GraphQLError;
+import graphql.Internal;
+import graphql.language.SourceLocation;
+
+import java.util.Collections;
+import java.util.List;
+
+@Internal
+public class IntrospectionDisabledError implements GraphQLError {
+
+    private final List<SourceLocation> locations;
+
+    public IntrospectionDisabledError(SourceLocation sourceLocation) {
+        locations = sourceLocation == null ? Collections.emptyList() : Collections.singletonList(sourceLocation);
+    }
+
+    @Override
+    public String getMessage() {
+        return "Introspection has been disabled for this request";
+    }
+
+    @Override
+    public List<SourceLocation> getLocations() {
+        return locations;
+    }
+
+    @Override
+    public ErrorClassification getErrorType() {
+        return ErrorType.IntrospectionDisabled;
+    }
+}

--- a/src/main/java/graphql/schema/visibility/NoIntrospectionGraphqlFieldVisibility.java
+++ b/src/main/java/graphql/schema/visibility/NoIntrospectionGraphqlFieldVisibility.java
@@ -12,10 +12,15 @@ import static graphql.schema.visibility.BlockedFields.newBlock;
  * This field visibility will prevent Introspection queries from being performed.  Technically this puts your
  * system in contravention of <a href="https://spec.graphql.org/October2021/#sec-Introspection">the specification</a>
  * but some production systems want this lock down in place.
+ *
+ * @deprecated This is no longer the best way to prevent Introspection - {@link graphql.introspection.Introspection#enabledJvmWide(boolean)}
+ * can be used instead
  */
 @PublicApi
+@Deprecated(since = "2024-03-16")
 public class NoIntrospectionGraphqlFieldVisibility implements GraphqlFieldVisibility {
 
+    @Deprecated(since = "2024-03-16")
     public static NoIntrospectionGraphqlFieldVisibility NO_INTROSPECTION_FIELD_VISIBILITY = new NoIntrospectionGraphqlFieldVisibility();
 
 

--- a/src/test/groovy/graphql/introspection/IntrospectionTest.groovy
+++ b/src/test/groovy/graphql/introspection/IntrospectionTest.groovy
@@ -1,6 +1,7 @@
 package graphql.introspection
 
-
+import graphql.ErrorType
+import graphql.ExecutionInput
 import graphql.TestUtil
 import graphql.schema.DataFetcher
 import graphql.schema.FieldCoordinates
@@ -688,4 +689,58 @@ class IntrospectionTest extends Specification {
         queryType["isOneOf"] == null
     }
 
+    def "jvm wide enablement"() {
+        def graphQL = TestUtil.graphQL("type Query { f : String } ").build()
+
+        when:
+        def er = graphQL.execute(IntrospectionQuery.INTROSPECTION_QUERY)
+
+        then:
+        er.errors.isEmpty()
+
+        when:
+        Introspection.enabledJvmWide(false)
+        er = graphQL.execute(IntrospectionQuery.INTROSPECTION_QUERY)
+
+        then:
+        er.errors[0] instanceof IntrospectionDisabledError
+        er.errors[0].getErrorType() == ErrorType.IntrospectionDisabled
+
+        when:
+        Introspection.enabledJvmWide(true)
+        er = graphQL.execute(IntrospectionQuery.INTROSPECTION_QUERY)
+
+        then:
+        er.errors.isEmpty()
+    }
+
+    def "per request enablement"() {
+        def graphQL = TestUtil.graphQL("type Query { f : String } ").build()
+
+        when:
+        // null context
+        def ei = ExecutionInput.newExecutionInput(IntrospectionQuery.INTROSPECTION_QUERY)
+                .build()
+        def er = graphQL.execute(ei)
+
+        then:
+        er.errors.isEmpty()
+
+        when:
+        ei = ExecutionInput.newExecutionInput(IntrospectionQuery.INTROSPECTION_QUERY)
+                .graphQLContext(Map.of(Introspection.INTROSPECTION_DISABLED, false)).build()
+        er = graphQL.execute(ei)
+
+        then:
+        er.errors.isEmpty()
+
+        when:
+        ei = ExecutionInput.newExecutionInput(IntrospectionQuery.INTROSPECTION_QUERY)
+                .graphQLContext(Map.of(Introspection.INTROSPECTION_DISABLED, true)).build()
+        er = graphQL.execute(ei)
+
+        then:
+        er.errors[0] instanceof IntrospectionDisabledError
+        er.errors[0].getErrorType() == ErrorType.IntrospectionDisabled
+    }
 }

--- a/src/test/groovy/graphql/introspection/IntrospectionTest.groovy
+++ b/src/test/groovy/graphql/introspection/IntrospectionTest.groovy
@@ -1,6 +1,5 @@
 package graphql.introspection
 
-import graphql.ErrorType
 import graphql.ExecutionInput
 import graphql.TestUtil
 import graphql.execution.AsyncSerialExecutionStrategy
@@ -23,6 +22,14 @@ import static graphql.schema.GraphQLObjectType.newObject
 import static graphql.schema.GraphQLSchema.newSchema
 
 class IntrospectionTest extends Specification {
+
+    def setup() {
+        Introspection.enabledJvmWide(true)
+    }
+
+    def cleanup() {
+        Introspection.enabledJvmWide(true)
+    }
 
     def "bug 1186 - introspection depth check"() {
         def spec = '''
@@ -705,7 +712,7 @@ class IntrospectionTest extends Specification {
 
         then:
         er.errors[0] instanceof IntrospectionDisabledError
-        er.errors[0].getErrorType() == ErrorType.IntrospectionDisabled
+        er.errors[0].getErrorType().toString() == "IntrospectionDisabled"
 
         when:
         Introspection.enabledJvmWide(true)
@@ -742,7 +749,7 @@ class IntrospectionTest extends Specification {
 
         then:
         er.errors[0] instanceof IntrospectionDisabledError
-        er.errors[0].getErrorType() == ErrorType.IntrospectionDisabled
+        er.errors[0].getErrorType().toString() == "IntrospectionDisabled"
     }
 
     def "mixed schema and other fields stop early"() {
@@ -767,7 +774,7 @@ class IntrospectionTest extends Specification {
 
         then:
         er.errors[0] instanceof IntrospectionDisabledError
-        er.errors[0].getErrorType() == ErrorType.IntrospectionDisabled
+        er.errors[0].getErrorType().toString() == "IntrospectionDisabled"
         er.data == null // stops hard
     }
 
@@ -787,7 +794,7 @@ class IntrospectionTest extends Specification {
 
         then:
         er.errors[0] instanceof IntrospectionDisabledError
-        er.errors[0].getErrorType() == ErrorType.IntrospectionDisabled
+        er.errors[0].getErrorType().toString() == "IntrospectionDisabled"
 
         when:
         Introspection.enabledJvmWide(true)


### PR DESCRIPTION
This adds the ability to disable Introspection - either JVM wide (eg always) or per request via  a well know context key

NoIntrospectionGraphqlFieldVisibility is another way to do this but it does not allow dynamic on or off and it makes the schema invalid according to spec. 

This stops the execution hard at the `__schema` and `__type` field level.