### PR TITLE
Performance pipeline improvements

### DIFF
--- a/.github/workflows/commit_performance_result.yml
+++ b/.github/workflows/commit_performance_result.yml
@@ -33,6 +33,7 @@ jobs:
             echo "Performance results already present"
             exit 0
           fi
+          git pull
           git commit -m "Add performance results for commit ${{ github.event.inputs.sha }}"
           git push
           

--- a/.github/workflows/publish_commit.yml
+++ b/.github/workflows/publish_commit.yml
@@ -1,8 +1,12 @@
 name: Publish Commit SHA for performance testing
 on:
-  push:
+  pull_request:
+    types:
+      - closed
     branches:
       - master
+    paths-ignore:
+      - 'performance-results/**'
 permissions:
   id-token: write # This is required for requesting the JWT
   contents: read  # This is required for actions/checkout


### PR DESCRIPTION
Fixes 2 problems seen lately on our performance pipeline, after enabling multiple concurrent runs

1. **Too many jobs.** We sent 36 jobs off in the space of a few minutes which was unnecessary. This is because the performance pipeline is triggered on every master commit, and some branches had many commits. This wasn't a problem before enabling concurrent pipeline runs. **Solution: change the performance pipeline to trigger on pull request merge instead**
2. **We had a race condition**, because two performance pipeline runs completed at almost the same time. The second pipeline couldn't commit the results because the HEAD of master changed during the copy step of the 2nd pipeline. **Solution: add another `git pull` before committing results.** Example of race condition: https://github.com/graphql-java/graphql-java/actions/runs/14025083675/job/39262341170