### PR TITLE
Added support for reactive Publishers to be returned from data fetchers

### DIFF
--- a/src/main/java/graphql/DuckTyped.java
+++ b/src/main/java/graphql/DuckTyped.java
@@ -1,0 +1,22 @@
+package graphql;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+
+/**
+ * An annotation that marks a method return value or method parameter as returning a duck type value.
+ * <p>
+ * For efficiency reasons, the graphql engine methods can return {@link Object} values
+ * which maybe two well known types of values.  Often a {@link java.util.concurrent.CompletableFuture}
+ * or a plain old {@link Object}, to represent an async value or a materialised value.
+ */
+@Internal
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = {METHOD, PARAMETER})
+public @interface DuckTyped {
+    String shape();
+}

--- a/src/main/java/graphql/Internal.java
+++ b/src/main/java/graphql/Internal.java
@@ -4,6 +4,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
 import static java.lang.annotation.ElementType.CONSTRUCTOR;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
@@ -17,6 +18,6 @@ import static java.lang.annotation.ElementType.TYPE;
  * In general unnecessary changes will be avoided but you should not depend on internal classes being stable
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(value = {CONSTRUCTOR, METHOD, TYPE, FIELD, PACKAGE})
+@Target(value = {CONSTRUCTOR, METHOD, TYPE, FIELD, PACKAGE, ANNOTATION_TYPE})
 public @interface  Internal {
 }

--- a/src/main/java/graphql/execution/ExecutionContext.java
+++ b/src/main/java/graphql/execution/ExecutionContext.java
@@ -171,6 +171,34 @@ public class ExecutionContext {
     }
 
     /**
+     * @return true if the current operation is a Query
+     */
+    public boolean isQueryOperation() {
+        return isOpType(OperationDefinition.Operation.QUERY);
+    }
+
+    /**
+     * @return true if the current operation is a Mutation
+     */
+    public boolean isMutationOperation() {
+        return isOpType(OperationDefinition.Operation.MUTATION);
+    }
+
+    /**
+     * @return true if the current operation is a Subscription
+     */
+    public boolean isSubscriptionOperation() {
+        return isOpType(OperationDefinition.Operation.SUBSCRIPTION);
+    }
+
+    private boolean isOpType(OperationDefinition.Operation operation) {
+        if (operationDefinition != null) {
+            return operation.equals(operationDefinition.getOperation());
+        }
+        return false;
+    }
+
+    /**
      * This method will only put one error per field path.
      *
      * @param error     the error to add

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -30,7 +30,6 @@ import graphql.extensions.ExtensionsBuilder;
 import graphql.introspection.Introspection;
 import graphql.language.Argument;
 import graphql.language.Field;
-import graphql.language.OperationDefinition;
 import graphql.normalized.ExecutableNormalizedField;
 import graphql.normalized.ExecutableNormalizedOperation;
 import graphql.schema.CoercingSerializeException;
@@ -502,7 +501,7 @@ public abstract class ExecutionStrategy {
         fetchCtx.onDispatched();
         fetchCtx.onFetchedValue(fetchedObject);
         // if it's a subscription, leave any reactive objects alone
-        if (!isSubscription(executionContext)) {
+        if (!executionContext.isSubscriptionOperation()) {
             // possible convert reactive objects into CompletableFutures
             fetchedObject = ReactiveSupport.fetchedObject(fetchedObject);
         }
@@ -1008,7 +1007,6 @@ public abstract class ExecutionStrategy {
      * if max nodes were exceeded for this request.
      *
      * @param executionContext the execution context in play
-     *
      * @return true if max nodes were exceeded
      */
     private boolean incrementAndCheckMaxNodesExceeded(ExecutionContext executionContext) {
@@ -1061,7 +1059,6 @@ public abstract class ExecutionStrategy {
      *
      * @param e this indicates that a null value was returned for a non null field, which needs to cause the parent field
      *          to become null OR continue on as an exception
-     *
      * @throws NonNullableFieldWasNullException if a non null field resolves to a null value
      */
     protected void assertNonNullFieldPrecondition(NonNullableFieldWasNullException e) throws NonNullableFieldWasNullException {
@@ -1176,7 +1173,5 @@ public abstract class ExecutionStrategy {
         }
     }
 
-    private static boolean isSubscription(ExecutionContext executionContext) {
-        return executionContext.getOperationDefinition().getOperation().equals(OperationDefinition.Operation.SUBSCRIPTION);
-    }
+
 }

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -2,6 +2,7 @@ package graphql.execution;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
+import graphql.DuckTyped;
 import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.ExperimentalApi;
@@ -24,6 +25,7 @@ import graphql.execution.instrumentation.parameters.InstrumentationExecutionStra
 import graphql.execution.instrumentation.parameters.InstrumentationFieldCompleteParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldParameters;
+import graphql.execution.reactive.ReactiveSupport;
 import graphql.extensions.ExtensionsBuilder;
 import graphql.introspection.Introspection;
 import graphql.language.Argument;
@@ -197,8 +199,8 @@ public abstract class ExecutionStrategy {
      * @throws NonNullableFieldWasNullException in the {@link CompletableFuture} if a non-null field resolved to a null value
      */
     @SuppressWarnings("unchecked")
-    protected Object /* CompletableFuture<Map<String, Object>> | Map<String, Object> */
-    executeObject(ExecutionContext executionContext, ExecutionStrategyParameters parameters) throws NonNullableFieldWasNullException {
+    @DuckTyped(shape = "CompletableFuture<Map<String, Object>> | Map<String, Object>")
+    protected Object executeObject(ExecutionContext executionContext, ExecutionStrategyParameters parameters) throws NonNullableFieldWasNullException {
         DataLoaderDispatchStrategy dataLoaderDispatcherStrategy = executionContext.getDataLoaderDispatcherStrategy();
         dataLoaderDispatcherStrategy.executeObject(executionContext, parameters);
         Instrumentation instrumentation = executionContext.getInstrumentation();
@@ -356,8 +358,8 @@ public abstract class ExecutionStrategy {
      * @throws NonNullableFieldWasNullException in the future if a non-null field resolved to a null value
      */
     @SuppressWarnings("unchecked")
-    protected Object /* CompletableFuture<Object> | Object */
-    resolveField(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
+    @DuckTyped(shape = " CompletableFuture<Object> | Object")
+    protected Object resolveField(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
         Object fieldWithInfo = resolveFieldWithInfo(executionContext, parameters);
         if (fieldWithInfo instanceof CompletableFuture) {
             return ((CompletableFuture<FieldValueInfo>) fieldWithInfo).thenCompose(FieldValueInfo::getFieldValueFuture);
@@ -384,8 +386,8 @@ public abstract class ExecutionStrategy {
      *                                          if a nonnull field resolves to a null value
      */
     @SuppressWarnings("unchecked")
-    protected Object /* CompletableFuture<FieldValueInfo> | FieldValueInfo */
-    resolveFieldWithInfo(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
+    @DuckTyped(shape = "CompletableFuture<FieldValueInfo> | FieldValueInfo")
+    protected Object resolveFieldWithInfo(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
         GraphQLFieldDefinition fieldDef = getFieldDef(executionContext, parameters, parameters.getField().getSingleField());
         Supplier<ExecutionStepInfo> executionStepInfo = FpKit.intraThreadMemoize(() -> createExecutionStepInfo(executionContext, parameters, fieldDef, null));
 
@@ -430,16 +432,16 @@ public abstract class ExecutionStrategy {
      *
      * @throws NonNullableFieldWasNullException in the future if a non null field resolves to a null value
      */
-    protected Object /*CompletableFuture<FetchedValue> | FetchedValue>*/
-    fetchField(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
+    @DuckTyped(shape = "CompletableFuture<FetchedValue> | FetchedValue")
+    protected Object fetchField(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
         MergedField field = parameters.getField();
         GraphQLObjectType parentType = (GraphQLObjectType) parameters.getExecutionStepInfo().getUnwrappedNonNullType();
         GraphQLFieldDefinition fieldDef = getFieldDef(executionContext.getGraphQLSchema(), parentType, field.getSingleField());
         return fetchField(fieldDef, executionContext, parameters);
     }
 
-    private Object /*CompletableFuture<FetchedValue> | FetchedValue>*/
-    fetchField(GraphQLFieldDefinition fieldDef, ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
+    @DuckTyped(shape = "CompletableFuture<FetchedValue> | FetchedValue")
+    private Object fetchField(GraphQLFieldDefinition fieldDef, ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
 
         if (incrementAndCheckMaxNodesExceeded(executionContext)) {
             return new FetchedValue(null, Collections.emptyList(), null);
@@ -498,6 +500,8 @@ public abstract class ExecutionStrategy {
         executionContext.getDataLoaderDispatcherStrategy().fieldFetched(executionContext, parameters, dataFetcher, fetchedObject);
         fetchCtx.onDispatched();
         fetchCtx.onFetchedValue(fetchedObject);
+        // possible convert reactive objects into CompletableFutures
+        fetchedObject = ReactiveSupport.fetchedObject(fetchedObject);
         if (fetchedObject instanceof CompletableFuture) {
             @SuppressWarnings("unchecked")
             CompletableFuture<Object> fetchedValue = (CompletableFuture<Object>) fetchedObject;
@@ -737,8 +741,8 @@ public abstract class ExecutionStrategy {
      *
      * @throws NonNullableFieldWasNullException inside the {@link CompletableFuture} if a non-null field resolves to a null value
      */
-    protected Object /* CompletableFuture<Object> | Object */
-    completeValueForNull(ExecutionStrategyParameters parameters) {
+    @DuckTyped(shape = "CompletableFuture<Object> | Object")
+    protected Object completeValueForNull(ExecutionStrategyParameters parameters) {
         try {
             return parameters.getNonNullFieldValidator().validate(parameters, null);
         } catch (Exception e) {
@@ -876,8 +880,8 @@ public abstract class ExecutionStrategy {
      *
      * @return a materialized scalar value or exceptionally completed {@link CompletableFuture} if there is a problem
      */
-    protected Object /* CompletableFuture<Object> | Object */
-    completeValueForScalar(ExecutionContext executionContext, ExecutionStrategyParameters parameters, GraphQLScalarType scalarType, Object result) {
+    @DuckTyped(shape = "CompletableFuture<Object> | Object")
+    protected Object completeValueForScalar(ExecutionContext executionContext, ExecutionStrategyParameters parameters, GraphQLScalarType scalarType, Object result) {
         Object serialized;
         try {
             serialized = scalarType.getCoercing().serialize(result, executionContext.getGraphQLContext(), executionContext.getLocale());
@@ -903,8 +907,8 @@ public abstract class ExecutionStrategy {
      *
      * @return a materialized enum value or exceptionally completed {@link CompletableFuture} if there is a problem
      */
-    protected Object /* CompletableFuture<Object> | Object */
-    completeValueForEnum(ExecutionContext executionContext, ExecutionStrategyParameters parameters, GraphQLEnumType enumType, Object result) {
+    @DuckTyped(shape = "CompletableFuture<Object> | Object")
+    protected Object completeValueForEnum(ExecutionContext executionContext, ExecutionStrategyParameters parameters, GraphQLEnumType enumType, Object result) {
         Object serialized;
         try {
             serialized = enumType.serialize(result, executionContext.getGraphQLContext(), executionContext.getLocale());
@@ -929,8 +933,8 @@ public abstract class ExecutionStrategy {
      *
      * @return a {@link CompletableFuture} promise to a map of object field values or a materialized map of object field values
      */
-    protected Object /* CompletableFuture<Map<String, Object>> | Map<String, Object> */
-    completeValueForObject(ExecutionContext executionContext, ExecutionStrategyParameters parameters, GraphQLObjectType resolvedObjectType, Object result) {
+    @DuckTyped(shape = "CompletableFuture<Map<String, Object>> | Map<String, Object>")
+    protected Object completeValueForObject(ExecutionContext executionContext, ExecutionStrategyParameters parameters, GraphQLObjectType resolvedObjectType, Object result) {
         ExecutionStepInfo executionStepInfo = parameters.getExecutionStepInfo();
 
         FieldCollectorParameters collectorParameters = newParameters()

--- a/src/main/java/graphql/execution/reactive/ReactiveSupport.java
+++ b/src/main/java/graphql/execution/reactive/ReactiveSupport.java
@@ -1,0 +1,176 @@
+package graphql.execution.reactive;
+
+import graphql.DuckTyped;
+import graphql.Internal;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * This provides support for a DataFetcher to be able to
+ * return a reactive streams {@link Publisher} or Java JDK {@link Flow.Publisher}
+ * as a value, and it can be turned into a {@link CompletableFuture}
+ * that we can get an async value from.
+ */
+@Internal
+public class ReactiveSupport {
+
+    @DuckTyped(shape = "CompletableFuture | Object")
+    public static Object fetchedObject(Object fetchedObject) {
+        if (fetchedObject instanceof Flow.Publisher) {
+            return flowPublisherToCF((Flow.Publisher<?>) fetchedObject);
+        }
+        if (fetchedObject instanceof Publisher) {
+            return reactivePublisherToCF((Publisher<?>) fetchedObject);
+        }
+        return fetchedObject;
+    }
+
+    private static CompletableFuture<Object> reactivePublisherToCF(Publisher<?> publisher) {
+        ReactivePublisherToCompletableFuture<Object> cf = new ReactivePublisherToCompletableFuture<>();
+        publisher.subscribe(cf);
+        return cf;
+    }
+
+    private static CompletableFuture<Object> flowPublisherToCF(Flow.Publisher<?> publisher) {
+        FlowPublisherToCompletableFuture<Object> cf = new FlowPublisherToCompletableFuture<>();
+        publisher.subscribe(cf);
+        return cf;
+    }
+
+    /**
+     * The implementations between reactive Publishers and Flow.Publishers are almost exactly the same except the
+     * subscription class is different.  So this is a common class that contains most of the common logic
+     *
+     * @param <T> for two
+     * @param <S> for subscription
+     */
+    private static abstract class PublisherToCompletableFuture<T, S> extends CompletableFuture<T> {
+
+        private final AtomicReference<S> subscriptionRef = new AtomicReference<>();
+
+        abstract void subscriptionCancel(S s);
+
+        @SuppressWarnings("SameParameterValue")
+        abstract void subscriptionRequest(S s, long howMany);
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            boolean cancelled = super.cancel(mayInterruptIfRunning);
+            if (cancelled) {
+                S s = subscriptionRef.getAndSet(null);
+                if (s != null) {
+                    subscriptionCancel(s);
+                }
+            }
+            return cancelled;
+        }
+
+        private boolean validateSubscription(S current, S next) {
+            Objects.requireNonNull(next, "Subscription cannot be null");
+            if (current != null) {
+                subscriptionCancel(next);
+                return false;
+            }
+            return true;
+        }
+
+
+        public void onSubscribeImpl(S s) {
+            if (validateSubscription(subscriptionRef.getAndSet(s), s)) {
+                subscriptionRequest(s, Long.MAX_VALUE);
+            }
+        }
+
+        public void onNextImpl(T t) {
+            S s = subscriptionRef.getAndSet(null);
+            if (s != null) {
+                complete(t);
+                subscriptionCancel(s);
+            }
+        }
+
+        public void onErrorImpl(Throwable t) {
+            if (subscriptionRef.getAndSet(null) != null) {
+                completeExceptionally(t);
+            }
+        }
+
+        public void onCompleteImpl() {
+            if (subscriptionRef.getAndSet(null) != null) {
+                complete(null);
+            }
+        }
+    }
+
+    private static class ReactivePublisherToCompletableFuture<T> extends PublisherToCompletableFuture<T, Subscription> implements Subscriber<T> {
+
+        @Override
+        void subscriptionCancel(Subscription subscription) {
+            subscription.cancel();
+        }
+
+        @Override
+        void subscriptionRequest(Subscription subscription, long howMany) {
+            subscription.request(howMany);
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            onSubscribeImpl(s);
+        }
+
+        @Override
+        public void onNext(T t) {
+            onNextImpl(t);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            onErrorImpl(t);
+        }
+
+        @Override
+        public void onComplete() {
+            onCompleteImpl();
+        }
+    }
+
+    private static class FlowPublisherToCompletableFuture<T> extends PublisherToCompletableFuture<T, Flow.Subscription> implements Flow.Subscriber<T> {
+
+        @Override
+        void subscriptionCancel(Flow.Subscription subscription) {
+            subscription.cancel();
+        }
+
+        @Override
+        void subscriptionRequest(Flow.Subscription subscription, long howMany) {
+            subscription.request(howMany);
+        }
+
+        @Override
+        public void onSubscribe(Flow.Subscription s) {
+            onSubscribeImpl(s);
+        }
+
+        @Override
+        public void onNext(T t) {
+            onNextImpl(t);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            onErrorImpl(t);
+        }
+
+        @Override
+        public void onComplete() {
+            onCompleteImpl();
+        }
+    }
+}

--- a/src/test/groovy/graphql/execution/ExecutionContextBuilderTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionContextBuilderTest.groovy
@@ -236,4 +236,33 @@ class ExecutionContextBuilderTest extends Specification {
         then:
         executionContext.getDataLoaderDispatcherStrategy() == mockDataLoaderDispatcherStrategy
     }
+
+    def "can detect operation type"() {
+        when:
+        def executionContext = new ExecutionContextBuilder()
+                .instrumentation(instrumentation)
+                .queryStrategy(queryStrategy)
+                .mutationStrategy(mutationStrategy)
+                .subscriptionStrategy(subscriptionStrategy)
+                .graphQLSchema(schema)
+                .executionId(executionId)
+                .graphQLContext(graphQLContext)
+                .root(root)
+                .operationDefinition(operation)
+                .fragmentsByName([MyFragment: fragment])
+                .dataLoaderRegistry(dataLoaderRegistry)
+                .operationDefinition(OperationDefinition.newOperationDefinition().operation(opType).build())
+                .build()
+
+        then:
+        executionContext.isQueryOperation() == isQuery
+        executionContext.isMutationOperation() == isMutation
+        executionContext.isSubscriptionOperation() == isSubscription
+
+        where:
+        opType                                     | isQuery | isMutation | isSubscription
+        OperationDefinition.Operation.QUERY        | true    | false      | false
+        OperationDefinition.Operation.MUTATION     | false   | true       | false
+        OperationDefinition.Operation.SUBSCRIPTION | false   | false      | true
+    }
 }

--- a/src/test/groovy/graphql/execution/pubsub/CountingFlux.groovy
+++ b/src/test/groovy/graphql/execution/pubsub/CountingFlux.groovy
@@ -1,0 +1,23 @@
+package graphql.execution.pubsub
+
+import reactor.core.publisher.Flux
+
+/**
+ * A flux that counts how many values it has given out
+ */
+class CountingFlux {
+    Flux<String> flux
+    Integer count = 0
+
+    CountingFlux(List<String> values) {
+        flux = Flux.generate({ -> 0 }, { Integer counter, sink ->
+            if (counter >= values.size()) {
+                sink.complete()
+            } else {
+                sink.next(values[counter])
+                count++
+            }
+            return counter + 1;
+        })
+    }
+}

--- a/src/test/groovy/graphql/execution/reactive/ReactiveSupportTest.groovy
+++ b/src/test/groovy/graphql/execution/reactive/ReactiveSupportTest.groovy
@@ -1,0 +1,222 @@
+package graphql.execution.reactive
+
+import graphql.GraphQL
+import graphql.TestUtil
+import graphql.execution.pubsub.CapturingSubscriber
+import graphql.execution.pubsub.CountingFlux
+import graphql.schema.DataFetcher
+import reactor.adapter.JdkFlowAdapter
+import reactor.core.publisher.Mono
+import spock.lang.Specification
+
+import java.time.Duration
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
+import java.util.concurrent.Flow
+
+class ReactiveSupportTest extends Specification {
+
+    private static Flow.Publisher<String> toFlow(Mono<String> stringMono) {
+        return JdkFlowAdapter.publisherToFlowPublisher(stringMono)
+    }
+
+    private static Mono<String> delayedMono(String X, Integer millis) {
+        Mono.just(X).delayElement(Duration.ofMillis(millis))
+    }
+
+    def "will pass through non reactive things and leave them as is"() {
+
+        when:
+        def val = ReactiveSupport.fetchedObject("X")
+        then:
+        val === "X"
+
+        when:
+        def cf = CompletableFuture.completedFuture("X")
+        val = ReactiveSupport.fetchedObject(cf)
+        then:
+        val === cf
+    }
+
+    def "can get a reactive or flow publisher and make a CF from it"() {
+
+        when:
+        CompletableFuture<?> cf = ReactiveSupport.fetchedObject(reactiveObject) as CompletableFuture<?>
+
+        then:
+        !cf.isCancelled()
+        !cf.isCompletedExceptionally()
+        cf.isDone()
+
+        cf.join() == "X"
+
+        where:
+        reactiveObject         || _
+        Mono.just("X")         || _
+        toFlow(Mono.just("X")) || _
+    }
+
+    def "can get a reactive or flow publisher that takes some time and make a CF from it"() {
+
+        when:
+        CompletableFuture<?> cf = ReactiveSupport.fetchedObject(reactiveObject) as CompletableFuture<?>
+
+        then:
+        !cf.isCancelled()
+        !cf.isCompletedExceptionally()
+        !cf.isDone()
+
+        cf.join() == "X"
+
+        where:
+        reactiveObject                || _
+        delayedMono("X", 100)         || _
+        toFlow(delayedMono("X", 100)) || _
+    }
+
+    def "can get a reactive or flow publisher with an error and make a CF from it"() {
+
+        when:
+        CompletableFuture<?> cf = ReactiveSupport.fetchedObject(reactiveObject) as CompletableFuture<?>
+
+        then:
+        !cf.isCancelled()
+        cf.isCompletedExceptionally()
+        cf.isDone()
+
+        when:
+        cf.join()
+
+        then:
+        def e = thrown(CompletionException.class)
+        e.cause.message == "Bang!"
+
+        where:
+        reactiveObject                                    || _
+        Mono.error(new RuntimeException("Bang!"))         || _
+        toFlow(Mono.error(new RuntimeException("Bang!"))) || _
+    }
+
+    def "can get a empty reactive or flow publisher and make a CF from it"() {
+
+        when:
+        CompletableFuture<?> cf = ReactiveSupport.fetchedObject(reactiveObject) as CompletableFuture<?>
+
+        then:
+        !cf.isCancelled()
+        !cf.isCompletedExceptionally()
+        cf.isDone()
+
+        cf.join() == null
+
+        where:
+        reactiveObject         || _
+        Mono.empty()         || _
+        toFlow(Mono.empty()) || _
+    }
+
+
+    def "can get a reactive or flow publisher but cancel it before a value turns up"() {
+
+        when:
+        CompletableFuture<?> cf = ReactiveSupport.fetchedObject(reactiveObject) as CompletableFuture<?>
+
+        then:
+        !cf.isCancelled()
+        !cf.isCompletedExceptionally()
+        !cf.isDone()
+
+        when:
+        def cfCancelled = cf.cancel(true)
+
+        then:
+        cfCancelled
+        cf.isCancelled()
+        cf.isCompletedExceptionally()
+        cf.isDone()
+
+        when:
+        cf.join()
+
+        then:
+        thrown(CancellationException.class)
+
+        where:
+        reactiveObject                 || _
+        delayedMono("X", 1000)         || _
+        toFlow(delayedMono("X", 1000)) || _
+
+    }
+
+
+    def "can get a reactive Flux and only take one value and make a CF from it"() {
+
+        def xyzStrings = ["X", "Y", "Z"]
+        when:
+        def countingFlux = new CountingFlux(xyzStrings)
+        CompletableFuture<?> cf = ReactiveSupport.fetchedObject(countingFlux.flux) as CompletableFuture<?>
+
+        then:
+        !cf.isCancelled()
+        !cf.isCompletedExceptionally()
+        cf.isDone()
+
+        cf.join() == "X"
+        countingFlux.count == 1
+
+        when:
+        def capturingSubscriber = new CapturingSubscriber<>()
+        countingFlux.flux.subscribe(capturingSubscriber)
+
+        then:
+        // second subscriber
+        capturingSubscriber.events == ["X", "Y", "Z"]
+        countingFlux.count == 4
+    }
+
+    def "integration test showing reactive values in data fetchers as well as the ones we know and love"() {
+        def sdl = """
+            type Query {
+                reactorField : String
+                flowField : String
+                cfField : String
+                materialisedField : String
+            }
+        """
+
+        // with some delay
+        def reactorDF = { env -> delayedMono("reactor", 100) } as DataFetcher
+        def flowDF = { env -> toFlow(delayedMono("flow", 50)) } as DataFetcher
+
+        def cfDF = { env -> CompletableFuture.completedFuture("cf") } as DataFetcher
+        def materialisedDF = { env -> "materialised" } as DataFetcher
+
+        def schema = TestUtil.schema(sdl, [Query: [
+                reactorField     : reactorDF,
+                flowField        : flowDF,
+                cfField          : cfDF,
+                materialisedField: materialisedDF,
+        ]])
+        def graphQL = GraphQL.newGraphQL(schema).build()
+
+        when:
+        def er = graphQL.execute("""
+            query q {
+                reactorField
+                flowField
+                cfField
+                materialisedField
+            }
+        """)
+
+        then:
+        er.errors.isEmpty()
+        er.data == [
+                reactorField     : "reactor",
+                flowField        : "flow",
+                cfField          : "cf",
+                materialisedField: "materialised"
+        ]
+    }
+}


### PR DESCRIPTION
This adds support for Reactive Publishers, both reactive streams Publishers and JDK Flow Publishers, to be returned from a `DataFetcher` as a value.

They will be turned into `CompletableFuture` by using a subscriber to ask for one value from them.

This is a lot like how reactor `Mono` has a `.toFuture()` method except now they can just return the Mono itself, since a Mono is a reactive streams Publisher.

The cost of this is 2 more `instanceof` checks like we already for for `CompleteableFuture`s