### PR TITLE
Added the ability to parse our ExecutionResult from a map that came from toSpecification

### DIFF
--- a/src/main/java/graphql/ExecutionResult.java
+++ b/src/main/java/graphql/ExecutionResult.java
@@ -56,6 +56,16 @@ public interface ExecutionResult {
      */
     Map<String, Object> toSpecification();
 
+    /**
+     * This allows you to turn a map of results from {@link #toSpecification()} and turn it back into a {@link ExecutionResult}
+     *
+     * @param specificationMap the specification result map
+     *
+     * @return a new {@link ExecutionResult} from that map
+     */
+    static ExecutionResult fromSpecification(Map<String, Object> specificationMap) {
+        return ExecutionResultImpl.fromSpecification(specificationMap);
+    }
 
     /**
      * This helps you transform the current {@link ExecutionResult} object into another one by starting a builder with all

--- a/src/main/java/graphql/ExecutionResultImpl.java
+++ b/src/main/java/graphql/ExecutionResultImpl.java
@@ -97,6 +97,24 @@ public class ExecutionResultImpl implements ExecutionResult {
         return map(errors, GraphQLError::toSpecification);
     }
 
+    @SuppressWarnings("unchecked")
+    static ExecutionResult fromSpecification(Map<String, Object> specificationMap) {
+        ExecutionResult.Builder<?> builder = ExecutionResult.newExecutionResult();
+        Object data = specificationMap.get("data");
+        if (data != null) {
+            builder.data(data);
+        }
+        List<Map<String, Object>> errors = (List<Map<String, Object>>) specificationMap.get("errors");
+        if (errors != null) {
+            builder.errors(GraphqlErrorHelper.fromSpecification(errors));
+        }
+        Map<Object, Object> extensions = (Map<Object, Object>) specificationMap.get("extensions");
+        if (extensions != null) {
+            builder.extensions(extensions);
+        }
+        return builder.build();
+    }
+
     @Override
     public String toString() {
         return "ExecutionResultImpl{" +

--- a/src/main/java/graphql/GraphQLError.java
+++ b/src/main/java/graphql/GraphQLError.java
@@ -71,6 +71,17 @@ public interface GraphQLError extends Serializable {
     }
 
     /**
+     * This can be called to turn a specification error map into {@link GraphQLError}
+     *
+     * @param specificationMap the map of values that should have come via {@link GraphQLError#toSpecification()}
+     *
+     * @return a {@link GraphQLError}
+     */
+    static GraphQLError fromSpecification(Map<String, Object> specificationMap) {
+        return GraphqlErrorHelper.fromSpecification(specificationMap);
+    }
+
+    /**
      * @return a new builder of {@link GraphQLError}s
      */
     static Builder<?> newError() {

--- a/src/test/groovy/graphql/ExecutionResultImplTest.groovy
+++ b/src/test/groovy/graphql/ExecutionResultImplTest.groovy
@@ -176,29 +176,58 @@ class ExecutionResultImplTest extends Specification {
 
     def "test setting extensions"() {
         given:
-        def startEr = new ExecutionResultImpl("Some Data", KNOWN_ERRORS,null)
+        def startEr = new ExecutionResultImpl("Some Data", KNOWN_ERRORS, null)
 
-        def er = ExecutionResultImpl.newExecutionResult().from(startEr).extensions([ext1:"here"]).build()
+        def er = ExecutionResultImpl.newExecutionResult().from(startEr).extensions([ext1: "here"]).build()
 
         when:
         def extensions = er.getExtensions()
 
         then:
-        extensions == [ext1:"here"]
+        extensions == [ext1: "here"]
     }
 
     def "test adding extension"() {
         given:
-        def startEr = new ExecutionResultImpl("Some Data", KNOWN_ERRORS,[ext1:"here"])
+        def startEr = new ExecutionResultImpl("Some Data", KNOWN_ERRORS, [ext1: "here"])
 
-        def er = ExecutionResultImpl.newExecutionResult().from(startEr).addExtension("ext2","aswell").build()
+        def er = ExecutionResultImpl.newExecutionResult().from(startEr).addExtension("ext2", "aswell").build()
 
         when:
         def extensions = er.getExtensions()
 
         then:
-        extensions == [ext1:"here", ext2 : "aswell"]
+        extensions == [ext1: "here", ext2: "aswell"]
     }
 
+    def "can parse out a map of to an ER"() {
+        when:
+        def map = [data: [f: "v"]]
+        def er = ExecutionResult.fromSpecification(map)
+        then:
+        er.data == [f: "v"]
+        er.extensions == null
+        er.errors.isEmpty()
 
+        when:
+        // GraphqlErrorHelperTest is more extensive tests for error parsing which we will not repeat here
+        map = [errors: [[message: "m0"], [message: "m1"]]]
+        er = ExecutionResult.fromSpecification(map)
+        then:
+        er.data == null
+        er.extensions == null
+        !er.errors.isEmpty()
+        er.errors[0].message == "m0"
+        er.errors[1].message == "m1"
+
+
+        when:
+        map = [data: [f: "v"], extensions: [ext1: "here", ext2: "and here"]]
+        er = ExecutionResult.fromSpecification(map)
+        then:
+        er.data == [f: "v"]
+        er.extensions == [ext1: "here", ext2: "and here"]
+        er.errors.isEmpty()
+
+    }
 }

--- a/src/test/groovy/graphql/GraphqlErrorHelperTest.groovy
+++ b/src/test/groovy/graphql/GraphqlErrorHelperTest.groovy
@@ -151,7 +151,7 @@ class GraphqlErrorHelperTest extends Specification {
             assert gErr.getErrorType() == ErrorType.DataFetchingException // default from error builder
             assert gErr.getLocations() == []
             assert gErr.getPath() == null
-            assert graphQLError.getExtensions() == null
+            assert gErr.getExtensions() == null
         }
     }
 }

--- a/src/test/groovy/graphql/GraphqlErrorHelperTest.groovy
+++ b/src/test/groovy/graphql/GraphqlErrorHelperTest.groovy
@@ -106,4 +106,52 @@ class GraphqlErrorHelperTest extends Specification {
                     message   : "has extensions"
         ]
     }
+
+    def "can parse out a map and make an error"() {
+        when:
+        def rawError = [message: "m"]
+        def graphQLError = GraphqlErrorHelper.fromSpecification(rawError)
+        then:
+        graphQLError.getMessage() == "m"
+        graphQLError.getErrorType() == ErrorType.DataFetchingException // default from error builder
+        graphQLError.getLocations() == []
+        graphQLError.getPath() == null
+        graphQLError.getExtensions() == null
+
+        when:
+        rawError = [message: "m"]
+        graphQLError = GraphQLError.fromSpecification(rawError) // just so we reference the public method
+        then:
+        graphQLError.getMessage() == "m"
+        graphQLError.getErrorType() == ErrorType.DataFetchingException // default from error builder
+        graphQLError.getLocations() == []
+        graphQLError.getPath() == null
+        graphQLError.getExtensions() == null
+
+        when:
+        def extensionsMap = [attr1: "a1", attr2: "a2", classification: "CLASSIFICATION-X"]
+        rawError = [message: "m", path: ["a", "b"], locations: [[line: 2, column: 3]], extensions: extensionsMap]
+        graphQLError = GraphqlErrorHelper.fromSpecification(rawError)
+
+        then:
+        graphQLError.getMessage() == "m"
+        graphQLError.getErrorType().toString() == "CLASSIFICATION-X"
+        graphQLError.getLocations() == [new SourceLocation(2, 3)]
+        graphQLError.getPath() == ["a", "b"]
+        graphQLError.getExtensions() == extensionsMap
+
+
+        when: "can do a list of errors"
+        def rawErrors = [[message: "m0"], [message: "m1"]]
+        def errors = GraphqlErrorHelper.fromSpecification(rawErrors)
+        then:
+        errors.size() == 2
+        errors.eachWithIndex { GraphQLError gErr, int i ->
+            assert gErr.getMessage() == "m" + i
+            assert gErr.getErrorType() == ErrorType.DataFetchingException // default from error builder
+            assert gErr.getLocations() == []
+            assert gErr.getPath() == null
+            assert graphQLError.getExtensions() == null
+        }
+    }
 }


### PR DESCRIPTION
We can today make a Map<String,Object> from an ExecutionResult but we can do the opposite

I needed to to this in some client reading HTTP graphql response code and making a ER was difficult and should be in graphql-java so here it is