### PR TITLE
Optimize DataFetchingSelectionSet.getImmediateFields() to avoid traversing descendants

### DIFF
--- a/src/test/groovy/graphql/schema/DataFetchingFieldSelectionSetImplTest.groovy
+++ b/src/test/groovy/graphql/schema/DataFetchingFieldSelectionSetImplTest.groovy
@@ -348,6 +348,54 @@ class DataFetchingFieldSelectionSetImplTest extends Specification {
         fields.collect({ field -> field.qualifiedName }) == expectedFieldName
     }
 
+
+    def "immediate fields followed by fields are computed"() {
+
+        when:
+        def ei = ExecutionInput.newExecutionInput(relayQuery).build()
+        def er = relayGraphql.execute(ei)
+
+        then:
+        er.getErrors().isEmpty()
+
+        then:
+        List<SelectedField> immediateFields = selectionSet.getImmediateFields()
+
+        then:
+        def expectedImmediateFieldName = [
+                "nodes",
+                "edges",
+                "totalCount"
+        ]
+
+        immediateFields.collect({ field -> field.qualifiedName }) == expectedImmediateFieldName
+
+        then:
+        List<SelectedField> fieldsGlob = selectionSet.getFields("**")
+        List<SelectedField> fields = selectionSet.getFields()
+
+        def expectedFieldName = [
+                "nodes",
+                "nodes/key",
+                "nodes/summary",
+                "nodes/status",
+                "nodes/status/name",
+                "nodes/stuff",
+                "nodes/stuff/name",
+                "edges",
+                "edges/cursor",
+                "edges/node",
+                "edges/node/description",
+                "edges/node/status",
+                "edges/node/status/name",
+                "totalCount"
+        ]
+
+        then:
+        fieldsGlob.collect({ field -> field.qualifiedName }) == expectedFieldName
+        fields.collect({ field -> field.qualifiedName }) == expectedFieldName
+    }
+
     def petSDL = '''
             type Query {
                 petUnion : PetUnion


### PR DESCRIPTION
Addresses #3854.

## Description

Computes immediate fields only for `getImmediateFields()` to avoid cost of traversing the entire sub-tree to build glob-patterns for descendant fields.

## Benchmark
Before:
```
Benchmark                                                          Mode  Cnt   Score   Error   Units
DFSelectionSetPerformance.benchMarkThroughput                     thrpt    9  10.424 ± 0.598  ops/ms
DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields  thrpt    9  21.992 ± 0.224  ops/ms
DFSelectionSetPerformance.benchMarkAvgTime                         avgt    9   0.096 ± 0.005   ms/op
DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields      avgt    9   0.044 ± 0.001   ms/op
```

After:
```
Benchmark                                                          Mode  Cnt     Score    Error   Units
DFSelectionSetPerformance.benchMarkThroughput                     thrpt    9    10.641 ±  0.118  ops/ms
DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields  thrpt    9  2667.783 ± 73.924  ops/ms
DFSelectionSetPerformance.benchMarkAvgTime                         avgt    9     0.094 ±  0.003   ms/op
DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields      avgt    9    ≈ 10⁻³            ms/op
```
