### PR TITLE
@defer: Early defer calls

### DIFF
--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -749,7 +749,7 @@ public abstract class ExecutionStrategy {
     protected Object /* CompletableFuture<Object> | Object */
     completeValueForNull(ExecutionStrategyParameters parameters) {
         try {
-            return parameters.getNonNullFieldValidator().validate(parameters.getPath(), null);
+            return parameters.getNonNullFieldValidator().validate(parameters, null);
         } catch (Exception e) {
             return Async.exceptionallyCompletedFuture(e);
         }
@@ -768,7 +768,7 @@ public abstract class ExecutionStrategy {
     protected FieldValueInfo completeValueForList(ExecutionContext executionContext, ExecutionStrategyParameters parameters, Object result) {
         Iterable<Object> resultIterable = toIterable(executionContext, parameters, result);
         try {
-            resultIterable = parameters.getNonNullFieldValidator().validate(parameters.getPath(), resultIterable);
+            resultIterable = parameters.getNonNullFieldValidator().validate(parameters, resultIterable);
         } catch (NonNullableFieldWasNullException e) {
             return new FieldValueInfo(LIST, exceptionallyCompletedFuture(e));
         }
@@ -895,7 +895,7 @@ public abstract class ExecutionStrategy {
         }
 
         try {
-            serialized = parameters.getNonNullFieldValidator().validate(parameters.getPath(), serialized);
+            serialized = parameters.getNonNullFieldValidator().validate(parameters, serialized);
         } catch (NonNullableFieldWasNullException e) {
             return exceptionallyCompletedFuture(e);
         }
@@ -921,7 +921,7 @@ public abstract class ExecutionStrategy {
             serialized = handleCoercionProblem(executionContext, parameters, e);
         }
         try {
-            serialized = parameters.getNonNullFieldValidator().validate(parameters.getPath(), serialized);
+            serialized = parameters.getNonNullFieldValidator().validate(parameters, serialized);
         } catch (NonNullableFieldWasNullException e) {
             return exceptionallyCompletedFuture(e);
         }

--- a/src/main/java/graphql/execution/ExecutionStrategyParameters.java
+++ b/src/main/java/graphql/execution/ExecutionStrategyParameters.java
@@ -3,6 +3,7 @@ package graphql.execution;
 import graphql.PublicApi;
 import graphql.execution.incremental.DeferredCallContext;
 
+import javax.annotation.Nullable;
 import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;

--- a/src/main/java/graphql/execution/MergedField.java
+++ b/src/main/java/graphql/execution/MergedField.java
@@ -139,6 +139,16 @@ public class MergedField {
         return deferredExecutions;
     }
 
+    /**
+     * Returns true if this field is part of a deferred execution
+     *
+     * @return true if this field is part of a deferred execution
+     */
+    @ExperimentalApi
+    public boolean isDeferred() {
+        return !deferredExecutions.isEmpty();
+    }
+
     public static Builder newMergedField() {
         return new Builder();
     }

--- a/src/main/java/graphql/execution/NonNullableFieldValidator.java
+++ b/src/main/java/graphql/execution/NonNullableFieldValidator.java
@@ -50,7 +50,7 @@ public class NonNullableFieldValidator {
                 //
                 NonNullableFieldWasNullException nonNullException = new NonNullableFieldWasNullException(executionStepInfo, path);
                 final GraphQLError error = new NonNullableFieldWasNullError(nonNullException);
-                if(parameters.getField().isDeferred()) {
+                if(parameters.getField() != null && parameters.getField().isDeferred()) {
                     parameters.getDeferredCallContext().addError(error);
                 } else {
                     executionContext.addError(error, path);

--- a/src/main/java/graphql/execution/incremental/DeferredCallContext.java
+++ b/src/main/java/graphql/execution/incremental/DeferredCallContext.java
@@ -23,13 +23,12 @@ public class DeferredCallContext {
 
     private final List<GraphQLError> errors = new CopyOnWriteArrayList<>();
 
-    public void onFetchingException(ResultPath path, SourceLocation sourceLocation, Throwable throwable) {
-        ExceptionWhileDataFetching error = new ExceptionWhileDataFetching(path, throwable, sourceLocation);
-        onError(error);
+    public void addError(GraphQLError graphqlError) {
+        errors.add(graphqlError);
     }
 
-    public void onError(GraphQLError graphqlError) {
-        errors.add(graphqlError);
+    public void addErrors(List<GraphQLError> errors) {
+        this.errors.addAll(errors);
     }
 
     /**

--- a/src/main/java/graphql/execution/incremental/DeferredExecutionSupport.java
+++ b/src/main/java/graphql/execution/incremental/DeferredExecutionSupport.java
@@ -115,7 +115,7 @@ public interface DeferredExecutionSupport {
             List<MergedField> mergedFields = deferredExecutionToFields.get(deferredExecution);
 
             List<CompletableFuture<DeferredFragmentCall.FieldWithExecutionResult>> calls = mergedFields.stream()
-                    .map(currentField -> this.createResultSupplier(currentField, deferredCallContext))
+                    .map(currentField -> this.createResultFuture(currentField, deferredCallContext))
                     .collect(Collectors.toList());
 
             return new DeferredFragmentCall(
@@ -126,7 +126,7 @@ public interface DeferredExecutionSupport {
             );
         }
 
-        private CompletableFuture<DeferredFragmentCall.FieldWithExecutionResult> createResultSupplier(
+        private CompletableFuture<DeferredFragmentCall.FieldWithExecutionResult> createResultFuture(
                 MergedField currentField,
                 DeferredCallContext deferredCallContext
         ) {

--- a/src/main/java/graphql/execution/incremental/IncrementalCall.java
+++ b/src/main/java/graphql/execution/incremental/IncrementalCall.java
@@ -11,4 +11,6 @@ import java.util.concurrent.CompletableFuture;
  */
 public interface IncrementalCall<T extends IncrementalPayload> {
     CompletableFuture<T> invoke();
+
+    int level();
 }

--- a/src/main/java/graphql/execution/incremental/IncrementalCallState.java
+++ b/src/main/java/graphql/execution/incremental/IncrementalCallState.java
@@ -20,15 +20,16 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static graphql.incremental.DelayedIncrementalPartialResultImpl.newIncrementalExecutionResult;
 
 /**
- * This provides support for @defer directives on fields that mean that results will be sent AFTER
- * the main result is sent via a Publisher stream.
+ * Manages the state of incremental calls (for fields that have been @defer'red or @stream'ed), which will result
+ * in data that is sent back to the client AFTER the initial response,
+ * via a {@link Publisher} of {@link DelayedIncrementalPartialResult}.
  */
 @Internal
 public class IncrementalCallState {
     private final AtomicBoolean incrementalCallsDetected = new AtomicBoolean(false);
 
     // PriorityBlockingQueue doesn't have a constructor that accepts just the comparator and
-    // uses the default initial capacity. 11 is the value used in the implementation I'm looking at,
+    // uses the default initial capacity. 11 is the default value used in the implementation I'm looking at,
     // and it seems reasonable for our use case.
     private static final int QUEUE_INITIAL_CAPACITY = 11;
     private final Queue<IncrementalCall<? extends IncrementalPayload>> incrementalCalls =

--- a/src/main/java/graphql/execution/incremental/StreamedCall.java
+++ b/src/main/java/graphql/execution/incremental/StreamedCall.java
@@ -16,4 +16,9 @@ public class StreamedCall implements IncrementalCall<StreamPayload> {
     public CompletableFuture<StreamPayload> invoke() {
         throw new UnsupportedOperationException("Not implemented yet.");
     }
+
+    @Override
+    public int level() {
+        throw new UnsupportedOperationException("Not implemented yet.");
+    }
 }

--- a/src/test/groovy/graphql/execution/NonNullableFieldValidatorTest.groovy
+++ b/src/test/groovy/graphql/execution/NonNullableFieldValidatorTest.groovy
@@ -12,10 +12,15 @@ class NonNullableFieldValidatorTest extends Specification {
     def "non nullable field throws exception"() {
         ExecutionStepInfo typeInfo = ExecutionStepInfo.newExecutionStepInfo().type(nonNull(GraphQLString)).build()
 
+
         NonNullableFieldValidator validator = new NonNullableFieldValidator(context, typeInfo)
 
+        def parameters = Mock(ExecutionStrategyParameters) {
+            getPath() >> ResultPath.rootPath()
+        }
+
         when:
-        validator.validate(ResultPath.rootPath(), null)
+        validator.validate(parameters, null)
 
         then:
         thrown(NonNullableFieldWasNullException)
@@ -27,8 +32,12 @@ class NonNullableFieldValidatorTest extends Specification {
 
         NonNullableFieldValidator validator = new NonNullableFieldValidator(context, typeInfo)
 
+        def parameters = Mock(ExecutionStrategyParameters) {
+            getPath() >> ResultPath.rootPath()
+        }
+
         when:
-        def result = validator.validate(ResultPath.rootPath(), null)
+        def result = validator.validate(parameters, null)
 
         then:
         result == null

--- a/src/test/groovy/graphql/execution/incremental/DeferExecutionSupportIntegrationTest.groovy
+++ b/src/test/groovy/graphql/execution/incremental/DeferExecutionSupportIntegrationTest.groovy
@@ -145,6 +145,7 @@ class DeferExecutionSupportIntegrationTest extends Specification {
                 )
                 .type(newTypeWiring("Post").dataFetcher("summary", resolve("A summary", 10)))
                 .type(newTypeWiring("Post").dataFetcher("text", resolve("The full text", 100)))
+                // the dataFetcher for wordCount is allowed to be called multiple times as it is queried as part of a list
                 .type(newTypeWiring("Post").dataFetcher("wordCount", resolve(45999, 10, true)))
                 .type(newTypeWiring("Post").dataFetcher("latestComment", resolve([title: "Comment title"], 10)))
                 .type(newTypeWiring("Post").dataFetcher("dataFetcherError", resolveWithException()))

--- a/src/test/groovy/graphql/execution/incremental/DeferredCallTest.groovy
+++ b/src/test/groovy/graphql/execution/incremental/DeferredCallTest.groovy
@@ -7,7 +7,6 @@ import graphql.execution.ResultPath
 import spock.lang.Specification
 
 import java.util.concurrent.CompletableFuture
-import java.util.function.Supplier
 
 import static graphql.execution.ResultPath.parse
 import static java.util.concurrent.CompletableFuture.completedFuture
@@ -82,38 +81,28 @@ class DeferredCallTest extends Specification {
         ]
     }
 
-    private static Supplier<CompletableFuture<DeferredFragmentCall.FieldWithExecutionResult>> createResolvedFieldCall(
+    private static CompletableFuture<DeferredFragmentCall.FieldWithExecutionResult> createResolvedFieldCall(
             String fieldName,
             Object data
     ) {
         return createResolvedFieldCall(fieldName, data, Collections.emptyList())
     }
 
-    private static Supplier<CompletableFuture<DeferredFragmentCall.FieldWithExecutionResult>> createResolvedFieldCall(
+    private static CompletableFuture<DeferredFragmentCall.FieldWithExecutionResult> createResolvedFieldCall(
             String fieldName,
             Object data,
             List<GraphQLError> errors
     ) {
-        return new Supplier<CompletableFuture<DeferredFragmentCall.FieldWithExecutionResult>>() {
-            @Override
-            CompletableFuture<DeferredFragmentCall.FieldWithExecutionResult> get() {
-                return completedFuture(
+        return completedFuture(
                         new DeferredFragmentCall.FieldWithExecutionResult(fieldName,
                                 new ExecutionResultImpl(data, errors)
                         )
-                )
-            }
-        }
+        )
     }
 
-    private static Supplier<CompletableFuture<DeferredFragmentCall.FieldWithExecutionResult>> createFieldCallThatThrowsException(
+    private static CompletableFuture<DeferredFragmentCall.FieldWithExecutionResult> createFieldCallThatThrowsException(
             Throwable exception
     ) {
-        return new Supplier<CompletableFuture<DeferredFragmentCall.FieldWithExecutionResult>>() {
-            @Override
-            CompletableFuture<DeferredFragmentCall.FieldWithExecutionResult> get() {
-                return CompletableFuture.failedFuture(exception)
-            }
-        }
+        return CompletableFuture.failedFuture(exception)
     }
 }


### PR DESCRIPTION
Start the execution of deferred fields as soon as they are identified, instead of just after the initial response is complete. This will result in lower overall latency for executions that have deferred fields.