### PR TITLE
Added field fetching method for Expedia

### DIFF
--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -17,6 +17,7 @@ import graphql.execution.directives.QueryDirectives;
 import graphql.execution.directives.QueryDirectivesImpl;
 import graphql.execution.incremental.DeferredExecutionSupport;
 import graphql.execution.instrumentation.ExecuteObjectInstrumentationContext;
+import graphql.execution.instrumentation.FieldFetchingInstrumentationContext;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionStrategyParameters;
@@ -487,7 +488,7 @@ public abstract class ExecutionStrategy {
         Instrumentation instrumentation = executionContext.getInstrumentation();
 
         InstrumentationFieldFetchParameters instrumentationFieldFetchParams = new InstrumentationFieldFetchParameters(executionContext, dataFetchingEnvironment, parameters, dataFetcher instanceof TrivialDataFetcher);
-        InstrumentationContext<Object> fetchCtx = nonNullCtx(instrumentation.beginFieldFetch(instrumentationFieldFetchParams,
+        FieldFetchingInstrumentationContext fetchCtx = FieldFetchingInstrumentationContext.nonNullCtx(instrumentation.beginFieldFetching(instrumentationFieldFetchParams,
                 executionContext.getInstrumentationState())
         );
 
@@ -496,6 +497,7 @@ public abstract class ExecutionStrategy {
         Object fetchedObject = invokeDataFetcher(executionContext, parameters, fieldDef, dataFetchingEnvironment, dataFetcher);
         executionContext.getDataLoaderDispatcherStrategy().fieldFetched(executionContext, parameters, dataFetcher, fetchedObject);
         fetchCtx.onDispatched();
+        fetchCtx.onFetchedValue(fetchedObject);
         if (fetchedObject instanceof CompletableFuture) {
             @SuppressWarnings("unchecked")
             CompletableFuture<Object> fetchedValue = (CompletableFuture<Object>) fetchedObject;

--- a/src/main/java/graphql/execution/instrumentation/FieldFetchingInstrumentationContext.java
+++ b/src/main/java/graphql/execution/instrumentation/FieldFetchingInstrumentationContext.java
@@ -1,0 +1,68 @@
+package graphql.execution.instrumentation;
+
+import graphql.Internal;
+import graphql.PublicSpi;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@PublicSpi
+public interface FieldFetchingInstrumentationContext extends InstrumentationContext<Object> {
+
+    @Internal
+    FieldFetchingInstrumentationContext NOOP = new FieldFetchingInstrumentationContext() {
+        @Override
+        public void onDispatched() {
+        }
+
+        @Override
+        public void onCompleted(Object result, Throwable t) {
+        }
+
+        @Override
+        public void onFetchedValue(Object fetchedValue) {
+        }
+    };
+
+    /**
+     * This creates a no-op {@link InstrumentationContext} if the one pass in is null
+     *
+     * @param nullableContext a {@link InstrumentationContext} that can be null
+     *
+     * @return a non null {@link InstrumentationContext} that maybe a no-op
+     */
+    @NotNull
+    @Internal
+    static FieldFetchingInstrumentationContext nonNullCtx(FieldFetchingInstrumentationContext nullableContext) {
+        return nullableContext == null ? NOOP : nullableContext;
+    }
+
+    @Internal
+    static FieldFetchingInstrumentationContext adapter(@Nullable InstrumentationContext<Object> context) {
+        if (context == null) {
+            return null;
+        }
+        return new FieldFetchingInstrumentationContext() {
+            @Override
+            public void onDispatched() {
+                context.onDispatched();
+            }
+
+            @Override
+            public void onCompleted(Object result, Throwable t) {
+                context.onCompleted(result, t);
+            }
+
+            @Override
+            public void onFetchedValue(Object fetchedValue) {
+            }
+        };
+    }
+
+    /**
+     * This is called back with value fetched for the field.
+     *
+     * @param fetchedValue a value that a field's {@link graphql.schema.DataFetcher} returned
+     */
+    default void onFetchedValue(Object fetchedValue) {
+    }
+}

--- a/src/main/java/graphql/execution/instrumentation/Instrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/Instrumentation.java
@@ -196,10 +196,29 @@ public interface Instrumentation {
      * @param state      the state created during the call to {@link #createStateAsync(InstrumentationCreateStateParameters)}
      *
      * @return a nullable {@link InstrumentationContext} object that will be called back when the step ends (assuming it's not null)
+     *
+     * @deprecated use {@link #beginFieldFetching(InstrumentationFieldFetchParameters, InstrumentationState)} instead
      */
+    @Deprecated(since = "2024-04-18")
     @Nullable
     default InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters, InstrumentationState state) {
         return noOp();
+    }
+
+    /**
+     * This is called just before a field {@link DataFetcher} is invoked. The {@link FieldFetchingInstrumentationContext#onFetchedValue(Object)}
+     * callback will be invoked once a value is returned by a {@link DataFetcher} but perhaps before
+     * its value is completed if it's a {@link CompletableFuture} value.
+     *
+     * @param parameters the parameters to this step
+     * @param state      the state created during the call to {@link #createStateAsync(InstrumentationCreateStateParameters)}
+     *
+     * @return a nullable {@link InstrumentationContext} object that will be called back when the step ends (assuming it's not null)
+     */
+    @Nullable
+    default FieldFetchingInstrumentationContext beginFieldFetching(InstrumentationFieldFetchParameters parameters, InstrumentationState state) {
+        InstrumentationContext<Object> ctx = beginFieldFetch(parameters, state);
+        return FieldFetchingInstrumentationContext.adapter(ctx);
     }
 
     /**

--- a/src/main/java/graphql/execution/instrumentation/NoContextChainedInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/NoContextChainedInstrumentation.java
@@ -99,6 +99,11 @@ public class NoContextChainedInstrumentation extends ChainedInstrumentation {
     }
 
     @Override
+    public FieldFetchingInstrumentationContext beginFieldFetching(InstrumentationFieldFetchParameters parameters, InstrumentationState state) {
+        return runAll(state, (instrumentation, specificState) -> instrumentation.beginFieldFetching(parameters, specificState));
+    }
+
+    @Override
     public @Nullable InstrumentationContext<Object> beginFieldCompletion(InstrumentationFieldCompleteParameters parameters, InstrumentationState state) {
         return runAll(state, (instrumentation, specificState) -> instrumentation.beginFieldCompletion(parameters, specificState));
     }

--- a/src/main/java/graphql/execution/instrumentation/SimplePerformantInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/SimplePerformantInstrumentation.java
@@ -102,7 +102,6 @@ public class SimplePerformantInstrumentation implements Instrumentation {
         return noOp();
     }
 
-
     @Override
     public @Nullable InstrumentationContext<Object> beginFieldCompletion(InstrumentationFieldCompleteParameters parameters, InstrumentationState state) {
         return noOp();

--- a/src/test/groovy/graphql/execution/instrumentation/ModernTestingInstrumentation.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/ModernTestingInstrumentation.groovy
@@ -86,9 +86,9 @@ class ModernTestingInstrumentation implements Instrumentation {
     }
 
     @Override
-    InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters, InstrumentationState state) {
+    FieldFetchingInstrumentationContext beginFieldFetching(InstrumentationFieldFetchParameters parameters, InstrumentationState state) {
         assert state == instrumentationState
-        return new TestingInstrumentContext("fetch-$parameters.field.name", executionList, throwableList, useOnDispatch)
+        return new TestingFieldFetchingInstrumentationContext("fetch-$parameters.field.name", executionList, throwableList, useOnDispatch)
     }
 
     @Override

--- a/src/test/groovy/graphql/execution/instrumentation/TestingFieldFetchingInstrumentationContext.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/TestingFieldFetchingInstrumentationContext.groovy
@@ -1,0 +1,9 @@
+package graphql.execution.instrumentation
+
+class TestingFieldFetchingInstrumentationContext extends TestingInstrumentContext<Map<String, Object>> implements FieldFetchingInstrumentationContext {
+
+    TestingFieldFetchingInstrumentationContext(Object op, Object executionList, Object throwableList, Boolean useOnDispatch) {
+        super(op, executionList, throwableList, useOnDispatch)
+    }
+}
+


### PR DESCRIPTION
When we changed InstrumentationContext to no longer take a CF as an argument, the callback to `beginFieldFetch` can no long know about the value that was fetched.

Expedia for example used to this know if the value was a SYNC or ASYNC value for this dispatch code.

This adds a new method with a new context class that can be called back with the object that was fetched (it might not be complete if its a CF say)

The default implementation calls back to the old method so that we dont break any one.  But should it?  v22 is only a few days old - if v22.1 was also breaking for this - the impact would be low - no zero but very low