### PR TITLE
Adding hashcode and equals for defer & stream payloads

### DIFF
--- a/src/main/java/graphql/incremental/DeferPayload.java
+++ b/src/main/java/graphql/incremental/DeferPayload.java
@@ -43,6 +43,11 @@ public class DeferPayload extends IncrementalPayload {
     }
 
     @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), data);
+    }
+
+    @Override
     public boolean equals(Object obj) {
         if (this == obj) return true;
         if (obj == null || getClass() != obj.getClass()) return false;

--- a/src/main/java/graphql/incremental/DeferPayload.java
+++ b/src/main/java/graphql/incremental/DeferPayload.java
@@ -8,6 +8,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Represents a defer payload
@@ -39,6 +40,15 @@ public class DeferPayload extends IncrementalPayload {
         Map<String, Object> map = new LinkedHashMap<>(super.toSpecification());
         map.put("data", data);
         return map;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        if (!super.equals(obj)) return false;
+        DeferPayload that = (DeferPayload) obj;
+        return Objects.equals(data, that.data);
     }
 
     /**

--- a/src/main/java/graphql/incremental/IncrementalPayload.java
+++ b/src/main/java/graphql/incremental/IncrementalPayload.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static java.util.stream.Collectors.toList;
 
@@ -82,6 +83,15 @@ public abstract class IncrementalPayload {
         return errors.stream().map(GraphQLError::toSpecification).collect(toList());
     }
 
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        IncrementalPayload that = (IncrementalPayload) obj;
+        return Objects.equals(path, that.path) &&
+                Objects.equals(label, that.label) &&
+                Objects.equals(errors, that.errors) &&
+                Objects.equals(extensions, that.extensions);
+    }
 
     protected static abstract class Builder<T extends Builder<T>> {
         protected List<Object> path;

--- a/src/main/java/graphql/incremental/IncrementalPayload.java
+++ b/src/main/java/graphql/incremental/IncrementalPayload.java
@@ -83,6 +83,10 @@ public abstract class IncrementalPayload {
         return errors.stream().map(GraphQLError::toSpecification).collect(toList());
     }
 
+    public int hashCode() {
+        return Objects.hash(path, label, errors, extensions);
+    }
+
     public boolean equals(Object obj) {
         if (this == obj) return true;
         if (obj == null || getClass() != obj.getClass()) return false;

--- a/src/main/java/graphql/incremental/StreamPayload.java
+++ b/src/main/java/graphql/incremental/StreamPayload.java
@@ -7,6 +7,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Represents a stream payload
@@ -38,6 +39,20 @@ public class StreamPayload extends IncrementalPayload {
         Map<String, Object> map = new LinkedHashMap<>(super.toSpecification());
         map.put("items", items);
         return map;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), items);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        if (!super.equals(obj)) return false;
+        StreamPayload that = (StreamPayload) obj;
+        return Objects.equals(items, that.items);
     }
 
     /**

--- a/src/test/groovy/graphql/incremental/DeferPayloadTest.groovy
+++ b/src/test/groovy/graphql/incremental/DeferPayloadTest.groovy
@@ -4,6 +4,8 @@ import graphql.GraphqlErrorBuilder
 import graphql.execution.ResultPath
 import spock.lang.Specification
 
+import static graphql.GraphQLError.newError
+
 class DeferPayloadTest extends Specification {
     def "null data is included"() {
         def payload = DeferPayload.newDeferredItem()
@@ -95,5 +97,45 @@ class DeferPayloadTest extends Specification {
                 ],
                 path      : ["test", "echo"],
         ]
+    }
+
+    def "equals method works correctly"() {
+        when:
+        def payload = DeferPayload.newDeferredItem()
+                .data("data1")
+                .path(["path1"])
+                .label("label1")
+                .errors([newError().message("message1").build()])
+                .extensions([key: "value1"])
+                .build()
+
+        def equivalentPayload = DeferPayload.newDeferredItem()
+                .data("data1")
+                .path(["path1"])
+                .label("label1")
+                .errors([newError().message("message1").build()])
+                .extensions([key: "value1"])
+                .build()
+
+        def totallyDifferentPayload = DeferPayload.newDeferredItem()
+                .data("data2")
+                .path(["path2"])
+                .label("label2")
+                .errors([newError().message("message2").build()])
+                .extensions([key: "value2"])
+                .build()
+
+        def slightlyDifferentPayload = DeferPayload.newDeferredItem()
+                .data("data1")
+                .path(["path1"])
+                .label("label1")
+                .errors([newError().message("message1").build()])
+                .extensions([key: "value2"])
+                .build()
+
+        then:
+        payload.equals(equivalentPayload)
+        !payload.equals(totallyDifferentPayload)
+        !payload.equals(slightlyDifferentPayload)
     }
 }

--- a/src/test/groovy/graphql/incremental/DeferPayloadTest.groovy
+++ b/src/test/groovy/graphql/incremental/DeferPayloadTest.groovy
@@ -99,7 +99,7 @@ class DeferPayloadTest extends Specification {
         ]
     }
 
-    def "equals method works correctly"() {
+    def "equals and hashcode methods work correctly"() {
         when:
         def payload = DeferPayload.newDeferredItem()
                 .data("data1")
@@ -134,8 +134,12 @@ class DeferPayloadTest extends Specification {
                 .build()
 
         then:
-        payload.equals(equivalentPayload)
-        !payload.equals(totallyDifferentPayload)
-        !payload.equals(slightlyDifferentPayload)
+        payload == equivalentPayload
+        payload != totallyDifferentPayload
+        payload != slightlyDifferentPayload
+
+        payload.hashCode() == equivalentPayload.hashCode()
+        payload.hashCode() != totallyDifferentPayload.hashCode()
+        payload.hashCode() != slightlyDifferentPayload.hashCode()
     }
 }

--- a/src/test/groovy/graphql/incremental/StreamPayloadTest.groovy
+++ b/src/test/groovy/graphql/incremental/StreamPayloadTest.groovy
@@ -1,8 +1,9 @@
 package graphql.incremental
 
-import graphql.GraphqlErrorBuilder
 import graphql.execution.ResultPath
 import spock.lang.Specification
+
+import static graphql.GraphqlErrorBuilder.newError
 
 class StreamPayloadTest extends Specification {
     def "null data is included"() {
@@ -25,11 +26,11 @@ class StreamPayloadTest extends Specification {
                 .items(["twow is that a bee"])
                 .path(["hello"])
                 .errors([])
-                .addError(GraphqlErrorBuilder.newError()
+                .addError(newError()
                         .message("wow")
                         .build())
                 .addErrors([
-                        GraphqlErrorBuilder.newError()
+                        newError()
                                 .message("yep")
                                 .build(),
                 ])
@@ -65,12 +66,12 @@ class StreamPayloadTest extends Specification {
         def payload = StreamPayload.newStreamedItem()
                 .items(["twow is that a bee"])
                 .path(ResultPath.fromList(["test", "echo"]))
-                .addError(GraphqlErrorBuilder.newError()
+                .addError(newError()
                         .message("wow")
                         .build())
                 .addErrors([])
                 .errors([
-                        GraphqlErrorBuilder.newError()
+                        newError()
                                 .message("yep")
                                 .build(),
                 ])
@@ -103,8 +104,8 @@ class StreamPayloadTest extends Specification {
         def items2 = ["test2", "test3"]
         def path1 = ["test", "echo"]
         def path2 = ["test", "echo", "foo"]
-        def errors1 = [GraphqlErrorBuilder.newError().message("error1").build()]
-        def errors2 = [GraphqlErrorBuilder.newError().message("error2").build()]
+        def errors1 = [newError().message("error1").build()]
+        def errors2 = [newError().message("error2").build()]
         def extensions1 = [echo: "1"]
         def extensions2 = [echo: "2"]
 

--- a/src/test/groovy/graphql/incremental/StreamPayloadTest.groovy
+++ b/src/test/groovy/graphql/incremental/StreamPayloadTest.groovy
@@ -96,4 +96,57 @@ class StreamPayloadTest extends Specification {
                 path      : ["test", "echo"],
         ]
     }
+
+    def "test equals and hashCode methods work"() {
+        given:
+        def items1 = ["test1"]
+        def items2 = ["test2", "test3"]
+        def path1 = ["test", "echo"]
+        def path2 = ["test", "echo", "foo"]
+        def errors1 = [GraphqlErrorBuilder.newError().message("error1").build()]
+        def errors2 = [GraphqlErrorBuilder.newError().message("error2").build()]
+        def extensions1 = [echo: "1"]
+        def extensions2 = [echo: "2"]
+
+        def payload = new StreamPayload.Builder()
+                .items(items1)
+                .path(path1)
+                .label("label1")
+                .errors(errors1)
+                .extensions(extensions1)
+                .build()
+
+        def equivalentPayload = new StreamPayload.Builder()
+                .items(items1)
+                .path(path1)
+                .label("label1")
+                .errors(errors1)
+                .extensions(extensions1)
+                .build()
+
+        def totallyDifferentPayload = new StreamPayload.Builder()
+                .items(items2)
+                .path(path2)
+                .label("label2")
+                .errors(errors2)
+                .extensions(extensions2)
+                .build()
+
+        def slightlyDifferentPayload = new StreamPayload.Builder()
+                .items(items2)
+                .path(path2)
+                .label("label1")
+                .errors(errors1)
+                .extensions(extensions2)
+                .build()
+
+        expect:
+        payload == equivalentPayload
+        payload != totallyDifferentPayload
+        payload != slightlyDifferentPayload
+
+        payload.hashCode() == equivalentPayload.hashCode()
+        payload.hashCode() != totallyDifferentPayload.hashCode()
+        payload.hashCode() != slightlyDifferentPayload.hashCode()
+    }
 }


### PR DESCRIPTION
Closes #3704 

Adding these handy methods to help cut down lines of code in tests