### PR TITLE
Add test result comment bot

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+permissions:
+  checks: write
 jobs:
   buildAndPublish:
     runs-on: ubuntu-latest
@@ -22,3 +24,8 @@ jobs:
           distribution: 'corretto'
       - name: build test and publish
         run: ./gradlew assemble && ./gradlew check --info && ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -x check --info --stacktrace
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2.18.0
+        if: always()
+        with:
+          files: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-permissions:
+permissions: # For test summary bot
   checks: write
 jobs:
   buildAndPublish:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,7 +11,7 @@ on:
       - 21.x
       - 20.x
       - 19.x
-permissions:
+permissions: # For test comment bot
   checks: write
   pull-requests: write
 jobs:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,6 +11,9 @@ on:
       - 21.x
       - 20.x
       - 19.x
+permissions:
+  checks: write
+  pull-requests: write
 jobs:
   buildAndTest:
     runs-on: ubuntu-latest
@@ -24,3 +27,9 @@ jobs:
           distribution: 'corretto'
       - name: build and test
         run: ./gradlew assemble && ./gradlew check --info --stacktrace
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2.18.0
+        if: always()
+        with:
+          files: '**/build/test-results/test/TEST-*.xml'
+

--- a/src/test/groovy/graphql/schema/DataFetcherFactoriesTest.groovy
+++ b/src/test/groovy/graphql/schema/DataFetcherFactoriesTest.groovy
@@ -10,6 +10,11 @@ class DataFetcherFactoriesTest extends Specification {
     def cfDF = new StaticDataFetcher(CompletableFuture.completedFuture("hello"))
     def pojoDF = new StaticDataFetcher("goodbye")
 
+    def "testing the GitHub Action on failing tests"() {
+        // TODO: I will remove this test before merging the PR. This is only to generate a test failure message.
+        false
+    }
+
     def "delegation happens as expected"() {
         given:
 

--- a/src/test/groovy/graphql/schema/DataFetcherFactoriesTest.groovy
+++ b/src/test/groovy/graphql/schema/DataFetcherFactoriesTest.groovy
@@ -12,7 +12,13 @@ class DataFetcherFactoriesTest extends Specification {
 
     def "testing the GitHub Action on failing tests"() {
         // TODO: I will remove this test before merging the PR. This is only to generate a test failure message.
-        false
+        def fetcherFactory = DataFetcherFactories.useDataFetcher(pojoDF)
+
+        when:
+        def value = fetcherFactory.get(null).get(null)
+
+        then:
+        value != "goodbye"
     }
 
     def "delegation happens as expected"() {

--- a/src/test/groovy/graphql/schema/DataFetcherFactoriesTest.groovy
+++ b/src/test/groovy/graphql/schema/DataFetcherFactoriesTest.groovy
@@ -10,17 +10,6 @@ class DataFetcherFactoriesTest extends Specification {
     def cfDF = new StaticDataFetcher(CompletableFuture.completedFuture("hello"))
     def pojoDF = new StaticDataFetcher("goodbye")
 
-    def "testing the GitHub Action on failing tests"() {
-        // TODO: I will remove this test before merging the PR. This is only to generate a test failure message.
-        def fetcherFactory = DataFetcherFactories.useDataFetcher(pojoDF)
-
-        when:
-        def value = fetcherFactory.get(null).get(null)
-
-        then:
-        value != "goodbye"
-    }
-
     def "delegation happens as expected"() {
         given:
 


### PR DESCRIPTION
Trying out this GitHub Action to help highlight which tests are failing in a PR or master build, because it's getting hard to read which test failed in plain text output with thousands of tests

GitHub Action source repo: https://github.com/EnricoMi/publish-unit-test-result-action