### PR TITLE
Avoid unnecessary String allocations in AstPrinter

### DIFF
--- a/src/main/java/graphql/language/AstPrinter.java
+++ b/src/main/java/graphql/language/AstPrinter.java
@@ -5,16 +5,14 @@ import graphql.collect.ImmutableKit;
 
 import java.io.PrintWriter;
 import java.io.Writer;
-import java.util.Collections;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.StringJoiner;
 
 import static graphql.Assert.assertShouldNeverHappen;
 import static graphql.Assert.assertTrue;
-import static graphql.util.EscapeUtil.escapeJsonString;
-import static java.lang.String.valueOf;
+import static graphql.util.EscapeUtil.escapeJsonStringTo;
 
 /**
  * This can take graphql language AST and print it out as a string
@@ -75,40 +73,57 @@ public class AstPrinter {
 
     private NodePrinter<Argument> argument() {
         if (compactMode) {
-            return (out, node) -> out.append(node.getName()).append(':').append(value(node.getValue()));
+            return (out, node) -> {
+                out.append(node.getName()).append(':');
+                value(out, node.getValue());
+            };
         }
-        return (out, node) -> out.append(node.getName()).append(": ").append(value(node.getValue()));
+        return (out, node) -> {
+            out.append(node.getName()).append(": ");
+            value(out, node.getValue());
+        };
     }
 
     private NodePrinter<Document> document() {
         if (compactMode) {
-            return (out, node) -> out.append(join(node.getDefinitions(), " "));
+            return (out, node) -> join(out, node.getDefinitions(), " ");
         }
-        return (out, node) -> out.append(join(node.getDefinitions(), "\n\n")).append("\n");
+        return (out, node) -> {
+            join(out, node.getDefinitions(), "\n\n");
+            out.append('\n');
+        };
     }
 
     private NodePrinter<Directive> directive() {
         final String argSep = compactMode ? "," : ", ";
         return (out, node) -> {
-            String arguments = wrap("(", join(node.getArguments(), argSep), ")");
-            out.append('@').append(node.getName()).append(arguments);
+            out.append('@');
+            out.append(node.getName());
+            if (!isEmpty(node.getArguments())) {
+                out.append('(');
+                join(out, node.getArguments(), argSep);
+                out.append(')');
+            }
         };
     }
 
     private NodePrinter<DirectiveDefinition> directiveDefinition() {
         final String argSep = compactMode ? "," : ", ";
         return (out, node) -> {
-            out.append(description(node));
-            String arguments = wrap("(", join(node.getInputValueDefinitions(), argSep), ")");
-            String locations = join(node.getDirectiveLocations(), " | ");
-            String repeatable = node.isRepeatable() ? "repeatable " : "";
-            out.append("directive @")
-                    .append(node.getName())
-                    .append(arguments)
-                    .append(" ")
-                    .append(repeatable)
-                    .append("on ")
-                    .append(locations);
+            description(out, node);
+            out.append("directive @");
+            out.append(node.getName());
+            if (!isEmpty(node.getInputValueDefinitions())) {
+                out.append('(');
+                join(out, node.getInputValueDefinitions(), argSep);
+                out.append(')');
+            }
+            out.append(" ");
+            if (node.isRepeatable()) {
+                out.append("repeatable ");
+            }
+            out.append("on ");
+            join(out, node.getDirectiveLocations(), " | ");
         };
     }
 
@@ -118,13 +133,15 @@ public class AstPrinter {
 
     private NodePrinter<EnumTypeDefinition> enumTypeDefinition() {
         return (out, node) -> {
-            out.append(description(node));
-            out.append(spaced(
-                    "enum",
-                    node.getName(),
-                    directives(node.getDirectives()),
-                    block(node.getEnumValueDefinitions())
-            ));
+            description(out, node);
+            out.append("enum ");
+            out.append(node.getName());
+            if (!isEmpty(node.getDirectives())) {
+                out.append(' ');
+                directives(out, node.getDirectives());
+            }
+            out.append(' ');
+            block(out, node.getEnumValueDefinitions());
         };
     }
 
@@ -134,11 +151,12 @@ public class AstPrinter {
 
     private NodePrinter<EnumValueDefinition> enumValueDefinition() {
         return (out, node) -> {
-            out.append(description(node));
-            out.append(spaced(
-                    node.getName(),
-                    directives(node.getDirectives())
-            ));
+            description(out, node);
+            out.append(node.getName());
+            if (!isEmpty(node.getDirectives())) {
+                out.append(' ');
+                directives(out, node.getDirectives());
+            }
         };
     }
 
@@ -146,128 +164,131 @@ public class AstPrinter {
         final String argSep = compactMode ? "," : ", ";
         final String aliasSuffix = compactMode ? ":" : ": ";
         return (out, node) -> {
-            String alias = wrap("", node.getAlias(), aliasSuffix);
             String name = node.getName();
-            String arguments = wrap("(", join(node.getArguments(), argSep), ")");
-            String directives = directives(node.getDirectives());
-            String selectionSet = node(node.getSelectionSet());
-
-            if (compactMode) {
-                out.append(spaced(
-                        alias + name + arguments,
-                        directives
-                ));
-                out.append(selectionSet);
-            } else {
-                out.append(spaced(
-                        alias + name + arguments,
-                        directives,
-                        selectionSet
-                ));
-            }
+                if (!isEmpty(node.getAlias())) {
+                    out.append(node.getAlias());
+                    out.append(aliasSuffix);
+                }
+                out.append(name);
+                if (!isEmpty(node.getArguments())) {
+                    out.append('(');
+                    join(out, node.getArguments(), argSep);
+                    out.append(')');
+                }
+                if (!isEmpty(node.getDirectives())) {
+                    out.append(' ');
+                    directives(out, node.getDirectives());
+                }
+                if (node.getSelectionSet() != null && !isEmpty(node.getSelectionSet().getSelections())) {
+                    if (!compactMode) {
+                        out.append(' ');
+                    }
+                    node(out, node.getSelectionSet());
+                }
         };
     }
-
 
     private NodePrinter<FieldDefinition> fieldDefinition() {
         final String argSep = compactMode ? "," : ", ";
         return (out, node) -> {
-            String args;
-            if (hasDescription(Collections.singletonList(node)) && !compactMode) {
-                out.append(description(node));
-                args = join(node.getInputValueDefinitions(), "\n");
-                out.append(node.getName())
-                        .append(wrap("(\n", args, ")"))
-                        .append(": ")
-                        .append(spaced(
-                                type(node.getType()),
-                                directives(node.getDirectives())
-                        ));
+            if (hasDescription(node) && !compactMode) {
+                description(out, node);
+                out.append(node.getName());
+                if (!isEmpty(node.getInputValueDefinitions())) {
+                    out.append("(\n");
+                    join(out, node.getInputValueDefinitions(), "\n");
+                    out.append(')');
+                }
+                out.append(": ");
+                type(out, node.getType());
+                if (!isEmpty(node.getDirectives())) {
+                    out.append(' ');
+                    directives(out, node.getDirectives());
+                }
             } else {
-                args = join(node.getInputValueDefinitions(), argSep);
-                out.append(node.getName())
-                        .append(wrap("(", args, ")"))
-                        .append(": ")
-                        .append(spaced(
-                                type(node.getType()),
-                                directives(node.getDirectives())
-                        ));
+                out.append(node.getName());
+                if (!isEmpty(node.getInputValueDefinitions())) {
+                    out.append('(');
+                    join(out, node.getInputValueDefinitions(), argSep);
+                    out.append(')');
+                }
+                out.append(": ");
+                type(out, node.getType());
+                if (!isEmpty(node.getDirectives())) {
+                    out.append(' ');
+                    directives(out, node.getDirectives());
+                }
             }
         };
     }
 
-    private boolean hasDescription(List<? extends Node> nodes) {
-        for (Node node : nodes) {
-            if (node instanceof AbstractDescribedNode) {
-                AbstractDescribedNode<?> describedNode = (AbstractDescribedNode<?>) node;
-                if (describedNode.getDescription() != null) {
-                    return true;
-                }
-            }
+    private static boolean hasDescription(Node<?> node) {
+        if (node instanceof AbstractDescribedNode) {
+            AbstractDescribedNode<?> describedNode = (AbstractDescribedNode<?>) node;
+            return describedNode.getDescription() != null;
         }
-
         return false;
     }
 
     private NodePrinter<FragmentDefinition> fragmentDefinition() {
         return (out, node) -> {
-            String name = node.getName();
-            String typeCondition = type(node.getTypeCondition());
-            String directives = directives(node.getDirectives());
-            String selectionSet = node(node.getSelectionSet());
-
-            out.append("fragment ").append(name).append(" on ").append(typeCondition)
-                    .append(' ')
-                    .append(directives)
-                    .append(selectionSet);
+            out.append("fragment ");
+            out.append(node.getName());
+            out.append(" on ");
+            type(out, node.getTypeCondition());
+            out.append(' ');
+            directives(out, node.getDirectives());
+            node(out, node.getSelectionSet());
         };
     }
 
     private NodePrinter<FragmentSpread> fragmentSpread() {
         return (out, node) -> {
-            String name = node.getName();
-            String directives = directives(node.getDirectives());
-
-            out.append("...").append(name).append(directives);
+            out.append("...");
+            out.append(node.getName());
+            directives(out, node.getDirectives());
         };
     }
 
     private NodePrinter<InlineFragment> inlineFragment() {
         return (out, node) -> {
-            TypeName typeName = node.getTypeCondition();
-            //Inline fragments may not have a type condition
-            String typeCondition = typeName == null ? "" : wrap("on ", type(typeName), "");
-            String directives = directives(node.getDirectives());
-            String selectionSet = node(node.getSelectionSet());
-
+            out.append("...");
             if (compactMode) {
                 // believe it or not but "...on Foo" is valid syntax
-                out.append("...");
-                out.append(spaced(
-                        typeCondition,
-                        directives
-                ));
-                out.append(selectionSet);
+                if (node.getTypeCondition() != null) {
+                    out.append("on ");
+                    type(out, node.getTypeCondition());
+                }
+                directives(out, node.getDirectives());
+                node(out, node.getSelectionSet());
             } else {
-                out.append(spaced(
-                        "...",
-                        typeCondition,
-                        directives,
-                        selectionSet
-                ));
+                if (node.getTypeCondition() != null) {
+                    out.append(" on ");
+                    type(out, node.getTypeCondition());
+                }
+                if (!isEmpty(node.getDirectives())) {
+                    out.append(' ');
+                    directives(out, node.getDirectives());
+                }
+                out.append(' ');
+                node(out, node.getSelectionSet());
             }
         };
     }
 
     private NodePrinter<InputObjectTypeDefinition> inputObjectTypeDefinition() {
         return (out, node) -> {
-            out.append(description(node));
-            out.append(spaced(
-                    "input",
-                    node.getName(),
-                    directives(node.getDirectives()),
-                    block(node.getInputValueDefinitions())
-            ));
+            description(out, node);
+            out.append("input ");
+            out.append(node.getName());
+            if (!isEmpty(node.getDirectives())) {
+                out.append(' ');
+                directives(out, node.getDirectives());
+            }
+            if (!isEmpty(node.getInputValueDefinitions())) {
+                out.append(' ');
+                block(out, node.getInputValueDefinitions());
+            }
         };
     }
 
@@ -275,192 +296,272 @@ public class AstPrinter {
         String nameTypeSep = compactMode ? ":" : ": ";
         String defaultValueEquals = compactMode ? "=" : "= ";
         return (out, node) -> {
-            Value defaultValue = node.getDefaultValue();
-            out.append(description(node));
-            out.append(spaced(
-                    node.getName() + nameTypeSep + type(node.getType()),
-                    wrap(defaultValueEquals, defaultValue, ""),
-                    directives(node.getDirectives())
-            ));
+            Value<?> defaultValue = node.getDefaultValue();
+            description(out, node);
+            out.append(node.getName());
+            out.append(nameTypeSep);
+            type(out, node.getType());
+            if (defaultValue != null) {
+                out.append(' ');
+                out.append(defaultValueEquals);
+                node(out, defaultValue);
+            }
+            if (!isEmpty(node.getDirectives())) {
+                out.append(' ');
+                directives(out, node.getDirectives());
+            }
         };
     }
 
     private NodePrinter<InterfaceTypeDefinition> interfaceTypeDefinition() {
         return (out, node) -> {
-            out.append(description(node));
-            out.append(spaced(
-                    "interface",
-                    node.getName(),
-                    wrap("implements ", join(node.getImplements(), " & "), ""),
-                    directives(node.getDirectives()),
-                    block(node.getFieldDefinitions())
-            ));
+            description(out, node);
+            out.append("interface ");
+            out.append(node.getName());
+            if (!isEmpty(node.getImplements())) {
+                out.append(" implements ");
+                join(out, node.getImplements(), " & ");
+            }
+            if (!isEmpty(node.getDirectives())) {
+                out.append(' ');
+                directives(out, node.getDirectives());
+            }
+            if (!isEmpty(node.getFieldDefinitions())) {
+                out.append(' ');
+                block(out, node.getFieldDefinitions());
+            }
         };
     }
 
     private NodePrinter<ObjectField> objectField() {
         String nameValueSep = compactMode ? ":" : " : ";
-        return (out, node) -> out.append(node.getName()).append(nameValueSep).append(value(node.getValue()));
+        return (out, node) -> {
+            out.append(node.getName());
+            out.append(nameValueSep);
+            value(out, node.getValue());
+        };
     }
 
     private NodePrinter<OperationDefinition> operationDefinition() {
         final String argSep = compactMode ? "," : ", ";
         return (out, node) -> {
-            String op = node.getOperation().toString().toLowerCase();
             String name = node.getName();
-            String varDefinitions = wrap("(", join(nvl(node.getVariableDefinitions()), argSep), ")");
-            String directives = directives(node.getDirectives());
-            String selectionSet = node(node.getSelectionSet());
-
             // Anonymous queries with no directives or variable definitions can use
             // the query short form.
-            if (isEmpty(name) && isEmpty(directives) && isEmpty(varDefinitions) && op.equals("query")) {
-                out.append(selectionSet);
+            if (isEmpty(name) && isEmpty(node.getDirectives()) && isEmpty(node.getVariableDefinitions())
+                    && node.getOperation() == OperationDefinition.Operation.QUERY) {
+                node(out, node.getSelectionSet());
             } else {
-                if (compactMode) {
-                    out.append(spaced(op, smooshed(name, varDefinitions), directives));
-                    out.append(selectionSet);
-                } else {
-                    out.append(spaced(op, smooshed(name, varDefinitions), directives, selectionSet));
+                out.append(node.getOperation().toString().toLowerCase());
+                if (!isEmpty(name)) {
+                    out.append(' ');
+                    out.append(name);
                 }
+                if (!isEmpty(node.getVariableDefinitions())) {
+                    if (isEmpty(name)) {
+                        out.append(' ');
+                    }
+                    out.append('(');
+                    join(out, node.getVariableDefinitions(), argSep);
+                    out.append(')');
+                }
+                if (!isEmpty(node.getDirectives())) {
+                    out.append(' ');
+                    directives(out, node.getDirectives());
+                }
+                if (!compactMode) {
+                    out.append(' ');
+                }
+                node(out, node.getSelectionSet());
             }
         };
     }
 
     private NodePrinter<OperationTypeDefinition> operationTypeDefinition() {
         String nameTypeSep = compactMode ? ":" : ": ";
-        return (out, node) -> out.append(node.getName()).append(nameTypeSep).append(type(node.getTypeName()));
+        return (out, node) -> {
+            out.append(node.getName());
+            out.append(nameTypeSep);
+            type(out, node.getTypeName());
+        };
     }
 
     private NodePrinter<ObjectTypeDefinition> objectTypeDefinition() {
         return (out, node) -> {
-            out.append(description(node));
-            out.append(spaced(
-                    "type",
-                    node.getName(),
-                    wrap("implements ", join(node.getImplements(), " & "), ""),
-                    directives(node.getDirectives()),
-                    block(node.getFieldDefinitions())
-            ));
+            description(out, node);
+            out.append("type ");
+            out.append(node.getName());
+            if (!isEmpty(node.getImplements())) {
+                out.append(" implements ");
+                join(out, node.getImplements(), " & ");
+            }
+            if (!isEmpty(node.getDirectives())) {
+                out.append(' ');
+                directives(out, node.getDirectives());
+            }
+            if (!isEmpty(node.getFieldDefinitions())) {
+                out.append(' ');
+                block(out, node.getFieldDefinitions());
+            }
         };
     }
 
     private NodePrinter<SelectionSet> selectionSet() {
-        return (out, node) -> {
-            String block = block(node.getSelections());
-            out.append(block);
-        };
+        return (out, node) -> block(out, node.getSelections());
     }
 
     private NodePrinter<ScalarTypeDefinition> scalarTypeDefinition() {
         return (out, node) -> {
-            out.append(description(node));
-            out.append(spaced(
-                    "scalar",
-                    node.getName(),
-                    directives(node.getDirectives())));
+            description(out, node);
+            out.append("scalar ");
+            out.append(node.getName());
+            if (!isEmpty(node.getDirectives())) {
+                out.append(' ');
+                directives(out, node.getDirectives());
+            }
         };
     }
 
 
     private NodePrinter<SchemaDefinition> schemaDefinition() {
         return (out, node) -> {
-            out.append(description(node));
-            out.append(spaced(
-                    "schema",
-                    directives(node.getDirectives()),
-                    block(node.getOperationTypeDefinitions())
-            ));
+            description(out, node);
+            out.append("schema ");
+            if (!isEmpty(node.getDirectives())) {
+                directives(out, node.getDirectives());
+                out.append(' ');
+            }
+            block(out, node.getOperationTypeDefinitions());
         };
     }
 
 
-    private NodePrinter<Type> type() {
-        return (out, node) -> out.append(type(node));
+    private NodePrinter<Type<?>> type() {
+        return this::type;
     }
 
-    private String type(Type type) {
+    private void type(StringBuilder out, Type<?> type) {
         if (type instanceof NonNullType) {
             NonNullType inner = (NonNullType) type;
-            return wrap("", type(inner.getType()), "!");
+            type(out, inner.getType());
+            out.append('!');
         } else if (type instanceof ListType) {
             ListType inner = (ListType) type;
-            return wrap("[", type(inner.getType()), "]");
+            out.append('[');
+            type(out, inner.getType());
+            out.append(']');
         } else {
             TypeName inner = (TypeName) type;
-            return inner.getName();
+            out.append(inner.getName());
         }
     }
 
     private NodePrinter<ObjectTypeExtensionDefinition> objectTypeExtensionDefinition() {
-        return (out, node) -> out.append("extend ").append(node(node, ObjectTypeDefinition.class));
+        return (out, node) -> {
+            out.append("extend ");
+            node(out, node, ObjectTypeDefinition.class);
+        };
     }
 
     private NodePrinter<EnumTypeExtensionDefinition> enumTypeExtensionDefinition() {
-        return (out, node) -> out.append("extend ").append(node(node, EnumTypeDefinition.class));
+        return (out, node) -> {
+            out.append("extend ");
+            node(out, node, EnumTypeDefinition.class);
+        };
     }
 
     private NodePrinter<InterfaceTypeDefinition> interfaceTypeExtensionDefinition() {
-        return (out, node) -> out.append("extend ").append(node(node, InterfaceTypeDefinition.class));
+        return (out, node) -> {
+            out.append("extend ");
+            node(out, node, InterfaceTypeDefinition.class);
+        };
     }
 
     private NodePrinter<UnionTypeExtensionDefinition> unionTypeExtensionDefinition() {
-        return (out, node) -> out.append("extend ").append(node(node, UnionTypeDefinition.class));
+        return (out, node) -> {
+            out.append("extend ");
+            node(out, node, UnionTypeDefinition.class);
+        };
     }
 
     private NodePrinter<ScalarTypeExtensionDefinition> scalarTypeExtensionDefinition() {
-        return (out, node) -> out.append("extend ").append(node(node, ScalarTypeDefinition.class));
+        return (out, node) -> {
+            out.append("extend ");
+            node(out, node, ScalarTypeDefinition.class);
+        };
     }
 
     private NodePrinter<InputObjectTypeExtensionDefinition> inputObjectTypeExtensionDefinition() {
-        return (out, node) -> out.append("extend ").append(node(node, InputObjectTypeDefinition.class));
+        return (out, node) -> {
+            out.append("extend ");
+            node(out, node, InputObjectTypeDefinition.class);
+        };
     }
 
     private NodePrinter<SchemaExtensionDefinition> schemaExtensionDefinition() {
-        return (out, node) -> out.append("extend ").append(node(node, SchemaDefinition.class));
+        return (out, node) -> {
+            out.append("extend ");
+            node(out, node, SchemaDefinition.class);
+        };
     }
 
     private NodePrinter<UnionTypeDefinition> unionTypeDefinition() {
         String barSep = compactMode ? "|" : " | ";
         String equals = compactMode ? "=" : "= ";
         return (out, node) -> {
-            out.append(description(node));
-            out.append(spaced(
-                    "union",
-                    node.getName(),
-                    directives(node.getDirectives()),
-                    equals + join(node.getMemberTypes(), barSep)
-            ));
+            description(out, node);
+            out.append("union ");
+            out.append(node.getName());
+            if (!isEmpty(node.getDirectives())) {
+                out.append(' ');
+                directives(out, node.getDirectives());
+            }
+            out.append(' ');
+            out.append(equals);
+            join(out, node.getMemberTypes(), barSep);
         };
     }
 
     private NodePrinter<VariableDefinition> variableDefinition() {
         String nameTypeSep = compactMode ? ":" : ": ";
         String defaultValueEquals = compactMode ? "=" : " = ";
-        return (out, node) -> out.append('$')
-                .append(node.getName())
-                .append(nameTypeSep)
-                .append(type(node.getType()))
-                .append(wrap(defaultValueEquals, node.getDefaultValue(), ""))
-                .append(directives(node.getDirectives()));
+        return (out, node) -> {
+            out.append('$');
+            out.append(node.getName());
+            out.append(nameTypeSep);
+            type(out, node.getType());
+            if (node.getDefaultValue() != null) {
+                out.append(defaultValueEquals);
+                node(out, node.getDefaultValue());
+            }
+            directives(out, node.getDirectives());
+        };
     }
 
     private NodePrinter<VariableReference> variableReference() {
         return (out, node) -> out.append('$').append(node.getName());
     }
 
-    private String node(Node node) {
+    private String node(Node<?> node) {
         return node(node, null);
     }
 
-    private String node(Node node, Class startClass) {
+    private void node(StringBuilder out, Node<?> node) {
+        node(out, node, null);
+    }
+
+    private String node(Node<?> node, Class<?> startClass) {
+        StringBuilder builder = new StringBuilder();
+        node(builder, node, startClass);
+        return builder.toString();
+    }
+
+    private void node(StringBuilder out, Node<?> node, Class<?> startClass) {
         if (startClass != null) {
             assertTrue(startClass.isInstance(node), () -> "The starting class must be in the inherit tree");
         }
-        StringBuilder builder = new StringBuilder();
-        NodePrinter<Node> printer = _findPrinter(node, startClass);
-        printer.print(builder, node);
-        return builder.toString();
+        NodePrinter<Node<?>> printer = _findPrinter(node, startClass);
+        printer.print(out, node);
     }
 
     @SuppressWarnings("unchecked")
@@ -473,7 +574,7 @@ public class AstPrinter {
             return (out, type) -> {
             };
         }
-        Class clazz = startClass != null ? startClass : node.getClass();
+        Class<?> clazz = startClass != null ? startClass : node.getClass();
         while (clazz != Object.class) {
             NodePrinter nodePrinter = printers.get(clazz);
             if (nodePrinter != null) {
@@ -485,67 +586,86 @@ public class AstPrinter {
         return assertShouldNeverHappen("We have a missing printer implementation for %s : report a bug!", clazz);
     }
 
-    private <T> boolean isEmpty(List<T> list) {
+    private static <T> boolean isEmpty(List<T> list) {
         return list == null || list.isEmpty();
     }
 
-    private boolean isEmpty(String s) {
+    private static boolean isEmpty(String s) {
         return s == null || s.isBlank();
     }
 
-    private <T> List<T> nvl(List<T> list) {
+    private static <T> List<T> nvl(List<T> list) {
         return list != null ? list : ImmutableKit.emptyList();
     }
 
-    private NodePrinter<Value> value() {
-        return (out, node) -> out.append(value(node));
+    private NodePrinter<Value<?>> value() {
+        return this::value;
     }
 
-    private String value(Value value) {
+    private void value(StringBuilder out, Value<?> value) {
         String argSep = compactMode ? "," : ", ";
         if (value instanceof IntValue) {
-            return valueOf(((IntValue) value).getValue());
+            out.append(((IntValue) value).getValue());
         } else if (value instanceof FloatValue) {
-            return valueOf(((FloatValue) value).getValue());
+            out.append(((FloatValue) value).getValue());
         } else if (value instanceof StringValue) {
-            return "\"" + escapeJsonString(((StringValue) value).getValue()) + "\"";
+            out.append('"');
+            escapeJsonStringTo(out, ((StringValue) value).getValue());
+            out.append('"');
         } else if (value instanceof EnumValue) {
-            return valueOf(((EnumValue) value).getName());
+            out.append(((EnumValue) value).getName());
         } else if (value instanceof BooleanValue) {
-            return valueOf(((BooleanValue) value).isValue());
+            out.append(((BooleanValue) value).isValue());
         } else if (value instanceof NullValue) {
-            return "null";
+            out.append("null");
         } else if (value instanceof ArrayValue) {
-            return "[" + join(((ArrayValue) value).getValues(), argSep) + "]";
+            out.append('[');
+            join(out, ((ArrayValue) value).getValues(), argSep);
+            out.append(']');
         } else if (value instanceof ObjectValue) {
-            return "{" + join(((ObjectValue) value).getObjectFields(), argSep) + "}";
+            out.append('{');
+            join(out, ((ObjectValue) value).getObjectFields(), argSep);
+            out.append('}');
         } else if (value instanceof VariableReference) {
-            return "$" + ((VariableReference) value).getName();
+            out.append('$');
+            out.append(((VariableReference) value).getName());
         }
-        return "";
     }
 
-    private String description(Node<?> node) {
+    private void description(StringBuilder out, Node<?> node) {
         Description description = ((AbstractDescribedNode<?>) node).getDescription();
         if (description == null || description.getContent() == null || compactMode) {
-            return "";
+            return;
         }
-        String s;
-        boolean startNewLine = description.getContent().length() > 0 && description.getContent().charAt(0) == '\n';
+;
         if (description.isMultiLine()) {
-            s = "\"\"\"" + (startNewLine ? "" : "\n") + description.getContent() + "\n\"\"\"\n";
+            out.append("\"\"\"");
+            if (description.getContent().isEmpty() || description.getContent().charAt(0) != '\n') {
+                out.append('\n');
+            }
+            out.append(description.getContent());
+            out.append("\n\"\"\"\n");
         } else {
-            s = "\"" + escapeJsonString(description.getContent()) + "\"\n";
+            out.append('"');
+            escapeJsonStringTo(out, description.getContent());
+            out.append("\"\n");
         }
-        return s;
     }
 
-    private String directives(List<Directive> directives) {
-        return join(nvl(directives), compactMode ? "" : " ");
+    private void directives(StringBuilder out, List<Directive> directives) {
+        join(out, nvl(directives), compactMode ? "" : " ");
     }
 
-    private <T extends Node> String join(List<T> nodes, String delim) {
-        return join(nodes, delim, "", "");
+    private <T extends Node<?>> void join(StringBuilder out, List<T> nodes, String delim) {
+        if (isEmpty(nodes)) {
+            return;
+        }
+        Iterator<T> iterator = nodes.iterator();
+        node(out, iterator.next());
+        while (iterator.hasNext()) {
+            out.append(delim);
+            node(out, iterator.next());
+        }
     }
 
     /*
@@ -553,58 +673,22 @@ public class AstPrinter {
      * This encodes that knowledge of those that don't require delimiters
      */
     @SuppressWarnings("SameParameterValue")
-    private <T extends Node> String joinTight(List<T> nodes, String delim, String prefix, String suffix) {
-        StringBuilder joined = new StringBuilder();
-        joined.append(prefix);
+    private <T extends Node<?>> void joinTight(StringBuilder output, List<T> nodes, String delim, String prefix, String suffix) {
+        output.append(prefix);
 
-        String lastNodeText = "";
         boolean first = true;
         for (T node : nodes) {
             if (first) {
                 first = false;
             } else {
-                boolean canButtTogether = lastNodeText.endsWith("}");
-                if (!canButtTogether) {
-                    joined.append(delim);
+                if (output.charAt(output.length() - 1) != '}') {
+                    output.append(delim);
                 }
             }
-            String nodeText = this.node(node);
-            lastNodeText = nodeText;
-            joined.append(nodeText);
+            node(output, node);
         }
 
-        joined.append(suffix);
-        return joined.toString();
-    }
-
-    private <T extends Node> String join(List<T> nodes, String delim, String prefix, String suffix) {
-        StringJoiner joiner = new StringJoiner(delim, prefix, suffix);
-
-        for (T node : nodes) {
-            joiner.add(node(node));
-        }
-
-        return joiner.toString();
-    }
-
-    private String spaced(String... args) {
-        return join(" ", args);
-    }
-
-    private String smooshed(String... args) {
-        return join("", args);
-    }
-
-    private String join(String delim, String... args) {
-        StringJoiner joiner = new StringJoiner(delim);
-
-        for (final String arg : args) {
-            if (!isEmpty(arg)) {
-                joiner.add(arg);
-            }
-        }
-
-        return joiner.toString();
+        output.append(suffix);
     }
 
     String wrap(String start, String maybeString, String end) {
@@ -617,27 +701,31 @@ public class AstPrinter {
         return start + maybeString + (!isEmpty(end) ? end : "");
     }
 
-    private <T extends Node> String block(List<T> nodes) {
+    private <T extends Node<?>> void block(StringBuilder out, List<T> nodes) {
         if (isEmpty(nodes)) {
-            return "";
+            return;
         }
         if (compactMode) {
-            String joinedNodes = joinTight(nodes, " ", "", "");
-            return "{" + joinedNodes + "}";
+            out.append('{');
+            joinTight(out, nodes, " ", "", "");
+            out.append('}');
+        } else {
+            int offset = out.length();
+            out.append("{\n");
+            join(out, nodes, "\n");
+            indent(out, offset);
+            out.append("\n}");
         }
-        return indent(new StringBuilder().append("{\n").append(join(nodes, "\n")))
-                + "\n}";
     }
 
-    private StringBuilder indent(StringBuilder maybeString) {
-        for (int i = 0; i < maybeString.length(); i++) {
+    private static void indent(StringBuilder maybeString, int offset) {
+        for (int i = offset; i < maybeString.length(); i++) {
             char c = maybeString.charAt(i);
             if (c == '\n') {
                 maybeString.replace(i, i + 1, "\n  ");
                 i += 3;
             }
         }
-        return maybeString;
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/src/main/java/graphql/util/EscapeUtil.java
+++ b/src/main/java/graphql/util/EscapeUtil.java
@@ -16,37 +16,41 @@ public final class EscapeUtil {
      * @return the encoded string
      */
     public static String escapeJsonString(String stringValue) {
+        StringBuilder sb = new StringBuilder(stringValue.length());
+        escapeJsonStringTo(sb, stringValue);
+        return sb.toString();
+    }
+
+    public static void escapeJsonStringTo(StringBuilder output, String stringValue) {
         int len = stringValue.length();
-        StringBuilder sb = new StringBuilder(len);
         for (int i = 0; i < len; i++) {
             char ch = stringValue.charAt(i);
             switch (ch) {
                 case '"':
-                    sb.append("\\\"");
+                    output.append("\\\"");
                     break;
                 case '\\':
-                    sb.append("\\\\");
+                    output.append("\\\\");
                     break;
                 case '\b':
-                    sb.append("\\b");
+                    output.append("\\b");
                     break;
                 case '\f':
-                    sb.append("\\f");
+                    output.append("\\f");
                     break;
                 case '\n':
-                    sb.append("\\n");
+                    output.append("\\n");
                     break;
                 case '\r':
-                    sb.append("\\r");
+                    output.append("\\r");
                     break;
                 case '\t':
-                    sb.append("\\t");
+                    output.append("\\t");
                     break;
                 default:
-                    sb.append(ch);
+                    output.append(ch);
             }
         }
-        return sb.toString();
     }
 
 }


### PR DESCRIPTION
Avoid the overhead of allocating unnecessary intermediate String instances in AstPrinter by only appending to the supplied StringBuilder. When running the AstPrinterBenchmark with the gc profiler, this significantly reduces the allocation rate:

before:

gc.alloc.rate:      4846.634 MB/sec
gc.alloc.rate.norm: 86960.001 B/op

after:

gc.alloc.rate:      2524.634 MB/sec
gc.alloc.rate.norm: 10432.000 B/op

The benchmarks also show a doubling in throughput.