### PR TITLE
Add method to AstPrinter to allow supplying Appendable

### DIFF
--- a/src/test/groovy/graphql/language/AstPrinterTest.groovy
+++ b/src/test/groovy/graphql/language/AstPrinterTest.groovy
@@ -3,6 +3,8 @@ package graphql.language
 import graphql.parser.Parser
 import spock.lang.Specification
 
+import java.nio.CharBuffer
+
 class AstPrinterTest extends Specification {
 
     Document parse(String input) {
@@ -768,5 +770,42 @@ extend input Input @directive {
         String output = printAst(field_with_empty_selection_set)
         then:
         output == "foo"
+    }
+
+    def "printAstTo writes to a StringBuilder instance"() {
+        def document = parse(starWarsSchema)
+        def output = new StringBuilder()
+        AstPrinter.printAstTo(document.getDefinitions().get(0), output)
+
+        expect:
+        output.toString() == """schema {
+  query: QueryType
+  mutation: Mutation
+}"""
+    }
+
+    def "printAstTo writes to a Writer instance"() {
+        def document = parse(starWarsSchema)
+        def output = new StringWriter()
+        AstPrinter.printAstTo(document.getDefinitions().get(0), output)
+
+        expect:
+        output.toString() == """schema {
+  query: QueryType
+  mutation: Mutation
+}"""
+    }
+
+    def "printAstTo writes to an Appendable instance"() {
+        def document = parse(starWarsSchema)
+        def output = CharBuffer.allocate(100)
+        AstPrinter.printAstTo(document.getDefinitions().get(0), output)
+        output.flip()
+
+        expect:
+        output.toString() == """schema {
+  query: QueryType
+  mutation: Mutation
+}"""
     }
 }


### PR DESCRIPTION
Add printAstTo to AstPrinter, which allows the caller to supply their own target Appendable. This can be useful for reusing StringBuilders for instance.