### PR TITLE
Avoid allocating in GraphQLInputObjectType.getFieldDefinitions

### DIFF
--- a/src/main/java/graphql/schema/GraphQLInputObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectType.java
@@ -1,5 +1,6 @@
 package graphql.schema;
 
+import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import graphql.Directives;
@@ -152,7 +153,8 @@ public class GraphQLInputObjectType implements GraphQLNamedInputType, GraphQLUnm
 
     @Override
     public List<GraphQLInputObjectField> getFieldDefinitions() {
-        return ImmutableList.copyOf(fieldMap.values());
+        ImmutableCollection<GraphQLInputObjectField> values = fieldMap.values();
+        return values instanceof ImmutableList<?> ? (ImmutableList<GraphQLInputObjectField>) values : ImmutableList.copyOf(values);
     }
 
     public InputObjectTypeDefinition getDefinition() {


### PR DESCRIPTION
Avoid copying / allocating a new List in GraphQLInputObjectType's getFieldDefinitions method. the field definitions are already stored as values in an ImmutableMap, and the default Guava implementation of the values method returns an ImmutableList; the issue arises due to the returned collection being a "partial view", which ImmutableList.copyOf uses as a signal that it should create a defensive copy of the passed in collection. In this particular case we just don't care if it's a partial view, since the owning ImmutableMap will be retained regardless.