### PR TITLE
Fix stale bot cache problem

### DIFF
--- a/.github/workflows/stale-pr-issue.yml
+++ b/.github/workflows/stale-pr-issue.yml
@@ -8,6 +8,7 @@ on:
     - cron: '0 0 * * *'
 
 permissions:
+  actions: write
   issues: write
   pull-requests: write
 


### PR DESCRIPTION
Our stale bot stopped working because of a cache problem. See reports of the same issue by others: https://github.com/actions/stale/issues/1133

This permission set will fix the cache issue.