### PR TITLE
SchemaGeneratorHelper that does NOT put in an entry for defaulted values

### DIFF
--- a/src/main/java/graphql/schema/DataFetcherFactories.java
+++ b/src/main/java/graphql/schema/DataFetcherFactories.java
@@ -20,7 +20,17 @@ public class DataFetcherFactories {
      * @return a data fetcher factory that always returns the provided data fetcher
      */
     public static <T> DataFetcherFactory<T> useDataFetcher(DataFetcher<T> dataFetcher) {
-        return fieldDefinition -> dataFetcher;
+        return new DataFetcherFactory<T>() {
+            @Override
+            public DataFetcher<T> get(DataFetcherFactoryEnvironment environment) {
+                return dataFetcher;
+            }
+
+            @Override
+            public DataFetcher<T> getViaField(GraphQLFieldDefinition fieldDefinition) {
+                return dataFetcher;
+            }
+        };
     }
 
     /**

--- a/src/main/java/graphql/schema/DataFetcherFactory.java
+++ b/src/main/java/graphql/schema/DataFetcherFactory.java
@@ -22,4 +22,17 @@ public interface DataFetcherFactory<T> {
      */
     DataFetcher<T> get(DataFetcherFactoryEnvironment environment);
 
+    /**
+     * Returns a {@link graphql.schema.DataFetcher} given the field definition
+     * which is cheaper in object allocation terms.
+     *
+     * @param fieldDefinition the field that needs the data fetcher
+     *
+     * @return a data fetcher
+     */
+
+    default DataFetcher<T> getViaField(GraphQLFieldDefinition fieldDefinition) {
+        return null;
+    }
+
 }

--- a/src/main/java/graphql/schema/GraphQLCodeRegistry.java
+++ b/src/main/java/graphql/schema/GraphQLCodeRegistry.java
@@ -95,9 +95,15 @@ public class GraphQLCodeRegistry {
                 dataFetcherFactory = defaultDataFetcherFactory;
             }
         }
-        return dataFetcherFactory.get(newDataFetchingFactoryEnvironment()
-                .fieldDefinition(fieldDefinition)
-                .build());
+        // call direct from the field - cheaper to not make a new environment object
+        DataFetcher<?> dataFetcher = dataFetcherFactory.getViaField(fieldDefinition);
+        if (dataFetcher == null) {
+            DataFetcherFactoryEnvironment factoryEnvironment = newDataFetchingFactoryEnvironment()
+                    .fieldDefinition(fieldDefinition)
+                    .build();
+            dataFetcher = dataFetcherFactory.get(factoryEnvironment);
+        }
+        return dataFetcher;
     }
 
     private static boolean hasDataFetcherImpl(FieldCoordinates coords, Map<FieldCoordinates, DataFetcherFactory<?>> dataFetcherMap, Map<String, DataFetcherFactory<?>> systemDataFetcherMap) {

--- a/src/main/java/graphql/schema/PropertyDataFetcher.java
+++ b/src/main/java/graphql/schema/PropertyDataFetcher.java
@@ -40,7 +40,17 @@ public class PropertyDataFetcher<T> implements LightDataFetcher<T> {
         }
     };
 
-    private static final DataFetcherFactory<?> SINGLETON_FETCHER_FACTORY = environment -> SINGLETON_FETCHER;
+    private static final DataFetcherFactory<?> SINGLETON_FETCHER_FACTORY = new DataFetcherFactory<Object>() {
+        @Override
+        public DataFetcher<Object> get(DataFetcherFactoryEnvironment environment) {
+            return SINGLETON_FETCHER;
+        }
+
+        @Override
+        public DataFetcher<Object> getViaField(GraphQLFieldDefinition fieldDefinition) {
+            return SINGLETON_FETCHER;
+        }
+    };
 
     /**
      * This returns the same singleton {@link PropertyDataFetcher} that fetches property values

--- a/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
+++ b/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
@@ -801,23 +801,27 @@ public class SchemaGeneratorHelper {
         // if they have already wired in a fetcher - then leave it alone
         FieldCoordinates coordinates = FieldCoordinates.coordinates(parentType.getName(), fieldDefinition.getName());
         if (!buildCtx.getCodeRegistry().hasDataFetcher(coordinates)) {
-            DataFetcherFactory<?> dataFetcherFactory = buildDataFetcherFactory(buildCtx,
+            Optional<DataFetcherFactory<?>> dataFetcherFactory = buildDataFetcherFactory(buildCtx,
                     parentType,
                     fieldDef,
                     fieldType,
                     appliedDirectives.first,
                     appliedDirectives.second);
-            buildCtx.getCodeRegistry().dataFetcher(coordinates, dataFetcherFactory);
+
+            // if the dataFetcherFactory is empty, then it must have been the code registry default one
+            // and hence we don't need to make a "map entry" in the code registry since it will be defaulted
+            // anyway
+            dataFetcherFactory.ifPresent(fetcherFactory -> buildCtx.getCodeRegistry().dataFetcher(coordinates, fetcherFactory));
         }
         return directivesObserve(buildCtx, fieldDefinition);
     }
 
-    private DataFetcherFactory<?> buildDataFetcherFactory(BuildContext buildCtx,
-                                                          TypeDefinition<?> parentType,
-                                                          FieldDefinition fieldDef,
-                                                          GraphQLOutputType fieldType,
-                                                          List<GraphQLDirective> directives,
-                                                          List<GraphQLAppliedDirective> appliedDirectives) {
+    private Optional<DataFetcherFactory<?>> buildDataFetcherFactory(BuildContext buildCtx,
+                                                                    TypeDefinition<?> parentType,
+                                                                    FieldDefinition fieldDef,
+                                                                    GraphQLOutputType fieldType,
+                                                                    List<GraphQLDirective> directives,
+                                                                    List<GraphQLAppliedDirective> appliedDirectives) {
         String fieldName = fieldDef.getName();
         String parentTypeName = parentType.getName();
         TypeDefinitionRegistry typeRegistry = buildCtx.getTypeRegistry();
@@ -847,7 +851,9 @@ public class SchemaGeneratorHelper {
                         if (dataFetcher == null) {
                             DataFetcherFactory<?> codeRegistryDFF = codeRegistry.getDefaultDataFetcherFactory();
                             if (codeRegistryDFF != null) {
-                                return codeRegistryDFF;
+                                // this will use the default of the code registry when its
+                                // asked for at runtime
+                                return Optional.empty();
                             }
                             dataFetcher = dataFetcherOfLastResort();
                         }
@@ -856,7 +862,7 @@ public class SchemaGeneratorHelper {
             }
             dataFetcherFactory = DataFetcherFactories.useDataFetcher(dataFetcher);
         }
-        return dataFetcherFactory;
+        return Optional.of(dataFetcherFactory);
     }
 
     GraphQLArgument buildArgument(BuildContext buildCtx, InputValueDefinition valueDefinition) {

--- a/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
@@ -15,6 +15,7 @@ import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironment
 import graphql.schema.LightDataFetcher
 import graphql.schema.PropertyDataFetcher
+import graphql.schema.SingletonPropertyDataFetcher
 import graphql.schema.StaticDataFetcher
 import org.awaitility.Awaitility
 import org.jetbrains.annotations.NotNull
@@ -100,7 +101,7 @@ class InstrumentationTest extends Specification {
 
         instrumentation.dfClasses.size() == 2
         instrumentation.dfClasses[0] == StaticDataFetcher.class
-        LightDataFetcher.class.isAssignableFrom(instrumentation.dfClasses[1])
+        instrumentation.dfClasses[1] == SingletonPropertyDataFetcher.class
 
         instrumentation.dfInvocations.size() == 2
 

--- a/src/test/groovy/graphql/schema/DataFetcherFactoriesTest.groovy
+++ b/src/test/groovy/graphql/schema/DataFetcherFactoriesTest.groovy
@@ -37,4 +37,14 @@ class DataFetcherFactoriesTest extends Specification {
         then:
         value == "goodbye"
     }
+
+    def "will use given df via field"() {
+        def fetcherFactory = DataFetcherFactories.useDataFetcher(pojoDF)
+
+        when:
+        def value = fetcherFactory.getViaField(null).get(null)
+
+        then:
+        value == "goodbye"
+    }
 }


### PR DESCRIPTION
If the code registry DFF value is the default then there is no need for a map entry since the lookup will default to the default