### PR TITLE
Add option to redact token details from parser error messages

### DIFF
--- a/src/main/java/graphql/parser/ExtendedBailStrategy.java
+++ b/src/main/java/graphql/parser/ExtendedBailStrategy.java
@@ -42,6 +42,10 @@ public class ExtendedBailStrategy extends BailErrorStrategy {
 
     InvalidSyntaxException mkMoreTokensException(Token token) {
         SourceLocation sourceLocation = AntlrHelper.createSourceLocation(multiSourceReader, token);
+        if (environment.getParserOptions().isRedactTokenParserErrorMessages()) {
+            return new MoreTokensSyntaxException(environment.getI18N(), sourceLocation);
+        }
+
         String sourcePreview = AntlrHelper.createPreview(multiSourceReader, token.getLine());
         return new MoreTokensSyntaxException(environment.getI18N(), sourceLocation,
                 token.getText(), sourcePreview);
@@ -66,7 +70,7 @@ public class ExtendedBailStrategy extends BailErrorStrategy {
         String msgKey;
         List<Object> args;
         SourceLocation location = sourceLocation == null ? SourceLocation.EMPTY : sourceLocation;
-        if (offendingToken == null) {
+        if (offendingToken == null || environment.getParserOptions().isRedactTokenParserErrorMessages()) {
             msgKey = "InvalidSyntaxBail.noToken";
             args = ImmutableList.of(location.getLine(), location.getColumn());
         } else {

--- a/src/main/java/graphql/parser/Parser.java
+++ b/src/main/java/graphql/parser/Parser.java
@@ -301,7 +301,7 @@ public class Parser {
                 String preview = AntlrHelper.createPreview(multiSourceReader, line);
                 String msgKey;
                 List<Object> args;
-                if (antlerMsg == null) {
+                if (antlerMsg == null || environment.getParserOptions().isRedactTokenParserErrorMessages()) {
                     msgKey = "InvalidSyntax.noMessage";
                     args = ImmutableList.of(sourceLocation.getLine(), sourceLocation.getColumn());
                 } else {

--- a/src/main/java/graphql/parser/ParserOptions.java
+++ b/src/main/java/graphql/parser/ParserOptions.java
@@ -62,6 +62,7 @@ public class ParserOptions {
             .maxTokens(MAX_QUERY_TOKENS) // to prevent a billion laughs style attacks, we set a default for graphql-java
             .maxWhitespaceTokens(MAX_WHITESPACE_TOKENS)
             .maxRuleDepth(MAX_RULE_DEPTH)
+            .redactTokenParserErrorMessages(false)
             .build();
 
     private static ParserOptions defaultJvmOperationParserOptions = newParserOptions()
@@ -73,6 +74,7 @@ public class ParserOptions {
             .maxTokens(MAX_QUERY_TOKENS) // to prevent a billion laughs style attacks, we set a default for graphql-java
             .maxWhitespaceTokens(MAX_WHITESPACE_TOKENS)
             .maxRuleDepth(MAX_RULE_DEPTH)
+            .redactTokenParserErrorMessages(false)
             .build();
 
     private static ParserOptions defaultJvmSdlParserOptions = newParserOptions()
@@ -84,6 +86,7 @@ public class ParserOptions {
             .maxTokens(Integer.MAX_VALUE) // we are less worried about a billion laughs with SDL parsing since the call path is not facing attackers
             .maxWhitespaceTokens(Integer.MAX_VALUE)
             .maxRuleDepth(Integer.MAX_VALUE)
+            .redactTokenParserErrorMessages(false)
             .build();
 
     /**
@@ -189,6 +192,7 @@ public class ParserOptions {
     private final int maxTokens;
     private final int maxWhitespaceTokens;
     private final int maxRuleDepth;
+    private final boolean redactTokenParserErrorMessages;
     private final ParsingListener parsingListener;
 
     private ParserOptions(Builder builder) {
@@ -200,6 +204,7 @@ public class ParserOptions {
         this.maxTokens = builder.maxTokens;
         this.maxWhitespaceTokens = builder.maxWhitespaceTokens;
         this.maxRuleDepth = builder.maxRuleDepth;
+        this.redactTokenParserErrorMessages = builder.redactTokenParserErrorMessages;
         this.parsingListener = builder.parsingListener;
     }
 
@@ -294,6 +299,14 @@ public class ParserOptions {
         return maxRuleDepth;
     }
 
+    /**
+     * Option to redact offending tokens in parser error messages.
+     * By default, the parser will include the offending token in the error message, if possible.
+     */
+    public boolean isRedactTokenParserErrorMessages() {
+        return redactTokenParserErrorMessages;
+    }
+
     public ParsingListener getParsingListener() {
         return parsingListener;
     }
@@ -319,6 +332,7 @@ public class ParserOptions {
         private int maxTokens = MAX_QUERY_TOKENS;
         private int maxWhitespaceTokens = MAX_WHITESPACE_TOKENS;
         private int maxRuleDepth = MAX_RULE_DEPTH;
+        private boolean redactTokenParserErrorMessages = false;
 
         Builder() {
         }
@@ -331,6 +345,7 @@ public class ParserOptions {
             this.maxTokens = parserOptions.maxTokens;
             this.maxWhitespaceTokens = parserOptions.maxWhitespaceTokens;
             this.maxRuleDepth = parserOptions.maxRuleDepth;
+            this.redactTokenParserErrorMessages = parserOptions.redactTokenParserErrorMessages;
             this.parsingListener = parserOptions.parsingListener;
         }
 
@@ -371,6 +386,11 @@ public class ParserOptions {
 
         public Builder maxRuleDepth(int maxRuleDepth) {
             this.maxRuleDepth = maxRuleDepth;
+            return this;
+        }
+
+        public Builder redactTokenParserErrorMessages(boolean redactTokenParserErrorMessages) {
+            this.redactTokenParserErrorMessages = redactTokenParserErrorMessages;
             return this;
         }
 

--- a/src/main/java/graphql/parser/exceptions/MoreTokensSyntaxException.java
+++ b/src/main/java/graphql/parser/exceptions/MoreTokensSyntaxException.java
@@ -14,4 +14,11 @@ public class MoreTokensSyntaxException extends InvalidSyntaxException {
         super(i18N.msg("InvalidSyntaxMoreTokens.full", offendingToken, sourceLocation.getLine(), sourceLocation.getColumn()),
                 sourceLocation, offendingToken, sourcePreview, null);
     }
+
+    @Internal
+    public MoreTokensSyntaxException(@NotNull I18n i18N, @NotNull SourceLocation sourceLocation) {
+        super(i18N.msg("InvalidSyntaxMoreTokens.noMessage", sourceLocation.getLine(), sourceLocation.getColumn()),
+                sourceLocation, null, null, null);
+    }
+
 }

--- a/src/main/resources/i18n/Parsing.properties
+++ b/src/main/resources/i18n/Parsing.properties
@@ -16,6 +16,7 @@ InvalidSyntax.full=Invalid syntax with ANTLR error ''{0}'' at line {1} column {2
 InvalidSyntaxBail.noToken=Invalid syntax at line {0} column {1}
 InvalidSyntaxBail.full=Invalid syntax with offending token ''{0}'' at line {1} column {2}
 #
+InvalidSyntaxMoreTokens.noMessage=Invalid syntax encountered. There are extra tokens in the text that have not been consumed. Offending token at line {0} column {1}
 InvalidSyntaxMoreTokens.full=Invalid syntax encountered. There are extra tokens in the text that have not been consumed. Offending token ''{0}'' at line {1} column {2}
 #
 ParseCancelled.full=More than {0} ''{1}'' tokens have been presented. To prevent Denial Of Service attacks, parsing has been cancelled.

--- a/src/main/resources/i18n/Parsing_de.properties
+++ b/src/main/resources/i18n/Parsing_de.properties
@@ -16,6 +16,7 @@ InvalidSyntax.full=Ungültige Syntax, ANTLR-Fehler ''{0}'' in Zeile {1} Spalte {
 InvalidSyntaxBail.noToken=Ungültige Syntax in Zeile {0} Spalte {1}
 InvalidSyntaxBail.full=Ungültige Syntax wegen des ungültigen Tokens ''{0}'' in Zeile {1} Spalte {2}
 #
+InvalidSyntaxMoreTokens.noMessage=Es wurde eine ungültige Syntax festgestellt. Es gibt zusätzliche Token im Text, die nicht konsumiert wurden. Ungültiges Token in Zeile {0} Spalte {1}
 InvalidSyntaxMoreTokens.full=Es wurde eine ungültige Syntax festgestellt. Es gibt zusätzliche Token im Text, die nicht konsumiert wurden. Ungültiges Token ''{0}'' in Zeile {1} Spalte {2}
 #
 ParseCancelled.full=Es wurden mehr als {0} ''{1}'' Token präsentiert. Um Denial-of-Service-Angriffe zu verhindern, wurde das Parsing abgebrochen.

--- a/src/main/resources/i18n/Parsing_nl.properties
+++ b/src/main/resources/i18n/Parsing_nl.properties
@@ -15,6 +15,7 @@ InvalidSyntax.full=Ongeldige syntaxis, ANTLR foutmelding ''{0}'' op lijn {1} kol
 InvalidSyntaxBail.noToken=Ongeldige syntaxis op lijn {0} kolom {1}
 InvalidSyntaxBail.full=Ongeldige syntaxis wegens ongeldige token ''{0}'' op lijn {1} kolom {2}
 #
+InvalidSyntaxMoreTokens.noMessage=Ongeldige syntaxis tegengekomen. Er zijn tokens in de tekst die niet zijn verwerkt. Ongeldige token op lijn {0} kolom {1}
 InvalidSyntaxMoreTokens.full=Ongeldige syntaxis tegengekomen. Er zijn tokens in de tekst die niet zijn verwerkt. Ongeldige token ''{0}'' op lijn {1} kolom {2}
 #
 ParseCancelled.full=Meer dan {0} ''{1}'' tokens zijn gepresenteerd. Om een DDoS-aanval te voorkomen is het parsen gestopt.

--- a/src/test/groovy/graphql/parser/ParserOptionsTest.groovy
+++ b/src/test/groovy/graphql/parser/ParserOptionsTest.groovy
@@ -30,13 +30,15 @@ class ParserOptionsTest extends Specification {
         defaultOptions.isCaptureLineComments()
         !defaultOptions.isCaptureIgnoredChars()
         defaultOptions.isReaderTrackData()
+        !defaultOptions.isRedactTokenParserErrorMessages()
 
         defaultOperationOptions.getMaxTokens() == 15_000
         defaultOperationOptions.getMaxWhitespaceTokens() == 200_000
         defaultOperationOptions.isCaptureSourceLocation()
         !defaultOperationOptions.isCaptureLineComments()
         !defaultOperationOptions.isCaptureIgnoredChars()
-        defaultOptions.isReaderTrackData()
+        defaultOperationOptions.isReaderTrackData()
+        !defaultOperationOptions.isRedactTokenParserErrorMessages()
 
         defaultSdlOptions.getMaxCharacters() == Integer.MAX_VALUE
         defaultSdlOptions.getMaxTokens() == Integer.MAX_VALUE
@@ -44,14 +46,16 @@ class ParserOptionsTest extends Specification {
         defaultSdlOptions.isCaptureSourceLocation()
         defaultSdlOptions.isCaptureLineComments()
         !defaultSdlOptions.isCaptureIgnoredChars()
-        defaultOptions.isReaderTrackData()
+        defaultSdlOptions.isReaderTrackData()
+        !defaultSdlOptions.isRedactTokenParserErrorMessages()
     }
 
     def "can set in new option JVM wide"() {
         def newDefaultOptions = defaultOptions.transform({
             it.captureIgnoredChars(true)
                     .readerTrackData(false)
-        }        )
+                    .redactTokenParserErrorMessages(true)
+        })
         def newDefaultOperationOptions = defaultOperationOptions.transform(
                 {
                     it.captureIgnoredChars(true)
@@ -84,6 +88,7 @@ class ParserOptionsTest extends Specification {
         currentDefaultOptions.isCaptureLineComments()
         currentDefaultOptions.isCaptureIgnoredChars()
         !currentDefaultOptions.isReaderTrackData()
+        currentDefaultOptions.isRedactTokenParserErrorMessages()
 
         currentDefaultOperationOptions.getMaxCharacters() == 1_000_000
         currentDefaultOperationOptions.getMaxTokens() == 15_000
@@ -92,6 +97,7 @@ class ParserOptionsTest extends Specification {
         currentDefaultOperationOptions.isCaptureLineComments()
         currentDefaultOperationOptions.isCaptureIgnoredChars()
         currentDefaultOperationOptions.isReaderTrackData()
+        !currentDefaultOperationOptions.isRedactTokenParserErrorMessages()
 
         currentDefaultSdlOptions.getMaxCharacters() == Integer.MAX_VALUE
         currentDefaultSdlOptions.getMaxTokens() == Integer.MAX_VALUE
@@ -100,5 +106,6 @@ class ParserOptionsTest extends Specification {
         currentDefaultSdlOptions.isCaptureLineComments()
         currentDefaultSdlOptions.isCaptureIgnoredChars()
         currentDefaultSdlOptions.isReaderTrackData()
+        !currentDefaultSdlOptions.isRedactTokenParserErrorMessages()
     }
 }


### PR DESCRIPTION
Addresses #3617 

Adds an option to redact the token from parser error messages. Note that the default behaviour will be the same as before, by default error messages provide token information if available, to assist with debugging.

There are three parsing messages to be redacted:
* `InvalidSyntax.full`
* `InvalidSyntaxBail.full`
* `InvalidSyntaxMoreTokens.full`