### PR TITLE
Update shadow plugin after ownership change

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
     id 'maven-publish'
     id 'antlr'
     id 'signing'
-    id "com.github.johnrengelman.shadow" version "8.1.1"
+    id "com.gradleup.shadow" version "8.3.0"
     id "biz.aQute.bnd.builder" version "6.4.0"
     id "io.github.gradle-nexus.publish-plugin" version "2.0.0"
     id "groovy"


### PR DESCRIPTION
The original maintainer of shadow has handed over the project to GradleUp, an umbrella organisation that manages Gradle open source projects.

Good news is, the project is continuing. The only difference is the plugin ID changes to reflect the new ownership by GradleUp.

This PR pulls in the next closest version to what we had before, to minimise breaking changes.

As a paranoid end-to-end check, I created the jar with shading with this new plugin version, and pulled it into a separate project, running our Hello World example which requires Antlr to work. It still works.

GitHub thread explaining ownership change: https://github.com/GradleUp/shadow/issues/908
Changelog with 8.3.0 release notes: https://github.com/GradleUp/shadow/blob/main/src/docs/changes/README.md#v830-2024-08-08