### PR TITLE
transformable IncrementalExecutionResult

### DIFF
--- a/src/main/java/graphql/incremental/IncrementalExecutionResultImpl.java
+++ b/src/main/java/graphql/incremental/IncrementalExecutionResultImpl.java
@@ -10,6 +10,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 @ExperimentalApi
@@ -50,6 +51,13 @@ public class IncrementalExecutionResultImpl extends ExecutionResultImpl implemen
 
     public static Builder fromExecutionResult(ExecutionResult executionResult) {
         return new Builder().from(executionResult);
+    }
+
+    @Override
+    public IncrementalExecutionResult transform(Consumer<ExecutionResult.Builder<?>> builderConsumer) {
+        var builder = fromExecutionResult(this);
+        builderConsumer.accept(builder);
+        return builder.build();
     }
 
     @Override

--- a/src/test/groovy/graphql/incremental/IncrementalExecutionResultTest.groovy
+++ b/src/test/groovy/graphql/incremental/IncrementalExecutionResultTest.groovy
@@ -121,10 +121,15 @@ class IncrementalExecutionResultTest extends Specification {
 
     def "transform returns IncrementalExecutionResult"() {
         when:
-        def initial = newIncrementalExecutionResult().build()
+        def initial = newIncrementalExecutionResult().hasNext(true).build()
 
         then:
-        def transformed = initial.transform { }
+        def transformed = initial.transform { b ->
+            b.addExtension("ext-key", "ext-value")
+            b.hasNext(false)
+        }
         transformed instanceof IncrementalExecutionResult
+        transformed.extensions == ["ext-key": "ext-value"]
+        transformed.hasNext == false
     }
 }

--- a/src/test/groovy/graphql/incremental/IncrementalExecutionResultTest.groovy
+++ b/src/test/groovy/graphql/incremental/IncrementalExecutionResultTest.groovy
@@ -1,9 +1,7 @@
 package graphql.incremental
 
 import graphql.execution.ResultPath
-import groovy.json.JsonOutput
 import io.reactivex.Flowable
-import org.reactivestreams.Publisher
 import spock.lang.Specification
 
 import static graphql.incremental.DeferPayload.newDeferredItem
@@ -119,5 +117,14 @@ class IncrementalExecutionResultTest extends Specification {
         newIncrementalExecutionResult.incrementalItemPublisher == incrementalExecutionResult.incrementalItemPublisher
         newIncrementalExecutionResult.hasNext() == incrementalExecutionResult.hasNext()
         newIncrementalExecutionResult.toSpecification() == incrementalExecutionResult.toSpecification()
+    }
+
+    def "transform returns IncrementalExecutionResult"() {
+        when:
+        def initial = newIncrementalExecutionResult().build()
+
+        then:
+        def transformed = initial.transform { }
+        transformed instanceof IncrementalExecutionResult
     }
 }


### PR DESCRIPTION
Calling `IncrementalExecutionResult.transform` will return an `ExecutionResultImpl` (rather than another `IncrementalExecutionResult`), which can cause incremental parts of the execution result to get lost.

This makes it difficult to add `@defer` support to a system with existing instrumentations, which might modify an ExecutionResult without knowing that it needs to be handled differently if it is incremental.

This PR overrides the implementation of `IncrementalExecutionResult.transform` to ensure that the transformed result retains its incremental nature.