### PR TITLE
21.x pull in 21.3 commits

### DIFF
--- a/.github/workflows/invoke_test_runner.yml
+++ b/.github/workflows/invoke_test_runner.yml
@@ -34,7 +34,7 @@ jobs:
     if: github.repository == 'graphql-java/graphql-java'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: '14'

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -13,7 +13,7 @@ jobs:
       MAVEN_CENTRAL_PGP_KEY: ${{ secrets.MAVEN_CENTRAL_PGP_KEY }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: gradle/wrapper-validation-action@v1
       - name: Set up JDK 11
         uses: actions/setup-java@v3

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,7 +16,7 @@ jobs:
   buildAndTest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: gradle/wrapper-validation-action@v1
       - name: Set up JDK 11
         uses: actions/setup-java@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       RELEASE_VERSION: ${{ github.event.inputs.version }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: gradle/wrapper-validation-action@v1
       - name: Set up JDK 11
         uses: actions/setup-java@v3

--- a/README.md
+++ b/README.md
@@ -5,15 +5,17 @@ Discuss and ask questions in our Discussions: https://github.com/graphql-java/gr
 This is a [GraphQL](https://github.com/graphql/graphql-spec) Java implementation.
 
 [![Build](https://github.com/graphql-java/graphql-java/actions/workflows/master.yml/badge.svg)](https://github.com/graphql-java/graphql-java/actions/workflows/master.yml)
-[![Latest Release](https://img.shields.io/maven-central/v/com.graphql-java/graphql-java?versionPrefix=20.)](https://maven-badges.herokuapp.com/maven-central/com.graphql-java/graphql-java/)
+[![Latest Release](https://img.shields.io/maven-central/v/com.graphql-java/graphql-java?versionPrefix=21.)](https://maven-badges.herokuapp.com/maven-central/com.graphql-java/graphql-java/)
 [![Latest Snapshot](https://img.shields.io/maven-central/v/com.graphql-java/graphql-java?label=maven-central%20snapshot&versionPrefix=0)](https://maven-badges.herokuapp.com/maven-central/com.graphql-java/graphql-java/)
 [![MIT licensed](https://img.shields.io/badge/license-MIT-green)](https://github.com/graphql-java/graphql-java/blob/master/LICENSE.md)
 
 ### Documentation
 
-We have a tutorial for beginners: [Getting started with GraphQL Java and Spring Boot](https://www.graphql-java.com/tutorials/getting-started-with-spring-boot/)
+See our tutorial for beginners: [Getting started with GraphQL Java and Spring Boot](https://www.graphql-java.com/tutorials/getting-started-with-spring-boot/)
 
-For details how to use `graphql-java` please look at the documentation: https://www.graphql-java.com/documentation/getting-started
+For further details, please see the documentation: https://www.graphql-java.com/documentation/getting-started
+
+If you're looking to learn more, we (the maintainers) have written a book! [GraphQL with Java and Spring](https://leanpub.com/graphql-java) includes everything you need to know to build a production ready GraphQL service. The book is available on [Leanpub](https://leanpub.com/graphql-java) and [Amazon](https://www.amazon.com/GraphQL-Java-Spring-Andreas-Marek-ebook/dp/B0C96ZYWPF/).
 
 Please take a look at our [list of releases](https://github.com/graphql-java/graphql-java/releases) if you want to learn more about new releases and the changelog.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,7 @@
 
 ## Supported Versions
 
-We support the latest release with security updates.
-
-We retain the discretion to backport security updates, this is decided on a case-by-case basis.
-
-| Version | Supported          |
-| ------- | ------------------ |
-| v20.x   | :white_check_mark: |
+As stated in our [Release Policy](https://www.graphql-java.com/blog/release-policy/), we will backport critical bugfixes and security fixes for versions dating back 18 months. These fixes will be backported depending on severity and demand.
 
 ## Reporting a Vulnerability
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,37 +20,52 @@ java {
     }
 }
 
+def makeDevelopmentVersion(parts) {
+    def version = String.join("-", parts)
+    println "created development version: $version"
+    return version
+}
+
 def getDevelopmentVersion() {
+    def dateTime = new SimpleDateFormat('yyyy-MM-dd\'T\'HH-mm-ss').format(new Date())
     def gitCheckOutput = new StringBuilder()
     def gitCheckError = new StringBuilder()
-    def gitCheck = ["git", "rev-parse", "--is-inside-work-tree"].execute()
+    def gitCheck = ["git", "-C", projectDir.toString(), "rev-parse", "--is-inside-work-tree"].execute()
     gitCheck.waitForProcessOutput(gitCheckOutput, gitCheckError)
     def isGit = gitCheckOutput.toString().trim()
     if (isGit != "true") {
-        def version = "0.0.0-" + new SimpleDateFormat('yyyy-MM-dd\'T\'HH-mm-ss').format(new Date()) + "-no-git"
-        println "created development version: $version"
-        return version
+        return makeDevelopmentVersion(["0.0.0", dateTime, "no-git"])
     }
 
-    def gitHashOutput = new StringBuilder()
-    def gitHashError = new StringBuilder()
-    def gitShortHash = ["git", "-C", projectDir.toString(), "rev-parse", "--short", "HEAD"].execute()
-    gitShortHash.waitForProcessOutput(gitHashOutput, gitHashError)
-    def gitHash = gitHashOutput.toString().trim()
-    if (gitHash.isEmpty()) {
-        println "git hash is empty: error: ${error.toString()}"
-        throw new IllegalStateException("git hash could not be determined")
+    def isCi = Boolean.parseBoolean(System.env.CI)
+    if (isCi) {
+        def gitHashOutput = new StringBuilder()
+        def gitHashError = new StringBuilder()
+        def gitShortHash = ["git", "-C", projectDir.toString(), "rev-parse", "--short", "HEAD"].execute()
+        gitShortHash.waitForProcessOutput(gitHashOutput, gitHashError)
+        def gitHash = gitHashOutput.toString().trim()
+        if (gitHash.isEmpty()) {
+            println "git hash is empty: error: ${gitHashError.toString()}"
+            throw new IllegalStateException("git hash could not be determined")
+        }
+
+        return makeDevelopmentVersion(["0.0.0", dateTime, gitHash])
     }
-    def version = "0.0.0-" + new SimpleDateFormat('yyyy-MM-dd\'T\'HH-mm-ss').format(new Date()) + "-" + gitHash
-    println "created development version: $version"
-    version
+
+    def gitRevParseOutput = new StringBuilder()
+    def gitRevParseError = new StringBuilder()
+    def gitRevParse = ["git", "-C", projectDir.toString(), "rev-parse", "--abbrev-ref", "HEAD"].execute()
+    gitRevParse.waitForProcessOutput(gitRevParseOutput, gitRevParseError)
+    def branchName = gitRevParseOutput.toString().trim()
+
+    return makeDevelopmentVersion(["0.0.0", branchName, "SNAPSHOT"])
 }
 
 def reactiveStreamsVersion = '1.0.3'
 def slf4jVersion = '2.0.7'
 def releaseVersion = System.env.RELEASE_VERSION
 def antlrVersion = '4.11.1' // https://mvnrepository.com/artifact/org.antlr/antlr4-runtime
-def guavaVersion = '32.1.1-jre'
+def guavaVersion = '32.1.2-jre'
 version = releaseVersion ? releaseVersion : getDevelopmentVersion()
 group = 'com.graphql-java'
 
@@ -87,17 +102,17 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:24.0.1'
     implementation 'org.antlr:antlr4-runtime:' + antlrVersion
     implementation 'org.slf4j:slf4j-api:' + slf4jVersion
-    api 'com.graphql-java:java-dataloader:3.2.0'
+    api 'com.graphql-java:java-dataloader:3.2.1'
     api 'org.reactivestreams:reactive-streams:' + reactiveStreamsVersion
     antlr 'org.antlr:antlr4:' + antlrVersion
     implementation 'com.google.guava:guava:' + guavaVersion
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation 'org.spockframework:spock-core:2.0-groovy-3.0'
-    testImplementation 'org.codehaus.groovy:groovy:3.0.18'
-    testImplementation 'org.codehaus.groovy:groovy-json:3.0.18'
+    testImplementation 'org.codehaus.groovy:groovy:3.0.19'
+    testImplementation 'org.codehaus.groovy:groovy-json:3.0.19'
     testImplementation 'com.google.code.gson:gson:2.10.1'
     testImplementation 'org.eclipse.jetty:jetty-server:11.0.15'
-    testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
+    testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.15.3'
     testImplementation 'org.slf4j:slf4j-simple:' + slf4jVersion
     testImplementation 'org.awaitility:awaitility-groovy:4.2.0'
     testImplementation 'com.github.javafaker:javafaker:1.0.2'
@@ -107,10 +122,10 @@ dependencies {
 
     testImplementation 'org.testng:testng:7.8.0' // use for reactive streams test inheritance
 
-    testImplementation 'org.openjdk.jmh:jmh-core:1.36'
-    testAnnotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess:1.36'
-    jmh 'org.openjdk.jmh:jmh-core:1.36'
-    jmh 'org.openjdk.jmh:jmh-generator-annprocess:1.36'
+    testImplementation 'org.openjdk.jmh:jmh-core:1.37'
+    testAnnotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess:1.37'
+    jmh 'org.openjdk.jmh:jmh-core:1.37'
+    jmh 'org.openjdk.jmh:jmh-generator-annprocess:1.37'
 }
 
 shadowJar {
@@ -155,7 +170,7 @@ shadowJar {
     bnd('''
 -exportcontents: graphql.*
 -removeheaders: Private-Package
-Import-Package: !com.google.*,!org.checkerframework.*,!javax.annotation.*,!graphql.com.google.*,!org.antlr.*,!graphql.org.antlr.*,!sun.misc.*,*
+Import-Package: !android.os.*,!com.google.*,!org.checkerframework.*,!javax.annotation.*,!graphql.com.google.*,!org.antlr.*,!graphql.org.antlr.*,!sun.misc.*,*
 ''')
 }
 
@@ -203,7 +218,10 @@ generateGrammarSource {
     arguments += ["-visitor"]
     outputDirectory = file("${project.buildDir}/generated-src/antlr/main/graphql/parser/antlr")
 }
-generateGrammarSource.inputs.dir('src/main/antlr')
+generateGrammarSource.inputs
+    .dir('src/main/antlr')
+    .withPropertyName('sourceDir')
+    .withPathSensitivity(PathSensitivity.RELATIVE)
 
 
 task sourcesJar(type: Jar) {

--- a/src/main/java/graphql/Directives.java
+++ b/src/main/java/graphql/Directives.java
@@ -15,6 +15,7 @@ import static graphql.introspection.Introspection.DirectiveLocation.FIELD_DEFINI
 import static graphql.introspection.Introspection.DirectiveLocation.FRAGMENT_SPREAD;
 import static graphql.introspection.Introspection.DirectiveLocation.INLINE_FRAGMENT;
 import static graphql.introspection.Introspection.DirectiveLocation.INPUT_FIELD_DEFINITION;
+import static graphql.introspection.Introspection.DirectiveLocation.INPUT_OBJECT;
 import static graphql.introspection.Introspection.DirectiveLocation.SCALAR;
 import static graphql.language.DirectiveLocation.newDirectiveLocation;
 import static graphql.language.InputValueDefinition.newInputValueDefinition;
@@ -31,10 +32,13 @@ public class Directives {
 
     private static final String SPECIFIED_BY = "specifiedBy";
     private static final String DEPRECATED = "deprecated";
+    private static final String ONE_OF = "oneOf";
 
     public static final String NO_LONGER_SUPPORTED = "No longer supported";
     public static final DirectiveDefinition DEPRECATED_DIRECTIVE_DEFINITION;
     public static final DirectiveDefinition SPECIFIED_BY_DIRECTIVE_DEFINITION;
+    @ExperimentalApi
+    public static final DirectiveDefinition ONE_OF_DIRECTIVE_DEFINITION;
 
 
     static {
@@ -64,6 +68,12 @@ public class Directives {
                                 .description(createDescription("The URL that specifies the behaviour of this scalar."))
                                 .type(newNonNullType(newTypeName().name("String").build()).build())
                                 .build())
+                .build();
+
+        ONE_OF_DIRECTIVE_DEFINITION = DirectiveDefinition.newDirectiveDefinition()
+                .name(ONE_OF)
+                .directiveLocation(newDirectiveLocation().name(INPUT_OBJECT.name()).build())
+                .description(createDescription("Indicates an Input Object is a OneOf Input Object."))
                 .build();
     }
 
@@ -117,6 +127,14 @@ public class Directives {
                     .description("The URL that specifies the behaviour of this scalar."))
             .validLocations(SCALAR)
             .definition(SPECIFIED_BY_DIRECTIVE_DEFINITION)
+            .build();
+
+    @ExperimentalApi
+    public static final GraphQLDirective OneOfDirective = GraphQLDirective.newDirective()
+            .name(ONE_OF)
+            .description("Indicates an Input Object is a OneOf Input Object.")
+            .validLocations(INPUT_OBJECT)
+            .definition(ONE_OF_DIRECTIVE_DEFINITION)
             .build();
 
     private static Description createDescription(String s) {

--- a/src/main/java/graphql/execution/Async.java
+++ b/src/main/java/graphql/execution/Async.java
@@ -2,6 +2,8 @@ package graphql.execution;
 
 import graphql.Assert;
 import graphql.Internal;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -207,4 +209,15 @@ public class Async {
         return result;
     }
 
+    /**
+     * If the passed in CompletableFuture is null then it creates a CompletableFuture that resolves to null
+     *
+     * @param completableFuture the CF to use
+     * @param <T>               for two
+     *
+     * @return the completableFuture if it's not null or one that always resoles to null
+     */
+    public static <T> @NotNull CompletableFuture<T> orNullCompletedFuture(@Nullable CompletableFuture<T> completableFuture) {
+        return completableFuture != null ? completableFuture : CompletableFuture.completedFuture(null);
+    }
 }

--- a/src/main/java/graphql/execution/OneOfNullValueException.java
+++ b/src/main/java/graphql/execution/OneOfNullValueException.java
@@ -1,0 +1,30 @@
+package graphql.execution;
+
+import graphql.ErrorType;
+import graphql.GraphQLError;
+import graphql.GraphQLException;
+import graphql.PublicApi;
+import graphql.language.SourceLocation;
+
+import java.util.List;
+
+/**
+ * The input map to One Of Input Types MUST only have 1 entry with a non null value
+ */
+@PublicApi
+public class OneOfNullValueException extends GraphQLException implements GraphQLError {
+
+    public OneOfNullValueException(String message) {
+        super(message);
+    }
+
+    @Override
+    public List<SourceLocation> getLocations() {
+        return null;
+    }
+
+    @Override
+    public ErrorType getErrorType() {
+        return ErrorType.ValidationError;
+    }
+}

--- a/src/main/java/graphql/execution/OneOfTooManyKeysException.java
+++ b/src/main/java/graphql/execution/OneOfTooManyKeysException.java
@@ -1,0 +1,32 @@
+package graphql.execution;
+
+import graphql.ErrorType;
+import graphql.GraphQLError;
+import graphql.GraphQLException;
+import graphql.PublicApi;
+import graphql.language.SourceLocation;
+import graphql.schema.GraphQLType;
+import graphql.schema.GraphQLTypeUtil;
+
+import java.util.List;
+
+/**
+ * The input map to One Of Input Types MUST only have 1 entry
+ */
+@PublicApi
+public class OneOfTooManyKeysException extends GraphQLException implements GraphQLError {
+
+    public OneOfTooManyKeysException(String message) {
+        super(message);
+    }
+
+    @Override
+    public List<SourceLocation> getLocations() {
+        return null;
+    }
+
+    @Override
+    public ErrorType getErrorType() {
+        return ErrorType.ValidationError;
+    }
+}

--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -1,10 +1,12 @@
 package graphql.execution;
 
 
+import graphql.Assert;
 import graphql.GraphQLContext;
 import graphql.Internal;
 import graphql.collect.ImmutableKit;
 import graphql.execution.values.InputInterceptor;
+import graphql.i18n.I18n;
 import graphql.language.Argument;
 import graphql.language.ArrayValue;
 import graphql.language.NullValue;
@@ -25,6 +27,7 @@ import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLScalarType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
+import graphql.schema.GraphQLTypeUtil;
 import graphql.schema.InputValueWithState;
 import graphql.schema.visibility.GraphqlFieldVisibility;
 import org.jetbrains.annotations.NotNull;
@@ -373,10 +376,41 @@ public class ValuesResolver {
                             locale);
                     coercedValues.put(argumentName, value);
                 }
+                // @oneOf input must be checked now that all variables and literals have been converted
+                GraphQLType unwrappedType = GraphQLTypeUtil.unwrapNonNull(argumentType);
+                if (unwrappedType instanceof GraphQLInputObjectType) {
+                    GraphQLInputObjectType inputObjectType = (GraphQLInputObjectType) unwrappedType;
+                    if (inputObjectType.isOneOf() && ! ValuesResolverConversion.isNullValue(value)) {
+                        validateOneOfInputTypes(inputObjectType, argumentValue, argumentName, value, locale);
+                    }
+                }
             }
 
         }
         return coercedValues;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void validateOneOfInputTypes(GraphQLInputObjectType oneOfInputType, Value argumentValue, String argumentName, Object inputValue, Locale locale) {
+        Assert.assertTrue(inputValue instanceof Map, () -> String.format("The coerced argument %s GraphQLInputObjectType is unexpectedly not a map", argumentName));
+        Map<String, Object> objectMap = (Map<String, Object>) inputValue;
+        int mapSize;
+        if (argumentValue instanceof ObjectValue) {
+            mapSize = ((ObjectValue) argumentValue).getObjectFields().size();
+        } else {
+            mapSize = objectMap.size();
+        }
+        if (mapSize != 1) {
+            String msg = I18n.i18n(I18n.BundleType.Execution, locale)
+                    .msg("Execution.handleOneOfNotOneFieldError", oneOfInputType.getName());
+            throw new OneOfTooManyKeysException(msg);
+        }
+        String fieldName = objectMap.keySet().iterator().next();
+        if (objectMap.get(fieldName) == null) {
+            String msg = I18n.i18n(I18n.BundleType.Execution, locale)
+                    .msg("Execution.handleOneOfValueIsNullError", oneOfInputType.getName() + "." + fieldName);
+            throw new OneOfNullValueException(msg);
+        }
     }
 
     private static Map<String, Argument> argumentMap(List<Argument> arguments) {

--- a/src/main/java/graphql/execution/directives/DirectivesResolver.java
+++ b/src/main/java/graphql/execution/directives/DirectivesResolver.java
@@ -11,6 +11,7 @@ import graphql.schema.GraphQLCodeRegistry;
 import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLSchema;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -25,14 +26,14 @@ public class DirectivesResolver {
     public DirectivesResolver() {
     }
 
-    public Map<String, GraphQLDirective> resolveDirectives(List<Directive> directives, GraphQLSchema schema, Map<String, Object> variables, GraphQLContext graphQLContext, Locale locale) {
+    public Map<String, List<GraphQLDirective>> resolveDirectives(List<Directive> directives, GraphQLSchema schema, Map<String, Object> variables, GraphQLContext graphQLContext, Locale locale) {
         GraphQLCodeRegistry codeRegistry = schema.getCodeRegistry();
-        Map<String, GraphQLDirective> directiveMap = new LinkedHashMap<>();
+        Map<String, List<GraphQLDirective>> directiveMap = new LinkedHashMap<>();
         directives.forEach(directive -> {
             GraphQLDirective protoType = schema.getDirective(directive.getName());
             if (protoType != null) {
                 GraphQLDirective newDirective = protoType.transform(builder -> buildArguments(builder, codeRegistry, protoType, directive, variables, graphQLContext, locale));
-                directiveMap.put(newDirective.getName(), newDirective);
+                directiveMap.computeIfAbsent(newDirective.getName(), k -> new ArrayList<>()).add(newDirective);
             }
         });
         return ImmutableMap.copyOf(directiveMap);

--- a/src/main/java/graphql/execution/instrumentation/Instrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/Instrumentation.java
@@ -63,9 +63,24 @@ public interface Instrumentation {
      *
      * @return a state object that is passed to each method
      */
+    @Deprecated
+    @DeprecatedAt("2023-08-25")
     @Nullable
     default InstrumentationState createState(InstrumentationCreateStateParameters parameters) {
         return createState();
+    }
+
+    /**
+     * This will be called just before execution to create an object, in an asynchronous manner, that is given back to all instrumentation methods
+     * to allow them to have per execution request state
+     *
+     * @param parameters the parameters to this step
+     *
+     * @return a state object that is passed to each method
+     */
+    @Nullable
+    default CompletableFuture<InstrumentationState> createStateAsync(InstrumentationCreateStateParameters parameters) {
+        return CompletableFuture.completedFuture(createState(parameters));
     }
 
     /**

--- a/src/main/java/graphql/execution/instrumentation/SimplePerformantInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/SimplePerformantInstrumentation.java
@@ -57,6 +57,12 @@ public class SimplePerformantInstrumentation implements Instrumentation {
     }
 
     @Override
+    public @Nullable CompletableFuture<InstrumentationState> createStateAsync(InstrumentationCreateStateParameters parameters) {
+        InstrumentationState state = createState(parameters);
+        return state == null ? null : CompletableFuture.completedFuture(state);
+    }
+
+    @Override
     public @NotNull InstrumentationContext<ExecutionResult> beginExecution(InstrumentationExecutionParameters parameters) {
         return assertShouldNeverHappen("The deprecated " + "beginExecution" + " was called");
     }

--- a/src/main/java/graphql/execution/instrumentation/dataloader/FieldLevelTrackingApproach.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/FieldLevelTrackingApproach.java
@@ -10,6 +10,7 @@ import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.InstrumentationState;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionStrategyParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
+import graphql.util.LockKit;
 import org.dataloader.DataLoaderRegistry;
 import org.slf4j.Logger;
 
@@ -28,6 +29,8 @@ public class FieldLevelTrackingApproach {
     private final Logger log;
 
     private static class CallStack implements InstrumentationState {
+
+        private final LockKit.ReentrantLock lock = new LockKit.ReentrantLock();
 
         private final LevelMap expectedFetchCountPerLevel = new LevelMap();
         private final LevelMap fetchCountPerLevel = new LevelMap();
@@ -124,10 +127,10 @@ public class FieldLevelTrackingApproach {
         int parentLevel = path.getLevel();
         int curLevel = parentLevel + 1;
         int fieldCount = parameters.getExecutionStrategyParameters().getFields().size();
-        synchronized (callStack) {
+        callStack.lock.runLocked(() -> {
             callStack.increaseExpectedFetchCount(curLevel, fieldCount);
             callStack.increaseHappenedStrategyCalls(curLevel);
-        }
+        });
 
         return new ExecutionStrategyInstrumentationContext() {
             @Override
@@ -142,10 +145,9 @@ public class FieldLevelTrackingApproach {
 
             @Override
             public void onFieldValuesInfo(List<FieldValueInfo> fieldValueInfoList) {
-                boolean dispatchNeeded;
-                synchronized (callStack) {
-                    dispatchNeeded = handleOnFieldValuesInfo(fieldValueInfoList, callStack, curLevel);
-                }
+                boolean dispatchNeeded = callStack.lock.callLocked(() ->
+                        handleOnFieldValuesInfo(fieldValueInfoList, callStack, curLevel)
+                );
                 if (dispatchNeeded) {
                     dispatch();
                 }
@@ -153,9 +155,9 @@ public class FieldLevelTrackingApproach {
 
             @Override
             public void onFieldValuesException() {
-                synchronized (callStack) {
-                    callStack.increaseHappenedOnFieldValueCalls(curLevel);
-                }
+                callStack.lock.runLocked(() ->
+                        callStack.increaseHappenedOnFieldValueCalls(curLevel)
+                );
             }
         };
     }
@@ -187,19 +189,17 @@ public class FieldLevelTrackingApproach {
         CallStack callStack = (CallStack) rawState;
         ResultPath path = parameters.getEnvironment().getExecutionStepInfo().getPath();
         int level = path.getLevel();
-        return new InstrumentationContext<Object>() {
+        return new InstrumentationContext<>() {
 
             @Override
             public void onDispatched(CompletableFuture<Object> result) {
-                boolean dispatchNeeded;
-                synchronized (callStack) {
+                boolean dispatchNeeded = callStack.lock.callLocked(() -> {
                     callStack.increaseFetchCount(level);
-                    dispatchNeeded = dispatchIfNeeded(callStack, level);
-                }
+                    return dispatchIfNeeded(callStack, level);
+                });
                 if (dispatchNeeded) {
                     dispatch();
                 }
-
             }
 
             @Override

--- a/src/main/java/graphql/introspection/Introspection.java
+++ b/src/main/java/graphql/introspection/Introspection.java
@@ -486,6 +486,14 @@ public class Introspection {
         return null;
     };
 
+    private static final IntrospectionDataFetcher<?> isOneOfFetcher = environment -> {
+        Object type = environment.getSource();
+        if (type instanceof GraphQLInputObjectType) {
+            return ((GraphQLInputObjectType) type).isOneOf();
+        }
+        return null;
+    };
+
     public static final GraphQLObjectType __Type = newObject()
             .name("__Type")
             .field(newFieldDefinition()
@@ -528,6 +536,10 @@ public class Introspection {
                     .name("ofType")
                     .type(typeRef("__Type")))
             .field(newFieldDefinition()
+                    .name("isOneOf")
+                    .description("This field is considered experimental because it has not yet been ratified in the graphql specification")
+                    .type(GraphQLBoolean))
+            .field(newFieldDefinition()
                     .name("specifiedByURL")
                     .type(GraphQLString))
             .field(newFieldDefinition()
@@ -547,6 +559,7 @@ public class Introspection {
         register(__Type, "enumValues", enumValuesTypesFetcher);
         register(__Type, "inputFields", inputFieldsFetcher);
         register(__Type, "ofType", OfTypeFetcher);
+        register(__Type, "isOneOf", isOneOfFetcher);
         register(__Type, "specifiedByURL", specifiedByUrlDataFetcher);
         register(__Type, "specifiedByUrl", specifiedByUrlDataFetcher); // note that this field is deprecated
     }

--- a/src/main/java/graphql/introspection/IntrospectionQueryBuilder.java
+++ b/src/main/java/graphql/introspection/IntrospectionQueryBuilder.java
@@ -33,6 +33,7 @@ public class IntrospectionQueryBuilder {
         private final boolean descriptions;
 
         private final boolean specifiedByUrl;
+        private final boolean isOneOf;
 
         private final boolean directiveIsRepeatable;
 
@@ -44,12 +45,14 @@ public class IntrospectionQueryBuilder {
 
         private Options(boolean descriptions,
                         boolean specifiedByUrl,
+                        boolean isOneOf,
                         boolean directiveIsRepeatable,
                         boolean schemaDescription,
                         boolean inputValueDeprecation,
                         int typeRefFragmentDepth) {
             this.descriptions = descriptions;
             this.specifiedByUrl = specifiedByUrl;
+            this.isOneOf = isOneOf;
             this.directiveIsRepeatable = directiveIsRepeatable;
             this.schemaDescription = schemaDescription;
             this.inputValueDeprecation = inputValueDeprecation;
@@ -62,6 +65,10 @@ public class IntrospectionQueryBuilder {
 
         public boolean isSpecifiedByUrl() {
             return specifiedByUrl;
+        }
+
+        public boolean isOneOf() {
+            return isOneOf;
         }
 
         public boolean isDirectiveIsRepeatable() {
@@ -85,6 +92,7 @@ public class IntrospectionQueryBuilder {
                     true,
                     false,
                     true,
+                    true,
                     false,
                     true,
                     7
@@ -101,6 +109,7 @@ public class IntrospectionQueryBuilder {
         public Options descriptions(boolean flag) {
             return new Options(flag,
                     this.specifiedByUrl,
+                    this.isOneOf,
                     this.directiveIsRepeatable,
                     this.schemaDescription,
                     this.inputValueDeprecation,
@@ -117,12 +126,32 @@ public class IntrospectionQueryBuilder {
         public Options specifiedByUrl(boolean flag) {
             return new Options(this.descriptions,
                     flag,
+                    this.isOneOf,
                     this.directiveIsRepeatable,
                     this.schemaDescription,
                     this.inputValueDeprecation,
                     this.typeRefFragmentDepth);
         }
 
+        /**
+         * This will allow you to include the `isOneOf` field for one of input types in the introspection query.
+         * <p>
+         * This option is only needed while `@oneOf` input types are new and in time the reason for this
+         * option will go away.
+         *
+         * @param flag whether to include them
+         *
+         * @return options
+         */
+        public Options isOneOf(boolean flag) {
+            return new Options(this.descriptions,
+                    this.specifiedByUrl,
+                    flag,
+                    this.directiveIsRepeatable,
+                    this.schemaDescription,
+                    this.inputValueDeprecation,
+                    this.typeRefFragmentDepth);
+        }
         /**
          * This will allow you to include the `isRepeatable` field for directives in the introspection query.
          *
@@ -133,6 +162,7 @@ public class IntrospectionQueryBuilder {
         public Options directiveIsRepeatable(boolean flag) {
             return new Options(this.descriptions,
                     this.specifiedByUrl,
+                    this.isOneOf,
                     flag,
                     this.schemaDescription,
                     this.inputValueDeprecation,
@@ -149,6 +179,7 @@ public class IntrospectionQueryBuilder {
         public Options schemaDescription(boolean flag) {
             return new Options(this.descriptions,
                     this.specifiedByUrl,
+                    this.isOneOf,
                     this.directiveIsRepeatable,
                     flag,
                     this.inputValueDeprecation,
@@ -165,6 +196,7 @@ public class IntrospectionQueryBuilder {
         public Options inputValueDeprecation(boolean flag) {
             return new Options(this.descriptions,
                     this.specifiedByUrl,
+                    this.isOneOf,
                     this.directiveIsRepeatable,
                     this.schemaDescription,
                     flag,
@@ -181,6 +213,7 @@ public class IntrospectionQueryBuilder {
         public Options typeRefFragmentDepth(int typeRefFragmentDepth) {
             return new Options(this.descriptions,
                     this.specifiedByUrl,
+                    this.isOneOf,
                     this.directiveIsRepeatable,
                     this.schemaDescription,
                     this.inputValueDeprecation,
@@ -249,6 +282,7 @@ public class IntrospectionQueryBuilder {
                 newField("name").build(),
                 options.descriptions ? newField("description").build() : null,
                 options.specifiedByUrl ? newField("specifiedByURL").build() : null,
+                options.isOneOf ? newField("isOneOf").build() : null,
                 newField("fields")
                         .arguments(ImmutableList.of(
                                 newArgument("includeDeprecated", BooleanValue.of(true)).build()

--- a/src/main/java/graphql/language/SourceLocation.java
+++ b/src/main/java/graphql/language/SourceLocation.java
@@ -2,6 +2,11 @@ package graphql.language;
 
 
 import graphql.PublicApi;
+import graphql.schema.GraphQLModifiedType;
+import graphql.schema.GraphQLNamedSchemaElement;
+import graphql.schema.GraphQLSchemaElement;
+import graphql.schema.GraphQLTypeUtil;
+import graphql.schema.idl.SchemaGenerator;
 
 import java.io.Serializable;
 import java.util.Objects;
@@ -74,4 +79,27 @@ public class SourceLocation implements Serializable {
                 (sourceName != null ? ", sourceName=" + sourceName : "") +
                 '}';
     }
+
+
+    /**
+     * This method can return {@link SourceLocation} that help create the given schema element.  If the
+     * schema is created from input files and {@link SchemaGenerator.Options#isCaptureAstDefinitions()}
+     * is set to true then schema elements contain a reference to the {@link SourceLocation} that helped
+     * create that runtime schema element.
+     *
+     * @param schemaElement the schema element
+     *
+     * @return the source location if available or null if it's not.
+     */
+    public static SourceLocation getLocation(GraphQLSchemaElement schemaElement) {
+        if (schemaElement instanceof GraphQLModifiedType) {
+            schemaElement = GraphQLTypeUtil.unwrapAllAs((GraphQLModifiedType) schemaElement);
+        }
+        if (schemaElement instanceof GraphQLNamedSchemaElement) {
+            Node<?> node = ((GraphQLNamedSchemaElement) schemaElement).getDefinition();
+            return node != null ? node.getSourceLocation() : null;
+        }
+        return null;
+    }
+
 }

--- a/src/main/java/graphql/language/VariableReference.java
+++ b/src/main/java/graphql/language/VariableReference.java
@@ -91,6 +91,10 @@ public class VariableReference extends AbstractNode<VariableReference> implement
         return visitor.visitVariableReference(this, context);
     }
 
+    public static VariableReference of(String name) {
+        return newVariableReference().name(name).build();
+    }
+
     public static Builder newVariableReference() {
         return new Builder();
     }

--- a/src/main/java/graphql/normalized/ExecutableNormalizedOperationFactory.java
+++ b/src/main/java/graphql/normalized/ExecutableNormalizedOperationFactory.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableSet;
 import graphql.GraphQLContext;
 import graphql.PublicApi;
 import graphql.collect.ImmutableKit;
+import graphql.execution.AbortExecutionException;
 import graphql.execution.CoercedVariables;
 import graphql.execution.MergedField;
 import graphql.execution.RawVariables;
@@ -64,6 +65,85 @@ import static java.util.Collections.singletonList;
  */
 @PublicApi
 public class ExecutableNormalizedOperationFactory {
+    public static class Options {
+        private final GraphQLContext graphQLContext;
+        private final Locale locale;
+        private final int maxChildrenDepth;
+
+        private Options(GraphQLContext graphQLContext,
+                        Locale locale,
+                        int maxChildrenDepth) {
+            this.graphQLContext = graphQLContext;
+            this.locale = locale;
+            this.maxChildrenDepth = maxChildrenDepth;
+        }
+
+        public static Options defaultOptions() {
+            return new Options(
+                    GraphQLContext.getDefault(),
+                    Locale.getDefault(),
+                    Integer.MAX_VALUE);
+        }
+
+        /**
+         * Locale to use when parsing the query.
+         * <p>
+         * e.g. can be passed to {@link graphql.schema.Coercing} for parsing.
+         *
+         * @param locale the locale to use
+         * @return new options object to use
+         */
+        public Options locale(Locale locale) {
+            return new Options(this.graphQLContext, locale, this.maxChildrenDepth);
+        }
+
+        /**
+         * Context object to use when parsing the operation.
+         * <p>
+         * Can be used to intercept input values e.g. using {@link graphql.execution.values.InputInterceptor}.
+         *
+         * @param graphQLContext the context to use
+         * @return new options object to use
+         */
+        public Options graphQLContext(GraphQLContext graphQLContext) {
+            return new Options(graphQLContext, this.locale, this.maxChildrenDepth);
+        }
+
+        /**
+         * Controls the maximum depth of the operation. Can be used to prevent
+         * against malicious operations.
+         *
+         * @param maxChildrenDepth the max depth
+         * @return new options object to use
+         */
+        public Options maxChildrenDepth(int maxChildrenDepth) {
+            return new Options(this.graphQLContext, this.locale, maxChildrenDepth);
+        }
+
+        /**
+         * @return context to use during operation parsing
+         * @see #graphQLContext(GraphQLContext)
+         */
+        public GraphQLContext getGraphQLContext() {
+            return graphQLContext;
+        }
+
+        /**
+         * @return locale to use during operation parsing
+         * @see #locale(Locale)
+         */
+        public Locale getLocale() {
+            return locale;
+        }
+
+        /**
+         * @return maximum children depth before aborting parsing
+         * @see #maxChildrenDepth(int)
+         */
+        public int getMaxChildrenDepth() {
+            return maxChildrenDepth;
+        }
+    }
 
     private final ConditionalNodes conditionalNodes = new ConditionalNodes();
 
@@ -90,8 +170,7 @@ public class ExecutableNormalizedOperationFactory {
                 getOperationResult.fragmentsByName,
                 coercedVariableValues,
                 null,
-                GraphQLContext.getDefault(),
-                Locale.getDefault());
+                Options.defaultOptions());
     }
 
     /**
@@ -114,8 +193,7 @@ public class ExecutableNormalizedOperationFactory {
                 fragments,
                 coercedVariableValues,
                 null,
-                GraphQLContext.getDefault(),
-                Locale.getDefault());
+                Options.defaultOptions());
     }
 
     /**
@@ -137,8 +215,7 @@ public class ExecutableNormalizedOperationFactory {
                 document,
                 operationName,
                 rawVariables,
-                GraphQLContext.getDefault(),
-                Locale.getDefault());
+                Options.defaultOptions());
     }
 
 
@@ -163,40 +240,64 @@ public class ExecutableNormalizedOperationFactory {
             GraphQLContext graphQLContext,
             Locale locale
     ) {
+        return createExecutableNormalizedOperationWithRawVariables(
+                graphQLSchema,
+                document,
+                operationName,
+                rawVariables,
+                Options.defaultOptions().graphQLContext(graphQLContext).locale(locale));
+    }
+
+
+    /**
+     * This will create a runtime representation of the graphql operation that would be executed
+     * in a runtime sense.
+     *
+     * @param graphQLSchema the schema to be used
+     * @param document      the {@link Document} holding the operation text
+     * @param operationName the operation name to use
+     * @param rawVariables  the raw variables that have not yet been coerced
+     * @param options       the {@link Options} to use for parsing
+     *
+     * @return a runtime representation of the graphql operation.
+     */
+    public static ExecutableNormalizedOperation createExecutableNormalizedOperationWithRawVariables(GraphQLSchema graphQLSchema,
+                                                                                                    Document document,
+                                                                                                    String operationName,
+                                                                                                    RawVariables rawVariables,
+                                                                                                    Options options) {
         NodeUtil.GetOperationResult getOperationResult = NodeUtil.getOperation(document, operationName);
+
         return new ExecutableNormalizedOperationFactory().createExecutableNormalizedOperationImplWithRawVariables(graphQLSchema,
                 getOperationResult.operationDefinition,
                 getOperationResult.fragmentsByName,
                 rawVariables,
-                graphQLContext,
-                locale);
+                options
+        );
     }
 
     private ExecutableNormalizedOperation createExecutableNormalizedOperationImplWithRawVariables(GraphQLSchema graphQLSchema,
                                                                                                   OperationDefinition operationDefinition,
                                                                                                   Map<String, FragmentDefinition> fragments,
                                                                                                   RawVariables rawVariables,
-                                                                                                  GraphQLContext graphQLContext,
-                                                                                                  Locale locale) {
-
+                                                                                                  Options options) {
         List<VariableDefinition> variableDefinitions = operationDefinition.getVariableDefinitions();
         CoercedVariables coercedVariableValues = ValuesResolver.coerceVariableValues(graphQLSchema,
                 variableDefinitions,
                 rawVariables,
-                graphQLContext,
-                locale);
+                options.getGraphQLContext(),
+                options.getLocale());
         Map<String, NormalizedInputValue> normalizedVariableValues = ValuesResolver.getNormalizedVariableValues(graphQLSchema,
                 variableDefinitions,
                 rawVariables,
-                graphQLContext,
-                locale);
+                options.getGraphQLContext(),
+                options.getLocale());
         return createNormalizedQueryImpl(graphQLSchema,
                 operationDefinition,
                 fragments,
                 coercedVariableValues,
                 normalizedVariableValues,
-                graphQLContext,
-                locale);
+                options);
     }
 
     /**
@@ -207,7 +308,7 @@ public class ExecutableNormalizedOperationFactory {
                                                                     Map<String, FragmentDefinition> fragments,
                                                                     CoercedVariables coercedVariableValues,
                                                                     @Nullable Map<String, NormalizedInputValue> normalizedVariableValues,
-                                                                    GraphQLContext graphQLContext, Locale locale) {
+                                                                    Options options) {
         FieldCollectorNormalizedQueryParams parameters = FieldCollectorNormalizedQueryParams
                 .newParameters()
                 .fragments(fragments)
@@ -226,8 +327,8 @@ public class ExecutableNormalizedOperationFactory {
         ImmutableListMultimap.Builder<FieldCoordinates, ExecutableNormalizedField> coordinatesToNormalizedFields = ImmutableListMultimap.builder();
 
         BiConsumer<ExecutableNormalizedField, MergedField> captureMergedField = (enf, mergedFld) -> {
-            //QueryDirectivesImpl is a lazy object and only computes itself when asked for
-            QueryDirectives queryDirectives = new QueryDirectivesImpl(mergedFld, graphQLSchema, coercedVariableValues.toMap(), graphQLContext, locale);
+            // QueryDirectivesImpl is a lazy object and only computes itself when asked for
+            QueryDirectives queryDirectives = new QueryDirectivesImpl(mergedFld, graphQLSchema, coercedVariableValues.toMap(), options.getGraphQLContext(), options.getLocale());
             normalizedFieldToQueryDirectives.put(enf, queryDirectives);
             normalizedFieldToMergedField.put(enf, mergedFld);
         };
@@ -241,16 +342,17 @@ public class ExecutableNormalizedOperationFactory {
             updateFieldToNFMap(topLevel, fieldAndAstParents, fieldToNormalizedField);
             updateCoordinatedToNFMap(coordinatesToNormalizedFields, topLevel);
 
-            buildFieldWithChildren(topLevel,
+            buildFieldWithChildren(
+                    topLevel,
                     fieldAndAstParents,
                     parameters,
                     fieldToNormalizedField,
                     captureMergedField,
                     coordinatesToNormalizedFields,
-                    1);
-
+                    1,
+                    options.getMaxChildrenDepth());
         }
-        for (FieldCollectorNormalizedQueryParams.PossibleMerger possibleMerger : parameters.possibleMergerList) {
+        for (FieldCollectorNormalizedQueryParams.PossibleMerger possibleMerger : parameters.getPossibleMergerList()) {
             List<ExecutableNormalizedField> childrenWithSameResultKey = possibleMerger.parent.getChildrenWithSameResultKey(possibleMerger.resultKey);
             ENFMerger.merge(possibleMerger.parent, childrenWithSameResultKey, graphQLSchema);
         }
@@ -272,7 +374,12 @@ public class ExecutableNormalizedOperationFactory {
                                         ImmutableListMultimap.Builder<Field, ExecutableNormalizedField> fieldNormalizedField,
                                         BiConsumer<ExecutableNormalizedField, MergedField> captureMergedField,
                                         ImmutableListMultimap.Builder<FieldCoordinates, ExecutableNormalizedField> coordinatesToNormalizedFields,
-                                        int curLevel) {
+                                        int curLevel,
+                                        int maxLevel) {
+        if (curLevel > maxLevel) {
+            throw new AbortExecutionException("Maximum query depth exceeded " + curLevel + " > " + maxLevel);
+        }
+
         CollectNFResult nextLevel = collectFromMergedField(fieldCollectorNormalizedQueryParams, executableNormalizedField, fieldAndAstParents, curLevel + 1);
 
         for (ExecutableNormalizedField childENF : nextLevel.children) {
@@ -291,7 +398,8 @@ public class ExecutableNormalizedOperationFactory {
                     fieldNormalizedField,
                     captureMergedField,
                     coordinatesToNormalizedFields,
-                    curLevel + 1);
+                    curLevel + 1,
+                    maxLevel);
         }
     }
 

--- a/src/main/java/graphql/normalized/FieldCollectorNormalizedQueryParams.java
+++ b/src/main/java/graphql/normalized/FieldCollectorNormalizedQueryParams.java
@@ -23,7 +23,7 @@ public class FieldCollectorNormalizedQueryParams {
     private final GraphQLContext graphQLContext;
     private final Locale locale;
 
-    public List<PossibleMerger> possibleMergerList = new ArrayList<>();
+    private final List<PossibleMerger> possibleMergerList = new ArrayList<>();
 
     public static class PossibleMerger {
         ExecutableNormalizedField parent;
@@ -37,6 +37,10 @@ public class FieldCollectorNormalizedQueryParams {
 
     public void addPossibleMergers(ExecutableNormalizedField parent, String resultKey) {
         possibleMergerList.add(new PossibleMerger(parent, resultKey));
+    }
+
+    public List<PossibleMerger> getPossibleMergerList() {
+        return possibleMergerList;
     }
 
     public GraphQLSchema getGraphQLSchema() {

--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -669,7 +669,12 @@ public class GraphqlAntlrToLanguage {
             addCommonData(intValue, ctx);
             return captureRuleContext(intValue.build(), ctx);
         } else if (ctx.FloatValue() != null) {
-            FloatValue.Builder floatValue = FloatValue.newFloatValue().value(new BigDecimal(ctx.FloatValue().getText()));
+            FloatValue.Builder floatValue;
+            try {
+                floatValue = FloatValue.newFloatValue().value(new BigDecimal(ctx.FloatValue().getText()));
+            } catch (NumberFormatException e) {
+                throw new InvalidSyntaxException("Invalid floating point value", null, ctx.FloatValue().getText(), null, e);
+            }
             addCommonData(floatValue, ctx);
             return captureRuleContext(floatValue.build(), ctx);
         } else if (ctx.BooleanValue() != null) {

--- a/src/main/java/graphql/parser/UnicodeUtil.java
+++ b/src/main/java/graphql/parser/UnicodeUtil.java
@@ -33,7 +33,12 @@ public class UnicodeUtil {
         int continueIndex = isBracedEscape(string, i) ? endIndexExclusive : endIndexExclusive - 1;
 
         String hexStr = string.substring(startIndex, endIndexExclusive);
-        int codePoint = Integer.parseInt(hexStr, 16);
+        int codePoint;
+        try {
+            codePoint = Integer.parseInt(hexStr, 16);
+        } catch (NumberFormatException e) {
+            throw new InvalidUnicodeSyntaxException(i18n, "InvalidUnicode.invalidHexString", sourceLocation, offendingToken(string, i, continueIndex));
+        }
 
         if (isTrailingSurrogateValue(codePoint)) {
             throw new InvalidUnicodeSyntaxException(i18n, "InvalidUnicode.trailingLeadingSurrogate", sourceLocation, offendingToken(string, i, continueIndex));

--- a/src/main/java/graphql/schema/GraphQLSchema.java
+++ b/src/main/java/graphql/schema/GraphQLSchema.java
@@ -917,6 +917,9 @@ public class GraphQLSchema {
             if (additionalDirectives.stream().noneMatch(d -> d.getName().equals(Directives.SpecifiedByDirective.getName()))) {
                 additionalDirectives.add(Directives.SpecifiedByDirective);
             }
+            if (additionalDirectives.stream().noneMatch(d -> d.getName().equals(Directives.OneOfDirective.getName()))) {
+                additionalDirectives.add(Directives.OneOfDirective);
+            }
 
             // quick build - no traversing
             final GraphQLSchema partiallyBuiltSchema = new GraphQLSchema(this);

--- a/src/main/java/graphql/schema/diff/DiffSet.java
+++ b/src/main/java/graphql/schema/diff/DiffSet.java
@@ -1,6 +1,7 @@
 package graphql.schema.diff;
 
 import graphql.Assert;
+import graphql.DeprecatedAt;
 import graphql.ExecutionResult;
 import graphql.GraphQL;
 import graphql.PublicApi;
@@ -15,6 +16,8 @@ import java.util.Map;
  * {@link graphql.introspection.IntrospectionQuery}.
  */
 @PublicApi
+@Deprecated
+@DeprecatedAt("2023-10-04")
 public class DiffSet {
 
     private final Map<String, Object> introspectionOld;
@@ -38,7 +41,6 @@ public class DiffSet {
     public Map<String, Object> getNew() {
         return introspectionNew;
     }
-
 
     /**
      * Creates a diff set out of the result of 2 introspection queries.

--- a/src/main/java/graphql/schema/diff/SchemaDiffSet.java
+++ b/src/main/java/graphql/schema/diff/SchemaDiffSet.java
@@ -1,0 +1,134 @@
+package graphql.schema.diff;
+
+import graphql.Assert;
+import graphql.ExecutionResult;
+import graphql.GraphQL;
+import graphql.PublicApi;
+import graphql.introspection.IntrospectionQuery;
+import graphql.introspection.IntrospectionResultToSchema;
+import graphql.language.Document;
+import graphql.parser.Parser;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.idl.SchemaPrinter;
+
+import java.util.Map;
+
+/**
+ * Interface used to define 2 schemas that can be diffed by the {@link SchemaDiff} operation.
+ */
+@PublicApi
+public class SchemaDiffSet {
+
+    private final Document oldSchemaDoc;
+    private final Document newSchemaDoc;
+    private final boolean supportsEnforcingDirectives;
+
+    private SchemaDiffSet(final Document oldSchemaDoc,
+                          final Document newSchemaDoc,
+                          final boolean supportsEnforcingDirectives) {
+        this.oldSchemaDoc = oldSchemaDoc;
+        this.newSchemaDoc = newSchemaDoc;
+        this.supportsEnforcingDirectives = supportsEnforcingDirectives;
+    }
+
+    /**
+     * @return Returns a IDL document that represents the old schema as part of a SchemaDiff operation.
+     */
+    public Document getOldSchemaDefinitionDoc() {
+        return this.oldSchemaDoc;
+    }
+
+    /**
+     * @return Returns a IDL document that represents the new schema created from the introspection result.
+     */
+    public Document getNewSchemaDefinitionDoc() {
+        return this.newSchemaDoc;
+    }
+
+    /**
+     * @return Flag indicating whether this diffset implementation can be used to enforce directives when performing schema diff.
+     */
+    public boolean supportsEnforcingDirectives() {
+        return this.supportsEnforcingDirectives;
+    }
+
+    /**
+     * Creates an schema diff set out of the result of 2 introspection queries.
+     *
+     * @param introspectionOld the older introspection query
+     * @param introspectionNew the newer introspection query
+     *
+     * @return a diff set representing them which will not support enforcing directives.
+     */
+    public static SchemaDiffSet diffSetFromIntrospection(final Map<String, Object> introspectionOld,
+                                                         final Map<String, Object> introspectionNew) {
+        final Document oldDoc = getDocumentFromIntrospection(introspectionOld);
+        final Document newDoc = getDocumentFromIntrospection(introspectionNew);
+        return new SchemaDiffSet(oldDoc, newDoc, false);
+    }
+
+    /**
+     * Creates an schema diff set out of the result of 2 introspection queries.
+     *
+     * @param oldSchema the older GraphQLSchema object to introspect.
+     * @param newSchema the new GraphQLSchema object to introspect.
+     *
+     * @return a diff set representing them which will not support enforcing directives.
+     */
+    public static SchemaDiffSet diffSetFromIntrospection(final GraphQLSchema oldSchema,
+                                                         final GraphQLSchema newSchema) {
+        final Map<String, Object> introspectionOld = introspect(oldSchema);
+        final Map<String, Object> introspectionNew = introspect(newSchema);
+        return diffSetFromIntrospection(introspectionOld, introspectionNew);
+    }
+
+    /**
+     * Creates an schema diff set out of the two SDL definition Strings.
+     *
+     * @param oldSchemaSdl the older SDL definition String.
+     * @param newSchemaSdl the newer SDL definition String.
+     *
+     * @return a diff set representing them which will support enforcing directives.
+     */
+    public static SchemaDiffSet diffSetFromSdl(final String oldSchemaSdl,
+                                               final String newSchemaSdl) {
+        final Document oldDoc = getDocumentFromSDLString(oldSchemaSdl);
+        final Document newDoc = getDocumentFromSDLString(newSchemaSdl);
+        return new SchemaDiffSet(oldDoc, newDoc, true);
+    }
+
+    /**
+     * Creates an schema diff set out of the two SDL definition Strings.
+     *
+     * @param oldSchema the older SDL definition String.
+     * @param newSchema the newer SDL definition String.
+     *
+     * @return a diff set representing them which will support enforcing directives.
+     */
+    public static SchemaDiffSet diffSetFromSdl(final GraphQLSchema oldSchema,
+                                               final GraphQLSchema newSchema) {
+        final String oldSchemaSdl = getSchemaSdl(oldSchema);
+        final String newSchemaSdl = getSchemaSdl(newSchema);
+        return diffSetFromSdl(oldSchemaSdl, newSchemaSdl);
+    }
+
+    private static Document getDocumentFromIntrospection(final Map<String, Object> introspectionResult) {
+        return new IntrospectionResultToSchema().createSchemaDefinition(introspectionResult);
+    }
+
+    private static Document getDocumentFromSDLString(final String sdlString) {
+        return Parser.parse(sdlString);
+    }
+
+    private static String getSchemaSdl(GraphQLSchema schema) {
+        final SchemaPrinter schemaPrinter = new SchemaPrinter();
+        return schemaPrinter.print(schema);
+    }
+
+    private static Map<String, Object> introspect(GraphQLSchema schema) {
+        GraphQL gql = GraphQL.newGraphQL(schema).build();
+        ExecutionResult result = gql.execute(IntrospectionQuery.INTROSPECTION_QUERY);
+        Assert.assertTrue(result.getErrors().size() == 0, () -> "The schema has errors during Introspection");
+        return result.getData();
+    }
+}

--- a/src/main/java/graphql/schema/diffing/DiffImpl.java
+++ b/src/main/java/graphql/schema/diffing/DiffImpl.java
@@ -400,19 +400,21 @@ public class DiffImpl {
                                              Map<Vertex, Double> isolatedVerticesCache,
                                              Map<Vertex, Vertex> nonFixedParentRestrictions) {
         if (nonFixedParentRestrictions.containsKey(v) || partialMapping.hasParentRestriction(v)) {
-            Vertex uParentRestriction = nonFixedParentRestrictions.get(v);
-            if (uParentRestriction == null) {
-                uParentRestriction = partialMapping.getParentRestriction(v);
-            }
+            if (!u.isIsolated()) { // Always allow mapping to isolated nodes
+                Vertex uParentRestriction = nonFixedParentRestrictions.get(v);
+                if (uParentRestriction == null) {
+                    uParentRestriction = partialMapping.getParentRestriction(v);
+                }
 
-            Collection<Edge> parentEdges = completeTargetGraph.getAdjacentEdgesInverseNonCopy(u);
-            if (parentEdges.size() != 1) {
-                return Integer.MAX_VALUE;
-            }
+                Collection<Edge> parentEdges = completeTargetGraph.getAdjacentEdgesInverseNonCopy(u);
+                if (parentEdges.size() != 1) {
+                    return Integer.MAX_VALUE;
+                }
 
-            Vertex uParent = parentEdges.iterator().next().getFrom();
-            if (uParent != uParentRestriction) {
-                return Integer.MAX_VALUE;
+                Vertex uParent = parentEdges.iterator().next().getFrom();
+                if (uParent != uParentRestriction) {
+                    return Integer.MAX_VALUE;
+                }
             }
         }
 

--- a/src/main/java/graphql/schema/diffing/ana/EditOperationAnalyzer.java
+++ b/src/main/java/graphql/schema/diffing/ana/EditOperationAnalyzer.java
@@ -244,7 +244,7 @@ public class EditOperationAnalyzer {
             if (isObjectDeleted(object.getName())) {
                 return;
             }
-            AppliedDirectiveObjectLocation location = new AppliedDirectiveObjectLocation(object.getName());
+            AppliedDirectiveObjectLocation location = new AppliedDirectiveObjectLocation(object.getName(), appliedDirective.getName());
             AppliedDirectiveDeletion appliedDirectiveDeletion = new AppliedDirectiveDeletion(location, appliedDirective.getName());
             getObjectModification(object.getName()).getDetails().add(appliedDirectiveDeletion);
         } else if (container.isOfType(SchemaGraph.INTERFACE)) {
@@ -252,7 +252,7 @@ public class EditOperationAnalyzer {
             if (isInterfaceDeleted(interfaze.getName())) {
                 return;
             }
-            AppliedDirectiveInterfaceLocation location = new AppliedDirectiveInterfaceLocation(interfaze.getName());
+            AppliedDirectiveInterfaceLocation location = new AppliedDirectiveInterfaceLocation(interfaze.getName(), appliedDirective.getName());
             AppliedDirectiveDeletion appliedDirectiveDeletion = new AppliedDirectiveDeletion(location, appliedDirective.getName());
             getInterfaceModification(interfaze.getName()).getDetails().add(appliedDirectiveDeletion);
         } else if (container.isOfType(SchemaGraph.SCALAR)) {
@@ -260,7 +260,7 @@ public class EditOperationAnalyzer {
             if (isScalarDeleted(scalar.getName())) {
                 return;
             }
-            AppliedDirectiveScalarLocation location = new AppliedDirectiveScalarLocation(scalar.getName());
+            AppliedDirectiveScalarLocation location = new AppliedDirectiveScalarLocation(scalar.getName(), appliedDirective.getName());
             AppliedDirectiveDeletion appliedDirectiveDeletion = new AppliedDirectiveDeletion(location, appliedDirective.getName());
             getScalarModification(scalar.getName()).getDetails().add(appliedDirectiveDeletion);
         } else if (container.isOfType(SchemaGraph.ENUM)) {
@@ -268,7 +268,7 @@ public class EditOperationAnalyzer {
             if (isEnumDeleted(enumVertex.getName())) {
                 return;
             }
-            AppliedDirectiveEnumLocation location = new AppliedDirectiveEnumLocation(enumVertex.getName());
+            AppliedDirectiveEnumLocation location = new AppliedDirectiveEnumLocation(enumVertex.getName(), appliedDirective.getName());
             AppliedDirectiveDeletion appliedDirectiveDeletion = new AppliedDirectiveDeletion(location, appliedDirective.getName());
             getEnumModification(enumVertex.getName()).getDetails().add(appliedDirectiveDeletion);
         } else if (container.isOfType(SchemaGraph.ENUM_VALUE)) {
@@ -280,7 +280,7 @@ public class EditOperationAnalyzer {
             if (isEnumValueDeletedFromExistingEnum(enumVertex.getName(), enumValue.getName())) {
                 return;
             }
-            AppliedDirectiveEnumValueLocation location = new AppliedDirectiveEnumValueLocation(enumVertex.getName(), enumValue.getName());
+            AppliedDirectiveEnumValueLocation location = new AppliedDirectiveEnumValueLocation(enumVertex.getName(), enumValue.getName(), appliedDirective.getName());
             AppliedDirectiveDeletion appliedDirectiveDeletion = new AppliedDirectiveDeletion(location, appliedDirective.getName());
             getEnumModification(enumVertex.getName()).getDetails().add(appliedDirectiveDeletion);
         } else if (container.isOfType(SchemaGraph.INPUT_OBJECT)) {
@@ -288,7 +288,7 @@ public class EditOperationAnalyzer {
             if (isInputObjectDeleted(inputObject.getName())) {
                 return;
             }
-            AppliedDirectiveInputObjectLocation location = new AppliedDirectiveInputObjectLocation(inputObject.getName());
+            AppliedDirectiveInputObjectLocation location = new AppliedDirectiveInputObjectLocation(inputObject.getName(), appliedDirective.getName());
             AppliedDirectiveDeletion appliedDirectiveDeletion = new AppliedDirectiveDeletion(location, appliedDirective.getName());
             getInputObjectModification(inputObject.getName()).getDetails().add(appliedDirectiveDeletion);
         } else if (container.isOfType(SchemaGraph.INPUT_FIELD)) {
@@ -300,7 +300,7 @@ public class EditOperationAnalyzer {
             if (isInputFieldDeletedFromExistingInputObject(inputObject.getName(), inputField.getName())) {
                 return;
             }
-            AppliedDirectiveInputObjectFieldLocation location = new AppliedDirectiveInputObjectFieldLocation(inputObject.getName(), inputField.getName());
+            AppliedDirectiveInputObjectFieldLocation location = new AppliedDirectiveInputObjectFieldLocation(inputObject.getName(), inputField.getName(), appliedDirective.getName());
             AppliedDirectiveDeletion appliedDirectiveDeletion = new AppliedDirectiveDeletion(location, appliedDirective.getName());
             getInputObjectModification(inputObject.getName()).getDetails().add(appliedDirectiveDeletion);
         } else if (container.isOfType(SchemaGraph.UNION)) {
@@ -308,7 +308,7 @@ public class EditOperationAnalyzer {
             if (isUnionDeleted(union.getName())) {
                 return;
             }
-            AppliedDirectiveUnionLocation location = new AppliedDirectiveUnionLocation(union.getName());
+            AppliedDirectiveUnionLocation location = new AppliedDirectiveUnionLocation(union.getName(), appliedDirective.getName());
             AppliedDirectiveDeletion appliedDirectiveDeletion = new AppliedDirectiveDeletion(location, appliedDirective.getName());
             getUnionModification(union.getName()).getDetails().add(appliedDirectiveDeletion);
         }
@@ -327,7 +327,7 @@ public class EditOperationAnalyzer {
                 if (isObjectDeleted(object.getName())) {
                     return;
                 }
-                AppliedDirectiveObjectFieldLocation location = new AppliedDirectiveObjectFieldLocation(object.getName(), field.getName());
+                AppliedDirectiveObjectFieldLocation location = new AppliedDirectiveObjectFieldLocation(object.getName(), field.getName(), appliedDirective.getName());
                 getObjectModification(object.getName()).getDetails().add(new AppliedDirectiveArgumentDeletion(location, deletedArgument.getName()));
             } else {
                 assertTrue(interfaceOrObjective.isOfType(SchemaGraph.INTERFACE));
@@ -335,7 +335,7 @@ public class EditOperationAnalyzer {
                 if (isInterfaceDeleted(interfaze.getName())) {
                     return;
                 }
-                AppliedDirectiveInterfaceFieldLocation location = new AppliedDirectiveInterfaceFieldLocation(interfaze.getName(), field.getName());
+                AppliedDirectiveInterfaceFieldLocation location = new AppliedDirectiveInterfaceFieldLocation(interfaze.getName(), field.getName(), appliedDirective.getName());
                 getInterfaceModification(interfaze.getName()).getDetails().add(new AppliedDirectiveArgumentDeletion(location, deletedArgument.getName()));
             }
         }
@@ -359,7 +359,7 @@ public class EditOperationAnalyzer {
             Vertex interfaceOrObjective = newSchemaGraph.getFieldsContainerForField(field);
             if (interfaceOrObjective.isOfType(SchemaGraph.OBJECT)) {
                 Vertex object = interfaceOrObjective;
-                AppliedDirectiveObjectFieldLocation location = new AppliedDirectiveObjectFieldLocation(object.getName(), field.getName());
+                AppliedDirectiveObjectFieldLocation location = new AppliedDirectiveObjectFieldLocation(object.getName(), field.getName(), appliedDirective.getName());
                 if (valueChanged) {
                     AppliedDirectiveArgumentValueModification argumentValueModification = new AppliedDirectiveArgumentValueModification(location, newArgumentName, oldValue, newValue);
                     getObjectModification(object.getName()).getDetails().add(argumentValueModification);
@@ -385,7 +385,7 @@ public class EditOperationAnalyzer {
             if (isObjectAdded(object.getName())) {
                 return;
             }
-            AppliedDirectiveObjectLocation location = new AppliedDirectiveObjectLocation(object.getName());
+            AppliedDirectiveObjectLocation location = new AppliedDirectiveObjectLocation(object.getName(), appliedDirective.getName());
             AppliedDirectiveAddition appliedDirectiveAddition = new AppliedDirectiveAddition(location, appliedDirective.getName());
             getObjectModification(object.getName()).getDetails().add(appliedDirectiveAddition);
         } else if (container.isOfType(SchemaGraph.INTERFACE)) {
@@ -393,7 +393,7 @@ public class EditOperationAnalyzer {
             if (isInterfaceAdded(interfaze.getName())) {
                 return;
             }
-            AppliedDirectiveInterfaceLocation location = new AppliedDirectiveInterfaceLocation(interfaze.getName());
+            AppliedDirectiveInterfaceLocation location = new AppliedDirectiveInterfaceLocation(interfaze.getName(), appliedDirective.getName());
             AppliedDirectiveAddition appliedDirectiveAddition = new AppliedDirectiveAddition(location, appliedDirective.getName());
             getInterfaceModification(interfaze.getName()).getDetails().add(appliedDirectiveAddition);
         } else if (container.isOfType(SchemaGraph.SCALAR)) {
@@ -401,7 +401,7 @@ public class EditOperationAnalyzer {
             if (isScalarAdded(scalar.getName())) {
                 return;
             }
-            AppliedDirectiveScalarLocation location = new AppliedDirectiveScalarLocation(scalar.getName());
+            AppliedDirectiveScalarLocation location = new AppliedDirectiveScalarLocation(scalar.getName(), appliedDirective.getName());
             AppliedDirectiveAddition appliedDirectiveAddition = new AppliedDirectiveAddition(location, appliedDirective.getName());
             getScalarModification(scalar.getName()).getDetails().add(appliedDirectiveAddition);
         } else if (container.isOfType(SchemaGraph.ENUM)) {
@@ -409,7 +409,7 @@ public class EditOperationAnalyzer {
             if (isEnumAdded(enumVertex.getName())) {
                 return;
             }
-            AppliedDirectiveEnumLocation location = new AppliedDirectiveEnumLocation(enumVertex.getName());
+            AppliedDirectiveEnumLocation location = new AppliedDirectiveEnumLocation(enumVertex.getName(), appliedDirective.getName());
             AppliedDirectiveAddition appliedDirectiveAddition = new AppliedDirectiveAddition(location, appliedDirective.getName());
             getEnumModification(enumVertex.getName()).getDetails().add(appliedDirectiveAddition);
         } else if (container.isOfType(SchemaGraph.ENUM_VALUE)) {
@@ -421,7 +421,7 @@ public class EditOperationAnalyzer {
             if (isNewEnumValueForExistingEnum(enumVertex.getName(), enumValue.getName())) {
                 return;
             }
-            AppliedDirectiveEnumValueLocation location = new AppliedDirectiveEnumValueLocation(enumVertex.getName(), enumValue.getName());
+            AppliedDirectiveEnumValueLocation location = new AppliedDirectiveEnumValueLocation(enumVertex.getName(), enumValue.getName(), appliedDirective.getName());
             AppliedDirectiveAddition appliedDirectiveAddition = new AppliedDirectiveAddition(location, appliedDirective.getName());
             getEnumModification(enumVertex.getName()).getDetails().add(appliedDirectiveAddition);
         } else if (container.isOfType(SchemaGraph.INPUT_OBJECT)) {
@@ -429,7 +429,7 @@ public class EditOperationAnalyzer {
             if (isInputObjectAdded(inputObject.getName())) {
                 return;
             }
-            AppliedDirectiveInputObjectLocation location = new AppliedDirectiveInputObjectLocation(inputObject.getName());
+            AppliedDirectiveInputObjectLocation location = new AppliedDirectiveInputObjectLocation(inputObject.getName(), appliedDirective.getName());
             AppliedDirectiveAddition appliedDirectiveAddition = new AppliedDirectiveAddition(location, appliedDirective.getName());
             getInputObjectModification(inputObject.getName()).getDetails().add(appliedDirectiveAddition);
         } else if (container.isOfType(SchemaGraph.INPUT_FIELD)) {
@@ -441,7 +441,7 @@ public class EditOperationAnalyzer {
             if (isNewInputFieldExistingInputObject(inputObject.getName(), inputField.getName())) {
                 return;
             }
-            AppliedDirectiveInputObjectFieldLocation location = new AppliedDirectiveInputObjectFieldLocation(inputObject.getName(), inputField.getName());
+            AppliedDirectiveInputObjectFieldLocation location = new AppliedDirectiveInputObjectFieldLocation(inputObject.getName(), inputField.getName(), appliedDirective.getName());
             AppliedDirectiveAddition appliedDirectiveAddition = new AppliedDirectiveAddition(location, appliedDirective.getName());
             getInputObjectModification(inputObject.getName()).getDetails().add(appliedDirectiveAddition);
         } else if (container.isOfType(SchemaGraph.UNION)) {
@@ -449,7 +449,7 @@ public class EditOperationAnalyzer {
             if (isUnionAdded(union.getName())) {
                 return;
             }
-            AppliedDirectiveUnionLocation location = new AppliedDirectiveUnionLocation(union.getName());
+            AppliedDirectiveUnionLocation location = new AppliedDirectiveUnionLocation(union.getName(), appliedDirective.getName());
             AppliedDirectiveAddition appliedDirectiveAddition = new AppliedDirectiveAddition(location, appliedDirective.getName());
             getUnionModification(union.getName()).getDetails().add(appliedDirectiveAddition);
         }
@@ -467,7 +467,7 @@ public class EditOperationAnalyzer {
             if (isFieldDeletedFromExistingObject(object.getName(), field.getName())) {
                 return;
             }
-            AppliedDirectiveObjectFieldLocation location = new AppliedDirectiveObjectFieldLocation(object.getName(), field.getName());
+            AppliedDirectiveObjectFieldLocation location = new AppliedDirectiveObjectFieldLocation(object.getName(), field.getName(), appliedDirective.getName());
             AppliedDirectiveDeletion appliedDirectiveDeletion = new AppliedDirectiveDeletion(location, appliedDirective.getName());
             getObjectModification(object.getName()).getDetails().add(appliedDirectiveDeletion);
         }
@@ -485,7 +485,7 @@ public class EditOperationAnalyzer {
             if (isFieldNewForExistingObject(object.getName(), field.getName())) {
                 return;
             }
-            AppliedDirectiveObjectFieldLocation location = new AppliedDirectiveObjectFieldLocation(object.getName(), field.getName());
+            AppliedDirectiveObjectFieldLocation location = new AppliedDirectiveObjectFieldLocation(object.getName(), field.getName(), appliedDirective.getName());
             AppliedDirectiveAddition appliedDirectiveAddition = new AppliedDirectiveAddition(location, appliedDirective.getName());
             getObjectModification(object.getName()).getDetails().add(appliedDirectiveAddition);
         }
@@ -508,7 +508,7 @@ public class EditOperationAnalyzer {
                 if (isArgumentDeletedFromExistingObjectField(object.getName(), field.getName(), argument.getName())) {
                     return;
                 }
-                AppliedDirectiveObjectFieldArgumentLocation location = new AppliedDirectiveObjectFieldArgumentLocation(object.getName(), field.getName(), argument.getName());
+                AppliedDirectiveObjectFieldArgumentLocation location = new AppliedDirectiveObjectFieldArgumentLocation(object.getName(), field.getName(), argument.getName(), appliedDirective.getName());
                 AppliedDirectiveDeletion appliedDirectiveDeletion = new AppliedDirectiveDeletion(location, appliedDirective.getName());
                 getObjectModification(object.getName()).getDetails().add(appliedDirectiveDeletion);
             } else {
@@ -523,7 +523,7 @@ public class EditOperationAnalyzer {
                 if (isArgumentDeletedFromExistingInterfaceField(interfaze.getName(), field.getName(), argument.getName())) {
                     return;
                 }
-                AppliedDirectiveInterfaceFieldArgumentLocation location = new AppliedDirectiveInterfaceFieldArgumentLocation(interfaze.getName(), field.getName(), argument.getName());
+                AppliedDirectiveInterfaceFieldArgumentLocation location = new AppliedDirectiveInterfaceFieldArgumentLocation(interfaze.getName(), field.getName(), argument.getName(), appliedDirective.getName());
                 AppliedDirectiveDeletion appliedDirectiveDeletion = new AppliedDirectiveDeletion(location, appliedDirective.getName());
                 getInterfaceModification(interfaze.getName()).getDetails().add(appliedDirectiveDeletion);
             }
@@ -559,7 +559,7 @@ public class EditOperationAnalyzer {
                 if (isArgumentNewForExistingObjectField(object.getName(), field.getName(), argument.getName())) {
                     return;
                 }
-                AppliedDirectiveObjectFieldArgumentLocation location = new AppliedDirectiveObjectFieldArgumentLocation(object.getName(), field.getName(), argument.getName());
+                AppliedDirectiveObjectFieldArgumentLocation location = new AppliedDirectiveObjectFieldArgumentLocation(object.getName(), field.getName(), argument.getName(), appliedDirective.getName());
                 AppliedDirectiveAddition appliedDirectiveAddition = new AppliedDirectiveAddition(location, appliedDirective.getName());
                 getObjectModification(object.getName()).getDetails().add(appliedDirectiveAddition);
             } else {
@@ -574,7 +574,7 @@ public class EditOperationAnalyzer {
                 if (isArgumentNewForExistingInterfaceField(interfaze.getName(), field.getName(), argument.getName())) {
                     return;
                 }
-                AppliedDirectiveInterfaceFieldArgumentLocation location = new AppliedDirectiveInterfaceFieldArgumentLocation(interfaze.getName(), field.getName(), argument.getName());
+                AppliedDirectiveInterfaceFieldArgumentLocation location = new AppliedDirectiveInterfaceFieldArgumentLocation(interfaze.getName(), field.getName(), argument.getName(), appliedDirective.getName());
                 AppliedDirectiveAddition appliedDirectiveAddition = new AppliedDirectiveAddition(location, appliedDirective.getName());
                 getInterfaceModification(interfaze.getName()).getDetails().add(appliedDirectiveAddition);
             }

--- a/src/main/java/graphql/schema/diffing/ana/SchemaDifference.java
+++ b/src/main/java/graphql/schema/diffing/ana/SchemaDifference.java
@@ -1250,10 +1250,12 @@ public interface SchemaDifference {
     class AppliedDirectiveObjectFieldLocation implements AppliedDirectiveLocationDetail {
         private final String objectName;
         private final String fieldName;
+        private final String directiveName;
 
-        public AppliedDirectiveObjectFieldLocation(String objectName, String fieldName) {
+        public AppliedDirectiveObjectFieldLocation(String objectName, String fieldName, String directiveName) {
             this.objectName = objectName;
             this.fieldName = fieldName;
+            this.directiveName = directiveName;
         }
 
         public String getFieldName() {
@@ -1263,15 +1265,23 @@ public interface SchemaDifference {
         public String getObjectName() {
             return objectName;
         }
+
+        public String getDirectiveName() {
+            return directiveName;
+        }
     }
 
     class AppliedDirectiveInterfaceFieldLocation implements AppliedDirectiveLocationDetail {
         private final String interfaceName;
         private final String fieldName;
 
-        public AppliedDirectiveInterfaceFieldLocation(String interfaceName, String fieldName) {
+        private final String directiveName;
+
+
+        public AppliedDirectiveInterfaceFieldLocation(String interfaceName, String fieldName, String directiveName) {
             this.interfaceName = interfaceName;
             this.fieldName = fieldName;
+            this.directiveName = directiveName;
         }
 
         public String getFieldName() {
@@ -1281,17 +1291,28 @@ public interface SchemaDifference {
         public String getInterfaceName() {
             return interfaceName;
         }
+
+        public String getDirectiveName() {
+            return directiveName;
+        }
     }
 
     class AppliedDirectiveScalarLocation implements AppliedDirectiveLocationDetail {
         private final String name;
 
-        public AppliedDirectiveScalarLocation(String name) {
+        private final String directiveName;
+
+        public AppliedDirectiveScalarLocation(String name, String directiveName) {
             this.name = name;
+            this.directiveName = directiveName;
         }
 
         public String getName() {
             return name;
+        }
+
+        public String getDirectiveName() {
+            return directiveName;
         }
     }
 
@@ -1301,25 +1322,38 @@ public interface SchemaDifference {
 
     class AppliedDirectiveObjectLocation implements AppliedDirectiveLocationDetail {
         private final String name;
+        private final String directiveName;
 
-        public AppliedDirectiveObjectLocation(String name) {
+
+        public AppliedDirectiveObjectLocation(String name, String directiveName) {
             this.name = name;
+            this.directiveName = directiveName;
         }
 
         public String getName() {
             return name;
+        }
+
+        public String getDirectiveName() {
+            return directiveName;
         }
     }
 
     class AppliedDirectiveInterfaceLocation implements AppliedDirectiveLocationDetail {
         private final String name;
+        private final String directiveName;
 
-        public AppliedDirectiveInterfaceLocation(String name) {
+        public AppliedDirectiveInterfaceLocation(String name, String directiveName) {
             this.name = name;
+            this.directiveName = directiveName;
         }
 
         public String getName() {
             return name;
+        }
+
+        public String getDirectiveName() {
+            return directiveName;
         }
     }
 
@@ -1327,11 +1361,14 @@ public interface SchemaDifference {
         private final String objectName;
         private final String fieldName;
         private final String argumentName;
+        private final String directiveName;
 
-        public AppliedDirectiveObjectFieldArgumentLocation(String objectName, String fieldName, String argumentName) {
+
+        public AppliedDirectiveObjectFieldArgumentLocation(String objectName, String fieldName, String argumentName, String directiveName) {
             this.objectName = objectName;
             this.fieldName = fieldName;
             this.argumentName = argumentName;
+            this.directiveName = directiveName;
         }
 
         public String getObjectName() {
@@ -1344,6 +1381,10 @@ public interface SchemaDifference {
 
         public String getArgumentName() {
             return argumentName;
+        }
+
+        public String getDirectiveName() {
+            return directiveName;
         }
     }
 
@@ -1369,11 +1410,14 @@ public interface SchemaDifference {
         private final String interfaceName;
         private final String fieldName;
         private final String argumentName;
+        private final String directiveName;
 
-        public AppliedDirectiveInterfaceFieldArgumentLocation(String interfaceName, String fieldName, String argumentName) {
+
+        public AppliedDirectiveInterfaceFieldArgumentLocation(String interfaceName, String fieldName, String argumentName, String directiveName) {
             this.interfaceName = interfaceName;
             this.fieldName = fieldName;
             this.argumentName = argumentName;
+            this.directiveName = directiveName;
         }
 
         public String getInterfaceName() {
@@ -1387,13 +1431,20 @@ public interface SchemaDifference {
         public String getArgumentName() {
             return argumentName;
         }
+
+        public String getDirectiveName() {
+            return directiveName;
+        }
     }
 
     class AppliedDirectiveUnionLocation implements AppliedDirectiveLocationDetail {
         private final String name;
+        private final String directiveName;
 
-        public AppliedDirectiveUnionLocation(String name) {
+
+        public AppliedDirectiveUnionLocation(String name, String directiveName) {
             this.name = name;
+            this.directiveName = directiveName;
         }
 
         public String getName() {
@@ -1403,23 +1454,33 @@ public interface SchemaDifference {
 
     class AppliedDirectiveEnumLocation implements AppliedDirectiveLocationDetail {
         private final String name;
+        private final String directiveName;
 
-        public AppliedDirectiveEnumLocation(String name) {
+
+        public AppliedDirectiveEnumLocation(String name, String directiveName) {
             this.name = name;
+            this.directiveName = directiveName;
         }
 
         public String getName() {
             return name;
+        }
+
+        public String getDirectiveName() {
+            return directiveName;
         }
     }
 
     class AppliedDirectiveEnumValueLocation implements AppliedDirectiveLocationDetail {
         private final String enumName;
         private final String valueName;
+        private final String directiveName;
 
-        public AppliedDirectiveEnumValueLocation(String enumName, String valueName) {
+
+        public AppliedDirectiveEnumValueLocation(String enumName, String valueName, String directiveName) {
             this.enumName = enumName;
             this.valueName = valueName;
+            this.directiveName = directiveName;
         }
 
         public String getEnumName() {
@@ -1429,17 +1490,28 @@ public interface SchemaDifference {
         public String getValueName() {
             return valueName;
         }
+
+        public String getDirectiveName() {
+            return directiveName;
+        }
     }
 
     class AppliedDirectiveInputObjectLocation implements AppliedDirectiveLocationDetail {
         private final String name;
+        private final String directiveName;
 
-        public AppliedDirectiveInputObjectLocation(String name) {
+
+        public AppliedDirectiveInputObjectLocation(String name, String directiveName) {
             this.name = name;
+            this.directiveName = directiveName;
         }
 
         public String getName() {
             return name;
+        }
+
+        public String getDirectiveName() {
+            return directiveName;
         }
     }
 
@@ -1447,10 +1519,13 @@ public interface SchemaDifference {
     class AppliedDirectiveInputObjectFieldLocation implements AppliedDirectiveLocationDetail {
         private final String inputObjectName;
         private final String fieldName;
+        private final String directiveName;
 
-        public AppliedDirectiveInputObjectFieldLocation(String inputObjectName, String fieldName) {
+
+        public AppliedDirectiveInputObjectFieldLocation(String inputObjectName, String fieldName, String directiveName) {
             this.inputObjectName = inputObjectName;
             this.fieldName = fieldName;
+            this.directiveName = directiveName;
         }
 
         public String getInputObjectName() {
@@ -1459,6 +1534,10 @@ public interface SchemaDifference {
 
         public String getFieldName() {
             return fieldName;
+        }
+
+        public String getDirectiveName() {
+            return directiveName;
         }
     }
 

--- a/src/main/java/graphql/schema/idl/DirectiveInfo.java
+++ b/src/main/java/graphql/schema/idl/DirectiveInfo.java
@@ -22,7 +22,9 @@ public class DirectiveInfo {
             Directives.IncludeDirective,
             Directives.SkipDirective,
             Directives.DeprecatedDirective,
-            Directives.SpecifiedByDirective);
+            Directives.SpecifiedByDirective,
+            Directives.OneOfDirective
+    );
 
     /**
      * A map from directive name to directive which provided by specification
@@ -31,7 +33,9 @@ public class DirectiveInfo {
             Directives.IncludeDirective.getName(), Directives.IncludeDirective,
             Directives.SkipDirective.getName(), Directives.SkipDirective,
             Directives.DeprecatedDirective.getName(), Directives.DeprecatedDirective,
-            Directives.SpecifiedByDirective.getName(), Directives.SpecifiedByDirective);
+            Directives.SpecifiedByDirective.getName(), Directives.SpecifiedByDirective,
+            Directives.OneOfDirective.getName(), Directives.OneOfDirective
+            );
 
     /**
      * Returns true if a directive with provided directiveName has been defined in graphql specification

--- a/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
+++ b/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
@@ -82,6 +82,7 @@ import static graphql.Assert.assertNotNull;
 import static graphql.Directives.DEPRECATED_DIRECTIVE_DEFINITION;
 import static graphql.Directives.IncludeDirective;
 import static graphql.Directives.NO_LONGER_SUPPORTED;
+import static graphql.Directives.ONE_OF_DIRECTIVE_DEFINITION;
 import static graphql.Directives.SPECIFIED_BY_DIRECTIVE_DEFINITION;
 import static graphql.Directives.SkipDirective;
 import static graphql.Directives.SpecifiedByDirective;
@@ -1079,6 +1080,7 @@ public class SchemaGeneratorHelper {
         // we synthesize this into the type registry - no need for them to add it
         typeRegistry.add(DEPRECATED_DIRECTIVE_DEFINITION);
         typeRegistry.add(SPECIFIED_BY_DIRECTIVE_DEFINITION);
+        typeRegistry.add(ONE_OF_DIRECTIVE_DEFINITION);
     }
 
     private Optional<OperationTypeDefinition> getOperationNamed(String name, Map<String, OperationTypeDefinition> operationTypeDefs) {

--- a/src/main/java/graphql/schema/validation/OneOfInputObjectRules.java
+++ b/src/main/java/graphql/schema/validation/OneOfInputObjectRules.java
@@ -1,0 +1,41 @@
+package graphql.schema.validation;
+
+import graphql.ExperimentalApi;
+import graphql.schema.GraphQLInputObjectField;
+import graphql.schema.GraphQLInputObjectType;
+import graphql.schema.GraphQLSchemaElement;
+import graphql.schema.GraphQLTypeUtil;
+import graphql.schema.GraphQLTypeVisitorStub;
+import graphql.util.TraversalControl;
+import graphql.util.TraverserContext;
+
+import static java.lang.String.format;
+
+/*
+ * Spec: If the Input Object is a OneOf Input Object then:
+ * The type of the input field must be nullable.
+ * The input field must not have a default value.
+ */
+@ExperimentalApi
+public class OneOfInputObjectRules extends GraphQLTypeVisitorStub {
+
+    @Override
+    public TraversalControl visitGraphQLInputObjectField(GraphQLInputObjectField inputObjectField, TraverserContext<GraphQLSchemaElement> context) {
+        GraphQLInputObjectType inputObjectType = (GraphQLInputObjectType) context.getParentNode();
+        if (!inputObjectType.isOneOf()) {
+            return TraversalControl.CONTINUE;
+        }
+        SchemaValidationErrorCollector errorCollector = context.getVarFromParents(SchemaValidationErrorCollector.class);
+        // error messages take from the reference implementation
+        if (inputObjectField.hasSetDefaultValue()) {
+            String message = format("OneOf input field %s.%s cannot have a default value.", inputObjectType.getName(), inputObjectField.getName());
+            errorCollector.addError(new SchemaValidationError(SchemaValidationErrorType.OneOfDefaultValueOnField, message));
+        }
+
+        if (GraphQLTypeUtil.isNonNull(inputObjectField.getType())) {
+            String message = format("OneOf input field %s.%s must be nullable.", inputObjectType.getName(), inputObjectField.getName());
+            errorCollector.addError(new SchemaValidationError(SchemaValidationErrorType.OneOfNonNullableField, message));
+        }
+        return TraversalControl.CONTINUE;
+    }
+}

--- a/src/main/java/graphql/schema/validation/SchemaValidationErrorType.java
+++ b/src/main/java/graphql/schema/validation/SchemaValidationErrorType.java
@@ -20,4 +20,6 @@ public enum SchemaValidationErrorType implements SchemaValidationErrorClassifica
     InvalidAppliedDirective,
     OutputTypeUsedInInputTypeContext,
     InputTypeUsedInOutputTypeContext,
+    OneOfDefaultValueOnField,
+    OneOfNonNullableField
 }

--- a/src/main/java/graphql/schema/validation/SchemaValidator.java
+++ b/src/main/java/graphql/schema/validation/SchemaValidator.java
@@ -25,6 +25,7 @@ public class SchemaValidator {
         rules.add(new AppliedDirectivesAreValid());
         rules.add(new AppliedDirectiveArgumentsAreValid());
         rules.add(new InputAndOutputTypesUsedAppropriately());
+        rules.add(new OneOfInputObjectRules());
     }
 
     public List<GraphQLTypeVisitor> getRules() {

--- a/src/main/java/graphql/util/FpKit.java
+++ b/src/main/java/graphql/util/FpKit.java
@@ -265,7 +265,7 @@ public class FpKit {
         return cf.thenApply(FpKit::flatList);
     }
 
-    public static <T> List<T> flatList(List<List<T>> listLists) {
+    public static <T> List<T> flatList(Collection<List<T>> listLists) {
         return listLists.stream()
                 .flatMap(List::stream)
                 .collect(ImmutableList.toImmutableList());

--- a/src/main/java/graphql/util/InterThreadMemoizedSupplier.java
+++ b/src/main/java/graphql/util/InterThreadMemoizedSupplier.java
@@ -5,7 +5,7 @@ import graphql.Internal;
 import java.util.function.Supplier;
 
 /**
- * This memoizing supplier DOES use synchronised double locking to set its value.
+ * This memoizing supplier DOES use locked double locking to set its value.
  *
  * @param <T> for two
  */
@@ -14,6 +14,7 @@ public class InterThreadMemoizedSupplier<T> implements Supplier<T> {
 
     private final Supplier<T> delegate;
     private volatile boolean initialized;
+    private final LockKit.ReentrantLock lock = new LockKit.ReentrantLock();
     private T value;
 
     public InterThreadMemoizedSupplier(Supplier<T> delegate) {
@@ -24,13 +25,16 @@ public class InterThreadMemoizedSupplier<T> implements Supplier<T> {
     @Override
     public T get() {
         if (!initialized) {
-            synchronized (this) {
+            lock.lock();
+            try {
                 if (initialized) {
                     return value;
                 }
                 value = delegate.get();
                 initialized = true;
                 return value;
+            } finally {
+                lock.unlock();
             }
         }
         return value;

--- a/src/main/java/graphql/util/LockKit.java
+++ b/src/main/java/graphql/util/LockKit.java
@@ -1,0 +1,87 @@
+package graphql.util;
+
+import graphql.Internal;
+
+import java.util.concurrent.locks.Lock;
+import java.util.function.Supplier;
+
+/**
+ * This provides reentrant locking support for our code base.  Future worlds like Loom virtual threads don't like
+ * synchronised calls since they pin the VT to the carrier thread.  Word on the street is that locks are preferred
+ * to synchronised.
+ */
+@Internal
+public class LockKit {
+
+    /**
+     * A class to run code inside a reentrant lock
+     */
+    public static class ReentrantLock {
+        private final Lock lock = new java.util.concurrent.locks.ReentrantLock();
+
+        /**
+         * Sometimes you need to directly lock things like for checked exceptions
+         * <p>
+         * It's on you to unlock it!
+         */
+        public void lock() {
+            lock.lock();
+        }
+
+        public void unlock() {
+            lock.unlock();
+        }
+
+        public void runLocked(Runnable codeToRun) {
+            lock.lock();
+            try {
+                codeToRun.run();
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        public <E> E callLocked(Supplier<E> codeToRun) {
+            lock.lock();
+            try {
+                return codeToRun.get();
+            } finally {
+                lock.unlock();
+            }
+        }
+    }
+
+
+    /**
+     * Will allow for lazy computation of some values just once
+     */
+    public static class ComputedOnce {
+
+        private volatile boolean beenComputed = false;
+        private final ReentrantLock lock = new ReentrantLock();
+
+
+        public boolean hasBeenComputed() {
+            return beenComputed;
+        }
+
+        public void runOnce(Runnable codeToRunOnce) {
+            if (beenComputed) {
+                return;
+            }
+            lock.runLocked(() -> {
+                // double lock check
+                if (beenComputed) {
+                    return;
+                }
+                try {
+                    codeToRunOnce.run();
+                    beenComputed = true;
+                } finally {
+                    // even for exceptions we will say its computed
+                    beenComputed = true;
+                }
+            });
+        }
+    }
+}

--- a/src/main/java/graphql/validation/rules/OverlappingFieldsCanBeMerged.java
+++ b/src/main/java/graphql/validation/rules/OverlappingFieldsCanBeMerged.java
@@ -135,7 +135,7 @@ public class OverlappingFieldsCanBeMerged extends AbstractRule {
             GraphQLFieldDefinition fieldDefinition = getVisibleFieldDefinition(fieldsContainer, field);
             fieldType = fieldDefinition != null ? fieldDefinition.getType() : null;
         }
-        fieldMap.get(responseName).add(new FieldAndType(field, fieldType, parentType));
+        fieldMap.get(responseName).add(new FieldAndType(field, fieldType, unwrappedParent));
     }
 
     private GraphQLFieldDefinition getVisibleFieldDefinition(GraphQLFieldsContainer fieldsContainer, Field field) {

--- a/src/main/resources/i18n/Execution.properties
+++ b/src/main/resources/i18n/Execution.properties
@@ -4,3 +4,5 @@
 # REMEMBER - a single quote ' in MessageFormat means things that are never replaced within them
 # so use 2 '' characters to make it one ' on output.  This will take for the form ''{0}''
 #
+Execution.handleOneOfNotOneFieldError=Exactly one key must be specified for OneOf type ''{0}''.
+Execution.handleOneOfValueIsNullError=OneOf type field ''{0}'' must be non-null.

--- a/src/main/resources/i18n/Validation.properties
+++ b/src/main/resources/i18n/Validation.properties
@@ -98,4 +98,3 @@ ArgumentValidationUtil.handleNotObjectError=Validation error ({0}) : argument ''
 ArgumentValidationUtil.handleMissingFieldsError=Validation error ({0}) : argument ''{1}'' with value ''{2}'' is missing required fields ''{3}''
 # suppress inspection "UnusedProperty"
 ArgumentValidationUtil.handleExtraFieldError=Validation error ({0}) : argument ''{1}'' with value ''{2}'' contains a field not in ''{3}'': ''{4}''
-#

--- a/src/test/groovy/graphql/Issue2141.groovy
+++ b/src/test/groovy/graphql/Issue2141.groovy
@@ -36,6 +36,9 @@ directive @include(
     if: Boolean!
   ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
+"Indicates an Input Object is a OneOf Input Object."
+directive @oneOf on INPUT_OBJECT
+
 "Directs the executor to skip this field or fragment when the `if` argument is true."
 directive @skip(
     "Skipped when true."

--- a/src/test/groovy/graphql/StarWarsIntrospectionTests.groovy
+++ b/src/test/groovy/graphql/StarWarsIntrospectionTests.groovy
@@ -430,6 +430,6 @@ class StarWarsIntrospectionTests extends Specification {
         schemaParts.get('mutationType').size() == 1
         schemaParts.get('subscriptionType') == null
         schemaParts.get('types').size() == 17
-        schemaParts.get('directives').size() == 4
+        schemaParts.get('directives').size() == 5
     }
 }

--- a/src/test/groovy/graphql/execution/ExecutionStrategyErrorsTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategyErrorsTest.groovy
@@ -1,0 +1,132 @@
+package graphql.execution
+
+import graphql.ExceptionWhileDataFetching
+import graphql.ExecutionInput
+import graphql.ExecutionResult
+import graphql.GraphQL
+import graphql.SerializationError
+import graphql.TestUtil
+import graphql.TypeMismatchError
+import graphql.execution.instrumentation.Instrumentation
+import graphql.execution.instrumentation.InstrumentationContext
+import graphql.execution.instrumentation.InstrumentationState
+import graphql.execution.instrumentation.SimplePerformantInstrumentation
+import graphql.execution.instrumentation.parameters.InstrumentationFieldCompleteParameters
+import graphql.schema.DataFetcher
+import spock.lang.Specification
+
+/**
+ * A test of errors that can happen inside a ES
+ */
+class ExecutionStrategyErrorsTest extends Specification {
+
+    def "can capture certain errors"() {
+        def sdl = '''
+            type Query {
+                notAList : [String]
+                notAFloat : Float
+                notAnProperObject : ImproperObject
+            }
+            
+            
+            type ImproperObject {
+                name : String
+                diceyListCall : [DiceyCall!]!
+                diceyListCallAbort : [DiceyCall!]!
+                diceyCall : DiceyCall
+            }
+            
+            type DiceyCall {
+                bang : String
+                abort : String
+                nonNull : String!
+            }
+        '''
+
+        DataFetcher dfNotAList = { env -> "noAList" }
+        DataFetcher dfNotAFloat = { env -> "noAFloat" }
+        DataFetcher dfDiceyBang = {
+            env -> throw new RuntimeException("dicey call")
+        }
+        DataFetcher dfDiceyAbort = {
+            env -> throw new AbortExecutionException("abort abort")
+        }
+        DataFetcher dfDiceyListCall = {
+            env -> ["x", null]
+        }
+        DataFetcher dfReturnsNull = {
+            env -> null
+        }
+
+        def schema = TestUtil.schema(sdl, [
+                Query         :
+                        [notAList: dfNotAList, notAFloat: dfNotAFloat],
+                ImproperObject:
+                        [diceyListCall: dfDiceyListCall],
+                DiceyCall     :
+                        [bang: dfDiceyBang, abort: dfDiceyAbort, nonNull: dfReturnsNull],
+        ]
+        )
+
+        Instrumentation instrumentation = new SimplePerformantInstrumentation() {
+            @Override
+            InstrumentationContext<ExecutionResult> beginFieldListComplete(InstrumentationFieldCompleteParameters parameters, InstrumentationState state) {
+                if (parameters.field.name == "diceyListCallAbort") {
+                    throw new AbortExecutionException("No lists for you")
+                }
+                return super.beginFieldListComplete(parameters, state)
+            }
+        }
+        def graphQL = GraphQL.newGraphQL(schema).instrumentation(instrumentation).build()
+
+
+        when:
+        def ei = ExecutionInput.newExecutionInput()
+                .query("""
+            query q {
+                notAList
+                notAFloat
+                notAnProperObject {
+                    name
+                    diceyListCallAbort {
+                        bang
+                    }    
+                    diceyListCall {
+                        bang
+                        abort
+                        nonNull
+                    }    
+                }
+            }
+        """)
+                .root([notAnProperObject: ["name"              : "make it drive errors",
+                                           "diceyListCall"     : [[:]],
+                                           "diceyListCallAbort": [[:]],
+                                           "diceyCall"         : [:]
+                ]])
+                .build()
+        def er = graphQL.execute(ei)
+
+        then:
+        er.errors.size() == 6
+        er.errors[0] instanceof TypeMismatchError
+        er.errors[0].path == ["notAList"]
+
+        er.errors[1] instanceof SerializationError
+        er.errors[1].path == ["notAFloat"]
+
+        er.errors[2] instanceof ExceptionWhileDataFetching
+        er.errors[2].path ==["notAnProperObject", "diceyListCall", 0, "bang"]
+        ((ExceptionWhileDataFetching)er.errors[2]).exception.message == "dicey call"
+
+        er.errors[3] instanceof ExceptionWhileDataFetching
+        er.errors[3].path ==["notAnProperObject", "diceyListCall", 0, "abort"]
+        ((ExceptionWhileDataFetching)er.errors[3]).exception.message == "abort abort"
+
+        er.errors[4] instanceof NonNullableFieldWasNullError
+        er.errors[4].path ==["notAnProperObject", "diceyListCall", 0, "nonNull"]
+
+        er.errors[5] instanceof NonNullableFieldWasNullError
+        er.errors[5].path ==["notAnProperObject", "diceyListCall", 1]  // the entry itself was null in a non null list entry
+    }
+}

--- a/src/test/groovy/graphql/execution/ValuesResolverTest.groovy
+++ b/src/test/groovy/graphql/execution/ValuesResolverTest.groovy
@@ -1,5 +1,6 @@
 package graphql.execution
 
+import graphql.Directives
 import graphql.ErrorType
 import graphql.ExecutionInput
 import graphql.GraphQLContext
@@ -22,6 +23,7 @@ import graphql.language.Value
 import graphql.language.VariableDefinition
 import graphql.language.VariableReference
 import graphql.schema.CoercingParseValueException
+import graphql.schema.GraphQLNonNull
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -137,22 +139,22 @@ class ValuesResolverTest extends Specification {
         given:
         def schema = TestUtil.schemaWithInputType(list(GraphQLString))
         VariableDefinition variableDefinition = new VariableDefinition("variable", new ListType(new TypeName("String")))
-        List<String> value = ["hello","world"]
+        List<String> value = ["hello", "world"]
         when:
         def resolvedValues = ValuesResolver.coerceVariableValues(schema, [variableDefinition], RawVariables.of([variable: value]), graphQLContext, locale)
         then:
-        resolvedValues.get('variable') == ['hello','world']
+        resolvedValues.get('variable') == ['hello', 'world']
     }
 
     def "getVariableValues: array value gets resolved to a list when the type is a List"() {
         given:
         def schema = TestUtil.schemaWithInputType(list(GraphQLString))
         VariableDefinition variableDefinition = new VariableDefinition("variable", new ListType(new TypeName("String")))
-        String[] value = ["hello","world"] as String[]
+        String[] value = ["hello", "world"] as String[]
         when:
         def resolvedValues = ValuesResolver.coerceVariableValues(schema, [variableDefinition], RawVariables.of([variable: value]), graphQLContext, locale)
         then:
-        resolvedValues.get('variable') == ['hello','world']
+        resolvedValues.get('variable') == ['hello', 'world']
     }
 
     def "getArgumentValues: resolves argument with variable reference"() {
@@ -343,6 +345,210 @@ class ValuesResolverTest extends Specification {
 
         then:
         values['arg'] == ['world']
+    }
+
+    def "getArgumentValues: invalid oneOf input because of duplicate keys - #testCase"() {
+        given: "schema defining input object"
+        def inputObjectType = newInputObject()
+                .name("oneOfInputObject")
+                .withAppliedDirective(Directives.OneOfDirective.toAppliedDirective())
+                .field(newInputObjectField()
+                        .name("a")
+                        .type(GraphQLString)
+                        .build())
+                .field(newInputObjectField()
+                        .name("b")
+                        .type(GraphQLInt)
+                        .build())
+                .build()
+
+        def argument = new Argument("arg", inputValue)
+
+        when:
+        def fieldArgument = newArgument().name("arg").type(inputObjectType).build()
+        ValuesResolver.getArgumentValues([fieldArgument], [argument], variables, graphQLContext, locale)
+
+        then:
+        def e = thrown(OneOfTooManyKeysException)
+        e.message == "Exactly one key must be specified for OneOf type 'oneOfInputObject'."
+
+        when: "input type is wrapped in non-null"
+        def nonNullInputObjectType = GraphQLNonNull.nonNull(inputObjectType)
+        def fieldArgumentNonNull = newArgument().name("arg").type(nonNullInputObjectType).build()
+        ValuesResolver.getArgumentValues([fieldArgumentNonNull], [argument], variables, graphQLContext, locale)
+
+        then:
+        def eNonNull = thrown(OneOfTooManyKeysException)
+        eNonNull.message == "Exactly one key must be specified for OneOf type 'oneOfInputObject'."
+
+        where:
+        // from https://github.com/graphql/graphql-spec/pull/825/files#diff-30a69c5a5eded8e1aea52e53dad1181e6ec8f549ca2c50570b035153e2de1c43R1692
+        testCase                             | inputValue   | variables
+
+        '{ a: "abc", b: 123 } {}'            | buildObjectLiteral([
+                a: StringValue.of("abc"),
+                b: IntValue.of(123)
+        ])                                                  | CoercedVariables.emptyVariables()
+
+        '{ a: null, b: 123 } {}'             | buildObjectLiteral([
+                a: NullValue.of(),
+                b: IntValue.of(123)
+        ])                                                  | CoercedVariables.emptyVariables()
+
+        '{ a: $var, b: 123 } { var: null }'  | buildObjectLiteral([
+                a: VariableReference.of("var"),
+                b: IntValue.of(123)
+        ])                                                  | CoercedVariables.of(["var": null])
+
+        '{ a: $var, b: 123 } {}'             | buildObjectLiteral([
+                a: VariableReference.of("var"),
+                b: IntValue.of(123)
+        ])                                                  | CoercedVariables.emptyVariables()
+
+        '{ a : "abc", b : null} {}'          | buildObjectLiteral([
+                a: StringValue.of("abc"),
+                b: NullValue.of()
+        ])                                                  | CoercedVariables.emptyVariables()
+
+        '{ a : null, b : null} {}'           | buildObjectLiteral([
+                a: NullValue.of(),
+                b: NullValue.of()
+        ])                                                  | CoercedVariables.emptyVariables()
+
+        '{ a : $a, b : $b} {a : "abc"}'      | buildObjectLiteral([
+                a: VariableReference.of("a"),
+                b: VariableReference.of("v")
+        ])                                                  | CoercedVariables.of(["a": "abc"])
+
+        '$var {var : { a : "abc", b : 123}}' | VariableReference.of("var")
+                                                            | CoercedVariables.of(["var": ["a": "abc", "b": 123]])
+
+        '$var {var : {}}'                    | VariableReference.of("var")
+                                                            | CoercedVariables.of(["var": [:]])
+    }
+
+    def "getArgumentValues: invalid oneOf input because of null value - #testCase"() {
+        given: "schema defining input object"
+        def inputObjectType = newInputObject()
+                .name("oneOfInputObject")
+                .withAppliedDirective(Directives.OneOfDirective.toAppliedDirective())
+                .field(newInputObjectField()
+                        .name("a")
+                        .type(GraphQLString)
+                        .build())
+                .field(newInputObjectField()
+                        .name("b")
+                        .type(GraphQLInt)
+                        .build())
+                .build()
+        def fieldArgument = newArgument().name("arg").type(inputObjectType).build()
+
+        when:
+        def argument = new Argument("arg", inputValue)
+        ValuesResolver.getArgumentValues([fieldArgument], [argument], variables, graphQLContext, locale)
+
+        then:
+        def e = thrown(OneOfNullValueException)
+        e.message == "OneOf type field 'oneOfInputObject.a' must be non-null."
+
+        where:
+        // from https://github.com/graphql/graphql-spec/pull/825/files#diff-30a69c5a5eded8e1aea52e53dad1181e6ec8f549ca2c50570b035153e2de1c43R1692
+        testCase                       | inputValue   | variables
+
+        '`{ a: null }` {}'             | buildObjectLiteral([
+                a: NullValue.of()
+        ])                                            | CoercedVariables.emptyVariables()
+
+        '`{ a: $var }`  { var : null}' | buildObjectLiteral([
+                a: VariableReference.of("var")
+        ])                                            | CoercedVariables.of(["var": null])
+
+    }
+
+    def "getArgumentValues: valid oneOf input - #testCase"() {
+        given: "schema defining input object"
+        def inputObjectType = newInputObject()
+                .name("oneOfInputObject")
+                .withAppliedDirective(Directives.OneOfDirective.toAppliedDirective())
+                .field(newInputObjectField()
+                        .name("a")
+                        .type(GraphQLString)
+                        .build())
+                .field(newInputObjectField()
+                        .name("b")
+                        .type(GraphQLInt)
+                        .build())
+                .build()
+        def fieldArgument = newArgument().name("arg").type(inputObjectType).build()
+
+        when:
+        def argument = new Argument("arg", inputValue)
+        def values = ValuesResolver.getArgumentValues([fieldArgument], [argument], variables, graphQLContext, locale)
+
+        then:
+        values == expectedValues
+
+        where:
+        // from https://github.com/graphql/graphql-spec/pull/825/files#diff-30a69c5a5eded8e1aea52e53dad1181e6ec8f549ca2c50570b035153e2de1c43R1692
+        testCase                       | inputValue   | variables                              | expectedValues
+
+        '{ b: 123 }` {}'               | buildObjectLiteral([
+                b: IntValue.of(123)
+        ])                                            | CoercedVariables.emptyVariables()      | [arg: [b: 123]]
+
+        '`$var` { var: { b: 123 } }'   | VariableReference.of("var")
+                                                      | CoercedVariables.of([var: [b: 123]])   | [arg: [b: 123]]
+
+        '{ a: "abc" }` {}'             | buildObjectLiteral([
+                a: StringValue.of("abc")
+        ])                                            | CoercedVariables.emptyVariables()      | [arg: [a: "abc"]]
+
+
+        '`$var` { var: { a: "abc" } }' | VariableReference.of("var")
+                                                      | CoercedVariables.of([var: [a: "abc"]]) | [arg: [a: "abc"]]
+
+        '{ a: $var }` { var : "abc"}'  | buildObjectLiteral([
+                a: VariableReference.of("var")
+        ])                                            | CoercedVariables.of([var: "abc"])      | [arg: [a: "abc"]]
+
+    }
+
+    def "getArgumentValues: invalid oneOf input no values where passed - #testCase"() {
+        given: "schema defining input object"
+        def inputObjectType = newInputObject()
+                .name("oneOfInputObject")
+                .withAppliedDirective(Directives.OneOfDirective.toAppliedDirective())
+                .field(newInputObjectField()
+                        .name("a")
+                        .type(GraphQLString)
+                        .build())
+                .field(newInputObjectField()
+                        .name("b")
+                        .type(GraphQLInt)
+                        .build())
+                .build()
+        def fieldArgument = newArgument().name("arg").type(inputObjectType).build()
+
+        when:
+        def argument = new Argument("arg", inputValue)
+        ValuesResolver.getArgumentValues([fieldArgument], [argument], variables, graphQLContext, locale)
+
+        then:
+        def e = thrown(OneOfNullValueException)
+        e.message == "OneOf type field 'oneOfInputObject.a' must be non-null."
+
+        where:
+        // from https://github.com/graphql/graphql-spec/pull/825/files#diff-30a69c5a5eded8e1aea52e53dad1181e6ec8f549ca2c50570b035153e2de1c43R1692
+        testCase                       | inputValue   | variables
+
+        '`{ a: null }` {}'             | buildObjectLiteral([
+                a: NullValue.of()
+        ])                                            | CoercedVariables.emptyVariables()
+
+        '`{ a: $var }`  { var : null}' | buildObjectLiteral([
+                a: VariableReference.of("var")
+        ])                                            | CoercedVariables.of(["var": null])
+
     }
 
     def "getVariableValues: enum as variable input"() {
@@ -594,7 +800,7 @@ class ValuesResolverTest extends Specification {
 
         def executionInput = ExecutionInput.newExecutionInput()
                 .query(mutation)
-                .variables([input: [name: 'Name', position: 'UNKNOWN_POSITION'] ])
+                .variables([input: [name: 'Name', position: 'UNKNOWN_POSITION']])
                 .build()
 
         def executionResult = graphQL.execute(executionInput)
@@ -632,7 +838,7 @@ class ValuesResolverTest extends Specification {
 
         def executionInput = ExecutionInput.newExecutionInput()
                 .query(mutation)
-                .variables([input: [name: 'Name', hilarious: 'sometimes'] ])
+                .variables([input: [name: 'Name', hilarious: 'sometimes']])
                 .build()
 
         def executionResult = graphQL.execute(executionInput)
@@ -670,7 +876,7 @@ class ValuesResolverTest extends Specification {
 
         def executionInput = ExecutionInput.newExecutionInput()
                 .query(mutation)
-                .variables([input: [name: 'Name', laughsPerMinute: 'none'] ])
+                .variables([input: [name: 'Name', laughsPerMinute: 'none']])
                 .build()
 
         def executionResult = graphQL.execute(executionInput)

--- a/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
@@ -5,6 +5,7 @@ import graphql.ExecutionResult
 import graphql.GraphQL
 import graphql.StarWarsSchema
 import graphql.execution.AsyncExecutionStrategy
+import graphql.execution.instrumentation.parameters.InstrumentationCreateStateParameters
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionStrategyParameters
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters
@@ -403,5 +404,57 @@ class InstrumentationTest extends Specification {
         ]
 
         instrumentation.executionList == expected
+    }
+
+    class StringInstrumentationState implements InstrumentationState {
+        StringInstrumentationState(String value) {
+            this.value = value
+        }
+
+        String value
+    }
+
+    def "can have an single async createState() in play"() {
+
+
+        given:
+
+        def query = '''query Q($var: String!) {
+                                  human(id: $var) {
+                                    id
+                                    name
+                                  }
+                                }
+                            '''
+
+
+        def instrumentation1 = new SimplePerformantInstrumentation() {
+            @Override
+            CompletableFuture<InstrumentationState> createStateAsync(InstrumentationCreateStateParameters parameters) {
+                return CompletableFuture.supplyAsync {
+                    return new StringInstrumentationState("I1")
+                } as CompletableFuture<InstrumentationState>
+            }
+
+            @Override
+            CompletableFuture<ExecutionResult> instrumentExecutionResult(ExecutionResult executionResult, InstrumentationExecutionParameters parameters, InstrumentationState state) {
+                return CompletableFuture.completedFuture(
+                        executionResult.transform { it.addExtension("i1", ((StringInstrumentationState) state).value) }
+                )
+            }
+        }
+
+        def graphQL = GraphQL
+                .newGraphQL(StarWarsSchema.starWarsSchema)
+                .instrumentation(instrumentation1)
+                .doNotAddDefaultInstrumentations() // important, otherwise a chained one wil be used
+                .build()
+
+        when:
+        def variables = [var: "1001"]
+        def er = graphQL.execute(ExecutionInput.newExecutionInput().query(query).variables(variables)) // Luke
+
+        then:
+        er.extensions == [i1: "I1"]
     }
 }

--- a/src/test/groovy/graphql/introspection/IntrospectionWithDirectivesSupportTest.groovy
+++ b/src/test/groovy/graphql/introspection/IntrospectionWithDirectivesSupportTest.groovy
@@ -89,7 +89,10 @@ class IntrospectionWithDirectivesSupportTest extends Specification {
 
         def schemaType = er.data["__schema"]
 
-        schemaType["directives"] == [[name: "include"], [name: "skip"], [name: "example"], [name: "secret"], [name: "noDefault"], [name: "deprecated"], [name: "specifiedBy"]]
+        schemaType["directives"] == [
+                [name: "include"], [name: "skip"], [name: "example"], [name: "secret"],
+                [name: "noDefault"], [name: "deprecated"], [name: "specifiedBy"], [name: "oneOf"]
+        ]
 
         schemaType["appliedDirectives"] == [[name: "example", args: [[name: "argName", value: '"onSchema"']]]]
 
@@ -170,7 +173,7 @@ class IntrospectionWithDirectivesSupportTest extends Specification {
 
         def definedDirectives = er.data["__schema"]["directives"]
         // secret is filter out
-        definedDirectives == [[name: "include"], [name: "skip"], [name: "example"], [name: "deprecated"], [name: "specifiedBy"]]
+        definedDirectives == [[name: "include"], [name: "skip"], [name: "example"], [name: "deprecated"], [name: "specifiedBy"], [name: "oneOf"]]
     }
 
     def "can set prefixes onto the Applied types"() {

--- a/src/test/groovy/graphql/language/SourceLocationTest.groovy
+++ b/src/test/groovy/graphql/language/SourceLocationTest.groovy
@@ -1,0 +1,71 @@
+package graphql.language
+
+import graphql.parser.MultiSourceReader
+import graphql.schema.idl.RuntimeWiring
+import graphql.schema.idl.SchemaGenerator
+import graphql.schema.idl.SchemaParser
+import spock.lang.Specification
+
+import static graphql.schema.FieldCoordinates.coordinates
+
+class SourceLocationTest extends Specification {
+
+    def "can get source location"() {
+        def sdl = """
+            type Query {
+                a : A!
+            }
+            
+            type A {
+                b : B
+            }
+            
+            type B {
+                c : String
+            } 
+        """
+
+        def sourceReader = MultiSourceReader.newMultiSourceReader().string(sdl, "sourceName").build()
+
+        def definitionRegistry = new SchemaParser().parse(sourceReader)
+        when:
+        def schema = new SchemaGenerator().makeExecutableSchema(definitionRegistry, RuntimeWiring.MOCKED_WIRING)
+        def schemaElement = schema.getType("Query")
+        def location = SourceLocation.getLocation(schemaElement)
+
+        then:
+        location.sourceName == "sourceName"
+        location.line == 2
+        location.column == 13
+
+        when:
+        schemaElement = schema.getFieldDefinition(coordinates("Query", "a"))
+        location = SourceLocation.getLocation(schemaElement)
+
+        then:
+        location.sourceName == "sourceName"
+        location.line == 3
+        location.column == 17
+
+        when:
+        schemaElement = schema.getFieldDefinition(coordinates("Query", "a")).getType()
+        // unwrapped
+        location = SourceLocation.getLocation(schemaElement)
+
+        then:
+        location.sourceName == "sourceName"
+        location.line == 6
+        location.column == 13
+
+        when:
+        schemaElement = schema.getType("A")
+        location = SourceLocation.getLocation(schemaElement)
+
+        then:
+        location.sourceName == "sourceName"
+        location.line == 6
+        location.column == 13
+
+
+    }
+}

--- a/src/test/groovy/graphql/schema/GraphQLInputObjectTypeTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLInputObjectTypeTest.groovy
@@ -1,7 +1,11 @@
 package graphql.schema
 
+import graphql.Directives
+import graphql.ExecutionInput
+import graphql.GraphQL
 import graphql.GraphQLContext
 import graphql.StarWarsSchema
+import graphql.TestUtil
 import graphql.language.ObjectValue
 import graphql.validation.ValidationUtil
 import spock.lang.Specification
@@ -78,5 +82,102 @@ class GraphQLInputObjectTypeTest extends Specification {
 
         expect:
         validationUtil.isValidLiteralValue(objectValue.build(), inputObjectType, schema, graphQLContext, Locale.ENGLISH)
+    }
+
+    def "can detect one of support"() {
+        when:
+        def inputObjectType = newInputObject().name("TestInputObjectType")
+                .field(newInputObjectField().name("NAME").type(GraphQLInt))
+                .build()
+        then:
+        !inputObjectType.isOneOf()
+
+        when:
+        inputObjectType = newInputObject().name("TestInputObjectType")
+                .field(newInputObjectField().name("NAME").type(GraphQLInt))
+                .withDirective(Directives.OneOfDirective)
+                .build()
+        then:
+        inputObjectType.isOneOf()
+
+        when:
+        inputObjectType = newInputObject().name("TestInputObjectType")
+                .field(newInputObjectField().name("NAME").type(GraphQLInt))
+                .withAppliedDirective(Directives.OneOfDirective.toAppliedDirective())
+                .build()
+        then:
+        inputObjectType.isOneOf()
+    }
+
+    def "e2e test of oneOf support"() {
+        def sdl = '''
+            type Query {
+                f(arg : OneOf) : [KV]
+            }
+            
+            type KV {
+                key : String
+                value : String
+            }
+            
+            input OneOf @oneOf {
+                a : String
+                b : Int
+            }
+        '''
+
+        DataFetcher df = { DataFetchingEnvironment env ->
+            Map<String, Object> arg = env.getArgument("arg")
+
+            def l = []
+            for (Map.Entry<String, Object> entry : arg.entrySet()) {
+                l.add(["key": entry.getKey(), "value": String.valueOf(entry.getValue())])
+            }
+            return l
+        }
+
+        def graphQLSchema = TestUtil.schema(sdl, [Query: [f: df]])
+        def graphQL = GraphQL.newGraphQL(graphQLSchema).build()
+
+        when:
+        def er = graphQL.execute('query q { f( arg : {a : "abc"}) { key value }}')
+        def l = (er.data["f"] as List)
+        then:
+        er.errors.isEmpty()
+        l.size() == 1
+        l[0]["key"] == "a"
+        l[0]["value"] == "abc"
+
+        when:
+        er = graphQL.execute('query q { f( arg : {b : 123}) { key value }}')
+        l = (er.data["f"] as List)
+
+        then:
+        er.errors.isEmpty()
+        l.size() == 1
+        l[0]["key"] == "b"
+        l[0]["value"] == "123"
+
+        when:
+        er = graphQL.execute('query q { f( arg : {a : "abc", b : 123}) { key value }}')
+        then:
+        !er.errors.isEmpty()
+        er.errors[0].message == "Exception while fetching data (/f) : Exactly one key must be specified for OneOf type 'OneOf'."
+
+        when:
+        def ei = ExecutionInput.newExecutionInput('query q($var : OneOf)  { f( arg : $var) { key value }}').variables([var: [a: "abc", b: 123]]).build()
+        er = graphQL.execute(ei)
+        then:
+        !er.errors.isEmpty()
+        er.errors[0].message == "Exception while fetching data (/f) : Exactly one key must be specified for OneOf type 'OneOf'."
+
+        when:
+        ei = ExecutionInput.newExecutionInput('query q($var : OneOf)  { f( arg : $var) { key value }}').variables([var: [a: null]]).build()
+        er = graphQL.execute(ei)
+        then:
+        !er.errors.isEmpty()
+        er.errors[0].message == "Exception while fetching data (/f) : OneOf type field 'OneOf.a' must be non-null."
+
+        // lots more covered in unit tests
     }
 }

--- a/src/test/groovy/graphql/schema/GraphQLSchemaTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLSchemaTest.groovy
@@ -136,22 +136,22 @@ class GraphQLSchemaTest extends Specification {
         when: "no additional directives have been specified"
         def schema = schemaBuilder.build()
         then:
-        schema.directives.size() == 4
+        schema.directives.size() == 5
 
         when: "clear directives is called"
         schema = schemaBuilder.clearDirectives().build()
         then:
-        schema.directives.size() == 2 // @deprecated and @specifiedBy is ALWAYS added if missing
+        schema.directives.size() == 3 // @deprecated and @specifiedBy and @oneOf is ALWAYS added if missing
 
         when: "clear directives is called with more directives"
         schema = schemaBuilder.clearDirectives().additionalDirective(Directives.SkipDirective).build()
         then:
-        schema.directives.size() == 3
+        schema.directives.size() == 4
 
         when: "the schema is transformed, things are copied"
         schema = schema.transform({ builder -> builder.additionalDirective(Directives.IncludeDirective) })
         then:
-        schema.directives.size() == 4
+        schema.directives.size() == 5
     }
 
     def "clear additional types works as expected"() {

--- a/src/test/groovy/graphql/schema/SchemaPrinterComparatorsTest.groovy
+++ b/src/test/groovy/graphql/schema/SchemaPrinterComparatorsTest.groovy
@@ -180,7 +180,7 @@ scalar TestScalar @a(a : 0, bb : 0) @bb(a : 0, bb : 0)
 
         when:
         def options = defaultOptions()
-        def result = new SchemaPrinter(options).directivesString(null, false, directives)
+        def result = new SchemaPrinter(options).directivesString(null, directives)
 
         then:
         result == ''' @a(a : 0, bb : 0) @bb(a : 0, bb : 0)'''

--- a/src/test/groovy/graphql/schema/diffing/SchemaDiffingTest.groovy
+++ b/src/test/groovy/graphql/schema/diffing/SchemaDiffingTest.groovy
@@ -34,14 +34,14 @@ class SchemaDiffingTest extends Specification {
         schemaGraph.getVerticesByType(SchemaGraph.INTERFACE).size() == 0
         schemaGraph.getVerticesByType(SchemaGraph.UNION).size() == 0
         schemaGraph.getVerticesByType(SchemaGraph.SCALAR).size() == 2
-        schemaGraph.getVerticesByType(SchemaGraph.FIELD).size() == 39
+        schemaGraph.getVerticesByType(SchemaGraph.FIELD).size() == 40
         schemaGraph.getVerticesByType(SchemaGraph.ARGUMENT).size() == 9
         schemaGraph.getVerticesByType(SchemaGraph.INPUT_FIELD).size() == 0
         schemaGraph.getVerticesByType(SchemaGraph.INPUT_OBJECT).size() == 0
-        schemaGraph.getVerticesByType(SchemaGraph.DIRECTIVE).size() == 4
+        schemaGraph.getVerticesByType(SchemaGraph.DIRECTIVE).size() == 5
         schemaGraph.getVerticesByType(SchemaGraph.APPLIED_ARGUMENT).size() == 0
         schemaGraph.getVerticesByType(SchemaGraph.APPLIED_DIRECTIVE).size() == 0
-        schemaGraph.size() == 91
+        schemaGraph.size() == 93
 
     }
 

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorAppliedDirectiveHelperTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorAppliedDirectiveHelperTest.groovy
@@ -58,6 +58,7 @@ class SchemaGeneratorAppliedDirectiveHelperTest extends Specification {
                 "deprecated",
                 "foo",
                 "include",
+                "oneOf",
                 "skip",
                 "specifiedBy",
         ]
@@ -107,6 +108,7 @@ class SchemaGeneratorAppliedDirectiveHelperTest extends Specification {
                 "deprecated",
                 "foo",
                 "include",
+                "oneOf",
                 "skip",
                 "specifiedBy",
         ]

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -2052,11 +2052,13 @@ class SchemaGeneratorTest extends Specification {
         directives = schema.getDirectives()
 
         then:
-        directives.size() == 7 // built in ones :  include / skip and deprecated
+        directives.size() == 8 // built in ones :  include / skip and deprecated
         def directiveNames = directives.collect { it.name }
         directiveNames.contains("include")
         directiveNames.contains("skip")
         directiveNames.contains("deprecated")
+        directiveNames.contains("specifiedBy")
+        directiveNames.contains("oneOf")
         directiveNames.contains("sd1")
         directiveNames.contains("sd2")
         directiveNames.contains("sd3")
@@ -2065,10 +2067,11 @@ class SchemaGeneratorTest extends Specification {
         directivesMap = schema.getDirectivesByName()
 
         then:
-        directivesMap.size() == 7 // built in ones
+        directivesMap.size() == 8 // built in ones
         directivesMap.containsKey("include")
         directivesMap.containsKey("skip")
         directivesMap.containsKey("deprecated")
+        directivesMap.containsKey("oneOf")
         directivesMap.containsKey("sd1")
         directivesMap.containsKey("sd2")
         directivesMap.containsKey("sd3")
@@ -2535,5 +2538,27 @@ class SchemaGeneratorTest extends Specification {
         then:
         newSchema.getDirectives().findAll { it.name == "skip" }.size() == 1
         newSchema.getDirectives().findAll { it.name == "include" }.size() == 1
+    }
+
+    def "oneOf directive is available implicitly"() {
+        def sdl = '''
+            type Query {
+                f(arg : OneOfInputType) : String
+            }
+            
+            input OneOfInputType @oneOf {
+                a : String
+                b : String
+            }
+        '''
+
+        when:
+        def schema = TestUtil.schema(sdl)
+        then:
+        schema.getDirectives().findAll { it.name == "oneOf" }.size() == 1
+
+        GraphQLInputObjectType inputObjectType = schema.getTypeAs("OneOfInputType")
+        inputObjectType.isOneOf()
+        inputObjectType.hasAppliedDirective("oneOf")
     }
 }

--- a/src/test/groovy/graphql/schema/idl/SchemaParserTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaParserTest.groovy
@@ -480,4 +480,14 @@ type Virus {
         def printedSchema = new SchemaPrinter(options).print(graphQL.graphQLSchema)
         printedSchema == schema
     }
+
+    def "testNumberFormatException"() {
+        when:
+        SchemaParser parser = new SchemaParser();
+        parser.parse("{B(t:66E3333333320,t:#\n66666666660)},622»» »»»6666662}}6666660t:z6666")
+
+        then:
+        thrown(SchemaProblem)
+    }
+
 }

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -3,13 +3,21 @@ package graphql.schema.idl
 import graphql.GraphQL
 import graphql.TestUtil
 import graphql.TypeResolutionEnvironment
+import graphql.introspection.Introspection
 import graphql.introspection.IntrospectionQuery
 import graphql.introspection.IntrospectionResultToSchema
+import graphql.language.Comment
+import graphql.language.DirectiveDefinition
+import graphql.language.EnumValueDefinition
+import graphql.language.FieldDefinition
 import graphql.language.IntValue
+import graphql.language.ScalarTypeDefinition
+import graphql.language.SchemaDefinition
 import graphql.language.StringValue
 import graphql.schema.Coercing
 import graphql.schema.GraphQLAppliedDirective
 import graphql.schema.GraphQLCodeRegistry
+import graphql.schema.GraphQLDirective
 import graphql.schema.GraphQLEnumType
 import graphql.schema.GraphQLEnumValueDefinition
 import graphql.schema.GraphQLFieldDefinition
@@ -30,11 +38,19 @@ import spock.lang.Specification
 
 import java.util.function.Predicate
 import java.util.function.UnaryOperator
+import java.util.stream.Collectors
 
+import static graphql.Scalars.GraphQLID
 import static graphql.Scalars.GraphQLInt
 import static graphql.Scalars.GraphQLString
 import static graphql.TestUtil.mockScalar
 import static graphql.TestUtil.mockTypeRuntimeWiring
+import static graphql.language.EnumTypeDefinition.newEnumTypeDefinition
+import static graphql.language.InputObjectTypeDefinition.newInputObjectDefinition
+import static graphql.language.InputValueDefinition.newInputValueDefinition
+import static graphql.language.InterfaceTypeDefinition.newInterfaceTypeDefinition
+import static graphql.language.ObjectTypeDefinition.newObjectTypeDefinition
+import static graphql.language.UnionTypeDefinition.newUnionTypeDefinition
 import static graphql.schema.GraphQLArgument.newArgument
 import static graphql.schema.GraphQLEnumType.newEnum
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
@@ -44,6 +60,7 @@ import static graphql.schema.GraphQLList.list
 import static graphql.schema.GraphQLNonNull.nonNull
 import static graphql.schema.GraphQLObjectType.newObject
 import static graphql.schema.GraphQLScalarType.newScalar
+import static graphql.schema.GraphQLTypeReference.typeRef
 import static graphql.schema.GraphQLUnionType.newUnionType
 import static graphql.schema.idl.RuntimeWiring.newRuntimeWiring
 import static graphql.schema.idl.SchemaPrinter.ExcludeGraphQLSpecifiedDirectivesPredicate
@@ -980,6 +997,9 @@ directive @interfaceImplementingTypeDirective on OBJECT
 
 directive @interfaceTypeDirective on INTERFACE
 
+"Indicates an Input Object is a OneOf Input Object."
+directive @oneOf on INPUT_OBJECT
+
 directive @query1 repeatable on OBJECT
 
 directive @query2(arg1: String) on OBJECT
@@ -1133,6 +1153,9 @@ directive @include(
     if: Boolean!
   ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
+"Indicates an Input Object is a OneOf Input Object."
+directive @oneOf on INPUT_OBJECT
+
 "Directs the executor to skip this field or fragment when the `if` argument is true."
 directive @skip(
     "Skipped when true."
@@ -1230,6 +1253,9 @@ directive @include(
 
 directive @moreComplex(arg1: String = "default", arg2: Int) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
+"Indicates an Input Object is a OneOf Input Object."
+directive @oneOf on INPUT_OBJECT
+
 "Directs the executor to skip this field or fragment when the `if` argument is true."
 directive @skip(
     "Skipped when true."
@@ -1294,6 +1320,9 @@ directive @include(
   ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
 directive @moreComplex(arg1: String = "default", arg2: Int) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+"Indicates an Input Object is a OneOf Input Object."
+directive @oneOf on INPUT_OBJECT
 
 "Directs the executor to skip this field or fragment when the `if` argument is true."
 directive @skip(
@@ -1426,6 +1455,9 @@ directive @include(
     "Included when true."
     if: Boolean!
   ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"Indicates an Input Object is a OneOf Input Object."
+directive @oneOf on INPUT_OBJECT
 
 "Directs the executor to skip this field or fragment when the `if` argument is true."
 directive @skip(
@@ -1929,6 +1961,9 @@ directive @include(
     if: Boolean!
   ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
+"Indicates an Input Object is a OneOf Input Object."
+directive @oneOf on INPUT_OBJECT
+
 "Directs the executor to skip this field or fragment when the `if` argument is true."
 directive @skip(
     "Skipped when true."
@@ -2135,6 +2170,9 @@ directive @skip(
     if: Boolean!
   ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
+"Indicates an Input Object is a OneOf Input Object."
+directive @oneOf on INPUT_OBJECT
+
 "Directs the executor to include this field or fragment only when the `if` argument is true"
 directive @include(
     "Included when true."
@@ -2250,6 +2288,358 @@ type TestObjectB {
 '''
     }
 
+    final def SDL_WITH_COMMENTS = '''#schema comment 1
+#       schema comment 2 with leading spaces
+schema {
+  query: Query
+  mutation: Mutation
+}
+
+"Marks the field, argument, input field or enum value as deprecated"
+directive @deprecated(
+    "The reason for the deprecation"
+    reason: String = "No longer supported"
+  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+
+" custom directive 'example' description 1"
+# custom directive 'example' comment 1
+directive @example on ENUM_VALUE
+
+"Directs the executor to include this field or fragment only when the `if` argument is true"
+directive @include(
+    "Included when true."
+    if: Boolean!
+  ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"Indicates an Input Object is a OneOf Input Object."
+directive @oneOf on INPUT_OBJECT
+
+"Directs the executor to skip this field or fragment when the `if` argument is true."
+directive @skip(
+    "Skipped when true."
+    if: Boolean!
+  ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"Exposes a URL that specifies the behaviour of this scalar."
+directive @specifiedBy(
+    "The URL that specifies the behaviour of this scalar."
+    url: String!
+  ) on SCALAR
+
+# interface Character comment 1
+# interface Character comment 2
+interface Character implements Node {
+  appearsIn: [Episode]
+  friends: [Character]
+  id: ID!
+  name: String
+}
+
+interface Node {
+  id: ID!
+}
+
+# union type Humanoid comment 1
+union Humanoid = Droid | Human
+
+type Droid implements Character & Node {
+  appearsIn: [Episode]!
+  friends: [Character]
+  id: ID!
+  madeOn: Planet
+  name: String!
+  primaryFunction: String
+}
+
+type Human implements Character & Node {
+  appearsIn: [Episode]!
+  friends: [Character]
+  homePlanet: String
+  id: ID!
+  name: String!
+}
+
+type Mutation {
+  shoot(
+    # arg 'id\'
+    id: String!,
+    # arg 'with\'
+    with: Gun
+  ): Query
+}
+
+type Planet {
+  hitBy: Asteroid
+  name: String
+}
+
+# type query comment 1
+# type query comment 2
+type Query {
+  # query field 'hero' comment
+  hero(episode: Episode): Character
+  # query field 'humanoid' comment
+  humanoid(id: ID!): Humanoid
+}
+
+# enum Episode comment 1
+# enum Episode comment 2
+enum Episode {
+  # enum value EMPIRE comment 1
+  EMPIRE
+  JEDI
+  NEWHOPE @example
+}
+
+"desc"
+# scalar Asteroid comment 1
+scalar Asteroid
+
+# input type Gun comment 1
+input Gun {
+  # gun 'caliber' input value comment
+  caliber: Int
+  # gun 'name' input value comment
+  name: String
+}
+'''
+
+    static List<Comment> makeComments(String... strings) {
+        return strings.stream()
+                .map(s -> new Comment(s, null))
+                .collect(Collectors.toList())
+    }
+
+    def "prints with AST comments"() {
+        given:
+        def exampleDirective = GraphQLDirective.newDirective().name("example").validLocation(Introspection.DirectiveLocation.ENUM_VALUE)
+                .description(" custom directive 'example' description 1")
+                .definition(DirectiveDefinition.newDirectiveDefinition().comments(makeComments(" custom directive 'example' comment 1")).build()).build()
+        def asteroidType = newScalar().name("Asteroid").description("desc")
+                .definition(ScalarTypeDefinition.newScalarTypeDefinition().comments(makeComments(" scalar Asteroid comment 1")).build())
+                .coercing(TestUtil.mockCoercing())
+                .build()
+        def nodeType = newInterface().name("Node")
+                .field(newFieldDefinition().name("id").type(nonNull(GraphQLID)).build())
+                .build()
+        def planetType = newObject().name("Planet")
+                .field(newFieldDefinition().name("hitBy").type(asteroidType).build())
+                .field(newFieldDefinition().name("name").type(GraphQLString).build())
+                .build()
+        def episodeType = newEnum().name("Episode")
+                .definition(newEnumTypeDefinition().comments(
+                        makeComments(" enum Episode comment 1", " enum Episode comment 2")).build())
+                .values(List.of(
+                        GraphQLEnumValueDefinition.newEnumValueDefinition().name("EMPIRE")
+                                .definition(EnumValueDefinition.newEnumValueDefinition().comments(makeComments(" enum value EMPIRE comment 1")).build()).build(),
+                        GraphQLEnumValueDefinition.newEnumValueDefinition().name("JEDI").build(),
+                        GraphQLEnumValueDefinition.newEnumValueDefinition().name("NEWHOPE").withDirective(exampleDirective).build()))
+                .build()
+        def characterType = newInterface().name("Character").withInterface(nodeType)
+                .definition(newInterfaceTypeDefinition().comments(
+                        makeComments(" interface Character comment 1", " interface Character comment 2")).build())
+                .field(newFieldDefinition().name("appearsIn").type(list(episodeType)).build())
+                .field(newFieldDefinition().name("friends").type(list(typeRef("Character"))).build())
+                .field(newFieldDefinition().name("id").type(nonNull(GraphQLID)).build())
+                .field(newFieldDefinition().name("name").type(GraphQLString).build())
+                .build()
+        def droidType = newObject().name("Droid").withInterfaces(characterType, nodeType)
+                .field(newFieldDefinition().name("appearsIn").type(nonNull(list(episodeType))).build())
+                .field(newFieldDefinition().name("friends").type(list(typeRef("Character"))).build())
+                .field(newFieldDefinition().name("id").type(nonNull(GraphQLID)).build())
+                .field(newFieldDefinition().name("madeOn").type(planetType).build())
+                .field(newFieldDefinition().name("name").type(nonNull(GraphQLString)).build())
+                .field(newFieldDefinition().name("primaryFunction").type(GraphQLString).build())
+                .build()
+        def humanType = newObject().name("Human").withInterfaces(characterType, nodeType)
+                .field(newFieldDefinition().name("appearsIn").type(nonNull(list(episodeType))).build())
+                .field(newFieldDefinition().name("friends").type(list(typeRef("Character"))).build())
+                .field(newFieldDefinition().name("homePlanet").type(GraphQLString).build())
+                .field(newFieldDefinition().name("id").type(nonNull(GraphQLID)).build())
+                .field(newFieldDefinition().name("name").type(nonNull(GraphQLString)).build())
+                .build()
+        def humanoidType = newUnionType().name("Humanoid")
+                .definition(newUnionTypeDefinition().comments(makeComments(" union type Humanoid comment 1")).build())
+                .possibleTypes(humanType, droidType)
+                .build()
+        def queryType = newObject().name("Query")
+                .definition(newObjectTypeDefinition().comments(makeComments(" type query comment 1", " type query comment 2")).build())
+                .field(newFieldDefinition().name("hero").type(characterType)
+                        .definition(FieldDefinition.newFieldDefinition().comments(makeComments(" query field 'hero' comment")).build())
+                        .argument(newArgument().name("episode").type(episodeType).build())
+                        .build())
+                .field(newFieldDefinition().name("humanoid").type(humanoidType)
+                        .definition(FieldDefinition.newFieldDefinition().comments(makeComments(" query field 'humanoid' comment")).build())
+                        .argument(newArgument().name("id").type(nonNull(GraphQLID)).build())
+                        .build())
+                .build()
+        def gunType = GraphQLInputObjectType.newInputObject().name("Gun")
+                .definition(newInputObjectDefinition().comments(makeComments(" input type Gun comment 1")).build())
+                .field(newInputObjectField().name("name").type(GraphQLString)
+                        .definition(newInputValueDefinition().comments(makeComments(" gun 'name' input value comment")).build()).build())
+                .field(newInputObjectField().name("caliber").type(GraphQLInt)
+                        .definition(newInputValueDefinition().comments(makeComments(" gun 'caliber' input value comment")).build()).build())
+                .build()
+        def schema = GraphQLSchema.newSchema()
+                .additionalDirective(exampleDirective)
+                .codeRegistry(GraphQLCodeRegistry.newCodeRegistry()
+                        .typeResolver(characterType, resolver)
+                        .typeResolver(humanoidType, resolver)
+                        .typeResolver(nodeType, resolver)
+                        .build())
+                .definition(SchemaDefinition.newSchemaDefinition().comments(
+                        makeComments("schema comment 1", "       schema comment 2 with leading spaces")).build())
+                .mutation(newObject().name("Mutation")
+                        .field(newFieldDefinition().name("shoot").type(queryType).arguments(List.of(
+                                newArgument().name("id").type(nonNull(GraphQLString))
+                                        .definition(newInputValueDefinition().comments(makeComments(" arg 'id'")).build()).build(),
+                                newArgument().name("with").type(gunType)
+                                        .definition(newInputValueDefinition().comments(makeComments(" arg 'with'")).build()).build()))
+                                .build())
+                        .build())
+                .query(queryType)
+                .build()
+        when:
+        def result = new SchemaPrinter(defaultOptions().includeSchemaDefinition(true).includeAstDefinitionComments(true)).print(schema)
+        println(result)
+
+        then:
+        result == SDL_WITH_COMMENTS
+    }
+
+    def "parses, generates and prints with AST comments"() {
+        given:
+        def registry = new SchemaParser().parse(SDL_WITH_COMMENTS)
+        def wiring = newRuntimeWiring()
+                .scalar(mockScalar(registry.scalars().get("Asteroid")))
+                .type(mockTypeRuntimeWiring("Character", true))
+                .type(mockTypeRuntimeWiring("Humanoid", true))
+                .type(mockTypeRuntimeWiring("Node", true))
+                .build()
+        def options = SchemaGenerator.Options.defaultOptions().useCommentsAsDescriptions(false)
+        def schema = new SchemaGenerator().makeExecutableSchema(options, registry, wiring)
+        when:
+        def result = new SchemaPrinter(defaultOptions().includeSchemaDefinition(true).includeAstDefinitionComments(true)).print(schema)
+        println(result)
+
+        // @TODO: Schema Parser seems to be ignoring directive and scalar comments and needs to be fixed.
+        // The expected result below should be the same as the SDL_WITH_COMMENTS above BUT with the two comments temporarily removed.
+        then:
+        result == '''#schema comment 1
+#       schema comment 2 with leading spaces
+schema {
+  query: Query
+  mutation: Mutation
+}
+
+"Marks the field, argument, input field or enum value as deprecated"
+directive @deprecated(
+    "The reason for the deprecation"
+    reason: String = "No longer supported"
+  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+
+" custom directive 'example' description 1"
+directive @example on ENUM_VALUE
+
+"Directs the executor to include this field or fragment only when the `if` argument is true"
+directive @include(
+    "Included when true."
+    if: Boolean!
+  ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"Indicates an Input Object is a OneOf Input Object."
+directive @oneOf on INPUT_OBJECT
+
+"Directs the executor to skip this field or fragment when the `if` argument is true."
+directive @skip(
+    "Skipped when true."
+    if: Boolean!
+  ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"Exposes a URL that specifies the behaviour of this scalar."
+directive @specifiedBy(
+    "The URL that specifies the behaviour of this scalar."
+    url: String!
+  ) on SCALAR
+
+# interface Character comment 1
+# interface Character comment 2
+interface Character implements Node {
+  appearsIn: [Episode]
+  friends: [Character]
+  id: ID!
+  name: String
+}
+
+interface Node {
+  id: ID!
+}
+
+# union type Humanoid comment 1
+union Humanoid = Droid | Human
+
+type Droid implements Character & Node {
+  appearsIn: [Episode]!
+  friends: [Character]
+  id: ID!
+  madeOn: Planet
+  name: String!
+  primaryFunction: String
+}
+
+type Human implements Character & Node {
+  appearsIn: [Episode]!
+  friends: [Character]
+  homePlanet: String
+  id: ID!
+  name: String!
+}
+
+type Mutation {
+  shoot(
+    # arg 'id\'
+    id: String!,
+    # arg 'with\'
+    with: Gun
+  ): Query
+}
+
+type Planet {
+  hitBy: Asteroid
+  name: String
+}
+
+# type query comment 1
+# type query comment 2
+type Query {
+  # query field 'hero' comment
+  hero(episode: Episode): Character
+  # query field 'humanoid' comment
+  humanoid(id: ID!): Humanoid
+}
+
+# enum Episode comment 1
+# enum Episode comment 2
+enum Episode {
+  # enum value EMPIRE comment 1
+  EMPIRE
+  JEDI
+  NEWHOPE @example
+}
+
+"desc"
+scalar Asteroid
+
+# input type Gun comment 1
+input Gun {
+  # gun 'caliber' input value comment
+  caliber: Int
+  # gun 'name' input value comment
+  name: String
+}
+'''
+    }
+
     def "issue 3285 - deprecated defaultValue on programmatic args prints as expected"() {
         def queryObjType = newObject().name("Query")
                 .field(newFieldDefinition().name("f").type(GraphQLString)
@@ -2266,5 +2656,48 @@ type TestObjectB {
   f(arg: String = null): String
 }
 '''
+    }
+
+    def "deprecated directive with custom reason"() {
+        given:
+        def enumType = newEnum().name("Enum")
+                .values(List.of(
+                        GraphQLEnumValueDefinition.newEnumValueDefinition().name("DEPRECATED_WITH_REASON").deprecationReason("Custom enum value reason").build()))
+                .build()
+        def fieldType = newObject().name("Field")
+                .field(newFieldDefinition().name("deprecatedWithReason").type(enumType).deprecate("Custom field reason").build())
+                .build()
+        def inputType = GraphQLInputObjectType.newInputObject().name("Input")
+                .field(newInputObjectField().name("deprecatedWithReason").type(enumType).deprecate("Custom input reason").build())
+                .build()
+        def queryType = newObject().name("Query")
+                .field(newFieldDefinition().name("field").type(fieldType)
+                        .argument(newArgument().name("deprecatedWithReason").type(inputType).deprecate("Custom argument reason").build()).build())
+                .build()
+        def schema = GraphQLSchema.newSchema()
+                .query(queryType)
+                .build()
+        when:
+        def result = "\n" + new SchemaPrinter(noDirectivesOption).print(schema)
+        println(result)
+
+        then:
+        result == """
+type Field {
+  deprecatedWithReason: Enum @deprecated(reason : "Custom field reason")
+}
+
+type Query {
+  field(deprecatedWithReason: Input @deprecated(reason : "Custom argument reason")): Field
+}
+
+enum Enum {
+  DEPRECATED_WITH_REASON @deprecated(reason : "Custom enum value reason")
+}
+
+input Input {
+  deprecatedWithReason: Enum @deprecated(reason : "Custom input reason")
+}
+"""
     }
 }

--- a/src/test/groovy/graphql/schema/validation/OneOfInputObjectRulesTest.groovy
+++ b/src/test/groovy/graphql/schema/validation/OneOfInputObjectRulesTest.groovy
@@ -1,0 +1,36 @@
+package graphql.schema.validation
+
+import graphql.TestUtil
+import graphql.schema.idl.SchemaGenerator
+import graphql.schema.idl.SchemaParser
+import spock.lang.Specification
+
+class OneOfInputObjectRulesTest extends Specification {
+
+    def "oneOf fields must be the right shape"() {
+
+        def sdl = """
+            type Query {
+                f(arg : OneOfInputType) : String
+            }
+            
+            input OneOfInputType @oneOf {
+                ok : String
+                badNonNull : String!
+                badDefaulted : String = "default"
+            }
+        """
+
+        when:
+        def registry = new SchemaParser().parse(sdl)
+        new SchemaGenerator().makeExecutableSchema(registry, TestUtil.getMockRuntimeWiring())
+
+        then:
+        def schemaProblem = thrown(InvalidSchemaException)
+        schemaProblem.errors.size() == 2
+        schemaProblem.errors[0].description == "OneOf input field OneOfInputType.badNonNull must be nullable."
+        schemaProblem.errors[0].classification == SchemaValidationErrorType.OneOfNonNullableField
+        schemaProblem.errors[1].description == "OneOf input field OneOfInputType.badDefaulted cannot have a default value."
+        schemaProblem.errors[1].classification == SchemaValidationErrorType.OneOfDefaultValueOnField
+    }
+}

--- a/src/test/groovy/graphql/schema/validation/SchemaValidatorTest.groovy
+++ b/src/test/groovy/graphql/schema/validation/SchemaValidatorTest.groovy
@@ -11,7 +11,7 @@ class SchemaValidatorTest extends Specification {
         def validator = new SchemaValidator()
         def rules = validator.rules
         then:
-        rules.size() == 7
+        rules.size() == 8
         rules[0] instanceof NoUnbrokenInputCycles
         rules[1] instanceof TypesImplementInterfaces
         rules[2] instanceof TypeAndFieldRule
@@ -19,6 +19,6 @@ class SchemaValidatorTest extends Specification {
         rules[4] instanceof AppliedDirectivesAreValid
         rules[5] instanceof AppliedDirectiveArgumentsAreValid
         rules[6] instanceof InputAndOutputTypesUsedAppropriately
+        rules[7] instanceof OneOfInputObjectRules
     }
-
 }

--- a/src/test/groovy/graphql/util/LockKitTest.groovy
+++ b/src/test/groovy/graphql/util/LockKitTest.groovy
@@ -1,0 +1,70 @@
+package graphql.util
+
+import spock.lang.Specification
+
+class LockKitTest extends Specification {
+
+
+    def "can run code under a lock (simple test)"() {
+        def sideEffect = 0
+
+        when:
+        LockKit.ReentrantLock lockedCode = new LockKit.ReentrantLock()
+        lockedCode.runLocked { sideEffect++ }
+
+        then:
+        sideEffect == 1
+    }
+
+    def "can call code under a lock (simple test)"() {
+
+        when:
+        LockKit.ReentrantLock lockedCode = new LockKit.ReentrantLock()
+        def val = lockedCode.callLocked { return "x" }
+
+        then:
+        val == "x"
+    }
+
+    def "is reentrant"() {
+
+        def sideEffect = 0
+
+        when:
+        LockKit.ReentrantLock lockedCode = new LockKit.ReentrantLock()
+        lockedCode.runLocked {
+            sideEffect++
+            lockedCode.runLocked {
+                sideEffect++
+            }
+        }
+
+        then:
+        sideEffect == 2
+    }
+
+    def "can compute once"() {
+        def sideEffect = 0
+
+        when:
+        LockKit.ComputedOnce computedOnce = new LockKit.ComputedOnce()
+
+        then:
+        !computedOnce.hasBeenComputed()
+        sideEffect == 0
+
+        when:
+        computedOnce.runOnce { sideEffect++ }
+
+        then:
+        computedOnce.hasBeenComputed()
+        sideEffect == 1
+
+        when:
+        computedOnce.runOnce { sideEffect++ }
+
+        then:
+        computedOnce.hasBeenComputed()
+        sideEffect == 1
+    }
+}

--- a/src/test/groovy/graphql/validation/SpecValidationSchema.java
+++ b/src/test/groovy/graphql/validation/SpecValidationSchema.java
@@ -1,5 +1,6 @@
 package graphql.validation;
 
+import graphql.Directives;
 import graphql.Scalars;
 import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLCodeRegistry;
@@ -184,6 +185,18 @@ public class SpecValidationSchema {
             .validLocations(FIELD, FRAGMENT_SPREAD, FRAGMENT_DEFINITION, INLINE_FRAGMENT, QUERY)
             .build();
 
+    public static final GraphQLInputObjectType oneOfInputType = GraphQLInputObjectType.newInputObject()
+            .name("oneOfInputType")
+            .withAppliedDirective(Directives.OneOfDirective.toAppliedDirective())
+            .field(GraphQLInputObjectField.newInputObjectField()
+                    .name("a")
+                    .type(GraphQLString))
+            .field(GraphQLInputObjectField.newInputObjectField()
+                    .name("b")
+                    .type(GraphQLString))
+            .build();
+
+
     public static final GraphQLObjectType queryRoot = GraphQLObjectType.newObject()
             .name("QueryRoot")
             .field(newFieldDefinition().name("dog").type(dog)
@@ -191,6 +204,9 @@ public class SpecValidationSchema {
                     .withDirective(dogDirective)
             )
             .field(newFieldDefinition().name("pet").type(pet))
+            .field(newFieldDefinition().name("oneOfField").type(GraphQLString)
+                    .argument(newArgument().name("oneOfArg").type(oneOfInputType).build())
+            )
             .build();
 
     public static final GraphQLObjectType subscriptionRoot = GraphQLObjectType.newObject()

--- a/src/test/groovy/graphql/validation/rules/OverlappingFieldsCanBeMergedTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/OverlappingFieldsCanBeMergedTest.groovy
@@ -337,6 +337,7 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
         def schema = schema('''
         type Dog {
             nickname: String
+            name : String
         }
         type Query { dog: Dog }
         ''')
@@ -347,6 +348,58 @@ class OverlappingFieldsCanBeMergedTest extends Specification {
         errorCollector.getErrors().size() == 1
         errorCollector.getErrors()[0].message == "Validation error (FieldsConflict@[aliasMaskingDirectFieldAccess]) : 'name' : 'nickname' and 'name' are different fields"
         errorCollector.getErrors()[0].locations == [new SourceLocation(3, 13), new SourceLocation(4, 13)]
+    }
+
+    def 'issue 3332 - Alias masking direct field access non fragment'() {
+        given:
+        def query = """
+        { dog {
+            name: nickname
+            name
+        }}
+         """
+        def schema = schema('''
+        type Dog {
+            name : String
+            nickname: String
+        }
+        type Query { dog: Dog }
+        ''')
+        when:
+        traverse(query, schema)
+
+        then:
+        errorCollector.getErrors().size() == 1
+        errorCollector.getErrors()[0].message == "Validation error (FieldsConflict@[dog]) : 'name' : 'nickname' and 'name' are different fields"
+        errorCollector.getErrors()[0].locations == [new SourceLocation(3, 13), new SourceLocation(4, 13)]
+    }
+
+    def 'issue 3332  -Alias masking direct field access non fragment with non null parent type'() {
+        given:
+        def query = """
+        query GetCat {
+              cat {
+                foo1
+                foo1: foo2
+              }
+            }
+         """
+        def schema = schema('''
+        type Query {    
+            cat: Cat! # non null parent type
+        }
+        type Cat {
+            foo1: String!
+            foo2: String!
+        }
+        ''')
+        when:
+        traverse(query, schema)
+
+        then:
+        errorCollector.getErrors().size() == 1
+        errorCollector.getErrors()[0].message == "Validation error (FieldsConflict@[cat]) : 'foo1' : 'foo1' and 'foo2' are different fields"
+        errorCollector.getErrors()[0].locations == [new SourceLocation(4, 17), new SourceLocation(5, 17)]
     }
 
     def 'conflicting args'() {

--- a/src/test/groovy/readme/InstrumentationExamples.java
+++ b/src/test/groovy/readme/InstrumentationExamples.java
@@ -15,6 +15,7 @@ import graphql.execution.instrumentation.fieldvalidation.FieldValidation;
 import graphql.execution.instrumentation.fieldvalidation.FieldValidationEnvironment;
 import graphql.execution.instrumentation.fieldvalidation.FieldValidationInstrumentation;
 import graphql.execution.instrumentation.fieldvalidation.SimpleFieldValidation;
+import graphql.execution.instrumentation.parameters.InstrumentationCreateStateParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
 import graphql.execution.instrumentation.tracing.TracingInstrumentation;
@@ -64,7 +65,7 @@ public class InstrumentationExamples {
 
     class CustomInstrumentation extends SimplePerformantInstrumentation {
         @Override
-        public InstrumentationState createState() {
+        public @Nullable InstrumentationState createState(InstrumentationCreateStateParameters parameters) {
             //
             // instrumentation state is passed during each invocation of an Instrumentation method
             // and allows you to put stateful data away and reference it during the query execution


### PR DESCRIPTION
This brings up the 21.x branch up to date with the last commit included in the 21.3 release, which was `42efd9b2` on master https://github.com/graphql-java/graphql-java/commit/42efd9b23ef9ae7ba862d9affefe04a03a9b99cb

You can verify this PR correctly pulls in all master commits up to git tag 21.3 by comparing the last commit on this branch vs the 21.3 commit on master
https://github.com/graphql-java/graphql-java/compare/42efd9b2..a79bebf

This PR is necessary because we previously released 21.3 off the master branch