### PR TITLE
Detect and prohibit new Guava classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,6 +125,8 @@ dependencies {
     testAnnotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess:1.37'
     jmh 'org.openjdk.jmh:jmh-core:1.37'
     jmh 'org.openjdk.jmh:jmh-generator-annprocess:1.37'
+
+    testImplementation "com.tngtech.archunit:archunit-junit5:1.2.0"
 }
 
 shadowJar {

--- a/src/test/groovy/graphql/GuavaLimitCheck.groovy
+++ b/src/test/groovy/graphql/GuavaLimitCheck.groovy
@@ -1,0 +1,78 @@
+package graphql
+
+import com.tngtech.archunit.core.domain.JavaClasses
+import com.tngtech.archunit.core.importer.ClassFileImporter
+import com.tngtech.archunit.core.importer.ImportOption
+import spock.lang.Specification
+
+/*
+ * We selectively shade in a few classes of Guava, however we want to minimise dependencies so we want to keep this list small.
+ * This check ensures no new Guava classes are added
+ */
+class GuavaLimitCheck extends Specification {
+
+    static final String GUAVA_PACKAGE_PREFIX = "com.google.common"
+
+    static final Set<String> ALLOWED_GUAVA_CLASSES = [
+            "com.google.common.collect.ImmutableMap",
+            "com.google.common.collect.ImmutableSet",
+            "com.google.common.collect.ImmutableList",
+            "com.google.common.base.Strings",
+            "com.google.common.collect.BiMap",
+            "com.google.common.collect.HashBiMap",
+            "com.google.common.collect.ImmutableCollection",
+            "com.google.common.collect.LinkedHashMultimap",
+            "com.google.common.collect.Multimap",
+            "com.google.common.collect.Table",
+            "com.google.common.collect.Sets",
+            "com.google.common.collect.Multimaps",
+            "com.google.common.collect.Iterables",
+            "com.google.common.collect.HashBasedTable",
+            "com.google.common.collect.HashMultimap",
+            "com.google.common.collect.Interner",
+            "com.google.common.collect.Interners"
+    ]
+
+    def "should identify which classes use prohibited Guava dependencies"() {
+        given:
+        JavaClasses importedClasses = new ClassFileImporter()
+                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+                .importPackages("graphql")
+
+        when:
+        Map<String, Set<String>> violationsByClass = [:]
+
+        importedClasses.each { javaClass ->
+            def className = javaClass.name
+            def guavaUsages = javaClass.getAccessesFromSelf()
+                    .collect { it.targetOwner }
+                    .findAll { it.packageName.startsWith(GUAVA_PACKAGE_PREFIX) && !ALLOWED_GUAVA_CLASSES.contains(it) }
+                    .toSet()
+
+            if (!guavaUsages.isEmpty()) {
+                violationsByClass[className] = guavaUsages
+            }
+        }
+
+        then:
+        violationsByClass.isEmpty()
+
+        cleanup: "if the test fails, provide detailed information about which classes have violations"
+        if (!violationsByClass.isEmpty()) {
+            def errorMessage = new StringBuilder("Prohibited Guava class usage found:\n")
+
+            violationsByClass.each { className, guavaClasses ->
+                errorMessage.append("\nClass: ${className} uses these prohibited Guava classes:\n")
+                guavaClasses.each { guavaClass ->
+                    errorMessage.append("  - ${guavaClass}\n")
+                }
+            }
+
+            errorMessage.append("\nEither:\n")
+            errorMessage.append("1. Preferred option: Replace them with alternatives that don't depend on Guava\n")
+            errorMessage.append("2. If absolutely necessary: Add these Guava classes to the shade configuration in the build.gradle file\n")
+
+            println errorMessage.toString()
+        }
+    }
+}

--- a/src/test/groovy/graphql/GuavaLimitCheck.groovy
+++ b/src/test/groovy/graphql/GuavaLimitCheck.groovy
@@ -46,7 +46,7 @@ class GuavaLimitCheck extends Specification {
             def className = javaClass.name
             def guavaUsages = javaClass.getAccessesFromSelf()
                     .collect { it.targetOwner }
-                    .findAll { it.packageName.startsWith(GUAVA_PACKAGE_PREFIX) && !ALLOWED_GUAVA_CLASSES.contains(it) }
+                    .findAll { it.packageName.startsWith(GUAVA_PACKAGE_PREFIX) && !ALLOWED_GUAVA_CLASSES.contains(it.fullName) }
                     .toSet()
 
             if (!guavaUsages.isEmpty()) {

--- a/src/test/groovy/graphql/GuavaLimitCheck.groovy
+++ b/src/test/groovy/graphql/GuavaLimitCheck.groovy
@@ -14,23 +14,34 @@ class GuavaLimitCheck extends Specification {
     static final String GUAVA_PACKAGE_PREFIX = "com.google.common"
 
     static final Set<String> ALLOWED_GUAVA_CLASSES = [
-            "com.google.common.collect.ImmutableMap",
-            "com.google.common.collect.ImmutableSet",
-            "com.google.common.collect.ImmutableList",
             "com.google.common.base.Strings",
             "com.google.common.collect.BiMap",
-            "com.google.common.collect.HashBiMap",
-            "com.google.common.collect.ImmutableCollection",
-            "com.google.common.collect.LinkedHashMultimap",
-            "com.google.common.collect.Multimap",
-            "com.google.common.collect.Table",
-            "com.google.common.collect.Sets",
-            "com.google.common.collect.Multimaps",
-            "com.google.common.collect.Iterables",
             "com.google.common.collect.HashBasedTable",
+            "com.google.common.collect.HashBiMap",
             "com.google.common.collect.HashMultimap",
+            "com.google.common.collect.HashMultiset",
+            "com.google.common.collect.ImmutableBiMap",
+            "com.google.common.collect.ImmutableCollection",
+            "com.google.common.collect.ImmutableList",
+            "com.google.common.collect.ImmutableList\$Builder",
+            "com.google.common.collect.ImmutableListMultimap",
+            "com.google.common.collect.ImmutableListMultimap\$Builder",
+            "com.google.common.collect.ImmutableMap",
+            "com.google.common.collect.ImmutableMap\$Builder",
+            "com.google.common.collect.ImmutableSet",
+            "com.google.common.collect.ImmutableSet\$Builder",
             "com.google.common.collect.Interner",
-            "com.google.common.collect.Interners"
+            "com.google.common.collect.Interners",
+            "com.google.common.collect.Iterables",
+            "com.google.common.collect.LinkedHashMultimap",
+            "com.google.common.collect.Maps",
+            "com.google.common.collect.Multimap",
+            "com.google.common.collect.Multimaps",
+            "com.google.common.collect.Multiset",
+            "com.google.common.collect.Multisets",
+            "com.google.common.collect.Sets",
+            "com.google.common.collect.Sets\$SetView",
+            "com.google.common.collect.Table"
     ]
 
     def "should identify which classes use prohibited Guava dependencies"() {


### PR DESCRIPTION
Fixes #3859 

## Problem
We want to keep dependencies to an absolute minimum as this is a low level library. However we make an exception for a few selected Guava classes which are shaded in.

There's a potential risk where someone uses a new Guava class in a pull request, and either: 
1. They are unaware that they should, where possible, use a non-Guava version of the method (which is different to their usual developer workflow)
2. Or they really must use a Guava class, we forget to shade in the new class in the Gradle build file, causing functionality to break

## Solution

This PR adds an Archunit test to detect new Guava class usage and produce a helpful error message to guide contributors to 1. use non-Guava versions where possible or 2. adjust the Gradle build file to shade in the new class

## Sample output

Example of deliberately failing pipeline (before I added the full set of exemptions): https://github.com/graphql-java/graphql-java/pull/3869/checks?check_run_id=39620708772

```
GuavaLimitCheck > should identify which classes use prohibited Guava dependencies STANDARD_OUT
    Prohibited Guava class usage found:

    Class: graphql.execution.ExecutionStrategy uses these prohibited Guava classes:
      - JavaClass{name='com.google.common.collect.Maps'}

    Class: graphql.schema.diffing.DiffImpl uses these prohibited Guava classes:
      - JavaClass{name='com.google.common.collect.Multiset'}
      - JavaClass{name='com.google.common.collect.HashMultiset'}
      - JavaClass{name='com.google.common.collect.Multisets'}

    Either:
    1. Preferred option: Replace them with alternatives that don't depend on Guava
    2. If absolutely necessary: Add these Guava classes to the shade configuration in the build.gradle file
```

## Note

We don't yet use anything from the `math` or `primitives` packages directly, but these are transitively used by `collect`, so they also need to be shaded in

```
 relocate('com.google.common', 'graphql.com.google.common') {
        include 'com.google.common.collect.*'
        include 'com.google.common.base.*'
        include 'com.google.common.math.*'
        include 'com.google.common.primitives.*'
    }
```