### PR TITLE
This provides validation on @oneof input types during validation phase

### DIFF
--- a/src/main/java/graphql/validation/ArgumentValidationUtil.java
+++ b/src/main/java/graphql/validation/ArgumentValidationUtil.java
@@ -91,6 +91,12 @@ public class ArgumentValidationUtil extends ValidationUtil {
         argumentNames.add(0, String.format("[%s]", index));
     }
 
+    @Override
+    protected void handleExtraOneOfFieldsError(GraphQLInputObjectType type, Value<?> value) {
+        errMsgKey = "ArgumentValidationUtil.extraOneOfFieldsError";
+        arguments.add(type.getName());
+    }
+
     public I18nMsg getMsgAndArgs() {
         StringBuilder argument = new StringBuilder(argumentName);
         for (String name : argumentNames) {

--- a/src/main/java/graphql/validation/ValidationUtil.java
+++ b/src/main/java/graphql/validation/ValidationUtil.java
@@ -3,6 +3,7 @@ package graphql.validation;
 
 import com.google.common.collect.ImmutableSet;
 import graphql.Assert;
+import graphql.Directives;
 import graphql.GraphQLContext;
 import graphql.GraphQLError;
 import graphql.Internal;
@@ -77,6 +78,9 @@ public class ValidationUtil {
     protected void handleFieldNotValidError(Value<?> value, GraphQLType type, int index) {
     }
 
+    protected void handleExtraOneOfFieldsError(GraphQLInputObjectType type, Value<?> value) {
+    }
+
     public boolean isValidLiteralValue(Value<?> value, GraphQLType type, GraphQLSchema schema, GraphQLContext graphQLContext, Locale locale) {
         if (value == null || value instanceof NullValue) {
             boolean valid = !(isNonNull(type));
@@ -95,18 +99,18 @@ public class ValidationUtil {
         if (type instanceof GraphQLScalarType) {
             Optional<GraphQLError> invalid = parseLiteral(value, ((GraphQLScalarType) type).getCoercing(), graphQLContext, locale);
             invalid.ifPresent(graphQLError -> handleScalarError(value, (GraphQLScalarType) type, graphQLError));
-            return !invalid.isPresent();
+            return invalid.isEmpty();
         }
         if (type instanceof GraphQLEnumType) {
             Optional<GraphQLError> invalid = parseLiteralEnum(value, (GraphQLEnumType) type, graphQLContext, locale);
             invalid.ifPresent(graphQLError -> handleEnumError(value, (GraphQLEnumType) type, graphQLError));
-            return !invalid.isPresent();
+            return invalid.isEmpty();
         }
 
         if (isList(type)) {
             return isValidLiteralValue(value, (GraphQLList) type, schema, graphQLContext, locale);
         }
-        return type instanceof GraphQLInputObjectType && isValidLiteralValue(value, (GraphQLInputObjectType) type, schema, graphQLContext, locale);
+        return type instanceof GraphQLInputObjectType && isValidLiteralValueForInputObjectType(value, (GraphQLInputObjectType) type, schema, graphQLContext, locale);
 
     }
 
@@ -128,7 +132,7 @@ public class ValidationUtil {
         }
     }
 
-    boolean isValidLiteralValue(Value<?> value, GraphQLInputObjectType type, GraphQLSchema schema, GraphQLContext graphQLContext, Locale locale) {
+    boolean isValidLiteralValueForInputObjectType(Value<?> value, GraphQLInputObjectType type, GraphQLSchema schema, GraphQLContext graphQLContext, Locale locale) {
         if (!(value instanceof ObjectValue)) {
             handleNotObjectError(value, type);
             return false;
@@ -156,8 +160,15 @@ public class ValidationUtil {
             }
 
         }
+        if (type.hasAppliedDirective(Directives.OneOfDirective.getName())) {
+            if (objectFieldMap.keySet() .size() != 1) {
+                handleExtraOneOfFieldsError(type,value);
+                return false;
+            }
+        }
         return true;
     }
+
 
     private Set<String> getMissingFields(GraphQLInputObjectType type, Map<String, ObjectField> objectFieldMap, GraphqlFieldVisibility fieldVisibility) {
         return fieldVisibility.getFieldDefinitions(type).stream()

--- a/src/main/java/graphql/validation/ValidationUtil.java
+++ b/src/main/java/graphql/validation/ValidationUtil.java
@@ -161,7 +161,7 @@ public class ValidationUtil {
 
         }
         if (type.hasAppliedDirective(Directives.OneOfDirective.getName())) {
-            if (objectFieldMap.keySet() .size() != 1) {
+            if (objectFieldMap.keySet().size() != 1) {
                 handleExtraOneOfFieldsError(type,value);
                 return false;
             }

--- a/src/main/resources/i18n/Validation.properties
+++ b/src/main/resources/i18n/Validation.properties
@@ -106,4 +106,5 @@ ArgumentValidationUtil.handleNotObjectError=Validation error ({0}) : argument ''
 ArgumentValidationUtil.handleMissingFieldsError=Validation error ({0}) : argument ''{1}'' with value ''{2}'' is missing required fields ''{3}''
 # suppress inspection "UnusedProperty"
 ArgumentValidationUtil.handleExtraFieldError=Validation error ({0}) : argument ''{1}'' with value ''{2}'' contains a field not in ''{3}'': ''{4}''
-
+# suppress inspection "UnusedProperty"
+ArgumentValidationUtil.extraOneOfFieldsError=Validation error ({0}) : Exactly one key must be specified for argument ''{1}'' of @oneOf input type ''{3}''

--- a/src/main/resources/i18n/Validation.properties
+++ b/src/main/resources/i18n/Validation.properties
@@ -107,4 +107,5 @@ ArgumentValidationUtil.handleMissingFieldsError=Validation error ({0}) : argumen
 # suppress inspection "UnusedProperty"
 ArgumentValidationUtil.handleExtraFieldError=Validation error ({0}) : argument ''{1}'' with value ''{2}'' contains a field not in ''{3}'': ''{4}''
 # suppress inspection "UnusedProperty"
-ArgumentValidationUtil.extraOneOfFieldsError=Validation error ({0}) : Exactly one key must be specified for argument ''{1}'' of @oneOf input type ''{3}''
+# suppress inspection "UnusedMessageFormatParameter"
+ArgumentValidationUtil.extraOneOfFieldsError=Validation error ({0}) : Exactly one key must be specified for OneOf type ''{3}''.

--- a/src/test/groovy/graphql/schema/GraphQLInputObjectTypeTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLInputObjectTypeTest.groovy
@@ -162,7 +162,8 @@ class GraphQLInputObjectTypeTest extends Specification {
         er = graphQL.execute('query q { f( arg : {a : "abc", b : 123}) { key value }}')
         then:
         !er.errors.isEmpty()
-        er.errors[0].message == "Exception while fetching data (/f) : Exactly one key must be specified for OneOf type 'OneOf'."
+        // caught during early validation
+        er.errors[0].message == "Validation error (WrongType@[f]) : Exactly one key must be specified for OneOf type 'OneOf'."
 
         when:
         def ei = ExecutionInput.newExecutionInput('query q($var : OneOf)  { f( arg : $var) { key value }}').variables([var: [a: "abc", b: 123]]).build()

--- a/src/test/groovy/graphql/validation/rules/ArgumentsOfCorrectTypeTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/ArgumentsOfCorrectTypeTest.groovy
@@ -335,6 +335,37 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         validationErrors.get(0).message == "Validation error (WrongType@[dog/doesKnowCommand]) : argument 'dogCommand' with value 'EnumValue{name='PRETTY'}' is not a valid 'DogCommand' - Literal value not in allowable values for enum 'DogCommand' - 'EnumValue{name='PRETTY'}'"
     }
 
+    def "invalid @oneOf argument - has more than 1 key - case #why"() {
+        when:
+        def validationErrors = validate(query)
+
+        then:
+        validationErrors.size() == 1
+        validationErrors.get(0).getValidationErrorType() == ValidationErrorType.WrongType
+        validationErrors.get(0).message == "Validation error (WrongType@[oneOfField]) : Exactly one key must be specified for argument 'oneOfArg' of @oneOf input type 'oneOfInputType'"
+
+        where:
+        why              | query                                             | _
+        'some variables' |
+                '''
+            query q($v1 : String) {
+              oneOfField(oneOfArg : { a : $v1, b : "y" })
+            }
+        '''                                               | _
+        'all variables'  |
+                '''
+            query q($v1 : String, $v2 : String) {
+              oneOfField(oneOfArg : { a : $v1, b : $v2 })
+            }
+        '''                                               | _
+        'all literals'   |
+                '''
+            query q {
+              oneOfField(oneOfArg : { a : "x", b : "y" })
+            }
+        '''                                               | _
+    }
+
     static List<ValidationError> validate(String query) {
         def document = new Parser().parseDocument(query)
         return new Validator().validateDocument(SpecValidationSchema.specValidationSchema, document, Locale.ENGLISH)

--- a/src/test/groovy/graphql/validation/rules/ArgumentsOfCorrectTypeTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/ArgumentsOfCorrectTypeTest.groovy
@@ -342,7 +342,7 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         then:
         validationErrors.size() == 1
         validationErrors.get(0).getValidationErrorType() == ValidationErrorType.WrongType
-        validationErrors.get(0).message == "Validation error (WrongType@[oneOfField]) : Exactly one key must be specified for argument 'oneOfArg' of @oneOf input type 'oneOfInputType'"
+        validationErrors.get(0).message == "Validation error (WrongType@[oneOfField]) : Exactly one key must be specified for OneOf type 'oneOfInputType'."
 
         where:
         why              | query                                             | _


### PR DESCRIPTION
Note this is only when the AST literals are present - pure variables are handled later still just like in JS

https://github.com/graphql-java/graphql-java/issues/3572

so `f(arg : { a : "x", b: $y})` will be handled but not `f(arg:$variable)` which uses the existing code and still is lazy at this stage

re: https://github.com/graphql-java/graphql-java/issues/3572