### PR TITLE
Update documentation examples to remove deprecated context method

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,3 @@ take the time to read it.
 ### License
 
 Copyright (c) 2015, Andreas Marek and [Contributors](https://github.com/graphql-java/graphql-java/graphs/contributors)
-
-### Supported by

--- a/README.zh_cn.md
+++ b/README.zh_cn.md
@@ -24,9 +24,3 @@
 ### License
 
 Copyright (c) 2015, Andreas Marek and [贡献者们](https://github.com/graphql-java/graphql-java/graphs/contributors)
-
-### 帮助支持
-
-![YourKit](https://www.yourkit.com/images/yklogo.png)
-
-[YourKit](https://www.yourkit.com/) 通过 YourKit Java Profiler 能力对该项目提供了支持。

--- a/src/test/groovy/readme/DataFetchingExamples.java
+++ b/src/test/groovy/readme/DataFetchingExamples.java
@@ -47,7 +47,7 @@ public class DataFetchingExamples {
         DataFetcher productsDataFetcher = new DataFetcher<List<ProductDTO>>() {
             @Override
             public List<ProductDTO> get(DataFetchingEnvironment environment) {
-                DatabaseSecurityCtx ctx = environment.getContext();
+                DatabaseSecurityCtx ctx = environment.getGraphQlContext().get("databaseSecurityCtx");
 
                 List<ProductDTO> products;
                 String match = environment.getArgument("match");

--- a/src/test/groovy/readme/DirectivesExamples.java
+++ b/src/test/groovy/readme/DirectivesExamples.java
@@ -39,7 +39,7 @@ public class DirectivesExamples {
 
         @Override
         public GraphQLFieldDefinition onField(SchemaDirectiveWiringEnvironment<GraphQLFieldDefinition> environment) {
-            String targetAuthRole = (String) environment.getDirective().getArgument("role").getArgumentValue().getValue();
+            String targetAuthRole = (String) environment.getAppliedDirective().getArgument("role").getArgumentValue().getValue();
 
             //
             // build a data fetcher that first checks authorisation roles before then calling the original data fetcher

--- a/src/test/groovy/readme/DirectivesExamples.java
+++ b/src/test/groovy/readme/DirectivesExamples.java
@@ -48,8 +48,7 @@ public class DirectivesExamples {
             DataFetcher authDataFetcher = new DataFetcher() {
                 @Override
                 public Object get(DataFetchingEnvironment dataFetchingEnvironment) throws Exception {
-                    Map<String, Object> contextMap = dataFetchingEnvironment.getContext();
-                    AuthorisationCtx authContext = (AuthorisationCtx) contextMap.get("authContext");
+                    AuthorisationCtx authContext = dataFetchingEnvironment.getGraphQlContext().get("authContext");
 
                     if (authContext.hasRole(targetAuthRole)) {
                         return originalDataFetcher.get(dataFetchingEnvironment);
@@ -83,7 +82,7 @@ public class DirectivesExamples {
 
         ExecutionInput executionInput = ExecutionInput.newExecutionInput()
                 .query(query)
-                .graphQLContext(builder -> builder.put("authCtx", authCtx))
+                .graphQLContext(builder -> builder.put("authContext", authCtx))
                 .build();
     }
 


### PR DESCRIPTION
Closes #3678 

We should be only referencing `GraphQLContext` rather than `Context` in the documentation

See the documentation changes in https://github.com/graphql-java/graphql-java-page/pull/184/files

This PR checks in the examples into this repo