### PR TITLE
fix incremental partial result builder

### DIFF
--- a/src/main/java/graphql/incremental/DelayedIncrementalPartialResultImpl.java
+++ b/src/main/java/graphql/incremental/DelayedIncrementalPartialResultImpl.java
@@ -75,8 +75,8 @@ public class DelayedIncrementalPartialResultImpl implements DelayedIncrementalPa
             return this;
         }
 
-        public Builder extensions(boolean hasNext) {
-            this.hasNext = hasNext;
+        public Builder extensions(Map<Object, Object> extensions) {
+            this.extensions = extensions;
             return this;
         }
 

--- a/src/test/groovy/graphql/incremental/IncrementalExecutionResultTest.groovy
+++ b/src/test/groovy/graphql/incremental/IncrementalExecutionResultTest.groovy
@@ -40,6 +40,7 @@ class IncrementalExecutionResultTest extends Specification {
                 ])
                 .hasNext(true)
                 .incremental([defer1, stream1, stream2])
+                .extensions([some: "map"])
                 .build()
 
         def toSpec = result.toSpecification()
@@ -47,6 +48,7 @@ class IncrementalExecutionResultTest extends Specification {
         then:
         toSpec == [
                 data       : [person: [name: "Luke Skywalker", films: [[title: "A New Hope"]]]],
+                extensions: [some: "map"],
                 hasNext    : true,
                 incremental: [
                         [path: ["person"], label: "homeWorldDefer", data: [homeWorld: "Tatooine"]],

--- a/src/test/groovy/graphql/incremental/IncrementalExecutionResultTest.groovy
+++ b/src/test/groovy/graphql/incremental/IncrementalExecutionResultTest.groovy
@@ -9,7 +9,7 @@ import static graphql.incremental.StreamPayload.newStreamedItem
 
 class IncrementalExecutionResultTest extends Specification {
 
-    def "sanity test to check builders work"() {
+    def "sanity test to check IncrementalExecutionResultImpl and item builders work"() {
         when:
         def defer1 = newDeferredItem()
                 .label("homeWorldDefer")
@@ -55,6 +55,30 @@ class IncrementalExecutionResultTest extends Specification {
                         [path: ["person", "films", 1], label: "filmsStream", items: [[title: "The Empire Strikes Back"]]],
                         [path: ["person", "films", 2], label: "filmsStream", items: [[title: "Return of the Jedi"]]],
                 ]
+        ]
+
+    }
+    def "sanity test to check DelayedIncrementalPartialResult builder works"() {
+        when:
+        def deferredItem = newDeferredItem()
+                .label("homeWorld")
+                .path(ResultPath.parse("/person"))
+                .data([homeWorld: "Tatooine"])
+                .build()
+
+        def result = DelayedIncrementalPartialResultImpl.newIncrementalExecutionResult()
+                .incrementalItems([deferredItem])
+                .hasNext(false)
+                .extensions([some: "map"])
+                .build()
+
+        def toSpec = result.toSpecification()
+
+        then:
+        toSpec == [
+                incremental: [[path: ["person"], label: "homeWorld", data: [homeWorld: "Tatooine"]]],
+                extensions: [some: "map"],
+                hasNext    : false,
         ]
 
     }

--- a/src/test/groovy/graphql/incremental/IncrementalExecutionResultTest.groovy
+++ b/src/test/groovy/graphql/incremental/IncrementalExecutionResultTest.groovy
@@ -9,7 +9,7 @@ import static graphql.incremental.StreamPayload.newStreamedItem
 
 class IncrementalExecutionResultTest extends Specification {
 
-    def "sanity test to check IncrementalExecutionResultImpl and item builders work"() {
+    def "sanity test to check IncrementalExecutionResultImpl builder and item builders work"() {
         when:
         def defer1 = newDeferredItem()
                 .label("homeWorldDefer")


### PR DESCRIPTION
it looks like there was a copy-paste error for this one function (copied from the hasNext part of the builder).

This change is to fix the function to allow us to properly add "extensions" to the builder. Similar to this one [here](https://github.com/graphql-java/graphql-java/blob/e01013f65f4554643e8b7c3df5143438fc5d414a/src/main/java/graphql/incremental/IncrementalPayload.java#L135C1-L138C10)

have also added a test for this builder