### PR TITLE
ResultPath: Check object type before casting to int

### DIFF
--- a/src/main/java/graphql/execution/ResultPath.java
+++ b/src/main/java/graphql/execution/ResultPath.java
@@ -149,8 +149,10 @@ public class ResultPath {
         for (Object object : objects) {
             if (object instanceof String) {
                 path = path.segment(((String) object));
-            } else {
+            } else if (object instanceof Integer) {
                 path = path.segment((int) object);
+            } else if (object != null) {
+                path = path.segment(object.toString());
             }
         }
         return path;

--- a/src/test/groovy/graphql/execution/ResultPathTest.groovy
+++ b/src/test/groovy/graphql/execution/ResultPathTest.groovy
@@ -212,6 +212,13 @@ class ResultPathTest extends Specification {
         path.toList() == ["a", "b"]
     }
 
+    def "pass any other object than string or int"(){
+        when:
+        ResultPath.fromList(["a", "b", true])
+
+        then:
+        notThrown(ClassCastException)
+    }
 
     def "can append paths"() {
         when:


### PR DESCRIPTION
This pull request adds a more robust validation to the `ResultPath.fromList` method. As you can pass any object to `GraphqlErrorException.Builder.path`, it can lead to a ClassCastException when casting directly to `int`.  this happened to me lol.

```java
public T path(List<Object> path) {
  this.path = path;
  return (T)this.asDerivedType();
}
```

> GraphqlErrorException.Builder.path