### PR TITLE
Fix bug with error handling in the defer execution code

### DIFF
--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -1153,7 +1153,7 @@ public abstract class ExecutionStrategy {
 
     // Errors that result from the execution of deferred fields are kept in the deferred context only.
     private static void addErrorToRightContext(GraphQLError error, ExecutionStrategyParameters parameters, ExecutionContext executionContext) {
-        if (parameters.getField() != null && parameters.getField().isDeferred()) {
+        if (parameters.getDeferredCallContext() != null) {
             parameters.getDeferredCallContext().addError(error);
         } else {
             executionContext.addError(error);
@@ -1161,7 +1161,7 @@ public abstract class ExecutionStrategy {
     }
 
     private static void addErrorsToRightContext(List<GraphQLError> errors, ExecutionStrategyParameters parameters, ExecutionContext executionContext) {
-        if (parameters.getField() != null && parameters.getField().isDeferred()) {
+        if (parameters.getDeferredCallContext() != null) {
             parameters.getDeferredCallContext().addErrors(errors);
         } else {
             executionContext.addErrors(errors);

--- a/src/main/java/graphql/execution/ExecutionStrategyParameters.java
+++ b/src/main/java/graphql/execution/ExecutionStrategyParameters.java
@@ -2,6 +2,7 @@ package graphql.execution;
 
 import graphql.PublicApi;
 import graphql.execution.incremental.DeferredCallContext;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.function.Consumer;
 
@@ -71,8 +72,38 @@ public class ExecutionStrategyParameters {
         return parent;
     }
 
+    /**
+     * Returns the deferred call context if we're in the scope of a deferred call.
+     * A new DeferredCallContext is created for each @defer block, and is passed down to all fields within the deferred call.
+     *
+     * <pre>
+     *     query {
+     *        ... @defer {
+     *            field1 {        # new DeferredCallContext created here
+     *                field1a     # DeferredCallContext passed down to this field
+     *            }
+     *        }
+     *
+     *        ... @defer {
+     *            field2          # new DeferredCallContext created here
+     *        }
+     *     }
+     * </pre>
+     *
+     * @return the deferred call context or null if we're not in the scope of a deferred call
+     */
+    @Nullable
     public DeferredCallContext getDeferredCallContext() {
         return deferredCallContext;
+    }
+
+    /**
+     * Returns true if we're in the scope of a deferred call.
+     *
+     * @return true if we're in the scope of a deferred call
+     */
+    public boolean isInDeferredContext() {
+        return deferredCallContext != null;
     }
 
     /**
@@ -187,9 +218,6 @@ public class ExecutionStrategyParameters {
         }
 
         public ExecutionStrategyParameters build() {
-            if (deferredCallContext == null) {
-                deferredCallContext = new DeferredCallContext();
-            }
             return new ExecutionStrategyParameters(executionStepInfo, source, localContext, fields, nonNullableFieldValidator, path, currentField, parent, deferredCallContext);
         }
     }

--- a/src/main/java/graphql/execution/MergedField.java
+++ b/src/main/java/graphql/execution/MergedField.java
@@ -139,6 +139,16 @@ public class MergedField {
         return deferredExecutions;
     }
 
+    /**
+     * Returns true if this field is part of a deferred execution
+     *
+     * @return true if this field is part of a deferred execution
+     */
+    @ExperimentalApi
+    public boolean isDeferred() {
+        return !deferredExecutions.isEmpty();
+    }
+
     public static Builder newMergedField() {
         return new Builder();
     }

--- a/src/main/java/graphql/execution/NonNullableFieldValidator.java
+++ b/src/main/java/graphql/execution/NonNullableFieldValidator.java
@@ -1,6 +1,7 @@
 package graphql.execution;
 
 
+import graphql.GraphQLError;
 import graphql.Internal;
 
 /**
@@ -23,7 +24,7 @@ public class NonNullableFieldValidator {
     /**
      * Called to check that a value is non null if the type requires it to be non null
      *
-     * @param path   the path to this place
+     * @param parameters the execution strategy parameters
      * @param result the result to check
      * @param <T>    the type of the result
      *
@@ -31,7 +32,7 @@ public class NonNullableFieldValidator {
      *
      * @throws NonNullableFieldWasNullException if the value is null but the type requires it to be non null
      */
-    public <T> T validate(ResultPath path, T result) throws NonNullableFieldWasNullException {
+    public <T> T validate(ExecutionStrategyParameters parameters, T result) throws NonNullableFieldWasNullException {
         if (result == null) {
             if (executionStepInfo.isNonNullType()) {
                 // see https://spec.graphql.org/October2021/#sec-Errors-and-Non-Nullability
@@ -46,8 +47,15 @@ public class NonNullableFieldValidator {
                 //
                 // We will do this until the spec makes this more explicit.
                 //
+                final ResultPath path = parameters.getPath();
+
                 NonNullableFieldWasNullException nonNullException = new NonNullableFieldWasNullException(executionStepInfo, path);
-                executionContext.addError(new NonNullableFieldWasNullError(nonNullException), path);
+                final GraphQLError error = new NonNullableFieldWasNullError(nonNullException);
+                if(parameters.getField() != null && parameters.getField().isDeferred()) {
+                    parameters.getDeferredCallContext().addError(error);
+                } else {
+                    executionContext.addError(error, path);
+                }
                 throw nonNullException;
             }
         }

--- a/src/main/java/graphql/execution/NonNullableFieldValidator.java
+++ b/src/main/java/graphql/execution/NonNullableFieldValidator.java
@@ -51,7 +51,7 @@ public class NonNullableFieldValidator {
 
                 NonNullableFieldWasNullException nonNullException = new NonNullableFieldWasNullException(executionStepInfo, path);
                 final GraphQLError error = new NonNullableFieldWasNullError(nonNullException);
-                if(parameters.getField() != null && parameters.getField().isDeferred()) {
+                if(parameters.getDeferredCallContext() != null) {
                     parameters.getDeferredCallContext().addError(error);
                 } else {
                     executionContext.addError(error, path);

--- a/src/main/java/graphql/execution/incremental/DeferredCallContext.java
+++ b/src/main/java/graphql/execution/incremental/DeferredCallContext.java
@@ -1,10 +1,7 @@
 package graphql.execution.incremental;
 
-import graphql.ExceptionWhileDataFetching;
 import graphql.GraphQLError;
 import graphql.Internal;
-import graphql.execution.ResultPath;
-import graphql.language.SourceLocation;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -23,12 +20,11 @@ public class DeferredCallContext {
 
     private final List<GraphQLError> errors = new CopyOnWriteArrayList<>();
 
-    public void onFetchingException(ResultPath path, SourceLocation sourceLocation, Throwable throwable) {
-        ExceptionWhileDataFetching error = new ExceptionWhileDataFetching(path, throwable, sourceLocation);
-        onError(error);
+    public void addErrors(List<GraphQLError> errors) {
+        this.errors.addAll(errors);
     }
 
-    public void onError(GraphQLError graphqlError) {
+    public void addError(GraphQLError graphqlError) {
         errors.add(graphqlError);
     }
 

--- a/src/test/groovy/graphql/execution/NonNullableFieldValidatorTest.groovy
+++ b/src/test/groovy/graphql/execution/NonNullableFieldValidatorTest.groovy
@@ -9,13 +9,17 @@ class NonNullableFieldValidatorTest extends Specification {
 
     ExecutionContext context = Mock(ExecutionContext)
 
+    def parameters = Mock(ExecutionStrategyParameters) {
+        getPath() >> ResultPath.rootPath()
+    }
+
     def "non nullable field throws exception"() {
         ExecutionStepInfo typeInfo = ExecutionStepInfo.newExecutionStepInfo().type(nonNull(GraphQLString)).build()
 
         NonNullableFieldValidator validator = new NonNullableFieldValidator(context, typeInfo)
 
         when:
-        validator.validate(ResultPath.rootPath(), null)
+        validator.validate(parameters, null)
 
         then:
         thrown(NonNullableFieldWasNullException)
@@ -28,7 +32,7 @@ class NonNullableFieldValidatorTest extends Specification {
         NonNullableFieldValidator validator = new NonNullableFieldValidator(context, typeInfo)
 
         when:
-        def result = validator.validate(ResultPath.rootPath(), null)
+        def result = validator.validate(parameters, null)
 
         then:
         result == null

--- a/src/test/groovy/graphql/execution/incremental/DeferExecutionSupportIntegrationTest.groovy
+++ b/src/test/groovy/graphql/execution/incremental/DeferExecutionSupportIntegrationTest.groovy
@@ -6,7 +6,9 @@ import graphql.ExecutionInput
 import graphql.ExecutionResult
 import graphql.ExperimentalApi
 import graphql.GraphQL
+import graphql.GraphqlErrorBuilder
 import graphql.TestUtil
+import graphql.execution.DataFetcherResult
 import graphql.execution.pubsub.CapturingSubscriber
 import graphql.incremental.DelayedIncrementalPartialResult
 import graphql.incremental.IncrementalExecutionResult
@@ -55,6 +57,7 @@ class DeferExecutionSupportIntegrationTest extends Specification {
                 comments: [Comment]
                 resolvesToNull: String
                 dataFetcherError: String
+                dataAndError: String
                 coercionError: Int 
                 typeMismatchError: [String]
                 nonNullableError: String!
@@ -128,6 +131,22 @@ class DeferExecutionSupportIntegrationTest extends Specification {
         }
     }
 
+    private static DataFetcher resolveWithDataAndError(Object data) {
+        return new DataFetcher() {
+            @Override
+            Object get(DataFetchingEnvironment environment) throws Exception {
+                return DataFetcherResult.newResult()
+                        .data(data)
+                        .error(
+                                GraphqlErrorBuilder.newError()
+                                        .message("Bang!")
+                                        .build()
+                        )
+                        .build()
+            }
+        }
+    }
+
     void setup() {
         def runtimeWiring = RuntimeWiring.newRuntimeWiring()
                 .type(newTypeWiring("Query")
@@ -148,6 +167,7 @@ class DeferExecutionSupportIntegrationTest extends Specification {
                 .type(newTypeWiring("Post").dataFetcher("wordCount", resolve(45999, 10, true)))
                 .type(newTypeWiring("Post").dataFetcher("latestComment", resolve([title: "Comment title"], 10)))
                 .type(newTypeWiring("Post").dataFetcher("dataFetcherError", resolveWithException()))
+                .type(newTypeWiring("Post").dataFetcher("dataAndError", resolveWithDataAndError("data")))
                 .type(newTypeWiring("Post").dataFetcher("coercionError", resolve("Not a number", 10)))
                 .type(newTypeWiring("Post").dataFetcher("typeMismatchError", resolve([a: "A Map instead of a List"], 10)))
                 .type(newTypeWiring("Post").dataFetcher("nonNullableError", resolve(null)))
@@ -1141,6 +1161,61 @@ class DeferExecutionSupportIntegrationTest extends Specification {
                                                          message   : "Exception while fetching data (/post/dataFetcherError) : Bang!!!",
                                                          locations : [[line: 6, column: 25]],
                                                          path      : ["post", "dataFetcherError"],
+                                                         extensions: [classification: "DataFetchingException"]
+                                                 ]],
+                                ],
+                        ]
+                ],
+                [
+                        hasNext    : false,
+                        incremental: [
+                                [
+                                        path: ["post"],
+                                        data: [text: "The full text"],
+                                ]
+                        ]
+                ]
+        ]
+    }
+
+    def "can handle data fetcher that returns both data and error"() {
+        def query = '''
+            query {
+                post {
+                    id
+                    ... @defer {
+                        dataAndError
+                    }
+                    ... @defer {
+                        text
+                    }
+                }
+            }
+        '''
+
+        when:
+        def initialResult = executeQuery(query)
+
+        then:
+        initialResult.toSpecification() == [
+                data   : [post: [id: "1001"]],
+                hasNext: true
+        ]
+
+        when:
+        def incrementalResults = getIncrementalResults(initialResult)
+
+        then:
+        incrementalResults == [
+                [
+                        hasNext    : true,
+                        incremental: [
+                                [
+                                        path  : ["post"],
+                                        data  : [dataAndError: "data"],
+                                        errors: [[
+                                                         message   : "Bang!",
+                                                         locations : [],
                                                          extensions: [classification: "DataFetchingException"]
                                                  ]],
                                 ],


### PR DESCRIPTION
Improvements in the error handling for deferred code.
- fixes bug where errors added by data fetchers that returned `DataFetcherResult` where not being added to deferred payloads
- Errors generated during the execution of deferred fields are kept in the correspondent `DeferredCallContext` only, no longer being duplicated in `ExecutionContext`