### PR TITLE
Allowing document compiler to handles directives and values down in the field tree

### DIFF
--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -77,8 +77,14 @@ public class Execution {
         List<VariableDefinition> variableDefinitions = operationDefinition.getVariableDefinitions();
 
         CoercedVariables coercedVariables;
+        NormalizedVariables normalizedVariableValues;
         try {
             coercedVariables = ValuesResolver.coerceVariableValues(graphQLSchema, variableDefinitions, inputVariables, executionInput.getGraphQLContext(), executionInput.getLocale());
+
+            normalizedVariableValues = ValuesResolver.getNormalizedVariableValues(graphQLSchema,
+                    variableDefinitions,
+                    inputVariables,
+                    executionInput.getGraphQLContext(), executionInput.getLocale());
         } catch (RuntimeException rte) {
             if (rte instanceof GraphQLError) {
                 return completedFuture(new ExecutionResultImpl((GraphQLError) rte));
@@ -100,6 +106,7 @@ public class Execution {
                 .root(executionInput.getRoot())
                 .fragmentsByName(fragmentsByName)
                 .coercedVariables(coercedVariables)
+                .normalizedVariableValues(normalizedVariableValues)
                 .document(document)
                 .operationDefinition(operationDefinition)
                 .dataLoaderRegistry(executionInput.getDataLoaderRegistry())

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -31,7 +31,6 @@ import graphql.schema.GraphQLSchema;
 import graphql.schema.impl.SchemaUtil;
 import org.jspecify.annotations.NonNull;
 import graphql.util.FpKit;
-import org.jetbrains.annotations.NotNull;
 import org.reactivestreams.Publisher;
 
 import java.util.Collections;
@@ -129,7 +128,7 @@ public class Execution {
         return ValuesResolver.coerceVariableValues(graphQLSchema, variableDefinitions, inputVariables, executionInput.getGraphQLContext(), executionInput.getLocale());
     }
 
-    private static @NotNull Supplier<NormalizedVariables> normalizedVariableValues(GraphQLSchema graphQLSchema, ExecutionInput executionInput, NodeUtil.GetOperationResult getOperationResult) {
+    private static @NonNull Supplier<NormalizedVariables> normalizedVariableValues(GraphQLSchema graphQLSchema, ExecutionInput executionInput, NodeUtil.GetOperationResult getOperationResult) {
         Supplier<NormalizedVariables> normalizedVariableValues;
         RawVariables inputVariables = executionInput.getRawVariables();
         List<VariableDefinition> variableDefinitions = getOperationResult.operationDefinition.getVariableDefinitions();

--- a/src/main/java/graphql/execution/ExecutionContext.java
+++ b/src/main/java/graphql/execution/ExecutionContext.java
@@ -45,7 +45,7 @@ public class ExecutionContext {
     private final OperationDefinition operationDefinition;
     private final Document document;
     private final CoercedVariables coercedVariables;
-    private final NormalizedVariables normalizedVariables;
+    private final Supplier<NormalizedVariables> normalizedVariables;
     private final Object root;
     private final Object context;
     private final GraphQLContext graphQLContext;
@@ -129,7 +129,10 @@ public class ExecutionContext {
         return coercedVariables;
     }
 
-    public NormalizedVariables getNormalizedVariables() {
+    /**
+     * @return a supplier that will give out the operations variables in normalized form
+     */
+    public Supplier<NormalizedVariables> getNormalizedVariables() {
         return normalizedVariables;
     }
 

--- a/src/main/java/graphql/execution/ExecutionContext.java
+++ b/src/main/java/graphql/execution/ExecutionContext.java
@@ -45,6 +45,7 @@ public class ExecutionContext {
     private final OperationDefinition operationDefinition;
     private final Document document;
     private final CoercedVariables coercedVariables;
+    private final NormalizedVariables normalizedVariables;
     private final Object root;
     private final Object context;
     private final GraphQLContext graphQLContext;
@@ -74,6 +75,7 @@ public class ExecutionContext {
         this.subscriptionStrategy = builder.subscriptionStrategy;
         this.fragmentsByName = builder.fragmentsByName;
         this.coercedVariables = builder.coercedVariables;
+        this.normalizedVariables = builder.normalizedVariables;
         this.document = builder.document;
         this.operationDefinition = builder.operationDefinition;
         this.context = builder.context;
@@ -125,6 +127,10 @@ public class ExecutionContext {
 
     public CoercedVariables getCoercedVariables() {
         return coercedVariables;
+    }
+
+    public NormalizedVariables getNormalizedVariables() {
+        return normalizedVariables;
     }
 
     /**

--- a/src/main/java/graphql/execution/ExecutionContextBuilder.java
+++ b/src/main/java/graphql/execution/ExecutionContextBuilder.java
@@ -18,6 +18,7 @@ import org.dataloader.DataLoaderRegistry;
 
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import static graphql.Assert.assertNotNull;
 import static graphql.collect.ImmutableKit.emptyList;
@@ -38,7 +39,7 @@ public class ExecutionContextBuilder {
     Document document;
     OperationDefinition operationDefinition;
     CoercedVariables coercedVariables = CoercedVariables.emptyVariables();
-    NormalizedVariables normalizedVariables = NormalizedVariables.emptyVariables();
+    Supplier<NormalizedVariables> normalizedVariables = NormalizedVariables::emptyVariables;
     ImmutableMap<String, FragmentDefinition> fragmentsByName = ImmutableKit.emptyMap();
     DataLoaderRegistry dataLoaderRegistry;
     Locale locale;
@@ -171,7 +172,7 @@ public class ExecutionContextBuilder {
         return this;
     }
 
-    public ExecutionContextBuilder normalizedVariableValues(NormalizedVariables normalizedVariables) {
+    public ExecutionContextBuilder normalizedVariableValues(Supplier<NormalizedVariables> normalizedVariables) {
         this.normalizedVariables = normalizedVariables;
         return this;
     }

--- a/src/main/java/graphql/execution/ExecutionContextBuilder.java
+++ b/src/main/java/graphql/execution/ExecutionContextBuilder.java
@@ -38,6 +38,7 @@ public class ExecutionContextBuilder {
     Document document;
     OperationDefinition operationDefinition;
     CoercedVariables coercedVariables = CoercedVariables.emptyVariables();
+    NormalizedVariables normalizedVariables = NormalizedVariables.emptyVariables();
     ImmutableMap<String, FragmentDefinition> fragmentsByName = ImmutableKit.emptyMap();
     DataLoaderRegistry dataLoaderRegistry;
     Locale locale;
@@ -167,6 +168,11 @@ public class ExecutionContextBuilder {
 
     public ExecutionContextBuilder coercedVariables(CoercedVariables coercedVariables) {
         this.coercedVariables = coercedVariables;
+        return this;
+    }
+
+    public ExecutionContextBuilder normalizedVariableValues(NormalizedVariables normalizedVariables) {
+        this.normalizedVariables = normalizedVariables;
         return this;
     }
 

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -463,8 +463,8 @@ public abstract class ExecutionStrategy {
             DataFetchingFieldSelectionSet fieldCollector = DataFetchingFieldSelectionSetImpl.newCollector(executionContext.getGraphQLSchema(), fieldDef.getType(), normalizedFieldSupplier);
             QueryDirectives queryDirectives = new QueryDirectivesImpl(field,
                     executionContext.getGraphQLSchema(),
-                    executionContext.getCoercedVariables().toMap(),
-                    executionContext.getNormalizedVariables().toMap(),
+                    executionContext.getCoercedVariables(),
+                    executionContext.getNormalizedVariables(),
                     executionContext.getGraphQLContext(),
                     executionContext.getLocale());
 

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -464,6 +464,7 @@ public abstract class ExecutionStrategy {
             QueryDirectives queryDirectives = new QueryDirectivesImpl(field,
                     executionContext.getGraphQLSchema(),
                     executionContext.getCoercedVariables().toMap(),
+                    executionContext.getNormalizedVariables().toMap(),
                     executionContext.getGraphQLContext(),
                     executionContext.getLocale());
 

--- a/src/main/java/graphql/execution/NormalizedVariables.java
+++ b/src/main/java/graphql/execution/NormalizedVariables.java
@@ -1,0 +1,45 @@
+package graphql.execution;
+
+import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
+import graphql.collect.ImmutableMapWithNullValues;
+import graphql.normalized.NormalizedInputValue;
+
+import java.util.Map;
+
+/**
+ * Holds coerced variables, that is their values are now in a normalized {@link graphql.normalized.NormalizedInputValue} form.
+ */
+@PublicApi
+public class NormalizedVariables {
+    private final ImmutableMapWithNullValues<String, NormalizedInputValue> normalisedVariables;
+
+    public NormalizedVariables(Map<String, NormalizedInputValue> normalisedVariables) {
+        this.normalisedVariables = ImmutableMapWithNullValues.copyOf(normalisedVariables);
+    }
+
+    public Map<String, NormalizedInputValue> toMap() {
+        return normalisedVariables;
+    }
+
+    public boolean containsKey(String key) {
+        return normalisedVariables.containsKey(key);
+    }
+
+    public Object get(String key) {
+        return normalisedVariables.get(key);
+    }
+
+    public static NormalizedVariables emptyVariables() {
+        return new NormalizedVariables(ImmutableKit.emptyMap());
+    }
+
+    public static NormalizedVariables of(Map<String, NormalizedInputValue> normalisedVariables) {
+        return new NormalizedVariables(normalisedVariables);
+    }
+
+    @Override
+    public String toString() {
+        return normalisedVariables.toString();
+    }
+}

--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -101,7 +101,7 @@ public class ValuesResolver {
      *
      * @return a map of the normalised values
      */
-    public static Map<String, NormalizedInputValue> getNormalizedVariableValues(
+    public static NormalizedVariables getNormalizedVariableValues(
             GraphQLSchema schema,
             List<VariableDefinition> variableDefinitions,
             RawVariables rawVariables,
@@ -131,9 +131,7 @@ public class ValuesResolver {
                 }
             }
         }
-
-        return result;
-
+        return NormalizedVariables.of(result);
     }
 
 

--- a/src/main/java/graphql/execution/directives/DirectivesResolver.java
+++ b/src/main/java/graphql/execution/directives/DirectivesResolver.java
@@ -1,6 +1,8 @@
 package graphql.execution.directives;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.google.common.collect.ImmutableBiMap;
 import graphql.GraphQLContext;
 import graphql.Internal;
 import graphql.execution.CoercedVariables;
@@ -11,8 +13,6 @@ import graphql.schema.GraphQLCodeRegistry;
 import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLSchema;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -26,17 +26,17 @@ public class DirectivesResolver {
     public DirectivesResolver() {
     }
 
-    public Map<String, List<GraphQLDirective>> resolveDirectives(List<Directive> directives, GraphQLSchema schema, Map<String, Object> variables, GraphQLContext graphQLContext, Locale locale) {
+    public BiMap<GraphQLDirective, Directive> resolveDirectives(List<Directive> directives, GraphQLSchema schema, Map<String, Object> variables, GraphQLContext graphQLContext, Locale locale) {
         GraphQLCodeRegistry codeRegistry = schema.getCodeRegistry();
-        Map<String, List<GraphQLDirective>> directiveMap = new LinkedHashMap<>();
+        BiMap<GraphQLDirective, Directive> directiveMap = HashBiMap.create();
         directives.forEach(directive -> {
             GraphQLDirective protoType = schema.getDirective(directive.getName());
             if (protoType != null) {
-                GraphQLDirective newDirective = protoType.transform(builder -> buildArguments(builder, codeRegistry, protoType, directive, variables, graphQLContext, locale));
-                directiveMap.computeIfAbsent(newDirective.getName(), k -> new ArrayList<>()).add(newDirective);
+                GraphQLDirective graphQLDirective = protoType.transform(builder -> buildArguments(builder, codeRegistry, protoType, directive, variables, graphQLContext, locale));
+                directiveMap.put(graphQLDirective, directive);
             }
         });
-        return ImmutableMap.copyOf(directiveMap);
+        return ImmutableBiMap.copyOf(directiveMap);
     }
 
     private void buildArguments(GraphQLDirective.Builder directiveBuilder,

--- a/src/main/java/graphql/execution/directives/DirectivesResolver.java
+++ b/src/main/java/graphql/execution/directives/DirectivesResolver.java
@@ -26,7 +26,7 @@ public class DirectivesResolver {
     public DirectivesResolver() {
     }
 
-    public BiMap<GraphQLDirective, Directive> resolveDirectives(List<Directive> directives, GraphQLSchema schema, Map<String, Object> variables, GraphQLContext graphQLContext, Locale locale) {
+    public BiMap<GraphQLDirective, Directive> resolveDirectives(List<Directive> directives, GraphQLSchema schema, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) {
         GraphQLCodeRegistry codeRegistry = schema.getCodeRegistry();
         BiMap<GraphQLDirective, Directive> directiveMap = HashBiMap.create();
         directives.forEach(directive -> {
@@ -43,10 +43,10 @@ public class DirectivesResolver {
                                 GraphQLCodeRegistry codeRegistry,
                                 GraphQLDirective protoType,
                                 Directive fieldDirective,
-                                Map<String, Object> variables,
+                                CoercedVariables variables,
                                 GraphQLContext graphQLContext,
                                 Locale locale) {
-        Map<String, Object> argumentValues = ValuesResolver.getArgumentValues(codeRegistry, protoType.getArguments(), fieldDirective.getArguments(), CoercedVariables.of(variables), graphQLContext, locale);
+        Map<String, Object> argumentValues = ValuesResolver.getArgumentValues(codeRegistry, protoType.getArguments(), fieldDirective.getArguments(), variables, graphQLContext, locale);
         directiveBuilder.clearArguments();
         protoType.getArguments().forEach(protoArg -> {
             if (argumentValues.containsKey(protoArg.getName())) {

--- a/src/main/java/graphql/execution/directives/QueryDirectives.java
+++ b/src/main/java/graphql/execution/directives/QueryDirectives.java
@@ -13,6 +13,7 @@ import graphql.schema.GraphQLSchema;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * This gives you access to the immediate directives on a {@link graphql.execution.MergedField}.  This does not include directives on parent
@@ -120,7 +121,7 @@ public interface QueryDirectives {
 
         Builder coercedVariables(CoercedVariables coercedVariables);
 
-        Builder normalizedVariables(NormalizedVariables normalizedVariables);
+        Builder normalizedVariables(Supplier<NormalizedVariables> normalizedVariables);
 
         Builder graphQLContext(GraphQLContext graphQLContext);
 

--- a/src/main/java/graphql/execution/directives/QueryDirectives.java
+++ b/src/main/java/graphql/execution/directives/QueryDirectives.java
@@ -4,7 +4,9 @@ import graphql.GraphQLContext;
 import graphql.PublicApi;
 import graphql.execution.CoercedVariables;
 import graphql.execution.MergedField;
+import graphql.execution.NormalizedVariables;
 import graphql.language.Field;
+import graphql.normalized.NormalizedInputValue;
 import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLSchema;
 
@@ -67,6 +69,16 @@ public interface QueryDirectives {
     Map<Field, List<QueryAppliedDirective>> getImmediateAppliedDirectivesByField();
 
     /**
+     * This will return a map of {@link QueryAppliedDirective} to a map of their argument values in {@link NormalizedInputValue} form
+     * <p>
+     * NOTE : This will only be available when {@link graphql.normalized.ExecutableNormalizedOperationFactory} is used
+     * to create the {@link QueryAppliedDirective} information
+     *
+     * @return a map of applied directive to named argument values
+     */
+    Map<QueryAppliedDirective, Map<String, NormalizedInputValue>> getNormalizedInputValueByImmediateAppliedDirectives();
+
+    /**
      * This will return a list of the named directives that are immediately on this merged field.
      *
      * Read above for why this is a list of directives and not just one
@@ -107,6 +119,8 @@ public interface QueryDirectives {
         Builder field(Field field);
 
         Builder coercedVariables(CoercedVariables coercedVariables);
+
+        Builder normalizedVariables(NormalizedVariables normalizedVariables);
 
         Builder graphQLContext(GraphQLContext graphQLContext);
 

--- a/src/main/java/graphql/execution/directives/QueryDirectivesBuilder.java
+++ b/src/main/java/graphql/execution/directives/QueryDirectivesBuilder.java
@@ -4,6 +4,7 @@ import graphql.GraphQLContext;
 import graphql.Internal;
 import graphql.execution.CoercedVariables;
 import graphql.execution.MergedField;
+import graphql.execution.NormalizedVariables;
 import graphql.language.Field;
 import graphql.schema.GraphQLSchema;
 
@@ -15,6 +16,7 @@ public class QueryDirectivesBuilder implements QueryDirectives.Builder {
     private MergedField mergedField;
     private GraphQLSchema schema;
     private CoercedVariables coercedVariables = CoercedVariables.emptyVariables();
+    private NormalizedVariables normalizedVariables = NormalizedVariables.emptyVariables();
     private GraphQLContext graphQLContext = GraphQLContext.getDefault();
     private Locale locale = Locale.getDefault();
 
@@ -43,6 +45,12 @@ public class QueryDirectivesBuilder implements QueryDirectives.Builder {
     }
 
     @Override
+    public QueryDirectives.Builder normalizedVariables(NormalizedVariables normalizedVariables) {
+        this.normalizedVariables = normalizedVariables;
+        return this;
+    }
+
+    @Override
     public QueryDirectives.Builder graphQLContext(GraphQLContext graphQLContext) {
         this.graphQLContext = graphQLContext;
         return this;
@@ -57,6 +65,6 @@ public class QueryDirectivesBuilder implements QueryDirectives.Builder {
 
     @Override
     public QueryDirectives build() {
-        return new QueryDirectivesImpl(mergedField, schema, coercedVariables.toMap(), graphQLContext, locale);
+        return new QueryDirectivesImpl(mergedField, schema, coercedVariables.toMap(), normalizedVariables.toMap(), graphQLContext, locale);
     }
 }

--- a/src/main/java/graphql/execution/directives/QueryDirectivesBuilder.java
+++ b/src/main/java/graphql/execution/directives/QueryDirectivesBuilder.java
@@ -9,6 +9,7 @@ import graphql.language.Field;
 import graphql.schema.GraphQLSchema;
 
 import java.util.Locale;
+import java.util.function.Supplier;
 
 @Internal
 public class QueryDirectivesBuilder implements QueryDirectives.Builder {
@@ -16,7 +17,7 @@ public class QueryDirectivesBuilder implements QueryDirectives.Builder {
     private MergedField mergedField;
     private GraphQLSchema schema;
     private CoercedVariables coercedVariables = CoercedVariables.emptyVariables();
-    private NormalizedVariables normalizedVariables = NormalizedVariables.emptyVariables();
+    private Supplier<NormalizedVariables> normalizedVariables = NormalizedVariables::emptyVariables;
     private GraphQLContext graphQLContext = GraphQLContext.getDefault();
     private Locale locale = Locale.getDefault();
 
@@ -45,7 +46,7 @@ public class QueryDirectivesBuilder implements QueryDirectives.Builder {
     }
 
     @Override
-    public QueryDirectives.Builder normalizedVariables(NormalizedVariables normalizedVariables) {
+    public QueryDirectives.Builder normalizedVariables(Supplier<NormalizedVariables> normalizedVariables) {
         this.normalizedVariables = normalizedVariables;
         return this;
     }
@@ -65,6 +66,6 @@ public class QueryDirectivesBuilder implements QueryDirectives.Builder {
 
     @Override
     public QueryDirectives build() {
-        return new QueryDirectivesImpl(mergedField, schema, coercedVariables.toMap(), normalizedVariables.toMap(), graphQLContext, locale);
+        return new QueryDirectivesImpl(mergedField, schema, coercedVariables, normalizedVariables, graphQLContext, locale);
     }
 }

--- a/src/main/java/graphql/execution/directives/QueryDirectivesImpl.java
+++ b/src/main/java/graphql/execution/directives/QueryDirectivesImpl.java
@@ -18,7 +18,6 @@ import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLSchema;
 import graphql.util.LockKit;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;

--- a/src/main/java/graphql/execution/directives/QueryDirectivesImpl.java
+++ b/src/main/java/graphql/execution/directives/QueryDirectivesImpl.java
@@ -70,20 +70,12 @@ public class QueryDirectivesImpl implements QueryDirectives {
             BiMap<QueryAppliedDirective, GraphQLDirective> gqlDirectiveCounterPartsInverse = gqlDirectiveCounterParts.inverse();
             mergedField.getFields().forEach(field -> {
                 List<Directive> directives = field.getDirectives();
-                Map<String, Directive> astDirectivesByName = FpKit.getByName(directives, Directive::getName);
-                Map<String, List<GraphQLDirective>> directivesMap = directivesResolver
+                BiMap<GraphQLDirective, Directive> directivesMap = directivesResolver
                         .resolveDirectives(directives, schema, coercedVariables, graphQLContext, locale);
-                ImmutableList<GraphQLDirective> resolvedDirectives = ImmutableList.copyOf(
-                        FpKit.flatList(directivesMap.values()));
 
-                // build a counterpart map of GraphQLDirective to AST directive
-                for (int i = 0; i < resolvedDirectives.size(); i++) {
-                    GraphQLDirective graphQLDirective = resolvedDirectives.get(i);
-                    Directive astDirective = astDirectivesByName.get(graphQLDirective.getName());
-                    if (astDirective != null) {
-                        directiveCounterParts.put(graphQLDirective, astDirective);
-                    }
-                }
+                directiveCounterParts.putAll(directivesMap);
+
+                ImmutableList<GraphQLDirective> resolvedDirectives = ImmutableList.copyOf(directivesMap.keySet());
 
                 ImmutableList.Builder<QueryAppliedDirective> appliedDirectiveBuilder = ImmutableList.builder();
                 for (GraphQLDirective resolvedDirective : resolvedDirectives) {

--- a/src/main/java/graphql/normalized/ArgumentMaker.java
+++ b/src/main/java/graphql/normalized/ArgumentMaker.java
@@ -12,8 +12,8 @@ import graphql.language.NullValue;
 import graphql.language.ObjectField;
 import graphql.language.ObjectValue;
 import graphql.language.Value;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.Map;
@@ -94,7 +94,7 @@ class ArgumentMaker {
         return (Value<?>) value;
     }
 
-    @NotNull
+    @NonNull
     private static Value<?> argValue(ExecutableNormalizedField executableNormalizedField,
                                      QueryAppliedDirective queryAppliedDirective,
                                      String argName,

--- a/src/main/java/graphql/normalized/ArgumentMaker.java
+++ b/src/main/java/graphql/normalized/ArgumentMaker.java
@@ -1,0 +1,110 @@
+package graphql.normalized;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import graphql.Internal;
+import graphql.execution.directives.QueryAppliedDirective;
+import graphql.execution.directives.QueryAppliedDirectiveArgument;
+import graphql.execution.directives.QueryDirectives;
+import graphql.language.Argument;
+import graphql.language.ArrayValue;
+import graphql.language.NullValue;
+import graphql.language.ObjectField;
+import graphql.language.ObjectValue;
+import graphql.language.Value;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.Map;
+
+import static graphql.collect.ImmutableKit.emptyMap;
+import static graphql.collect.ImmutableKit.map;
+import static graphql.language.Argument.newArgument;
+
+/**
+ * This class is a peer class and broken out of {@link ExecutableNormalizedOperationToAstCompiler} to deal with
+ * argument value making.
+ */
+@Internal
+class ArgumentMaker {
+
+    static List<Argument> createArguments(ExecutableNormalizedField executableNormalizedField,
+                                          VariableAccumulator variableAccumulator) {
+        ImmutableList.Builder<Argument> result = ImmutableList.builder();
+        ImmutableMap<String, NormalizedInputValue> normalizedArguments = executableNormalizedField.getNormalizedArguments();
+        for (String argName : normalizedArguments.keySet()) {
+            NormalizedInputValue normalizedInputValue = normalizedArguments.get(argName);
+            Value<?> value = argValue(executableNormalizedField, null, argName, normalizedInputValue, variableAccumulator);
+            Argument argument = newArgument()
+                    .name(argName)
+                    .value(value)
+                    .build();
+            result.add(argument);
+        }
+        return result.build();
+    }
+
+    static List<Argument> createDirectiveArguments(ExecutableNormalizedField executableNormalizedField,
+                                                   QueryDirectives queryDirectives,
+                                                   QueryAppliedDirective queryAppliedDirective,
+                                                   VariableAccumulator variableAccumulator) {
+
+        Map<String, NormalizedInputValue> argValueMap = queryDirectives.getNormalizedInputValueByImmediateAppliedDirectives().getOrDefault(queryAppliedDirective, emptyMap());
+
+        ImmutableList.Builder<Argument> result = ImmutableList.builder();
+        for (QueryAppliedDirectiveArgument directiveArgument : queryAppliedDirective.getArguments()) {
+            String argName = directiveArgument.getName();
+            if (argValueMap != null && argValueMap.containsKey(argName)) {
+                NormalizedInputValue normalizedInputValue = argValueMap.get(argName);
+                Value<?> value = argValue(executableNormalizedField, queryAppliedDirective, argName, normalizedInputValue, variableAccumulator);
+                Argument argument = newArgument()
+                        .name(argName)
+                        .value(value)
+                        .build();
+                result.add(argument);
+            }
+        }
+        return result.build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Value<?> argValue(ExecutableNormalizedField executableNormalizedField,
+                                     QueryAppliedDirective queryAppliedDirective,
+                                     String argName,
+                                     @Nullable Object value,
+                                     VariableAccumulator variableAccumulator) {
+        if (value instanceof List) {
+            ArrayValue.Builder arrayValue = ArrayValue.newArrayValue();
+            arrayValue.values(map((List<Object>) value, val -> argValue(executableNormalizedField, queryAppliedDirective, argName, val, variableAccumulator)));
+            return arrayValue.build();
+        }
+        if (value instanceof Map) {
+            ObjectValue.Builder objectValue = ObjectValue.newObjectValue();
+            Map<String, Object> map = (Map<String, Object>) value;
+            for (String fieldName : map.keySet()) {
+                Value<?> fieldValue = argValue(executableNormalizedField, queryAppliedDirective, argName, (NormalizedInputValue) map.get(fieldName), variableAccumulator);
+                objectValue.objectField(ObjectField.newObjectField().name(fieldName).value(fieldValue).build());
+            }
+            return objectValue.build();
+        }
+        if (value == null) {
+            return NullValue.newNullValue().build();
+        }
+        return (Value<?>) value;
+    }
+
+    @NotNull
+    private static Value<?> argValue(ExecutableNormalizedField executableNormalizedField,
+                                     QueryAppliedDirective queryAppliedDirective,
+                                     String argName,
+                                     NormalizedInputValue normalizedInputValue,
+                                     VariableAccumulator variableAccumulator) {
+        if (variableAccumulator.shouldMakeVariable(executableNormalizedField, queryAppliedDirective, argName, normalizedInputValue)) {
+            VariableValueWithDefinition variableWithDefinition = variableAccumulator.accumulateVariable(normalizedInputValue);
+            return variableWithDefinition.getVariableReference();
+        } else {
+            return argValue(executableNormalizedField, queryAppliedDirective, argName, normalizedInputValue.getValue(), variableAccumulator);
+        }
+    }
+}

--- a/src/main/java/graphql/normalized/ExecutableNormalizedOperationFactory.java
+++ b/src/main/java/graphql/normalized/ExecutableNormalizedOperationFactory.java
@@ -518,11 +518,10 @@ public class ExecutableNormalizedOperationFactory {
 
         private void captureMergedField(ExecutableNormalizedField enf, MergedField mergedFld) {
             // QueryDirectivesImpl is a lazy object and only computes itself when asked for
-            Map<String, NormalizedInputValue> normalizedVariableValues = Optional.ofNullable(this.normalizedVariableValues).map(NormalizedVariables::toMap).orElse(null);
             QueryDirectives queryDirectives = new QueryDirectivesImpl(mergedFld,
                     graphQLSchema,
-                    coercedVariableValues.toMap(),
-                    normalizedVariableValues,
+                    coercedVariableValues,
+                    () -> normalizedVariableValues,
                     options.getGraphQLContext(),
                     options.getLocale());
             normalizedFieldToQueryDirectives.put(enf, queryDirectives);

--- a/src/main/java/graphql/normalized/ExecutableNormalizedOperationFactory.java
+++ b/src/main/java/graphql/normalized/ExecutableNormalizedOperationFactory.java
@@ -12,6 +12,7 @@ import graphql.collect.ImmutableKit;
 import graphql.execution.AbortExecutionException;
 import graphql.execution.CoercedVariables;
 import graphql.execution.MergedField;
+import graphql.execution.NormalizedVariables;
 import graphql.execution.RawVariables;
 import graphql.execution.ValuesResolver;
 import graphql.execution.conditional.ConditionalNodes;
@@ -52,6 +53,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -423,7 +425,7 @@ public class ExecutableNormalizedOperationFactory {
                 rawVariables,
                 options.getGraphQLContext(),
                 options.getLocale());
-        Map<String, NormalizedInputValue> normalizedVariableValues = ValuesResolver.getNormalizedVariableValues(graphQLSchema,
+        NormalizedVariables normalizedVariableValues = ValuesResolver.getNormalizedVariableValues(graphQLSchema,
                 variableDefinitions,
                 rawVariables,
                 options.getGraphQLContext(),
@@ -445,7 +447,7 @@ public class ExecutableNormalizedOperationFactory {
         private final OperationDefinition operationDefinition;
         private final Map<String, FragmentDefinition> fragments;
         private final CoercedVariables coercedVariableValues;
-        private final @Nullable Map<String, NormalizedInputValue> normalizedVariableValues;
+        private final @Nullable NormalizedVariables normalizedVariableValues;
         private final Options options;
 
         private final List<PossibleMerger> possibleMergerList = new ArrayList<>();
@@ -462,7 +464,7 @@ public class ExecutableNormalizedOperationFactory {
                 OperationDefinition operationDefinition,
                 Map<String, FragmentDefinition> fragments,
                 CoercedVariables coercedVariableValues,
-                @Nullable Map<String, NormalizedInputValue> normalizedVariableValues,
+                @Nullable NormalizedVariables normalizedVariableValues,
                 Options options
         ) {
             this.graphQLSchema = graphQLSchema;
@@ -516,7 +518,13 @@ public class ExecutableNormalizedOperationFactory {
 
         private void captureMergedField(ExecutableNormalizedField enf, MergedField mergedFld) {
             // QueryDirectivesImpl is a lazy object and only computes itself when asked for
-            QueryDirectives queryDirectives = new QueryDirectivesImpl(mergedFld, graphQLSchema, coercedVariableValues.toMap(), options.getGraphQLContext(), options.getLocale());
+            Map<String, NormalizedInputValue> normalizedVariableValues = Optional.ofNullable(this.normalizedVariableValues).map(NormalizedVariables::toMap).orElse(null);
+            QueryDirectives queryDirectives = new QueryDirectivesImpl(mergedFld,
+                    graphQLSchema,
+                    coercedVariableValues.toMap(),
+                    normalizedVariableValues,
+                    options.getGraphQLContext(),
+                    options.getLocale());
             normalizedFieldToQueryDirectives.put(enf, queryDirectives);
             normalizedFieldToMergedField.put(enf, mergedFld);
         }
@@ -674,7 +682,7 @@ public class ExecutableNormalizedOperationFactory {
             Map<String, Object> argumentValues = ValuesResolver.getArgumentValues(fieldDefinition.getArguments(), field.getArguments(), CoercedVariables.of(this.coercedVariableValues.toMap()), this.options.graphQLContext, this.options.locale);
             Map<String, NormalizedInputValue> normalizedArgumentValues = null;
             if (this.normalizedVariableValues != null) {
-                normalizedArgumentValues = ValuesResolver.getNormalizedArgumentValues(fieldDefinition.getArguments(), field.getArguments(), this.normalizedVariableValues);
+                normalizedArgumentValues = ValuesResolver.getNormalizedArgumentValues(fieldDefinition.getArguments(), field.getArguments(), this.normalizedVariableValues.toMap());
             }
             ImmutableList<String> objectTypeNames = map(objectTypes, GraphQLObjectType::getName);
             return ExecutableNormalizedField.newNormalizedField()

--- a/src/main/java/graphql/normalized/VariableAccumulator.java
+++ b/src/main/java/graphql/normalized/VariableAccumulator.java
@@ -1,6 +1,7 @@
 package graphql.normalized;
 
 import graphql.Internal;
+import graphql.execution.directives.QueryAppliedDirective;
 import graphql.language.VariableDefinition;
 import org.jetbrains.annotations.Nullable;
 
@@ -28,8 +29,12 @@ public class VariableAccumulator {
         valueWithDefinitions = new ArrayList<>();
     }
 
-    public boolean shouldMakeVariable(ExecutableNormalizedField executableNormalizedField, String argName, NormalizedInputValue normalizedInputValue) {
-        return variablePredicate != null && variablePredicate.shouldMakeVariable(executableNormalizedField, argName, normalizedInputValue);
+    public boolean shouldMakeVariable(ExecutableNormalizedField executableNormalizedField, QueryAppliedDirective queryAppliedDirective, String argName, NormalizedInputValue normalizedInputValue) {
+        if (queryAppliedDirective != null) {
+            return variablePredicate != null && variablePredicate.shouldMakeVariable(executableNormalizedField, queryAppliedDirective, argName, normalizedInputValue);
+        } else {
+            return variablePredicate != null && variablePredicate.shouldMakeVariable(executableNormalizedField, argName, normalizedInputValue);
+        }
     }
 
     public VariableValueWithDefinition accumulateVariable(NormalizedInputValue normalizedInputValue) {

--- a/src/main/java/graphql/normalized/VariableAccumulator.java
+++ b/src/main/java/graphql/normalized/VariableAccumulator.java
@@ -30,6 +30,8 @@ public class VariableAccumulator {
     }
 
     public boolean shouldMakeVariable(ExecutableNormalizedField executableNormalizedField, QueryAppliedDirective queryAppliedDirective, String argName, NormalizedInputValue normalizedInputValue) {
+        // when a variable is used on the argument to a query directive then the queryAppliedDirective will be nonnull.
+        // otherwise it must be a field argument
         if (queryAppliedDirective != null) {
             return variablePredicate != null && variablePredicate.shouldMakeVariable(executableNormalizedField, queryAppliedDirective, argName, normalizedInputValue);
         } else {

--- a/src/main/java/graphql/normalized/VariablePredicate.java
+++ b/src/main/java/graphql/normalized/VariablePredicate.java
@@ -1,6 +1,7 @@
 package graphql.normalized;
 
 import graphql.PublicSpi;
+import graphql.execution.directives.QueryAppliedDirective;
 
 /**
  * This predicate indicates whether a variable should be made for this field argument OR whether it will be compiled
@@ -17,5 +18,25 @@ public interface VariablePredicate {
      *
      * @return true if a variable should be made
      */
-    boolean shouldMakeVariable(ExecutableNormalizedField executableNormalizedField, String argName, NormalizedInputValue normalizedInputValue);
+    boolean shouldMakeVariable(ExecutableNormalizedField executableNormalizedField,
+                               String argName,
+                               NormalizedInputValue normalizedInputValue);
+
+    /**
+     * Return true if a variable should be made for this query directive argument
+     * on the specified field
+     *
+     * @param executableNormalizedField the field in question
+     * @param queryAppliedDirective     the query directive in question
+     * @param argName                   the argument on the directive
+     * @param normalizedInputValue      the input value for that argument
+     *
+     * @return true if a variable should be made
+     */
+    default boolean shouldMakeVariable(ExecutableNormalizedField executableNormalizedField,
+                                       QueryAppliedDirective queryAppliedDirective,
+                                       String argName,
+                                       NormalizedInputValue normalizedInputValue) {
+        return false;
+    }
 }

--- a/src/test/groovy/graphql/execution/directives/QueryDirectivesImplTest.groovy
+++ b/src/test/groovy/graphql/execution/directives/QueryDirectivesImplTest.groovy
@@ -35,7 +35,10 @@ class QueryDirectivesImplTest extends Specification {
 
         def mergedField = MergedField.newMergedField([f1, f2]).build()
 
-        def impl = new QueryDirectivesImpl(mergedField, schema, [var: 10], [var : new NormalizedInputValue("type", IntValue.of(10))], GraphQLContext.getDefault(), Locale.getDefault())
+        def impl = new QueryDirectivesImpl(mergedField, schema,
+                CoercedVariables.of([var: 10]),
+                { -> NormalizedVariables.of([var: new NormalizedInputValue("type", IntValue.of(10))]) },
+                GraphQLContext.getDefault(), Locale.getDefault())
 
         when:
         def directives = impl.getImmediateDirectivesByName()
@@ -80,7 +83,7 @@ class QueryDirectivesImplTest extends Specification {
                 .mergedField(mergedField)
                 .schema(schema)
                 .coercedVariables(CoercedVariables.of([var: 10]))
-                .normalizedVariables(NormalizedVariables.of([var: new NormalizedInputValue("type", IntValue.of(10))]))
+                .normalizedVariables({ NormalizedVariables.of([var: new NormalizedInputValue("type", IntValue.of(10))]) })
                 .graphQLContext(GraphQLContext.getDefault())
                 .locale(Locale.getDefault())
                 .build()

--- a/src/test/groovy/graphql/execution/directives/QueryDirectivesImplTest.groovy
+++ b/src/test/groovy/graphql/execution/directives/QueryDirectivesImplTest.groovy
@@ -4,6 +4,9 @@ import graphql.GraphQLContext
 import graphql.TestUtil
 import graphql.execution.CoercedVariables
 import graphql.execution.MergedField
+import graphql.execution.NormalizedVariables
+import graphql.language.IntValue
+import graphql.normalized.NormalizedInputValue
 import spock.lang.Specification
 
 import static graphql.language.AstPrinter.printAst
@@ -32,7 +35,7 @@ class QueryDirectivesImplTest extends Specification {
 
         def mergedField = MergedField.newMergedField([f1, f2]).build()
 
-        def impl = new QueryDirectivesImpl(mergedField, schema, [var: 10], GraphQLContext.getDefault(), Locale.getDefault())
+        def impl = new QueryDirectivesImpl(mergedField, schema, [var: 10], [var : new NormalizedInputValue("type", IntValue.of(10))], GraphQLContext.getDefault(), Locale.getDefault())
 
         when:
         def directives = impl.getImmediateDirectivesByName()
@@ -77,6 +80,7 @@ class QueryDirectivesImplTest extends Specification {
                 .mergedField(mergedField)
                 .schema(schema)
                 .coercedVariables(CoercedVariables.of([var: 10]))
+                .normalizedVariables(NormalizedVariables.of([var: new NormalizedInputValue("type", IntValue.of(10))]))
                 .graphQLContext(GraphQLContext.getDefault())
                 .locale(Locale.getDefault())
                 .build()

--- a/src/test/groovy/graphql/execution/values/InputInterceptorTest.groovy
+++ b/src/test/groovy/graphql/execution/values/InputInterceptorTest.groovy
@@ -98,7 +98,7 @@ class InputInterceptorTest extends Specification {
             ''')
                 .graphQLContext({ it.put(InputInterceptor.class, interceptor) })
                 .variables(
-                        "booleanArg": "truthy",
+                        "booleanArg": false,
                         "stringArg": "sdrawkcab"
 
                 )

--- a/src/test/groovy/graphql/normalized/ENOToAstCompilerDirectivesTest.groovy
+++ b/src/test/groovy/graphql/normalized/ENOToAstCompilerDirectivesTest.groovy
@@ -1,0 +1,169 @@
+package graphql.normalized
+
+import graphql.schema.GraphQLSchema
+
+import static graphql.language.OperationDefinition.Operation.QUERY
+
+/**
+ * Test related to ENO and directives
+ */
+class ENOToAstCompilerDirectivesTest extends ENOToAstCompilerTestBase {
+
+    def "can extract variables or inline values for directives on the query"() {
+        def sdl = '''
+            type Query {
+                foo(fooArg : String) : Foo
+            }
+            
+            type Foo {
+                bar(barArg : String) : String
+            }
+            
+            directive @optIn(to : [String!]!) repeatable on FIELD
+        '''
+
+        def query = '''
+            query named($fooArgVar : String, $barArgVar : String,  $skipVar : Boolean!, $optVar : [String!]!) {
+                foo(fooArg : $fooArgVar) @skip(if : $skipVar) {
+                    bar(barArg : $barArgVar) @optIn(to : ["optToX"]) @optIn(to : $optVar)
+                }
+            }
+        '''
+        GraphQLSchema schema = mkSchema(sdl)
+        def eno = createNormalizedTree(schema, query,
+                [fooArgVar: "fooArgVar", barArgVar: "barArgVar", skipVar: false, optVar: ["optToY"]])
+
+        when:
+        def result = localCompileToDocument(schema, QUERY, "named",
+                eno.getTopLevelFields(), eno.getNormalizedFieldToQueryDirectives(),
+                allVariables)
+        def document = result.document
+        def vars = result.variables
+        def ast = printDoc(document)
+
+        then:
+        vars == [v0: "barArgVar", v1: ["optToX"], v2: ["optToY"], v3: "fooArgVar", v4: false]
+        //
+        // the below is what ir currently produces but its WRONG
+        // fix up when the other tests starts to work
+        //
+        ast == '''query named($v0: String, $v1: [String!]!, $v2: [String!]!, $v3: String, $v4: Boolean!) {
+  foo(fooArg: $v3) @skip(if: $v4) {
+    bar(barArg: $v0) @optIn(to: $v1) @optIn(to: $v2)
+  }
+}
+'''
+
+
+        when: "it has no variables"
+
+
+        result = localCompileToDocument(schema, QUERY, "named",
+                eno.getTopLevelFields(), eno.getNormalizedFieldToQueryDirectives(),
+                noVariables)
+        document = result.document
+        vars = result.variables
+        ast = printDoc(document)
+
+        then:
+        vars == [:]
+        ast == '''query named {
+  foo(fooArg: "fooArgVar") @skip(if: false) {
+    bar(barArg: "barArgVar") @optIn(to: ["optToX"]) @optIn(to: ["optToY"])
+  }
+}
+'''
+
+    }
+
+    def "can handle quite a pathological fragment query as expected"() {
+        def sdl = '''
+        directive @timeout(afterMillis : Int) on FIELD | FRAGMENT_DEFINITION | FRAGMENT_SPREAD | INLINE_FRAGMENT | QUERY
+        
+        directive @cached(forMillis : Int) on FIELD | FRAGMENT_DEFINITION | FRAGMENT_SPREAD | INLINE_FRAGMENT | QUERY
+        
+        directive @importance(place : String) on FIELD | FRAGMENT_DEFINITION | FRAGMENT_SPREAD | INLINE_FRAGMENT | QUERY
+ 
+        type Query {
+            books(searchString : String) : [Book]
+        }
+        
+        type Book {
+         id :  ID
+         title : String
+         review : String
+        }
+    '''
+
+        def pathologicalQuery = '''
+        fragment Details on Book @timeout(afterMillis: 25) @cached(forMillis : 25) @importance(place:"FragDef") {
+            title
+            review @timeout(afterMillis: 5) @cached(forMillis : 5)
+            ...InnerDetails @timeout(afterMillis: 26) 
+        }
+        
+        fragment InnerDetails on Book  @timeout(afterMillis: 27) {
+            review @timeout(afterMillis: 28)
+        }
+        
+        query Books @timeout(afterMillis: 30) @importance(place:"Operation") {
+            books(searchString: "monkey") {
+                id
+                 ...Details @timeout(afterMillis: 20)
+                 ...on Book @timeout(afterMillis: 15) {
+                    review @timeout(afterMillis: 10) @cached(forMillis : 10)
+                }
+            }
+        }
+    '''
+
+        GraphQLSchema schema = mkSchema(sdl)
+        def eno = createNormalizedTree(schema, pathologicalQuery, [:])
+
+        when:
+        def result = localCompileToDocument(schema, QUERY, "Books",
+                eno.getTopLevelFields(), eno.getNormalizedFieldToQueryDirectives(),
+                allVariables)
+        def document = result.document
+        def vars = result.variables
+        def ast = printDoc(document)
+
+        then:
+        vars == [v0:5, v1:5, v2:28, v3:10, v4:10, v5:"monkey"]
+        //
+        // the below is what ir currently produces but its WRONG
+        // fix up when the other tests starts to work
+        //
+        ast == '''query Books($v0: Int, $v1: Int, $v2: Int, $v3: Int, $v4: Int, $v5: String) {
+  books(searchString: $v5) {
+    id
+    review @cached(forMillis: $v1) @cached(forMillis: $v4) @timeout(afterMillis: $v0) @timeout(afterMillis: $v2) @timeout(afterMillis: $v3)
+    title
+  }
+}
+'''
+
+
+        when: "it has no variables"
+
+
+        result = localCompileToDocument(schema, QUERY, "Books",
+                eno.getTopLevelFields(), eno.getNormalizedFieldToQueryDirectives(),
+                noVariables)
+        document = result.document
+        vars = result.variables
+        ast = printDoc(document)
+
+        then:
+        vars == [:]
+        ast == '''query Books {
+  books(searchString: "monkey") {
+    id
+    review @cached(forMillis: 5) @cached(forMillis: 10) @timeout(afterMillis: 5) @timeout(afterMillis: 28) @timeout(afterMillis: 10)
+    title
+  }
+}
+'''
+
+    }
+}

--- a/src/test/groovy/graphql/normalized/ExecutableNormalizedOperationToAstCompilerTest.groovy
+++ b/src/test/groovy/graphql/normalized/ExecutableNormalizedOperationToAstCompilerTest.groovy
@@ -134,7 +134,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
         def fields = createNormalizedFields(schema, query)
         when:
         def result = localCompileToDocument(schema, QUERY, null, fields, noVariables)
-        def printed = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def printed = printDoc(result.document)
         then:
         printed == '''{
   animal {
@@ -204,7 +204,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
 
         when:
         def result = localCompileToDocument(schema, QUERY, null, tree.topLevelFields, noVariables)
-        def printed = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def printed = printDoc(result.document)
 
         then:
         printed == """{
@@ -255,7 +255,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
 
         when:
         def result = localCompileToDocument(schema, QUERY, null, tree.topLevelFields, noVariables)
-        def printed = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def printed = printDoc(result.document)
 
         then:
         printed == """{
@@ -336,7 +336,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
 
         when:
         def result = localCompileToDocument(schema, QUERY, null, tree.topLevelFields, noVariables)
-        def printed = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def printed = printDoc(result.document)
 
         then:
         printed == """{
@@ -428,7 +428,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
 
         when:
         def result = localCompileToDocument(schema, QUERY, null, tree.topLevelFields, noVariables)
-        def printed = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def printed = printDoc(result.document)
 
         then:
         printed == """{
@@ -523,7 +523,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
 
         when:
         def result = localCompileToDocument(schema, QUERY, null, tree.topLevelFields, noVariables)
-        def printed = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def printed = printDoc(result.document)
 
         then:
         printed == """{
@@ -590,7 +590,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
 
         when:
         def result = localCompileToDocument(schema, QUERY, null, tree.topLevelFields, noVariables)
-        def printed = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def printed = printDoc(result.document)
 
         then:
         printed == """{
@@ -647,7 +647,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
 
         when:
         def result = localCompileToDocument(schema, QUERY, null, tree.topLevelFields, noVariables)
-        def printed = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def printed = printDoc(result.document)
 
         then:
         printed == """{
@@ -705,7 +705,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
 
         when:
         def result = localCompileToDocument(schema, QUERY, null, tree.topLevelFields, noVariables)
-        def printed = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def printed = printDoc(result.document)
 
         then:
         // Perhaps the typename should be hoisted out of the fragments, but the impl currently generates
@@ -772,7 +772,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
 
         when:
         def result = localCompileToDocument(schema, QUERY, null, tree.topLevelFields, noVariables)
-        def printed = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def printed = printDoc(result.document)
 
         then:
         // Note: the name field is spread across both fragments
@@ -870,7 +870,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
 
         when:
         def result = localCompileToDocument(schema, QUERY, null, tree.topLevelFields, noVariables)
-        def printed = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def printed = printDoc(result.document)
 
         then:
         // Ensure that age location name etc are not surrounded by fragments unnecessarily
@@ -968,7 +968,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
 
         when:
         def result = localCompileToDocument(schema, QUERY, null, tree.topLevelFields, noVariables)
-        def printed = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def printed = printDoc(result.document)
 
         then:
         // Ensure that __typename id fieldId fieldName etc. are not surrounded by fragments unnecessarily
@@ -1035,7 +1035,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
         def fields = createNormalizedFields(schema, query)
         when:
         def result = localCompileToDocument(schema, QUERY, null, fields, noVariables)
-        def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def documentPrinted = printDoc(result.document)
 
         then:
         documentPrinted == '''{
@@ -1069,7 +1069,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
         def fields = createNormalizedFields(schema, query)
         when:
         def result = localCompileToDocument(schema, QUERY, null, fields, noVariables)
-        def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def documentPrinted = printDoc(result.document)
 
         then:
         documentPrinted == '''{
@@ -1095,7 +1095,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
         def fields = createNormalizedFields(schema, query)
         when:
         def result = localCompileToDocument(schema, QUERY, "My_Op23", fields, noVariables)
-        def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def documentPrinted = printDoc(result.document)
 
         then:
         documentPrinted == '''query My_Op23 {
@@ -1140,7 +1140,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
         def fields = createNormalizedFields(schema, query)
         when:
         def result = localCompileToDocument(schema, QUERY, null, fields, noVariables)
-        def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def documentPrinted = printDoc(result.document)
 
         then:
         documentPrinted == '''{
@@ -1174,7 +1174,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
         def fields = createNormalizedFields(schema, query, ["v": 123])
         when:
         def result = localCompileToDocument(schema, QUERY, null, fields, allVariables)
-        def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def documentPrinted = printDoc(result.document)
 
         then:
         fields[0].normalizedArguments["arg"].value["a"].value["b"].value["c"].value.isEqualTo(IntValue.of(123))
@@ -1206,7 +1206,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
         def fields = createNormalizedFields(schema, query)
         when:
         def result = localCompileToDocument(schema, MUTATION, null, fields, noVariables)
-        def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def documentPrinted = printDoc(result.document)
 
         then:
         documentPrinted == '''mutation {
@@ -1237,7 +1237,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
         def fields = createNormalizedFields(schema, query)
         when:
         def result = localCompileToDocument(schema, SUBSCRIPTION, null, fields, noVariables)
-        def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def documentPrinted = printDoc(result.document)
 
         then:
         documentPrinted == '''subscription {
@@ -1287,7 +1287,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
         OperationDefinition operationDefinition = result.document.getDefinitionsOfType(OperationDefinition.class)[0]
         def fooField = (Field) operationDefinition.selectionSet.children[0]
         def nameField = (Field) fooField.selectionSet.children[0]
-        def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def documentPrinted = printDoc(result.document)
 
         then:
 
@@ -1332,7 +1332,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
         def fields = createNormalizedFields(schema, query)
         when:
         def result = localCompileToDocument(schema, MUTATION, null, fields, noVariables)
-        def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def documentPrinted = printDoc(result.document)
 
         then:
         documentPrinted == '''mutation {
@@ -1377,7 +1377,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
         def fields = createNormalizedFields(schema, query)
         when:
         def result = localCompileToDocument(schema, QUERY, null, fields, noVariables)
-        def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def documentPrinted = printDoc(result.document)
         then:
         documentPrinted == '''{
   foo1(arg: {arg1 : "Query"}) {
@@ -1409,7 +1409,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
         def fields = createNormalizedFields(schema, query)
         when:
         def result = localCompileToDocument(schema, QUERY, null, fields, noVariables)
-        def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def documentPrinted = printDoc(result.document)
         then:
         documentPrinted == '''{
   __schema {
@@ -1444,7 +1444,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
         def fields = createNormalizedFields(schema, query)
         when:
         def result = localCompileToDocument(schema, QUERY, null, fields, noVariables)
-        def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def documentPrinted = printDoc(result.document)
         then:
         documentPrinted == '''{
   __type(name: "World") {
@@ -1488,7 +1488,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
         def fields = createNormalizedFields(schema, query)
         when:
         def result = localCompileToDocument(schema, QUERY, null, fields, noVariables)
-        def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def documentPrinted = printDoc(result.document)
         then:
         documentPrinted == '''{
   foo1 {
@@ -1527,7 +1527,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
         def fields = createNormalizedFields(schema, query)
         when:
         def result = localCompileToDocument(schema, QUERY, null, fields, noVariables)
-        def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def documentPrinted = printDoc(result.document)
         then:
         documentPrinted == '''{
   foo1 {
@@ -1578,7 +1578,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
         def fields = createNormalizedFields(schema, query)
         when:
         def result = localCompileToDocument(schema, QUERY, null, fields, noVariables)
-        def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def documentPrinted = printDoc(result.document)
         then:
         // Note: the typename field moves out of a fragment because AFoo is the only impl
         documentPrinted == '''{
@@ -1629,7 +1629,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
         def fields = createNormalizedFields(schema, query)
         when:
         def result = localCompileToDocument(schema, QUERY, null, fields, noVariables)
-        def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def documentPrinted = printDoc(result.document)
         then:
         // Note: the typename field moves out of a fragment because AFoo is the only impl
         documentPrinted == '''{
@@ -1679,7 +1679,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
         def fields = createNormalizedFields(schema, query)
         when:
         def result = localCompileToDocument(schema, QUERY, null, fields, noVariables)
-        def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def documentPrinted = printDoc(result.document)
         then:
         // Note: the typename field moves out of a fragment because AFoo is the only impl
         documentPrinted == '''{
@@ -1715,7 +1715,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
 
         when:
         def result = localCompileToDocument(schema, MUTATION, null, fields, jsonVariables)
-        def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def documentPrinted = printDoc(result.document)
 
         then:
         result.variables == [v0: ["48x48": "hello"]]
@@ -1747,7 +1747,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
 
         when:
         def result = localCompileToDocument(schema, MUTATION, null, fields, jsonVariables)
-        def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def documentPrinted = printDoc(result.document)
 
         then:
         result.variables == [v0: "hello there"]
@@ -1779,7 +1779,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
 
         when:
         def result = localCompileToDocument(schema, MUTATION, null, fields, jsonVariables)
-        def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def documentPrinted = printDoc(result.document)
 
         then:
         result.variables == [v0: 1]
@@ -1809,7 +1809,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
 
         when:
         def result = localCompileToDocument(schema, MUTATION, null, fields, noVariables)
-        def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def documentPrinted = printDoc(result.document)
 
         then:
         result.variables == [:]
@@ -1839,7 +1839,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
 
         when:
         def result = localCompileToDocument(schema, MUTATION, null, fields, noVariables)
-        def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def documentPrinted = printDoc(result.document)
 
         then:
         result.variables == [:]
@@ -1869,7 +1869,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
 
         when:
         def result = localCompileToDocument(schema, MUTATION, null, fields, jsonVariables)
-        def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def documentPrinted = printDoc(result.document)
 
         then:
         result.variables == [v0: [one: "two", three: ["four", "five"]]]
@@ -1899,7 +1899,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
 
         when:
         def result = localCompileToDocument(schema, MUTATION, null, fields, jsonVariables)
-        def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def documentPrinted = printDoc(result.document)
 
         then:
         result.variables.size() == 2
@@ -1936,7 +1936,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
 
         when:
         def result = localCompileToDocument(schema, MUTATION, null, fields, jsonVariables)
-        def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def documentPrinted = printDoc(result.document)
         def vars = result.variables
 
         then:
@@ -1973,7 +1973,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
 
         when:
         def result = localCompileToDocument(schema, MUTATION, null, fields, noVariables)
-        def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def documentPrinted = printDoc(result.document)
 
         then:
         result.variables == [:]
@@ -2008,7 +2008,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
 
         when:
         def result = localCompileToDocument(schema, MUTATION, null, fields, noVariables)
-        def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def documentPrinted = printDoc(result.document)
 
         then:
         result.variables == [:]
@@ -2051,7 +2051,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
 
         when:
         def result = localCompileToDocument(schema, MUTATION, null, fields, jsonVariables)
-        def documentPrinted = AstPrinter.printAst(new AstSorter().sort(result.document))
+        def documentPrinted = printDoc(result.document)
 
         then:
         result.variables.size() == 1
@@ -2126,7 +2126,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
         def result = localCompileToDocument(schema, QUERY, "named", fields, allVariables)
         def document = result.document
         def vars = result.variables
-        def ast = AstPrinter.printAst(new AstSorter().sort(document))
+        def ast = printDoc(document)
 
         then:
 
@@ -2169,7 +2169,7 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
         result = localCompileToDocument(schema, QUERY, "named", fields, noVariables)
         document = result.document
         vars = result.variables
-        ast = AstPrinter.printAst(new AstSorter().sort(document))
+        ast = printDoc(document)
 
         then: "they should be inlined as values"
 
@@ -2195,7 +2195,70 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
 '''
     }
 
-    private ExecutableNormalizedOperation createNormalizedTree(GraphQLSchema schema, String query, Map<String, Object> variables = [:]) {
+    def "can extract variables or inline values for directives on the query"() {
+        def sdl = '''
+            type Query {
+                foo(fooArg : String) : Foo
+            }
+            
+            type Foo {
+                bar(barArg : String) : String
+            }
+            
+            directive @optIn(to : [String!]!) repeatable on FIELD
+        '''
+
+        def query = '''
+            query named($fooArgVar : String, $barArgVar : String,  $skipVar : Boolean!) {
+                foo(fooArg : $fooArgVar) @skip(if : $skipVar) {
+                    bar(barArg : $barArgVar) @optIn(to : ["optToX"])
+                }
+            }
+        '''
+        GraphQLSchema schema = mkSchema(sdl)
+        def fields = createNormalizedFields(schema, query,
+                [fooArgVar: "fooArgVar", barArgVar: "barArgVar", skipVar: false])
+
+        when:
+        def result = localCompileToDocument(schema, QUERY, "named", fields, allVariables)
+        def document = result.document
+        def vars = result.variables
+        def ast = printDoc(document)
+
+        then:
+        vars == [v0:"barArgVar", v1:"fooArgVar"]
+        //
+        // the below is what ir currently produces but its WRONG
+        // fix up when the other tests starts to work
+        //
+        ast == '''query named($v0: String, $v1: String) {
+  foo(fooArg: $v1) {
+    bar(barArg: $v0)
+  }
+}
+'''
+
+
+        when: "it has no variables"
+
+
+        result = localCompileToDocument(schema, QUERY, "named", fields, noVariables)
+        document = result.document
+        vars = result.variables
+        ast = printDoc(document)
+
+        then:
+        vars == [:]
+        ast == '''query named {
+  foo(fooArg: "fooArgVar") @skip(if: false) {
+    bar(barArg: "barArgVar") @optIn(to: ["optToX"])
+  }
+}
+'''
+
+    }
+
+    private static ExecutableNormalizedOperation createNormalizedTree(GraphQLSchema schema, String query, Map<String, Object> variables = [:]) {
         assertValidQuery(schema, query, variables)
         Document originalDocument = TestUtil.parseQuery(query)
 
@@ -2203,16 +2266,16 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
         return ExecutableNormalizedOperationFactory.createExecutableNormalizedOperationWithRawVariables(schema, originalDocument, null, RawVariables.of(variables), options)
     }
 
-    private List<ExecutableNormalizedField> createNormalizedFields(GraphQLSchema schema, String query, Map<String, Object> variables = [:]) {
+    private static List<ExecutableNormalizedField> createNormalizedFields(GraphQLSchema schema, String query, Map<String, Object> variables = [:]) {
         return createNormalizedTree(schema, query, variables).getTopLevelFields()
     }
 
-    private void assertValidQuery(GraphQLSchema graphQLSchema, String query, Map variables = [:]) {
+    private static void assertValidQuery(GraphQLSchema graphQLSchema, String query, Map variables = [:]) {
         GraphQL graphQL = GraphQL.newGraphQL(graphQLSchema).build()
         assert graphQL.execute(newExecutionInput().query(query).variables(variables)).errors.isEmpty()
     }
 
-    GraphQLSchema mkSchema(String sdl) {
+    static GraphQLSchema mkSchema(String sdl) {
         def wiringFactory = new TestLiveMockedWiringFactory([JsonScalar.JSON_SCALAR])
         def runtimeWiring = RuntimeWiring.newRuntimeWiring()
                 .wiringFactory(wiringFactory).build()
@@ -2227,6 +2290,14 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
             VariablePredicate variablePredicate
     ) {
         return localCompileToDocument(schema, operationKind, operationName, topLevelFields, Map.of(), variablePredicate);
+    }
+
+    private static Document sortDoc(Document doc) {
+        return new AstSorter().sort(doc)
+    }
+
+    private static printDoc(Document doc) {
+        return AstPrinter.printAst(sortDoc(doc))
     }
 
     private static ExecutableNormalizedOperationToAstCompiler.CompilerResult localCompileToDocument(

--- a/src/test/groovy/graphql/normalized/ExecutableNormalizedOperationToAstCompilerTest.groovy
+++ b/src/test/groovy/graphql/normalized/ExecutableNormalizedOperationToAstCompilerTest.groovy
@@ -1294,8 +1294,8 @@ abstract class ExecutableNormalizedOperationToAstCompilerTest extends Specificat
         fooField.directives.size() == 1
         nameField.directives.size() == 1
         documentPrinted == '''subscription {
-  foo1(arg: {arg1 : "Subscription"}) @optIn(to: "foo") {
-    name @optIn(to: "devOps")
+  foo1(arg: {arg1 : "Subscription"}) @optIn(to: ["foo"]) {
+    name @optIn(to: ["devOps"])
   }
 }
 '''

--- a/src/test/groovy/graphql/schema/CoercingTest.groovy
+++ b/src/test/groovy/graphql/schema/CoercingTest.groovy
@@ -1,6 +1,7 @@
 package graphql.schema
 
 import graphql.ExecutionInput
+import graphql.GraphQLContext
 import graphql.TestUtil
 import graphql.analysis.MaxQueryDepthInstrumentation
 import graphql.language.ArrayValue
@@ -13,6 +14,7 @@ import graphql.language.StringValue
 import graphql.language.VariableReference
 import graphql.schema.idl.RuntimeWiring
 import graphql.schema.idl.TypeRuntimeWiring
+import org.jetbrains.annotations.NotNull
 import spock.lang.Specification
 
 import java.time.ZonedDateTime
@@ -243,6 +245,11 @@ class CoercingTest extends Specification {
         @Override
         Object parseLiteral(Object input) throws CoercingParseLiteralException {
             return input
+        }
+
+        @Override
+        StringValue valueToLiteral(@NotNull Object input, @NotNull GraphQLContext graphQLContext, @NotNull Locale locale) {
+            return new StringValue(input.toString())
         }
     })
     .build()


### PR DESCRIPTION
Previously the ENO compiler would not respect "immediate" directives on a field. 

While it has the `QueryDirectives` object - this doe not have "Normalised" values for directive arguments.

This PR adds that.  This PR is more extensive that I had hoped - but adding Normalised values in multiple places will set us up for betterness later