### PR TITLE
Implement equals/hashCode for GraphqlErrorImpl

### DIFF
--- a/src/main/java/graphql/GraphqlErrorBuilder.java
+++ b/src/main/java/graphql/GraphqlErrorBuilder.java
@@ -9,6 +9,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static graphql.Assert.assertNotNull;
 
@@ -132,6 +133,13 @@ public class GraphqlErrorBuilder<B extends GraphqlErrorBuilder<B>> implements Gr
         return new GraphqlErrorImpl(message, locations, errorType, path, extensions);
     }
 
+    /**
+     * A simple implementation of a {@link GraphQLError}.
+     * <p>
+     * This provides {@link #hashCode()} and {@link #equals(Object)} methods that afford comparison with other
+     * {@link GraphQLError} implementations. However, the values in the {@link #getExtensions()} {@link Map} <b>must</b>
+     * in turn implement {@code hashCode()} and {@link #equals(Object)} for this to function correctly.
+     */
     private static class GraphqlErrorImpl implements GraphQLError {
         private final String message;
         private final List<SourceLocation> locations;
@@ -175,6 +183,28 @@ public class GraphqlErrorBuilder<B extends GraphqlErrorBuilder<B>> implements Gr
         @Override
         public String toString() {
             return message;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof GraphQLError)) return false;
+            GraphQLError that = (GraphQLError) o;
+            return Objects.equals(getMessage(), that.getMessage())
+                    && Objects.equals(getLocations(), that.getLocations())
+                    && Objects.equals(getErrorType(), that.getErrorType())
+                    && Objects.equals(getPath(), that.getPath())
+                    && Objects.equals(getExtensions(), that.getExtensions());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(
+                    getMessage(),
+                    getLocations(),
+                    getErrorType(),
+                    getPath(),
+                    getExtensions());
         }
     }
 

--- a/src/main/java/graphql/GraphqlErrorBuilder.java
+++ b/src/main/java/graphql/GraphqlErrorBuilder.java
@@ -137,8 +137,13 @@ public class GraphqlErrorBuilder<B extends GraphqlErrorBuilder<B>> implements Gr
      * A simple implementation of a {@link GraphQLError}.
      * <p>
      * This provides {@link #hashCode()} and {@link #equals(Object)} methods that afford comparison with other
-     * {@link GraphQLError} implementations. However, the values in the {@link #getExtensions()} {@link Map} <b>must</b>
-     * in turn implement {@code hashCode()} and {@link #equals(Object)} for this to function correctly.
+     * {@link GraphQLError} implementations. However, the values provided in the following fields <b>must</b>
+     * in turn implement {@link #hashCode()} and {@link #equals(Object)} for this to function correctly:
+     * <ul>
+     *   <li>the values in the {@link #getPath()} {@link List}.
+     *   <li>the {@link #getErrorType()} {@link ErrorClassification}.
+     *   <li>the values in the {@link #getExtensions()} {@link Map}.
+     * </ul>
      */
     private static class GraphqlErrorImpl implements GraphQLError {
         private final String message;

--- a/src/test/groovy/graphql/GraphqlErrorBuilderTest.groovy
+++ b/src/test/groovy/graphql/GraphqlErrorBuilderTest.groovy
@@ -153,49 +153,65 @@ class GraphqlErrorBuilderTest extends Specification {
 
     }
 
-    def "implements equals correctly"() {
+    def "implements equals/hashCode correctly for matching errors"() {
         when:
-        def error1 = GraphQLError.newError().message("msg")
-                .locations(null)
-                .extensions([x : "y"])
-                .path(null)
-                .build()
-        def error2 = GraphQLError.newError().message("msg")
-                .locations(null)
-                .extensions([x : "y"])
-                .path(null)
-                .build()
-        def error3 = GraphQLError.newError().message("msg3")
-                .locations(null)
-                .extensions([x : "y"])
-                .path(null)
-                .build()
+        def firstError = toGraphQLError(first)
+        def secondError = toGraphQLError(second)
+
         then:
-        error1 == error2
-        error1 != error3
-        error2 != error3
+        firstError == secondError
+        firstError.hashCode() == secondError.hashCode()
+
+        where:
+        first                                                          | second
+        [message: "msg"]                                               | [message: "msg"]
+        [message: "msg", locations: [new SourceLocation(1, 2)]]        | [message: "msg", locations: [new SourceLocation(1, 2)]]
+        [message: "msg", errorType: ErrorType.InvalidSyntax]           | [message: "msg", errorType: ErrorType.InvalidSyntax]
+        [message: "msg", path: ["items", 1, "item"]]                   | [message: "msg", path: ["items", 1, "item"]]
+        [message: "msg", extensions: [aBoolean: true, aString: "foo"]] | [message: "msg", extensions: [aBoolean: true, aString: "foo"]]
     }
 
-    def "implements hashCode correctly"() {
+    def "implements equals/hashCode correctly for different errors"() {
         when:
-        def error1 = GraphQLError.newError().message("msg")
-                .locations(null)
-                .extensions([x : "y"])
-                .path(null)
-                .build()
-        def error2 = GraphQLError.newError().message("msg")
-                .locations(null)
-                .extensions([x : "y"])
-                .path(null)
-                .build()
-        def error3 = GraphQLError.newError().message("msg3")
-                .locations(null)
-                .extensions([x : "y"])
-                .path(null)
-                .build()
-        def errors = [error1, error2, error3] as Set
+        def firstError = toGraphQLError(first)
+        def secondError = toGraphQLError(second)
+
         then:
-        errors == [error1, error3] as Set
-        errors == [error2, error3] as Set
+        firstError != secondError
+        firstError.hashCode() != secondError.hashCode()
+
+        where:
+        first                                                   | second
+        [message: "msg"]                                        | [message: "different msg"]
+        [message: "msg", locations: [new SourceLocation(1, 2)]] | [message: "msg", locations: [new SourceLocation(3, 4)]]
+        [message: "msg", errorType: ErrorType.InvalidSyntax]    | [message: "msg", errorType: ErrorType.DataFetchingException]
+        [message: "msg", path: ["items", "1", "item"]]          | [message: "msg", path: ["items"]]
+        [message: "msg", extensions: [aBoolean: false]]         | [message: "msg", extensions: [aString: "foo"]]
+    }
+
+    private static GraphQLError toGraphQLError(Map<String, Object> errorFields) {
+        def errorBuilder = GraphQLError.newError();
+        errorFields.forEach { key, value ->
+            if (value != null) {
+                switch (key) {
+                    case "message":
+                        errorBuilder.message(value as String);
+                        break;
+                    case "locations":
+                        errorBuilder.locations(value as List<SourceLocation>);
+                        break;
+                    case "errorType":
+                        errorBuilder.errorType(value as ErrorClassification);
+                        break;
+                    case "path":
+                        errorBuilder.path(value as List<Object>);
+                        break;
+                    case "extensions":
+                        errorBuilder.extensions(value as Map<String, Object>);
+                        break;
+                }
+            }
+        }
+        return errorBuilder.build();
     }
 }

--- a/src/test/groovy/graphql/GraphqlErrorBuilderTest.groovy
+++ b/src/test/groovy/graphql/GraphqlErrorBuilderTest.groovy
@@ -152,4 +152,50 @@ class GraphqlErrorBuilderTest extends Specification {
         error.path == null
 
     }
+
+    def "implements equals correctly"() {
+        when:
+        def error1 = GraphQLError.newError().message("msg")
+                .locations(null)
+                .extensions([x : "y"])
+                .path(null)
+                .build()
+        def error2 = GraphQLError.newError().message("msg")
+                .locations(null)
+                .extensions([x : "y"])
+                .path(null)
+                .build()
+        def error3 = GraphQLError.newError().message("msg3")
+                .locations(null)
+                .extensions([x : "y"])
+                .path(null)
+                .build()
+        then:
+        error1 == error2
+        error1 != error3
+        error2 != error3
+    }
+
+    def "implements hashCode correctly"() {
+        when:
+        def error1 = GraphQLError.newError().message("msg")
+                .locations(null)
+                .extensions([x : "y"])
+                .path(null)
+                .build()
+        def error2 = GraphQLError.newError().message("msg")
+                .locations(null)
+                .extensions([x : "y"])
+                .path(null)
+                .build()
+        def error3 = GraphQLError.newError().message("msg3")
+                .locations(null)
+                .extensions([x : "y"])
+                .path(null)
+                .build()
+        def errors = [error1, error2, error3] as Set
+        then:
+        errors == [error1, error3] as Set
+        errors == [error2, error3] as Set
+    }
 }


### PR DESCRIPTION
We have a great many tests that verify that the errors emitted from a `DataFetcher` fit a certain shape.

However, verifying equality of these errors is fiddly and error-prone, as we must directly check each individual attribute on every error - this is painful especially when we are trying to perform assertions on a `List` of `GraphQLError`s.

To this end, we add `#equals` / `#hashCode` methods on `GraphqlErrorImpl`. However, it is important to note that `equals` will return `true` if all the attributes match, even if the implementing class is _not_ a `GraphqlErrorImpl`. This is done so that different implementations may be swapped in and out with causing test failures.