### PR TITLE
Putting createState back into Instrumentation

### DIFF
--- a/src/main/java/graphql/execution/instrumentation/Instrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/Instrumentation.java
@@ -50,9 +50,22 @@ public interface Instrumentation {
      */
     @Nullable
     default CompletableFuture<InstrumentationState> createStateAsync(InstrumentationCreateStateParameters parameters) {
-        return null;
+        return CompletableFuture.completedFuture(createState(parameters));
     }
 
+    /**
+     * This method is retained for backwards compatibility reasons so that previous {@link Instrumentation} implementations
+     * continue to work.  The graphql-java code only called {@link #createStateAsync(InstrumentationCreateStateParameters)}
+     * but the default implementation calls back to this method.
+     *
+     * @param parameters the parameters to this step
+     *
+     * @return a state object that is passed to each method
+     */
+    @Nullable
+    default InstrumentationState createState(InstrumentationCreateStateParameters parameters) {
+        return null;
+    }
 
     /**
      * This is called right at the start of query execution, and it's the first step in the instrumentation chain.

--- a/src/main/java/graphql/execution/instrumentation/Instrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/Instrumentation.java
@@ -50,7 +50,8 @@ public interface Instrumentation {
      */
     @Nullable
     default CompletableFuture<InstrumentationState> createStateAsync(InstrumentationCreateStateParameters parameters) {
-        return CompletableFuture.completedFuture(createState(parameters));
+        InstrumentationState state = createState(parameters);
+        return state == null ? null : CompletableFuture.completedFuture(state);
     }
 
     /**

--- a/src/main/java/graphql/execution/instrumentation/SimplePerformantInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/SimplePerformantInstrumentation.java
@@ -48,6 +48,12 @@ public class SimplePerformantInstrumentation implements Instrumentation {
 
     @Override
     public @Nullable CompletableFuture<InstrumentationState> createStateAsync(InstrumentationCreateStateParameters parameters) {
+        InstrumentationState state = createState(parameters);
+        return state == null ? null : CompletableFuture.completedFuture(state);
+    }
+
+    @Override
+    public @Nullable InstrumentationState createState(InstrumentationCreateStateParameters parameters) {
         return null;
     }
 


### PR DESCRIPTION
I have had revisionist thoughts on removing createState - while its not strictly needed - it breaks people without enough reward

So I have restored it and said its not deprecated