### PR TITLE
Update deprecated reason if changed by schema transformer

### DIFF
--- a/src/test/groovy/graphql/schema/SchemaTransformerTest.groovy
+++ b/src/test/groovy/graphql/schema/SchemaTransformerTest.groovy
@@ -960,7 +960,7 @@ type Query {
         visitedCodeRegistry instanceof GraphQLCodeRegistry.Builder
     }
 
-    def "deprecation transformation overrides existing deprecated directive reason for object type"() {
+    def "deprecation transformation correctly overrides existing deprecated directive reasons"() {
         def schema = TestUtil.schema("""
           schema {
             query: QueryType


### PR DESCRIPTION
Fixes #3786 

### Background

With the schema transformer, it's possible to update the deprecated reason stored on a field definition.

@t2gran reported that the schema printer wasn't printing out the correct deprecated reason when it had been changed by a schema transformer. See #3786 and test in this gist: https://gist.github.com/t2gran/69b149357477870ba25e00375a2626a2. The bug was happening on fields in object types, interface types, and input types. I've recycled the gist object type test and added interface and input type cases.

The root cause was that the schema printer didn't re-check deprecated reason arguments if the deprecated directive already existed. Previously it (incorrectly) assumed that if the deprecated directive already existed, then the reason was fine. This PR fixes that.

I got nerd sniped 😄