### PR TITLE
nested nullable list validation bugfix

### DIFF
--- a/src/main/java/graphql/schema/idl/errors/DirectiveIllegalArgumentTypeError.java
+++ b/src/main/java/graphql/schema/idl/errors/DirectiveIllegalArgumentTypeError.java
@@ -16,7 +16,6 @@ public class DirectiveIllegalArgumentTypeError extends BaseError {
     public static final String NOT_A_VALID_SCALAR_LITERAL_MESSAGE = "Argument value is not a valid value of scalar '%s'.";
     public static final String MISSING_REQUIRED_FIELD_MESSAGE = "Missing required field '%s'.";
     public static final String EXPECTED_NON_NULL_MESSAGE = "Argument value is 'null', expected a non-null value.";
-    public static final String EXPECTED_LIST_MESSAGE = "Argument value is '%s', expected a list value.";
     public static final String EXPECTED_OBJECT_MESSAGE = "Argument value is of type '%s', expected an Object value.";
 
     public DirectiveIllegalArgumentTypeError(Node element, String elementName, String directiveName, String argumentName, String detailedMessaged) {

--- a/src/test/groovy/graphql/schema/idl/SchemaTypeCheckerTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaTypeCheckerTest.groovy
@@ -1511,6 +1511,7 @@ class SchemaTypeCheckerTest extends Specification {
 
         allowedArgType | argValue                                                                               | detailedMessage
         "ACustomDate"  | '"AFailingDate"'                                                                       | format(NOT_A_VALID_SCALAR_LITERAL_MESSAGE, "ACustomDate")
+        "[String]"     | 123                                                                                    | format(NOT_A_VALID_SCALAR_LITERAL_MESSAGE, "String")
         "[String!]"    | '["str", null]'                                                                        | format(EXPECTED_NON_NULL_MESSAGE)
         "[[String!]!]" | '[["str"], ["str2", null]]'                                                            | format(EXPECTED_NON_NULL_MESSAGE)
         "[[String!]!]" | '[["str"], ["str2", "str3"], null]'                                                    | format(EXPECTED_NON_NULL_MESSAGE)
@@ -1567,8 +1568,10 @@ class SchemaTypeCheckerTest extends Specification {
         "ACustomDate"  | '2002'
         "[String]"     | '["str", null]'
         "[String]"     | 'null'
+        "[String]"     | '"str"'          // see #2001
         "[String!]!"   | '["str"]'
         "[[String!]!]" | '[["str"], ["str2", "str3"]]'
+        "[[String]]"   | '[["str"], ["str2", null], null]'
         "[[String!]]"  | '[["str"], ["str2", "str3"], null]'
         "WEEKDAY"      | 'MONDAY'
         "UserInput"    | '{ fieldNonNull: "str" }'

--- a/src/test/groovy/graphql/schema/idl/SchemaTypeCheckerTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaTypeCheckerTest.groovy
@@ -21,7 +21,6 @@ import spock.lang.Unroll
 import static graphql.schema.GraphQLScalarType.newScalar
 import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.DUPLICATED_KEYS_MESSAGE
 import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.EXPECTED_ENUM_MESSAGE
-import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.EXPECTED_LIST_MESSAGE
 import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.EXPECTED_NON_NULL_MESSAGE
 import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.EXPECTED_OBJECT_MESSAGE
 import static graphql.schema.idl.errors.DirectiveIllegalArgumentTypeError.MISSING_REQUIRED_FIELD_MESSAGE
@@ -1514,11 +1513,11 @@ class SchemaTypeCheckerTest extends Specification {
         "ACustomDate"  | '"AFailingDate"'                                                                       | format(NOT_A_VALID_SCALAR_LITERAL_MESSAGE, "ACustomDate")
         "[String!]"    | '["str", null]'                                                                        | format(EXPECTED_NON_NULL_MESSAGE)
         "[[String!]!]" | '[["str"], ["str2", null]]'                                                            | format(EXPECTED_NON_NULL_MESSAGE)
+        "[[String!]!]" | '[["str"], ["str2", "str3"], null]'                                                    | format(EXPECTED_NON_NULL_MESSAGE)
         "WEEKDAY"      | '"somestr"'                                                                            | format(EXPECTED_ENUM_MESSAGE, "StringValue")
         "WEEKDAY"      | 'SATURDAY'                                                                             | format(MUST_BE_VALID_ENUM_VALUE_MESSAGE, "SATURDAY", "MONDAY,TUESDAY")
         "UserInput"    | '{ fieldNonNull: "str", fieldNonNull: "dupeKey" }'                                     | format(DUPLICATED_KEYS_MESSAGE, "fieldNonNull")
         "UserInput"    | '{ fieldNonNull: "str", unknown: "field" }'                                            | format(UNKNOWN_FIELDS_MESSAGE, "unknown", "UserInput")
-        "UserInput"    | '{ fieldNonNull: "str", fieldArrayOfArray: ["ArrayInsteadOfArrayOfArray"] }'           | format(EXPECTED_LIST_MESSAGE, "StringValue")
         "UserInput"    | '{ fieldNonNull: "str", fieldNestedInput: "strInsteadOfObject" }'                      | format(EXPECTED_OBJECT_MESSAGE, "StringValue")
         "UserInput"    | '{ field: "missing the `fieldNonNull` entry"}'                                         | format(MISSING_REQUIRED_FIELD_MESSAGE, "fieldNonNull")
     }
@@ -1570,6 +1569,7 @@ class SchemaTypeCheckerTest extends Specification {
         "[String]"     | 'null'
         "[String!]!"   | '["str"]'
         "[[String!]!]" | '[["str"], ["str2", "str3"]]'
+        "[[String!]]"  | '[["str"], ["str2", "str3"], null]'
         "WEEKDAY"      | 'MONDAY'
         "UserInput"    | '{ fieldNonNull: "str" }'
         "UserInput"    | '{ fieldNonNull: "str", fieldString: "Hey" }'


### PR DESCRIPTION
When validating directive arguments that use nested list types, it looks like the validator does not allow nulls to be used in valid positions.

For example, given a type like `[[String!]]`, it rejects the value `[null]`.

After looking into this, it looks like #2001 added support for coercing singleton items into lists, but didn't handle null values. The relevant part of the spec is this:
> If the value passed as an input to a list type is not a list *and not the null value*, then the result of input coercion is a list of size one.

This PR changes scalar-to-list coercion to allow null values in nested lists. A side effect of this is that the validation error `Argument value is X', expected a list value.` will never be raised.