### PR TITLE
Added ExecutionInput cancellation

### DIFF
--- a/src/main/java/graphql/ExecutionInput.java
+++ b/src/main/java/graphql/ExecutionInput.java
@@ -45,8 +45,7 @@ public class ExecutionInput {
         this.locale = builder.locale != null ? builder.locale : Locale.getDefault(); // always have a locale in place
         this.localContext = builder.localContext;
         this.extensions = builder.extensions;
-
-        cancelled = new AtomicBoolean(false);
+        this.cancelled = builder.cancelled;
     }
 
     /**
@@ -147,8 +146,8 @@ public class ExecutionInput {
      * The graphql engine will check this frequently and if that is true, it will
      * throw a {@link graphql.execution.AbortExecutionException} to cancel the execution.
      * <p>
-     * This is a best-efforts cancellation.  Asynchronous data fetching code may still continue to
-     * run.
+     * This is a cooperative cancellation.  Some asynchronous data fetching code may still continue to
+     * run but there will be no more efforts run future field fetches say.
      *
      * @return true if the execution should be cancelled
      */
@@ -157,9 +156,10 @@ public class ExecutionInput {
     }
 
     /**
-     * This can be called to cancel the graphql execution.
+     * This can be called to cancel the graphql execution.  Remember this is a cooperative cancellation
+     * and the graphql engine needs to be running on a thread to allow is to respect this flag.
      */
-    private void cancel() {
+    public void cancel() {
         cancelled.set(true);
     }
 
@@ -176,7 +176,8 @@ public class ExecutionInput {
                 .query(this.query)
                 .operationName(this.operationName)
                 .context(this.context)
-                .transfer(this.graphQLContext)
+                .internalTransferContext(this.graphQLContext)
+                .internalTransferCancelBoolean(this.cancelled)
                 .localContext(this.localContext)
                 .root(this.root)
                 .dataLoaderRegistry(this.dataLoaderRegistry)
@@ -232,7 +233,7 @@ public class ExecutionInput {
         private Object localContext;
         private Object root;
         private RawVariables rawVariables = RawVariables.emptyVariables();
-        public Map<String, Object> extensions = ImmutableKit.emptyMap();
+        private Map<String, Object> extensions = ImmutableKit.emptyMap();
         //
         // this is important - it allows code to later known if we never really set a dataloader and hence it can optimize
         // dataloader field tracking away.
@@ -240,6 +241,7 @@ public class ExecutionInput {
         private DataLoaderRegistry dataLoaderRegistry = EMPTY_DATALOADER_REGISTRY;
         private Locale locale = Locale.getDefault();
         private ExecutionId executionId;
+        private AtomicBoolean cancelled = new AtomicBoolean(false);
 
         public Builder query(String query) {
             this.query = assertNotNull(query, () -> "query can't be null");
@@ -330,10 +332,17 @@ public class ExecutionInput {
         }
 
         // hidden on purpose
-        private Builder transfer(GraphQLContext graphQLContext) {
+        private Builder internalTransferContext(GraphQLContext graphQLContext) {
             this.graphQLContext = Assert.assertNotNull(graphQLContext);
             return this;
         }
+
+        // hidden on purpose
+        private Builder internalTransferCancelBoolean(AtomicBoolean cancelled) {
+            this.cancelled = cancelled;
+            return this;
+        }
+
 
         public Builder root(Object root) {
             this.root = root;

--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -483,7 +483,6 @@ public class GraphQL {
     private PreparsedDocumentEntry parseAndValidate(AtomicReference<ExecutionInput> executionInputRef, GraphQLSchema graphQLSchema, InstrumentationState instrumentationState) {
 
         ExecutionInput executionInput = executionInputRef.get();
-        String query = executionInput.getQuery();
 
         ParseAndValidateResult parseResult = parse(executionInput, graphQLSchema, instrumentationState);
         if (parseResult.isFailure()) {

--- a/src/main/java/graphql/execution/AbstractAsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AbstractAsyncExecutionStrategy.java
@@ -27,7 +27,6 @@ public abstract class AbstractAsyncExecutionStrategy extends ExecutionStrategy {
                 handleNonNullException(executionContext, overallResult, exception);
                 return;
             }
-            executionContext.checkIsCancelled();
 
             Map<String, Object> resolvedValuesByField = Maps.newLinkedHashMapWithExpectedSize(fieldNames.size());
             int ix = 0;

--- a/src/main/java/graphql/execution/AbstractAsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AbstractAsyncExecutionStrategy.java
@@ -28,6 +28,8 @@ public abstract class AbstractAsyncExecutionStrategy extends ExecutionStrategy {
                 handleNonNullException(executionContext, overallResult, exception);
                 return;
             }
+            checkIsCancelled(executionContext);
+
             Map<String, Object> resolvedValuesByField = Maps.newLinkedHashMapWithExpectedSize(fieldNames.size());
             int ix = 0;
             for (Object result : results) {

--- a/src/main/java/graphql/execution/AbstractAsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AbstractAsyncExecutionStrategy.java
@@ -22,7 +22,7 @@ public abstract class AbstractAsyncExecutionStrategy extends ExecutionStrategy {
     }
 
     protected BiConsumer<List<Object>, Throwable> handleResults(ExecutionContext executionContext, List<String> fieldNames, CompletableFuture<ExecutionResult> overallResult) {
-        return (List<Object> results, Throwable exception) -> executionContext.run(() -> {
+        return (List<Object> results, Throwable exception) -> executionContext.run(exception, () -> {
             if (exception != null) {
                 handleNonNullException(executionContext, overallResult, exception);
                 return;

--- a/src/main/java/graphql/execution/AbstractAsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AbstractAsyncExecutionStrategy.java
@@ -28,7 +28,7 @@ public abstract class AbstractAsyncExecutionStrategy extends ExecutionStrategy {
                 handleNonNullException(executionContext, overallResult, exception);
                 return;
             }
-            checkIsCancelled(executionContext);
+            executionContext.checkIsCancelled();
 
             Map<String, Object> resolvedValuesByField = Maps.newLinkedHashMapWithExpectedSize(fieldNames.size());
             int ix = 0;

--- a/src/main/java/graphql/execution/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncExecutionStrategy.java
@@ -61,7 +61,7 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
             executionStrategyCtx.onDispatched();
 
             futures.await().whenComplete((completeValueInfos, throwable) -> {
-                executionContext.run(() -> {
+                executionContext.run(throwable,() -> {
                     List<String> fieldsExecutedOnInitialResult = deferredExecutionSupport.getNonDeferredFieldNames(fieldNames);
 
                     BiConsumer<List<Object>, Throwable> handleResultsConsumer = handleResults(executionContext, fieldsExecutedOnInitialResult, overallResult);
@@ -78,7 +78,7 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
                     executionStrategyCtx.onFieldValuesInfo(completeValueInfos);
                     fieldValuesFutures.await().whenComplete(handleResultsConsumer);
                 });
-            }).exceptionally((ex) -> executionContext.call(() -> {
+            }).exceptionally((ex) -> executionContext.call(ex,() -> {
                 // if there are any issues with combining/handling the field results,
                 // complete the future at all costs and bubble up any thrown exception so
                 // the execution does not hang.

--- a/src/main/java/graphql/execution/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncExecutionStrategy.java
@@ -38,7 +38,7 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
     @Override
     @SuppressWarnings("FutureReturnValueIgnored")
     public CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) throws NonNullableFieldWasNullException {
-        checkIsCancelled(executionContext);
+        executionContext.checkIsCancelled();
 
         DataLoaderDispatchStrategy dataLoaderDispatcherStrategy = executionContext.getDataLoaderDispatcherStrategy();
         dataLoaderDispatcherStrategy.executionStrategy(executionContext, parameters);
@@ -70,7 +70,7 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
                 return;
             }
 
-            checkIsCancelled(executionContext);
+            executionContext.checkIsCancelled();
 
             Async.CombinedBuilder<Object> fieldValuesFutures = Async.ofExpectedSize(completeValueInfos.size());
             for (FieldValueInfo completeValueInfo : completeValueInfos) {

--- a/src/main/java/graphql/execution/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncExecutionStrategy.java
@@ -38,6 +38,8 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
     @Override
     @SuppressWarnings("FutureReturnValueIgnored")
     public CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) throws NonNullableFieldWasNullException {
+        checkIsCancelled(executionContext);
+
         DataLoaderDispatchStrategy dataLoaderDispatcherStrategy = executionContext.getDataLoaderDispatcherStrategy();
         dataLoaderDispatcherStrategy.executionStrategy(executionContext, parameters);
         Instrumentation instrumentation = executionContext.getInstrumentation();
@@ -67,6 +69,8 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
                 handleResultsConsumer.accept(null, throwable.getCause());
                 return;
             }
+
+            checkIsCancelled(executionContext);
 
             Async.CombinedBuilder<Object> fieldValuesFutures = Async.ofExpectedSize(completeValueInfos.size());
             for (FieldValueInfo completeValueInfo : completeValueInfos) {

--- a/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
@@ -32,7 +32,7 @@ public class AsyncSerialExecutionStrategy extends AbstractAsyncExecutionStrategy
     @Override
     @SuppressWarnings({"TypeParameterUnusedInFormals", "FutureReturnValueIgnored"})
     public CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) throws NonNullableFieldWasNullException {
-        checkIsCancelled(executionContext);
+        executionContext.checkIsCancelled();
 
         DataLoaderDispatchStrategy dataLoaderDispatcherStrategy = executionContext.getDataLoaderDispatcherStrategy();
 
@@ -52,7 +52,7 @@ public class AsyncSerialExecutionStrategy extends AbstractAsyncExecutionStrategy
         }
 
         CompletableFuture<List<Object>> resultsFuture = Async.eachSequentially(fieldNames, (fieldName, prevResults) -> {
-            checkIsCancelled(executionContext);
+            executionContext.checkIsCancelled();
 
             MergedField currentField = fields.getSubField(fieldName);
             ResultPath fieldPath = parameters.getPath().segment(mkNameForPath(currentField));

--- a/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
@@ -32,6 +32,8 @@ public class AsyncSerialExecutionStrategy extends AbstractAsyncExecutionStrategy
     @Override
     @SuppressWarnings({"TypeParameterUnusedInFormals", "FutureReturnValueIgnored"})
     public CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) throws NonNullableFieldWasNullException {
+        checkIsCancelled(executionContext);
+
         DataLoaderDispatchStrategy dataLoaderDispatcherStrategy = executionContext.getDataLoaderDispatcherStrategy();
 
         Instrumentation instrumentation = executionContext.getInstrumentation();
@@ -50,6 +52,8 @@ public class AsyncSerialExecutionStrategy extends AbstractAsyncExecutionStrategy
         }
 
         CompletableFuture<List<Object>> resultsFuture = Async.eachSequentially(fieldNames, (fieldName, prevResults) -> {
+            checkIsCancelled(executionContext);
+
             MergedField currentField = fields.getSubField(fieldName);
             ResultPath fieldPath = parameters.getPath().segment(mkNameForPath(currentField));
             ExecutionStrategyParameters newParameters = parameters

--- a/src/main/java/graphql/execution/EngineRunningObserver.java
+++ b/src/main/java/graphql/execution/EngineRunningObserver.java
@@ -1,15 +1,45 @@
 package graphql.execution;
 
+import graphql.ExecutionInput;
 import graphql.ExperimentalApi;
 import graphql.GraphQLContext;
 import org.jspecify.annotations.NullMarked;
 
+/**
+ * This class lets you observe the running state of the graphql-java engine.  As it processes and dispatches graphql fields,
+ * the engine moves in and out of a running and not running state.  As it does this, the callback is called with information telling you the current
+ * state.
+ * <p>
+ * If the engine is cancelled via {@link ExecutionInput#cancel()} then the observer will also be called to indicate that.
+ */
 @ExperimentalApi
 @NullMarked
 public interface EngineRunningObserver {
 
+    enum RunningState {
+        /**
+         * Represents that the engine code is actively running its own code
+         */
+        RUNNING,
+        /**
+         * Represents that the engine code is asynchronously waiting for fetching to happen
+         */
+        NOT_RUNNING,
+        /**
+         * Represents that the engine code has been cancelled via {@link ExecutionInput#cancel()}
+         */
+        CANCELLED
+    }
+
 
     String ENGINE_RUNNING_OBSERVER_KEY = "__ENGINE_RUNNING_OBSERVER";
 
-    void runningStateChanged(ExecutionId executionId, GraphQLContext graphQLContext, boolean runningState);
+
+    /**
+     * This will be called when the running state of the graphql-java engine changes.
+     *
+     * @param executionId    the id of the current execution
+     * @param graphQLContext the graphql context
+     */
+    void runningStateChanged(ExecutionId executionId, GraphQLContext graphQLContext, RunningState runningState);
 }

--- a/src/main/java/graphql/execution/ExecutionContext.java
+++ b/src/main/java/graphql/execution/ExecutionContext.java
@@ -334,6 +334,16 @@ public class ExecutionContext {
     }
 
     /**
+     * This will abort the execution via {@link AbortExecutionException} if the {@link ExecutionInput} has been cancelled
+     */
+    @Internal
+    public void checkIsCancelled() {
+        if (getExecutionInput().isCancelled()) {
+            throw new AbortExecutionException("Execution has been asked to be cancelled");
+        }
+    }
+
+    /**
      * This helps you transform the current ExecutionContext object into another one by starting a builder with all
      * the current values and allows you to transform it how you want.
      *

--- a/src/main/java/graphql/execution/ExecutionContext.java
+++ b/src/main/java/graphql/execution/ExecutionContext.java
@@ -381,9 +381,14 @@ public class ExecutionContext {
     }
 
     public <T> T call(Supplier<T> callable) {
+        return call(null,callable);
+    }
+
+    public <T> T call(Throwable currentThrowable, Supplier<T> callable) {
         if (isRunning.incrementAndGet() == 1 && engineRunningObserver != null) {
             engineRunningObserver.runningStateChanged(executionId, graphQLContext, true);
         }
+        checkIsCancelled(currentThrowable);
         try {
             return callable.get();
         } finally {
@@ -394,9 +399,14 @@ public class ExecutionContext {
     }
 
     public void run(Runnable runnable) {
+        run(null,runnable);
+    }
+
+    public void run(Throwable currentThrowable, Runnable runnable) {
         if (isRunning.incrementAndGet() == 1 && engineRunningObserver != null) {
             engineRunningObserver.runningStateChanged(executionId, graphQLContext, true);
         }
+        checkIsCancelled(currentThrowable);
         try {
             runnable.run();
         } finally {
@@ -404,6 +414,13 @@ public class ExecutionContext {
                 engineRunningObserver.runningStateChanged(executionId, graphQLContext, false);
             }
 
+        }
+    }
+
+    private void checkIsCancelled(Throwable currentThrowable) {
+        // no need to check if we already have an exception in place
+        if (currentThrowable == null) {
+            checkIsCancelled();
         }
     }
 

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -226,7 +226,7 @@ public abstract class ExecutionStrategy {
             if (fieldValueInfosResult instanceof CompletableFuture) {
                 CompletableFuture<List<FieldValueInfo>> fieldValueInfos = (CompletableFuture<List<FieldValueInfo>>) fieldValueInfosResult;
                 fieldValueInfos.whenComplete((completeValueInfos, throwable) -> {
-                    executionContext.run(() -> {
+                    executionContext.run(throwable,() -> {
                         if (throwable != null) {
                             handleResultsConsumer.accept(null, throwable);
                             return;
@@ -280,7 +280,7 @@ public abstract class ExecutionStrategy {
 
     private BiConsumer<List<Object>, Throwable> buildFieldValueMap(List<String> fieldNames, CompletableFuture<Map<String, Object>> overallResult, ExecutionContext executionContext) {
         return (List<Object> results, Throwable exception) -> {
-            executionContext.run(() -> {
+            executionContext.run(exception,() -> {
                 if (exception != null) {
                     handleValueException(overallResult, exception, executionContext);
                     return;
@@ -514,7 +514,7 @@ public abstract class ExecutionStrategy {
             @SuppressWarnings("unchecked")
             CompletableFuture<Object> fetchedValue = (CompletableFuture<Object>) fetchedObject;
             return fetchedValue
-                    .handle((result, exception) -> executionContext.call(() -> {
+                    .handle((result, exception) -> executionContext.call(exception,() -> {
                         fetchCtx.onCompleted(result, exception);
                         if (exception != null) {
                             CompletableFuture<Object> handleFetchingExceptionResult = handleFetchingException(dataFetchingEnvironment.get(), parameters, exception);
@@ -843,7 +843,7 @@ public abstract class ExecutionStrategy {
             overallResult.whenComplete(completeListCtx::onCompleted);
 
             resultsFuture.whenComplete((results, exception) -> {
-                executionContext.run(() -> {
+                executionContext.run(exception, () -> {
                     if (exception != null) {
                         handleValueException(overallResult, exception, executionContext);
                         return;

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -226,7 +226,7 @@ public abstract class ExecutionStrategy {
             if (fieldValueInfosResult instanceof CompletableFuture) {
                 CompletableFuture<List<FieldValueInfo>> fieldValueInfos = (CompletableFuture<List<FieldValueInfo>>) fieldValueInfosResult;
                 fieldValueInfos.whenComplete((completeValueInfos, throwable) -> {
-                    executionContext.run(() -> {
+                    executionContext.run(throwable,() -> {
                         if (throwable != null) {
                             handleResultsConsumer.accept(null, throwable);
                             return;
@@ -280,7 +280,7 @@ public abstract class ExecutionStrategy {
 
     private BiConsumer<List<Object>, Throwable> buildFieldValueMap(List<String> fieldNames, CompletableFuture<Map<String, Object>> overallResult, ExecutionContext executionContext) {
         return (List<Object> results, Throwable exception) -> {
-            executionContext.run(() -> {
+            executionContext.run(exception,() -> {
                 if (exception != null) {
                     handleValueException(overallResult, exception, executionContext);
                     return;
@@ -488,7 +488,7 @@ public abstract class ExecutionStrategy {
             CompletableFuture<Object> fetchedValue = (CompletableFuture<Object>) fetchedObject;
             executionContext.decrementRunning(fetchedValue);
             CompletableFuture<FetchedValue> fetchedValueCF = fetchedValue
-                    .handle((result, exception) -> executionContext.call(() -> {
+                    .handle((result, exception) -> executionContext.call(exception,() -> {
                         fetchCtx.onCompleted(result, exception);
                         if (exception != null) {
                             CompletableFuture<Object> handleFetchingExceptionResult = handleFetchingException(dataFetchingEnvironment.get(), parameters, exception);
@@ -819,7 +819,7 @@ public abstract class ExecutionStrategy {
             overallResult.whenComplete(completeListCtx::onCompleted);
 
             resultsFuture.whenComplete((results, exception) -> {
-                executionContext.run(() -> {
+                executionContext.run(exception,() -> {
                     if (exception != null) {
                         handleValueException(overallResult, exception, executionContext);
                         return;

--- a/src/main/java/graphql/execution/SubscriptionExecutionStrategy.java
+++ b/src/main/java/graphql/execution/SubscriptionExecutionStrategy.java
@@ -56,6 +56,7 @@ public class SubscriptionExecutionStrategy extends ExecutionStrategy {
 
     @Override
     public CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) throws NonNullableFieldWasNullException {
+        checkIsCancelled(executionContext);
 
         Instrumentation instrumentation = executionContext.getInstrumentation();
         InstrumentationExecutionStrategyParameters instrumentationParameters = new InstrumentationExecutionStrategyParameters(executionContext, parameters);
@@ -69,6 +70,8 @@ public class SubscriptionExecutionStrategy extends ExecutionStrategy {
         //
         // when the upstream source event stream completes, subscribe to it and wire in our adapter
         CompletableFuture<ExecutionResult> overallResult = sourceEventStream.thenApply((publisher) -> {
+            checkIsCancelled(executionContext);
+
             if (publisher == null) {
                 return new ExecutionResultImpl(null, executionContext.getErrors());
             }
@@ -132,6 +135,10 @@ public class SubscriptionExecutionStrategy extends ExecutionStrategy {
      */
 
     private CompletableFuture<ExecutionResult> executeSubscriptionEvent(ExecutionContext executionContext, ExecutionStrategyParameters parameters, Object eventPayload) {
+        // this possible exception wil be caught by the reactive Publishers and the
+        // reactive stream will be made into an error state
+        checkIsCancelled(executionContext);
+
         Instrumentation instrumentation = executionContext.getInstrumentation();
 
         ExecutionContext newExecutionContext = executionContext.transform(builder -> builder

--- a/src/main/java/graphql/execution/SubscriptionExecutionStrategy.java
+++ b/src/main/java/graphql/execution/SubscriptionExecutionStrategy.java
@@ -56,7 +56,7 @@ public class SubscriptionExecutionStrategy extends ExecutionStrategy {
 
     @Override
     public CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext, ExecutionStrategyParameters parameters) throws NonNullableFieldWasNullException {
-        checkIsCancelled(executionContext);
+        executionContext.checkIsCancelled();
 
         Instrumentation instrumentation = executionContext.getInstrumentation();
         InstrumentationExecutionStrategyParameters instrumentationParameters = new InstrumentationExecutionStrategyParameters(executionContext, parameters);
@@ -70,7 +70,7 @@ public class SubscriptionExecutionStrategy extends ExecutionStrategy {
         //
         // when the upstream source event stream completes, subscribe to it and wire in our adapter
         CompletableFuture<ExecutionResult> overallResult = sourceEventStream.thenApply((publisher) -> {
-            checkIsCancelled(executionContext);
+            executionContext.checkIsCancelled();
 
             if (publisher == null) {
                 return new ExecutionResultImpl(null, executionContext.getErrors());
@@ -137,7 +137,7 @@ public class SubscriptionExecutionStrategy extends ExecutionStrategy {
     private CompletableFuture<ExecutionResult> executeSubscriptionEvent(ExecutionContext executionContext, ExecutionStrategyParameters parameters, Object eventPayload) {
         // this possible exception wil be caught by the reactive Publishers and the
         // reactive stream will be made into an error state
-        checkIsCancelled(executionContext);
+        executionContext.checkIsCancelled();
 
         Instrumentation instrumentation = executionContext.getInstrumentation();
 

--- a/src/test/groovy/graphql/ExecutionInputTest.groovy
+++ b/src/test/groovy/graphql/ExecutionInputTest.groovy
@@ -3,10 +3,13 @@ package graphql
 import graphql.execution.ExecutionId
 import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironment
+import org.awaitility.Awaitility
 import org.dataloader.DataLoaderRegistry
 import spock.lang.Specification
 
-import java.util.function.UnaryOperator
+import java.time.Duration
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
 
 class ExecutionInputTest extends Specification {
 
@@ -104,9 +107,11 @@ class ExecutionInputTest extends Specification {
                 .locale(Locale.GERMAN)
                 .build()
         def graphQLContext = executionInputOld.getGraphQLContext()
-        def executionInput = executionInputOld.transform({ bldg -> bldg
-                .query("new query")
-                .variables(variables) })
+        def executionInput = executionInputOld.transform({ bldg ->
+            bldg
+                    .query("new query")
+                    .variables(variables)
+        })
 
         then:
         executionInput.graphQLContext == graphQLContext
@@ -161,5 +166,65 @@ class ExecutionInputTest extends Specification {
         then:
         er.errors.isEmpty()
         er.data["fetch"] == "{locale=German, executionId=ID123, graphqlContext=b}"
+    }
+
+    def "can cancel the execution"() {
+        def sdl = '''
+            type Query {
+                fetch1 : Inner
+                fetch2 : Inner
+            }
+            
+            type Inner {
+                f : String
+            }
+                
+        '''
+
+        CountDownLatch fieldLatch = new CountDownLatch(1)
+
+        DataFetcher df1Sec = { DataFetchingEnvironment env ->
+            return CompletableFuture.supplyAsync {
+                fieldLatch.await()
+                Thread.sleep(1000)
+                return [f: "x"]
+            }
+        }
+        DataFetcher df10Sec = { DataFetchingEnvironment env ->
+            return CompletableFuture.supplyAsync {
+                fieldLatch.await()
+                Thread.sleep(10000)
+                return "x"
+            }
+        }
+
+        def fetcherMap = ["Query": ["fetch1": df1Sec, "fetch2": df1Sec],
+                          "Inner": ["f": df10Sec]
+        ]
+        def schema = TestUtil.schema(sdl, fetcherMap)
+        def graphQL = GraphQL.newGraphQL(schema).build()
+
+        when:
+        ExecutionInput executionInput = ExecutionInput.newExecutionInput()
+                .query("query q { fetch1 { f }  fetch2 { f } }")
+                .build()
+
+        def cf = graphQL.executeAsync(executionInput)
+
+        Thread.sleep(250) // let it get into the field fetching say
+
+        // lets cancel it
+        executionInput.cancel()
+
+        // let the DFs run
+        fieldLatch.countDown()
+
+        Awaitility.await().atMost(Duration.ofSeconds(60)).until({ -> cf.isDone() })
+
+        def er = cf.join()
+
+        then:
+        !er.errors.isEmpty()
+        er.errors[0]["message"] == "Execution has been asked to be cancelled"
     }
 }

--- a/src/test/groovy/graphql/ExecutionInputTest.groovy
+++ b/src/test/groovy/graphql/ExecutionInputTest.groovy
@@ -184,14 +184,18 @@ class ExecutionInputTest extends Specification {
         CountDownLatch fieldLatch = new CountDownLatch(1)
 
         DataFetcher df1Sec = { DataFetchingEnvironment env ->
+            println("Entering DF1")
             return CompletableFuture.supplyAsync {
+                println("DF1 async run")
                 fieldLatch.await()
                 Thread.sleep(1000)
                 return [f: "x"]
             }
         }
         DataFetcher df10Sec = { DataFetchingEnvironment env ->
+            println("Entering DF10")
             return CompletableFuture.supplyAsync {
+                println("DF10 async run")
                 fieldLatch.await()
                 Thread.sleep(10000)
                 return "x"
@@ -214,11 +218,14 @@ class ExecutionInputTest extends Specification {
         Thread.sleep(250) // let it get into the field fetching say
 
         // lets cancel it
+        println("cancelling")
         executionInput.cancel()
 
         // let the DFs run
+        println("make the fields run")
         fieldLatch.countDown()
 
+        println("and await for the overall CF to complete")
         Awaitility.await().atMost(Duration.ofSeconds(60)).until({ -> cf.isDone() })
 
         def er = cf.join()

--- a/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/AsyncExecutionStrategyTest.groovy
@@ -1,8 +1,8 @@
 package graphql.execution
 
 import graphql.ErrorType
+import graphql.ExecutionInput
 import graphql.ExecutionResult
-import graphql.ExperimentalApi
 import graphql.GraphQLContext
 import graphql.execution.instrumentation.ExecutionStrategyInstrumentationContext
 import graphql.execution.instrumentation.InstrumentationState
@@ -108,6 +108,7 @@ abstract class AsyncExecutionStrategyTest extends Specification {
                 .instrumentation(SimplePerformantInstrumentation.INSTANCE)
                 .valueUnboxer(ValueUnboxer.DEFAULT)
                 .graphQLContext(graphqlContextMock)
+                .executionInput(ExecutionInput.newExecutionInput("{}").build())
                 .locale(Locale.getDefault())
                 .build()
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
@@ -150,6 +151,7 @@ abstract class AsyncExecutionStrategyTest extends Specification {
                 .instrumentation(SimplePerformantInstrumentation.INSTANCE)
                 .locale(Locale.getDefault())
                 .graphQLContext(graphqlContextMock)
+                .executionInput(ExecutionInput.newExecutionInput("{}").build())
                 .build()
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
@@ -192,6 +194,7 @@ abstract class AsyncExecutionStrategyTest extends Specification {
                 .valueUnboxer(ValueUnboxer.DEFAULT)
                 .instrumentation(SimplePerformantInstrumentation.INSTANCE)
                 .graphQLContext(graphqlContextMock)
+                .executionInput(ExecutionInput.newExecutionInput("{}").build())
                 .locale(Locale.getDefault())
                 .build()
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
@@ -235,6 +238,7 @@ abstract class AsyncExecutionStrategyTest extends Specification {
                 .valueUnboxer(ValueUnboxer.DEFAULT)
                 .locale(Locale.getDefault())
                 .graphQLContext(graphqlContextMock)
+                .executionInput(ExecutionInput.newExecutionInput("{}").build())
                 .build()
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
@@ -274,6 +278,7 @@ abstract class AsyncExecutionStrategyTest extends Specification {
                 .operationDefinition(operation)
                 .valueUnboxer(ValueUnboxer.DEFAULT)
                 .graphQLContext(graphqlContextMock)
+                .executionInput(ExecutionInput.newExecutionInput("{}").build())
                 .locale(Locale.getDefault())
                 .instrumentation(new SimplePerformantInstrumentation() {
 

--- a/src/test/groovy/graphql/execution/AsyncSerialExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/AsyncSerialExecutionStrategyTest.groovy
@@ -1,5 +1,6 @@
 package graphql.execution
 
+import graphql.ExecutionInput
 import graphql.GraphQLContext
 import graphql.execution.instrumentation.SimplePerformantInstrumentation
 import graphql.language.Field
@@ -106,6 +107,7 @@ class AsyncSerialExecutionStrategyTest extends Specification {
                 .valueUnboxer(ValueUnboxer.DEFAULT)
                 .locale(Locale.getDefault())
                 .graphQLContext(GraphQLContext.getDefault())
+                .executionInput(ExecutionInput.newExecutionInput("{}").build())
                 .build()
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()
@@ -152,6 +154,7 @@ class AsyncSerialExecutionStrategyTest extends Specification {
                 .valueUnboxer(ValueUnboxer.DEFAULT)
                 .locale(Locale.getDefault())
                 .graphQLContext(GraphQLContext.getDefault())
+                .executionInput(ExecutionInput.newExecutionInput("{}").build())
                 .build()
         ExecutionStrategyParameters executionStrategyParameters = ExecutionStrategyParameters
                 .newParameters()

--- a/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
@@ -2,6 +2,7 @@ package graphql.execution
 
 import graphql.Assert
 import graphql.ExceptionWhileDataFetching
+import graphql.ExecutionInput
 import graphql.ExecutionResult
 import graphql.GraphQLContext
 import graphql.GraphqlErrorBuilder
@@ -78,6 +79,7 @@ class ExecutionStrategyTest extends Specification {
                 .subscriptionStrategy(executionStrategy)
                 .coercedVariables(CoercedVariables.of(variables))
                 .graphQLContext(GraphQLContext.newContext().of("key", "context").build())
+                .executionInput(ExecutionInput.newExecutionInput("{}").build())
                 .root("root")
                 .dataLoaderRegistry(new DataLoaderRegistry())
                 .locale(Locale.getDefault())
@@ -125,6 +127,7 @@ class ExecutionStrategyTest extends Specification {
 
         builder.operationDefinition(operation)
         builder.executionId(ExecutionId.generate())
+        builder.executionInput(ExecutionInput.newExecutionInput("{}").build())
 
         def executionContext = builder.build()
         def result = new Object()

--- a/src/test/groovy/graphql/execution/SubscriptionExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/SubscriptionExecutionStrategyTest.groovy
@@ -712,7 +712,7 @@ class SubscriptionExecutionStrategyTest extends Specification {
 
     def "we can cancel the operation and the upstream publisher is told"() {
         List<Runnable> promises = []
-        Publisher<Object> publisher = new RxJavaMessagePublisher(10)
+        RxJavaMessagePublisher publisher = new RxJavaMessagePublisher(10)
 
         DataFetcher newMessageDF = { env -> return publisher }
         DataFetcher senderDF = dfThatDoesNotComplete("sender", promises)
@@ -750,6 +750,7 @@ class SubscriptionExecutionStrategyTest extends Specification {
         messages.size() == 1
         def error = messages[0].errors[0]
         assert error.message == "Execution has been asked to be cancelled"
+        publisher.counter == 2
     }
 
     private static DataFetcher<?> dfThatDoesNotComplete(String propertyName, List<Runnable> promises) {

--- a/src/test/groovy/graphql/execution/pubsub/RxJavaMessagePublisher.java
+++ b/src/test/groovy/graphql/execution/pubsub/RxJavaMessagePublisher.java
@@ -4,6 +4,8 @@ import io.reactivex.Flowable;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 /**
  * This example publisher will create count "messages" and then terminate. Its
  * uses tRxJava Flowable as a backing publisher
@@ -11,10 +13,18 @@ import org.reactivestreams.Subscriber;
 public class RxJavaMessagePublisher implements Publisher<Message> {
 
     private final Flowable<Message> flowable;
+    private final AtomicInteger counter = new AtomicInteger();
 
     public RxJavaMessagePublisher(final int count) {
         flowable = Flowable.range(0, count)
-                .map(at -> examineMessage(new Message("sender" + at, "text" + at), at));
+                .map(at -> {
+                    counter.incrementAndGet();
+                    return examineMessage(new Message("sender" + at, "text" + at), at);
+                });
+    }
+
+    public int getCounter() {
+        return counter.get();
     }
 
     @Override


### PR DESCRIPTION
Addressing #3879

This allows the graphql operation to be co-operatively cancelled.  It use the "engine run state" tracking to know when its a good time to cancel and abort