### PR TITLE
AstPrinter: Empty types should not include braces `{}`

### DIFF
--- a/src/main/java/graphql/language/AstPrinter.java
+++ b/src/main/java/graphql/language/AstPrinter.java
@@ -619,7 +619,7 @@ public class AstPrinter {
 
     private <T extends Node> String block(List<T> nodes) {
         if (isEmpty(nodes)) {
-            return "{}";
+            return "";
         }
         if (compactMode) {
             String joinedNodes = joinTight(nodes, " ", "", "");

--- a/src/test/groovy/graphql/language/AstPrinterTest.groovy
+++ b/src/test/groovy/graphql/language/AstPrinterTest.groovy
@@ -696,7 +696,7 @@ extend input Input @directive {
         def result = AstPrinter.printAstCompact(interfaceType)
 
         then:
-        result == "interface Resource implements Node & Extra {}"
+        result == "interface Resource implements Node & Extra"
 
     }
 
@@ -713,7 +713,7 @@ extend input Input @directive {
         def result = AstPrinter.printAstCompact(interfaceType)
 
         then:
-        result == "extend interface Resource implements Node & Extra {}"
+        result == "extend interface Resource implements Node & Extra"
 
     }
 
@@ -746,5 +746,27 @@ extend input Input @directive {
         then:
         result == "directive @d2 on FIELD | ENUM"
 
+    }
+
+    def "empty type does not include braces"() {
+        def sdl = "type Query"
+        def document = parse(sdl)
+
+        when:
+        String output = printAst(document)
+        then:
+        output == "type Query\n"
+    }
+
+    def "empty selection set does not include braces"() {
+        // technically below is not valid graphql and will never be parsed as is
+        def field_with_empty_selection_set = Field.newField("foo")
+                .selectionSet(SelectionSet.newSelectionSet().build())
+                .build()
+
+        when:
+        String output = printAst(field_with_empty_selection_set)
+        then:
+        output == "foo"
     }
 }


### PR DESCRIPTION
## Description
In the latest version of the [spec](https://spec.graphql.org/draft/#ObjectTypeDefinition), empty types (input objects, object types) must be represented without curly braces, i.e the following is valid:
```graphql
type Query 
# below only here to make the sdl valid 
extend type Query {
  foo: String
}
```
while the following technically isn't (note the `{}`):
```graphql
type Query {}
# below only here to make the sdl valid 
extend type Query {
  foo: String
}
```
Because of historical reasons, `graphql-java` supports parsing of both syntaxes. However its `AstPrinter` prints the spec invalid form. While this is ok in systems where `graphql-java`'s GraphQL parser is the only one in use, it fails in poly-parser systems where stricter (albeit spec-compliant) parsers might fail to parse `graphql-java` printed SDL output.

## Approach
This PR updates the `AstPrinter` to be spec-compliant, i.e serialize empty types, empty selection sets (although should never happen) without the `{}`.

## Follow ups
If there is interest, I can follow up with another PR that (while breaking backwards-compatibilty) will make the parser spec compliant as well, i.e only allow the form without braces `{}`. 
