### PR TITLE
Ready: Add @deprecated validation for input object fields, field arguments, directive arguments

### DIFF
--- a/src/main/java/graphql/schema/validation/DeprecatedInputObjectAndArgumentsAreValid.java
+++ b/src/main/java/graphql/schema/validation/DeprecatedInputObjectAndArgumentsAreValid.java
@@ -1,0 +1,37 @@
+package graphql.schema.validation;
+
+import graphql.Internal;
+import graphql.schema.GraphQLAppliedDirective;
+import graphql.schema.GraphQLInputObjectField;
+import graphql.schema.GraphQLInputObjectType;
+import graphql.schema.GraphQLSchemaElement;
+import graphql.schema.GraphQLTypeUtil;
+import graphql.schema.GraphQLTypeVisitorStub;
+import graphql.util.TraversalControl;
+import graphql.util.TraverserContext;
+
+import static java.lang.String.format;
+
+/*
+  From the spec:
+  The @deprecated directive must not appear on required (non-null without a default) arguments
+  or input object field definitions.
+ */
+@Internal
+public class DeprecatedInputObjectAndArgumentsAreValid extends GraphQLTypeVisitorStub {
+
+    @Override
+    public TraversalControl visitGraphQLInputObjectField(GraphQLInputObjectField inputObjectField, TraverserContext<GraphQLSchemaElement> context) {
+        // There can only be at most one @deprecated, because it is not a repeatable directive
+        GraphQLAppliedDirective deprecatedDirective = inputObjectField.getAppliedDirective("deprecated");
+
+        if (deprecatedDirective != null && GraphQLTypeUtil.isNonNull(inputObjectField.getType()) && !inputObjectField.hasSetDefaultValue()) {
+            GraphQLInputObjectType inputObjectType = (GraphQLInputObjectType) context.getParentNode();
+            SchemaValidationErrorCollector errorCollector = context.getVarFromParents(SchemaValidationErrorCollector.class);
+            String message = format("Required input field %s.%s cannot be deprecated.", inputObjectType.getName(), inputObjectField.getName());
+            errorCollector.addError(new SchemaValidationError(SchemaValidationErrorType.RequiredInputFieldCannotBeDeprecated, message));
+        }
+        return TraversalControl.CONTINUE;
+    }
+
+}

--- a/src/main/java/graphql/schema/validation/DeprecatedInputObjectAndArgumentsAreValid.java
+++ b/src/main/java/graphql/schema/validation/DeprecatedInputObjectAndArgumentsAreValid.java
@@ -1,5 +1,6 @@
 package graphql.schema.validation;
 
+import graphql.Directives;
 import graphql.Internal;
 import graphql.schema.GraphQLAppliedDirective;
 import graphql.schema.GraphQLArgument;
@@ -26,7 +27,7 @@ public class DeprecatedInputObjectAndArgumentsAreValid extends GraphQLTypeVisito
     @Override
     public TraversalControl visitGraphQLInputObjectField(GraphQLInputObjectField inputObjectField, TraverserContext<GraphQLSchemaElement> context) {
         // There can only be at most one @deprecated, because it is not a repeatable directive
-        GraphQLAppliedDirective deprecatedDirective = inputObjectField.getAppliedDirective("deprecated");
+        GraphQLAppliedDirective deprecatedDirective = inputObjectField.getAppliedDirective(Directives.DEPRECATED_DIRECTIVE_DEFINITION.getName());
 
         if (deprecatedDirective != null && GraphQLTypeUtil.isNonNull(inputObjectField.getType()) && !inputObjectField.hasSetDefaultValue()) {
             GraphQLInputObjectType inputObjectType = (GraphQLInputObjectType) context.getParentNode();
@@ -42,7 +43,7 @@ public class DeprecatedInputObjectAndArgumentsAreValid extends GraphQLTypeVisito
     @Override
     public TraversalControl visitGraphQLArgument(GraphQLArgument argument, TraverserContext<GraphQLSchemaElement> context) {
         // There can only be at most one @deprecated, because it is not a repeatable directive
-        GraphQLAppliedDirective deprecatedDirective = argument.getAppliedDirective("deprecated");
+        GraphQLAppliedDirective deprecatedDirective = argument.getAppliedDirective(Directives.DEPRECATED_DIRECTIVE_DEFINITION.getName());
 
         if (deprecatedDirective != null && GraphQLTypeUtil.isNonNull(argument.getType()) && !argument.hasSetDefaultValue()) {
             if (context.getParentNode() instanceof GraphQLFieldDefinition) {

--- a/src/main/java/graphql/schema/validation/DeprecatedInputObjectAndArgumentsAreValid.java
+++ b/src/main/java/graphql/schema/validation/DeprecatedInputObjectAndArgumentsAreValid.java
@@ -2,6 +2,9 @@ package graphql.schema.validation;
 
 import graphql.Internal;
 import graphql.schema.GraphQLAppliedDirective;
+import graphql.schema.GraphQLArgument;
+import graphql.schema.GraphQLDirective;
+import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLInputObjectField;
 import graphql.schema.GraphQLInputObjectType;
 import graphql.schema.GraphQLSchemaElement;
@@ -28,8 +31,31 @@ public class DeprecatedInputObjectAndArgumentsAreValid extends GraphQLTypeVisito
         if (deprecatedDirective != null && GraphQLTypeUtil.isNonNull(inputObjectField.getType()) && !inputObjectField.hasSetDefaultValue()) {
             GraphQLInputObjectType inputObjectType = (GraphQLInputObjectType) context.getParentNode();
             SchemaValidationErrorCollector errorCollector = context.getVarFromParents(SchemaValidationErrorCollector.class);
-            String message = format("Required input field %s.%s cannot be deprecated.", inputObjectType.getName(), inputObjectField.getName());
+            String message = format("Required input field '%s.%s' cannot be deprecated.", inputObjectType.getName(), inputObjectField.getName());
             errorCollector.addError(new SchemaValidationError(SchemaValidationErrorType.RequiredInputFieldCannotBeDeprecated, message));
+        }
+        return TraversalControl.CONTINUE;
+    }
+
+    // An argument can appear as either a field argument or a directive argument. This visitor will visit both field arguments and directive arguments.
+    // An applied directive's argument cannot be deprecated.
+    @Override
+    public TraversalControl visitGraphQLArgument(GraphQLArgument argument, TraverserContext<GraphQLSchemaElement> context) {
+        // There can only be at most one @deprecated, because it is not a repeatable directive
+        GraphQLAppliedDirective deprecatedDirective = argument.getAppliedDirective("deprecated");
+
+        if (deprecatedDirective != null && GraphQLTypeUtil.isNonNull(argument.getType()) && !argument.hasSetDefaultValue()) {
+            if (context.getParentNode() instanceof GraphQLFieldDefinition) {
+                GraphQLFieldDefinition fieldDefinition = (GraphQLFieldDefinition) context.getParentNode();
+                SchemaValidationErrorCollector errorCollector = context.getVarFromParents(SchemaValidationErrorCollector.class);
+                String message = format("Required argument '%s' on field '%s' cannot be deprecated.", argument.getName(), fieldDefinition.getName());
+                errorCollector.addError(new SchemaValidationError(SchemaValidationErrorType.RequiredFieldArgumentCannotBeDeprecated, message));
+            } else if (context.getParentNode() instanceof GraphQLDirective) {
+                GraphQLDirective directive = (GraphQLDirective) context.getParentNode();
+                SchemaValidationErrorCollector errorCollector = context.getVarFromParents(SchemaValidationErrorCollector.class);
+                String message = format("Required argument '%s' on directive '%s' cannot be deprecated.", argument.getName(), directive.getName());
+                errorCollector.addError(new SchemaValidationError(SchemaValidationErrorType.RequiredDirectiveArgumentCannotBeDeprecated, message));
+            }
         }
         return TraversalControl.CONTINUE;
     }

--- a/src/main/java/graphql/schema/validation/SchemaValidationErrorType.java
+++ b/src/main/java/graphql/schema/validation/SchemaValidationErrorType.java
@@ -21,5 +21,8 @@ public enum SchemaValidationErrorType implements SchemaValidationErrorClassifica
     OutputTypeUsedInInputTypeContext,
     InputTypeUsedInOutputTypeContext,
     OneOfDefaultValueOnField,
-    OneOfNonNullableField
+    OneOfNonNullableField,
+    RequiredInputFieldCannotBeDeprecated,
+    RequiredFieldArgumentCannotBeDeprecated,
+    RequiredDirectiveArgumentCannotBeDeprecated
 }

--- a/src/main/java/graphql/schema/validation/SchemaValidator.java
+++ b/src/main/java/graphql/schema/validation/SchemaValidator.java
@@ -26,6 +26,7 @@ public class SchemaValidator {
         rules.add(new AppliedDirectiveArgumentsAreValid());
         rules.add(new InputAndOutputTypesUsedAppropriately());
         rules.add(new OneOfInputObjectRules());
+        rules.add(new DeprecatedInputObjectAndArgumentsAreValid());
     }
 
     public List<GraphQLTypeVisitor> getRules() {

--- a/src/test/groovy/graphql/schema/validation/DeprecatedInputObjectAndArgumentsAreValidTest.groovy
+++ b/src/test/groovy/graphql/schema/validation/DeprecatedInputObjectAndArgumentsAreValidTest.groovy
@@ -211,7 +211,7 @@ class DeprecatedInputObjectAndArgumentsAreValidTest extends Specification {
             directive @pizzaDirective(name: String!, likesPineapples: Boolean! @deprecated(reason: "Don't need this directive argument")) on FIELD_DEFINITION
 
             type Query {
-              pizza(name: String!): String @pizzaDirective(name: "Stefano", likesPineapples: true)
+              pizza(name: String!): String @pizzaDirective(name: "Stefano", likesPineapples: false)
             }
 
             type Mutation {
@@ -233,7 +233,7 @@ class DeprecatedInputObjectAndArgumentsAreValidTest extends Specification {
             directive @pizzaDirective(name: String! @deprecated, likesPineapples: Boolean! @deprecated(reason: "Don't need this directive argument")) on FIELD_DEFINITION
 
             type Query {
-              pizza(name: String!): String @pizzaDirective(name: "Stefano", likesPineapples: true)
+              pizza(name: String!): String @pizzaDirective(name: "Stefano", likesPineapples: false)
             }
 
             type Mutation {
@@ -256,7 +256,7 @@ class DeprecatedInputObjectAndArgumentsAreValidTest extends Specification {
             directive @pizzaDirective(name: String!, likesPineapples: Boolean @deprecated(reason: "Don't need this directive argument")) on FIELD_DEFINITION
 
             type Query {
-              pizza(name: String!): String @pizzaDirective(name: "Stefano", likesPineapples: true)
+              pizza(name: String!): String @pizzaDirective(name: "Stefano", likesPineapples: false)
             }
 
             type Mutation {
@@ -277,7 +277,7 @@ class DeprecatedInputObjectAndArgumentsAreValidTest extends Specification {
             directive @pizzaDirective(name: String!, likesPineapples: Boolean! = false @deprecated(reason: "Don't need this directive argument")) on FIELD_DEFINITION
 
             type Query {
-              pizza(name: String!): String @pizzaDirective(name: "Stefano", likesPineapples: true)
+              pizza(name: String!): String @pizzaDirective(name: "Stefano", likesPineapples: false)
             }
 
             type Mutation {

--- a/src/test/groovy/graphql/schema/validation/DeprecatedInputObjectAndArgumentsAreValidTest.groovy
+++ b/src/test/groovy/graphql/schema/validation/DeprecatedInputObjectAndArgumentsAreValidTest.groovy
@@ -18,6 +18,7 @@ class DeprecatedInputObjectAndArgumentsAreValidTest extends Specification {
             input PizzaInfo {
               name: String!
               pineapples: Boolean! @deprecated(reason: "Don't need this input field")
+              spicy: Boolean @deprecated(reason: "Don't need this nullable input field")
             }
         '''
 
@@ -27,7 +28,59 @@ class DeprecatedInputObjectAndArgumentsAreValidTest extends Specification {
         then:
         def schemaProblem = thrown(InvalidSchemaException)
         schemaProblem.getErrors().size() == 1
-        schemaProblem.getErrors().first().description == "Required input field PizzaInfo.pineapples cannot be deprecated."
+        schemaProblem.getErrors().first().description == "Required input field 'PizzaInfo.pineapples' cannot be deprecated."
+    }
+
+    def "multiple required input fields cannot be deprecated"() {
+        def sdl = '''
+            type Query {
+              pizza(name: String!): String
+            }
+            
+            type Mutation {
+              updatePizza(pizzaInfo: PizzaInfo!): String
+            }
+            
+            input PizzaInfo {
+              name: String!
+              pineapples: Boolean! @deprecated(reason: "Don't need this input field")
+              spicy: Boolean! @deprecated(reason: "Don't need this input field")
+            }
+        '''
+
+        when:
+        TestUtil.schema(sdl)
+
+        then:
+        def schemaProblem = thrown(InvalidSchemaException)
+        schemaProblem.getErrors().size() == 2
+        schemaProblem.getErrors()[0].description == "Required input field 'PizzaInfo.pineapples' cannot be deprecated."
+        schemaProblem.getErrors()[1].description == "Required input field 'PizzaInfo.spicy' cannot be deprecated."
+    }
+
+    def "required input field list cannot be deprecated"() {
+        def sdl = '''
+            type Query {
+              pizza(name: String!): String
+            }
+            
+            type Mutation {
+              updatePizza(pizzaInfos: [PizzaInfo]!): String
+            }
+            
+            input PizzaInfo {
+              name: String!
+              pineapples: Boolean! @deprecated(reason: "Don't need this input field")
+            }
+        '''
+
+        when:
+        TestUtil.schema(sdl)
+
+        then:
+        def schemaProblem = thrown(InvalidSchemaException)
+        schemaProblem.getErrors().size() == 1
+        schemaProblem.getErrors().first().description == "Required input field 'PizzaInfo.pineapples' cannot be deprecated."
     }
 
     def "nullable input field can be deprecated"() {
@@ -67,6 +120,170 @@ class DeprecatedInputObjectAndArgumentsAreValidTest extends Specification {
               name: String!
               pineapples: Boolean! = false @deprecated(reason: "Don't need this input field")
             }
+        '''
+
+        when:
+        TestUtil.schema(sdl)
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "required field argument cannot be deprecated"() {
+        def sdl = '''
+            type Query {
+              pizza(name: String!): String
+            }
+            
+            type Mutation {
+              updatePizza(name: String!, pineapples: Boolean! @deprecated(reason: "Don't need this field argument")): String
+            }
+        '''
+
+        when:
+        TestUtil.schema(sdl)
+
+        then:
+        def schemaProblem = thrown(InvalidSchemaException)
+        schemaProblem.getErrors().size() == 1
+        schemaProblem.getErrors().first().description == "Required argument 'pineapples' on field 'updatePizza' cannot be deprecated."
+    }
+
+    def "multiple required field arguments cannot be deprecated"() {
+        def sdl = '''
+            type Query {
+              pizza(name: String!): String
+            }
+            
+            type Mutation {
+              updatePizza(name: String! @deprecated(reason: "yeah nah"), pineapples: Boolean! @deprecated(reason: "Don't need this field argument")): String
+            }
+        '''
+
+        when:
+        TestUtil.schema(sdl)
+
+        then:
+        def schemaProblem = thrown(InvalidSchemaException)
+        schemaProblem.getErrors().size() == 2
+        schemaProblem.getErrors()[0].description == "Required argument 'name' on field 'updatePizza' cannot be deprecated."
+        schemaProblem.getErrors()[1].description == "Required argument 'pineapples' on field 'updatePizza' cannot be deprecated."
+    }
+
+    def "nullable field argument can be deprecated"() {
+        def sdl = '''
+            type Query {
+              pizza(name: String!): String
+            }
+            
+            type Mutation {
+              updatePizza(name: String!, pineapples: Boolean @deprecated(reason: "Don't need this field argument")): String
+            }
+        '''
+
+        when:
+        TestUtil.schema(sdl)
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "non-nullable field argument with default value can be deprecated"() {
+        def sdl = '''
+            type Query {
+              pizza(name: String!): String
+            }
+            
+            type Mutation {
+              updatePizza(name: String!, pineapples: Boolean! = false @deprecated(reason: "Don't need this field argument")): String
+            }
+        '''
+
+        when:
+        TestUtil.schema(sdl)
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "required directive argument cannot be deprecated"() {
+        def sdl = '''
+            directive @pizzaDirective(name: String!, likesPineapples: Boolean! @deprecated(reason: "Don't need this directive argument")) on FIELD_DEFINITION
+
+            type Query {
+              pizza(name: String!): String @pizzaDirective(name: "Stefano", likesPineapples: true)
+            }
+
+            type Mutation {
+              updatePizza(name: String!, pineapples: Boolean!): String
+            }
+        '''
+
+        when:
+        TestUtil.schema(sdl)
+
+        then:
+        def schemaProblem = thrown(InvalidSchemaException)
+        schemaProblem.getErrors().size() == 1
+        schemaProblem.getErrors().first().description == "Required argument 'likesPineapples' on directive 'pizzaDirective' cannot be deprecated."
+    }
+
+    def "multiple required directive arguments cannot be deprecated"() {
+        def sdl = '''
+            directive @pizzaDirective(name: String! @deprecated, likesPineapples: Boolean! @deprecated(reason: "Don't need this directive argument")) on FIELD_DEFINITION
+
+            type Query {
+              pizza(name: String!): String @pizzaDirective(name: "Stefano", likesPineapples: true)
+            }
+
+            type Mutation {
+              updatePizza(name: String!, pineapples: Boolean!): String
+            }
+        '''
+
+        when:
+        TestUtil.schema(sdl)
+
+        then:
+        def schemaProblem = thrown(InvalidSchemaException)
+        schemaProblem.getErrors().size() == 2
+        schemaProblem.getErrors()[0].description == "Required argument 'name' on directive 'pizzaDirective' cannot be deprecated."
+        schemaProblem.getErrors()[1].description == "Required argument 'likesPineapples' on directive 'pizzaDirective' cannot be deprecated."
+    }
+
+    def "nullable directive argument can be deprecated"() {
+        def sdl = '''
+            directive @pizzaDirective(name: String!, likesPineapples: Boolean @deprecated(reason: "Don't need this directive argument")) on FIELD_DEFINITION
+
+            type Query {
+              pizza(name: String!): String @pizzaDirective(name: "Stefano", likesPineapples: true)
+            }
+
+            type Mutation {
+              updatePizza(name: String!, pineapples: Boolean!): String
+            }
+
+        '''
+
+        when:
+        TestUtil.schema(sdl)
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "non-nullable directive argument with default value can be deprecated"() {
+        def sdl = '''
+            directive @pizzaDirective(name: String!, likesPineapples: Boolean! = false @deprecated(reason: "Don't need this directive argument")) on FIELD_DEFINITION
+
+            type Query {
+              pizza(name: String!): String @pizzaDirective(name: "Stefano", likesPineapples: true)
+            }
+
+            type Mutation {
+              updatePizza(name: String!, pineapples: Boolean!): String
+            }
+
         '''
 
         when:

--- a/src/test/groovy/graphql/schema/validation/DeprecatedInputObjectAndArgumentsAreValidTest.groovy
+++ b/src/test/groovy/graphql/schema/validation/DeprecatedInputObjectAndArgumentsAreValidTest.groovy
@@ -1,0 +1,79 @@
+package graphql.schema.validation
+
+import graphql.TestUtil
+import spock.lang.Specification
+
+class DeprecatedInputObjectAndArgumentsAreValidTest extends Specification {
+
+    def "required input field cannot be deprecated"() {
+        def sdl = '''
+            type Query {
+              pizza(name: String!): String
+            }
+            
+            type Mutation {
+              updatePizza(pizzaInfo: PizzaInfo!): String
+            }
+            
+            input PizzaInfo {
+              name: String!
+              pineapples: Boolean! @deprecated(reason: "Don't need this input field")
+            }
+        '''
+
+        when:
+        TestUtil.schema(sdl)
+
+        then:
+        def schemaProblem = thrown(InvalidSchemaException)
+        schemaProblem.getErrors().size() == 1
+        schemaProblem.getErrors().first().description == "Required input field PizzaInfo.pineapples cannot be deprecated."
+    }
+
+    def "nullable input field can be deprecated"() {
+        def sdl = '''
+            type Query {
+              pizza(name: String!): String
+            }
+            
+            type Mutation {
+              updatePizza(pizzaInfo: PizzaInfo!): String
+            }
+            
+            input PizzaInfo {
+              name: String!
+              pineapples: Boolean @deprecated(reason: "Don't need this input field")
+            }
+        '''
+
+        when:
+        TestUtil.schema(sdl)
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "non-nullable input field with default value can be deprecated"() {
+        def sdl = '''
+            type Query {
+              pizza(name: String!): String
+            }
+            
+            type Mutation {
+              updatePizza(pizzaInfo: PizzaInfo!): String
+            }
+            
+            input PizzaInfo {
+              name: String!
+              pineapples: Boolean! = false @deprecated(reason: "Don't need this input field")
+            }
+        '''
+
+        when:
+        TestUtil.schema(sdl)
+
+        then:
+        noExceptionThrown()
+    }
+
+}

--- a/src/test/groovy/graphql/schema/validation/SchemaValidatorTest.groovy
+++ b/src/test/groovy/graphql/schema/validation/SchemaValidatorTest.groovy
@@ -11,7 +11,7 @@ class SchemaValidatorTest extends Specification {
         def validator = new SchemaValidator()
         def rules = validator.rules
         then:
-        rules.size() == 8
+        rules.size() == 9
         rules[0] instanceof NoUnbrokenInputCycles
         rules[1] instanceof TypesImplementInterfaces
         rules[2] instanceof TypeAndFieldRule
@@ -20,5 +20,6 @@ class SchemaValidatorTest extends Specification {
         rules[5] instanceof AppliedDirectiveArgumentsAreValid
         rules[6] instanceof InputAndOutputTypesUsedAppropriately
         rules[7] instanceof OneOfInputObjectRules
+        rules[8] instanceof DeprecatedInputObjectAndArgumentsAreValid
     }
 }


### PR DESCRIPTION
Fixes #3590

From the [GraphQL specification](https://spec.graphql.org/draft/#sec--deprecated):

> The @deprecated directive must not appear on required (non-null without a default) arguments or input object field definitions.

This PR adds the schema validation rule to enforce this line of the spec.