### PR TITLE
Singleton property data fetcher

### DIFF
--- a/src/main/java/graphql/schema/DataFetcherFactories.java
+++ b/src/main/java/graphql/schema/DataFetcherFactories.java
@@ -20,7 +20,17 @@ public class DataFetcherFactories {
      * @return a data fetcher factory that always returns the provided data fetcher
      */
     public static <T> DataFetcherFactory<T> useDataFetcher(DataFetcher<T> dataFetcher) {
-        return fieldDefinition -> dataFetcher;
+        return new DataFetcherFactory<T>() {
+            @Override
+            public DataFetcher<T> get(DataFetcherFactoryEnvironment environment) {
+                return dataFetcher;
+            }
+
+            @Override
+            public DataFetcher<T> getViaField(GraphQLFieldDefinition fieldDefinition) {
+                return dataFetcher;
+            }
+        };
     }
 
     /**

--- a/src/main/java/graphql/schema/DataFetcherFactories.java
+++ b/src/main/java/graphql/schema/DataFetcherFactories.java
@@ -20,14 +20,15 @@ public class DataFetcherFactories {
      * @return a data fetcher factory that always returns the provided data fetcher
      */
     public static <T> DataFetcherFactory<T> useDataFetcher(DataFetcher<T> dataFetcher) {
-        return new DataFetcherFactory<T>() {
+        //noinspection deprecation
+        return new DataFetcherFactory<>() {
             @Override
             public DataFetcher<T> get(DataFetcherFactoryEnvironment environment) {
                 return dataFetcher;
             }
 
             @Override
-            public DataFetcher<T> getViaField(GraphQLFieldDefinition fieldDefinition) {
+            public DataFetcher<T> get(GraphQLFieldDefinition fieldDefinition) {
                 return dataFetcher;
             }
         };
@@ -42,7 +43,7 @@ public class DataFetcherFactories {
      *
      * @return a new data fetcher that wraps the provided data fetcher
      */
-    public static DataFetcher wrapDataFetcher(DataFetcher delegateDataFetcher, BiFunction<DataFetchingEnvironment, Object, Object> mapFunction) {
+    public static DataFetcher<?> wrapDataFetcher(DataFetcher<?> delegateDataFetcher, BiFunction<DataFetchingEnvironment, Object, Object> mapFunction) {
         return environment -> {
             Object value = delegateDataFetcher.get(environment);
             if (value instanceof CompletionStage) {

--- a/src/main/java/graphql/schema/DataFetcherFactory.java
+++ b/src/main/java/graphql/schema/DataFetcherFactory.java
@@ -22,4 +22,17 @@ public interface DataFetcherFactory<T> {
      */
     DataFetcher<T> get(DataFetcherFactoryEnvironment environment);
 
+    /**
+     * Returns a {@link graphql.schema.DataFetcher} given the field definition
+     * which is cheaper in object allocation terms.
+     *
+     * @param fieldDefinition the field that needs the data fetcher
+     *
+     * @return a data fetcher
+     */
+
+    default DataFetcher<T> getViaField(GraphQLFieldDefinition fieldDefinition) {
+        return null;
+    }
+
 }

--- a/src/main/java/graphql/schema/DataFetcherFactory.java
+++ b/src/main/java/graphql/schema/DataFetcherFactory.java
@@ -19,7 +19,10 @@ public interface DataFetcherFactory<T> {
      * @param environment the environment that needs the data fetcher
      *
      * @return a data fetcher
+     *
+     * @deprecated This method will go away at some point and {@link DataFetcherFactory#get(GraphQLFieldDefinition)} will be used
      */
+    @Deprecated(since = "2024-11-26")
     DataFetcher<T> get(DataFetcherFactoryEnvironment environment);
 
     /**
@@ -31,7 +34,7 @@ public interface DataFetcherFactory<T> {
      * @return a data fetcher
      */
 
-    default DataFetcher<T> getViaField(GraphQLFieldDefinition fieldDefinition) {
+    default DataFetcher<T> get(GraphQLFieldDefinition fieldDefinition) {
         return null;
     }
 

--- a/src/main/java/graphql/schema/DataFetcherFactoryEnvironment.java
+++ b/src/main/java/graphql/schema/DataFetcherFactoryEnvironment.java
@@ -5,8 +5,12 @@ import graphql.PublicApi;
 /**
  * This is passed to a {@link graphql.schema.DataFetcherFactory} when it is invoked to
  * get a {@link graphql.schema.DataFetcher}
+ *
+ * @deprecated This class will go away at some point in the future since its pointless wrapper
+ * of a {@link GraphQLFieldDefinition}
  */
 @PublicApi
+@Deprecated(since = "2024-11-26")
 public class DataFetcherFactoryEnvironment {
     private final GraphQLFieldDefinition fieldDefinition;
 

--- a/src/main/java/graphql/schema/GraphQLCodeRegistry.java
+++ b/src/main/java/graphql/schema/GraphQLCodeRegistry.java
@@ -95,9 +95,15 @@ public class GraphQLCodeRegistry {
                 dataFetcherFactory = defaultDataFetcherFactory;
             }
         }
-        return dataFetcherFactory.get(newDataFetchingFactoryEnvironment()
-                .fieldDefinition(fieldDefinition)
-                .build());
+        // call direct from the field - cheaper to not make a new environment object
+        DataFetcher<?> dataFetcher = dataFetcherFactory.getViaField(fieldDefinition);
+        if (dataFetcher == null) {
+            DataFetcherFactoryEnvironment factoryEnvironment = newDataFetchingFactoryEnvironment()
+                    .fieldDefinition(fieldDefinition)
+                    .build();
+            dataFetcher = dataFetcherFactory.get(factoryEnvironment);
+        }
+        return dataFetcher;
     }
 
     private static boolean hasDataFetcherImpl(FieldCoordinates coords, Map<FieldCoordinates, DataFetcherFactory<?>> dataFetcherMap, Map<String, DataFetcherFactory<?>> systemDataFetcherMap) {

--- a/src/main/java/graphql/schema/GraphQLCodeRegistry.java
+++ b/src/main/java/graphql/schema/GraphQLCodeRegistry.java
@@ -84,6 +84,7 @@ public class GraphQLCodeRegistry {
         return hasDataFetcherImpl(coordinates, dataFetcherMap, systemDataFetcherMap);
     }
 
+    @SuppressWarnings("deprecation")
     private static DataFetcher<?> getDataFetcherImpl(FieldCoordinates coordinates, GraphQLFieldDefinition fieldDefinition, Map<FieldCoordinates, DataFetcherFactory<?>> dataFetcherMap, Map<String, DataFetcherFactory<?>> systemDataFetcherMap, DataFetcherFactory<?> defaultDataFetcherFactory) {
         assertNotNull(coordinates);
         assertNotNull(fieldDefinition);
@@ -96,7 +97,7 @@ public class GraphQLCodeRegistry {
             }
         }
         // call direct from the field - cheaper to not make a new environment object
-        DataFetcher<?> dataFetcher = dataFetcherFactory.getViaField(fieldDefinition);
+        DataFetcher<?> dataFetcher = dataFetcherFactory.get(fieldDefinition);
         if (dataFetcher == null) {
             DataFetcherFactoryEnvironment factoryEnvironment = newDataFetchingFactoryEnvironment()
                     .fieldDefinition(fieldDefinition)

--- a/src/main/java/graphql/schema/GraphQLCodeRegistry.java
+++ b/src/main/java/graphql/schema/GraphQLCodeRegistry.java
@@ -189,7 +189,7 @@ public class GraphQLCodeRegistry {
         private final Map<String, DataFetcherFactory<?>> systemDataFetcherMap = new LinkedHashMap<>();
         private final Map<String, TypeResolver> typeResolverMap = new HashMap<>();
         private GraphqlFieldVisibility fieldVisibility = DEFAULT_FIELD_VISIBILITY;
-        private DataFetcherFactory<?> defaultDataFetcherFactory = env -> PropertyDataFetcher.fetching(env.getFieldDefinition().getName());
+        private DataFetcherFactory<?> defaultDataFetcherFactory = PropertyDataFetcher.singletonFactory();
         private boolean changed = false;
 
         private Builder() {

--- a/src/main/java/graphql/schema/PropertyDataFetcher.java
+++ b/src/main/java/graphql/schema/PropertyDataFetcher.java
@@ -40,7 +40,17 @@ public class PropertyDataFetcher<T> implements LightDataFetcher<T> {
         }
     };
 
-    private static final DataFetcherFactory<?> SINGLETON_FETCHER_FACTORY = environment -> SINGLETON_FETCHER;
+    private static final DataFetcherFactory<?> SINGLETON_FETCHER_FACTORY = new DataFetcherFactory<Object>() {
+        @Override
+        public DataFetcher<Object> get(DataFetcherFactoryEnvironment environment) {
+            return SINGLETON_FETCHER;
+        }
+
+        @Override
+        public DataFetcher<Object> getViaField(GraphQLFieldDefinition fieldDefinition) {
+            return SINGLETON_FETCHER;
+        }
+    };
 
     /**
      * This returns the same singleton {@link PropertyDataFetcher} that fetches property values

--- a/src/main/java/graphql/schema/idl/MockedWiringFactory.java
+++ b/src/main/java/graphql/schema/idl/MockedWiringFactory.java
@@ -44,7 +44,7 @@ public class MockedWiringFactory implements WiringFactory {
 
     @Override
     public DataFetcher getDataFetcher(FieldWiringEnvironment environment) {
-        return new PropertyDataFetcher(environment.getFieldDefinition().getName());
+        return PropertyDataFetcher.singleton();
     }
 
     @Override

--- a/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
+++ b/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
@@ -849,7 +849,7 @@ public class SchemaGeneratorHelper {
                             if (codeRegistryDFF != null) {
                                 return codeRegistryDFF;
                             }
-                            dataFetcher = dataFetcherOfLastResort(wiringEnvironment);
+                            dataFetcher = dataFetcherOfLastResort();
                         }
                     }
                 }
@@ -1087,9 +1087,8 @@ public class SchemaGeneratorHelper {
         return Optional.ofNullable(operationTypeDefs.get(name));
     }
 
-    private DataFetcher<?> dataFetcherOfLastResort(FieldWiringEnvironment environment) {
-        String fieldName = environment.getFieldDefinition().getName();
-        return new PropertyDataFetcher(fieldName);
+    private DataFetcher<?> dataFetcherOfLastResort() {
+        return PropertyDataFetcher.singleton();
     }
 
     private List<Directive> directivesOf(List<? extends TypeDefinition<?>> typeDefinitions) {

--- a/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
+++ b/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
@@ -801,23 +801,27 @@ public class SchemaGeneratorHelper {
         // if they have already wired in a fetcher - then leave it alone
         FieldCoordinates coordinates = FieldCoordinates.coordinates(parentType.getName(), fieldDefinition.getName());
         if (!buildCtx.getCodeRegistry().hasDataFetcher(coordinates)) {
-            DataFetcherFactory<?> dataFetcherFactory = buildDataFetcherFactory(buildCtx,
+            Optional<DataFetcherFactory<?>> dataFetcherFactory = buildDataFetcherFactory(buildCtx,
                     parentType,
                     fieldDef,
                     fieldType,
                     appliedDirectives.first,
                     appliedDirectives.second);
-            buildCtx.getCodeRegistry().dataFetcher(coordinates, dataFetcherFactory);
+
+            // if the dataFetcherFactory is empty, then it must have been the code registry default one
+            // and hence we don't need to make a "map entry" in the code registry since it will be defaulted
+            // anyway
+            dataFetcherFactory.ifPresent(fetcherFactory -> buildCtx.getCodeRegistry().dataFetcher(coordinates, fetcherFactory));
         }
         return directivesObserve(buildCtx, fieldDefinition);
     }
 
-    private DataFetcherFactory<?> buildDataFetcherFactory(BuildContext buildCtx,
-                                                          TypeDefinition<?> parentType,
-                                                          FieldDefinition fieldDef,
-                                                          GraphQLOutputType fieldType,
-                                                          List<GraphQLDirective> directives,
-                                                          List<GraphQLAppliedDirective> appliedDirectives) {
+    private Optional<DataFetcherFactory<?>> buildDataFetcherFactory(BuildContext buildCtx,
+                                                                    TypeDefinition<?> parentType,
+                                                                    FieldDefinition fieldDef,
+                                                                    GraphQLOutputType fieldType,
+                                                                    List<GraphQLDirective> directives,
+                                                                    List<GraphQLAppliedDirective> appliedDirectives) {
         String fieldName = fieldDef.getName();
         String parentTypeName = parentType.getName();
         TypeDefinitionRegistry typeRegistry = buildCtx.getTypeRegistry();
@@ -847,7 +851,9 @@ public class SchemaGeneratorHelper {
                         if (dataFetcher == null) {
                             DataFetcherFactory<?> codeRegistryDFF = codeRegistry.getDefaultDataFetcherFactory();
                             if (codeRegistryDFF != null) {
-                                return codeRegistryDFF;
+                                // this will use the default of the code registry when its
+                                // asked for at runtime
+                                return Optional.empty();
                             }
                             dataFetcher = dataFetcherOfLastResort();
                         }
@@ -856,7 +862,7 @@ public class SchemaGeneratorHelper {
             }
             dataFetcherFactory = DataFetcherFactories.useDataFetcher(dataFetcher);
         }
-        return dataFetcherFactory;
+        return Optional.of(dataFetcherFactory);
     }
 
     GraphQLArgument buildArgument(BuildContext buildCtx, InputValueDefinition valueDefinition) {

--- a/src/test/groovy/graphql/DataFetcherTest.groovy
+++ b/src/test/groovy/graphql/DataFetcherTest.groovy
@@ -56,14 +56,14 @@ class DataFetcherTest extends Specification {
 
     }
 
-    def mkDFE(String propertyName, GraphQLOutputType type) {
+    def env(String propertyName, GraphQLOutputType type) {
         def fieldDefinition = GraphQLFieldDefinition.newFieldDefinition().name(propertyName).type(type).build()
         newDataFetchingEnvironment().source(dataHolder).fieldType(type).fieldDefinition(fieldDefinition).build()
     }
 
     def "get property value"() {
         given:
-        def environment = mkDFE("property", GraphQLString)
+        def environment = env("property", GraphQLString)
         when:
         def result = fetcher.get(environment)
         then:
@@ -77,7 +77,7 @@ class DataFetcherTest extends Specification {
 
     def "get Boolean property value"() {
         given:
-        def environment = mkDFE("booleanField", GraphQLBoolean)
+        def environment = env("booleanField", GraphQLBoolean)
         when:
         def result = fetcher.get(environment)
         then:
@@ -91,7 +91,7 @@ class DataFetcherTest extends Specification {
 
     def "get Boolean property value with get"() {
         given:
-        def environment = mkDFE("booleanFieldWithGet", GraphQLBoolean)
+        def environment = env("booleanFieldWithGet", GraphQLBoolean)
         when:
         def result = fetcher.get(environment)
         then:
@@ -105,7 +105,7 @@ class DataFetcherTest extends Specification {
 
     def "get public field value as property"() {
         given:
-        def environment = mkDFE("publicField", GraphQLString)
+        def environment = env("publicField", GraphQLString)
         when:
         def result = fetcher.get(environment)
         then:

--- a/src/test/groovy/graphql/DataFetcherTest.groovy
+++ b/src/test/groovy/graphql/DataFetcherTest.groovy
@@ -1,6 +1,7 @@
 package graphql
 
 
+import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLOutputType
 import graphql.schema.PropertyDataFetcher
 import spock.lang.Specification
@@ -55,43 +56,64 @@ class DataFetcherTest extends Specification {
 
     }
 
-    def env(GraphQLOutputType type) {
-        newDataFetchingEnvironment().source(dataHolder).fieldType(type).build()
+    def mkDFE(String propertyName, GraphQLOutputType type) {
+        def fieldDefinition = GraphQLFieldDefinition.newFieldDefinition().name(propertyName).type(type).build()
+        newDataFetchingEnvironment().source(dataHolder).fieldType(type).fieldDefinition(fieldDefinition).build()
     }
 
     def "get property value"() {
         given:
-        def environment = env(GraphQLString)
+        def environment = mkDFE("property", GraphQLString)
         when:
-        def result = new PropertyDataFetcher("property").get(environment)
+        def result = fetcher.get(environment)
         then:
         result == "propertyValue"
+
+        where:
+        fetcher                             | _
+        new PropertyDataFetcher("property") | _
+        PropertyDataFetcher.singleton()     | _
     }
 
     def "get Boolean property value"() {
         given:
-        def environment = env(GraphQLBoolean)
+        def environment = mkDFE("booleanField", GraphQLBoolean)
         when:
-        def result = new PropertyDataFetcher("booleanField").get(environment)
+        def result = fetcher.get(environment)
         then:
         result == true
+
+        where:
+        fetcher                                 | _
+        new PropertyDataFetcher("booleanField") | _
+        PropertyDataFetcher.singleton()         | _
     }
 
     def "get Boolean property value with get"() {
         given:
-        def environment = env(GraphQLBoolean)
+        def environment = mkDFE("booleanFieldWithGet", GraphQLBoolean)
         when:
-        def result = new PropertyDataFetcher("booleanFieldWithGet").get(environment)
+        def result = fetcher.get(environment)
         then:
         result == false
+
+        where:
+        fetcher                                        | _
+        new PropertyDataFetcher("booleanFieldWithGet") | _
+        PropertyDataFetcher.singleton()                | _
     }
 
     def "get public field value as property"() {
         given:
-        def environment = env(GraphQLString)
+        def environment = mkDFE("publicField", GraphQLString)
         when:
-        def result = new PropertyDataFetcher("publicField").get(environment)
+        def result = fetcher.get(environment)
         then:
         result == "publicValue"
+
+        where:
+        fetcher                                | _
+        new PropertyDataFetcher("publicField") | _
+        PropertyDataFetcher.singleton()        | _
     }
 }

--- a/src/test/groovy/graphql/LargeSchemaDataFetcherTest.groovy
+++ b/src/test/groovy/graphql/LargeSchemaDataFetcherTest.groovy
@@ -1,0 +1,43 @@
+package graphql
+
+
+import graphql.schema.FieldCoordinates
+import graphql.schema.GraphQLFieldDefinition
+import graphql.schema.PropertyDataFetcher
+import spock.lang.Specification
+
+class LargeSchemaDataFetcherTest extends Specification {
+
+    def howManyFields = 100_000
+
+    def "large schema with lots of fields has a property data fetcher by default"() {
+        def sdl = """
+            type Query {
+                ${mkFields()}
+            }
+        """
+
+        when:
+        def schema = TestUtil.schema(sdl)
+        def codeRegistry = schema.getCodeRegistry()
+
+        then:
+
+        for (int i = 0; i < howManyFields; i++) {
+            def fieldName = "f$i"
+            def fieldDef = GraphQLFieldDefinition.newFieldDefinition().name(fieldName).type(Scalars.GraphQLString).build()
+            def df = codeRegistry.getDataFetcher(FieldCoordinates.coordinates("Query", fieldName), fieldDef)
+
+            // in the future we hope to make this the same DF instance
+            assert df instanceof PropertyDataFetcher
+        }
+    }
+
+    def mkFields() {
+        StringBuilder sb = new StringBuilder()
+        for (int i = 0; i < howManyFields; i++) {
+            sb.append("f$i : String\n")
+        }
+        return sb.toString()
+    }
+}

--- a/src/test/groovy/graphql/LargeSchemaDataFetcherTest.groovy
+++ b/src/test/groovy/graphql/LargeSchemaDataFetcherTest.groovy
@@ -21,15 +21,15 @@ class LargeSchemaDataFetcherTest extends Specification {
         def schema = TestUtil.schema(sdl)
         def codeRegistry = schema.getCodeRegistry()
 
+        def singletonDF = PropertyDataFetcher.singleton()
+
         then:
 
         for (int i = 0; i < howManyFields; i++) {
             def fieldName = "f$i"
             def fieldDef = GraphQLFieldDefinition.newFieldDefinition().name(fieldName).type(Scalars.GraphQLString).build()
             def df = codeRegistry.getDataFetcher(FieldCoordinates.coordinates("Query", fieldName), fieldDef)
-
-            // in the future we hope to make this the same DF instance
-            assert df instanceof PropertyDataFetcher
+            assert df == singletonDF
         }
     }
 

--- a/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
@@ -99,7 +99,7 @@ class InstrumentationTest extends Specification {
 
         instrumentation.dfClasses.size() == 2
         instrumentation.dfClasses[0] == StaticDataFetcher.class
-        instrumentation.dfClasses[1] == PropertyDataFetcher.class
+        PropertyDataFetcher.isAssignableFrom(instrumentation.dfClasses[1])
 
         instrumentation.dfInvocations.size() == 2
 

--- a/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
@@ -15,6 +15,7 @@ import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironment
 import graphql.schema.LightDataFetcher
 import graphql.schema.PropertyDataFetcher
+import graphql.schema.SingletonPropertyDataFetcher
 import graphql.schema.StaticDataFetcher
 import org.awaitility.Awaitility
 import org.jetbrains.annotations.NotNull
@@ -100,7 +101,7 @@ class InstrumentationTest extends Specification {
 
         instrumentation.dfClasses.size() == 2
         instrumentation.dfClasses[0] == StaticDataFetcher.class
-        LightDataFetcher.class.isAssignableFrom(instrumentation.dfClasses[1])
+        instrumentation.dfClasses[1] == SingletonPropertyDataFetcher.class
 
         instrumentation.dfInvocations.size() == 2
 

--- a/src/test/groovy/graphql/schema/DataFetcherFactoriesTest.groovy
+++ b/src/test/groovy/graphql/schema/DataFetcherFactoriesTest.groovy
@@ -32,7 +32,7 @@ class DataFetcherFactoriesTest extends Specification {
         def fetcherFactory = DataFetcherFactories.useDataFetcher(pojoDF)
 
         when:
-        def value = fetcherFactory.get(null).get(null)
+        def value = fetcherFactory.get((GraphQLFieldDefinition)null).get(null)
 
         then:
         value == "goodbye"
@@ -42,7 +42,7 @@ class DataFetcherFactoriesTest extends Specification {
         def fetcherFactory = DataFetcherFactories.useDataFetcher(pojoDF)
 
         when:
-        def value = fetcherFactory.getViaField(null).get(null)
+        def value = fetcherFactory.get((GraphQLFieldDefinition) null).get(null)
 
         then:
         value == "goodbye"

--- a/src/test/groovy/graphql/schema/DataFetcherFactoriesTest.groovy
+++ b/src/test/groovy/graphql/schema/DataFetcherFactoriesTest.groovy
@@ -37,4 +37,14 @@ class DataFetcherFactoriesTest extends Specification {
         then:
         value == "goodbye"
     }
+
+    def "will use given df via field"() {
+        def fetcherFactory = DataFetcherFactories.useDataFetcher(pojoDF)
+
+        when:
+        def value = fetcherFactory.getViaField(null).get(null)
+
+        then:
+        value == "goodbye"
+    }
 }

--- a/src/test/groovy/graphql/schema/GraphQLCodeRegistryTest.groovy
+++ b/src/test/groovy/graphql/schema/GraphQLCodeRegistryTest.groovy
@@ -288,7 +288,7 @@ class GraphQLCodeRegistryTest extends Specification {
 
         // when nothing is specified then its a plain old PropertyDataFetcher
         def queryType = schema.getObjectType("Query")
-        schema.getCodeRegistry().getDataFetcher(queryType, queryType.getFieldDefinition("neitherSpecified")) instanceof LightDataFetcher
+        schema.getCodeRegistry().getDataFetcher(queryType, queryType.getFieldDefinition("neitherSpecified")) instanceof SingletonPropertyDataFetcher
     }
 
     def "will detect system versus user data fetchers"() {

--- a/src/test/groovy/graphql/schema/PropertyDataFetcherTest.groovy
+++ b/src/test/groovy/graphql/schema/PropertyDataFetcherTest.groovy
@@ -35,7 +35,7 @@ class PropertyDataFetcherTest extends Specification {
         PropertyDataFetcherHelper.setUseLambdaFactory(true)
     }
 
-    def mkDFE(String propertyName, Object obj) {
+    def env(String propertyName, Object obj) {
         def fieldDefinition = GraphQLFieldDefinition.newFieldDefinition().name(propertyName).type(Scalars.GraphQLString).build()
         newDataFetchingEnvironment()
                 .source(obj)
@@ -50,7 +50,7 @@ class PropertyDataFetcherTest extends Specification {
 
     def "null source is always null"() {
         given:
-        def environment = mkDFE("someProperty", null)
+        def environment = env("someProperty", null)
 
         expect:
         fetcher.get(environment) == null
@@ -62,7 +62,7 @@ class PropertyDataFetcherTest extends Specification {
     }
 
     def "function based fetcher works with non null source"() {
-        def environment = mkDFE("notused", new SomeObject(value: "aValue"))
+        def environment = env("notused", new SomeObject(value: "aValue"))
         Function<Object, String> f = { obj -> obj['value'] }
         def fetcher = PropertyDataFetcher.fetching(f)
         expect:
@@ -70,7 +70,7 @@ class PropertyDataFetcherTest extends Specification {
     }
 
     def "function based fetcher works with null source"() {
-        def environment = mkDFE("notused", null)
+        def environment = env("notused", null)
         Function<Object, String> f = { obj -> obj['value'] }
         def fetcher = PropertyDataFetcher.fetching(f)
         expect:
@@ -79,7 +79,7 @@ class PropertyDataFetcherTest extends Specification {
 
     def "fetch via map lookup"() {
         given:
-        def environment = mkDFE("mapProperty", ["mapProperty": "aValue"])
+        def environment = env("mapProperty", ["mapProperty": "aValue"])
 
         expect:
         fetcher.get(environment) == "aValue"
@@ -92,7 +92,7 @@ class PropertyDataFetcherTest extends Specification {
 
     def "fetch via public getter with private subclass"() {
         given:
-        def environment = mkDFE("packageProtectedProperty", TestClass.createPackageProtectedImpl("aValue"))
+        def environment = env("packageProtectedProperty", TestClass.createPackageProtectedImpl("aValue"))
 
         expect:
         fetcher.get(environment) == "aValue"
@@ -105,7 +105,7 @@ class PropertyDataFetcherTest extends Specification {
 
     def "fetch via method that isn't present"() {
         given:
-        def environment = mkDFE("valueNotPresent", new TestClass())
+        def environment = env("valueNotPresent", new TestClass())
 
         when:
         def result = fetcher.get(environment)
@@ -122,7 +122,7 @@ class PropertyDataFetcherTest extends Specification {
 
     def "fetch via method that is private"() {
         given:
-        def environment = mkDFE("privateProperty", new TestClass())
+        def environment = env("privateProperty", new TestClass())
 
         when:
         def result = fetcher.get(environment)
@@ -140,7 +140,7 @@ class PropertyDataFetcherTest extends Specification {
     def "fetch via method that is private with setAccessible OFF"() {
         given:
         PropertyDataFetcher.setUseSetAccessible(false)
-        def environment = mkDFE("privateProperty", new TestClass())
+        def environment = env("privateProperty", new TestClass())
 
         when:
         def result = fetcher.get(environment)
@@ -157,7 +157,7 @@ class PropertyDataFetcherTest extends Specification {
 
     def "fetch via record method"() {
         given:
-        def environment = mkDFE("recordProperty", new RecordLikeClass())
+        def environment = env("recordProperty", new RecordLikeClass())
 
         when:
         def fetcher = new PropertyDataFetcher("recordProperty")
@@ -204,7 +204,7 @@ class PropertyDataFetcherTest extends Specification {
 
     def "fetch via record method with singleton fetcher"() {
         given:
-        def environment = mkDFE("recordProperty", new RecordLikeClass())
+        def environment = env("recordProperty", new RecordLikeClass())
 
         when:
         def fetcher = PropertyDataFetcher.singleton()
@@ -215,7 +215,7 @@ class PropertyDataFetcherTest extends Specification {
 
     def "can fetch record like methods that are public and on super classes"() {
         given:
-        def environment = mkDFE("recordProperty", new RecordLikeTwoClassesDown())
+        def environment = env("recordProperty", new RecordLikeTwoClassesDown())
 
         when:
         def result = fetcher.get(environment)
@@ -235,7 +235,7 @@ class PropertyDataFetcherTest extends Specification {
         PropertyDataFetcherHelper.clearReflectionCache()
 
         when:
-        def environment = mkDFE("recordProperty", new RecordLikeClass())
+        def environment = env("recordProperty", new RecordLikeClass())
         def fetcher = new PropertyDataFetcher("recordProperty")
         def result = fetcher.get(environment)
 
@@ -243,7 +243,7 @@ class PropertyDataFetcherTest extends Specification {
         result == "recordProperty"
 
         when:
-        environment = mkDFE("recordProperty", new RecordLikeTwoClassesDown())
+        environment = env("recordProperty", new RecordLikeTwoClassesDown())
         fetcher = new PropertyDataFetcher("recordProperty")
         result = fetcher.get(environment)
 
@@ -257,7 +257,7 @@ class PropertyDataFetcherTest extends Specification {
         PropertyDataFetcherHelper.clearReflectionCache()
 
         when:
-        def environment = mkDFE("recordLike", new ConfusedPojo())
+        def environment = env("recordLike", new ConfusedPojo())
         def result = fetcher.get(environment)
 
         then:
@@ -271,7 +271,7 @@ class PropertyDataFetcherTest extends Specification {
 
     def "fetch via public method"() {
         given:
-        def environment = mkDFE("publicProperty", new TestClass())
+        def environment = env("publicProperty", new TestClass())
 
         when:
         def result = fetcher.get(environment)
@@ -288,7 +288,7 @@ class PropertyDataFetcherTest extends Specification {
 
     def "fetch via public method declared two classes up"() {
         given:
-        def environment = mkDFE("publicProperty", new TwoClassesDown("aValue"))
+        def environment = env("publicProperty", new TwoClassesDown("aValue"))
         def fetcher = new PropertyDataFetcher("publicProperty")
 
         when:
@@ -305,7 +305,7 @@ class PropertyDataFetcherTest extends Specification {
 
     def "fetch via property only defined on package protected impl"() {
         given:
-        def environment = mkDFE("propertyOnlyDefinedOnPackageProtectedImpl", TestClass.createPackageProtectedImpl("aValue"))
+        def environment = env("propertyOnlyDefinedOnPackageProtectedImpl", TestClass.createPackageProtectedImpl("aValue"))
 
         when:
         def result = fetcher.get(environment)
@@ -323,7 +323,7 @@ class PropertyDataFetcherTest extends Specification {
     def "fetch via public field"() {
         given:
 
-        def environment = mkDFE("publicField", new TestClass())
+        def environment = env("publicField", new TestClass())
         def result = fetcher.get(environment)
 
         expect:
@@ -337,7 +337,7 @@ class PropertyDataFetcherTest extends Specification {
 
     def "fetch via private field"() {
         given:
-        def environment = mkDFE("privateField", new TestClass())
+        def environment = env("privateField", new TestClass())
         def result = fetcher.get(environment)
 
         expect:
@@ -352,7 +352,7 @@ class PropertyDataFetcherTest extends Specification {
     def "fetch via private field when setAccessible OFF"() {
         given:
         PropertyDataFetcher.setUseSetAccessible(false)
-        def environment = mkDFE("privateField", new TestClass())
+        def environment = env("privateField", new TestClass())
         def result = fetcher.get(environment)
 
         expect:
@@ -366,7 +366,7 @@ class PropertyDataFetcherTest extends Specification {
 
     def "fetch when caching is in place has no bad effects"() {
 
-        def environment = mkDFE("publicProperty", new TestClass())
+        def environment = env("publicProperty", new TestClass())
         def fetcher = new PropertyDataFetcher("publicProperty")
         when:
         def result = fetcher.get(environment)
@@ -441,7 +441,7 @@ class PropertyDataFetcherTest extends Specification {
 
     def "support for DFE on methods"() {
         given:
-        def environment = mkDFE("methodWithDFE", new ClassWithDFEMethods())
+        def environment = env("methodWithDFE", new ClassWithDFEMethods())
         def fetcher = new PropertyDataFetcher("methodWithDFE")
 
         when:
@@ -495,7 +495,7 @@ class PropertyDataFetcherTest extends Specification {
 
     def "finds interface methods"() {
         when:
-        def environment = mkDFE("methodYouMustImplement", new ClassWithInterfaces())
+        def environment = env("methodYouMustImplement", new ClassWithInterfaces())
         def fetcher = new PropertyDataFetcher("methodYouMustImplement")
         def result = fetcher.get(environment)
         then:
@@ -522,7 +522,7 @@ class PropertyDataFetcherTest extends Specification {
     }
 
     def "finds interface methods with inheritance"() {
-        def environment = mkDFE("methodYouMustImplement", new ClassWithInteritanceAndInterfaces.StartingClass())
+        def environment = env("methodYouMustImplement", new ClassWithInteritanceAndInterfaces.StartingClass())
 
         when:
         def fetcher = new PropertyDataFetcher("methodYouMustImplement")
@@ -536,7 +536,7 @@ class PropertyDataFetcherTest extends Specification {
         then:
         result == "methodThatIsADefault"
 
-        def environment2 = mkDFE("methodYouMustImplement", new ClassWithInteritanceAndInterfaces.InheritedClass())
+        def environment2 = env("methodYouMustImplement", new ClassWithInteritanceAndInterfaces.InheritedClass())
 
         when:
         fetcher = new PropertyDataFetcher("methodYouMustImplement")
@@ -565,7 +565,7 @@ class PropertyDataFetcherTest extends Specification {
 
     def "ensure DFE is passed to method"() {
 
-        def environment = mkDFE("methodUsesDataFetchingEnvironment", new ClassWithDFEMethods())
+        def environment = env("methodUsesDataFetchingEnvironment", new ClassWithDFEMethods())
         def fetcher = new PropertyDataFetcher("methodUsesDataFetchingEnvironment")
         when:
         def result = fetcher.get(environment)
@@ -580,7 +580,7 @@ class PropertyDataFetcherTest extends Specification {
     }
 
     def "negative caching works as expected"() {
-        def environment = mkDFE("doesNotExist", new ClassWithDFEMethods())
+        def environment = env("doesNotExist", new ClassWithDFEMethods())
         def fetcher = new PropertyDataFetcher("doesNotExist")
         when:
         def result = fetcher.get(environment)
@@ -671,7 +671,7 @@ class PropertyDataFetcherTest extends Specification {
     def "search for private getter in class hierarchy"() {
         given:
         Bar bar = new Baz()
-        def dfe = mkDFE("something", bar)
+        def dfe = env("something", bar)
 
         when:
         def result = fetcher.get(dfe)
@@ -695,7 +695,7 @@ class PropertyDataFetcherTest extends Specification {
     def "issue 3247 - record like statics should not be used"() {
         given:
         def payload = new UpdateOrganizerSubscriptionPayload(true, new OrganizerSubscriptionError())
-        def dfe = mkDFE("success", payload)
+        def dfe = env("success", payload)
 
         when:
         def result = fetcher.get(dfe)
@@ -719,7 +719,7 @@ class PropertyDataFetcherTest extends Specification {
     def "issue 3247 - record like statics should not be found"() {
         given:
         def errorShape = new OrganizerSubscriptionError()
-        def dfe = mkDFE("message", errorShape)
+        def dfe = env("message", errorShape)
 
         when:
         def result = fetcher.get(dfe)
@@ -743,7 +743,7 @@ class PropertyDataFetcherTest extends Specification {
     def "issue 3247 - getter statics should be found"() {
         given:
         def objectInQuestion = new BarClassWithStaticProperties()
-        def dfe = mkDFE("foo", objectInQuestion)
+        def dfe = env("foo", objectInQuestion)
         PropertyDataFetcher propertyDataFetcher = new PropertyDataFetcher("foo")
 
         when:
@@ -794,7 +794,7 @@ class PropertyDataFetcherTest extends Specification {
         Locale oldLocale = Locale.getDefault()
         Locale.setDefault(new Locale("tr", "TR"))
 
-        def environment = mkDFE("id", new OtherObject(id: "aValue"))
+        def environment = env("id", new OtherObject(id: "aValue"))
 
         when:
         def fetcher = PropertyDataFetcher.fetching("id")

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -2282,6 +2282,11 @@ class SchemaGeneratorTest extends Specification {
             DataFetcher get(DataFetcherFactoryEnvironment environment) {
                 return df
             }
+
+            @Override
+            DataFetcher get(GraphQLFieldDefinition fieldDefinition) {
+                return df
+            }
         }
 
         GraphQLCodeRegistry codeRegistry = newCodeRegistry()

--- a/src/test/groovy/graphql/schema/idl/TestLiveMockedWiringFactory.groovy
+++ b/src/test/groovy/graphql/schema/idl/TestLiveMockedWiringFactory.groovy
@@ -74,7 +74,7 @@ class TestLiveMockedWiringFactory implements WiringFactory {
 
     @Override
     DataFetcher getDataFetcher(FieldWiringEnvironment environment) {
-        return new PropertyDataFetcher(environment.getFieldDefinition().getName())
+        return PropertyDataFetcher.singleton()
     }
 
     @Override

--- a/src/test/groovy/graphql/schema/idl/TestMockedWiringFactory.groovy
+++ b/src/test/groovy/graphql/schema/idl/TestMockedWiringFactory.groovy
@@ -49,12 +49,8 @@ class TestMockedWiringFactory implements WiringFactory {
 
     @Override
     boolean providesDataFetcher(FieldWiringEnvironment environment) {
-        return true
-    }
-
-    @Override
-    DataFetcher getDataFetcher(FieldWiringEnvironment environment) {
-        return new PropertyDataFetcher(environment.getFieldDefinition().getName())
+        // rely on defaulting in code registry
+        return false
     }
 
     @Override


### PR DESCRIPTION
This adds support for a singleton property data fetcher

Before we create a `new PropertyDataFetcher()` for every defaulted field in the schema.  

This means for large schemas with 1000s of fields, we have a new object per field that ALWAYS fetches values with the name of the field. 

This can be static and hence we can save memory by default since MOST fields can use this static fetcher