### PR TITLE
Add test reporting to pull request workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,7 +25,7 @@ jobs:
       - name: build and test
         run: ./gradlew assemble && ./gradlew check --info --stacktrace
       - name: test report
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@v1.9.1
         if: success() || failure()
         with:
           name: junit tests

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,3 +24,10 @@ jobs:
           distribution: 'corretto'
       - name: build and test
         run: ./gradlew assemble && ./gradlew check --info --stacktrace
+      - name: test report
+        uses: dorny/test-reporter@v1
+        if: success() || failure()
+        with:
+          name: junit tests
+          path: '**/build/test-results/test/TEST-*.xml'
+          reporter: java-junit

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,6 +13,7 @@ on:
       - 19.x
 permissions: # needed for test-reporter
   contents: read
+  actions: read
   id-token: write
   checks: write
 jobs:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,7 +11,9 @@ on:
       - 21.x
       - 20.x
       - 19.x
-permissions:
+permissions: # needed for test-reporter
+  contents: read
+  actions: read
   checks: write
 jobs:
   buildAndTest:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,6 +11,8 @@ on:
       - 21.x
       - 20.x
       - 19.x
+permissions:
+  checks: write
 jobs:
   buildAndTest:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,7 +14,6 @@ on:
 permissions: # needed for test-reporter
   contents: read
   actions: read
-  id-token: write
   checks: write
 jobs:
   buildAndTest:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,7 +13,7 @@ on:
       - 19.x
 permissions: # needed for test-reporter
   contents: read
-  actions: read
+  id-token: write
   checks: write
 jobs:
   buildAndTest:


### PR DESCRIPTION
On a build with failing tests it is currently hard to see exactly which test failed.

We thus add a popular test reporter to publish JUnit test results so that they can easily be examined.

As workflows need to be approved by the maintainer to run, we will only be able to confirm whether this works once the maintainer enables this themselves.