### PR TITLE
OneOf validation test case

### DIFF
--- a/src/test/groovy/graphql/schema/GraphQLInputObjectTypeTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLInputObjectTypeTest.groovy
@@ -180,4 +180,23 @@ class GraphQLInputObjectTypeTest extends Specification {
 
         // lots more covered in unit tests
     }
+
+    def "rejects invalid OneOf values before invoking data fetchers"() {
+        def sdl = '''
+            type Query {
+                f(arg: OneOf): Boolean
+            }
+            
+            input OneOf @oneOf { a: Int b: Int }
+        '''
+
+        def graphQLSchema = TestUtil.schema(sdl)
+        def graphQL = GraphQL.newGraphQL(graphQLSchema).build()
+
+        when:
+        def er = graphQL.execute('{ f(arg : {a: 0, b: 0}) }')
+        then:
+        !er.errors.isEmpty()
+        er.errors[0].message == "Exception while fetching data (/f) : Exactly one key must be specified for OneOf type 'OneOf'."
+    }
 }

--- a/src/test/groovy/graphql/schema/GraphQLInputObjectTypeTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLInputObjectTypeTest.groovy
@@ -181,6 +181,10 @@ class GraphQLInputObjectTypeTest extends Specification {
         // lots more covered in unit tests
     }
 
+    /**
+     * This test fails because OneOf validators are never invoked.
+     * Validators are never invoked because arguments are never accessed by a data fetcher
+     */
     def "rejects invalid OneOf values before invoking data fetchers"() {
         def sdl = '''
             type Query {


### PR DESCRIPTION
This is a test case illustrating a validation issue with OneOf types.

The issue is that OneOf validation (and maybe other input validations?) are driven by calls to `DataFetchingEnvironment.getArgument`. If a data fetcher does not call `getArgument`, `getArguments`, or accesses arguments via  other means, then validations don't run.

This is counter to section 6.11 of the graphql spec:
> only requests which pass all validation rules should be executed. If validation errors are known, they should be reported in the list of “errors” in the response and the request must fail without execution
