### PR TITLE
Only use JetBrains nullability annotations

### DIFF
--- a/src/main/java/graphql/execution/MergedField.java
+++ b/src/main/java/graphql/execution/MergedField.java
@@ -6,8 +6,8 @@ import graphql.PublicApi;
 import graphql.execution.incremental.DeferredExecution;
 import graphql.language.Argument;
 import graphql.language.Field;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;

--- a/src/main/java/graphql/execution/incremental/DeferredExecution.java
+++ b/src/main/java/graphql/execution/incremental/DeferredExecution.java
@@ -2,8 +2,7 @@ package graphql.execution.incremental;
 
 import graphql.ExperimentalApi;
 import graphql.normalized.incremental.NormalizedDeferredExecution;
-
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Represents details about the defer execution that can be associated with a {@link graphql.execution.MergedField}.

--- a/src/main/java/graphql/incremental/DeferPayload.java
+++ b/src/main/java/graphql/incremental/DeferPayload.java
@@ -3,8 +3,8 @@ package graphql.incremental;
 import graphql.ExecutionResult;
 import graphql.ExperimentalApi;
 import graphql.GraphQLError;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/graphql/incremental/DelayedIncrementalPartialResult.java
+++ b/src/main/java/graphql/incremental/DelayedIncrementalPartialResult.java
@@ -1,8 +1,8 @@
 package graphql.incremental;
 
 import graphql.ExperimentalApi;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 

--- a/src/main/java/graphql/incremental/IncrementalExecutionResult.java
+++ b/src/main/java/graphql/incremental/IncrementalExecutionResult.java
@@ -2,9 +2,9 @@ package graphql.incremental;
 
 import graphql.ExecutionResult;
 import graphql.ExperimentalApi;
+import org.jetbrains.annotations.Nullable;
 import org.reactivestreams.Publisher;
 
-import javax.annotation.Nullable;
 import java.util.List;
 
 /**

--- a/src/main/java/graphql/incremental/IncrementalExecutionResultImpl.java
+++ b/src/main/java/graphql/incremental/IncrementalExecutionResultImpl.java
@@ -3,9 +3,9 @@ package graphql.incremental;
 import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.ExperimentalApi;
+import org.jetbrains.annotations.Nullable;
 import org.reactivestreams.Publisher;
 
-import javax.annotation.Nullable;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;

--- a/src/main/java/graphql/incremental/IncrementalPayload.java
+++ b/src/main/java/graphql/incremental/IncrementalPayload.java
@@ -3,8 +3,8 @@ package graphql.incremental;
 import graphql.ExperimentalApi;
 import graphql.GraphQLError;
 import graphql.execution.ResultPath;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/src/main/java/graphql/incremental/StreamPayload.java
+++ b/src/main/java/graphql/incremental/StreamPayload.java
@@ -2,8 +2,8 @@ package graphql.incremental;
 
 import graphql.ExperimentalApi;
 import graphql.GraphQLError;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/graphql/normalized/incremental/NormalizedDeferredExecution.java
+++ b/src/main/java/graphql/normalized/incremental/NormalizedDeferredExecution.java
@@ -2,8 +2,8 @@ package graphql.normalized.incremental;
 
 import graphql.ExperimentalApi;
 import graphql.schema.GraphQLObjectType;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.util.Set;
 
 /**

--- a/src/test/java/reproductions/SubscriptionReproduction.java
+++ b/src/test/java/reproductions/SubscriptionReproduction.java
@@ -9,6 +9,7 @@ import graphql.schema.GraphQLSchema;
 import graphql.schema.idl.RuntimeWiring;
 import graphql.schema.idl.SchemaGenerator;
 import graphql.schema.idl.SchemaParser;
+import org.jetbrains.annotations.NotNull;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -16,7 +17,6 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
-import javax.annotation.Nonnull;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
@@ -134,7 +134,7 @@ public class SubscriptionReproduction {
         return counter;
     }
 
-    private @Nonnull Object mkValue(Integer counter) {
+    private @NotNull Object mkValue(Integer counter) {
         // name and isFavorite are future values via DFs
         return Map.of(
                 "counter", counter,


### PR DESCRIPTION
Let's only use the JetBrains nullability annotations, rather than a mix of JetBrains and javax annotations.