### PR TITLE
Start draining deferred results on subscription

### DIFF
--- a/src/main/java/graphql/execution/incremental/IncrementalCallState.java
+++ b/src/main/java/graphql/execution/incremental/IncrementalCallState.java
@@ -94,8 +94,9 @@ public class IncrementalCallState {
     }
 
     /**
-     * When this is called the deferred execution will begin once the {@link Publisher} is subscribed
-     * to.
+     * This method will return a {@link Publisher} of deferred results.  No field processing will be done
+     * until a {@link org.reactivestreams.Subscriber} is attached to this publisher.  Once a {@link org.reactivestreams.Subscriber}
+     * is attached the deferred field result processing will be started and published as a series of events.
      *
      * @return the publisher of deferred results
      */

--- a/src/main/java/graphql/incremental/IncrementalExecutionResult.java
+++ b/src/main/java/graphql/incremental/IncrementalExecutionResult.java
@@ -86,6 +86,7 @@ import java.util.List;
 public interface IncrementalExecutionResult extends ExecutionResult {
     /**
      * Indicates whether there are pending incremental data.
+     *
      * @return "true" if there are incremental data, "false" otherwise.
      */
     boolean hasNext();
@@ -103,7 +104,11 @@ public interface IncrementalExecutionResult extends ExecutionResult {
     List<IncrementalPayload> getIncremental();
 
     /**
-     * This {@link Publisher} will asynchronously emit events containing defer and/or stream payloads.
+     * This method will return a {@link Publisher} of deferred results.  No field processing will be done
+     * until a {@link org.reactivestreams.Subscriber} is attached to this publisher.
+     * <p>
+     * Once a {@link org.reactivestreams.Subscriber} is attached the deferred field result processing will be
+     * started and published as a series of events.
      *
      * @return a {@link Publisher} that clients can subscribe to receive incremental payloads.
      */

--- a/src/test/groovy/graphql/execution/incremental/DeferExecutionSupportIntegrationTest.groovy
+++ b/src/test/groovy/graphql/execution/incremental/DeferExecutionSupportIntegrationTest.groovy
@@ -1512,7 +1512,9 @@ class DeferExecutionSupportIntegrationTest extends Specification {
         deferredResultStream.subscribe(subscriber)
 
         Awaitility.await().untilTrue(subscriber.isDone())
-
+        if (subscriber.throwable != null) {
+            throw new RuntimeException(subscriber.throwable)
+        }
         return subscriber.getEvents()
                 .collect { it.toSpecification() }
     }

--- a/src/test/groovy/graphql/execution/incremental/IncrementalCallStateDeferTest.groovy
+++ b/src/test/groovy/graphql/execution/incremental/IncrementalCallStateDeferTest.groovy
@@ -234,10 +234,10 @@ class IncrementalCallStateDeferTest extends Specification {
             CompletableFuture<DeferredFragmentCall.FieldWithExecutionResult> get() {
                 return CompletableFuture.supplyAsync({
                     Thread.sleep(sleepTime)
+                    String data = dataSupplier.get()
                     if (data == "Bang") {
                         throw new RuntimeException(data)
                     }
-                    String data = dataSupplier.get()
                     new DeferredFragmentCall.FieldWithExecutionResult(data.toLowerCase(), new ExecutionResultImpl(data, []))
                 })
             }
@@ -281,6 +281,9 @@ class IncrementalCallStateDeferTest extends Specification {
         def subscriber = new CapturingSubscriber<DelayedIncrementalPartialResult>()
         publisher.subscribe(subscriber)
         Awaitility.await().untilTrue(subscriber.isDone())
+        if (subscriber.throwable != null) {
+            throw new RuntimeException(subscriber.throwable)
+        }
         return subscriber.getEvents()
     }
 }

--- a/src/test/groovy/graphql/execution/incremental/IncrementalCallStateDeferTest.groovy
+++ b/src/test/groovy/graphql/execution/incremental/IncrementalCallStateDeferTest.groovy
@@ -3,6 +3,7 @@ package graphql.execution.incremental
 
 import graphql.ExecutionResultImpl
 import graphql.execution.ResultPath
+import graphql.execution.pubsub.CapturingSubscriber
 import graphql.incremental.DelayedIncrementalPartialResult
 import org.awaitility.Awaitility
 import spock.lang.Specification
@@ -239,7 +240,7 @@ class IncrementalCallStateDeferTest extends Specification {
     }
 
     private static List<DelayedIncrementalPartialResult> startAndWaitCalls(IncrementalCallState incrementalCallState) {
-        def subscriber = new graphql.execution.pubsub.CapturingSubscriber<DelayedIncrementalPartialResult>()
+        def subscriber = new CapturingSubscriber<DelayedIncrementalPartialResult>()
 
         incrementalCallState.startDeferredCalls().subscribe(subscriber)
 


### PR DESCRIPTION
POC - this should be what we are doding on defer to only start the publisher work on subscribe happening