### PR TITLE
JS like Batching

### DIFF
--- a/src/main/java/graphql/execution/AbstractAsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AbstractAsyncExecutionStrategy.java
@@ -5,7 +5,6 @@ import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.PublicSpi;
 
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -24,8 +23,10 @@ public abstract class AbstractAsyncExecutionStrategy extends ExecutionStrategy {
 
     protected BiConsumer<List<Object>, Throwable> handleResults(ExecutionContext executionContext, List<String> fieldNames, CompletableFuture<ExecutionResult> overallResult) {
         return (List<Object> results, Throwable exception) -> {
+            executionContext.running();
             if (exception != null) {
                 handleNonNullException(executionContext, overallResult, exception);
+                executionContext.finished();
                 return;
             }
             Map<String, Object> resolvedValuesByField = Maps.newLinkedHashMapWithExpectedSize(fieldNames.size());
@@ -35,6 +36,7 @@ public abstract class AbstractAsyncExecutionStrategy extends ExecutionStrategy {
                 resolvedValuesByField.put(fieldName, result);
             }
             overallResult.complete(new ExecutionResultImpl(resolvedValuesByField, executionContext.getErrors()));
+            executionContext.finished();
         };
     }
 }

--- a/src/main/java/graphql/execution/DataLoaderDispatchStrategy.java
+++ b/src/main/java/graphql/execution/DataLoaderDispatchStrategy.java
@@ -2,8 +2,10 @@ package graphql.execution;
 
 import graphql.Internal;
 import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 @Internal
 public interface DataLoaderDispatchStrategy {
@@ -44,7 +46,7 @@ public interface DataLoaderDispatchStrategy {
     default void fieldFetched(ExecutionContext executionContext,
                               ExecutionStrategyParameters executionStrategyParameters,
                               DataFetcher<?> dataFetcher,
-                              Object fetchedValue) {
+                              Object fetchedValue, Supplier<DataFetchingEnvironment> dataFetchingEnvironment) {
 
     }
 

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -29,8 +29,8 @@ import graphql.language.VariableDefinition;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.impl.SchemaUtil;
-import org.jspecify.annotations.NonNull;
 import graphql.util.FpKit;
+import org.jspecify.annotations.NonNull;
 import org.reactivestreams.Publisher;
 
 import java.util.Collections;
@@ -57,6 +57,8 @@ public class Execution {
     private final Instrumentation instrumentation;
     private final ValueUnboxer valueUnboxer;
     private final boolean doNotAutomaticallyDispatchDataLoader;
+
+    public static final String EXECUTION_CONTEXT_KEY = "__GraphQL_Java_ExecutionContext";
 
     public Execution(ExecutionStrategy queryStrategy,
                      ExecutionStrategy mutationStrategy,
@@ -114,6 +116,8 @@ public class Execution {
                 .build();
 
         executionContext.getGraphQLContext().put(ResultNodesInfo.RESULT_NODES_INFO, executionContext.getResultNodesInfo());
+        executionContext.getGraphQLContext().put(EXECUTION_CONTEXT_KEY, executionContext);
+
 
         InstrumentationExecutionParameters parameters = new InstrumentationExecutionParameters(
                 executionInput, graphQLSchema

--- a/src/main/java/graphql/execution/ExecutionContext.java
+++ b/src/main/java/graphql/execution/ExecutionContext.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -62,6 +63,8 @@ public class ExecutionContext {
     private final ExecutionInput executionInput;
     private final Supplier<ExecutableNormalizedOperation> queryTree;
     private final boolean propagateErrorsOnNonNullContractFailure;
+
+    private final AtomicInteger isRunning = new AtomicInteger(0);
 
     // this is modified after creation so it needs to be volatile to ensure visibility across Threads
     private volatile DataLoaderDispatchStrategy dataLoaderDispatcherStrategy = DataLoaderDispatchStrategy.NO_OP;
@@ -348,5 +351,17 @@ public class ExecutionContext {
 
     public ResultNodesInfo getResultNodesInfo() {
         return resultNodesInfo;
+    }
+
+    public boolean isRunning() {
+        return isRunning.get() > 0;
+    }
+
+    public void running() {
+        isRunning.incrementAndGet();
+    }
+
+    public void finished() {
+        isRunning.decrementAndGet();
     }
 }

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -496,7 +496,7 @@ public abstract class ExecutionStrategy {
         dataFetcher = instrumentation.instrumentDataFetcher(dataFetcher, instrumentationFieldFetchParams, executionContext.getInstrumentationState());
         dataFetcher = executionContext.getDataLoaderDispatcherStrategy().modifyDataFetcher(dataFetcher);
         Object fetchedObject = invokeDataFetcher(executionContext, parameters, fieldDef, dataFetchingEnvironment, dataFetcher);
-        executionContext.getDataLoaderDispatcherStrategy().fieldFetched(executionContext, parameters, dataFetcher, fetchedObject);
+        executionContext.getDataLoaderDispatcherStrategy().fieldFetched(executionContext, parameters, dataFetcher, fetchedObject, dataFetchingEnvironment);
         fetchCtx.onDispatched();
         fetchCtx.onFetchedValue(fetchedObject);
         // if it's a subscription, leave any reactive objects alone

--- a/src/main/java/graphql/execution/instrumentation/dataloader/DataLoaderCF.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/DataLoaderCF.java
@@ -1,0 +1,99 @@
+package graphql.execution.instrumentation.dataloader;
+
+import graphql.ExperimentalApi;
+import graphql.Internal;
+import graphql.execution.DataLoaderDispatchStrategy;
+import graphql.execution.ExecutionContext;
+import graphql.schema.DataFetchingEnvironment;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Supplier;
+
+import static graphql.execution.Execution.EXECUTION_CONTEXT_KEY;
+
+@Internal
+public class DataLoaderCF<T> extends CompletableFuture<T> {
+    final DataFetchingEnvironment dfe;
+    final String dataLoaderName;
+    final Object key;
+    final CompletableFuture<Object> dataLoaderCF;
+
+    volatile CountDownLatch latch;
+
+    public DataLoaderCF(DataFetchingEnvironment dfe, String dataLoaderName, Object key) {
+        this.dfe = dfe;
+        this.dataLoaderName = dataLoaderName;
+        this.key = key;
+        if (dataLoaderName != null) {
+            dataLoaderCF = dfe.getDataLoaderRegistry().getDataLoader(dataLoaderName).load(key);
+            dataLoaderCF.whenComplete((value, throwable) -> {
+                System.out.println("underlying DataLoader completed");
+                if (throwable != null) {
+                    completeExceptionally(throwable);
+                } else {
+                    complete((T) value);
+                }
+                // post completion hook
+                if (latch != null) {
+                    latch.countDown();
+                }
+            });
+        } else {
+            dataLoaderCF = null;
+        }
+    }
+
+    DataLoaderCF() {
+        this.dfe = null;
+        this.dataLoaderName = null;
+        this.key = null;
+        dataLoaderCF = null;
+    }
+
+    @Override
+    public <U> CompletableFuture<U> newIncompleteFuture() {
+        return new DataLoaderCF<>();
+    }
+
+    public static boolean isDataLoaderCF(Object object) {
+        return object instanceof DataLoaderCF;
+    }
+
+    @ExperimentalApi
+    public static <T> CompletableFuture<T> newDataLoaderCF(DataFetchingEnvironment dfe, String dataLoaderName, Object key) {
+        DataLoaderCF<T> result = new DataLoaderCF<>(dfe, dataLoaderName, key);
+        ExecutionContext executionContext = dfe.getGraphQlContext().get(EXECUTION_CONTEXT_KEY);
+        DataLoaderDispatchStrategy dataLoaderDispatcherStrategy = executionContext.getDataLoaderDispatcherStrategy();
+        if (dataLoaderDispatcherStrategy instanceof PerLevelDataLoaderDispatchStrategy) {
+            ((PerLevelDataLoaderDispatchStrategy) dataLoaderDispatcherStrategy).newDataLoaderCF(result);
+        }
+        return result;
+    }
+
+
+    @ExperimentalApi
+    public static <U> CompletableFuture<U> supplyAsyncDataLoaderCF(DataFetchingEnvironment env, Supplier<U> supplier) {
+        DataLoaderCF<U> d = new DataLoaderCF<>(env, null, null);
+        d.defaultExecutor().execute(() -> {
+            d.complete(supplier.get());
+        });
+        return d;
+
+    }
+
+    @ExperimentalApi
+    public static <U> CompletableFuture<U> wrap(DataFetchingEnvironment env, CompletableFuture<U> completableFuture) {
+        DataLoaderCF<U> d = new DataLoaderCF<>(env, null, null);
+        completableFuture.whenComplete((u, ex) -> {
+            if (ex != null) {
+                d.completeExceptionally(ex);
+            } else {
+                d.complete(u);
+            }
+        });
+        return d;
+    }
+
+
+}

--- a/src/main/java/graphql/execution/instrumentation/dataloader/PerLevelDataLoaderDispatchStrategyWithDeferAlwaysDispatch.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/PerLevelDataLoaderDispatchStrategyWithDeferAlwaysDispatch.java
@@ -7,6 +7,7 @@ import graphql.execution.ExecutionContext;
 import graphql.execution.ExecutionStrategyParameters;
 import graphql.execution.FieldValueInfo;
 import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
 import graphql.util.LockKit;
 import org.dataloader.DataLoaderRegistry;
 
@@ -14,6 +15,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 
 /**
  * The execution of a query can be divided into 2 phases: first, the non-deferred fields are executed and only once
@@ -173,7 +175,7 @@ public class PerLevelDataLoaderDispatchStrategyWithDeferAlwaysDispatch implement
     public void fieldFetched(ExecutionContext executionContext,
                              ExecutionStrategyParameters parameters,
                              DataFetcher<?> dataFetcher,
-                             Object fetchedValue) {
+                             Object fetchedValue, Supplier<DataFetchingEnvironment> dataFetchingEnvironment) {
 
         final boolean dispatchNeeded;
 

--- a/src/test/groovy/graphql/DataLoaderCFTest.groovy
+++ b/src/test/groovy/graphql/DataLoaderCFTest.groovy
@@ -1,0 +1,287 @@
+package graphql
+
+import graphql.execution.instrumentation.dataloader.DataLoaderCF
+import graphql.schema.DataFetcher
+import org.dataloader.BatchLoader
+import org.dataloader.DataLoader
+import org.dataloader.DataLoaderFactory
+import org.dataloader.DataLoaderRegistry
+import spock.lang.Specification
+
+import java.util.concurrent.CompletableFuture
+
+import static graphql.ExecutionInput.newExecutionInput
+
+class DataLoaderCFTest extends Specification {
+
+
+    def "chained data loaders"() {
+        given:
+        def sdl = '''
+
+        type Query {
+          dogName: String
+          catName: String
+        }
+        '''
+        int batchLoadCalls = 0
+        BatchLoader<String, String> batchLoader = { keys ->
+            return CompletableFuture.supplyAsync {
+                batchLoadCalls++
+                Thread.sleep(250)
+                println "BatchLoader called with keys: $keys"
+                assert keys.size() == 2
+                return ["Luna", "Tiger"]
+            }
+        }
+
+        DataLoader<String, String> nameDataLoader = DataLoaderFactory.newDataLoader(batchLoader);
+
+        DataLoaderRegistry dataLoaderRegistry = new DataLoaderRegistry();
+        dataLoaderRegistry.register("name", nameDataLoader);
+
+        def df1 = { env ->
+            return DataLoaderCF.newDataLoaderCF(env, "name", "Key1").thenCompose {
+                result ->
+                    {
+                        return DataLoaderCF.newDataLoaderCF(env, "name", result)
+                    }
+            }
+        } as DataFetcher
+
+        def df2 = { env ->
+            return DataLoaderCF.newDataLoaderCF(env, "name", "Key2").thenCompose {
+                result ->
+                    {
+                        return DataLoaderCF.newDataLoaderCF(env, "name", result)
+                    }
+            }
+        } as DataFetcher
+
+
+        def fetchers = ["Query": ["dogName": df1, "catName": df2]]
+        def schema = TestUtil.schema(sdl, fetchers)
+        def graphQL = GraphQL.newGraphQL(schema).build()
+
+        def query = "{ dogName catName } "
+        def ei = newExecutionInput(query).dataLoaderRegistry(dataLoaderRegistry).build()
+
+        when:
+        def er = graphQL.execute(ei)
+        then:
+        er.data == [dogName: "Luna", catName: "Tiger"]
+        batchLoadCalls == 2
+    }
+
+    def "more complicated chained data loader for one DF"() {
+        given:
+        def sdl = '''
+
+        type Query {
+           foo: String
+        }
+        '''
+        int batchLoadCalls1 = 0
+        BatchLoader<String, String> batchLoader1 = { keys ->
+            return CompletableFuture.supplyAsync {
+                batchLoadCalls1++
+                Thread.sleep(250)
+                println "BatchLoader1 called with keys: $keys"
+                return keys.collect { String key ->
+                    key + "-batchloader1"
+                }
+            }
+        }
+        int batchLoadCalls2 = 0
+        BatchLoader<String, String> batchLoader2 = { keys ->
+            return CompletableFuture.supplyAsync {
+                batchLoadCalls2++
+                Thread.sleep(250)
+                println "BatchLoader2 called with keys: $keys"
+                return keys.collect { String key ->
+                    key + "-batchloader2"
+                }
+            }
+        }
+
+
+        DataLoader<String, String> dl1 = DataLoaderFactory.newDataLoader(batchLoader1);
+        DataLoader<String, String> dl2 = DataLoaderFactory.newDataLoader(batchLoader2);
+
+        DataLoaderRegistry dataLoaderRegistry = new DataLoaderRegistry();
+        dataLoaderRegistry.register("dl1", dl1);
+        dataLoaderRegistry.register("dl2", dl2);
+
+        def df = { env ->
+            return DataLoaderCF.newDataLoaderCF(env, "dl1", "start").thenCompose {
+                firstDLResult ->
+
+                    def otherCF1 = DataLoaderCF.supplyAsyncDataLoaderCF(env, {
+                        Thread.sleep(1000)
+                        return "otherCF1"
+                    })
+                    def otherCF2 = DataLoaderCF.supplyAsyncDataLoaderCF(env, {
+                        Thread.sleep(1000)
+                        return "otherCF2"
+                    })
+
+                    def secondDL = DataLoaderCF.newDataLoaderCF(env, "dl2", firstDLResult).thenApply {
+                        secondDLResult ->
+                            return secondDLResult + "-apply"
+                    }
+                    return otherCF1.thenCompose {
+                        otherCF1Result ->
+                            otherCF2.thenCompose {
+                                otherCF2Result ->
+                                    secondDL.thenApply {
+                                        secondDLResult ->
+                                            return firstDLResult + "-" + otherCF1Result + "-" + otherCF2Result + "-" + secondDLResult
+                                    }
+                            }
+                    }
+
+            }
+        } as DataFetcher
+
+
+        def fetchers = ["Query": ["foo": df]]
+        def schema = TestUtil.schema(sdl, fetchers)
+        def graphQL = GraphQL.newGraphQL(schema).build()
+
+        def query = "{ foo } "
+        def ei = newExecutionInput(query).dataLoaderRegistry(dataLoaderRegistry).build()
+
+        when:
+        def er = graphQL.execute(ei)
+        then:
+        er.data == [foo: "start-batchloader1-otherCF1-otherCF2-start-batchloader1-batchloader2-apply"]
+        batchLoadCalls1 == 1
+        batchLoadCalls2 == 1
+    }
+
+
+    def "chained data loaders with an isolated data loader"() {
+        given:
+        def sdl = '''
+
+        type Query {
+          dogName: String
+          catName: String
+        }
+        '''
+        int batchLoadCalls = 0
+        BatchLoader<String, String> batchLoader = { keys ->
+            return CompletableFuture.supplyAsync {
+                batchLoadCalls++
+                Thread.sleep(250)
+                println "BatchLoader called with keys: $keys"
+                return keys.collect { String key ->
+                    key.substring(0, key.length() - 1) + (Integer.parseInt(key.substring(key.length() - 1, key.length())) + 1)
+                }
+            }
+        }
+
+        DataLoader<String, String> nameDataLoader = DataLoaderFactory.newDataLoader(batchLoader);
+
+        DataLoaderRegistry dataLoaderRegistry = new DataLoaderRegistry();
+        dataLoaderRegistry.register("name", nameDataLoader);
+
+        def df1 = { env ->
+            return DataLoaderCF.newDataLoaderCF(env, "name", "Luna0").thenCompose {
+                result ->
+                    {
+                        return DataLoaderCF.supplyAsyncDataLoaderCF(env, {
+                            Thread.sleep(1000)
+                            return "foo"
+                        }).thenCompose {
+                            return DataLoaderCF.newDataLoaderCF(env, "name", result)
+                        }
+                    }
+            }
+        } as DataFetcher
+
+        def df2 = { env ->
+            return DataLoaderCF.newDataLoaderCF(env, "name", "Tiger0").thenCompose {
+                result ->
+                    {
+                        return DataLoaderCF.newDataLoaderCF(env, "name", result)
+                    }
+            }
+        } as DataFetcher
+
+
+        def fetchers = ["Query": ["dogName": df1, "catName": df2]]
+        def schema = TestUtil.schema(sdl, fetchers)
+        def graphQL = GraphQL.newGraphQL(schema).build()
+
+        def query = "{ dogName catName } "
+        def ei = newExecutionInput(query).dataLoaderRegistry(dataLoaderRegistry).build()
+
+        when:
+        def er = graphQL.execute(ei)
+        then:
+        er.data == [dogName: "Luna2", catName: "Tiger2"]
+        batchLoadCalls == 3
+    }
+
+    def "chained data loaders with two isolated data loaders"() {
+        // TODO: this test is naturally flaky, because there is no guarantee that the Thread.sleep(1000) finish close
+        // enough time wise to be batched together
+        given:
+        def sdl = '''
+
+        type Query {
+          foo: String
+         bar: String
+        }
+        '''
+        int batchLoadCalls = 0
+        BatchLoader<String, String> batchLoader = { keys ->
+            return CompletableFuture.supplyAsync {
+                batchLoadCalls++
+                Thread.sleep(250)
+                println "BatchLoader called with keys: $keys"
+                return keys;
+            }
+        }
+
+        DataLoader<String, String> nameDataLoader = DataLoaderFactory.newDataLoader(batchLoader);
+
+        DataLoaderRegistry dataLoaderRegistry = new DataLoaderRegistry();
+        dataLoaderRegistry.register("dl", nameDataLoader);
+
+        def fooDF = { env ->
+            return DataLoaderCF.supplyAsyncDataLoaderCF(env, {
+                Thread.sleep(1000)
+                return "fooFirstValue"
+            }).thenCompose {
+                return DataLoaderCF.newDataLoaderCF(env, "dl", it)
+            }
+        } as DataFetcher
+
+        def barDF = { env ->
+            return DataLoaderCF.supplyAsyncDataLoaderCF(env, {
+                Thread.sleep(1000)
+                return "barFirstValue"
+            }).thenCompose {
+                return DataLoaderCF.newDataLoaderCF(env, "dl", it)
+            }
+        } as DataFetcher
+
+
+        def fetchers = ["Query": ["foo": fooDF, "bar": barDF]]
+        def schema = TestUtil.schema(sdl, fetchers)
+        def graphQL = GraphQL.newGraphQL(schema).build()
+
+        def query = "{ foo bar } "
+        def ei = newExecutionInput(query).dataLoaderRegistry(dataLoaderRegistry).build()
+
+        when:
+        def er = graphQL.execute(ei)
+        then:
+        er.data == [foo: "fooFirstValue", bar: "barFirstValue"]
+        batchLoadCalls == 1
+    }
+
+
+}

--- a/src/test/groovy/graphql/DataLoaderCFTest.groovy
+++ b/src/test/groovy/graphql/DataLoaderCFTest.groovy
@@ -1,5 +1,6 @@
 package graphql
 
+
 import graphql.execution.instrumentation.dataloader.DataLoaderCF
 import graphql.schema.DataFetcher
 import org.dataloader.BatchLoader


### PR DESCRIPTION
This is a modified version of #3872 

Probably the closest Java can get to the JS dataloader batching:

- we track now if the engine is running in the ExecutionContext (regardless of thread)
- a very small batch window of 0.1ms is started every time a new DataLoaderCF is created.
- if the DatatLoaderCF encounters a running engine while trying to dispatch  the time window resets to avoid dispatching while the engine is running

