### PR TITLE
This introduces a Traversal Options to allow skipping the coercing of field arguments

### DIFF
--- a/src/main/java/graphql/analysis/NodeVisitorWithTypeTracking.java
+++ b/src/main/java/graphql/analysis/NodeVisitorWithTypeTracking.java
@@ -30,6 +30,7 @@ import graphql.schema.GraphQLUnmodifiedType;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
+import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
 
@@ -50,13 +51,20 @@ public class NodeVisitorWithTypeTracking extends NodeVisitorStub {
     private final GraphQLSchema schema;
     private final Map<String, FragmentDefinition> fragmentsByName;
     private final ConditionalNodes conditionalNodes = new ConditionalNodes();
+    private final QueryTraversalOptions options;
 
-    public NodeVisitorWithTypeTracking(QueryVisitor preOrderCallback, QueryVisitor postOrderCallback, Map<String, Object> variables, GraphQLSchema schema, Map<String, FragmentDefinition> fragmentsByName) {
+    public NodeVisitorWithTypeTracking(QueryVisitor preOrderCallback,
+                                       QueryVisitor postOrderCallback,
+                                       Map<String, Object> variables,
+                                       GraphQLSchema schema,
+                                       Map<String, FragmentDefinition> fragmentsByName,
+                                       QueryTraversalOptions options) {
         this.preOrderCallback = preOrderCallback;
         this.postOrderCallback = postOrderCallback;
         this.variables = variables;
         this.schema = schema;
         this.fragmentsByName = fragmentsByName;
+        this.options = options;
     }
 
     @Override
@@ -156,12 +164,17 @@ public class NodeVisitorWithTypeTracking extends NodeVisitorStub {
         boolean isTypeNameIntrospectionField = fieldDefinition == schema.getIntrospectionTypenameFieldDefinition();
         GraphQLFieldsContainer fieldsContainer = !isTypeNameIntrospectionField ? (GraphQLFieldsContainer) unwrapAll(parentEnv.getOutputType()) : null;
         GraphQLCodeRegistry codeRegistry = schema.getCodeRegistry();
-        Map<String, Object> argumentValues = ValuesResolver.getArgumentValues(codeRegistry,
-                fieldDefinition.getArguments(),
-                field.getArguments(),
-                CoercedVariables.of(variables),
-                GraphQLContext.getDefault(),
-                Locale.getDefault());
+        Map<String, Object> argumentValues;
+        if (options.isCoerceFieldArguments()) {
+            argumentValues = ValuesResolver.getArgumentValues(codeRegistry,
+                    fieldDefinition.getArguments(),
+                    field.getArguments(),
+                    CoercedVariables.of(variables),
+                    GraphQLContext.getDefault(),
+                    Locale.getDefault());
+        } else {
+            argumentValues = Collections.emptyMap();
+        }
         QueryVisitorFieldEnvironment environment = new QueryVisitorFieldEnvironmentImpl(isTypeNameIntrospectionField,
                 field,
                 fieldDefinition,

--- a/src/main/java/graphql/analysis/QueryTraversalOptions.java
+++ b/src/main/java/graphql/analysis/QueryTraversalOptions.java
@@ -1,0 +1,31 @@
+package graphql.analysis;
+
+import graphql.PublicApi;
+
+/**
+ * This options object controls how {@link QueryTraverser} works
+ */
+@PublicApi
+public class QueryTraversalOptions {
+
+    private final boolean coerceFieldArguments;
+
+    private QueryTraversalOptions(boolean coerceFieldArguments) {
+        this.coerceFieldArguments = coerceFieldArguments;
+    }
+
+    /**
+     * @return true if field arguments should be coerced.  This is true by default.
+     */
+    public boolean isCoerceFieldArguments() {
+        return coerceFieldArguments;
+    }
+
+    public static QueryTraversalOptions defaultOptions() {
+        return new QueryTraversalOptions(true);
+    }
+
+    public QueryTraversalOptions coerceFieldArguments(boolean coerceFieldArguments) {
+        return new QueryTraversalOptions(coerceFieldArguments);
+    }
+}

--- a/src/test/groovy/graphql/analysis/QueryTraversalOptionsTest.groovy
+++ b/src/test/groovy/graphql/analysis/QueryTraversalOptionsTest.groovy
@@ -1,0 +1,20 @@
+package graphql.analysis
+
+import spock.lang.Specification
+
+class QueryTraversalOptionsTest extends Specification {
+
+    def "defaulting works as expected"() {
+        when:
+        def options = QueryTraversalOptions.defaultOptions()
+
+        then:
+        options.isCoerceFieldArguments()
+
+        when:
+        options = QueryTraversalOptions.defaultOptions().coerceFieldArguments(false)
+
+        then:
+        !options.isCoerceFieldArguments()
+    }
+}


### PR DESCRIPTION
The default is the old behaviour of coercing by default

But this can turned off via options

I used an options class so we can extend with further options in the future.