### PR TITLE
DataLoader on Mutations and Queries

### DIFF
--- a/src/main/java/graphql/execution/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncExecutionStrategy.java
@@ -72,14 +72,14 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
             for (FieldValueInfo completeValueInfo : completeValueInfos) {
                 fieldValuesFutures.addObject(completeValueInfo.getFieldValueObject());
             }
-            dataLoaderDispatcherStrategy.executionStrategyOnFieldValuesInfo(completeValueInfos, parameters);
+            dataLoaderDispatcherStrategy.executionStrategyOnFieldValuesInfo(completeValueInfos);
             executionStrategyCtx.onFieldValuesInfo(completeValueInfos);
             fieldValuesFutures.await().whenComplete(handleResultsConsumer);
         }).exceptionally((ex) -> {
             // if there are any issues with combining/handling the field results,
             // complete the future at all costs and bubble up any thrown exception so
             // the execution does not hang.
-            dataLoaderDispatcherStrategy.executionStrategyOnFieldValuesException(ex, parameters);
+            dataLoaderDispatcherStrategy.executionStrategyOnFieldValuesException(ex);
             executionStrategyCtx.onFieldValuesException();
             overallResult.completeExceptionally(ex);
             return null;

--- a/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
@@ -62,12 +62,12 @@ public class AsyncSerialExecutionStrategy extends AbstractAsyncExecutionStrategy
             if (fieldWithInfo instanceof CompletableFuture) {
                 //noinspection unchecked
                 return ((CompletableFuture<FieldValueInfo>) fieldWithInfo).thenCompose( fvi -> {
-                    dataLoaderDispatcherStrategy.executionStrategyOnFieldValuesInfo(List.of(fvi), newParameters);
+                    dataLoaderDispatcherStrategy.executionStrategyOnFieldValuesInfo(List.of(fvi));
                     return fvi.getFieldValueFuture();
                 });
             } else {
                 FieldValueInfo fvi = (FieldValueInfo) fieldWithInfo;
-                dataLoaderDispatcherStrategy.executionStrategyOnFieldValuesInfo(List.of(fvi), newParameters);
+                dataLoaderDispatcherStrategy.executionStrategyOnFieldValuesInfo(List.of(fvi));
                 return fvi.getFieldValueObject();
             }
         });

--- a/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
@@ -33,7 +33,6 @@ public class AsyncSerialExecutionStrategy extends AbstractAsyncExecutionStrategy
     @SuppressWarnings({"TypeParameterUnusedInFormals", "FutureReturnValueIgnored"})
     public CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) throws NonNullableFieldWasNullException {
         DataLoaderDispatchStrategy dataLoaderDispatcherStrategy = executionContext.getDataLoaderDispatcherStrategy();
-        dataLoaderDispatcherStrategy.executionStrategy(executionContext, parameters);
 
         Instrumentation instrumentation = executionContext.getInstrumentation();
         InstrumentationExecutionStrategyParameters instrumentationParameters = new InstrumentationExecutionStrategyParameters(executionContext, parameters);
@@ -56,6 +55,9 @@ public class AsyncSerialExecutionStrategy extends AbstractAsyncExecutionStrategy
             ExecutionStrategyParameters newParameters = parameters
                     .transform(builder -> builder.field(currentField).path(fieldPath));
             //return resolveField(executionContext, newParameters);
+
+            dataLoaderDispatcherStrategy.executionSerialStrategy(executionContext, newParameters);
+
             Object fieldWithInfo = resolveFieldWithInfo(executionContext, newParameters);
             if (fieldWithInfo instanceof CompletableFuture) {
                 //noinspection unchecked

--- a/src/main/java/graphql/execution/DataLoaderDispatchStrategy.java
+++ b/src/main/java/graphql/execution/DataLoaderDispatchStrategy.java
@@ -20,11 +20,11 @@ public interface DataLoaderDispatchStrategy {
 
     }
 
-    default void executionStrategyOnFieldValuesInfo(List<FieldValueInfo> fieldValueInfoList, ExecutionStrategyParameters parameters) {
+    default void executionStrategyOnFieldValuesInfo(List<FieldValueInfo> fieldValueInfoList) {
 
     }
 
-    default void executionStrategyOnFieldValuesException(Throwable t, ExecutionStrategyParameters parameters) {
+    default void executionStrategyOnFieldValuesException(Throwable t) {
 
     }
 

--- a/src/main/java/graphql/execution/DataLoaderDispatchStrategy.java
+++ b/src/main/java/graphql/execution/DataLoaderDispatchStrategy.java
@@ -16,6 +16,10 @@ public interface DataLoaderDispatchStrategy {
 
     }
 
+    default void executionSerialStrategy(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
+
+    }
+
     default void executionStrategyOnFieldValuesInfo(List<FieldValueInfo> fieldValueInfoList, ExecutionStrategyParameters parameters) {
 
     }

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -228,7 +228,7 @@ public class Execution {
         if (executionContext.getDataLoaderRegistry() == EMPTY_DATALOADER_REGISTRY || doNotAutomaticallyDispatchDataLoader) {
             return DataLoaderDispatchStrategy.NO_OP;
         }
-        if (executionStrategy instanceof AsyncExecutionStrategy) {
+        if (! executionContext.isSubscriptionOperation()) {
             boolean deferEnabled = Optional.ofNullable(executionContext.getGraphQLContext())
                     .map(graphqlContext -> graphqlContext.getBoolean(ExperimentalApi.ENABLE_INCREMENTAL_SUPPORT))
                     .orElse(false);

--- a/src/main/java/graphql/execution/ExecutionContext.java
+++ b/src/main/java/graphql/execution/ExecutionContext.java
@@ -171,6 +171,34 @@ public class ExecutionContext {
     }
 
     /**
+     * @return true if the current operation is a Query
+     */
+    public boolean isQueryOperation() {
+        return isOpType(OperationDefinition.Operation.QUERY);
+    }
+
+    /**
+     * @return true if the current operation is a Mutation
+     */
+    public boolean isMutationOperation() {
+        return isOpType(OperationDefinition.Operation.MUTATION);
+    }
+
+    /**
+     * @return true if the current operation is a Subscription
+     */
+    public boolean isSubscriptionOperation() {
+        return isOpType(OperationDefinition.Operation.SUBSCRIPTION);
+    }
+
+    private boolean isOpType(OperationDefinition.Operation operation) {
+        if (operationDefinition != null) {
+            return operation.equals(operationDefinition.getOperation());
+        }
+        return false;
+    }
+
+    /**
      * This method will only put one error per field path.
      *
      * @param error     the error to add

--- a/src/main/java/graphql/execution/instrumentation/dataloader/FallbackDataLoaderDispatchStrategy.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/FallbackDataLoaderDispatchStrategy.java
@@ -7,7 +7,7 @@ import graphql.schema.DataFetcher;
 
 
 /**
- * Used when the execution strategy is not an AsyncExecutionStrategy: simply dispatch always after each DF.
+ * Used when we cant guarantee the fields will be counted right: simply dispatch always after each DF.
  */
 @Internal
 public class FallbackDataLoaderDispatchStrategy implements DataLoaderDispatchStrategy {

--- a/src/main/java/graphql/execution/instrumentation/dataloader/PerLevelDataLoaderDispatchStrategy.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/PerLevelDataLoaderDispatchStrategy.java
@@ -6,7 +6,6 @@ import graphql.execution.DataLoaderDispatchStrategy;
 import graphql.execution.ExecutionContext;
 import graphql.execution.ExecutionStrategyParameters;
 import graphql.execution.FieldValueInfo;
-import graphql.execution.MergedField;
 import graphql.schema.DataFetcher;
 import graphql.util.LockKit;
 import org.dataloader.DataLoaderRegistry;
@@ -27,46 +26,72 @@ public class PerLevelDataLoaderDispatchStrategy implements DataLoaderDispatchStr
         private final LockKit.ReentrantLock lock = new LockKit.ReentrantLock();
         private final LevelMap expectedFetchCountPerLevel = new LevelMap();
         private final LevelMap fetchCountPerLevel = new LevelMap();
-        private final LevelMap expectedStrategyCallsPerLevel = new LevelMap();
-        private final LevelMap happenedStrategyCallsPerLevel = new LevelMap();
+
+        private final LevelMap expectedExecuteObjectCallsPerLevel = new LevelMap();
+        private final LevelMap happenedExecuteObjectCallsPerLevel = new LevelMap();
+
         private final LevelMap happenedOnFieldValueCallsPerLevel = new LevelMap();
 
         private final Set<Integer> dispatchedLevels = new LinkedHashSet<>();
 
         public CallStack() {
-            expectedStrategyCallsPerLevel.set(1, 1);
+            expectedExecuteObjectCallsPerLevel.set(1, 1);
         }
 
         void increaseExpectedFetchCount(int level, int count) {
             expectedFetchCountPerLevel.increment(level, count);
         }
 
+        void clearExpectedFetchCount() {
+            expectedFetchCountPerLevel.clear();
+        }
+
         void increaseFetchCount(int level) {
             fetchCountPerLevel.increment(level, 1);
         }
 
-        void increaseExpectedStrategyCalls(int level, int count) {
-            expectedStrategyCallsPerLevel.increment(level, count);
+        void clearFetchCount() {
+            fetchCountPerLevel.clear();
         }
 
-        void increaseHappenedStrategyCalls(int level) {
-            happenedStrategyCallsPerLevel.increment(level, 1);
+        void increaseExpectedExecuteObjectCalls(int level, int count) {
+            expectedExecuteObjectCallsPerLevel.increment(level, count);
+        }
+
+        void clearExpectedObjectCalls() {
+            expectedExecuteObjectCallsPerLevel.clear();
+        }
+
+        void increaseHappenedExecuteObjectCalls(int level) {
+            happenedExecuteObjectCallsPerLevel.increment(level, 1);
+        }
+
+        void clearHappenedExecuteObjectCalls() {
+            happenedExecuteObjectCallsPerLevel.clear();
         }
 
         void increaseHappenedOnFieldValueCalls(int level) {
             happenedOnFieldValueCallsPerLevel.increment(level, 1);
         }
 
-        boolean allStrategyCallsHappened(int level) {
-            return happenedStrategyCallsPerLevel.get(level) == expectedStrategyCallsPerLevel.get(level);
+        void clearHappenedOnFieldValueCalls() {
+            happenedOnFieldValueCallsPerLevel.clear();
+        }
+
+        boolean allExecuteObjectCallsHappened(int level) {
+            return happenedExecuteObjectCallsPerLevel.get(level) == expectedExecuteObjectCallsPerLevel.get(level);
         }
 
         boolean allOnFieldCallsHappened(int level) {
-            return happenedOnFieldValueCallsPerLevel.get(level) == expectedStrategyCallsPerLevel.get(level);
+            return happenedOnFieldValueCallsPerLevel.get(level) == expectedExecuteObjectCallsPerLevel.get(level);
         }
 
         boolean allFetchesHappened(int level) {
             return fetchCountPerLevel.get(level) == expectedFetchCountPerLevel.get(level);
+        }
+
+        void clearDispatchLevels() {
+            dispatchedLevels.clear();
         }
 
         @Override
@@ -74,8 +99,8 @@ public class PerLevelDataLoaderDispatchStrategy implements DataLoaderDispatchStr
             return "CallStack{" +
                     "expectedFetchCountPerLevel=" + expectedFetchCountPerLevel +
                     ", fetchCountPerLevel=" + fetchCountPerLevel +
-                    ", expectedStrategyCallsPerLevel=" + expectedStrategyCallsPerLevel +
-                    ", happenedStrategyCallsPerLevel=" + happenedStrategyCallsPerLevel +
+                    ", expectedExecuteObjectCallsPerLevel=" + expectedExecuteObjectCallsPerLevel +
+                    ", happenedExecuteObjectCallsPerLevel=" + happenedExecuteObjectCallsPerLevel +
                     ", happenedOnFieldValueCallsPerLevel=" + happenedOnFieldValueCallsPerLevel +
                     ", dispatchedLevels" + dispatchedLevels +
                     '}';
@@ -83,10 +108,10 @@ public class PerLevelDataLoaderDispatchStrategy implements DataLoaderDispatchStr
 
 
         public boolean dispatchIfNotDispatchedBefore(int level) {
-//            if (dispatchedLevels.contains(level)) {
-//                Assert.assertShouldNeverHappen("level " + level + " already dispatched");
-//                return false;
-//            }
+            if (dispatchedLevels.contains(level)) {
+                Assert.assertShouldNeverHappen("level " + level + " already dispatched");
+                return false;
+            }
             dispatchedLevels.add(level);
             return true;
         }
@@ -105,25 +130,23 @@ public class PerLevelDataLoaderDispatchStrategy implements DataLoaderDispatchStr
     @Override
     public void executionStrategy(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
         int curLevel = parameters.getExecutionStepInfo().getPath().getLevel() + 1;
-        increaseCallCounts(curLevel, parameters);
+        increaseHappenedExecuteObjectAndIncreaseExpectedFetchCount(curLevel, parameters);
     }
 
     @Override
     public void executionSerialStrategy(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
-        int curLevel = parameters.getExecutionStepInfo().getPath().getLevel() + 1;
-        increaseCallCounts(curLevel, 1);
+        resetCallStack();
+        increaseHappenedExecuteObjectAndIncreaseExpectedFetchCount(1, 1);
     }
 
     @Override
-    public void executionStrategyOnFieldValuesInfo(List<FieldValueInfo> fieldValueInfoList, ExecutionStrategyParameters parameters) {
-        int curLevel = parameters.getPath().getLevel() + 1;
-        onFieldValuesInfoDispatchIfNeeded(fieldValueInfoList, curLevel, parameters);
+    public void executionStrategyOnFieldValuesInfo(List<FieldValueInfo> fieldValueInfoList) {
+        onFieldValuesInfoDispatchIfNeeded(fieldValueInfoList, 1);
     }
 
-    public void executionStrategyOnFieldValuesException(Throwable t, ExecutionStrategyParameters executionStrategyParameters) {
-        int curLevel = executionStrategyParameters.getPath().getLevel() + 1;
+    public void executionStrategyOnFieldValuesException(Throwable t) {
         callStack.lock.runLocked(() ->
-                callStack.increaseHappenedOnFieldValueCalls(curLevel)
+                callStack.increaseHappenedOnFieldValueCalls(1)
         );
     }
 
@@ -131,13 +154,13 @@ public class PerLevelDataLoaderDispatchStrategy implements DataLoaderDispatchStr
     @Override
     public void executeObject(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
         int curLevel = parameters.getExecutionStepInfo().getPath().getLevel() + 1;
-        increaseCallCounts(curLevel, parameters);
+        increaseHappenedExecuteObjectAndIncreaseExpectedFetchCount(curLevel, parameters);
     }
 
     @Override
     public void executeObjectOnFieldValuesInfo(List<FieldValueInfo> fieldValueInfoList, ExecutionStrategyParameters parameters) {
         int curLevel = parameters.getPath().getLevel() + 1;
-        onFieldValuesInfoDispatchIfNeeded(fieldValueInfoList, curLevel, parameters);
+        onFieldValuesInfoDispatchIfNeeded(fieldValueInfoList, curLevel);
     }
 
 
@@ -149,19 +172,30 @@ public class PerLevelDataLoaderDispatchStrategy implements DataLoaderDispatchStr
         );
     }
 
-
-    private void increaseCallCounts(int curLevel, ExecutionStrategyParameters executionStrategyParameters) {
-        increaseCallCounts(curLevel, executionStrategyParameters.getFields().size());
+    private void increaseHappenedExecuteObjectAndIncreaseExpectedFetchCount(int curLevel, ExecutionStrategyParameters executionStrategyParameters) {
+        increaseHappenedExecuteObjectAndIncreaseExpectedFetchCount(curLevel, executionStrategyParameters.getFields().size());
     }
 
-    private void increaseCallCounts(int curLevel, int fieldCount) {
+    private void increaseHappenedExecuteObjectAndIncreaseExpectedFetchCount(int curLevel, int fieldCount) {
         callStack.lock.runLocked(() -> {
+            callStack.increaseHappenedExecuteObjectCalls(curLevel);
             callStack.increaseExpectedFetchCount(curLevel, fieldCount);
-            callStack.increaseHappenedStrategyCalls(curLevel);
         });
     }
 
-    private void onFieldValuesInfoDispatchIfNeeded(List<FieldValueInfo> fieldValueInfoList, int curLevel, ExecutionStrategyParameters parameters) {
+    private void resetCallStack() {
+        callStack.lock.runLocked(() -> {
+            callStack.clearDispatchLevels();
+            callStack.clearExpectedObjectCalls();
+            callStack.clearExpectedFetchCount();
+            callStack.clearFetchCount();
+            callStack.clearHappenedExecuteObjectCalls();
+            callStack.clearHappenedOnFieldValueCalls();
+            callStack.expectedExecuteObjectCallsPerLevel.set(1, 1);
+        });
+    }
+
+    private void onFieldValuesInfoDispatchIfNeeded(List<FieldValueInfo> fieldValueInfoList, int curLevel) {
         boolean dispatchNeeded = callStack.lock.callLocked(() ->
                 handleOnFieldValuesInfo(fieldValueInfoList, curLevel)
         );
@@ -175,18 +209,21 @@ public class PerLevelDataLoaderDispatchStrategy implements DataLoaderDispatchStr
 //
     private boolean handleOnFieldValuesInfo(List<FieldValueInfo> fieldValueInfos, int curLevel) {
         callStack.increaseHappenedOnFieldValueCalls(curLevel);
-        int expectedStrategyCalls = getCountForList(fieldValueInfos);
-        callStack.increaseExpectedStrategyCalls(curLevel + 1, expectedStrategyCalls);
+        int expectedOnObjectCalls = getObjectCountForList(fieldValueInfos);
+        callStack.increaseExpectedExecuteObjectCalls(curLevel + 1, expectedOnObjectCalls);
         return dispatchIfNeeded(curLevel + 1);
     }
 
-    private int getCountForList(List<FieldValueInfo> fieldValueInfos) {
+    /**
+     * the amount of (non nullable) objects that will require an execute object call
+     */
+    private int getObjectCountForList(List<FieldValueInfo> fieldValueInfos) {
         int result = 0;
         for (FieldValueInfo fieldValueInfo : fieldValueInfos) {
             if (fieldValueInfo.getCompleteValueType() == FieldValueInfo.CompleteValueType.OBJECT) {
                 result += 1;
             } else if (fieldValueInfo.getCompleteValueType() == FieldValueInfo.CompleteValueType.LIST) {
-                result += getCountForList(fieldValueInfo.getFieldValueInfos());
+                result += getObjectCountForList(fieldValueInfo.getFieldValueInfos());
             }
         }
         return result;
@@ -230,7 +267,7 @@ public class PerLevelDataLoaderDispatchStrategy implements DataLoaderDispatchStr
             return callStack.allFetchesHappened(1);
         }
         if (levelReady(level - 1) && callStack.allOnFieldCallsHappened(level - 1)
-                && callStack.allStrategyCallsHappened(level) && callStack.allFetchesHappened(level)) {
+                && callStack.allExecuteObjectCallsHappened(level) && callStack.allFetchesHappened(level)) {
 
             return true;
         }

--- a/src/main/java/graphql/execution/instrumentation/dataloader/PerLevelDataLoaderDispatchStrategy.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/PerLevelDataLoaderDispatchStrategy.java
@@ -83,10 +83,10 @@ public class PerLevelDataLoaderDispatchStrategy implements DataLoaderDispatchStr
 
 
         public boolean dispatchIfNotDispatchedBefore(int level) {
-            if (dispatchedLevels.contains(level)) {
-                Assert.assertShouldNeverHappen("level " + level + " already dispatched");
-                return false;
-            }
+//            if (dispatchedLevels.contains(level)) {
+//                Assert.assertShouldNeverHappen("level " + level + " already dispatched");
+//                return false;
+//            }
             dispatchedLevels.add(level);
             return true;
         }
@@ -106,6 +106,12 @@ public class PerLevelDataLoaderDispatchStrategy implements DataLoaderDispatchStr
     public void executionStrategy(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
         int curLevel = parameters.getExecutionStepInfo().getPath().getLevel() + 1;
         increaseCallCounts(curLevel, parameters);
+    }
+
+    @Override
+    public void executionSerialStrategy(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
+        int curLevel = parameters.getExecutionStepInfo().getPath().getLevel() + 1;
+        increaseCallCounts(curLevel, 1);
     }
 
     @Override
@@ -145,7 +151,10 @@ public class PerLevelDataLoaderDispatchStrategy implements DataLoaderDispatchStr
 
 
     private void increaseCallCounts(int curLevel, ExecutionStrategyParameters executionStrategyParameters) {
-        int fieldCount = executionStrategyParameters.getFields().size();
+        increaseCallCounts(curLevel, executionStrategyParameters.getFields().size());
+    }
+
+    private void increaseCallCounts(int curLevel, int fieldCount) {
         callStack.lock.runLocked(() -> {
             callStack.increaseExpectedFetchCount(curLevel, fieldCount);
             callStack.increaseHappenedStrategyCalls(curLevel);

--- a/src/main/java/graphql/execution/instrumentation/dataloader/PerLevelDataLoaderDispatchStrategyWithDeferAlwaysDispatch.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/PerLevelDataLoaderDispatchStrategyWithDeferAlwaysDispatch.java
@@ -137,19 +137,17 @@ public class PerLevelDataLoaderDispatchStrategyWithDeferAlwaysDispatch implement
     }
 
     @Override
-    public void executionStrategyOnFieldValuesInfo(List<FieldValueInfo> fieldValueInfoList, ExecutionStrategyParameters parameters) {
+    public void executionStrategyOnFieldValuesInfo(List<FieldValueInfo> fieldValueInfoList) {
         if (this.startedDeferredExecution.get()) {
             this.dispatch();
         }
-        int curLevel = parameters.getPath().getLevel() + 1;
-        onFieldValuesInfoDispatchIfNeeded(fieldValueInfoList, curLevel, parameters);
+        onFieldValuesInfoDispatchIfNeeded(fieldValueInfoList, 1);
     }
 
     @Override
-    public void executionStrategyOnFieldValuesException(Throwable t, ExecutionStrategyParameters executionStrategyParameters) {
-        int curLevel = executionStrategyParameters.getPath().getLevel() + 1;
+    public void executionStrategyOnFieldValuesException(Throwable t) {
         callStack.lock.runLocked(() ->
-                callStack.increaseHappenedOnFieldValueCalls(curLevel)
+                callStack.increaseHappenedOnFieldValueCalls(1)
         );
     }
 
@@ -159,7 +157,7 @@ public class PerLevelDataLoaderDispatchStrategyWithDeferAlwaysDispatch implement
             this.dispatch();
         }
         int curLevel = parameters.getPath().getLevel() + 1;
-        onFieldValuesInfoDispatchIfNeeded(fieldValueInfoList, curLevel, parameters);
+        onFieldValuesInfoDispatchIfNeeded(fieldValueInfoList, curLevel);
     }
 
 
@@ -207,7 +205,7 @@ public class PerLevelDataLoaderDispatchStrategyWithDeferAlwaysDispatch implement
         });
     }
 
-    private void onFieldValuesInfoDispatchIfNeeded(List<FieldValueInfo> fieldValueInfoList, int curLevel, ExecutionStrategyParameters parameters) {
+    private void onFieldValuesInfoDispatchIfNeeded(List<FieldValueInfo> fieldValueInfoList, int curLevel) {
         boolean dispatchNeeded = callStack.lock.callLocked(() ->
                 handleOnFieldValuesInfo(fieldValueInfoList, curLevel)
         );

--- a/src/test/groovy/graphql/MutationTest.groovy
+++ b/src/test/groovy/graphql/MutationTest.groovy
@@ -1,7 +1,12 @@
 package graphql
 
+import graphql.schema.DataFetcher
+import org.dataloader.BatchLoader
+import org.dataloader.DataLoaderFactory
+import org.dataloader.DataLoaderRegistry
 import spock.lang.Specification
 
+import java.util.concurrent.CompletableFuture
 
 class MutationTest extends Specification {
 
@@ -102,4 +107,119 @@ class MutationTest extends Specification {
         executionResult.errors.every({ it instanceof ExceptionWhileDataFetching })
 
     }
+
+    def "simple async mutation"() {
+        def sdl = """
+            type Query {
+                q : String
+            }
+            
+            type Mutation {
+                plus1(arg: Int) : Int
+                plus2(arg: Int) : Int
+                plus3(arg: Int) : Int
+            }
+        """
+
+        def mutationDF = { env ->
+            CompletableFuture.supplyAsync {
+
+                def fieldName = env.getField().name
+                def factor = Integer.parseInt(fieldName.substring(fieldName.length() - 1))
+                def value = env.getArgument("arg")
+
+                return value + factor
+            }
+        } as DataFetcher
+
+        def schema = TestUtil.schema(sdl, [Mutation: [
+                plus1: mutationDF,
+                plus2: mutationDF,
+                plus3: mutationDF,
+        ]])
+
+        def graphQL = GraphQL.newGraphQL(schema).build()
+
+        when:
+        def er = graphQL.execute("""
+            mutation m {
+                plus1(arg:10)
+                plus2(arg:10)
+                plus3(arg:10)
+             }
+        """)
+
+        then:
+        er.errors.isEmpty()
+        er.data == [
+                plus1: 11,
+                plus2: 12,
+                plus3: 13,
+        ]
+    }
+
+    def "simple async mutation with DataLoader"() {
+        def sdl = """
+            type Query {
+                q : String
+            }
+            
+            type Mutation {
+                plus1(arg: Int) : Int
+                plus2(arg: Int) : Int
+                plus3(arg: Int) : Int
+            }
+        """
+
+        BatchLoader<Integer, Integer> batchLoader = { keys ->
+            CompletableFuture.supplyAsync {
+                return keys
+            }
+
+        } as BatchLoader
+
+
+        DataLoaderRegistry dlReg = DataLoaderRegistry.newRegistry()
+                .register("dl", DataLoaderFactory.newDataLoader(batchLoader))
+                .build()
+
+        def mutationDF = { env ->
+            def fieldName = env.getField().name
+            def factor = Integer.parseInt(fieldName.substring(fieldName.length() - 1))
+            def value = env.getArgument("arg")
+
+            def key = value + factor
+            return env.getDataLoader("dl").load(key)
+        } as DataFetcher
+
+        def schema = TestUtil.schema(sdl, [Mutation: [
+                plus1: mutationDF,
+                plus2: mutationDF,
+                plus3: mutationDF,
+        ]])
+
+
+        def graphQL = GraphQL.newGraphQL(schema)
+                .build()
+
+
+        def ei = ExecutionInput.newExecutionInput("""
+            mutation m {
+                plus1(arg:10)
+                plus2(arg:10)
+                plus3(arg:10)
+             }
+        """).dataLoaderRegistry(dlReg).build()
+        when:
+        def er = graphQL.execute(ei)
+
+        then:
+        er.errors.isEmpty()
+        er.data == [
+                plus1: 11,
+                plus2: 12,
+                plus3: 13,
+        ]
+    }
+
 }

--- a/src/test/groovy/graphql/MutationTest.groovy
+++ b/src/test/groovy/graphql/MutationTest.groovy
@@ -1,7 +1,9 @@
 package graphql
 
 import graphql.schema.DataFetcher
+import org.awaitility.Awaitility
 import org.dataloader.BatchLoader
+import org.dataloader.BatchLoaderWithContext
 import org.dataloader.DataLoaderFactory
 import org.dataloader.DataLoaderRegistry
 import spock.lang.Specification
@@ -169,6 +171,7 @@ class MutationTest extends Specification {
                 plus2(arg: Int) : Int
                 plus3(arg: Int) : Int
             }
+           
         """
 
         BatchLoader<Integer, Integer> batchLoader = { keys ->
@@ -222,4 +225,239 @@ class MutationTest extends Specification {
         ]
     }
 
+    /*
+     This test shows a dataloader being called at the mutation field level, in serial via AsyncSerialExecutionStrategy, and then
+     again at the sub field level, in parallel, via AsyncExecutionStrategy.
+     */
+    def "more complex async mutation with DataLoader"() {
+        def sdl = """
+            type Query {
+                q : String
+            }
+            
+            type Mutation {
+                topLevelF1(arg: Int) : ComplexType
+                topLevelF2(arg: Int) : ComplexType
+                topLevelF3(arg: Int) : ComplexType
+                topLevelF4(arg: Int) : ComplexType
+            }
+            
+            type ComplexType {
+                f1 : ComplexType
+                f2 : ComplexType
+                f3 : ComplexType
+                f4 : ComplexType
+                end : String
+            }
+        """
+
+        def emptyComplexMap = [
+                f1: null,
+                f2: null,
+                f3: null,
+                f4: null,
+        ]
+
+        BatchLoaderWithContext<Integer, Map> fieldBatchLoader = { keys, context ->
+            assert keys.size() == 2, "since only f1 and f2 are DL based, we will only get 2 key values"
+
+            def batchValue = [
+                    emptyComplexMap,
+                    emptyComplexMap,
+            ]
+            CompletableFuture.supplyAsync {
+                return batchValue
+            }
+
+        } as BatchLoaderWithContext
+
+        BatchLoader<Integer, Integer> mutationBatchLoader = { keys ->
+            CompletableFuture.supplyAsync {
+                return keys
+            }
+
+        } as BatchLoader
+
+
+        DataLoaderRegistry dlReg = DataLoaderRegistry.newRegistry()
+                .register("topLevelDL", DataLoaderFactory.newDataLoader(mutationBatchLoader))
+                .register("fieldDL", DataLoaderFactory.newDataLoader(fieldBatchLoader))
+                .build()
+
+        def mutationDF = { env ->
+            def fieldName = env.getField().name
+            def factor = Integer.parseInt(fieldName.substring(fieldName.length() - 1))
+            def value = env.getArgument("arg")
+
+            def key = value + factor
+            return env.getDataLoader("topLevelDL").load(key)
+        } as DataFetcher
+
+        def fieldDataLoaderDF = { env ->
+            def fieldName = env.getField().name
+            def level = env.getExecutionStepInfo().getPath().getLevel()
+            return env.getDataLoader("fieldDL").load(fieldName, level)
+        } as DataFetcher
+
+        def fieldDataLoaderNonDF = { env ->
+            return emptyComplexMap
+        } as DataFetcher
+
+        def schema = TestUtil.schema(sdl,
+                [Mutation   : [
+                        topLevelF1: mutationDF,
+                        topLevelF2: mutationDF,
+                        topLevelF3: mutationDF,
+                        topLevelF4: mutationDF,
+                ],
+                 // only f1 and f3 are using data loaders - f2 and f4 are plain old property based
+                 // so some fields with batch loader and some without
+                 ComplexType: [
+                         f1: fieldDataLoaderDF,
+                         f2: fieldDataLoaderNonDF,
+                         f3: fieldDataLoaderDF,
+                         f4: fieldDataLoaderNonDF,
+                 ]
+                ])
+
+
+        def graphQL = GraphQL.newGraphQL(schema)
+                .build()
+
+
+        def ei = ExecutionInput.newExecutionInput("""
+            mutation m {
+                topLevelF1(arg:10) {
+                    f1 {
+                        f1 { end } 
+                        f2 { end }
+                        f3 { end }
+                        f4 { end }
+                    }
+                    f2 {
+                        f1 { end }
+                        f2 { end }
+                        f3 { end }
+                        f4 { end }
+                    }
+                    f3 {
+                        f1 { end }
+                        f2 { end }
+                        f3 { end }
+                        f4 { end }
+                    }
+                    f4 {
+                        f1 { end }
+                        f2 { end }
+                        f3 { end }
+                        f4 { end }
+                    }
+                }
+                    
+                topLevelF2(arg:10) {
+                    f1 {
+                        f1 { end } 
+                        f2 { end }
+                        f3 { end }
+                        f4 { end }
+                    }
+                    f2 {
+                        f1 { end }
+                        f2 { end }
+                        f3 { end }
+                        f4 { end }
+                    }
+                    f3 {
+                        f1 { end }
+                        f2 { end }
+                        f3 { end }
+                        f4 { end }
+                    }
+                    f4 {
+                        f1 { end }
+                        f2 { end }
+                        f3 { end }
+                        f4 { end }
+                    }
+                }
+                
+                topLevelF3(arg:10) {
+                    f1 {
+                        f1 { end } 
+                        f2 { end }
+                        f3 { end }
+                        f4 { end }
+                    }
+                    f2 {
+                        f1 { end }
+                        f2 { end }
+                        f3 { end }
+                        f4 { end }
+                    }
+                    f3 {
+                        f1 { end }
+                        f2 { end }
+                        f3 { end }
+                        f4 { end }
+                    }
+                    f4 {
+                        f1 { end }
+                        f2 { end }
+                        f3 { end }
+                        f4 { end }
+                    }
+                }
+
+                topLevelF4(arg:10) {
+                    f1 {
+                        f1 { end } 
+                        f2 { end }
+                        f3 { end }
+                        f4 { end }
+                    }
+                    f2 {
+                        f1 { end }
+                        f2 { end }
+                        f3 { end }
+                        f4 { end }
+                    }
+                    f3 {
+                        f1 { end }
+                        f2 { end }
+                        f3 { end }
+                        f4 { end }
+                    }
+                    f4 {
+                        f1 { end }
+                        f2 { end }
+                        f3 { end }
+                        f4 { end }
+                    }
+                }
+             }
+        """).dataLoaderRegistry(dlReg).build()
+        when:
+        def cf = graphQL.executeAsync(ei)
+
+        Awaitility.await().until { cf.isDone() }
+        def er = cf.join()
+
+        then:
+
+        er.errors.isEmpty()
+
+        def expectedMap = [
+                f1: [f1: [end: null], f2: [end: null], f3: [end: null], f4: [end: null]],
+                f2: [f1: [end: null], f2: [end: null], f3: [end: null], f4: [end: null]],
+                f3: [f1: [end: null], f2: [end: null], f3: [end: null], f4: [end: null]],
+                f4: [f1: [end: null], f2: [end: null], f3: [end: null], f4: [end: null]],
+        ]
+
+        er.data == [
+                topLevelF1: expectedMap,
+                topLevelF2: expectedMap,
+                topLevelF3: expectedMap,
+                topLevelF4: expectedMap,
+        ]
+    }
 }

--- a/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherTest.groovy
@@ -20,7 +20,6 @@ import org.jetbrains.annotations.NotNull
 import org.reactivestreams.Publisher
 import reactor.core.publisher.Mono
 import spock.lang.Specification
-import spock.lang.Unroll
 
 import java.time.Duration
 import java.util.concurrent.CompletableFuture
@@ -121,10 +120,10 @@ class DataLoaderDispatcherTest extends Specification {
     }
 
 
-    @Unroll
-    def "ensure DataLoaderDispatcher works for #executionStrategyName"() {
+    def "ensure DataLoaderDispatcher works for async serial execution strategy"() {
 
         given:
+        def executionStrategy = new AsyncSerialExecutionStrategy()
         def starWarsWiring = new StarWarsDataLoaderWiring()
         def dlRegistry = starWarsWiring.newDataLoaderRegistry()
 
@@ -143,10 +142,6 @@ class DataLoaderDispatcherTest extends Specification {
         then:
         er.data == expectedQueryData
 
-        where:
-        executionStrategyName          | executionStrategy                  || _
-        "AsyncExecutionStrategy"       | new AsyncSerialExecutionStrategy() || _
-        "AsyncSerialExecutionStrategy" | new AsyncSerialExecutionStrategy() || _
     }
 
     def "basic batch loading is possible"() {

--- a/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherTest.groovy
@@ -19,6 +19,7 @@ import org.dataloader.DataLoaderRegistry
 import org.jetbrains.annotations.NotNull
 import org.reactivestreams.Publisher
 import reactor.core.publisher.Mono
+import spock.lang.Ignore
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -120,6 +121,7 @@ class DataLoaderDispatcherTest extends Specification {
     }
 
 
+    @Ignore
     @Unroll
     def "ensure DataLoaderDispatcher works for #executionStrategyName"() {
 

--- a/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/dataloader/DataLoaderDispatcherTest.groovy
@@ -19,10 +19,10 @@ import org.dataloader.DataLoaderRegistry
 import org.jetbrains.annotations.NotNull
 import org.reactivestreams.Publisher
 import reactor.core.publisher.Mono
-import spock.lang.Ignore
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import java.time.Duration
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
 
@@ -121,7 +121,6 @@ class DataLoaderDispatcherTest extends Specification {
     }
 
 
-    @Ignore
     @Unroll
     def "ensure DataLoaderDispatcher works for #executionStrategyName"() {
 
@@ -138,6 +137,7 @@ class DataLoaderDispatcherTest extends Specification {
 
         def asyncResult = graphql.executeAsync(newExecutionInput().query(query).dataLoaderRegistry(dlRegistry))
 
+        Awaitility.await().atMost(Duration.ofMillis(200)).until { -> asyncResult.isDone() }
         def er = asyncResult.join()
 
         then:


### PR DESCRIPTION
ThisPR for the https://github.com/graphql-java/graphql-java/issues/3711 issue where mutations dont allow DataLoader delayed dispatching (rather it dispatches ALWAYS)

Mutations run in serial and hence dispatch one field at a time.  However the data loader dispatching code previoiusly assumed that all of the mutation top level fields would be dispatched at once and hence it waited for all to be dispatched before it dispatched the dataloaders.

This changes that so that it expects one field at a time and it resets the tracing callstack per mutation field
