### PR TITLE
3662 - fixes dataloader dispatching during subscriptions

### DIFF
--- a/src/main/java/graphql/execution/ExecutionContext.java
+++ b/src/main/java/graphql/execution/ExecutionContext.java
@@ -86,6 +86,7 @@ public class ExecutionContext {
         this.errors.set(builder.errors);
         this.localContext = builder.localContext;
         this.executionInput = builder.executionInput;
+        this.dataLoaderDispatcherStrategy = builder.dataLoaderDispatcherStrategy;
         this.queryTree = FpKit.interThreadMemoize(() -> ExecutableNormalizedOperationFactory.createExecutableNormalizedOperation(graphQLSchema, operationDefinition, fragmentsByName, coercedVariables));
     }
 

--- a/src/main/java/graphql/execution/ExecutionContextBuilder.java
+++ b/src/main/java/graphql/execution/ExecutionContextBuilder.java
@@ -45,6 +45,7 @@ public class ExecutionContextBuilder {
     ValueUnboxer valueUnboxer;
     Object localContext;
     ExecutionInput executionInput;
+    DataLoaderDispatchStrategy dataLoaderDispatcherStrategy = DataLoaderDispatchStrategy.NO_OP;
 
     /**
      * @return a new builder of {@link graphql.execution.ExecutionContext}s
@@ -90,6 +91,7 @@ public class ExecutionContextBuilder {
         errors = ImmutableList.copyOf(other.getErrors());
         valueUnboxer = other.getValueUnboxer();
         executionInput = other.getExecutionInput();
+        dataLoaderDispatcherStrategy = other.getDataLoaderDispatcherStrategy();
     }
 
     public ExecutionContextBuilder instrumentation(Instrumentation instrumentation) {
@@ -200,6 +202,12 @@ public class ExecutionContextBuilder {
 
     public ExecutionContextBuilder executionInput(ExecutionInput executionInput) {
         this.executionInput = executionInput;
+        return this;
+    }
+
+    @Internal
+    public ExecutionContextBuilder dataLoaderDispatcherStrategy(DataLoaderDispatchStrategy dataLoaderDispatcherStrategy) {
+        this.dataLoaderDispatcherStrategy = dataLoaderDispatcherStrategy;
         return this;
     }
 

--- a/src/test/groovy/graphql/execution/ExecutionContextBuilderTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionContextBuilderTest.groovy
@@ -25,24 +25,26 @@ class ExecutionContextBuilderTest extends Specification {
     def operation = document.definitions[0] as OperationDefinition
     def fragment = document.definitions[1] as FragmentDefinition
     def dataLoaderRegistry = new DataLoaderRegistry()
+    def mockDataLoaderDispatcherStrategy = Mock(DataLoaderDispatchStrategy)
 
     def "builds the correct ExecutionContext"() {
         when:
         def executionContext = new ExecutionContextBuilder()
-            .instrumentation(instrumentation)
-            .queryStrategy(queryStrategy)
-            .mutationStrategy(mutationStrategy)
-            .subscriptionStrategy(subscriptionStrategy)
-            .graphQLSchema(schema)
-            .executionId(executionId)
-            .context(context) // Retain deprecated builder for test coverage
-            .graphQLContext(graphQLContext)
-            .root(root)
-            .operationDefinition(operation)
-            .fragmentsByName([MyFragment: fragment])
-            .variables([var: 'value']) // Retain deprecated builder for test coverage
-            .dataLoaderRegistry(dataLoaderRegistry)
-            .build()
+                .instrumentation(instrumentation)
+                .queryStrategy(queryStrategy)
+                .mutationStrategy(mutationStrategy)
+                .subscriptionStrategy(subscriptionStrategy)
+                .graphQLSchema(schema)
+                .executionId(executionId)
+                .context(context) // Retain deprecated builder for test coverage
+                .graphQLContext(graphQLContext)
+                .root(root)
+                .operationDefinition(operation)
+                .fragmentsByName([MyFragment: fragment])
+                .variables([var: 'value']) // Retain deprecated builder for test coverage
+                .dataLoaderRegistry(dataLoaderRegistry)
+                .dataLoaderDispatcherStrategy(mockDataLoaderDispatcherStrategy)
+                .build()
 
         then:
         executionContext.executionId == executionId
@@ -58,6 +60,7 @@ class ExecutionContextBuilderTest extends Specification {
         executionContext.getFragmentsByName() == [MyFragment: fragment]
         executionContext.operationDefinition == operation
         executionContext.dataLoaderRegistry == dataLoaderRegistry
+        executionContext.dataLoaderDispatcherStrategy == mockDataLoaderDispatcherStrategy
     }
 
     def "builds the correct ExecutionContext with coerced variables"() {
@@ -66,19 +69,19 @@ class ExecutionContextBuilderTest extends Specification {
 
         when:
         def executionContext = new ExecutionContextBuilder()
-            .instrumentation(instrumentation)
-            .queryStrategy(queryStrategy)
-            .mutationStrategy(mutationStrategy)
-            .subscriptionStrategy(subscriptionStrategy)
-            .graphQLSchema(schema)
-            .executionId(executionId)
-            .graphQLContext(graphQLContext)
-            .root(root)
-            .operationDefinition(operation)
-            .fragmentsByName([MyFragment: fragment])
-            .coercedVariables(coercedVariables)
-            .dataLoaderRegistry(dataLoaderRegistry)
-            .build()
+                .instrumentation(instrumentation)
+                .queryStrategy(queryStrategy)
+                .mutationStrategy(mutationStrategy)
+                .subscriptionStrategy(subscriptionStrategy)
+                .graphQLSchema(schema)
+                .executionId(executionId)
+                .graphQLContext(graphQLContext)
+                .root(root)
+                .operationDefinition(operation)
+                .fragmentsByName([MyFragment: fragment])
+                .coercedVariables(coercedVariables)
+                .dataLoaderRegistry(dataLoaderRegistry)
+                .build()
 
         then:
         executionContext.executionId == executionId
@@ -204,5 +207,33 @@ class ExecutionContextBuilderTest extends Specification {
         executionContext.getFragmentsByName() == [MyFragment: fragment]
         executionContext.operationDefinition == operation
         executionContext.dataLoaderRegistry == dataLoaderRegistry
+    }
+
+    def "transform copies dispatcher"() {
+        given:
+        def oldCoercedVariables = CoercedVariables.emptyVariables()
+        def executionContextOld = new ExecutionContextBuilder()
+                .instrumentation(instrumentation)
+                .queryStrategy(queryStrategy)
+                .mutationStrategy(mutationStrategy)
+                .subscriptionStrategy(subscriptionStrategy)
+                .graphQLSchema(schema)
+                .executionId(executionId)
+                .graphQLContext(graphQLContext)
+                .root(root)
+                .operationDefinition(operation)
+                .coercedVariables(oldCoercedVariables)
+                .fragmentsByName([MyFragment: fragment])
+                .dataLoaderRegistry(dataLoaderRegistry)
+                .dataLoaderDispatcherStrategy(DataLoaderDispatchStrategy.NO_OP)
+                .build()
+
+        when:
+        def executionContext = executionContextOld
+                .transform(builder -> builder
+                .dataLoaderDispatcherStrategy(mockDataLoaderDispatcherStrategy))
+
+        then:
+        executionContext.getDataLoaderDispatcherStrategy() == mockDataLoaderDispatcherStrategy
     }
 }


### PR DESCRIPTION


Fixes #3662 

The ExecutionContextBuilder was not copying the DataLoaderDispatchStrategy and this gets "transformed" during subscription execution.  This caused it to fallback to the default NOOP implementation which is wrong.

The integration test was written first - it hung the dataloader as described in the bug and then with this fix applied it works.  TDD!
