### PR TITLE
Add nullability annotations in DataFetchingEnvironment & sub-classes

### DIFF
--- a/src/main/java/graphql/schema/DataFetchingEnvironment.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironment.java
@@ -13,6 +13,8 @@ import graphql.language.FragmentDefinition;
 import graphql.language.OperationDefinition;
 import org.dataloader.DataLoader;
 import org.dataloader.DataLoaderRegistry;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.Locale;
@@ -37,6 +39,7 @@ public interface DataFetchingEnvironment extends IntrospectionDataFetchingEnviro
      *
      * @return can be null for the root query, otherwise it is never null
      */
+    @Nullable
     <T> T getSource();
 
     /**
@@ -61,6 +64,7 @@ public interface DataFetchingEnvironment extends IntrospectionDataFetchingEnviro
      *
      * @return the named argument or null if it's not present
      */
+    @Nullable
     <T> T getArgument(String name);
 
     /**
@@ -97,6 +101,7 @@ public interface DataFetchingEnvironment extends IntrospectionDataFetchingEnviro
      *
      * @return can NOT be null
      */
+    @NotNull
     GraphQLContext getGraphQlContext();
 
     /**
@@ -114,6 +119,7 @@ public interface DataFetchingEnvironment extends IntrospectionDataFetchingEnviro
      *
      * @return can be null if no field context objects are passed back by previous parent fields
      */
+    @Nullable
     <T> T getLocalContext();
 
     /**
@@ -228,6 +234,7 @@ public interface DataFetchingEnvironment extends IntrospectionDataFetchingEnviro
      *
      * @see org.dataloader.DataLoaderRegistry#getDataLoader(String)
      */
+    @Nullable
     <K, V> DataLoader<K, V> getDataLoader(String dataLoaderName);
 
     /**

--- a/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
@@ -17,6 +17,8 @@ import graphql.language.FragmentDefinition;
 import graphql.language.OperationDefinition;
 import org.dataloader.DataLoader;
 import org.dataloader.DataLoaderRegistry;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.Locale;
@@ -129,12 +131,12 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
     }
 
     @Override
-    public GraphQLContext getGraphQlContext() {
+    public @NotNull GraphQLContext getGraphQlContext() {
         return graphQLContext;
     }
 
     @Override
-    public <T> T getLocalContext() {
+    public <T> @Nullable T getLocalContext() {
         return (T) localContext;
     }
 
@@ -204,7 +206,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
     }
 
     @Override
-    public <K, V> DataLoader<K, V> getDataLoader(String dataLoaderName) {
+    public <K, V> @Nullable DataLoader<K, V> getDataLoader(String dataLoaderName) {
         return dataLoaderRegistry.getDataLoader(dataLoaderName);
     }
 

--- a/src/main/java/graphql/schema/DelegatingDataFetchingEnvironment.java
+++ b/src/main/java/graphql/schema/DelegatingDataFetchingEnvironment.java
@@ -12,6 +12,8 @@ import graphql.language.FragmentDefinition;
 import graphql.language.OperationDefinition;
 import org.dataloader.DataLoader;
 import org.dataloader.DataLoaderRegistry;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.Locale;
@@ -70,12 +72,12 @@ public class DelegatingDataFetchingEnvironment implements DataFetchingEnvironmen
     }
 
     @Override
-    public GraphQLContext getGraphQlContext() {
+    public @NotNull GraphQLContext getGraphQlContext() {
         return delegateEnvironment.getGraphQlContext();
     }
 
     @Override
-    public <T> T getLocalContext() {
+    public <T> @Nullable T getLocalContext() {
         return delegateEnvironment.getLocalContext();
     }
 
@@ -146,7 +148,7 @@ public class DelegatingDataFetchingEnvironment implements DataFetchingEnvironmen
     }
 
     @Override
-    public <K, V> DataLoader<K, V> getDataLoader(String dataLoaderName) {
+    public <K, V> @Nullable DataLoader<K, V> getDataLoader(String dataLoaderName) {
         return delegateEnvironment.getDataLoader(dataLoaderName);
     }
 

--- a/src/test/groovy/graphql/schema/DelegatingDataFetchingEnvironmentTest.groovy
+++ b/src/test/groovy/graphql/schema/DelegatingDataFetchingEnvironmentTest.groovy
@@ -1,6 +1,7 @@
 package graphql.schema
 
 import graphql.GraphQLContext
+import org.jetbrains.annotations.NotNull
 import spock.lang.Specification
 
 class DelegatingDataFetchingEnvironmentTest extends Specification {
@@ -22,6 +23,7 @@ class DelegatingDataFetchingEnvironmentTest extends Specification {
 
         when:
         def delegatingDFE = new DelegatingDataFetchingEnvironment(dfe) {
+            @NotNull
             @Override
             GraphQLContext getGraphQlContext() {
                 return GraphQLContext.of(["key": "overriddenContext"])


### PR DESCRIPTION
While using Netflix' DGS with Kotlin, we ran into an issue where it was not immediately clear that `DataFetchingEnvironment.getLocalContext` can return `null`. After reading the documentation and the rest of the `DataFetchingEnvironment` interface, I noticed the lack of nullability annotations for Kotlin interoperability. However, I also saw that other classes in this project already use the Jetbrains annotations. 

In this PR I added nullability annotations to all methods of the `DataFetchingEnvironment` interface that had mentions about nullability in their documentation. For patching the whole class I currently lack the overview of the bigger picture of this interface.

I followed through on sub-classes that override these methods.