### PR TITLE
Filter out negative line and column error locations in toSpecification

### DIFF
--- a/src/main/java/graphql/GraphqlErrorHelper.java
+++ b/src/main/java/graphql/GraphqlErrorHelper.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import static graphql.collect.ImmutableKit.map;
+import static graphql.collect.ImmutableKit.mapAndDropNulls;
 
 /**
  * This little helper allows GraphQlErrors to implement
@@ -51,14 +51,20 @@ public class GraphqlErrorHelper {
     }
 
     public static Object locations(List<SourceLocation> locations) {
-        return map(locations, GraphqlErrorHelper::location);
+        return mapAndDropNulls(locations, GraphqlErrorHelper::location);
     }
 
+    /**
+     *  Positive integers starting from 1 required for error locations,
+     *  from the spec <a href="https://spec.graphql.org/draft/#sec-Errors.Error-Result-Format">...</a>
+     */
     public static Object location(SourceLocation location) {
-        Map<String, Integer> map = new LinkedHashMap<>();
-        map.put("line", location.getLine());
-        map.put("column", location.getColumn());
-        return map;
+        int line = location.getLine();
+        int column = location.getColumn();
+        if (line < 1 || column < 1) {
+            return null;
+        }
+        return Map.of("line", line, "column", column);
     }
 
     public static int hashCode(GraphQLError dis) {


### PR DESCRIPTION
Fixes https://github.com/graphql-java/graphql-java/issues/3661

Internally graphql-java represents an "empty" `SourceLocation` as line -1 and column -1. 
https://github.com/graphql-java/graphql-java/blob/ee32161909b10a80659aa5d8e7495f07519026d1/src/main/java/graphql/parser/ExtendedBailStrategy.java#L72

However in the issue raised it turns out the specification requires these numbers to be positive integers, starting at 1. https://spec.graphql.org/draft/#sel-GAPHRPFCCaCGX5zM

This PR updates the toSpecification method to filter out error locations that do not have both a positive line and column number. This only changes `toSpecification` and not any internal representation of SourceLocation.

This could be considered a breaking change, however it's necessary to bring behaviour in line with the spec.