### PR TITLE
19.x Backport #3526 and PR #3527 

### DIFF
--- a/src/main/java/graphql/ErrorClassification.java
+++ b/src/main/java/graphql/ErrorClassification.java
@@ -23,4 +23,21 @@ public interface ErrorClassification {
     default Object toSpecification(GraphQLError error) {
         return String.valueOf(this);
     }
+
+    /**
+     * This produces a simple ErrorClassification that represents the provided String.  You can
+     * use this factory method to give out simple but custom error classifications.
+     *
+     * @param errorClassification the string that represents the error classification
+     *
+     * @return a ErrorClassification that is that provided string
+     */
+    static ErrorClassification errorClassification(String errorClassification) {
+        return new ErrorClassification() {
+            @Override
+            public String toString() {
+                return errorClassification;
+            }
+        };
+    }
 }

--- a/src/main/java/graphql/execution/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncExecutionStrategy.java
@@ -5,10 +5,12 @@ import graphql.PublicApi;
 import graphql.execution.instrumentation.ExecutionStrategyInstrumentationContext;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionStrategyParameters;
+import graphql.introspection.Introspection;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 
@@ -46,6 +48,12 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
 
         MergedSelectionSet fields = parameters.getFields();
         Set<String> fieldNames = fields.keySet();
+
+        Optional<ExecutionResult> isNotSensible = Introspection.isIntrospectionSensible(executionContext.getGraphQLContext(),fields);
+        if (isNotSensible.isPresent()) {
+            return CompletableFuture.completedFuture(isNotSensible.get());
+        }
+
         Async.CombinedBuilder<FieldValueInfo> futures = Async.ofExpectedSize(fields.size());
         List<String> resolvedFields = new ArrayList<>(fieldNames.size());
         for (String fieldName : fieldNames) {

--- a/src/main/java/graphql/execution/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncExecutionStrategy.java
@@ -49,7 +49,7 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
         MergedSelectionSet fields = parameters.getFields();
         Set<String> fieldNames = fields.keySet();
 
-        Optional<ExecutionResult> isNotSensible = Introspection.isIntrospectionSensible(executionContext.getGraphQLContext(),fields);
+        Optional<ExecutionResult> isNotSensible = Introspection.isIntrospectionSensible(fields, executionContext);
         if (isNotSensible.isPresent()) {
             return CompletableFuture.completedFuture(isNotSensible.get());
         }

--- a/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
@@ -6,8 +6,10 @@ import graphql.PublicApi;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionStrategyParameters;
+import graphql.introspection.Introspection;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import static graphql.execution.instrumentation.SimpleInstrumentationContext.nonNullCtx;
@@ -38,6 +40,13 @@ public class AsyncSerialExecutionStrategy extends AbstractAsyncExecutionStrategy
         );
         MergedSelectionSet fields = parameters.getFields();
         ImmutableList<String> fieldNames = ImmutableList.copyOf(fields.keySet());
+
+        // this is highly unlikely since Mutations cant do introspection BUT in theory someone could make the query strategy this code
+        // so belts and braces
+        Optional<ExecutionResult> isNotSensible = Introspection.isIntrospectionSensible(executionContext.getGraphQLContext(), fields);
+        if (isNotSensible.isPresent()) {
+            return CompletableFuture.completedFuture(isNotSensible.get());
+        }
 
         CompletableFuture<List<ExecutionResult>> resultsFuture = Async.eachSequentially(fieldNames, (fieldName, index, prevResults) -> {
             MergedField currentField = fields.getSubField(fieldName);

--- a/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
@@ -43,7 +43,7 @@ public class AsyncSerialExecutionStrategy extends AbstractAsyncExecutionStrategy
 
         // this is highly unlikely since Mutations cant do introspection BUT in theory someone could make the query strategy this code
         // so belts and braces
-        Optional<ExecutionResult> isNotSensible = Introspection.isIntrospectionSensible(executionContext.getGraphQLContext(), fields);
+        Optional<ExecutionResult> isNotSensible = Introspection.isIntrospectionSensible(fields, executionContext);
         if (isNotSensible.isPresent()) {
             return CompletableFuture.completedFuture(isNotSensible.get());
         }

--- a/src/main/java/graphql/introspection/GoodFaithIntrospection.java
+++ b/src/main/java/graphql/introspection/GoodFaithIntrospection.java
@@ -1,0 +1,125 @@
+package graphql.introspection;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import graphql.ErrorClassification;
+import graphql.ExecutionResult;
+import graphql.ExecutionResultImpl;
+import graphql.GraphQLContext;
+import graphql.GraphQLError;
+import graphql.PublicApi;
+import graphql.execution.ExecutionContext;
+import graphql.language.SourceLocation;
+import graphql.normalized.ExecutableNormalizedField;
+import graphql.normalized.ExecutableNormalizedOperation;
+import graphql.schema.FieldCoordinates;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static graphql.schema.FieldCoordinates.coordinates;
+
+/**
+ * This {@link graphql.execution.instrumentation.Instrumentation} ensure that a submitted introspection query is done in
+ * good faith.
+ * <p>
+ * There are attack vectors where a crafted introspection query can cause the engine to spend too much time
+ * producing introspection data.  This is especially true on large schemas with lots of types and fields.
+ * <p>
+ * Schemas form a cyclic graph and hence it's possible to send in introspection queries that can reference those cycles
+ * and in large schemas this can be expensive and perhaps a "denial of service".
+ * <p>
+ * This instrumentation only allows one __schema field or one __type field to be present, and it does not allow the `__Type` fields
+ * to form a cycle, i.e., that can only be present once.  This allows the standard and common introspection queries to work
+ * so tooling such as graphiql can work.
+ */
+@PublicApi
+public class GoodFaithIntrospection {
+
+    /**
+     * Placing a boolean value under this key in the per request {@link GraphQLContext} will enable
+     * or disable Good Faith Introspection on that request.
+     */
+    public static final String GOOD_FAITH_INTROSPECTION_DISABLED = "GOOD_FAITH_INTROSPECTION_DISABLED";
+
+    private static final AtomicBoolean ENABLED_STATE = new AtomicBoolean(true);
+
+    /**
+     * @return true if good faith introspection is enabled
+     */
+    public static boolean isEnabledJvmWide() {
+        return ENABLED_STATE.get();
+    }
+
+    /**
+     * This allows you to disable good faith introspection, which is on by default.
+     *
+     * @param flag the desired state
+     *
+     * @return the previous state
+     */
+    public static boolean enabledJvmWide(boolean flag) {
+        return ENABLED_STATE.getAndSet(flag);
+    }
+
+    private static final Map<FieldCoordinates, Integer> ALLOWED_FIELD_INSTANCES = new HashMap<>();
+
+    static {
+        ALLOWED_FIELD_INSTANCES.put(coordinates("Query", "__schema"), 1);
+        ALLOWED_FIELD_INSTANCES.put(coordinates("Query", "__type"), 1);
+        ALLOWED_FIELD_INSTANCES.put(coordinates("__Type", "fields"), 1);
+        ALLOWED_FIELD_INSTANCES.put(coordinates("__Type", "inputFields"), 1);
+        ALLOWED_FIELD_INSTANCES.put(coordinates("__Type", "interfaces"), 1);
+        ALLOWED_FIELD_INSTANCES.put(coordinates("__Type", "possibleTypes"), 1);
+    }
+
+    public static Optional<ExecutionResult> checkIntrospection(ExecutionContext executionContext) {
+        if (isIntrospectionEnabled(executionContext.getGraphQLContext())) {
+            ExecutableNormalizedOperation operation = executionContext.getNormalizedQueryTree().get();
+            ImmutableListMultimap<FieldCoordinates, ExecutableNormalizedField> coordinatesToENFs = operation.getCoordinatesToNormalizedFields();
+            for (Map.Entry<FieldCoordinates, Integer> entry : ALLOWED_FIELD_INSTANCES.entrySet()) {
+                FieldCoordinates coordinates = entry.getKey();
+                Integer allowSize = entry.getValue();
+                ImmutableList<ExecutableNormalizedField> normalizedFields = coordinatesToENFs.get(coordinates);
+                if (normalizedFields.size() > allowSize) {
+                    BadFaithIntrospectionError error = new BadFaithIntrospectionError(coordinates.toString());
+                    return Optional.of(ExecutionResultImpl.newExecutionResult().addError(error).build());
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static boolean isIntrospectionEnabled(GraphQLContext graphQlContext) {
+        if (!isEnabledJvmWide()) {
+            return false;
+        }
+        return !graphQlContext.getOrDefault(GOOD_FAITH_INTROSPECTION_DISABLED, false);
+    }
+
+    public static class BadFaithIntrospectionError implements GraphQLError {
+        private final String message;
+
+        public BadFaithIntrospectionError(String qualifiedField) {
+            this.message = String.format("This request is not asking for introspection in good faith - %s is present too often!", qualifiedField);
+        }
+
+        @Override
+        public String getMessage() {
+            return message;
+        }
+
+        @Override
+        public ErrorClassification getErrorType() {
+            return ErrorClassification.errorClassification("BadFaithIntrospection");
+        }
+
+        @Override
+        public List<SourceLocation> getLocations() {
+            return null;
+        }
+    }
+}

--- a/src/main/java/graphql/introspection/Introspection.java
+++ b/src/main/java/graphql/introspection/Introspection.java
@@ -3,8 +3,13 @@ package graphql.introspection;
 
 import com.google.common.collect.ImmutableSet;
 import graphql.Assert;
+import graphql.ExecutionResult;
+import graphql.ExecutionResultImpl;
+import graphql.GraphQLContext;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.execution.MergedField;
+import graphql.execution.MergedSelectionSet;
 import graphql.execution.ValuesResolver;
 import graphql.language.AstPrinter;
 import graphql.schema.FieldCoordinates;
@@ -31,13 +36,16 @@ import graphql.schema.GraphQLScalarType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLUnionType;
 import graphql.schema.InputValueWithState;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import static graphql.Assert.assertTrue;
@@ -56,8 +64,83 @@ import static graphql.schema.GraphQLTypeUtil.unwrapAllAs;
 import static graphql.schema.GraphQLTypeUtil.unwrapOne;
 import static graphql.schema.visibility.DefaultGraphqlFieldVisibility.DEFAULT_FIELD_VISIBILITY;
 
+/**
+ * GraphQl has a unique capability called <a href="https://spec.graphql.org/October2021/#sec-Introspection">Introspection</a> that allow
+ * consumers to inspect the system and discover the fields and types available and makes the system self documented.
+ * <p>
+ * Some security recommendations such as <a href="https://owasp.org/www-chapter-vancouver/assets/presentations/2020-06_GraphQL_Security.pdf">OWASP</a>
+ * recommend that introspection be disabled in production.  The {@link Introspection#enabledJvmWide(boolean)} method can be used to disable
+ * introspection for the whole JVM or you can place {@link Introspection#INTROSPECTION_DISABLED} into the {@link GraphQLContext} of a request
+ * to disable introspection for that request.
+ */
 @PublicApi
 public class Introspection {
+
+
+    /**
+     * Placing a boolean value under this key in the per request {@link GraphQLContext} will enable
+     * or disable Introspection on that request.
+     */
+    public static final String INTROSPECTION_DISABLED = "INTROSPECTION_DISABLED";
+    private static final AtomicBoolean INTROSPECTION_ENABLED_STATE = new AtomicBoolean(true);
+
+    /**
+     * This static method will enable / disable Introspection at a JVM wide level.
+     *
+     * @param enabled the flag indicating the desired enabled state
+     *
+     * @return the previous state of enablement
+     */
+    public static boolean enabledJvmWide(boolean enabled) {
+        return INTROSPECTION_ENABLED_STATE.getAndSet(enabled);
+    }
+
+    /**
+     * @return true if Introspection is enabled at a JVM wide level or false otherwise
+     */
+    public static boolean isEnabledJvmWide() {
+        return INTROSPECTION_ENABLED_STATE.get();
+    }
+
+    /**
+     * This will look in to the field selection set and see if there are introspection fields,
+     * and if there is,it checks if introspection should run, and if not it will return an errored {@link ExecutionResult}
+     * that can be returned to the user.
+     *
+     * @param mergedSelectionSet the fields to be executed
+     *
+     * @return an optional error result
+     */
+    public static Optional<ExecutionResult> isIntrospectionSensible(GraphQLContext graphQLContext, MergedSelectionSet mergedSelectionSet) {
+        MergedField schemaField = mergedSelectionSet.getSubField(SchemaMetaFieldDef.getName());
+        if (schemaField != null) {
+            if (!isIntrospectionEnabled(graphQLContext)) {
+                return mkDisabledError(schemaField);
+            }
+        }
+        MergedField typeField = mergedSelectionSet.getSubField(TypeMetaFieldDef.getName());
+        if (typeField != null) {
+            if (!isIntrospectionEnabled(graphQLContext)) {
+                return mkDisabledError(typeField);
+            }
+        }
+        // later we can put a good faith check code here to check the fields make sense
+        return Optional.empty();
+    }
+
+    @NotNull
+    private static Optional<ExecutionResult> mkDisabledError(MergedField schemaField) {
+        IntrospectionDisabledError error = new IntrospectionDisabledError(schemaField.getSingleField().getSourceLocation());
+        return Optional.of(ExecutionResultImpl.newExecutionResult().addError(error).build());
+    }
+
+    private static boolean isIntrospectionEnabled(GraphQLContext graphQlContext) {
+        if (!isEnabledJvmWide()) {
+            return false;
+        }
+        return !graphQlContext.getOrDefault(INTROSPECTION_DISABLED, false);
+    }
+
     private static final Map<FieldCoordinates, IntrospectionDataFetcher<?>> introspectionDataFetchers = new LinkedHashMap<>();
 
     private static void register(GraphQLFieldsContainer parentType, String fieldName, IntrospectionDataFetcher<?> introspectionDataFetcher) {
@@ -592,6 +675,7 @@ public class Introspection {
         return environment.getGraphQLSchema().getType(name);
     };
 
+    // __typename is always available
     public static final IntrospectionDataFetcher<?> TypeNameMetaFieldDefDataFetcher = environment -> simplePrint(environment.getParentType());
 
     @Internal

--- a/src/main/java/graphql/introspection/Introspection.java
+++ b/src/main/java/graphql/introspection/Introspection.java
@@ -8,6 +8,7 @@ import graphql.ExecutionResultImpl;
 import graphql.GraphQLContext;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.execution.ExecutionContext;
 import graphql.execution.MergedField;
 import graphql.execution.MergedSelectionSet;
 import graphql.execution.ValuesResolver;
@@ -108,10 +109,12 @@ public class Introspection {
      * that can be returned to the user.
      *
      * @param mergedSelectionSet the fields to be executed
+     * @param executionContext   the execution context in play
      *
      * @return an optional error result
      */
-    public static Optional<ExecutionResult> isIntrospectionSensible(GraphQLContext graphQLContext, MergedSelectionSet mergedSelectionSet) {
+    public static Optional<ExecutionResult> isIntrospectionSensible(MergedSelectionSet mergedSelectionSet, ExecutionContext executionContext) {
+        GraphQLContext graphQLContext = executionContext.getGraphQLContext();
         MergedField schemaField = mergedSelectionSet.getSubField(SchemaMetaFieldDef.getName());
         if (schemaField != null) {
             if (!isIntrospectionEnabled(graphQLContext)) {
@@ -124,7 +127,10 @@ public class Introspection {
                 return mkDisabledError(typeField);
             }
         }
-        // later we can put a good faith check code here to check the fields make sense
+        if (schemaField != null || typeField != null)
+        {
+            return GoodFaithIntrospection.checkIntrospection(executionContext);
+        }
         return Optional.empty();
     }
 

--- a/src/main/java/graphql/introspection/IntrospectionDisabledError.java
+++ b/src/main/java/graphql/introspection/IntrospectionDisabledError.java
@@ -1,0 +1,35 @@
+package graphql.introspection;
+
+import graphql.ErrorClassification;
+import graphql.ErrorType;
+import graphql.GraphQLError;
+import graphql.Internal;
+import graphql.language.SourceLocation;
+
+import java.util.Collections;
+import java.util.List;
+
+@Internal
+public class IntrospectionDisabledError implements GraphQLError {
+
+    private final List<SourceLocation> locations;
+
+    public IntrospectionDisabledError(SourceLocation sourceLocation) {
+        locations = sourceLocation == null ? Collections.emptyList() : Collections.singletonList(sourceLocation);
+    }
+
+    @Override
+    public String getMessage() {
+        return "Introspection has been disabled for this request";
+    }
+
+    @Override
+    public List<SourceLocation> getLocations() {
+        return locations;
+    }
+
+    @Override
+    public ErrorClassification getErrorType() {
+        return ErrorClassification.errorClassification("IntrospectionDisabled");
+    }
+}

--- a/src/main/java/graphql/schema/visibility/NoIntrospectionGraphqlFieldVisibility.java
+++ b/src/main/java/graphql/schema/visibility/NoIntrospectionGraphqlFieldVisibility.java
@@ -10,12 +10,17 @@ import static graphql.schema.visibility.BlockedFields.newBlock;
 
 /**
  * This field visibility will prevent Introspection queries from being performed.  Technically this puts your
- * system in contravention of the specification - http://facebook.github.io/graphql/#sec-Introspection but some
- * production systems want this lock down in place.
+ * system in contravention of <a href="https://spec.graphql.org/October2021/#sec-Introspection">the specification</a>
+ * but some production systems want this lock down in place.
+ *
+ * @deprecated This is no longer the best way to prevent Introspection - {@link graphql.introspection.Introspection#enabledJvmWide(boolean)}
+ * can be used instead
  */
 @PublicApi
+@Deprecated // (since = "2024-03-16")
 public class NoIntrospectionGraphqlFieldVisibility implements GraphqlFieldVisibility {
 
+    @Deprecated // (since = "2024-03-16")
     public static NoIntrospectionGraphqlFieldVisibility NO_INTROSPECTION_FIELD_VISIBILITY = new NoIntrospectionGraphqlFieldVisibility();
 
 

--- a/src/test/groovy/graphql/introspection/GoodFaithIntrospectionInstrumentationTest.groovy
+++ b/src/test/groovy/graphql/introspection/GoodFaithIntrospectionInstrumentationTest.groovy
@@ -1,0 +1,136 @@
+package graphql.introspection
+
+import graphql.ExecutionInput
+import graphql.ExecutionResult
+import graphql.TestUtil
+import spock.lang.Specification
+
+class GoodFaithIntrospectionInstrumentationTest extends Specification {
+
+    def graphql = TestUtil.graphQL("type Query { normalField : String }").build()
+
+    def setup() {
+        GoodFaithIntrospection.enabledJvmWide(true)
+    }
+    def cleanup() {
+        GoodFaithIntrospection.enabledJvmWide(true)
+    }
+
+    def "test asking for introspection in good faith"() {
+
+        when:
+        ExecutionResult er = graphql.execute(IntrospectionQuery.INTROSPECTION_QUERY)
+        then:
+        er.errors.isEmpty()
+    }
+
+    def "test asking for introspection in bad faith"() {
+
+        when:
+        ExecutionResult er = graphql.execute(query)
+        then:
+        !er.errors.isEmpty()
+        er.errors[0] instanceof GoodFaithIntrospection.BadFaithIntrospectionError
+
+        where:
+        query                                                                                                    | _
+        // long attack
+        """
+        query badActor{__schema{types{fields{type{fields{type{fields{type{fields{type{name}}}}}}}}}}}
+        """                                                                                           | _
+        // a case for __Type interfaces
+        """ query badActor {
+                __schema { types { interfaces { fields { type { interfaces { name } } } } } }
+            }
+        """                                                                                           | _
+        // a case for __Type inputFields
+        """ query badActor {
+                __schema { types { inputFields { type { inputFields { name }}}}}
+            }
+        """                                                                                           | _
+        // a case for __Type possibleTypes
+        """ query badActor {
+                __schema { types { inputFields { type { inputFields { name }}}}}
+            }
+        """                                                                                           | _
+        // a case leading from __InputValue
+        """ query badActor {
+                __schema { types { fields { args { type { name fields { name }}}}}}
+            }
+        """                                                                                           | _
+        // a case leading from __Field
+        """ query badActor {
+                __schema { types { fields { type { name fields { name }}}}}
+            }
+        """                                                                                           | _
+        // a case for __type
+        """ query badActor {
+                __type(name : "t") { name }
+                alias1 :  __type(name : "t1") { name }
+            }
+        """                                                                                           | _
+        // a case for schema repeated - dont ask twice
+        """ query badActor {
+                __schema { types { name} }
+                alias1 : __schema { types { name} }
+            }
+        """                                                                                           | _
+    }
+
+    def "mixed general queries and introspections will be stopped anyway"() {
+        def query = """
+            query goodAndBad {
+                normalField
+                __schema{types{fields{type{fields{type{fields{type{fields{type{name}}}}}}}}}}
+            }
+        """
+
+        when:
+        ExecutionResult er = graphql.execute(query)
+        then:
+        !er.errors.isEmpty()
+        er.errors[0] instanceof GoodFaithIntrospection.BadFaithIntrospectionError
+        er.data == null // it stopped hard - it did not continue to normal business
+    }
+
+    def "can be disabled"() {
+        when:
+        def currentState = GoodFaithIntrospection.isEnabledJvmWide()
+
+        then:
+        currentState
+
+        when:
+        def prevState = GoodFaithIntrospection.enabledJvmWide(false)
+
+        then:
+        prevState
+
+        when:
+        ExecutionResult er = graphql.execute("query badActor{__schema{types{fields{type{fields{type{fields{type{fields{type{name}}}}}}}}}}}")
+
+        then:
+        er.errors.isEmpty()
+    }
+
+    def "can be disabled per request"() {
+        when:
+        def context = [(GoodFaithIntrospection.GOOD_FAITH_INTROSPECTION_DISABLED): true]
+        ExecutionInput executionInput = ExecutionInput.newExecutionInput("query badActor{__schema{types{fields{type{fields{type{fields{type{fields{type{name}}}}}}}}}}}")
+                .graphQLContext(context).build()
+        ExecutionResult er = graphql.execute(executionInput)
+
+        then:
+        er.errors.isEmpty()
+
+        when:
+        context = [(GoodFaithIntrospection.GOOD_FAITH_INTROSPECTION_DISABLED): false]
+        executionInput = ExecutionInput.newExecutionInput("query badActor{__schema{types{fields{type{fields{type{fields{type{fields{type{name}}}}}}}}}}}")
+                .graphQLContext(context).build()
+        er = graphql.execute(executionInput)
+
+        then:
+        !er.errors.isEmpty()
+        er.errors[0] instanceof GoodFaithIntrospection.BadFaithIntrospectionError
+    }
+}

--- a/src/test/groovy/graphql/normalized/ExecutableNormalizedOperationToAstCompilerTest.groovy
+++ b/src/test/groovy/graphql/normalized/ExecutableNormalizedOperationToAstCompilerTest.groovy
@@ -1324,17 +1324,10 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
 '''
     }
 
-    def "introspection query can be printed"() {
+    def "introspection query can be printed __schema"() {
         def sdl = '''
         type Query {
-            foo1: Foo 
-        }
-        interface Foo {
-            test: String
-        }
-        type AFoo implements Foo {
-            test: String
-            aFoo: String
+            f: String 
         }
         '''
         def query = '''
@@ -1346,14 +1339,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
                     }
                 }
             }
-        
-            __type(name: "World") {
-                name
-                fields {
-                    name
-                }
-            }
-        }
+         }
         '''
 
         GraphQLSchema schema = mkSchema(sdl)
@@ -1370,6 +1356,34 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
       }
     }
   }
+}
+'''
+    }
+
+    def "introspection query can be printed __type"() {
+        def sdl = '''
+        type Query {
+            f: String 
+        }
+        '''
+        def query = '''
+        query introspection_query {
+            __type(name: "World") {
+                name
+                fields {
+                    name
+                }
+            }
+        }
+        '''
+
+        GraphQLSchema schema = mkSchema(sdl)
+        def fields = createNormalizedFields(schema, query)
+        when:
+        def result = compileToDocument(schema, QUERY, null, fields, noVariables)
+        def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
+        then:
+        documentPrinted == '''{
   __type(name: "World") {
     fields {
       name


### PR DESCRIPTION
Backport of https://github.com/graphql-java/graphql-java/pull/3526 and PR https://github.com/graphql-java/graphql-java/pull/3527 - pulls in introspection disabling and Good Faith Introspection

Remember we're back in the stone age with Java 8, small adjustments for this