### PR TITLE
initial test case

### DIFF
--- a/src/test/groovy/graphql/parser/MultiSourceReaderTest.groovy
+++ b/src/test/groovy/graphql/parser/MultiSourceReaderTest.groovy
@@ -1,5 +1,6 @@
 package graphql.parser
 
+import graphql.schema.idl.SchemaParser
 import spock.lang.Specification
 
 class MultiSourceReaderTest extends Specification {
@@ -108,6 +109,25 @@ type C {
 
     }
 
+    def "can read sdl types when newlines are missing"() {
+        def a = "type A { field: String }"
+        def b = "type B { field: String }"
+
+        when:
+        multiSource = MultiSourceReader.newMultiSourceReader()
+                .reader(new StringReader(a), "a")
+                .reader(new StringReader(b), "b")
+                .build()
+        def tdr = new SchemaParser().parse(multiSource)
+
+        then:
+        def typeA = tdr.getType("A").get()
+        typeA.sourceLocation.sourceName == "a"
+        typeA.sourceLocation.line == 1
+        def typeB = tdr.getType("B").get()
+        typeB.sourceLocation.sourceName == "b"
+        typeB.sourceLocation.line == 1
+    }
 
     def "does not track data if told too"() {
         when:


### PR DESCRIPTION
This test case fails with:
```
Condition not satisfied:

typeB.sourceLocation.sourceName == "b"
|     |              |          |
|     |              a          false
|     |                         1 difference (0% similarity)
|     |                         (a)
|     |                         (b)
|     SourceLocation{line=1, column=25, sourceName=a}
ObjectTypeDefinition{name='B', implements=[], directives=[], fieldDefinitions=[FieldDefinition{name='field', type=TypeName{name='String'}, inputValueDefinitions=[], directives=[]}]}

Condition not satisfied:

typeB.sourceLocation.sourceName == "b"
|     |              |          |
|     |              a          false
|     |                         1 difference (0% similarity)
|     |                         (a)
|     |                         (b)
|     SourceLocation{line=1, column=25, sourceName=a}
ObjectTypeDefinition{name='B', implements=[], directives=[], fieldDefinitions=[FieldDefinition{name='field', type=TypeName{name='String'}, inputValueDefinitions=[], directives=[]}]}

	at graphql.parser.MultiSourceReaderTest.can read sdl types when newlines are missing(MultiSourceReaderTest.groovy:128)


```