### PR TITLE
Fix MultiSourceReader compatibility with Java 16+

### DIFF
--- a/src/main/java/graphql/parser/MultiSourceReader.java
+++ b/src/main/java/graphql/parser/MultiSourceReader.java
@@ -23,12 +23,27 @@ import java.util.List;
 @PublicApi
 public class MultiSourceReader extends Reader {
 
+    // In Java version 16+, LineNumberReader.read considers end-of-stream to be a line terminator
+    // and will increment the line number, whereas in previous versions it doesn't.
+    private static final boolean LINE_NUMBER_READER_EOS_IS_TERMINATOR;
+
     private final List<SourcePart> sourceParts;
     private final StringBuilder data = new StringBuilder();
     private int currentIndex = 0;
     private int overallLineNumber = 0;
     private final boolean trackData;
     private final LockKit.ReentrantLock readerLock = new LockKit.ReentrantLock();
+
+    static {
+        LineNumberReader reader = new LineNumberReader(new StringReader("a"));
+        try {
+            reader.read();
+            reader.read();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        LINE_NUMBER_READER_EOS_IS_TERMINATOR = reader.getLineNumber() > 0;
+    }
 
 
     private MultiSourceReader(Builder builder) {
@@ -46,10 +61,16 @@ public class MultiSourceReader extends Reader {
                 }
                 SourcePart sourcePart = sourceParts.get(currentIndex);
                 int read = sourcePart.lineReader.read(cbuf, off, len);
-                overallLineNumber = calcLineNumber();
                 if (read == -1) {
                     currentIndex++;
-                } else {
+                    sourcePart.reachedEndOfStream = true;
+                } else if (read > 0) {
+                    sourcePart.lastRead = cbuf[off + read - 1];
+                }
+                // note: calcLineNumber() must be called after updating sourcePart.reachedEndOfStream
+                // and sourcePart.lastRead
+                overallLineNumber = calcLineNumber();
+                if (read != -1) {
                     trackData(cbuf, off, read);
                     return read;
                 }
@@ -68,7 +89,7 @@ public class MultiSourceReader extends Reader {
     private int calcLineNumber() {
         int linenumber = 0;
         for (SourcePart sourcePart : sourceParts) {
-            linenumber += sourcePart.lineReader.getLineNumber();
+            linenumber += sourcePart.getLineNumber();
         }
         return linenumber;
     }
@@ -125,7 +146,7 @@ public class MultiSourceReader extends Reader {
             sourceAndLine.sourceName = sourcePart.sourceName;
             if (sourcePart == currentPart) {
                 // we cant go any further
-                int partLineNumber = currentPart.lineReader.getLineNumber();
+                int partLineNumber = currentPart.getLineNumber();
                 previousPage = page;
                 page += partLineNumber;
                 if (page > overallLineNumber) {
@@ -136,7 +157,7 @@ public class MultiSourceReader extends Reader {
                 return sourceAndLine;
             } else {
                 previousPage = page;
-                int partLineNumber = sourcePart.lineReader.getLineNumber();
+                int partLineNumber = sourcePart.getLineNumber();
                 page += partLineNumber;
                 if (page > overallLineNumber) {
                     sourceAndLine.line = overallLineNumber - previousPage;
@@ -157,9 +178,9 @@ public class MultiSourceReader extends Reader {
                 return 0;
             }
             if (currentIndex >= sourceParts.size()) {
-                return sourceParts.get(sourceParts.size() - 1).lineReader.getLineNumber();
+                return sourceParts.get(sourceParts.size() - 1).getLineNumber();
             }
-            return sourceParts.get(currentIndex).lineReader.getLineNumber();
+            return sourceParts.get(currentIndex).getLineNumber();
         });
     }
 
@@ -220,6 +241,24 @@ public class MultiSourceReader extends Reader {
         String sourceName;
         LineNumberReader lineReader;
         boolean closed;
+        char lastRead;
+        boolean reachedEndOfStream = false;
+
+        /**
+         * This handles the discrepancy between LineNumberReader.getLineNumber() for Java versions
+         * 16+ vs below. Use this instead of lineReader.getLineNumber() directly.
+         * @return The current line number. EOS is not considered a line terminator.
+         */
+        int getLineNumber() {
+            int lineNumber = lineReader.getLineNumber();
+            if (reachedEndOfStream
+                    && LINE_NUMBER_READER_EOS_IS_TERMINATOR
+                    && lastRead != '\r'
+                    && lastRead != '\n') {
+                return Math.max(lineNumber - 1, 0);
+            }
+            return lineNumber;
+        }
     }
 
 


### PR DESCRIPTION
This is a fix for https://github.com/graphql-java/graphql-java/issues/2709

`LineNumberReader` was updated in Java 16 to consider EOS a line terminator, so if a source doesn't end in newline, `getLineNumber()` will return 1 + the value in older Java versions. We ran into this issue at Airbnb where we use `MultiSourceReader` to read graphqls files. If a schema file didn't end in newline, the `SourceLocation` for some types would be incorrect. This PR attempts to address this issue.

Testing:
I ran the unit tests with Java 11 and Java 20 (this required bumping the language version in build.gradle) with and without this fix. Without this fix, `LineNumberingTest`, `MultiSourceReaderTest`, `ParserExceptionTest`, `TypeDefinitionRegistryTest` fail with Java 20 as described in the open issue. With this fix, they succeed.
This also fixed the bug we ran into at Airbnb.