### PR TITLE
require non-empty directive locations

### DIFF
--- a/src/main/java/graphql/schema/GraphQLDirective.java
+++ b/src/main/java/graphql/schema/GraphQLDirective.java
@@ -7,7 +7,11 @@ import graphql.language.DirectiveDefinition;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 

--- a/src/main/java/graphql/schema/GraphQLDirective.java
+++ b/src/main/java/graphql/schema/GraphQLDirective.java
@@ -7,15 +7,13 @@ import graphql.language.DirectiveDefinition;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 
-import static graphql.Assert.*;
+import static graphql.Assert.assertNotEmpty;
+import static graphql.Assert.assertNotNull;
+import static graphql.Assert.assertValidName;
 import static graphql.introspection.Introspection.DirectiveLocation;
 import static graphql.util.FpKit.getByName;
 

--- a/src/main/java/graphql/schema/GraphQLDirective.java
+++ b/src/main/java/graphql/schema/GraphQLDirective.java
@@ -15,8 +15,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 
-import static graphql.Assert.assertNotNull;
-import static graphql.Assert.assertValidName;
+import static graphql.Assert.*;
 import static graphql.introspection.Introspection.DirectiveLocation;
 import static graphql.util.FpKit.getByName;
 
@@ -52,6 +51,7 @@ public class GraphQLDirective implements GraphQLNamedSchemaElement {
                              DirectiveDefinition definition) {
         assertValidName(name);
         assertNotNull(arguments, () -> "arguments can't be null");
+        assertNotEmpty(locations, () -> "locations can't be empty");
         this.name = name;
         this.description = description;
         this.repeatable = repeatable;

--- a/src/test/groovy/graphql/TestUtil.groovy
+++ b/src/test/groovy/graphql/TestUtil.groovy
@@ -2,32 +2,11 @@ package graphql
 
 import graphql.execution.MergedField
 import graphql.execution.MergedSelectionSet
-import graphql.language.Document
-import graphql.language.Field
-import graphql.language.NullValue
-import graphql.language.ObjectTypeDefinition
-import graphql.language.OperationDefinition
-import graphql.language.ScalarTypeDefinition
-import graphql.language.Type
+import graphql.introspection.Introspection.DirectiveLocation
+import graphql.language.*
 import graphql.parser.Parser
-import graphql.schema.Coercing
-import graphql.schema.DataFetcher
-import graphql.schema.GraphQLAppliedDirectiveArgument
-import graphql.schema.GraphQLAppliedDirective
-import graphql.schema.GraphQLArgument
-import graphql.schema.GraphQLDirective
-import graphql.schema.GraphQLInputType
-import graphql.schema.GraphQLObjectType
-import graphql.schema.GraphQLScalarType
-import graphql.schema.GraphQLSchema
-import graphql.schema.GraphQLType
-import graphql.schema.TypeResolver
-import graphql.schema.idl.RuntimeWiring
-import graphql.schema.idl.SchemaGenerator
-import graphql.schema.idl.SchemaParser
-import graphql.schema.idl.TestMockedWiringFactory
-import graphql.schema.idl.TypeRuntimeWiring
-import graphql.schema.idl.WiringFactory
+import graphql.schema.*
+import graphql.schema.idl.*
 import graphql.schema.idl.errors.SchemaProblem
 import groovy.json.JsonOutput
 
@@ -194,13 +173,19 @@ class TestUtil {
                 .name(definition.getName())
                 .description(definition.getDescription() == null ? null : definition.getDescription().getContent())
                 .coercing(mockCoercing())
-                .replaceDirectives(definition.getDirectives().stream().map({ mockDirective(it.getName()) }).collect(Collectors.toList()))
+                .replaceDirectives(
+                        definition.getDirectives()
+                                .stream()
+                                .map({ mockDirective(it.getName(), DirectiveLocation.SCALAR) })
+                                .collect(Collectors.toList()))
                 .definition(definition)
                 .build()
     }
 
-    static GraphQLDirective mockDirective(String name) {
-        newDirective().name(name).description(name).build()
+    static GraphQLDirective mockDirective(String name, DirectiveLocation location, GraphQLArgument arg = null) {
+        def b = newDirective().name(name).description(name).validLocation(location)
+        if (arg != null) b.argument(arg)
+        b.build()
     }
 
     static TypeRuntimeWiring mockTypeRuntimeWiring(String typeName, boolean withResolver) {

--- a/src/test/groovy/graphql/TestUtil.groovy
+++ b/src/test/groovy/graphql/TestUtil.groovy
@@ -3,10 +3,32 @@ package graphql
 import graphql.execution.MergedField
 import graphql.execution.MergedSelectionSet
 import graphql.introspection.Introspection.DirectiveLocation
-import graphql.language.*
+import graphql.language.Document
+import graphql.language.Field
+import graphql.language.NullValue
+import graphql.language.ObjectTypeDefinition
+import graphql.language.OperationDefinition
+import graphql.language.ScalarTypeDefinition
+import graphql.language.Type
 import graphql.parser.Parser
-import graphql.schema.*
-import graphql.schema.idl.*
+import graphql.schema.Coercing
+import graphql.schema.DataFetcher
+import graphql.schema.GraphQLAppliedDirective
+import graphql.schema.GraphQLAppliedDirectiveArgument
+import graphql.schema.GraphQLArgument
+import graphql.schema.GraphQLDirective
+import graphql.schema.GraphQLInputType
+import graphql.schema.GraphQLObjectType
+import graphql.schema.GraphQLScalarType
+import graphql.schema.GraphQLSchema
+import graphql.schema.GraphQLType
+import graphql.schema.TypeResolver
+import graphql.schema.idl.RuntimeWiring
+import graphql.schema.idl.SchemaGenerator
+import graphql.schema.idl.SchemaParser
+import graphql.schema.idl.TestMockedWiringFactory
+import graphql.schema.idl.TypeRuntimeWiring
+import graphql.schema.idl.WiringFactory
 import graphql.schema.idl.errors.SchemaProblem
 import groovy.json.JsonOutput
 
@@ -176,13 +198,13 @@ class TestUtil {
                 .replaceDirectives(
                         definition.getDirectives()
                                 .stream()
-                                .map({ mockDirective(it.getName(), DirectiveLocation.SCALAR) })
+                                .map({ mkDirective(it.getName(), DirectiveLocation.SCALAR) })
                                 .collect(Collectors.toList()))
                 .definition(definition)
                 .build()
     }
 
-    static GraphQLDirective mockDirective(String name, DirectiveLocation location, GraphQLArgument arg = null) {
+    static GraphQLDirective mkDirective(String name, DirectiveLocation location, GraphQLArgument arg = null) {
         def b = newDirective().name(name).description(name).validLocation(location)
         if (arg != null) b.argument(arg)
         b.build()

--- a/src/test/groovy/graphql/schema/GraphQLArgumentTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLArgumentTest.groovy
@@ -13,7 +13,7 @@ import static graphql.schema.GraphQLArgument.newArgument
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
 import static graphql.schema.GraphQLObjectType.newObject
 import static graphql.schema.GraphQLSchema.newSchema
-import static graphql.TestUtil.mockDirective
+import static graphql.TestUtil.mkDirective
 
 class GraphQLArgumentTest extends Specification {
 
@@ -23,7 +23,7 @@ class GraphQLArgumentTest extends Specification {
                 .description("A1_description")
                 .type(GraphQLInt)
                 .deprecate("custom reason")
-                .withDirective(mockDirective("directive1", ARGUMENT_DEFINITION))
+                .withDirective(mkDirective("directive1", ARGUMENT_DEFINITION))
                 .build()
         when:
         def transformedArgument = startingArgument.transform({
@@ -31,7 +31,7 @@ class GraphQLArgumentTest extends Specification {
                     .name("A2")
                     .description("A2_description")
                     .type(GraphQLString)
-                    .withDirective(mockDirective("directive3", ARGUMENT_DEFINITION))
+                    .withDirective(mkDirective("directive3", ARGUMENT_DEFINITION))
                     .value("VALUE") // Retain deprecated for test coverage
                     .deprecate(null)
                     .defaultValue("DEFAULT") // Retain deprecated for test coverage
@@ -82,7 +82,7 @@ class GraphQLArgumentTest extends Specification {
         given:
         def builder = newArgument().name("A1")
                 .type(GraphQLInt)
-                .withDirective(mockDirective("directive1", ARGUMENT_DEFINITION))
+                .withDirective(mkDirective("directive1", ARGUMENT_DEFINITION))
 
         when:
         argument = builder.build()
@@ -97,8 +97,8 @@ class GraphQLArgumentTest extends Specification {
         when:
         argument = builder
                 .clearDirectives()
-                .withDirective(mockDirective("directive2", ARGUMENT_DEFINITION))
-                .withDirective(mockDirective("directive3", ARGUMENT_DEFINITION))
+                .withDirective(mkDirective("directive2", ARGUMENT_DEFINITION))
+                .withDirective(mkDirective("directive3", ARGUMENT_DEFINITION))
                 .build()
 
         then:
@@ -110,9 +110,9 @@ class GraphQLArgumentTest extends Specification {
         when:
         argument = builder
                 .replaceDirectives([
-                        mockDirective("directive1", ARGUMENT_DEFINITION),
-                        mockDirective("directive2", ARGUMENT_DEFINITION),
-                        mockDirective("directive3", ARGUMENT_DEFINITION)]) // overwrite
+                        mkDirective("directive1", ARGUMENT_DEFINITION),
+                        mkDirective("directive2", ARGUMENT_DEFINITION),
+                        mkDirective("directive3", ARGUMENT_DEFINITION)]) // overwrite
                 .build()
 
         then:
@@ -199,7 +199,7 @@ class GraphQLArgumentTest extends Specification {
     def "Applied schema directives arguments are validated for programmatic schemas"() {
         given:
         def arg = newArgument().name("arg").type(GraphQLInt).valueProgrammatic(ImmutableKit.emptyMap()).build() // Retain for test coverage
-        def directive = mockDirective("cached", ARGUMENT_DEFINITION, arg)
+        def directive = mkDirective("cached", ARGUMENT_DEFINITION, arg)
         def field = newFieldDefinition()
                 .name("hello")
                 .type(GraphQLString)

--- a/src/test/groovy/graphql/schema/GraphQLArgumentTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLArgumentTest.groovy
@@ -1,6 +1,7 @@
 package graphql.schema
 
 import graphql.collect.ImmutableKit
+import static graphql.introspection.Introspection.DirectiveLocation.ARGUMENT_DEFINITION
 import graphql.language.FloatValue
 import graphql.schema.validation.InvalidSchemaException
 import spock.lang.Specification
@@ -9,10 +10,10 @@ import static graphql.Scalars.GraphQLFloat
 import static graphql.Scalars.GraphQLInt
 import static graphql.Scalars.GraphQLString
 import static graphql.schema.GraphQLArgument.newArgument
-import static graphql.schema.GraphQLDirective.newDirective
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
 import static graphql.schema.GraphQLObjectType.newObject
 import static graphql.schema.GraphQLSchema.newSchema
+import static graphql.TestUtil.mockDirective
 
 class GraphQLArgumentTest extends Specification {
 
@@ -22,7 +23,7 @@ class GraphQLArgumentTest extends Specification {
                 .description("A1_description")
                 .type(GraphQLInt)
                 .deprecate("custom reason")
-                .withDirective(newDirective().name("directive1"))
+                .withDirective(mockDirective("directive1", ARGUMENT_DEFINITION))
                 .build()
         when:
         def transformedArgument = startingArgument.transform({
@@ -30,7 +31,7 @@ class GraphQLArgumentTest extends Specification {
                     .name("A2")
                     .description("A2_description")
                     .type(GraphQLString)
-                    .withDirective(newDirective().name("directive3"))
+                    .withDirective(mockDirective("directive3", ARGUMENT_DEFINITION))
                     .value("VALUE") // Retain deprecated for test coverage
                     .deprecate(null)
                     .defaultValue("DEFAULT") // Retain deprecated for test coverage
@@ -79,9 +80,9 @@ class GraphQLArgumentTest extends Specification {
         def argument
 
         given:
-        def builder = GraphQLArgument.newArgument().name("A1")
+        def builder = newArgument().name("A1")
                 .type(GraphQLInt)
-                .withDirective(newDirective().name("directive1"))
+                .withDirective(mockDirective("directive1", ARGUMENT_DEFINITION))
 
         when:
         argument = builder.build()
@@ -96,8 +97,8 @@ class GraphQLArgumentTest extends Specification {
         when:
         argument = builder
                 .clearDirectives()
-                .withDirective(newDirective().name("directive2"))
-                .withDirective(newDirective().name("directive3"))
+                .withDirective(mockDirective("directive2", ARGUMENT_DEFINITION))
+                .withDirective(mockDirective("directive3", ARGUMENT_DEFINITION))
                 .build()
 
         then:
@@ -109,9 +110,9 @@ class GraphQLArgumentTest extends Specification {
         when:
         argument = builder
                 .replaceDirectives([
-                        newDirective().name("directive1").build(),
-                        newDirective().name("directive2").build(),
-                        newDirective().name("directive3").build()]) // overwrite
+                        mockDirective("directive1", ARGUMENT_DEFINITION),
+                        mockDirective("directive2", ARGUMENT_DEFINITION),
+                        mockDirective("directive3", ARGUMENT_DEFINITION)]) // overwrite
                 .build()
 
         then:
@@ -198,7 +199,7 @@ class GraphQLArgumentTest extends Specification {
     def "Applied schema directives arguments are validated for programmatic schemas"() {
         given:
         def arg = newArgument().name("arg").type(GraphQLInt).valueProgrammatic(ImmutableKit.emptyMap()).build() // Retain for test coverage
-        def directive = GraphQLDirective.newDirective().name("cached").argument(arg).build()
+        def directive = mockDirective("cached", ARGUMENT_DEFINITION, arg)
         def field = newFieldDefinition()
                 .name("hello")
                 .type(GraphQLString)

--- a/src/test/groovy/graphql/schema/GraphQLDirectiveTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLDirectiveTest.groovy
@@ -1,6 +1,8 @@
 package graphql.schema
 
+import graphql.AssertException
 import graphql.TestUtil
+import graphql.introspection.Introspection
 import graphql.language.Node
 import spock.lang.Specification
 
@@ -168,8 +170,37 @@ class GraphQLDirectiveTest extends Specification {
 
         then:
         assertDirectiveContainer(scalarType)
-
     }
+
+    def "throws an error on missing required properties"() {
+        given:
+        def validDirective = GraphQLDirective.newDirective()
+                .name("dir")
+                .validLocation(Introspection.DirectiveLocation.SCALAR)
+                .build()
+
+        when:
+        validDirective.transform { it.name(null) }
+
+        then:
+        def e = thrown(AssertException)
+        e.message.contains("Name must be non-null, non-empty")
+
+        when:
+        validDirective.transform { it.replaceArguments(null) }
+
+        then:
+        def e2 = thrown(AssertException)
+        e2.message.contains("arguments must not be null")
+
+        when:
+        validDirective.transform { it.clearValidLocations() }
+
+        then:
+        def e3 = thrown(AssertException)
+        e3.message.contains("locations can't be empty")
+    }
+
 
     static boolean assertDirectiveContainer(GraphQLDirectiveContainer container) {
         assert container.hasDirective("d1") // Retain for test coverage

--- a/src/test/groovy/graphql/schema/GraphQLEnumValueDefinitionTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLEnumValueDefinitionTest.groovy
@@ -4,7 +4,7 @@ import static graphql.introspection.Introspection.DirectiveLocation
 import spock.lang.Specification
 
 import static graphql.schema.GraphQLEnumValueDefinition.newEnumValueDefinition
-import static graphql.TestUtil.mockDirective
+import static graphql.TestUtil.mkDirective
 
 class GraphQLEnumValueDefinitionTest extends Specification {
     def "object can be transformed"() {
@@ -12,14 +12,14 @@ class GraphQLEnumValueDefinitionTest extends Specification {
         def startEnumValue = newEnumValueDefinition().name("EV1")
                 .description("EV1_description")
                 .value("A")
-                .withDirective(mockDirective("directive1", DirectiveLocation.ENUM_VALUE))
+                .withDirective(mkDirective("directive1", DirectiveLocation.ENUM_VALUE))
                 .build()
         when:
         def transformedEnumValue = startEnumValue.transform({
             it
                     .name("EV2")
                     .value("X")
-                    .withDirective(mockDirective("directive2", DirectiveLocation.ENUM_VALUE))
+                    .withDirective(mkDirective("directive2", DirectiveLocation.ENUM_VALUE))
         })
 
         then:

--- a/src/test/groovy/graphql/schema/GraphQLEnumValueDefinitionTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLEnumValueDefinitionTest.groovy
@@ -1,9 +1,10 @@
 package graphql.schema
 
+import static graphql.introspection.Introspection.DirectiveLocation
 import spock.lang.Specification
 
-import static graphql.schema.GraphQLDirective.newDirective
 import static graphql.schema.GraphQLEnumValueDefinition.newEnumValueDefinition
+import static graphql.TestUtil.mockDirective
 
 class GraphQLEnumValueDefinitionTest extends Specification {
     def "object can be transformed"() {
@@ -11,15 +12,14 @@ class GraphQLEnumValueDefinitionTest extends Specification {
         def startEnumValue = newEnumValueDefinition().name("EV1")
                 .description("EV1_description")
                 .value("A")
-                .withDirective(newDirective().name("directive1"))
+                .withDirective(mockDirective("directive1", DirectiveLocation.ENUM_VALUE))
                 .build()
         when:
         def transformedEnumValue = startEnumValue.transform({
             it
                     .name("EV2")
                     .value("X")
-                    .withDirective(newDirective().name("directive2"))
-
+                    .withDirective(mockDirective("directive2", DirectiveLocation.ENUM_VALUE))
         })
 
         then:

--- a/src/test/groovy/graphql/schema/GraphQLFieldDefinitionTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLFieldDefinitionTest.groovy
@@ -11,7 +11,7 @@ import static graphql.Scalars.GraphQLFloat
 import static graphql.Scalars.GraphQLInt
 import static graphql.Scalars.GraphQLString
 import static graphql.TestUtil.mockArguments
-import static graphql.TestUtil.mockDirective
+import static graphql.TestUtil.mkDirective
 import static graphql.schema.DefaultGraphqlTypeComparatorRegistry.newComparators
 import static graphql.schema.GraphQLArgument.newArgument
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
@@ -36,8 +36,8 @@ class GraphQLFieldDefinitionTest extends Specification {
                 .deprecate("F1_deprecated")
                 .argument(newArgument().name("argStr").type(GraphQLString))
                 .argument(newArgument().name("argInt").type(GraphQLInt))
-                .withDirective(mockDirective("directive1", Introspection.DirectiveLocation.FIELD_DEFINITION))
-                .withDirective(mockDirective("directive2", Introspection.DirectiveLocation.FIELD_DEFINITION))
+                .withDirective(mkDirective("directive1", Introspection.DirectiveLocation.FIELD_DEFINITION))
+                .withDirective(mkDirective("directive2", Introspection.DirectiveLocation.FIELD_DEFINITION))
                 .build()
 
         when:
@@ -48,7 +48,7 @@ class GraphQLFieldDefinitionTest extends Specification {
                     .argument(newArgument().name("argStr").type(GraphQLString))
                     .argument(newArgument().name("argInt").type(GraphQLBoolean))
                     .argument(newArgument().name("argIntAdded").type(GraphQLInt))
-                    .withDirective(mockDirective("directive3", Introspection.DirectiveLocation.FIELD_DEFINITION))
+                    .withDirective(mkDirective("directive3", Introspection.DirectiveLocation.FIELD_DEFINITION))
         })
 
         then:

--- a/src/test/groovy/graphql/schema/GraphQLFieldDefinitionTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLFieldDefinitionTest.groovy
@@ -2,6 +2,7 @@ package graphql.schema
 
 import graphql.AssertException
 import graphql.TestUtil
+import graphql.introspection.Introspection
 import graphql.schema.idl.SchemaPrinter
 import spock.lang.Specification
 
@@ -10,9 +11,9 @@ import static graphql.Scalars.GraphQLFloat
 import static graphql.Scalars.GraphQLInt
 import static graphql.Scalars.GraphQLString
 import static graphql.TestUtil.mockArguments
+import static graphql.TestUtil.mockDirective
 import static graphql.schema.DefaultGraphqlTypeComparatorRegistry.newComparators
 import static graphql.schema.GraphQLArgument.newArgument
-import static graphql.schema.GraphQLDirective.newDirective
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
 import static graphql.schema.idl.SchemaPrinter.Options.defaultOptions
 
@@ -35,8 +36,8 @@ class GraphQLFieldDefinitionTest extends Specification {
                 .deprecate("F1_deprecated")
                 .argument(newArgument().name("argStr").type(GraphQLString))
                 .argument(newArgument().name("argInt").type(GraphQLInt))
-                .withDirective(newDirective().name("directive1"))
-                .withDirective(newDirective().name("directive2"))
+                .withDirective(mockDirective("directive1", Introspection.DirectiveLocation.FIELD_DEFINITION))
+                .withDirective(mockDirective("directive2", Introspection.DirectiveLocation.FIELD_DEFINITION))
                 .build()
 
         when:
@@ -47,13 +48,10 @@ class GraphQLFieldDefinitionTest extends Specification {
                     .argument(newArgument().name("argStr").type(GraphQLString))
                     .argument(newArgument().name("argInt").type(GraphQLBoolean))
                     .argument(newArgument().name("argIntAdded").type(GraphQLInt))
-                    .withDirective(newDirective().name("directive3"))
-
+                    .withDirective(mockDirective("directive3", Introspection.DirectiveLocation.FIELD_DEFINITION))
         })
 
-
         then:
-
         startingField.name == "F1"
         startingField.type == GraphQLFloat
         startingField.description == "F1_description"

--- a/src/test/groovy/graphql/schema/GraphQLInputObjectFieldTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLInputObjectFieldTest.groovy
@@ -7,7 +7,7 @@ import spock.lang.Specification
 import static graphql.Scalars.GraphQLFloat
 import static graphql.Scalars.GraphQLInt
 import static graphql.schema.GraphQLInputObjectField.newInputObjectField
-import static graphql.TestUtil.mockDirective
+import static graphql.TestUtil.mkDirective
 
 class GraphQLInputObjectFieldTest extends Specification {
 
@@ -17,8 +17,8 @@ class GraphQLInputObjectFieldTest extends Specification {
                 .name("F1")
                 .type(GraphQLFloat)
                 .description("F1_description")
-                .withDirective(mockDirective("directive1", Introspection.DirectiveLocation.INPUT_FIELD_DEFINITION))
-                .withDirective(mockDirective("directive2", Introspection.DirectiveLocation.INPUT_FIELD_DEFINITION))
+                .withDirective(mkDirective("directive1", Introspection.DirectiveLocation.INPUT_FIELD_DEFINITION))
+                .withDirective(mkDirective("directive2", Introspection.DirectiveLocation.INPUT_FIELD_DEFINITION))
                 .deprecate("No longer useful")
                 .build()
 
@@ -27,7 +27,7 @@ class GraphQLInputObjectFieldTest extends Specification {
             builder.name("F2")
                     .type(GraphQLInt)
                     .deprecate(null)
-                    .withDirective(mockDirective("directive3", Introspection.DirectiveLocation.INPUT_FIELD_DEFINITION))
+                    .withDirective(mkDirective("directive3", Introspection.DirectiveLocation.INPUT_FIELD_DEFINITION))
         })
 
         then:

--- a/src/test/groovy/graphql/schema/GraphQLInputObjectFieldTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLInputObjectFieldTest.groovy
@@ -1,12 +1,13 @@
 package graphql.schema
 
+import graphql.introspection.Introspection
 import graphql.language.FloatValue
 import spock.lang.Specification
 
 import static graphql.Scalars.GraphQLFloat
 import static graphql.Scalars.GraphQLInt
-import static graphql.schema.GraphQLDirective.newDirective
 import static graphql.schema.GraphQLInputObjectField.newInputObjectField
+import static graphql.TestUtil.mockDirective
 
 class GraphQLInputObjectFieldTest extends Specification {
 
@@ -16,8 +17,8 @@ class GraphQLInputObjectFieldTest extends Specification {
                 .name("F1")
                 .type(GraphQLFloat)
                 .description("F1_description")
-                .withDirective(newDirective().name("directive1"))
-                .withDirective(newDirective().name("directive2"))
+                .withDirective(mockDirective("directive1", Introspection.DirectiveLocation.INPUT_FIELD_DEFINITION))
+                .withDirective(mockDirective("directive2", Introspection.DirectiveLocation.INPUT_FIELD_DEFINITION))
                 .deprecate("No longer useful")
                 .build()
 
@@ -26,13 +27,10 @@ class GraphQLInputObjectFieldTest extends Specification {
             builder.name("F2")
                     .type(GraphQLInt)
                     .deprecate(null)
-                    .withDirective(newDirective().name("directive3"))
-
+                    .withDirective(mockDirective("directive3", Introspection.DirectiveLocation.INPUT_FIELD_DEFINITION))
         })
 
-
         then:
-
         startingField.name == "F1"
         startingField.type == GraphQLFloat
         startingField.description == "F1_description"

--- a/src/test/groovy/graphql/schema/GraphQLScalarTypeTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLScalarTypeTest.groovy
@@ -3,7 +3,7 @@ package graphql.schema
 import graphql.introspection.Introspection
 import spock.lang.Specification
 
-import static graphql.TestUtil.mockDirective
+import static graphql.TestUtil.mkDirective
 
 class GraphQLScalarTypeTest extends Specification {
     Coercing<String, String> coercing = new Coercing<String, String>() {
@@ -29,14 +29,14 @@ class GraphQLScalarTypeTest extends Specification {
                 .name("S1")
                 .description("S1_description")
                 .coercing(coercing)
-                .withDirective(mockDirective("directive1", Introspection.DirectiveLocation.SCALAR))
-                .withDirective(mockDirective("directive2", Introspection.DirectiveLocation.SCALAR))
+                .withDirective(mkDirective("directive1", Introspection.DirectiveLocation.SCALAR))
+                .withDirective(mkDirective("directive2", Introspection.DirectiveLocation.SCALAR))
                 .build()
         when:
         def transformedScalar = startingScalar.transform({ builder ->
             builder.name("S2")
                     .description("S2_description")
-                    .withDirective(mockDirective("directive3", Introspection.DirectiveLocation.SCALAR))
+                    .withDirective(mkDirective("directive3", Introspection.DirectiveLocation.SCALAR))
         })
 
         then:

--- a/src/test/groovy/graphql/schema/GraphQLScalarTypeTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLScalarTypeTest.groovy
@@ -1,8 +1,9 @@
 package graphql.schema
 
+import graphql.introspection.Introspection
 import spock.lang.Specification
 
-import static graphql.schema.GraphQLDirective.newDirective
+import static graphql.TestUtil.mockDirective
 
 class GraphQLScalarTypeTest extends Specification {
     Coercing<String, String> coercing = new Coercing<String, String>() {
@@ -28,14 +29,14 @@ class GraphQLScalarTypeTest extends Specification {
                 .name("S1")
                 .description("S1_description")
                 .coercing(coercing)
-                .withDirective(newDirective().name("directive1"))
-                .withDirective(newDirective().name("directive2"))
+                .withDirective(mockDirective("directive1", Introspection.DirectiveLocation.SCALAR))
+                .withDirective(mockDirective("directive2", Introspection.DirectiveLocation.SCALAR))
                 .build()
         when:
         def transformedScalar = startingScalar.transform({ builder ->
             builder.name("S2")
                     .description("S2_description")
-                    .withDirective(newDirective().name("directive3"))
+                    .withDirective(mockDirective("directive3", Introspection.DirectiveLocation.SCALAR))
         })
 
         then:
@@ -55,6 +56,5 @@ class GraphQLScalarTypeTest extends Specification {
         transformedScalar.getDirective("directive1") != null
         transformedScalar.getDirective("directive2") != null
         transformedScalar.getDirective("directive3") != null
-
     }
 }

--- a/src/test/groovy/graphql/schema/SchemaTraverserTest.groovy
+++ b/src/test/groovy/graphql/schema/SchemaTraverserTest.groovy
@@ -6,25 +6,22 @@ import graphql.util.TraversalControl
 import graphql.util.TraverserContext
 import spock.lang.Specification
 
+import static graphql.introspection.Introspection.DirectiveLocation
 import static graphql.schema.GraphQLArgument.newArgument
 import static graphql.schema.GraphQLTypeReference.typeRef
 import static graphql.schema.GraphqlTypeComparatorRegistry.BY_NAME_REGISTRY
+import static graphql.TestUtil.mockDirective
 
 class SchemaTraverserTest extends Specification {
-
 
     def "reachable scalar type"() {
 
         when:
-
         def visitor = new GraphQLTestingVisitor()
         new SchemaTraverser().depthFirst(visitor, Scalars.GraphQLString)
 
         then:
-
         visitor.getStack() == ["scalar: String", "fallback: String"]
-
-
     }
 
     def "reachable string argument type"() {
@@ -48,7 +45,6 @@ class SchemaTraverserTest extends Specification {
                 .build())
         then:
         visitor.getStack() == ["argument: Test", "fallback: Test", "scalar: Int", "fallback: Int"]
-
     }
 
     def "reachable enum type"() {
@@ -65,7 +61,6 @@ class SchemaTraverserTest extends Specification {
         visitor.getStack() == ["enum: foo", "fallback: foo",
                                "enum value: abc", "fallback: abc",
                                "enum value: bar", "fallback: bar"]
-
     }
 
     def "reachable field definition type"() {
@@ -77,7 +72,6 @@ class SchemaTraverserTest extends Specification {
                 .build())
         then:
         visitor.getStack() == ["field: foo", "fallback: foo", "scalar: String", "fallback: String"]
-
     }
 
     def "reachable input object field type"() {
@@ -106,7 +100,6 @@ class SchemaTraverserTest extends Specification {
                                "input object field: bar", "fallback: bar",
                                "scalar: String", "fallback: String"]
     }
-
 
     def "reachable interface type"() {
         when:
@@ -163,7 +156,6 @@ class SchemaTraverserTest extends Specification {
                                "interface: bar", "fallback: bar"]
     }
 
-
     def "reachable reference type"() {
         when:
         def visitor = new GraphQLTestingVisitor()
@@ -210,8 +202,7 @@ class SchemaTraverserTest extends Specification {
         def scalarType = GraphQLScalarType.newScalar()
                 .name("foo")
                 .coercing(coercing)
-                .withDirective(GraphQLDirective.newDirective()
-                        .name("bar"))
+                .withDirective(mockDirective("bar", DirectiveLocation.SCALAR))
                 .withAppliedDirective(GraphQLAppliedDirective.newDirective()
                         .name("barApplied"))
                 .build()
@@ -227,8 +218,7 @@ class SchemaTraverserTest extends Specification {
         def visitor = new GraphQLTestingVisitor()
         def objectType = GraphQLObjectType.newObject()
                 .name("foo")
-                .withDirective(GraphQLDirective.newDirective()
-                        .name("bar"))
+                .withDirective(mockDirective("bar", DirectiveLocation.OBJECT))
                 .withAppliedDirective(GraphQLAppliedDirective.newDirective()
                         .name("barApplied"))
                 .build()
@@ -245,8 +235,7 @@ class SchemaTraverserTest extends Specification {
         def fieldDefinition = GraphQLFieldDefinition.newFieldDefinition()
                 .name("foo")
                 .type(Scalars.GraphQLString)
-                .withDirective(GraphQLDirective.newDirective()
-                        .name("bar"))
+                .withDirective(mockDirective("bar", DirectiveLocation.FIELD_DEFINITION))
                 .withAppliedDirective(GraphQLAppliedDirective.newDirective()
                         .name("barApplied"))
                 .build()
@@ -263,8 +252,7 @@ class SchemaTraverserTest extends Specification {
         def argument = newArgument()
                 .name("foo")
                 .type(Scalars.GraphQLString)
-                .withDirective(GraphQLDirective.newDirective()
-                        .name("bar"))
+                .withDirective(mockDirective("bar", DirectiveLocation.ARGUMENT_DEFINITION))
                 .withAppliedDirective(GraphQLAppliedDirective.newDirective()
                         .name("barApplied"))
                 .build()
@@ -280,8 +268,7 @@ class SchemaTraverserTest extends Specification {
         def visitor = new GraphQLTestingVisitor()
         def interfaceType = GraphQLInterfaceType.newInterface()
                 .name("foo")
-                .withDirective(GraphQLDirective.newDirective()
-                        .name("bar"))
+                .withDirective(mockDirective("bar", DirectiveLocation.INTERFACE))
                 .withAppliedDirective(GraphQLAppliedDirective.newDirective()
                         .name("barApplied"))
                 .build()
@@ -298,8 +285,7 @@ class SchemaTraverserTest extends Specification {
         def unionType = GraphQLUnionType.newUnionType()
                 .name("foo")
                 .possibleType(GraphQLObjectType.newObject().name("dummy").build())
-                .withDirective(GraphQLDirective.newDirective()
-                        .name("bar"))
+                .withDirective(mockDirective("bar", DirectiveLocation.UNION))
                 .build()
         new SchemaTraverser().depthFirst(visitor, unionType)
         then:
@@ -312,8 +298,7 @@ class SchemaTraverserTest extends Specification {
         def enumType = GraphQLEnumType.newEnum()
                 .name("foo")
                 .value("dummy")
-                .withDirective(GraphQLDirective.newDirective()
-                        .name("bar"))
+                .withDirective(mockDirective("bar", DirectiveLocation.ENUM))
                 .build()
         new SchemaTraverser().depthFirst(visitor, enumType)
         then:
@@ -325,8 +310,7 @@ class SchemaTraverserTest extends Specification {
         def visitor = new GraphQLTestingVisitor()
         def enumValue = GraphQLEnumValueDefinition.newEnumValueDefinition()
                 .name("foo")
-                .withDirective(GraphQLDirective.newDirective()
-                        .name("bar"))
+                .withDirective(mockDirective("bar", DirectiveLocation.ENUM_VALUE))
                 .build()
         new SchemaTraverser().depthFirst(visitor, enumValue)
         then:
@@ -338,8 +322,7 @@ class SchemaTraverserTest extends Specification {
         def visitor = new GraphQLTestingVisitor()
         def inputObjectType = GraphQLInputObjectType.newInputObject()
                 .name("foo")
-                .withDirective(GraphQLDirective.newDirective()
-                        .name("bar"))
+                .withDirective(mockDirective("bar", DirectiveLocation.INPUT_OBJECT))
                 .build()
         new SchemaTraverser().depthFirst(visitor, inputObjectType)
         then:
@@ -352,8 +335,7 @@ class SchemaTraverserTest extends Specification {
         def inputField = GraphQLInputObjectField.newInputObjectField()
                 .name("foo")
                 .type(Scalars.GraphQLString)
-                .withDirective(GraphQLDirective.newDirective()
-                        .name("bar"))
+                .withDirective(mockDirective("bar", DirectiveLocation.INPUT_FIELD_DEFINITION))
                 .build()
         new SchemaTraverser().depthFirst(visitor, inputField)
         then:

--- a/src/test/groovy/graphql/schema/SchemaTraverserTest.groovy
+++ b/src/test/groovy/graphql/schema/SchemaTraverserTest.groovy
@@ -10,7 +10,7 @@ import static graphql.introspection.Introspection.DirectiveLocation
 import static graphql.schema.GraphQLArgument.newArgument
 import static graphql.schema.GraphQLTypeReference.typeRef
 import static graphql.schema.GraphqlTypeComparatorRegistry.BY_NAME_REGISTRY
-import static graphql.TestUtil.mockDirective
+import static graphql.TestUtil.mkDirective
 
 class SchemaTraverserTest extends Specification {
 
@@ -202,7 +202,7 @@ class SchemaTraverserTest extends Specification {
         def scalarType = GraphQLScalarType.newScalar()
                 .name("foo")
                 .coercing(coercing)
-                .withDirective(mockDirective("bar", DirectiveLocation.SCALAR))
+                .withDirective(mkDirective("bar", DirectiveLocation.SCALAR))
                 .withAppliedDirective(GraphQLAppliedDirective.newDirective()
                         .name("barApplied"))
                 .build()
@@ -218,7 +218,7 @@ class SchemaTraverserTest extends Specification {
         def visitor = new GraphQLTestingVisitor()
         def objectType = GraphQLObjectType.newObject()
                 .name("foo")
-                .withDirective(mockDirective("bar", DirectiveLocation.OBJECT))
+                .withDirective(mkDirective("bar", DirectiveLocation.OBJECT))
                 .withAppliedDirective(GraphQLAppliedDirective.newDirective()
                         .name("barApplied"))
                 .build()
@@ -235,7 +235,7 @@ class SchemaTraverserTest extends Specification {
         def fieldDefinition = GraphQLFieldDefinition.newFieldDefinition()
                 .name("foo")
                 .type(Scalars.GraphQLString)
-                .withDirective(mockDirective("bar", DirectiveLocation.FIELD_DEFINITION))
+                .withDirective(mkDirective("bar", DirectiveLocation.FIELD_DEFINITION))
                 .withAppliedDirective(GraphQLAppliedDirective.newDirective()
                         .name("barApplied"))
                 .build()
@@ -252,7 +252,7 @@ class SchemaTraverserTest extends Specification {
         def argument = newArgument()
                 .name("foo")
                 .type(Scalars.GraphQLString)
-                .withDirective(mockDirective("bar", DirectiveLocation.ARGUMENT_DEFINITION))
+                .withDirective(mkDirective("bar", DirectiveLocation.ARGUMENT_DEFINITION))
                 .withAppliedDirective(GraphQLAppliedDirective.newDirective()
                         .name("barApplied"))
                 .build()
@@ -268,7 +268,7 @@ class SchemaTraverserTest extends Specification {
         def visitor = new GraphQLTestingVisitor()
         def interfaceType = GraphQLInterfaceType.newInterface()
                 .name("foo")
-                .withDirective(mockDirective("bar", DirectiveLocation.INTERFACE))
+                .withDirective(mkDirective("bar", DirectiveLocation.INTERFACE))
                 .withAppliedDirective(GraphQLAppliedDirective.newDirective()
                         .name("barApplied"))
                 .build()
@@ -285,7 +285,7 @@ class SchemaTraverserTest extends Specification {
         def unionType = GraphQLUnionType.newUnionType()
                 .name("foo")
                 .possibleType(GraphQLObjectType.newObject().name("dummy").build())
-                .withDirective(mockDirective("bar", DirectiveLocation.UNION))
+                .withDirective(mkDirective("bar", DirectiveLocation.UNION))
                 .build()
         new SchemaTraverser().depthFirst(visitor, unionType)
         then:
@@ -298,7 +298,7 @@ class SchemaTraverserTest extends Specification {
         def enumType = GraphQLEnumType.newEnum()
                 .name("foo")
                 .value("dummy")
-                .withDirective(mockDirective("bar", DirectiveLocation.ENUM))
+                .withDirective(mkDirective("bar", DirectiveLocation.ENUM))
                 .build()
         new SchemaTraverser().depthFirst(visitor, enumType)
         then:
@@ -310,7 +310,7 @@ class SchemaTraverserTest extends Specification {
         def visitor = new GraphQLTestingVisitor()
         def enumValue = GraphQLEnumValueDefinition.newEnumValueDefinition()
                 .name("foo")
-                .withDirective(mockDirective("bar", DirectiveLocation.ENUM_VALUE))
+                .withDirective(mkDirective("bar", DirectiveLocation.ENUM_VALUE))
                 .build()
         new SchemaTraverser().depthFirst(visitor, enumValue)
         then:
@@ -322,7 +322,7 @@ class SchemaTraverserTest extends Specification {
         def visitor = new GraphQLTestingVisitor()
         def inputObjectType = GraphQLInputObjectType.newInputObject()
                 .name("foo")
-                .withDirective(mockDirective("bar", DirectiveLocation.INPUT_OBJECT))
+                .withDirective(mkDirective("bar", DirectiveLocation.INPUT_OBJECT))
                 .build()
         new SchemaTraverser().depthFirst(visitor, inputObjectType)
         then:
@@ -335,7 +335,7 @@ class SchemaTraverserTest extends Specification {
         def inputField = GraphQLInputObjectField.newInputObjectField()
                 .name("foo")
                 .type(Scalars.GraphQLString)
-                .withDirective(mockDirective("bar", DirectiveLocation.INPUT_FIELD_DEFINITION))
+                .withDirective(mkDirective("bar", DirectiveLocation.INPUT_FIELD_DEFINITION))
                 .build()
         new SchemaTraverser().depthFirst(visitor, inputField)
         then:

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -1,6 +1,5 @@
 package graphql.schema.idl
 
-
 import graphql.TestUtil
 import graphql.introspection.Introspection
 import graphql.language.Node
@@ -11,7 +10,6 @@ import graphql.schema.DataFetchingEnvironment
 import graphql.schema.GraphQLAppliedDirective
 import graphql.schema.GraphQLArgument
 import graphql.schema.GraphQLCodeRegistry
-import graphql.schema.GraphQLDirective
 import graphql.schema.GraphQLDirectiveContainer
 import graphql.schema.GraphQLEnumType
 import graphql.schema.GraphQLFieldDefinition
@@ -44,6 +42,7 @@ import static graphql.language.AstPrinter.printAst
 import static graphql.schema.GraphQLCodeRegistry.newCodeRegistry
 import static graphql.schema.idl.SchemaGenerator.Options.defaultOptions
 import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring
+import static graphql.TestUtil.mockDirective
 
 class SchemaGeneratorTest extends Specification {
 

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -8,7 +8,6 @@ import graphql.schema.DataFetcherFactory
 import graphql.schema.DataFetcherFactoryEnvironment
 import graphql.schema.DataFetchingEnvironment
 import graphql.schema.GraphQLAppliedDirective
-import graphql.schema.GraphQLArgument
 import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLDirectiveContainer
 import graphql.schema.GraphQLEnumType
@@ -42,7 +41,6 @@ import static graphql.language.AstPrinter.printAst
 import static graphql.schema.GraphQLCodeRegistry.newCodeRegistry
 import static graphql.schema.idl.SchemaGenerator.Options.defaultOptions
 import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring
-import static graphql.TestUtil.mockDirective
 
 class SchemaGeneratorTest extends Specification {
 

--- a/src/test/groovy/graphql/validation/rules/KnownArgumentNamesTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/KnownArgumentNamesTest.groovy
@@ -1,5 +1,6 @@
 package graphql.validation.rules
 
+import graphql.introspection.Introspection
 import graphql.language.Argument
 import graphql.language.BooleanValue
 import graphql.language.StringValue
@@ -52,7 +53,9 @@ class KnownArgumentNamesTest extends Specification {
         given:
         Argument argument = Argument.newArgument("unknownArg", BooleanValue.newBooleanValue(true).build()).build()
         def fieldDefinition = GraphQLFieldDefinition.newFieldDefinition().name("field").type(GraphQLString).build()
-        def directiveDefinition = GraphQLDirective.newDirective().name("directive")
+        def directiveDefinition = GraphQLDirective.newDirective()
+                .name("directive")
+                .validLocation(Introspection.DirectiveLocation.FIELD_DEFINITION)
                 .argument(GraphQLArgument.newArgument().name("knownArg").type(GraphQLBoolean).build()).build()
         validationContext.getFieldDef() >> fieldDefinition
         validationContext.getDirective() >> directiveDefinition
@@ -66,7 +69,9 @@ class KnownArgumentNamesTest extends Specification {
         given:
         Argument argument = Argument.newArgument("knownArg", BooleanValue.newBooleanValue(true).build()).build()
         def fieldDefinition = GraphQLFieldDefinition.newFieldDefinition().name("field").type(GraphQLString).build()
-        def directiveDefinition = GraphQLDirective.newDirective().name("directive")
+        def directiveDefinition = GraphQLDirective.newDirective()
+                .name("directive")
+                .validLocation(Introspection.DirectiveLocation.FIELD_DEFINITION)
                 .argument(GraphQLArgument.newArgument().name("knownArg").type(GraphQLBoolean).build()).build()
         validationContext.getFieldDef() >> fieldDefinition
         validationContext.getDirective() >> directiveDefinition
@@ -81,7 +86,9 @@ class KnownArgumentNamesTest extends Specification {
         Argument argument = Argument.newArgument("unknownArg", BooleanValue.newBooleanValue(true).build()).build()
         def fieldDefinition = GraphQLFieldDefinition.newFieldDefinition().name("field").type(GraphQLString)
                 .argument(GraphQLArgument.newArgument().name("unknownArg").type(GraphQLString).build()).build()
-        def directiveDefinition = GraphQLDirective.newDirective().name("directive")
+        def directiveDefinition = GraphQLDirective.newDirective()
+                .name("directive")
+                .validLocation(Introspection.DirectiveLocation.FIELD_DEFINITION)
                 .argument(GraphQLArgument.newArgument().name("knownArg").type(GraphQLBoolean).build()).build()
         validationContext.getFieldDef() >> fieldDefinition
         validationContext.getDirective() >> directiveDefinition

--- a/src/test/groovy/graphql/validation/rules/ProvidedNonNullArgumentsTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/ProvidedNonNullArgumentsTest.groovy
@@ -1,5 +1,6 @@
 package graphql.validation.rules
 
+import graphql.introspection.Introspection
 import graphql.language.Argument
 import graphql.language.Directive
 import graphql.language.Field
@@ -111,6 +112,7 @@ class ProvidedNonNullArgumentsTest extends Specification {
                 .name("arg").type(GraphQLNonNull.nonNull(GraphQLString))
         def graphQLDirective = GraphQLDirective.newDirective()
                 .name("directive")
+                .validLocation(Introspection.DirectiveLocation.SCALAR)
                 .argument(directiveArg)
                 .build()
         validationContext.getDirective() >> graphQLDirective
@@ -149,6 +151,7 @@ class ProvidedNonNullArgumentsTest extends Specification {
                 .defaultValueProgrammatic("defaultVal")
         def graphQLDirective = GraphQLDirective.newDirective()
                 .name("directive")
+                .validLocation(Introspection.DirectiveLocation.SCALAR)
                 .argument(directiveArg)
                 .build()
         validationContext.getDirective() >> graphQLDirective
@@ -167,6 +170,7 @@ class ProvidedNonNullArgumentsTest extends Specification {
         def directiveArg = GraphQLArgument.newArgument().name("arg").type(GraphQLNonNull.nonNull(GraphQLString))
         def graphQLDirective = GraphQLDirective.newDirective()
                 .name("directive")
+                .validLocation(Introspection.DirectiveLocation.SCALAR)
                 .argument(directiveArg)
                 .build()
         validationContext.getDirective() >> graphQLDirective


### PR DESCRIPTION
It's possible to programmatically create a `GraphQLDirective` without setting it's valid locations. These missing locations are not validated at schema creation time either, allowing the schema without directive locations to be rendered with`SchemaPrinter`, producing SDL like:
```
directive @foo on
directive @bar on
```

Trying to reparse this rendered sdl fails with an InvalidSyntaxError.

This PR addresses this by requiring that at the time that a `GraphQLDirective` is created, it must have a non-empty set of locations configured. This is similar to existing validations for name and arguments. As a result of this new requirement, I had to update a number of tests that create directives without locations.

There are 2 spec-related aspects to this:
1. Does the spec actually require a directive location?
It's not clear to me that it does. The [grammar](https://spec.graphql.org/October2021/#DirectiveLocations) part of DirectiveLocations (which I don't fully grok) seems ambiguous. I also did a shallow check of graphql-js and didn't find anything indicating a requirement for directive locations. 
If they are indeed *not* required, then this PR may be over-reaching by requiring non-empty locations in the GraphQLDirective constructor

2. The spec requires that [directives be applied in valid locations](https://spec.graphql.org/October2021/#sec-Directives-Are-In-Valid-Locations)
This suggests that some of the unit tests in this PR, which create and use directives that have no validLocations, are maybe a little lax.
Maybe this is fine at the level of individual schema objects, so long as they're eventually validated at schema creation? Feedback welcome!