### PR TITLE
Use client locale if possible in validation of incoming requests

### DIFF
--- a/src/main/java/graphql/validation/rules/ArgumentsOfCorrectType.java
+++ b/src/main/java/graphql/validation/rules/ArgumentsOfCorrectType.java
@@ -28,7 +28,7 @@ public class ArgumentsOfCorrectType extends AbstractRule {
             return;
         }
         ArgumentValidationUtil validationUtil = new ArgumentValidationUtil(argument);
-        if (!validationUtil.isValidLiteralValue(argument.getValue(), fieldArgument.getType(), getValidationContext().getSchema(), getValidationContext().getGraphQLContext(), Locale.getDefault())) {
+        if (!validationUtil.isValidLiteralValue(argument.getValue(), fieldArgument.getType(), getValidationContext().getSchema(), getValidationContext().getGraphQLContext(), getValidationContext().getI18n().getLocale())) {
             String message = i18n(WrongType, validationUtil.getMsgAndArgs());
             addError(ValidationError.newValidationError()
                     .validationErrorType(WrongType)

--- a/src/main/java/graphql/validation/rules/VariableDefaultValuesOfCorrectType.java
+++ b/src/main/java/graphql/validation/rules/VariableDefaultValuesOfCorrectType.java
@@ -27,7 +27,7 @@ public class VariableDefaultValuesOfCorrectType extends AbstractRule {
             return;
         }
         if (variableDefinition.getDefaultValue() != null
-                && !getValidationUtil().isValidLiteralValue(variableDefinition.getDefaultValue(), inputType, getValidationContext().getSchema(), getValidationContext().getGraphQLContext(), Locale.getDefault())) {
+                && !getValidationUtil().isValidLiteralValue(variableDefinition.getDefaultValue(), inputType, getValidationContext().getSchema(), getValidationContext().getGraphQLContext(), getValidationContext().getI18n().getLocale())) {
             String message = i18n(BadValueForDefaultArg, "VariableDefaultValuesOfCorrectType.badDefault", variableDefinition.getDefaultValue(), simplePrint(inputType));
             addError(BadValueForDefaultArg, variableDefinition.getSourceLocation(), message);
         }

--- a/src/test/groovy/graphql/validation/rules/ArgumentsOfCorrectTypeTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/ArgumentsOfCorrectTypeTest.groovy
@@ -44,6 +44,25 @@ class ArgumentsOfCorrectTypeTest extends Specification {
         i18n.getLocale() >> Locale.ENGLISH
     }
 
+    def "error message uses locale of client (German), not server (English)"() {
+        def query = """
+            query getDog {
+              dog @objectArgumentDirective(myObject: { id: "1" }) {
+                name
+              }           
+            }
+        """
+        def document = new Parser().parseDocument(query)
+
+        when:
+        def validationErrors = new Validator().validateDocument(SpecValidationSchema.specValidationSchema, document, Locale.GERMAN)
+
+        then:
+        validationErrors.size() == 1
+        validationErrors.get(0).getValidationErrorType() == ValidationErrorType.WrongType
+        validationErrors.get(0).message == "Validierungsfehler (WrongType@[dog]) : Argument 'myObject' mit Wert 'ObjectValue{objectFields=[ObjectField{name='id', value=StringValue{value='1'}}]}' fehlen Pflichtfelder '[name]'"
+    }
+
     def "valid type results in no error"() {
         given:
         def variableReference = new VariableReference("ref")

--- a/src/test/groovy/graphql/validation/rules/ArgumentsOfCorrectTypeTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/ArgumentsOfCorrectTypeTest.groovy
@@ -1,6 +1,7 @@
 package graphql.validation.rules
 
 import graphql.GraphQLContext
+import graphql.i18n.I18n
 import graphql.language.Argument
 import graphql.language.ArrayValue
 import graphql.language.BooleanValue
@@ -33,11 +34,14 @@ class ArgumentsOfCorrectTypeTest extends Specification {
     ArgumentsOfCorrectType argumentsOfCorrectType
     ValidationContext validationContext = Mock(ValidationContext)
     ValidationErrorCollector errorCollector = new ValidationErrorCollector()
+    I18n i18n = Mock(I18n)
 
     def setup() {
         argumentsOfCorrectType = new ArgumentsOfCorrectType(validationContext, errorCollector)
         def context = GraphQLContext.getDefault()
         validationContext.getGraphQLContext() >> context
+        validationContext.getI18n() >> i18n
+        i18n.getLocale() >> Locale.ENGLISH
     }
 
     def "valid type results in no error"() {

--- a/src/test/groovy/graphql/validation/rules/VariableDefaultValuesOfCorrectTypeTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/VariableDefaultValuesOfCorrectTypeTest.groovy
@@ -19,10 +19,13 @@ class VariableDefaultValuesOfCorrectTypeTest extends Specification {
     ValidationContext validationContext = Mock(ValidationContext)
     ValidationErrorCollector errorCollector = new ValidationErrorCollector()
     VariableDefaultValuesOfCorrectType defaultValuesOfCorrectType = new VariableDefaultValuesOfCorrectType(validationContext, errorCollector)
+    I18n i18n = Mock(I18n)
 
     void setup() {
         def context = GraphQLContext.getDefault()
         validationContext.getGraphQLContext() >> context
+        validationContext.getI18n() >> i18n
+        i18n.getLocale() >> Locale.ENGLISH
     }
 
     def "default value has wrong type"() {

--- a/src/test/groovy/graphql/validation/rules/VariableDefaultValuesOfCorrectTypeTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/VariableDefaultValuesOfCorrectTypeTest.groovy
@@ -73,4 +73,38 @@ class VariableDefaultValuesOfCorrectTypeTest extends Specification {
         validationErrors[0].getValidationErrorType() == ValidationErrorType.BadValueForDefaultArg
         validationErrors[0].message == "Validation error (BadValueForDefaultArg) : Bad default value 'StringValue{value='NotANumber'}' for type 'Int'"
     }
+
+    def "default value has wrong type with error message of client (German), not server (English)"() {
+        setup:
+        def schema = '''
+            type User {
+                id: String
+            }
+            
+            type Query {
+                getUsers(howMany: Int) : [User]
+            }
+        '''
+
+        def query = '''
+            query($howMany: Int = "NotANumber") {
+                getUsers(howMany: $howMany) {
+                    id
+                } 
+            }
+        '''
+
+        def graphQlSchema = TestUtil.schema(schema)
+        def document = TestUtil.parseQuery(query)
+        def validator = new Validator()
+
+        when:
+        def validationErrors = validator.validateDocument(graphQlSchema, document, Locale.GERMAN)
+
+        then:
+        !validationErrors.empty
+        validationErrors.size() == 1
+        validationErrors[0].getValidationErrorType() == ValidationErrorType.BadValueForDefaultArg
+        validationErrors[0].message == "Validierungsfehler (BadValueForDefaultArg) : Ungültiger Standardwert 'StringValue{value='NotANumber'}' für Typ 'Int'"
+    }
 }


### PR DESCRIPTION
Fixes #3779 , thanks @replikonio for reporting!

This updates 2 validation rules to use the locale in the validation context. This locale is set as the client's locale (via ExecutionInput) or defaults to the JVM default locale.

One validation rule for incoming requests `VariableTypesMatch` was already using the client's locale. This updates 2 more rules to use the client's locale as well.
