### PR TITLE
add a default max nodes count for the ExecutableNormalizedFactory 

### DIFF
--- a/src/main/java/graphql/normalized/ExecutableNormalizedOperationFactory.java
+++ b/src/main/java/graphql/normalized/ExecutableNormalizedOperationFactory.java
@@ -64,7 +64,6 @@ import static graphql.schema.GraphQLTypeUtil.unwrapAll;
 import static graphql.util.FpKit.filterSet;
 import static graphql.util.FpKit.groupingBy;
 import static graphql.util.FpKit.intersection;
-import static java.util.Collections.max;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toCollection;
@@ -102,7 +101,7 @@ public class ExecutableNormalizedOperationFactory {
                     GraphQLContext.getDefault(),
                     Locale.getDefault(),
                     Integer.MAX_VALUE,
-                    Integer.MAX_VALUE,
+                    100_000,
                     false);
         }
 
@@ -470,7 +469,7 @@ public class ExecutableNormalizedOperationFactory {
                         topLevel,
                         fieldAndAstParents,
                         1);
-                maxDepthSeen = Math.max(maxDepthSeen,depthSeen);
+                maxDepthSeen = Math.max(maxDepthSeen, depthSeen);
             }
             // getPossibleMergerList
             for (PossibleMerger possibleMerger : possibleMergerList) {
@@ -498,8 +497,8 @@ public class ExecutableNormalizedOperationFactory {
         }
 
         private int buildFieldWithChildren(ExecutableNormalizedField executableNormalizedField,
-                                            ImmutableList<FieldAndAstParent> fieldAndAstParents,
-                                            int curLevel) {
+                                           ImmutableList<FieldAndAstParent> fieldAndAstParents,
+                                           int curLevel) {
             checkMaxDepthExceeded(curLevel);
 
             CollectNFResult nextLevel = collectFromMergedField(executableNormalizedField, fieldAndAstParents, curLevel + 1);
@@ -518,7 +517,7 @@ public class ExecutableNormalizedOperationFactory {
                 int depthSeen = buildFieldWithChildren(childENF,
                         childFieldAndAstParents,
                         curLevel + 1);
-                maxDepthSeen = Math.max(maxDepthSeen,depthSeen);
+                maxDepthSeen = Math.max(maxDepthSeen, depthSeen);
 
                 checkMaxDepthExceeded(maxDepthSeen);
             }

--- a/src/main/java/graphql/normalized/ExecutableNormalizedOperationFactory.java
+++ b/src/main/java/graphql/normalized/ExecutableNormalizedOperationFactory.java
@@ -77,12 +77,26 @@ import static java.util.stream.Collectors.toSet;
 public class ExecutableNormalizedOperationFactory {
 
     public static class Options {
+
+
         private final GraphQLContext graphQLContext;
         private final Locale locale;
         private final int maxChildrenDepth;
         private final int maxFieldsCount;
 
         private final boolean deferSupport;
+
+        /**
+         * The default max fields count is 100,000.
+         * This is big enough for even very large queries, but
+         * can be changed via {#setDefaultOptions
+         */
+        public static final int DEFAULT_MAX_FIELDS_COUNT = 100_000;
+        private static Options defaultOptions = new Options(GraphQLContext.getDefault(),
+                Locale.getDefault(),
+                Integer.MAX_VALUE,
+                DEFAULT_MAX_FIELDS_COUNT,
+                false);
 
         private Options(GraphQLContext graphQLContext,
                         Locale locale,
@@ -96,13 +110,23 @@ public class ExecutableNormalizedOperationFactory {
             this.maxFieldsCount = maxFieldsCount;
         }
 
+        /**
+         * Sets new default Options used when creating instances of {@link ExecutableNormalizedOperation}.
+         *
+         * @param options new default options
+         */
+        public static void setDefaultOptions(Options options) {
+            defaultOptions = Assert.assertNotNull(options);
+        }
+
+
+        /**
+         * Returns the default options used when creating instances of {@link ExecutableNormalizedOperation}.
+         *
+         * @return the default options
+         */
         public static Options defaultOptions() {
-            return new Options(
-                    GraphQLContext.getDefault(),
-                    Locale.getDefault(),
-                    Integer.MAX_VALUE,
-                    100_000,
-                    false);
+            return defaultOptions;
         }
 
         /**

--- a/src/test/groovy/graphql/normalized/ExecutableNormalizedOperationFactoryTest.groovy
+++ b/src/test/groovy/graphql/normalized/ExecutableNormalizedOperationFactoryTest.groovy
@@ -3165,7 +3165,7 @@ fragment personName on Person {
 
         GraphQLSchema graphQLSchema = TestUtil.schema(schema)
 
-        String query = "{ foo { foo{ name}}} "
+        String query = "{foo{foo{name}}} "
 
         assertValidQuery(graphQLSchema, query)
 


### PR DESCRIPTION
The ENOF should have a default max nodes, which is high, but still prevents a to large memory creation