### PR TITLE
Update agent's shadow plugin to new namespace

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
     id 'java-library'
     id 'maven-publish'
-    id "com.github.johnrengelman.shadow" version "8.1.1"
+    id "com.gradleup.shadow" version "8.3.0"
 }
 
 dependencies {


### PR DESCRIPTION
Adding the same shadow plugin update to the Agent's build.gradle as well

Context: the original maintainer of shadow has handed over the project to a new organisation, which meant the plugin ID changed.

GitHub thread explaining ownership change: https://github.com/GradleUp/shadow/issues/908
Changelog with 8.3.0 release notes: https://github.com/GradleUp/shadow/blob/main/src/docs/changes/README.md#v830-2024-08-08