### PR TITLE
migrate from jetbrains annotations to jspecify

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,10 +99,10 @@ jar {
 }
 
 dependencies {
-    compileOnly 'org.jetbrains:annotations:26.0.2'
     implementation 'org.antlr:antlr4-runtime:' + antlrVersion
     api 'com.graphql-java:java-dataloader:3.4.0'
     api 'org.reactivestreams:reactive-streams:' + reactiveStreamsVersion
+    api "org.jspecify:jspecify:1.0.0"
     antlr 'org.antlr:antlr4:' + antlrVersion
     implementation 'com.google.guava:guava:' + guavaVersion
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'

--- a/src/main/java/graphql/GraphQLError.java
+++ b/src/main/java/graphql/GraphQLError.java
@@ -3,7 +3,7 @@ package graphql;
 
 import graphql.execution.ResultPath;
 import graphql.language.SourceLocation;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.io.Serializable;
 import java.util.List;

--- a/src/main/java/graphql/GraphqlErrorBuilder.java
+++ b/src/main/java/graphql/GraphqlErrorBuilder.java
@@ -4,7 +4,7 @@ import graphql.execution.DataFetcherResult;
 import graphql.execution.ResultPath;
 import graphql.language.SourceLocation;
 import graphql.schema.DataFetchingEnvironment;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/graphql/ParseAndValidate.java
+++ b/src/main/java/graphql/ParseAndValidate.java
@@ -8,7 +8,7 @@ import graphql.parser.ParserOptions;
 import graphql.schema.GraphQLSchema;
 import graphql.validation.ValidationError;
 import graphql.validation.Validator;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 import java.util.List;
 import java.util.Locale;
@@ -42,7 +42,7 @@ public class ParseAndValidate {
      *
      * @return a result object that indicates how this operation went
      */
-    public static ParseAndValidateResult parseAndValidate(@NotNull GraphQLSchema graphQLSchema, @NotNull ExecutionInput executionInput) {
+    public static ParseAndValidateResult parseAndValidate(@NonNull GraphQLSchema graphQLSchema, @NonNull ExecutionInput executionInput) {
         ParseAndValidateResult result = parse(executionInput);
         if (!result.isFailure()) {
             List<ValidationError> errors = validate(graphQLSchema, result.getDocument(), executionInput.getLocale());
@@ -58,7 +58,7 @@ public class ParseAndValidate {
      *
      * @return a result object that indicates how this operation went
      */
-    public static ParseAndValidateResult parse(@NotNull ExecutionInput executionInput) {
+    public static ParseAndValidateResult parse(@NonNull ExecutionInput executionInput) {
         try {
             //
             // we allow the caller to specify new parser options by context
@@ -87,7 +87,7 @@ public class ParseAndValidate {
      *
      * @return a result object that indicates how this operation went
      */
-    public static List<ValidationError> validate(@NotNull GraphQLSchema graphQLSchema, @NotNull Document parsedDocument, @NotNull Locale locale) {
+    public static List<ValidationError> validate(@NonNull GraphQLSchema graphQLSchema, @NonNull Document parsedDocument, @NonNull Locale locale) {
         return validate(graphQLSchema, parsedDocument, ruleClass -> true, locale);
     }
 
@@ -99,7 +99,7 @@ public class ParseAndValidate {
      *
      * @return a result object that indicates how this operation went
      */
-    public static List<ValidationError> validate(@NotNull GraphQLSchema graphQLSchema, @NotNull Document parsedDocument) {
+    public static List<ValidationError> validate(@NonNull GraphQLSchema graphQLSchema, @NonNull Document parsedDocument) {
         return validate(graphQLSchema, parsedDocument, ruleClass -> true, Locale.getDefault());
     }
 
@@ -113,7 +113,7 @@ public class ParseAndValidate {
      *
      * @return a result object that indicates how this operation went
      */
-    public static List<ValidationError> validate(@NotNull GraphQLSchema graphQLSchema, @NotNull Document parsedDocument, @NotNull Predicate<Class<?>> rulePredicate, @NotNull Locale locale) {
+    public static List<ValidationError> validate(@NonNull GraphQLSchema graphQLSchema, @NonNull Document parsedDocument, @NonNull Predicate<Class<?>> rulePredicate, @NonNull Locale locale) {
         Validator validator = new Validator();
         return validator.validateDocument(graphQLSchema, parsedDocument, rulePredicate, locale);
     }
@@ -127,7 +127,7 @@ public class ParseAndValidate {
      *
      * @return a result object that indicates how this operation went
      */
-    public static List<ValidationError> validate(@NotNull GraphQLSchema graphQLSchema, @NotNull Document parsedDocument, @NotNull Predicate<Class<?>> rulePredicate) {
+    public static List<ValidationError> validate(@NonNull GraphQLSchema graphQLSchema, @NonNull Document parsedDocument, @NonNull Predicate<Class<?>> rulePredicate) {
         Validator validator = new Validator();
         return validator.validateDocument(graphQLSchema, parsedDocument, rulePredicate, Locale.getDefault());
     }

--- a/src/main/java/graphql/analysis/MaxQueryComplexityInstrumentation.java
+++ b/src/main/java/graphql/analysis/MaxQueryComplexityInstrumentation.java
@@ -11,7 +11,7 @@ import graphql.execution.instrumentation.parameters.InstrumentationCreateStatePa
 import graphql.execution.instrumentation.parameters.InstrumentationExecuteOperationParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationValidationParameters;
 import graphql.validation.ValidationError;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;

--- a/src/main/java/graphql/analysis/MaxQueryDepthInstrumentation.java
+++ b/src/main/java/graphql/analysis/MaxQueryDepthInstrumentation.java
@@ -8,7 +8,7 @@ import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.InstrumentationState;
 import graphql.execution.instrumentation.SimplePerformantInstrumentation;
 import graphql.execution.instrumentation.parameters.InstrumentationExecuteOperationParameters;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/graphql/analysis/values/ValueVisitor.java
+++ b/src/main/java/graphql/analysis/values/ValueVisitor.java
@@ -10,7 +10,7 @@ import graphql.schema.GraphQLInputSchemaElement;
 import graphql.schema.GraphQLInputValueDefinition;
 import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLScalarType;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/graphql/execution/Async.java
+++ b/src/main/java/graphql/execution/Async.java
@@ -2,8 +2,8 @@ package graphql.execution;
 
 import graphql.Assert;
 import graphql.Internal;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -230,7 +230,7 @@ public class Async {
         }
 
         @SuppressWarnings("unchecked")
-        @NotNull
+        @NonNull
         private CompletableFuture<T>[] copyOnlyCFsToArray() {
             if (cfCount == array.length) {
                 // if it's all CFs - make a type safe copy via C code
@@ -258,7 +258,7 @@ public class Async {
             }
         }
 
-        @NotNull
+        @NonNull
         private List<T> materialisedList(Object[] array) {
             List<T> results = new ArrayList<>(array.length);
             for (Object object : array) {
@@ -405,7 +405,7 @@ public class Async {
      *
      * @return the completableFuture if it's not null or one that always resoles to null
      */
-    public static <T> @NotNull CompletableFuture<T> orNullCompletedFuture(@Nullable CompletableFuture<T> completableFuture) {
+    public static <T> @NonNull CompletableFuture<T> orNullCompletedFuture(@Nullable CompletableFuture<T> completableFuture) {
         return completableFuture != null ? completableFuture : CompletableFuture.completedFuture(null);
     }
 }

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -29,7 +29,7 @@ import graphql.language.VariableDefinition;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.impl.SchemaUtil;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import org.reactivestreams.Publisher;
 
 import java.util.Collections;
@@ -118,7 +118,7 @@ public class Execution {
         return executeOperation(executionContext, executionInput.getRoot(), executionContext.getOperationDefinition());
     }
 
-    private static @NotNull CoercedVariables coerceVariableValues(GraphQLSchema graphQLSchema, ExecutionInput executionInput, OperationDefinition operationDefinition) {
+    private static @NonNull CoercedVariables coerceVariableValues(GraphQLSchema graphQLSchema, ExecutionInput executionInput, OperationDefinition operationDefinition) {
         RawVariables inputVariables = executionInput.getRawVariables();
         List<VariableDefinition> variableDefinitions = operationDefinition.getVariableDefinitions();
         return ValuesResolver.coerceVariableValues(graphQLSchema, variableDefinitions, inputVariables, executionInput.getGraphQLContext(), executionInput.getLocale());

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -48,7 +48,7 @@ import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
 import graphql.schema.LightDataFetcher;
 import graphql.util.FpKit;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -266,8 +266,7 @@ public abstract class ExecutionStrategy {
         }
     }
 
-    @NotNull
-    private static Async.CombinedBuilder<Object> fieldValuesCombinedBuilder(List<FieldValueInfo> completeValueInfos) {
+    private static Async.@NonNull CombinedBuilder<Object> fieldValuesCombinedBuilder(List<FieldValueInfo> completeValueInfos) {
         Async.CombinedBuilder<Object> resultFutures = Async.ofExpectedSize(completeValueInfos.size());
         for (FieldValueInfo completeValueInfo : completeValueInfos) {
             resultFutures.addObject(completeValueInfo.getFieldValueObject());
@@ -286,7 +285,7 @@ public abstract class ExecutionStrategy {
         };
     }
 
-    @NotNull
+    @NonNull
     private static Map<String, Object> buildFieldValueMap(List<String> fieldNames, List<Object> results) {
         Map<String, Object> resolvedValuesByField = Maps.newLinkedHashMapWithExpectedSize(fieldNames.size());
         int ix = 0;
@@ -312,8 +311,7 @@ public abstract class ExecutionStrategy {
 
     }
 
-    @NotNull
-    Async.CombinedBuilder<FieldValueInfo> getAsyncFieldValueInfo(
+    Async.@NonNull CombinedBuilder<FieldValueInfo> getAsyncFieldValueInfo(
             ExecutionContext executionContext,
             ExecutionStrategyParameters parameters,
             DeferredExecutionSupport deferredExecutionSupport
@@ -1007,6 +1005,7 @@ public abstract class ExecutionStrategy {
      * if max nodes were exceeded for this request.
      *
      * @param executionContext the execution context in play
+     *
      * @return true if max nodes were exceeded
      */
     private boolean incrementAndCheckMaxNodesExceeded(ExecutionContext executionContext) {
@@ -1059,6 +1058,7 @@ public abstract class ExecutionStrategy {
      *
      * @param e this indicates that a null value was returned for a non null field, which needs to cause the parent field
      *          to become null OR continue on as an exception
+     *
      * @throws NonNullableFieldWasNullException if a non null field resolves to a null value
      */
     protected void assertNonNullFieldPrecondition(NonNullableFieldWasNullException e) throws NonNullableFieldWasNullException {
@@ -1136,7 +1136,7 @@ public abstract class ExecutionStrategy {
                 .build();
     }
 
-    @NotNull
+    @NonNull
     private static Supplier<ImmutableMapWithNullValues<String, Object>> getArgumentValues(ExecutionContext executionContext,
                                                                                           List<GraphQLArgument> fieldArgDefs,
                                                                                           List<Argument> fieldArgs) {

--- a/src/main/java/graphql/execution/ExecutionStrategyParameters.java
+++ b/src/main/java/graphql/execution/ExecutionStrategyParameters.java
@@ -2,7 +2,7 @@ package graphql.execution;
 
 import graphql.PublicApi;
 import graphql.execution.incremental.DeferredCallContext;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.util.function.Consumer;
 

--- a/src/main/java/graphql/execution/MergedField.java
+++ b/src/main/java/graphql/execution/MergedField.java
@@ -6,7 +6,7 @@ import graphql.PublicApi;
 import graphql.execution.incremental.DeferredExecution;
 import graphql.language.Argument;
 import graphql.language.Field;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.Objects;

--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -27,8 +27,8 @@ import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
 import graphql.schema.InputValueWithState;
 import graphql.schema.visibility.GraphqlFieldVisibility;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -198,7 +198,7 @@ public class ValuesResolver {
         return result;
     }
 
-    @NotNull
+    @NonNull
     public static Map<String, Object> getArgumentValues(
             GraphQLCodeRegistry codeRegistry,
             List<GraphQLArgument> argumentTypes,
@@ -225,9 +225,9 @@ public class ValuesResolver {
      * @return a value converted to a literal
      */
     public static Value<?> valueToLiteral(
-            @NotNull GraphqlFieldVisibility fieldVisibility,
-            @NotNull InputValueWithState inputValueWithState,
-            @NotNull GraphQLType type,
+            @NonNull GraphqlFieldVisibility fieldVisibility,
+            @NonNull InputValueWithState inputValueWithState,
+            @NonNull GraphQLType type,
             GraphQLContext graphqlContext,
             Locale locale
     ) {
@@ -241,8 +241,8 @@ public class ValuesResolver {
     }
 
     public static Value<?> valueToLiteral(
-            @NotNull InputValueWithState inputValueWithState,
-            @NotNull GraphQLType type,
+            @NonNull InputValueWithState inputValueWithState,
+            @NonNull GraphQLType type,
             GraphQLContext graphqlContext,
             Locale locale
     ) {
@@ -318,7 +318,7 @@ public class ValuesResolver {
     }
 
 
-    @NotNull
+    @NonNull
     private static Map<String, Object> getArgumentValuesImpl(
             InputInterceptor inputInterceptor,
             GraphqlFieldVisibility fieldVisibility,

--- a/src/main/java/graphql/execution/ValuesResolverConversion.java
+++ b/src/main/java/graphql/execution/ValuesResolverConversion.java
@@ -26,8 +26,8 @@ import graphql.schema.InputValueWithState;
 import graphql.schema.visibility.DefaultGraphqlFieldVisibility;
 import graphql.schema.visibility.GraphqlFieldVisibility;
 import graphql.util.FpKit;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -220,7 +220,7 @@ class ValuesResolverConversion {
             GraphQLScalarType scalarType,
             Object value,
             GraphQLContext graphqlContext,
-            @NotNull Locale locale
+            @NonNull Locale locale
     ) {
         return scalarType.getCoercing().valueToLiteral(value, graphqlContext, locale);
 
@@ -714,7 +714,7 @@ class ValuesResolverConversion {
             GraphQLScalarType scalarType,
             CoercedVariables coercedVariables,
             GraphQLContext graphqlContext,
-            @NotNull Locale locale
+            @NonNull Locale locale
     ) {
         // the CoercingParseLiteralException exception that could happen here has been validated earlier via ValidationUtil
         return scalarType.getCoercing().parseLiteral(

--- a/src/main/java/graphql/execution/conditional/ConditionalNodeDecisionEnvironment.java
+++ b/src/main/java/graphql/execution/conditional/ConditionalNodeDecisionEnvironment.java
@@ -5,7 +5,7 @@ import graphql.execution.CoercedVariables;
 import graphql.language.Directive;
 import graphql.language.DirectivesContainer;
 import graphql.schema.GraphQLSchema;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 
@@ -39,7 +39,8 @@ public interface ConditionalNodeDecisionEnvironment {
     /**
      * @return the {@link GraphQLSchema} in question - this can be null for certain call paths
      */
-    @Nullable GraphQLSchema getGraphQlSchema();
+    @Nullable
+    GraphQLSchema getGraphQlSchema();
 
     /**
      * @return a graphql context

--- a/src/main/java/graphql/execution/conditional/ConditionalNodes.java
+++ b/src/main/java/graphql/execution/conditional/ConditionalNodes.java
@@ -11,7 +11,7 @@ import graphql.language.DirectivesContainer;
 import graphql.language.NodeUtil;
 import graphql.language.VariableReference;
 import graphql.schema.GraphQLSchema;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/graphql/execution/directives/QueryAppliedDirective.java
+++ b/src/main/java/graphql/execution/directives/QueryAppliedDirective.java
@@ -7,9 +7,9 @@ import graphql.language.Directive;
 import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphqlTypeBuilder;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -47,7 +47,7 @@ public class QueryAppliedDirective {
         this.definition = definition;
     }
 
-    @NotNull
+    @NonNull
     public String getName() {
         return name;
     }

--- a/src/main/java/graphql/execution/directives/QueryAppliedDirectiveArgument.java
+++ b/src/main/java/graphql/execution/directives/QueryAppliedDirectiveArgument.java
@@ -10,8 +10,8 @@ import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLInputType;
 import graphql.schema.GraphqlTypeBuilder;
 import graphql.schema.InputValueWithState;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Locale;
 import java.util.function.Consumer;
@@ -47,12 +47,12 @@ public class QueryAppliedDirectiveArgument {
         this.definition = definition;
     }
 
-    @NotNull
+    @NonNull
     public String getName() {
         return name;
     }
 
-    @NotNull
+    @NonNull
     public GraphQLInputType getType() {
         return originalType;
     }
@@ -64,7 +64,7 @@ public class QueryAppliedDirectiveArgument {
     /**
      * @return an input value with state for an applied directive argument
      */
-    public @NotNull InputValueWithState getArgumentValue() {
+    public @NonNull InputValueWithState getArgumentValue() {
         return value;
     }
 
@@ -166,7 +166,7 @@ public class QueryAppliedDirectiveArgument {
          *
          * @return this builder
          */
-        public Builder valueLiteral(@NotNull Value<?> value) {
+        public Builder valueLiteral(@NonNull Value<?> value) {
             this.value = InputValueWithState.newLiteralValue(value);
             return this;
         }
@@ -181,7 +181,7 @@ public class QueryAppliedDirectiveArgument {
             return this;
         }
 
-        public Builder inputValueWithState(@NotNull InputValueWithState value) {
+        public Builder inputValueWithState(@NonNull InputValueWithState value) {
             this.value = Assert.assertNotNull(value);
             return this;
         }

--- a/src/main/java/graphql/execution/incremental/DeferredExecution.java
+++ b/src/main/java/graphql/execution/incremental/DeferredExecution.java
@@ -2,7 +2,7 @@ package graphql.execution.incremental;
 
 import graphql.ExperimentalApi;
 import graphql.normalized.incremental.NormalizedDeferredExecution;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents details about the defer execution that can be associated with a {@link graphql.execution.MergedField}.

--- a/src/main/java/graphql/execution/incremental/IncrementalUtils.java
+++ b/src/main/java/graphql/execution/incremental/IncrementalUtils.java
@@ -7,7 +7,7 @@ import graphql.execution.CoercedVariables;
 import graphql.execution.ValuesResolver;
 import graphql.language.Directive;
 import graphql.language.NodeUtil;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.Locale;

--- a/src/main/java/graphql/execution/instrumentation/ChainedInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/ChainedInstrumentation.java
@@ -20,8 +20,8 @@ import graphql.language.Document;
 import graphql.schema.DataFetcher;
 import graphql.schema.GraphQLSchema;
 import graphql.validation.ValidationError;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.AbstractMap;
 import java.util.Arrays;
@@ -111,7 +111,7 @@ public class ChainedInstrumentation implements Instrumentation {
     }
 
     @Override
-    public @NotNull CompletableFuture<InstrumentationState> createStateAsync(InstrumentationCreateStateParameters parameters) {
+    public @NonNull CompletableFuture<InstrumentationState> createStateAsync(InstrumentationCreateStateParameters parameters) {
         return ChainedInstrumentationState.combineAll(instrumentations, parameters);
     }
 
@@ -212,41 +212,41 @@ public class ChainedInstrumentation implements Instrumentation {
         return chainedCtx(state, (instrumentation, specificState) -> instrumentation.beginFieldListCompletion(parameters, specificState));
     }
 
-    @NotNull
+    @NonNull
     @Override
     public ExecutionInput instrumentExecutionInput(ExecutionInput executionInput, InstrumentationExecutionParameters parameters, InstrumentationState state) {
         return chainedInstrument(state, executionInput, (instrumentation, specificState, accumulator) -> instrumentation.instrumentExecutionInput(accumulator, parameters, specificState));
     }
 
-    @NotNull
+    @NonNull
     @Override
     public DocumentAndVariables instrumentDocumentAndVariables(DocumentAndVariables documentAndVariables, InstrumentationExecutionParameters parameters, InstrumentationState state) {
         return chainedInstrument(state, documentAndVariables, (instrumentation, specificState, accumulator) ->
                 instrumentation.instrumentDocumentAndVariables(accumulator, parameters, specificState));
     }
 
-    @NotNull
+    @NonNull
     @Override
     public GraphQLSchema instrumentSchema(GraphQLSchema schema, InstrumentationExecutionParameters parameters, InstrumentationState state) {
         return chainedInstrument(state, schema, (instrumentation, specificState, accumulator) ->
                 instrumentation.instrumentSchema(accumulator, parameters, specificState));
     }
 
-    @NotNull
+    @NonNull
     @Override
     public ExecutionContext instrumentExecutionContext(ExecutionContext executionContext, InstrumentationExecutionParameters parameters, InstrumentationState state) {
         return chainedInstrument(state, executionContext, (instrumentation, specificState, accumulator) ->
                 instrumentation.instrumentExecutionContext(accumulator, parameters, specificState));
     }
 
-    @NotNull
+    @NonNull
     @Override
     public DataFetcher<?> instrumentDataFetcher(DataFetcher<?> dataFetcher, InstrumentationFieldFetchParameters parameters, InstrumentationState state) {
         return chainedInstrument(state, dataFetcher, (Instrumentation instrumentation, InstrumentationState specificState, DataFetcher<?> accumulator) ->
                 instrumentation.instrumentDataFetcher(accumulator, parameters, specificState));
     }
 
-    @NotNull
+    @NonNull
     @Override
     public CompletableFuture<ExecutionResult> instrumentExecutionResult(ExecutionResult executionResult, InstrumentationExecutionParameters parameters, InstrumentationState state) {
         ImmutableList<Map.Entry<Instrumentation, InstrumentationState>> entries = chainedMapAndDropNulls(state, AbstractMap.SimpleEntry::new);

--- a/src/main/java/graphql/execution/instrumentation/ExecuteObjectInstrumentationContext.java
+++ b/src/main/java/graphql/execution/instrumentation/ExecuteObjectInstrumentationContext.java
@@ -3,11 +3,10 @@ package graphql.execution.instrumentation;
 import graphql.Internal;
 import graphql.PublicSpi;
 import graphql.execution.FieldValueInfo;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 
 @PublicSpi
 public interface ExecuteObjectInstrumentationContext extends InstrumentationContext<Map<String, Object>> {
@@ -30,7 +29,7 @@ public interface ExecuteObjectInstrumentationContext extends InstrumentationCont
      *
      * @return a non null {@link InstrumentationContext} that maybe a no-op
      */
-    @NotNull
+    @NonNull
     @Internal
     static ExecuteObjectInstrumentationContext nonNullCtx(ExecuteObjectInstrumentationContext nullableContext) {
         return nullableContext == null ? NOOP : nullableContext;

--- a/src/main/java/graphql/execution/instrumentation/ExecutionStrategyInstrumentationContext.java
+++ b/src/main/java/graphql/execution/instrumentation/ExecutionStrategyInstrumentationContext.java
@@ -4,10 +4,9 @@ import graphql.ExecutionResult;
 import graphql.Internal;
 import graphql.PublicSpi;
 import graphql.execution.FieldValueInfo;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 @PublicSpi
 public interface ExecutionStrategyInstrumentationContext extends InstrumentationContext<ExecutionResult> {
@@ -27,7 +26,7 @@ public interface ExecutionStrategyInstrumentationContext extends Instrumentation
      *
      * @return a non null {@link InstrumentationContext} that maybe a no-op
      */
-    @NotNull
+    @NonNull
     @Internal
     static ExecutionStrategyInstrumentationContext nonNullCtx(ExecutionStrategyInstrumentationContext nullableContext) {
         return nullableContext == null ? NOOP : nullableContext;

--- a/src/main/java/graphql/execution/instrumentation/FieldFetchingInstrumentationContext.java
+++ b/src/main/java/graphql/execution/instrumentation/FieldFetchingInstrumentationContext.java
@@ -3,8 +3,8 @@ package graphql.execution.instrumentation;
 import graphql.Internal;
 import graphql.PublicSpi;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * FieldFetchingInstrumentationContext is returned back from the {@link Instrumentation#beginFieldFetching(InstrumentationFieldFetchParameters, InstrumentationState)}
@@ -43,7 +43,7 @@ public interface FieldFetchingInstrumentationContext extends InstrumentationCont
      * @param nullableContext a {@link InstrumentationContext} that can be null
      * @return a non-null {@link InstrumentationContext} that maybe a no-op
      */
-    @NotNull
+    @NonNull
     @Internal
     static FieldFetchingInstrumentationContext nonNullCtx(FieldFetchingInstrumentationContext nullableContext) {
         return nullableContext == null ? NOOP : nullableContext;

--- a/src/main/java/graphql/execution/instrumentation/Instrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/Instrumentation.java
@@ -17,8 +17,8 @@ import graphql.language.Document;
 import graphql.schema.DataFetcher;
 import graphql.schema.GraphQLSchema;
 import graphql.validation.ValidationError;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -262,7 +262,7 @@ public interface Instrumentation {
      *
      * @return a non-null instrumented ExecutionInput, the default is to return to the same object
      */
-    @NotNull
+    @NonNull
     default ExecutionInput instrumentExecutionInput(ExecutionInput executionInput, InstrumentationExecutionParameters parameters, InstrumentationState state) {
         return executionInput;
     }
@@ -276,7 +276,7 @@ public interface Instrumentation {
      *
      * @return a non-null instrumented DocumentAndVariables, the default is to return to the same objects
      */
-    @NotNull
+    @NonNull
     default DocumentAndVariables instrumentDocumentAndVariables(DocumentAndVariables documentAndVariables, InstrumentationExecutionParameters parameters, InstrumentationState state) {
         return documentAndVariables;
     }
@@ -291,7 +291,7 @@ public interface Instrumentation {
      *
      * @return a non-null instrumented GraphQLSchema, the default is to return to the same object
      */
-    @NotNull
+    @NonNull
     default GraphQLSchema instrumentSchema(GraphQLSchema schema, InstrumentationExecutionParameters parameters, InstrumentationState state) {
         return schema;
     }
@@ -306,7 +306,7 @@ public interface Instrumentation {
      *
      * @return a non-null instrumented ExecutionContext, the default is to return to the same object
      */
-    @NotNull
+    @NonNull
     default ExecutionContext instrumentExecutionContext(ExecutionContext executionContext, InstrumentationExecutionParameters parameters, InstrumentationState state) {
         return executionContext;
     }
@@ -323,7 +323,7 @@ public interface Instrumentation {
      *
      * @return a non-null instrumented DataFetcher, the default is to return to the same object
      */
-    @NotNull
+    @NonNull
     default DataFetcher<?> instrumentDataFetcher(DataFetcher<?> dataFetcher, InstrumentationFieldFetchParameters parameters, InstrumentationState state) {
         return dataFetcher;
     }
@@ -337,7 +337,7 @@ public interface Instrumentation {
      *
      * @return a new execution result completable future
      */
-    @NotNull
+    @NonNull
     default CompletableFuture<ExecutionResult> instrumentExecutionResult(ExecutionResult executionResult, InstrumentationExecutionParameters parameters, InstrumentationState state) {
         return CompletableFuture.completedFuture(executionResult);
     }

--- a/src/main/java/graphql/execution/instrumentation/NoContextChainedInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/NoContextChainedInstrumentation.java
@@ -11,7 +11,7 @@ import graphql.execution.instrumentation.parameters.InstrumentationFieldParamete
 import graphql.execution.instrumentation.parameters.InstrumentationValidationParameters;
 import graphql.language.Document;
 import graphql.validation.ValidationError;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.function.BiConsumer;

--- a/src/main/java/graphql/execution/instrumentation/SimpleInstrumentationContext.java
+++ b/src/main/java/graphql/execution/instrumentation/SimpleInstrumentationContext.java
@@ -1,11 +1,9 @@
 package graphql.execution.instrumentation;
 
 import graphql.PublicApi;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 
 /**
  * A simple implementation of {@link InstrumentationContext}
@@ -43,7 +41,7 @@ public class SimpleInstrumentationContext<T> implements InstrumentationContext<T
      *
      * @return a non null {@link InstrumentationContext} that maybe a no-op
      */
-    @NotNull
+    @NonNull
     public static <T> InstrumentationContext<T> nonNullCtx(InstrumentationContext<T> nullableContext) {
         return nullableContext == null ? noOp() : nullableContext;
     }

--- a/src/main/java/graphql/execution/instrumentation/SimplePerformantInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/SimplePerformantInstrumentation.java
@@ -16,13 +16,12 @@ import graphql.language.Document;
 import graphql.schema.DataFetcher;
 import graphql.schema.GraphQLSchema;
 import graphql.validation.ValidationError;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-import static graphql.Assert.assertShouldNeverHappen;
 import static graphql.execution.instrumentation.SimpleInstrumentationContext.noOp;
 
 /**
@@ -113,32 +112,32 @@ public class SimplePerformantInstrumentation implements Instrumentation {
     }
 
     @Override
-    public @NotNull ExecutionInput instrumentExecutionInput(ExecutionInput executionInput, InstrumentationExecutionParameters parameters, InstrumentationState state) {
+    public @NonNull ExecutionInput instrumentExecutionInput(ExecutionInput executionInput, InstrumentationExecutionParameters parameters, InstrumentationState state) {
         return executionInput;
     }
 
     @Override
-    public @NotNull DocumentAndVariables instrumentDocumentAndVariables(DocumentAndVariables documentAndVariables, InstrumentationExecutionParameters parameters, InstrumentationState state) {
+    public @NonNull DocumentAndVariables instrumentDocumentAndVariables(DocumentAndVariables documentAndVariables, InstrumentationExecutionParameters parameters, InstrumentationState state) {
         return documentAndVariables;
     }
 
     @Override
-    public @NotNull GraphQLSchema instrumentSchema(GraphQLSchema schema, InstrumentationExecutionParameters parameters, InstrumentationState state) {
+    public @NonNull GraphQLSchema instrumentSchema(GraphQLSchema schema, InstrumentationExecutionParameters parameters, InstrumentationState state) {
         return schema;
     }
 
     @Override
-    public @NotNull ExecutionContext instrumentExecutionContext(ExecutionContext executionContext, InstrumentationExecutionParameters parameters, InstrumentationState state) {
+    public @NonNull ExecutionContext instrumentExecutionContext(ExecutionContext executionContext, InstrumentationExecutionParameters parameters, InstrumentationState state) {
         return executionContext;
     }
 
     @Override
-    public @NotNull DataFetcher<?> instrumentDataFetcher(DataFetcher<?> dataFetcher, InstrumentationFieldFetchParameters parameters, InstrumentationState state) {
+    public @NonNull DataFetcher<?> instrumentDataFetcher(DataFetcher<?> dataFetcher, InstrumentationFieldFetchParameters parameters, InstrumentationState state) {
         return dataFetcher;
     }
 
     @Override
-    public @NotNull CompletableFuture<ExecutionResult> instrumentExecutionResult(ExecutionResult executionResult, InstrumentationExecutionParameters parameters, InstrumentationState state) {
+    public @NonNull CompletableFuture<ExecutionResult> instrumentExecutionResult(ExecutionResult executionResult, InstrumentationExecutionParameters parameters, InstrumentationState state) {
         return CompletableFuture.completedFuture(executionResult);
     }
 }

--- a/src/main/java/graphql/execution/instrumentation/fieldvalidation/FieldValidationInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/fieldvalidation/FieldValidationInstrumentation.java
@@ -8,7 +8,7 @@ import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.InstrumentationState;
 import graphql.execution.instrumentation.SimplePerformantInstrumentation;
 import graphql.execution.instrumentation.parameters.InstrumentationExecuteOperationParameters;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 

--- a/src/main/java/graphql/execution/instrumentation/threadpools/ExecutorInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/threadpools/ExecutorInstrumentation.java
@@ -10,7 +10,7 @@ import graphql.execution.instrumentation.SimplePerformantInstrumentation;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -108,7 +108,7 @@ public class ExecutorInstrumentation extends SimplePerformantInstrumentation {
     }
 
     @Override
-    public @NotNull DataFetcher<?> instrumentDataFetcher(DataFetcher<?> originalDataFetcher, InstrumentationFieldFetchParameters parameters, InstrumentationState state) {
+    public @NonNull DataFetcher<?> instrumentDataFetcher(DataFetcher<?> originalDataFetcher, InstrumentationFieldFetchParameters parameters, InstrumentationState state) {
         if (originalDataFetcher instanceof TrivialDataFetcher) {
             return originalDataFetcher;
         }

--- a/src/main/java/graphql/execution/instrumentation/tracing/TracingInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/tracing/TracingInstrumentation.java
@@ -14,8 +14,8 @@ import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchPar
 import graphql.execution.instrumentation.parameters.InstrumentationValidationParameters;
 import graphql.language.Document;
 import graphql.validation.ValidationError;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -77,7 +77,7 @@ public class TracingInstrumentation extends SimplePerformantInstrumentation {
     }
 
     @Override
-    public @NotNull CompletableFuture<ExecutionResult> instrumentExecutionResult(ExecutionResult executionResult, InstrumentationExecutionParameters parameters, InstrumentationState rawState) {
+    public @NonNull CompletableFuture<ExecutionResult> instrumentExecutionResult(ExecutionResult executionResult, InstrumentationExecutionParameters parameters, InstrumentationState rawState) {
         Map<Object, Object> currentExt = executionResult.getExtensions();
 
         TracingSupport tracingSupport = ofState(rawState);

--- a/src/main/java/graphql/execution/reactive/CompletionStageMappingOrderedPublisher.java
+++ b/src/main/java/graphql/execution/reactive/CompletionStageMappingOrderedPublisher.java
@@ -1,7 +1,7 @@
 package graphql.execution.reactive;
 
 import graphql.Internal;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 
@@ -30,7 +30,7 @@ public class CompletionStageMappingOrderedPublisher<D, U> extends CompletionStag
     }
 
     @Override
-    protected @NotNull Subscriber<? super U> createSubscriber(Subscriber<? super D> downstreamSubscriber) {
+    protected @NonNull Subscriber<? super U> createSubscriber(Subscriber<? super D> downstreamSubscriber) {
         return new CompletionStageOrderedSubscriber<>(mapper, downstreamSubscriber);
     }
 }

--- a/src/main/java/graphql/execution/reactive/CompletionStageMappingPublisher.java
+++ b/src/main/java/graphql/execution/reactive/CompletionStageMappingPublisher.java
@@ -1,7 +1,7 @@
 package graphql.execution.reactive;
 
 import graphql.Internal;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 
@@ -39,7 +39,7 @@ public class CompletionStageMappingPublisher<D, U> implements Publisher<D> {
         upstreamPublisher.subscribe(createSubscriber(downstreamSubscriber));
     }
 
-    @NotNull
+    @NonNull
     protected Subscriber<? super U> createSubscriber(Subscriber<? super D> downstreamSubscriber) {
         return new CompletionStageSubscriber<>(mapper, downstreamSubscriber);
     }

--- a/src/main/java/graphql/execution/reactive/CompletionStageSubscriber.java
+++ b/src/main/java/graphql/execution/reactive/CompletionStageSubscriber.java
@@ -2,7 +2,7 @@ package graphql.execution.reactive;
 
 import graphql.Internal;
 import graphql.util.LockKit;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
@@ -69,7 +69,7 @@ public class CompletionStageSubscriber<U, D> implements Subscriber<U> {
         }
     }
 
-    @NotNull
+    @NonNull
     private BiConsumer<D, Throwable> whenComplete(CompletionStage<D> completionStage) {
         return (d, throwable) -> {
             if (isTerminal()) {

--- a/src/main/java/graphql/execution/reactive/NonBlockingMutexExecutor.java
+++ b/src/main/java/graphql/execution/reactive/NonBlockingMutexExecutor.java
@@ -2,7 +2,7 @@ package graphql.execution.reactive;
 
 
 import graphql.Internal;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
@@ -37,7 +37,7 @@ class NonBlockingMutexExecutor implements Executor {
     private final AtomicReference<RunNode> last = new AtomicReference<>();
 
     @Override
-    public void execute(final @NotNull Runnable command) {
+    public void execute(final @NonNull Runnable command) {
         final RunNode newNode = new RunNode(assertNotNull(command, () -> "Runnable must not be null"));
         final RunNode prevLast = last.getAndSet(newNode);
         if (prevLast != null) {

--- a/src/main/java/graphql/execution/values/InputInterceptor.java
+++ b/src/main/java/graphql/execution/values/InputInterceptor.java
@@ -3,8 +3,8 @@ package graphql.execution.values;
 import graphql.GraphQLContext;
 import graphql.Internal;
 import graphql.schema.GraphQLInputType;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Locale;
 
@@ -36,7 +36,7 @@ public interface InputInterceptor {
      * @return a value that may differ from the original value
      */
     Object intercept(@Nullable Object value,
-                     @NotNull GraphQLInputType graphQLType,
-                     @NotNull GraphQLContext graphqlContext,
-                     @NotNull Locale locale);
+                     @NonNull GraphQLInputType graphQLType,
+                     @NonNull GraphQLContext graphqlContext,
+                     @NonNull Locale locale);
 }

--- a/src/main/java/graphql/execution/values/legacycoercing/LegacyCoercingInputInterceptor.java
+++ b/src/main/java/graphql/execution/values/legacycoercing/LegacyCoercingInputInterceptor.java
@@ -5,8 +5,8 @@ import graphql.Scalars;
 import graphql.execution.values.InputInterceptor;
 import graphql.scalar.CoercingUtil;
 import graphql.schema.GraphQLInputType;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.math.BigDecimal;
 import java.util.Locale;
@@ -77,7 +77,7 @@ public class LegacyCoercingInputInterceptor implements InputInterceptor {
     }
 
     @Override
-    public Object intercept(@Nullable Object input, @NotNull GraphQLInputType graphQLType, @NotNull GraphQLContext graphqlContext, @NotNull Locale locale) {
+    public Object intercept(@Nullable Object input, @NonNull GraphQLInputType graphQLType, @NonNull GraphQLContext graphqlContext, @NonNull Locale locale) {
         if (isLegacyValue(input, graphQLType)) {
             // we ONLY apply the new behavior IF it's an old acceptable legacy value.
             // so for compliant values - we change nothing and invoke no behaviour

--- a/src/main/java/graphql/extensions/DefaultExtensionsMerger.java
+++ b/src/main/java/graphql/extensions/DefaultExtensionsMerger.java
@@ -2,7 +2,7 @@ package graphql.extensions;
 
 import com.google.common.collect.Sets;
 import graphql.Internal;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -15,8 +15,8 @@ import java.util.Set;
 @Internal
 public class DefaultExtensionsMerger implements ExtensionsMerger {
     @Override
-    @NotNull
-    public Map<Object, Object> merge(@NotNull Map<Object, Object> leftMap, @NotNull Map<Object, Object> rightMap) {
+    @NonNull
+    public Map<Object, Object> merge(@NonNull Map<Object, Object> leftMap, @NonNull Map<Object, Object> rightMap) {
         if (leftMap.isEmpty()) {
             return mapCast(rightMap);
         }
@@ -55,7 +55,7 @@ public class DefaultExtensionsMerger implements ExtensionsMerger {
         }
     }
 
-    @NotNull
+    @NonNull
     private List<Object> appendLists(Object leftVal, Object rightVal) {
         List<Object> target = new ArrayList<>(listCast(leftVal));
         target.addAll(listCast(rightVal));

--- a/src/main/java/graphql/extensions/ExtensionsBuilder.java
+++ b/src/main/java/graphql/extensions/ExtensionsBuilder.java
@@ -3,8 +3,8 @@ package graphql.extensions;
 import com.google.common.collect.ImmutableMap;
 import graphql.ExecutionResult;
 import graphql.PublicApi;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -69,7 +69,7 @@ public class ExtensionsBuilder {
      *
      * @return this builder for fluent style reasons
      */
-    public ExtensionsBuilder addValues(@NotNull Map<Object, Object> newValues) {
+    public ExtensionsBuilder addValues(@NonNull Map<Object, Object> newValues) {
         assertNotNull(newValues);
         if (!newValues.isEmpty()) {
             changes.add(newValues);
@@ -85,7 +85,7 @@ public class ExtensionsBuilder {
      *
      * @return this builder for fluent style reasons
      */
-    public ExtensionsBuilder addValue(@NotNull Object key, @Nullable Object value) {
+    public ExtensionsBuilder addValue(@NonNull Object key, @Nullable Object value) {
         assertNotNull(key);
         return addValues(Collections.singletonMap(key, value));
     }

--- a/src/main/java/graphql/extensions/ExtensionsMerger.java
+++ b/src/main/java/graphql/extensions/ExtensionsMerger.java
@@ -1,7 +1,7 @@
 package graphql.extensions;
 
 import graphql.PublicSpi;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 import java.util.Map;
 
@@ -40,6 +40,6 @@ public interface ExtensionsMerger {
      *
      * @return a non null merged map
      */
-    @NotNull
-    Map<Object, Object> merge(@NotNull Map<Object, Object> leftMap, @NotNull Map<Object, Object> rightMap);
+    @NonNull
+    Map<Object, Object> merge(@NonNull Map<Object, Object> leftMap, @NonNull Map<Object, Object> rightMap);
 }

--- a/src/main/java/graphql/incremental/DeferPayload.java
+++ b/src/main/java/graphql/incremental/DeferPayload.java
@@ -3,7 +3,7 @@ package graphql.incremental;
 import graphql.ExecutionResult;
 import graphql.ExperimentalApi;
 import graphql.GraphQLError;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/src/main/java/graphql/incremental/DelayedIncrementalPartialResult.java
+++ b/src/main/java/graphql/incremental/DelayedIncrementalPartialResult.java
@@ -1,7 +1,7 @@
 package graphql.incremental;
 
 import graphql.ExperimentalApi;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/graphql/incremental/IncrementalExecutionResult.java
+++ b/src/main/java/graphql/incremental/IncrementalExecutionResult.java
@@ -2,7 +2,7 @@ package graphql.incremental;
 
 import graphql.ExecutionResult;
 import graphql.ExperimentalApi;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Publisher;
 
 import java.util.List;

--- a/src/main/java/graphql/incremental/IncrementalExecutionResultImpl.java
+++ b/src/main/java/graphql/incremental/IncrementalExecutionResultImpl.java
@@ -3,7 +3,7 @@ package graphql.incremental;
 import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.ExperimentalApi;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Publisher;
 
 import java.util.LinkedHashMap;

--- a/src/main/java/graphql/incremental/IncrementalPayload.java
+++ b/src/main/java/graphql/incremental/IncrementalPayload.java
@@ -3,7 +3,7 @@ package graphql.incremental;
 import graphql.ExperimentalApi;
 import graphql.GraphQLError;
 import graphql.execution.ResultPath;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;

--- a/src/main/java/graphql/incremental/StreamPayload.java
+++ b/src/main/java/graphql/incremental/StreamPayload.java
@@ -2,7 +2,7 @@ package graphql.incremental;
 
 import graphql.ExperimentalApi;
 import graphql.GraphQLError;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/src/main/java/graphql/introspection/Introspection.java
+++ b/src/main/java/graphql/introspection/Introspection.java
@@ -36,7 +36,7 @@ import graphql.schema.GraphQLScalarType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLUnionType;
 import graphql.schema.InputValueWithState;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -134,7 +134,7 @@ public class Introspection {
         return Optional.empty();
     }
 
-    @NotNull
+    @NonNull
     private static Optional<ExecutionResult> mkDisabledError(MergedField schemaField) {
         IntrospectionDisabledError error = new IntrospectionDisabledError(schemaField.getSingleField().getSourceLocation());
         return Optional.of(ExecutionResult.newExecutionResult().addError(error).build());

--- a/src/main/java/graphql/introspection/IntrospectionWithDirectivesSupport.java
+++ b/src/main/java/graphql/introspection/IntrospectionWithDirectivesSupport.java
@@ -8,8 +8,8 @@ import graphql.execution.ValuesResolver;
 import graphql.language.AstPrinter;
 import graphql.language.Node;
 import graphql.schema.DataFetcher;
-import graphql.schema.GraphQLAppliedDirectiveArgument;
 import graphql.schema.GraphQLAppliedDirective;
+import graphql.schema.GraphQLAppliedDirectiveArgument;
 import graphql.schema.GraphQLCodeRegistry;
 import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLDirectiveContainer;
@@ -23,7 +23,7 @@ import graphql.schema.InputValueWithState;
 import graphql.schema.SchemaTransformer;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 import java.util.List;
 import java.util.Set;
@@ -238,7 +238,7 @@ public class IntrospectionWithDirectivesSupport {
         }).collect(toList());
     }
 
-    @NotNull
+    @NonNull
     private DirectivePredicateEnvironment buildDirectivePredicateEnv(GraphQLSchema schema, boolean isDefinedDirective, GraphQLDirectiveContainer container, String directiveName) {
         return new DirectivePredicateEnvironment() {
             @Override

--- a/src/main/java/graphql/normalized/ExecutableNormalizedField.java
+++ b/src/main/java/graphql/normalized/ExecutableNormalizedField.java
@@ -19,8 +19,8 @@ import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLUnionType;
 import graphql.util.FpKit;
 import graphql.util.MutableRef;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -136,7 +136,7 @@ public class ExecutableNormalizedField {
      *
      * @return true if the field is conditional
      */
-    public boolean isConditional(@NotNull GraphQLSchema schema) {
+    public boolean isConditional(@NonNull GraphQLSchema schema) {
         if (parent == null) {
             return false;
         }
@@ -655,7 +655,7 @@ public class ExecutableNormalizedField {
             return this;
         }
 
-        public Builder astArguments(@NotNull List<Argument> astArguments) {
+        public Builder astArguments(@NonNull List<Argument> astArguments) {
             this.astArguments = ImmutableList.copyOf(astArguments);
             return this;
         }

--- a/src/main/java/graphql/normalized/ExecutableNormalizedOperationFactory.java
+++ b/src/main/java/graphql/normalized/ExecutableNormalizedOperationFactory.java
@@ -42,7 +42,7 @@ import graphql.schema.GraphQLType;
 import graphql.schema.GraphQLUnionType;
 import graphql.schema.GraphQLUnmodifiedType;
 import graphql.schema.impl.SchemaUtil;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/src/main/java/graphql/normalized/ExecutableNormalizedOperationToAstCompiler.java
+++ b/src/main/java/graphql/normalized/ExecutableNormalizedOperationToAstCompiler.java
@@ -29,8 +29,8 @@ import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLUnmodifiedType;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -100,10 +100,10 @@ public class ExecutableNormalizedOperationToAstCompiler {
      *
      * @return a {@link CompilerResult} object
      */
-    public static CompilerResult compileToDocument(@NotNull GraphQLSchema schema,
-                                                   @NotNull OperationDefinition.Operation operationKind,
+    public static CompilerResult compileToDocument(@NonNull GraphQLSchema schema,
+                                                   OperationDefinition.@NonNull Operation operationKind,
                                                    @Nullable String operationName,
-                                                   @NotNull List<ExecutableNormalizedField> topLevelFields,
+                                                   @NonNull List<ExecutableNormalizedField> topLevelFields,
                                                    @Nullable VariablePredicate variablePredicate) {
         return compileToDocument(schema, operationKind, operationName, topLevelFields, Map.of(), variablePredicate);
     }
@@ -123,11 +123,11 @@ public class ExecutableNormalizedOperationToAstCompiler {
      *
      * @return a {@link CompilerResult} object
      */
-    public static CompilerResult compileToDocument(@NotNull GraphQLSchema schema,
-                                                   @NotNull OperationDefinition.Operation operationKind,
+    public static CompilerResult compileToDocument(@NonNull GraphQLSchema schema,
+                                                   OperationDefinition.@NonNull Operation operationKind,
                                                    @Nullable String operationName,
-                                                   @NotNull List<ExecutableNormalizedField> topLevelFields,
-                                                   @NotNull Map<ExecutableNormalizedField, QueryDirectives> normalizedFieldToQueryDirectives,
+                                                   @NonNull List<ExecutableNormalizedField> topLevelFields,
+                                                   @NonNull Map<ExecutableNormalizedField, QueryDirectives> normalizedFieldToQueryDirectives,
                                                    @Nullable VariablePredicate variablePredicate) {
         return compileToDocument(schema, operationKind, operationName, topLevelFields, normalizedFieldToQueryDirectives, variablePredicate, false);
     }
@@ -150,10 +150,10 @@ public class ExecutableNormalizedOperationToAstCompiler {
      * @see ExecutableNormalizedOperationToAstCompiler#compileToDocument(GraphQLSchema, OperationDefinition.Operation, String, List, VariablePredicate)
      */
     @ExperimentalApi
-    public static CompilerResult compileToDocumentWithDeferSupport(@NotNull GraphQLSchema schema,
-                                                                   @NotNull OperationDefinition.Operation operationKind,
+    public static CompilerResult compileToDocumentWithDeferSupport(@NonNull GraphQLSchema schema,
+                                                                   OperationDefinition.@NonNull Operation operationKind,
                                                                    @Nullable String operationName,
-                                                                   @NotNull List<ExecutableNormalizedField> topLevelFields,
+                                                                   @NonNull List<ExecutableNormalizedField> topLevelFields,
                                                                    @Nullable VariablePredicate variablePredicate
     ) {
         return compileToDocumentWithDeferSupport(schema, operationKind, operationName, topLevelFields, Map.of(), variablePredicate);
@@ -177,21 +177,21 @@ public class ExecutableNormalizedOperationToAstCompiler {
      * @see ExecutableNormalizedOperationToAstCompiler#compileToDocument(GraphQLSchema, OperationDefinition.Operation, String, List, Map, VariablePredicate)
      */
     @ExperimentalApi
-    public static CompilerResult compileToDocumentWithDeferSupport(@NotNull GraphQLSchema schema,
-                                                                   @NotNull OperationDefinition.Operation operationKind,
+    public static CompilerResult compileToDocumentWithDeferSupport(@NonNull GraphQLSchema schema,
+                                                                   OperationDefinition.@NonNull Operation operationKind,
                                                                    @Nullable String operationName,
-                                                                   @NotNull List<ExecutableNormalizedField> topLevelFields,
-                                                                   @NotNull Map<ExecutableNormalizedField, QueryDirectives> normalizedFieldToQueryDirectives,
+                                                                   @NonNull List<ExecutableNormalizedField> topLevelFields,
+                                                                   @NonNull Map<ExecutableNormalizedField, QueryDirectives> normalizedFieldToQueryDirectives,
                                                                    @Nullable VariablePredicate variablePredicate
     ) {
         return compileToDocument(schema, operationKind, operationName, topLevelFields, normalizedFieldToQueryDirectives, variablePredicate, true);
     }
 
-    private static CompilerResult compileToDocument(@NotNull GraphQLSchema schema,
-                                                    @NotNull OperationDefinition.Operation operationKind,
+    private static CompilerResult compileToDocument(@NonNull GraphQLSchema schema,
+                                                    OperationDefinition.@NonNull Operation operationKind,
                                                     @Nullable String operationName,
-                                                    @NotNull List<ExecutableNormalizedField> topLevelFields,
-                                                    @NotNull Map<ExecutableNormalizedField, QueryDirectives> normalizedFieldToQueryDirectives,
+                                                    @NonNull List<ExecutableNormalizedField> topLevelFields,
+                                                    @NonNull Map<ExecutableNormalizedField, QueryDirectives> normalizedFieldToQueryDirectives,
                                                     @Nullable VariablePredicate variablePredicate,
                                                     boolean deferSupport) {
         GraphQLObjectType operationType = getOperationType(schema, operationKind);
@@ -216,9 +216,9 @@ public class ExecutableNormalizedOperationToAstCompiler {
     }
 
     private static List<Selection<?>> subselectionsForNormalizedField(GraphQLSchema schema,
-                                                                      @NotNull String parentOutputType,
+                                                                      @NonNull String parentOutputType,
                                                                       List<ExecutableNormalizedField> executableNormalizedFields,
-                                                                      @NotNull Map<ExecutableNormalizedField, QueryDirectives> normalizedFieldToQueryDirectives,
+                                                                      @NonNull Map<ExecutableNormalizedField, QueryDirectives> normalizedFieldToQueryDirectives,
                                                                       VariableAccumulator variableAccumulator,
                                                                       boolean deferSupport) {
         if (deferSupport) {
@@ -229,9 +229,9 @@ public class ExecutableNormalizedOperationToAstCompiler {
     }
 
     private static List<Selection<?>> subselectionsForNormalizedFieldNoDeferSupport(GraphQLSchema schema,
-                                                                                    @NotNull String parentOutputType,
+                                                                                    @NonNull String parentOutputType,
                                                                                     List<ExecutableNormalizedField> executableNormalizedFields,
-                                                                                    @NotNull Map<ExecutableNormalizedField, QueryDirectives> normalizedFieldToQueryDirectives,
+                                                                                    @NonNull Map<ExecutableNormalizedField, QueryDirectives> normalizedFieldToQueryDirectives,
                                                                                     VariableAccumulator variableAccumulator) {
         ImmutableList.Builder<Selection<?>> selections = ImmutableList.builder();
 
@@ -265,9 +265,9 @@ public class ExecutableNormalizedOperationToAstCompiler {
 
 
     private static List<Selection<?>> subselectionsForNormalizedFieldWithDeferSupport(GraphQLSchema schema,
-                                                                                      @NotNull String parentOutputType,
+                                                                                      @NonNull String parentOutputType,
                                                                                       List<ExecutableNormalizedField> executableNormalizedFields,
-                                                                                      @NotNull Map<ExecutableNormalizedField, QueryDirectives> normalizedFieldToQueryDirectives,
+                                                                                      @NonNull Map<ExecutableNormalizedField, QueryDirectives> normalizedFieldToQueryDirectives,
                                                                                       VariableAccumulator variableAccumulator) {
         ImmutableList.Builder<Selection<?>> selections = ImmutableList.builder();
 
@@ -339,7 +339,7 @@ public class ExecutableNormalizedOperationToAstCompiler {
      */
     private static Map<String, Field> selectionForNormalizedField(GraphQLSchema schema,
                                                                   ExecutableNormalizedField executableNormalizedField,
-                                                                  @NotNull Map<ExecutableNormalizedField, QueryDirectives> normalizedFieldToQueryDirectives,
+                                                                  @NonNull Map<ExecutableNormalizedField, QueryDirectives> normalizedFieldToQueryDirectives,
                                                                   VariableAccumulator variableAccumulator,
                                                                   boolean deferSupport) {
         Map<String, Field> groupedFields = new LinkedHashMap<>();
@@ -357,7 +357,7 @@ public class ExecutableNormalizedOperationToAstCompiler {
     private static Field selectionForNormalizedField(GraphQLSchema schema,
                                                      String objectTypeName,
                                                      ExecutableNormalizedField executableNormalizedField,
-                                                     @NotNull Map<ExecutableNormalizedField, QueryDirectives> normalizedFieldToQueryDirectives,
+                                                     @NonNull Map<ExecutableNormalizedField, QueryDirectives> normalizedFieldToQueryDirectives,
                                                      VariableAccumulator variableAccumulator,
                                                      boolean deferSupport) {
         final List<Selection<?>> subSelections;
@@ -448,7 +448,7 @@ public class ExecutableNormalizedOperationToAstCompiler {
         return (Value<?>) value;
     }
 
-    @NotNull
+    @NonNull
     private static Value<?> argValue(ExecutableNormalizedField executableNormalizedField,
                                      String argName,
                                      NormalizedInputValue normalizedInputValue,
@@ -461,7 +461,7 @@ public class ExecutableNormalizedOperationToAstCompiler {
         }
     }
 
-    @NotNull
+    @NonNull
     private static GraphQLFieldDefinition getFieldDefinition(GraphQLSchema schema,
                                                              String parentType,
                                                              ExecutableNormalizedField nf) {
@@ -470,8 +470,8 @@ public class ExecutableNormalizedOperationToAstCompiler {
 
 
     @Nullable
-    private static GraphQLObjectType getOperationType(@NotNull GraphQLSchema schema,
-                                                      @NotNull OperationDefinition.Operation operationKind) {
+    private static GraphQLObjectType getOperationType(@NonNull GraphQLSchema schema,
+                                                      OperationDefinition.@NonNull Operation operationKind) {
         switch (operationKind) {
             case QUERY:
                 return schema.getQueryType();

--- a/src/main/java/graphql/normalized/ValueToVariableValueCompiler.java
+++ b/src/main/java/graphql/normalized/ValueToVariableValueCompiler.java
@@ -15,8 +15,8 @@ import graphql.language.Value;
 import graphql.language.VariableDefinition;
 import graphql.language.VariableReference;
 import graphql.parser.Parser;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -76,7 +76,7 @@ public class ValueToVariableValueCompiler {
                 .collect(toList());
     }
 
-    @NotNull
+    @NonNull
     private static Map<String, Object> normalisedValueToVariableValues(Map<String, Object> objectMap) {
         Map<String, Object> output = new LinkedHashMap<>();
         objectMap.forEach((k, v) -> {
@@ -97,7 +97,7 @@ public class ValueToVariableValueCompiler {
         return map;
     }
 
-    @NotNull
+    @NonNull
     private static List<Object> toVariableValues(List<Value> arrayValues) {
         // some values can be null (NullValue) and hence we can use Immutable Lists
         return arrayValues.stream()

--- a/src/main/java/graphql/normalized/VariableAccumulator.java
+++ b/src/main/java/graphql/normalized/VariableAccumulator.java
@@ -2,7 +2,7 @@ package graphql.normalized;
 
 import graphql.Internal;
 import graphql.language.VariableDefinition;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;

--- a/src/main/java/graphql/normalized/incremental/NormalizedDeferredExecution.java
+++ b/src/main/java/graphql/normalized/incremental/NormalizedDeferredExecution.java
@@ -2,7 +2,7 @@ package graphql.normalized.incremental;
 
 import graphql.ExperimentalApi;
 import graphql.schema.GraphQLObjectType;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Set;
 

--- a/src/main/java/graphql/normalized/nf/NormalizedDocument.java
+++ b/src/main/java/graphql/normalized/nf/NormalizedDocument.java
@@ -2,7 +2,7 @@ package graphql.normalized.nf;
 
 import graphql.Assert;
 import graphql.ExperimentalApi;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/graphql/normalized/nf/NormalizedDocumentFactory.java
+++ b/src/main/java/graphql/normalized/nf/NormalizedDocumentFactory.java
@@ -34,7 +34,7 @@ import graphql.schema.GraphQLType;
 import graphql.schema.GraphQLUnionType;
 import graphql.schema.GraphQLUnmodifiedType;
 import graphql.schema.impl.SchemaUtil;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/src/main/java/graphql/normalized/nf/NormalizedField.java
+++ b/src/main/java/graphql/normalized/nf/NormalizedField.java
@@ -20,8 +20,8 @@ import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLUnionType;
 import graphql.util.FpKit;
 import graphql.util.MutableRef;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -135,7 +135,7 @@ public class NormalizedField {
      * @param schema - the graphql schema in play
      * @return true if the field is conditional
      */
-    public boolean isConditional(@NotNull GraphQLSchema schema) {
+    public boolean isConditional(@NonNull GraphQLSchema schema) {
         if (parent == null) {
             return false;
         }
@@ -637,12 +637,12 @@ public class NormalizedField {
             return this;
         }
 
-        public Builder astArguments(@NotNull List<Argument> astArguments) {
+        public Builder astArguments(@NonNull List<Argument> astArguments) {
             this.astArguments = ImmutableList.copyOf(astArguments);
             return this;
         }
 
-        public Builder astDirectives(@NotNull List<Directive> astDirectives) {
+        public Builder astDirectives(@NonNull List<Directive> astDirectives) {
             this.astDirectives = astDirectives;
             return this;
         }

--- a/src/main/java/graphql/normalized/nf/NormalizedOperationToAstCompiler.java
+++ b/src/main/java/graphql/normalized/nf/NormalizedOperationToAstCompiler.java
@@ -18,8 +18,8 @@ import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLUnmodifiedType;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -70,7 +70,7 @@ public class NormalizedOperationToAstCompiler {
         }
     }
 
-    public static CompilerResult compileToDocument(@NotNull GraphQLSchema schema,
+    public static CompilerResult compileToDocument(@NonNull GraphQLSchema schema,
                                                    NormalizedOperation normalizedOperation) {
         GraphQLObjectType operationType = getOperationType(schema, normalizedOperation.getOperation());
 
@@ -93,7 +93,7 @@ public class NormalizedOperationToAstCompiler {
     }
 
     private static List<Selection<?>> subSelectionsForNormalizedField(GraphQLSchema schema,
-                                                                      @NotNull String parentOutputType,
+                                                                      @NonNull String parentOutputType,
                                                                       List<NormalizedField> normalizedFields
     ) {
         ImmutableList.Builder<Selection<?>> selections = ImmutableList.builder();
@@ -187,7 +187,7 @@ public class NormalizedOperationToAstCompiler {
     }
 
 
-    @NotNull
+    @NonNull
     private static GraphQLFieldDefinition getFieldDefinition(GraphQLSchema schema,
                                                              String parentType,
                                                              NormalizedField nf) {
@@ -196,8 +196,8 @@ public class NormalizedOperationToAstCompiler {
 
 
     @Nullable
-    private static GraphQLObjectType getOperationType(@NotNull GraphQLSchema schema,
-                                                      @NotNull OperationDefinition.Operation operationKind) {
+    private static GraphQLObjectType getOperationType(@NonNull GraphQLSchema schema,
+                                                      OperationDefinition.@NonNull Operation operationKind) {
         switch (operationKind) {
             case QUERY:
                 return schema.getQueryType();

--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -67,7 +67,7 @@ import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.TerminalNode;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;

--- a/src/main/java/graphql/parser/Parser.java
+++ b/src/main/java/graphql/parser/Parser.java
@@ -25,7 +25,7 @@ import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.atn.PredictionMode;
 import org.antlr.v4.runtime.tree.ParseTreeListener;
 import org.antlr.v4.runtime.tree.TerminalNode;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -270,7 +270,7 @@ public class Parser {
         return multiSourceReader;
     }
 
-    @NotNull
+    @NonNull
     private static SafeTokenReader setupSafeTokenReader(ParserEnvironment environment, ParserOptions parserOptions, MultiSourceReader multiSourceReader) {
         int maxCharacters = parserOptions.getMaxCharacters();
         Consumer<Integer> onTooManyCharacters = it -> {
@@ -279,7 +279,7 @@ public class Parser {
         return new SafeTokenReader(multiSourceReader, maxCharacters, onTooManyCharacters);
     }
 
-    @NotNull
+    @NonNull
     private static CodePointCharStream setupCharStream(SafeTokenReader safeTokenReader) {
         CodePointCharStream charStream;
         try {
@@ -290,7 +290,7 @@ public class Parser {
         return charStream;
     }
 
-    @NotNull
+    @NonNull
     private static GraphqlLexer setupGraphqlLexer(ParserEnvironment environment, MultiSourceReader multiSourceReader, CodePointCharStream charStream) {
         GraphqlLexer lexer = new GraphqlLexer(charStream);
         lexer.removeErrorListeners();
@@ -315,7 +315,7 @@ public class Parser {
         return lexer;
     }
 
-    @NotNull
+    @NonNull
     private SafeTokenSource getSafeTokenSource(ParserEnvironment environment, ParserOptions parserOptions, MultiSourceReader multiSourceReader, GraphqlLexer lexer) {
         int maxTokens = parserOptions.getMaxTokens();
         int maxWhitespaceTokens = parserOptions.getMaxWhitespaceTokens();

--- a/src/main/java/graphql/parser/SafeTokenReader.java
+++ b/src/main/java/graphql/parser/SafeTokenReader.java
@@ -1,7 +1,7 @@
 package graphql.parser;
 
 import graphql.Internal;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -40,7 +40,7 @@ public class SafeTokenReader extends Reader {
     }
 
     @Override
-    public int read(char @NotNull [] buff, int off, int len) throws IOException {
+    public int read(char @NonNull [] buff, int off, int len) throws IOException {
         int howMany = delegate.read(buff, off, len);
         return checkHowMany(howMany, howMany);
     }
@@ -52,13 +52,13 @@ public class SafeTokenReader extends Reader {
     }
 
     @Override
-    public int read(@NotNull CharBuffer target) throws IOException {
+    public int read(@NonNull CharBuffer target) throws IOException {
         int howMany = delegate.read(target);
         return checkHowMany(howMany, howMany);
     }
 
     @Override
-    public int read( char @NotNull [] buff) throws IOException {
+    public int read(char @NonNull [] buff) throws IOException {
         int howMany = delegate.read(buff);
         return checkHowMany(howMany, howMany);
     }

--- a/src/main/java/graphql/parser/exceptions/InvalidUnicodeSyntaxException.java
+++ b/src/main/java/graphql/parser/exceptions/InvalidUnicodeSyntaxException.java
@@ -4,12 +4,12 @@ import graphql.Internal;
 import graphql.i18n.I18n;
 import graphql.language.SourceLocation;
 import graphql.parser.InvalidSyntaxException;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Internal
 public class InvalidUnicodeSyntaxException extends InvalidSyntaxException {
 
-    public InvalidUnicodeSyntaxException(@NotNull I18n i18N, @NotNull String msgKey, @NotNull SourceLocation sourceLocation, @NotNull String offendingToken) {
+    public InvalidUnicodeSyntaxException(@NonNull I18n i18N, @NonNull String msgKey, @NonNull SourceLocation sourceLocation, @NonNull String offendingToken) {
         super(i18N.msg(msgKey, offendingToken, sourceLocation.getLine(), sourceLocation.getColumn()),
                 sourceLocation, offendingToken, null, null);
     }

--- a/src/main/java/graphql/parser/exceptions/MoreTokensSyntaxException.java
+++ b/src/main/java/graphql/parser/exceptions/MoreTokensSyntaxException.java
@@ -4,19 +4,19 @@ import graphql.Internal;
 import graphql.i18n.I18n;
 import graphql.language.SourceLocation;
 import graphql.parser.InvalidSyntaxException;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Internal
 public class MoreTokensSyntaxException extends InvalidSyntaxException {
 
     @Internal
-    public MoreTokensSyntaxException(@NotNull I18n i18N, @NotNull SourceLocation sourceLocation, @NotNull String offendingToken, @NotNull String sourcePreview) {
+    public MoreTokensSyntaxException(@NonNull I18n i18N, @NonNull SourceLocation sourceLocation, @NonNull String offendingToken, @NonNull String sourcePreview) {
         super(i18N.msg("InvalidSyntaxMoreTokens.full", offendingToken, sourceLocation.getLine(), sourceLocation.getColumn()),
                 sourceLocation, offendingToken, sourcePreview, null);
     }
 
     @Internal
-    public MoreTokensSyntaxException(@NotNull I18n i18N, @NotNull SourceLocation sourceLocation) {
+    public MoreTokensSyntaxException(@NonNull I18n i18N, @NonNull SourceLocation sourceLocation) {
         super(i18N.msg("InvalidSyntaxMoreTokens.noMessage", sourceLocation.getLine(), sourceLocation.getColumn()),
                 sourceLocation, null, null, null);
     }

--- a/src/main/java/graphql/parser/exceptions/ParseCancelledException.java
+++ b/src/main/java/graphql/parser/exceptions/ParseCancelledException.java
@@ -4,14 +4,14 @@ import graphql.Internal;
 import graphql.i18n.I18n;
 import graphql.language.SourceLocation;
 import graphql.parser.InvalidSyntaxException;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 @Internal
 public class ParseCancelledException extends InvalidSyntaxException {
 
     @Internal
-    public ParseCancelledException(@NotNull I18n i18N, @Nullable SourceLocation sourceLocation, @Nullable String offendingToken, int maxTokens, @NotNull String tokenType) {
+    public ParseCancelledException(@NonNull I18n i18N, @Nullable SourceLocation sourceLocation, @Nullable String offendingToken, int maxTokens, @NonNull String tokenType) {
         super(i18N.msg("ParseCancelled.full", maxTokens, tokenType),
                 sourceLocation, offendingToken, null, null);
     }

--- a/src/main/java/graphql/parser/exceptions/ParseCancelledTooDeepException.java
+++ b/src/main/java/graphql/parser/exceptions/ParseCancelledTooDeepException.java
@@ -4,14 +4,14 @@ import graphql.Internal;
 import graphql.i18n.I18n;
 import graphql.language.SourceLocation;
 import graphql.parser.InvalidSyntaxException;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 @Internal
 public class ParseCancelledTooDeepException extends InvalidSyntaxException {
 
     @Internal
-    public ParseCancelledTooDeepException(@NotNull I18n i18N, @Nullable SourceLocation sourceLocation, @Nullable String offendingToken, int maxTokens, @NotNull String tokenType) {
+    public ParseCancelledTooDeepException(@NonNull I18n i18N, @Nullable SourceLocation sourceLocation, @Nullable String offendingToken, int maxTokens, @NonNull String tokenType) {
         super(i18N.msg("ParseCancelled.tooDeep", maxTokens, tokenType),
                 sourceLocation, offendingToken, null, null);
     }

--- a/src/main/java/graphql/parser/exceptions/ParseCancelledTooManyCharsException.java
+++ b/src/main/java/graphql/parser/exceptions/ParseCancelledTooManyCharsException.java
@@ -3,13 +3,13 @@ package graphql.parser.exceptions;
 import graphql.Internal;
 import graphql.i18n.I18n;
 import graphql.parser.InvalidSyntaxException;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Internal
 public class ParseCancelledTooManyCharsException extends InvalidSyntaxException {
 
     @Internal
-    public ParseCancelledTooManyCharsException(@NotNull I18n i18N, int maxCharacters) {
+    public ParseCancelledTooManyCharsException(@NonNull I18n i18N, int maxCharacters) {
         super(i18N.msg("ParseCancelled.tooManyChars", maxCharacters),
                 null, null, null, null);
     }

--- a/src/main/java/graphql/scalar/GraphqlBooleanCoercing.java
+++ b/src/main/java/graphql/scalar/GraphqlBooleanCoercing.java
@@ -9,8 +9,8 @@ import graphql.schema.Coercing;
 import graphql.schema.CoercingParseLiteralException;
 import graphql.schema.CoercingParseValueException;
 import graphql.schema.CoercingSerializeException;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.math.BigDecimal;
 import java.util.Locale;
@@ -54,8 +54,8 @@ public class GraphqlBooleanCoercing implements Coercing<Boolean, Boolean> {
 
     }
 
-    @NotNull
-    private Boolean serializeImpl(@NotNull Object input, @NotNull Locale locale) {
+    @NonNull
+    private Boolean serializeImpl(@NonNull Object input, @NonNull Locale locale) {
         Boolean result = convertImpl(input);
         if (result == null) {
             throw new CoercingSerializeException(
@@ -65,8 +65,8 @@ public class GraphqlBooleanCoercing implements Coercing<Boolean, Boolean> {
         return result;
     }
 
-    @NotNull
-    private Boolean parseValueImpl(@NotNull Object input, @NotNull Locale locale) {
+    @NonNull
+    private Boolean parseValueImpl(@NonNull Object input, @NonNull Locale locale) {
         if (!(input instanceof Boolean)) {
             throw new CoercingParseValueException(
                     i18nMsg(locale, "Boolean.unexpectedRawValueType", typeName(input))
@@ -75,7 +75,7 @@ public class GraphqlBooleanCoercing implements Coercing<Boolean, Boolean> {
         return (Boolean) input;
     }
 
-    private static boolean parseLiteralImpl(@NotNull Object input, @NotNull Locale locale) {
+    private static boolean parseLiteralImpl(@NonNull Object input, @NonNull Locale locale) {
         if (!(input instanceof BooleanValue)) {
             throw new CoercingParseLiteralException(
                     i18nMsg(locale, "Boolean.unexpectedAstType", typeName(input))
@@ -84,8 +84,8 @@ public class GraphqlBooleanCoercing implements Coercing<Boolean, Boolean> {
         return ((BooleanValue) input).isValue();
     }
 
-    @NotNull
-    private BooleanValue valueToLiteralImpl(@NotNull Object input, @NotNull Locale locale) {
+    @NonNull
+    private BooleanValue valueToLiteralImpl(@NonNull Object input, @NonNull Locale locale) {
         Boolean result = convertImpl(input);
         if (result == null) {
             assertShouldNeverHappen(i18nMsg(locale, "Boolean.notBoolean", typeName(input)));
@@ -95,45 +95,45 @@ public class GraphqlBooleanCoercing implements Coercing<Boolean, Boolean> {
 
     @Override
     @Deprecated
-    public Boolean serialize(@NotNull Object dataFetcherResult) {
+    public Boolean serialize(@NonNull Object dataFetcherResult) {
         return serializeImpl(dataFetcherResult, Locale.getDefault());
     }
 
     @Override
-    public @Nullable Boolean serialize(@NotNull Object dataFetcherResult, @NotNull GraphQLContext graphQLContext, @NotNull Locale locale) throws CoercingSerializeException {
+    public @Nullable Boolean serialize(@NonNull Object dataFetcherResult, @NonNull GraphQLContext graphQLContext, @NonNull Locale locale) throws CoercingSerializeException {
         return serializeImpl(dataFetcherResult, locale);
     }
 
     @Override
     @Deprecated
-    public Boolean parseValue(@NotNull Object input) {
+    public Boolean parseValue(@NonNull Object input) {
         return parseValueImpl(input, Locale.getDefault());
     }
 
     @Override
-    public Boolean parseValue(@NotNull Object input, @NotNull GraphQLContext graphQLContext, @NotNull Locale locale) throws CoercingParseValueException {
+    public Boolean parseValue(@NonNull Object input, @NonNull GraphQLContext graphQLContext, @NonNull Locale locale) throws CoercingParseValueException {
         return parseValueImpl(input, locale);
     }
 
     @Override
     @Deprecated
-    public Boolean parseLiteral(@NotNull Object input) {
+    public Boolean parseLiteral(@NonNull Object input) {
         return parseLiteralImpl(input, Locale.getDefault());
     }
 
     @Override
-    public @Nullable Boolean parseLiteral(@NotNull Value<?> input, @NotNull CoercedVariables variables, @NotNull GraphQLContext graphQLContext, @NotNull Locale locale) throws CoercingParseLiteralException {
+    public @Nullable Boolean parseLiteral(@NonNull Value<?> input, @NonNull CoercedVariables variables, @NonNull GraphQLContext graphQLContext, @NonNull Locale locale) throws CoercingParseLiteralException {
         return parseLiteralImpl(input, locale);
     }
 
     @Override
     @Deprecated
-    public @NotNull Value<?> valueToLiteral(@NotNull Object input) {
+    public @NonNull Value<?> valueToLiteral(@NonNull Object input) {
         return valueToLiteralImpl(input, Locale.getDefault());
     }
 
     @Override
-    public @NotNull Value<?> valueToLiteral(@NotNull Object input, @NotNull GraphQLContext graphQLContext, @NotNull Locale locale) {
+    public @NonNull Value<?> valueToLiteral(@NonNull Object input, @NonNull GraphQLContext graphQLContext, @NonNull Locale locale) {
         return valueToLiteralImpl(input, locale);
     }
 }

--- a/src/main/java/graphql/scalar/GraphqlFloatCoercing.java
+++ b/src/main/java/graphql/scalar/GraphqlFloatCoercing.java
@@ -10,8 +10,8 @@ import graphql.schema.Coercing;
 import graphql.schema.CoercingParseLiteralException;
 import graphql.schema.CoercingParseValueException;
 import graphql.schema.CoercingSerializeException;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.math.BigDecimal;
 import java.util.Locale;
@@ -52,8 +52,8 @@ public class GraphqlFloatCoercing implements Coercing<Double, Double> {
         return doubleInput;
     }
 
-    @NotNull
-    private Double serialiseImpl(Object input, @NotNull Locale locale) {
+    @NonNull
+    private Double serialiseImpl(Object input, @NonNull Locale locale) {
         Double result = convertImpl(input);
         if (result == null) {
             throw new CoercingSerializeException(
@@ -63,8 +63,8 @@ public class GraphqlFloatCoercing implements Coercing<Double, Double> {
         return result;
     }
 
-    @NotNull
-    private Double parseValueImpl(@NotNull Object input, @NotNull Locale locale) {
+    @NonNull
+    private Double parseValueImpl(@NonNull Object input, @NonNull Locale locale) {
         if (!(input instanceof Number)) {
             throw new CoercingParseValueException(
                     i18nMsg(locale, "Float.unexpectedRawValueType", typeName(input))
@@ -81,7 +81,7 @@ public class GraphqlFloatCoercing implements Coercing<Double, Double> {
         return result;
     }
 
-    private static double parseLiteralImpl(@NotNull Object input, @NotNull Locale locale) {
+    private static double parseLiteralImpl(@NonNull Object input, @NonNull Locale locale) {
         if (input instanceof IntValue) {
             return ((IntValue) input).getValue().doubleValue();
         } else if (input instanceof FloatValue) {
@@ -93,8 +93,8 @@ public class GraphqlFloatCoercing implements Coercing<Double, Double> {
         }
     }
 
-    @NotNull
-    private FloatValue valueToLiteralImpl(Object input, @NotNull Locale locale) {
+    @NonNull
+    private FloatValue valueToLiteralImpl(Object input, @NonNull Locale locale) {
         Double result = convertImpl(input);
         if (result == null) {
             assertShouldNeverHappen(i18nMsg(locale, "Float.notFloat", typeName(input)));
@@ -104,45 +104,45 @@ public class GraphqlFloatCoercing implements Coercing<Double, Double> {
 
     @Override
     @Deprecated
-    public Double serialize(@NotNull Object dataFetcherResult) {
+    public Double serialize(@NonNull Object dataFetcherResult) {
         return serialiseImpl(dataFetcherResult, Locale.getDefault());
     }
 
     @Override
-    public @Nullable Double serialize(@NotNull Object dataFetcherResult, @NotNull GraphQLContext graphQLContext, @NotNull Locale locale) throws CoercingSerializeException {
+    public @Nullable Double serialize(@NonNull Object dataFetcherResult, @NonNull GraphQLContext graphQLContext, @NonNull Locale locale) throws CoercingSerializeException {
         return serialiseImpl(dataFetcherResult, locale);
     }
 
     @Override
     @Deprecated
-    public @NotNull Double parseValue(@NotNull Object input) {
+    public @NonNull Double parseValue(@NonNull Object input) {
         return parseValueImpl(input, Locale.getDefault());
     }
 
     @Override
-    public Double parseValue(@NotNull Object input, @NotNull GraphQLContext graphQLContext, @NotNull Locale locale) throws CoercingParseValueException {
+    public Double parseValue(@NonNull Object input, @NonNull GraphQLContext graphQLContext, @NonNull Locale locale) throws CoercingParseValueException {
         return parseValueImpl(input, locale);
     }
 
     @Override
     @Deprecated
-    public Double parseLiteral(@NotNull Object input) {
+    public Double parseLiteral(@NonNull Object input) {
         return parseLiteralImpl(input, Locale.getDefault());
     }
 
     @Override
-    public @Nullable Double parseLiteral(@NotNull Value<?> input, @NotNull CoercedVariables variables, @NotNull GraphQLContext graphQLContext, @NotNull Locale locale) throws CoercingParseLiteralException {
+    public @Nullable Double parseLiteral(@NonNull Value<?> input, @NonNull CoercedVariables variables, @NonNull GraphQLContext graphQLContext, @NonNull Locale locale) throws CoercingParseLiteralException {
         return parseLiteralImpl(input, locale);
     }
 
     @Override
     @Deprecated
-    public Value valueToLiteral(@NotNull Object input) {
+    public Value valueToLiteral(@NonNull Object input) {
         return valueToLiteralImpl(input, Locale.getDefault());
     }
 
     @Override
-    public @NotNull Value<?> valueToLiteral(@NotNull Object input, @NotNull GraphQLContext graphQLContext, @NotNull Locale locale) {
+    public @NonNull Value<?> valueToLiteral(@NonNull Object input, @NonNull GraphQLContext graphQLContext, @NonNull Locale locale) {
         return valueToLiteralImpl(input, locale);
     }
 }

--- a/src/main/java/graphql/scalar/GraphqlIDCoercing.java
+++ b/src/main/java/graphql/scalar/GraphqlIDCoercing.java
@@ -10,14 +10,13 @@ import graphql.schema.Coercing;
 import graphql.schema.CoercingParseLiteralException;
 import graphql.schema.CoercingParseValueException;
 import graphql.schema.CoercingSerializeException;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.math.BigInteger;
 import java.util.Locale;
 import java.util.UUID;
 
-import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertShouldNeverHappen;
 import static graphql.scalar.CoercingUtil.i18nMsg;
 import static graphql.scalar.CoercingUtil.typeName;
@@ -49,8 +48,8 @@ public class GraphqlIDCoercing implements Coercing<Object, Object> {
 
     }
 
-    @NotNull
-    private String serializeImpl(Object input, @NotNull Locale locale) {
+    @NonNull
+    private String serializeImpl(Object input, @NonNull Locale locale) {
         String result = String.valueOf(input);
         if (result == null) {
             throw new CoercingSerializeException(
@@ -60,8 +59,8 @@ public class GraphqlIDCoercing implements Coercing<Object, Object> {
         return result;
     }
 
-    @NotNull
-    private String parseValueImpl(Object input, @NotNull Locale locale) {
+    @NonNull
+    private String parseValueImpl(Object input, @NonNull Locale locale) {
         String result = convertImpl(input);
         if (result == null) {
             throw new CoercingParseValueException(
@@ -71,7 +70,7 @@ public class GraphqlIDCoercing implements Coercing<Object, Object> {
         return result;
     }
 
-    private String parseLiteralImpl(Object input, @NotNull Locale locale) {
+    private String parseLiteralImpl(Object input, @NonNull Locale locale) {
         if (input instanceof StringValue) {
             return ((StringValue) input).getValue();
         }
@@ -83,8 +82,8 @@ public class GraphqlIDCoercing implements Coercing<Object, Object> {
         );
     }
 
-    @NotNull
-    private StringValue valueToLiteralImpl(Object input, @NotNull Locale locale) {
+    @NonNull
+    private StringValue valueToLiteralImpl(Object input, @NonNull Locale locale) {
         String result = convertImpl(input);
         if (result == null) {
             assertShouldNeverHappen(i18nMsg(locale, "ID.notId", typeName(input)));
@@ -94,45 +93,45 @@ public class GraphqlIDCoercing implements Coercing<Object, Object> {
 
     @Override
     @Deprecated
-    public String serialize(@NotNull Object dataFetcherResult) {
+    public String serialize(@NonNull Object dataFetcherResult) {
         return serializeImpl(dataFetcherResult, Locale.getDefault());
     }
 
     @Override
-    public @Nullable Object serialize(@NotNull Object dataFetcherResult, @NotNull GraphQLContext graphQLContext, @NotNull Locale locale) throws CoercingSerializeException {
+    public @Nullable Object serialize(@NonNull Object dataFetcherResult, @NonNull GraphQLContext graphQLContext, @NonNull Locale locale) throws CoercingSerializeException {
         return serializeImpl(dataFetcherResult, locale);
     }
 
     @Override
     @Deprecated
-    public String parseValue(@NotNull Object input) {
+    public String parseValue(@NonNull Object input) {
         return parseValueImpl(input, Locale.getDefault());
     }
 
     @Override
-    public Object parseValue(@NotNull Object input, @NotNull GraphQLContext graphQLContext, @NotNull Locale locale) throws CoercingParseValueException {
+    public Object parseValue(@NonNull Object input, @NonNull GraphQLContext graphQLContext, @NonNull Locale locale) throws CoercingParseValueException {
         return parseValueImpl(input, locale);
     }
 
     @Override
     @Deprecated
-    public String parseLiteral(@NotNull Object input) {
+    public String parseLiteral(@NonNull Object input) {
         return parseLiteralImpl(input, Locale.getDefault());
     }
 
     @Override
-    public @Nullable Object parseLiteral(@NotNull Value<?> input, @NotNull CoercedVariables variables, @NotNull GraphQLContext graphQLContext, @NotNull Locale locale) throws CoercingParseLiteralException {
+    public @Nullable Object parseLiteral(@NonNull Value<?> input, @NonNull CoercedVariables variables, @NonNull GraphQLContext graphQLContext, @NonNull Locale locale) throws CoercingParseLiteralException {
         return parseLiteralImpl(input, locale);
     }
 
     @Override
     @Deprecated
-    public Value valueToLiteral(@NotNull Object input) {
+    public Value valueToLiteral(@NonNull Object input) {
         return valueToLiteralImpl(input, Locale.getDefault());
     }
 
     @Override
-    public @NotNull Value<?> valueToLiteral(@NotNull Object input, @NotNull GraphQLContext graphQLContext, @NotNull Locale locale) {
+    public @NonNull Value<?> valueToLiteral(@NonNull Object input, @NonNull GraphQLContext graphQLContext, @NonNull Locale locale) {
         return valueToLiteralImpl(input, locale);
     }
 }

--- a/src/main/java/graphql/scalar/GraphqlIntCoercing.java
+++ b/src/main/java/graphql/scalar/GraphqlIntCoercing.java
@@ -9,8 +9,8 @@ import graphql.schema.Coercing;
 import graphql.schema.CoercingParseLiteralException;
 import graphql.schema.CoercingParseValueException;
 import graphql.schema.CoercingSerializeException;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -51,8 +51,8 @@ public class GraphqlIntCoercing implements Coercing<Integer, Integer> {
         }
     }
 
-    @NotNull
-    private Integer serialiseImpl(Object input, @NotNull Locale locale) {
+    @NonNull
+    private Integer serialiseImpl(Object input, @NonNull Locale locale) {
         Integer result = convertImpl(input);
         if (result == null) {
             throw new CoercingSerializeException(
@@ -62,8 +62,8 @@ public class GraphqlIntCoercing implements Coercing<Integer, Integer> {
         return result;
     }
 
-    @NotNull
-    private Integer parseValueImpl(@NotNull Object input, @NotNull Locale locale) {
+    @NonNull
+    private Integer parseValueImpl(@NonNull Object input, @NonNull Locale locale) {
         if (!(input instanceof Number)) {
             throw new CoercingParseValueException(
                     i18nMsg(locale, "Int.notInt", typeName(input))
@@ -104,7 +104,7 @@ public class GraphqlIntCoercing implements Coercing<Integer, Integer> {
         }
     }
 
-    private static int parseLiteralImpl(Object input, @NotNull Locale locale) {
+    private static int parseLiteralImpl(Object input, @NonNull Locale locale) {
         if (!(input instanceof IntValue)) {
             throw new CoercingParseLiteralException(
                     i18nMsg(locale, "Scalar.unexpectedAstType", "IntValue", typeName(input))
@@ -119,7 +119,7 @@ public class GraphqlIntCoercing implements Coercing<Integer, Integer> {
         return value.intValue();
     }
 
-    private IntValue valueToLiteralImpl(Object input, @NotNull Locale locale) {
+    private IntValue valueToLiteralImpl(Object input, @NonNull Locale locale) {
         Integer result = convertImpl(input);
         if (result == null) {
             assertShouldNeverHappen(i18nMsg(locale, "Int.notInt", typeName(input)));
@@ -130,45 +130,45 @@ public class GraphqlIntCoercing implements Coercing<Integer, Integer> {
 
     @Override
     @Deprecated
-    public Integer serialize(@NotNull Object dataFetcherResult) {
+    public Integer serialize(@NonNull Object dataFetcherResult) {
         return serialiseImpl(dataFetcherResult, Locale.getDefault());
     }
 
     @Override
-    public @Nullable Integer serialize(@NotNull Object dataFetcherResult, @NotNull GraphQLContext graphQLContext, @NotNull Locale locale) throws CoercingSerializeException {
+    public @Nullable Integer serialize(@NonNull Object dataFetcherResult, @NonNull GraphQLContext graphQLContext, @NonNull Locale locale) throws CoercingSerializeException {
         return serialiseImpl(dataFetcherResult, locale);
     }
 
     @Override
     @Deprecated
-    public Integer parseValue(@NotNull Object input) {
+    public Integer parseValue(@NonNull Object input) {
         return parseValueImpl(input, Locale.getDefault());
     }
 
     @Override
-    public Integer parseValue(@NotNull Object input, @NotNull GraphQLContext graphQLContext, @NotNull Locale locale) throws CoercingParseValueException {
+    public Integer parseValue(@NonNull Object input, @NonNull GraphQLContext graphQLContext, @NonNull Locale locale) throws CoercingParseValueException {
         return parseValueImpl(input, locale);
     }
 
     @Override
     @Deprecated
-    public Integer parseLiteral(@NotNull Object input) {
+    public Integer parseLiteral(@NonNull Object input) {
         return parseLiteralImpl(input, Locale.getDefault());
     }
 
     @Override
-    public @Nullable Integer parseLiteral(@NotNull Value<?> input, @NotNull CoercedVariables variables, @NotNull GraphQLContext graphQLContext, @NotNull Locale locale) throws CoercingParseLiteralException {
+    public @Nullable Integer parseLiteral(@NonNull Value<?> input, @NonNull CoercedVariables variables, @NonNull GraphQLContext graphQLContext, @NonNull Locale locale) throws CoercingParseLiteralException {
         return parseLiteralImpl(input, locale);
     }
 
     @Override
     @Deprecated
-    public @NotNull Value<?> valueToLiteral(@NotNull Object input) {
+    public @NonNull Value<?> valueToLiteral(@NonNull Object input) {
         return valueToLiteralImpl(input, Locale.getDefault());
     }
 
     @Override
-    public @NotNull Value<?> valueToLiteral(@NotNull Object input, @NotNull GraphQLContext graphQLContext, @NotNull Locale locale) {
+    public @NonNull Value<?> valueToLiteral(@NonNull Object input, @NonNull GraphQLContext graphQLContext, @NonNull Locale locale) {
         return valueToLiteralImpl(input, locale);
     }
 }

--- a/src/main/java/graphql/scalar/GraphqlStringCoercing.java
+++ b/src/main/java/graphql/scalar/GraphqlStringCoercing.java
@@ -9,8 +9,8 @@ import graphql.schema.Coercing;
 import graphql.schema.CoercingParseLiteralException;
 import graphql.schema.CoercingParseValueException;
 import graphql.schema.CoercingSerializeException;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Locale;
 
@@ -28,7 +28,7 @@ public class GraphqlStringCoercing implements Coercing<String, String> {
         return String.valueOf(input);
     }
 
-    private String parseValueImpl(@NotNull Object input, @NotNull Locale locale) {
+    private String parseValueImpl(@NonNull Object input, @NonNull Locale locale) {
         if (!(input instanceof String)) {
             throw new CoercingParseValueException(
                     i18nMsg(locale, "String.unexpectedRawValueType", typeName(input))
@@ -37,7 +37,7 @@ public class GraphqlStringCoercing implements Coercing<String, String> {
         return (String) input;
     }
 
-    private String parseLiteralImpl(@NotNull Object input, Locale locale) {
+    private String parseLiteralImpl(@NonNull Object input, Locale locale) {
         if (!(input instanceof StringValue)) {
             throw new CoercingParseLiteralException(
                     i18nMsg(locale, "Scalar.unexpectedAstType", "StringValue", typeName(input))
@@ -46,51 +46,51 @@ public class GraphqlStringCoercing implements Coercing<String, String> {
         return ((StringValue) input).getValue();
     }
 
-    private StringValue valueToLiteralImpl(@NotNull Object input) {
+    private StringValue valueToLiteralImpl(@NonNull Object input) {
         return StringValue.newStringValue(input.toString()).build();
     }
 
     @Override
     @Deprecated
-    public String serialize(@NotNull Object dataFetcherResult) {
+    public String serialize(@NonNull Object dataFetcherResult) {
         return toStringImpl(dataFetcherResult);
     }
 
     @Override
-    public @Nullable String serialize(@NotNull Object dataFetcherResult, @NotNull GraphQLContext graphQLContext, @NotNull Locale locale) throws CoercingSerializeException {
+    public @Nullable String serialize(@NonNull Object dataFetcherResult, @NonNull GraphQLContext graphQLContext, @NonNull Locale locale) throws CoercingSerializeException {
         return toStringImpl(dataFetcherResult);
     }
 
     @Override
     @Deprecated
-    public String parseValue(@NotNull Object input) {
+    public String parseValue(@NonNull Object input) {
         return parseValueImpl(input, Locale.getDefault());
     }
 
     @Override
-    public String parseValue(@NotNull Object input, @NotNull GraphQLContext graphQLContext, @NotNull Locale locale) throws CoercingParseValueException {
+    public String parseValue(@NonNull Object input, @NonNull GraphQLContext graphQLContext, @NonNull Locale locale) throws CoercingParseValueException {
         return parseValueImpl(input, locale);
     }
 
     @Override
     @Deprecated
-    public String parseLiteral(@NotNull Object input) {
+    public String parseLiteral(@NonNull Object input) {
         return parseLiteralImpl(input, Locale.getDefault());
     }
 
     @Override
-    public @Nullable String parseLiteral(@NotNull Value<?> input, @NotNull CoercedVariables variables, @NotNull GraphQLContext graphQLContext, @NotNull Locale locale) throws CoercingParseLiteralException {
+    public @Nullable String parseLiteral(@NonNull Value<?> input, @NonNull CoercedVariables variables, @NonNull GraphQLContext graphQLContext, @NonNull Locale locale) throws CoercingParseLiteralException {
         return parseLiteralImpl(input, locale);
     }
 
     @Override
     @Deprecated
-    public @NotNull Value<?> valueToLiteral(@NotNull Object input) {
+    public @NonNull Value<?> valueToLiteral(@NonNull Object input) {
         return valueToLiteralImpl(input);
     }
 
     @Override
-    public @NotNull Value<?> valueToLiteral(@NotNull Object input, @NotNull GraphQLContext graphQLContext, @NotNull Locale locale) {
+    public @NonNull Value<?> valueToLiteral(@NonNull Object input, @NonNull GraphQLContext graphQLContext, @NonNull Locale locale) {
         return valueToLiteralImpl(input);
     }
 }

--- a/src/main/java/graphql/schema/Coercing.java
+++ b/src/main/java/graphql/schema/Coercing.java
@@ -5,8 +5,8 @@ import graphql.GraphQLContext;
 import graphql.PublicSpi;
 import graphql.execution.CoercedVariables;
 import graphql.language.Value;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Locale;
 import java.util.Map;
@@ -54,7 +54,7 @@ public interface Coercing<I, O> {
      * @throws graphql.schema.CoercingSerializeException if value input can't be serialized
      */
     @Deprecated(since = "2022-08-22")
-    default @Nullable O serialize(@NotNull Object dataFetcherResult) throws CoercingSerializeException {
+    default @Nullable O serialize(@NonNull Object dataFetcherResult) throws CoercingSerializeException {
         throw new UnsupportedOperationException("The non deprecated version of serialize has not been implemented by this scalar : " + this.getClass());
     }
 
@@ -75,7 +75,7 @@ public interface Coercing<I, O> {
      *
      * @throws graphql.schema.CoercingSerializeException if value input can't be serialized
      */
-    default @Nullable O serialize(@NotNull Object dataFetcherResult, @NotNull GraphQLContext graphQLContext, @NotNull Locale locale) throws CoercingSerializeException {
+    default @Nullable O serialize(@NonNull Object dataFetcherResult, @NonNull GraphQLContext graphQLContext, @NonNull Locale locale) throws CoercingSerializeException {
         assertNotNull(dataFetcherResult);
         assertNotNull(graphQLContext);
         return serialize(dataFetcherResult);
@@ -98,7 +98,7 @@ public interface Coercing<I, O> {
      * @throws graphql.schema.CoercingParseValueException if value input can't be parsed
      */
     @Deprecated(since = "2022-08-22")
-    default @Nullable I parseValue(@NotNull Object input) throws CoercingParseValueException {
+    default @Nullable I parseValue(@NonNull Object input) throws CoercingParseValueException {
         throw new UnsupportedOperationException("The non deprecated version of parseValue has not been implemented by this scalar : " + this.getClass());
     }
 
@@ -119,7 +119,7 @@ public interface Coercing<I, O> {
      * @throws graphql.schema.CoercingParseValueException if value input can't be parsed
      */
     @Nullable
-    default I parseValue(@NotNull Object input, @NotNull GraphQLContext graphQLContext, @NotNull Locale locale) throws CoercingParseValueException {
+    default I parseValue(@NonNull Object input, @NonNull GraphQLContext graphQLContext, @NonNull Locale locale) throws CoercingParseValueException {
         assertNotNull(input);
         assertNotNull(graphQLContext);
         assertNotNull(locale);
@@ -144,7 +144,7 @@ public interface Coercing<I, O> {
      * @throws graphql.schema.CoercingParseLiteralException if input literal can't be parsed
      */
     @Deprecated(since = "2022-08-22")
-    default @Nullable I parseLiteral(@NotNull Object input) throws CoercingParseLiteralException {
+    default @Nullable I parseLiteral(@NonNull Object input) throws CoercingParseLiteralException {
         throw new UnsupportedOperationException("The non deprecated version of parseLiteral has not been implemented by this scalar : " + this.getClass());
     }
 
@@ -198,7 +198,7 @@ public interface Coercing<I, O> {
      *
      * @throws graphql.schema.CoercingParseLiteralException if input literal can't be parsed
      */
-    default @Nullable I parseLiteral(@NotNull Value<?> input, @NotNull CoercedVariables variables, @NotNull GraphQLContext graphQLContext, @NotNull Locale locale) throws CoercingParseLiteralException {
+    default @Nullable I parseLiteral(@NonNull Value<?> input, @NonNull CoercedVariables variables, @NonNull GraphQLContext graphQLContext, @NonNull Locale locale) throws CoercingParseLiteralException {
         assertNotNull(input);
         assertNotNull(graphQLContext);
         assertNotNull(locale);
@@ -218,7 +218,7 @@ public interface Coercing<I, O> {
      * @return The literal matching the external input value.
      */
     @Deprecated(since = "2022-08-22")
-    default @NotNull Value valueToLiteral(@NotNull Object input) {
+    default @NonNull Value valueToLiteral(@NonNull Object input) {
         throw new UnsupportedOperationException("The non deprecated version of valueToLiteral has not been implemented by this scalar : " + this.getClass());
     }
 
@@ -233,7 +233,7 @@ public interface Coercing<I, O> {
      *
      * @return The literal matching the external input value.
      */
-    default @NotNull Value<?> valueToLiteral(@NotNull Object input, @NotNull GraphQLContext graphQLContext, @NotNull Locale locale) {
+    default @NonNull Value<?> valueToLiteral(@NonNull Object input, @NonNull GraphQLContext graphQLContext, @NonNull Locale locale) {
         assertNotNull(input);
         assertNotNull(graphQLContext);
         assertNotNull(locale);

--- a/src/main/java/graphql/schema/DataFetchingEnvironment.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironment.java
@@ -13,8 +13,8 @@ import graphql.language.FragmentDefinition;
 import graphql.language.OperationDefinition;
 import org.dataloader.DataLoader;
 import org.dataloader.DataLoaderRegistry;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.Locale;
@@ -101,7 +101,7 @@ public interface DataFetchingEnvironment extends IntrospectionDataFetchingEnviro
      *
      * @return can NOT be null
      */
-    @NotNull
+    @NonNull
     GraphQLContext getGraphQlContext();
 
     /**

--- a/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
@@ -17,8 +17,8 @@ import graphql.language.FragmentDefinition;
 import graphql.language.OperationDefinition;
 import org.dataloader.DataLoader;
 import org.dataloader.DataLoaderRegistry;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.Locale;
@@ -131,7 +131,7 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
     }
 
     @Override
-    public @NotNull GraphQLContext getGraphQlContext() {
+    public @NonNull GraphQLContext getGraphQlContext() {
         return graphQLContext;
     }
 

--- a/src/main/java/graphql/schema/DelegatingDataFetchingEnvironment.java
+++ b/src/main/java/graphql/schema/DelegatingDataFetchingEnvironment.java
@@ -12,8 +12,8 @@ import graphql.language.FragmentDefinition;
 import graphql.language.OperationDefinition;
 import org.dataloader.DataLoader;
 import org.dataloader.DataLoaderRegistry;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.Locale;
@@ -72,7 +72,7 @@ public class DelegatingDataFetchingEnvironment implements DataFetchingEnvironmen
     }
 
     @Override
-    public @NotNull GraphQLContext getGraphQlContext() {
+    public @NonNull GraphQLContext getGraphQlContext() {
         return delegateEnvironment.getGraphQlContext();
     }
 

--- a/src/main/java/graphql/schema/GraphQLAppliedDirectiveArgument.java
+++ b/src/main/java/graphql/schema/GraphQLAppliedDirectiveArgument.java
@@ -8,8 +8,8 @@ import graphql.language.Argument;
 import graphql.language.Value;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -70,7 +70,7 @@ public class GraphQLAppliedDirectiveArgument implements GraphQLNamedSchemaElemen
     /**
      * @return an input value with state for an applied directive argument
      */
-    public @NotNull InputValueWithState getArgumentValue() {
+    public @NonNull InputValueWithState getArgumentValue() {
         return value;
     }
 
@@ -218,7 +218,7 @@ public class GraphQLAppliedDirectiveArgument implements GraphQLNamedSchemaElemen
          *
          * @return this builder
          */
-        public Builder valueLiteral(@NotNull Value<?> value) {
+        public Builder valueLiteral(@NonNull Value<?> value) {
             this.value = InputValueWithState.newLiteralValue(value);
             return this;
         }
@@ -233,7 +233,7 @@ public class GraphQLAppliedDirectiveArgument implements GraphQLNamedSchemaElemen
             return this;
         }
 
-        public Builder inputValueWithState(@NotNull InputValueWithState value) {
+        public Builder inputValueWithState(@NonNull InputValueWithState value) {
             this.value = Assert.assertNotNull(value);
             return this;
         }

--- a/src/main/java/graphql/schema/GraphQLArgument.java
+++ b/src/main/java/graphql/schema/GraphQLArgument.java
@@ -8,8 +8,8 @@ import graphql.language.InputValueDefinition;
 import graphql.language.Value;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -104,7 +104,7 @@ public class GraphQLArgument implements GraphQLNamedSchemaElement, GraphQLInputV
      *
      * @return a {@link InputValueWithState} that represents the arguments default value
      */
-    public @NotNull InputValueWithState getArgumentDefaultValue() {
+    public @NonNull InputValueWithState getArgumentDefaultValue() {
         return defaultValue;
     }
 
@@ -125,7 +125,7 @@ public class GraphQLArgument implements GraphQLNamedSchemaElement, GraphQLInputV
      * @deprecated use {@link GraphQLAppliedDirectiveArgument} instead
      */
     @Deprecated(since = "2022-02-24")
-    public @NotNull InputValueWithState getArgumentValue() {
+    public @NonNull InputValueWithState getArgumentValue() {
         return value;
     }
 
@@ -382,7 +382,7 @@ public class GraphQLArgument implements GraphQLNamedSchemaElement, GraphQLInputV
          *
          * @return this builder
          */
-        public Builder defaultValueLiteral(@NotNull Value defaultValue) {
+        public Builder defaultValueLiteral(@NonNull Value defaultValue) {
             this.defaultValue = InputValueWithState.newLiteralValue(defaultValue);
             return this;
         }
@@ -432,7 +432,7 @@ public class GraphQLArgument implements GraphQLNamedSchemaElement, GraphQLInputV
          * @deprecated use {@link  GraphQLAppliedDirectiveArgument} methods instead
          */
         @Deprecated(since = "2022-02-24")
-        public Builder valueLiteral(@NotNull Value value) {
+        public Builder valueLiteral(@NonNull Value value) {
             this.value = InputValueWithState.newLiteralValue(value);
             return this;
         }

--- a/src/main/java/graphql/schema/GraphQLEnumType.java
+++ b/src/main/java/graphql/schema/GraphQLEnumType.java
@@ -13,7 +13,7 @@ import graphql.language.Value;
 import graphql.util.FpKit;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -150,7 +150,7 @@ public class GraphQLEnumType implements GraphQLNamedInputType, GraphQLNamedOutpu
                 (fld1, fld2) -> assertShouldNeverHappen("Duplicated definition for field '%s' in type '%s'", fld1.getName(), this.name)));
     }
 
-    private Object getValueByName(@NotNull Object value, GraphQLContext graphQLContext, Locale locale) {
+    private Object getValueByName(@NonNull Object value, GraphQLContext graphQLContext, Locale locale) {
         GraphQLEnumValueDefinition enumValueDefinition = valueDefinitionMap.get(value.toString());
         if (enumValueDefinition != null) {
             return enumValueDefinition.getValue();

--- a/src/main/java/graphql/schema/GraphQLInputObjectField.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectField.java
@@ -8,7 +8,7 @@ import graphql.language.InputValueDefinition;
 import graphql.language.Value;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -87,7 +87,7 @@ public class GraphQLInputObjectField implements GraphQLNamedSchemaElement, Graph
      *
      * @return a input value with captured state
      */
-    public @NotNull InputValueWithState getInputFieldDefaultValue() {
+    public @NonNull InputValueWithState getInputFieldDefaultValue() {
         return defaultValue;
     }
 

--- a/src/main/java/graphql/schema/GraphQLNamedSchemaElement.java
+++ b/src/main/java/graphql/schema/GraphQLNamedSchemaElement.java
@@ -2,8 +2,8 @@ package graphql.schema;
 
 import graphql.PublicApi;
 import graphql.language.Node;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A Schema element which has a name and also a description and AST Node which it is based on.
@@ -14,7 +14,7 @@ public interface GraphQLNamedSchemaElement extends GraphQLSchemaElement {
     /**
      * @return the name of this element.  This cant be null
      */
-    @NotNull
+    @NonNull
     String getName();
 
     /**

--- a/src/main/java/graphql/schema/GraphQLSchema.java
+++ b/src/main/java/graphql/schema/GraphQLSchema.java
@@ -18,8 +18,8 @@ import graphql.schema.impl.SchemaUtil;
 import graphql.schema.validation.InvalidSchemaException;
 import graphql.schema.validation.SchemaValidationError;
 import graphql.schema.validation.SchemaValidator;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -230,7 +230,7 @@ public class GraphQLSchema {
      *
      * @return the type
      */
-    public @Nullable GraphQLType getType(@NotNull String typeName) {
+    public @Nullable GraphQLType getType(@NonNull String typeName) {
         return typeMap.get(typeName);
     }
 

--- a/src/main/java/graphql/schema/InputValueWithState.java
+++ b/src/main/java/graphql/schema/InputValueWithState.java
@@ -2,8 +2,8 @@ package graphql.schema;
 
 import graphql.PublicApi;
 import graphql.language.Value;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import static graphql.Assert.assertNotNull;
 
@@ -44,7 +44,7 @@ public class InputValueWithState {
 
     public static final InputValueWithState NOT_SET = new InputValueWithState(State.NOT_SET, null);
 
-    public static InputValueWithState newLiteralValue(@NotNull Value value) {
+    public static InputValueWithState newLiteralValue(@NonNull Value value) {
         assertNotNull(value, () -> "value literal can't be null");
         return new InputValueWithState(State.LITERAL, value);
     }

--- a/src/main/java/graphql/schema/diffing/SchemaGraph.java
+++ b/src/main/java/graphql/schema/diffing/SchemaGraph.java
@@ -7,7 +7,7 @@ import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Table;
 import graphql.ExperimentalApi;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -18,7 +18,6 @@ import java.util.Optional;
 import java.util.function.Predicate;
 
 import static graphql.Assert.assertTrue;
-import static java.lang.String.format;
 
 @ExperimentalApi
 public class SchemaGraph {

--- a/src/main/java/graphql/schema/usage/SchemaUsageSupport.java
+++ b/src/main/java/graphql/schema/usage/SchemaUsageSupport.java
@@ -22,7 +22,6 @@ import graphql.schema.GraphQLUnionType;
 import graphql.schema.SchemaTraverser;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.HashSet;
 import java.util.List;

--- a/src/main/java/graphql/schema/visitor/GraphQLSchemaVisitorEnvironmentImpl.java
+++ b/src/main/java/graphql/schema/visitor/GraphQLSchemaVisitorEnvironmentImpl.java
@@ -6,13 +6,16 @@ import graphql.schema.GraphQLModifiedType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLSchemaElement;
 import graphql.util.TraverserContext;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 
-import static graphql.schema.visitor.GraphQLSchemaTraversalControl.*;
+import static graphql.schema.visitor.GraphQLSchemaTraversalControl.CONTINUE;
+import static graphql.schema.visitor.GraphQLSchemaTraversalControl.Control;
+import static graphql.schema.visitor.GraphQLSchemaTraversalControl.DELETE;
+import static graphql.schema.visitor.GraphQLSchemaTraversalControl.QUIT;
 
 @Internal
 class GraphQLSchemaVisitorEnvironmentImpl<T extends GraphQLSchemaElement> implements GraphQLSchemaVisitorEnvironment<T> {
@@ -50,7 +53,7 @@ class GraphQLSchemaVisitorEnvironmentImpl<T extends GraphQLSchemaElement> implem
         return buildParentsImpl(schemaElement -> !(schemaElement instanceof GraphQLModifiedType));
     }
 
-    @NotNull
+    @NonNull
     private List<GraphQLSchemaElement> buildParentsImpl(Predicate<GraphQLSchemaElement> predicate) {
         List<GraphQLSchemaElement> list = new ArrayList<>();
         TraverserContext<GraphQLSchemaElement> parentContext = context.getParentContext();

--- a/src/main/java/graphql/util/Interning.java
+++ b/src/main/java/graphql/util/Interning.java
@@ -3,7 +3,7 @@ package graphql.util;
 import com.google.common.collect.Interner;
 import com.google.common.collect.Interners;
 import graphql.Internal;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Interner allowing object-identity comparison of key entities like field names.  This is useful on hotspot
@@ -18,7 +18,7 @@ public class Interning {
 
     private static final Interner<String> INTERNER = Interners.newWeakInterner();
 
-    public static @NotNull String intern(@NotNull String name) {
+    public static @NonNull String intern(@NonNull String name) {
         return INTERNER.intern(name);
     }
 

--- a/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
@@ -13,8 +13,6 @@ import graphql.language.AstPrinter
 import graphql.parser.Parser
 import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironment
-import graphql.schema.LightDataFetcher
-import graphql.schema.PropertyDataFetcher
 import graphql.schema.SingletonPropertyDataFetcher
 import graphql.schema.StaticDataFetcher
 import org.awaitility.Awaitility

--- a/src/test/groovy/graphql/execution/reactive/tck/CompletionStageMappingOrderedPublisherRandomCompleteTckVerificationTest.java
+++ b/src/test/groovy/graphql/execution/reactive/tck/CompletionStageMappingOrderedPublisherRandomCompleteTckVerificationTest.java
@@ -1,9 +1,8 @@
 package graphql.execution.reactive.tck;
 
 import graphql.execution.reactive.CompletionStageMappingOrderedPublisher;
-import graphql.execution.reactive.CompletionStageMappingPublisher;
 import io.reactivex.Flowable;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.tck.PublisherVerification;
 import org.reactivestreams.tck.TestEnvironment;
@@ -48,7 +47,7 @@ public class CompletionStageMappingOrderedPublisherRandomCompleteTckVerification
         return true;
     }
 
-    @NotNull
+    @NonNull
     private static Function<Integer, CompletionStage<String>> mapperFunc() {
         return i -> CompletableFuture.supplyAsync(() -> {
             int ms = rand(0, 5);

--- a/src/test/groovy/graphql/execution/reactive/tck/CompletionStageMappingPublisherRandomCompleteTckVerificationTest.java
+++ b/src/test/groovy/graphql/execution/reactive/tck/CompletionStageMappingPublisherRandomCompleteTckVerificationTest.java
@@ -2,7 +2,7 @@ package graphql.execution.reactive.tck;
 
 import graphql.execution.reactive.CompletionStageMappingPublisher;
 import io.reactivex.Flowable;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.tck.PublisherVerification;
 import org.reactivestreams.tck.TestEnvironment;
@@ -47,7 +47,7 @@ public class CompletionStageMappingPublisherRandomCompleteTckVerificationTest ex
         return true;
     }
 
-    @NotNull
+    @NonNull
     private static Function<Integer, CompletionStage<String>> mapperFunc() {
         return i -> CompletableFuture.supplyAsync(() -> {
             int ms = rand(0, 5);

--- a/src/test/groovy/readme/InstrumentationExamples.java
+++ b/src/test/groovy/readme/InstrumentationExamples.java
@@ -21,8 +21,8 @@ import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchPar
 import graphql.execution.instrumentation.tracing.TracingInstrumentation;
 import graphql.schema.DataFetcher;
 import graphql.schema.GraphQLSchema;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -86,7 +86,7 @@ public class InstrumentationExamples {
         }
 
         @Override
-        public @NotNull DataFetcher<?> instrumentDataFetcher(DataFetcher<?> dataFetcher, InstrumentationFieldFetchParameters parameters, InstrumentationState state) {
+        public @NonNull DataFetcher<?> instrumentDataFetcher(DataFetcher<?> dataFetcher, InstrumentationFieldFetchParameters parameters, InstrumentationState state) {
             //
             // this allows you to intercept the data fetcher used to fetch a field and provide another one, perhaps
             // that enforces certain behaviours or has certain side effects on the data
@@ -95,7 +95,7 @@ public class InstrumentationExamples {
         }
 
         @Override
-        public @NotNull CompletableFuture<ExecutionResult> instrumentExecutionResult(ExecutionResult executionResult, InstrumentationExecutionParameters parameters, InstrumentationState state) {
+        public @NonNull CompletableFuture<ExecutionResult> instrumentExecutionResult(ExecutionResult executionResult, InstrumentationExecutionParameters parameters, InstrumentationState state) {
             //
             // this allows you to instrument the execution result somehow.  For example the Tracing support uses this to put
             // the `extensions` map of data in place

--- a/src/test/java/reproductions/SubscriptionReproduction.java
+++ b/src/test/java/reproductions/SubscriptionReproduction.java
@@ -9,7 +9,7 @@ import graphql.schema.GraphQLSchema;
 import graphql.schema.idl.RuntimeWiring;
 import graphql.schema.idl.SchemaGenerator;
 import graphql.schema.idl.SchemaParser;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -134,7 +134,7 @@ public class SubscriptionReproduction {
         return counter;
     }
 
-    private @NotNull Object mkValue(Integer counter) {
+    private @NonNull Object mkValue(Integer counter) {
         // name and isFavorite are future values via DFs
         return Map.of(
                 "counter", counter,


### PR DESCRIPTION
Following the Spring project: https://docs.spring.io/spring-framework/reference/7.0-SNAPSHOT/core/null-safety.html

this PR moves from Jetbrains annotations to the jspecify project ones: https://jspecify.dev/

This is compatible with Kotlin:

>However, the compiler understands JSpecify annotations and is able to use them to make Kotlin code see null-safe types when calling into Java code. The Kotlin compiler correctly interprets @Nullable and @NullMarked starting at version 1.8.20, @NonNull starting at 2.0.0, and @NullUnmarked starting in 2.0.20.

> As of [version 2.1.0](https://kotlinlang.org/docs/whatsnew21.html#change-of-jspecify-nullability-mismatch-diagnostics-severity-to-strict), the Kotlin compiler emits errors by default for problems found using JSpecify nullness. To change those to warnings, pass the -Xnullability-annotations=@org.jspecify.annotations:warn flag.

From https://jspecify.dev/docs/whether/#kotlin