### PR TITLE
Optimize GraphQLUnionType.isPossibleType

### DIFF
--- a/src/main/java/graphql/schema/GraphQLUnionType.java
+++ b/src/main/java/graphql/schema/GraphQLUnionType.java
@@ -96,7 +96,12 @@ public class GraphQLUnionType implements GraphQLNamedOutputType, GraphQLComposit
      * @return true if the object type is a member of this union type.
      */
     public boolean isPossibleType(GraphQLObjectType graphQLObjectType) {
-        return getTypes().stream().anyMatch(nt -> nt.getName().equals(graphQLObjectType.getName()));
+        for (GraphQLNamedOutputType type : getTypes()) {
+            if (type.getName().equals(graphQLObjectType.getName())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     // to be removed in a future version when all code is in the code registry


### PR DESCRIPTION
Remove the allocation overhead of the stream / lambda in isPossibleType; don't have the flame graph on hand any longer unfortunately but this was showing up as an allocation hotspot for one of our apps.