### PR TITLE
Revert "Update shadow plugin after ownership change"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
     id 'maven-publish'
     id 'antlr'
     id 'signing'
-    id "com.gradleup.shadow" version "8.3.0"
+    id "com.github.johnrengelman.shadow" version "8.1.1"
     id "biz.aQute.bnd.builder" version "6.4.0"
     id "io.github.gradle-nexus.publish-plugin" version "2.0.0"
     id "groovy"


### PR DESCRIPTION
Reverts graphql-java/graphql-java#3791

I'll debug later, I suspect this caused failing PR builds. This is mysterious, because the original PR's build did pass