### PR TITLE
delete legacy Execution Strategy resolve field method

### DIFF
--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -340,33 +340,6 @@ public abstract class ExecutionStrategy {
     }
 
     /**
-     * Called to fetch a value for a field and resolve it further in terms of the graphql query.  This will call
-     * #fetchField followed by #completeField and the completed Object is returned.
-     * <p>
-     * An execution strategy can iterate the fields to be executed and call this method for each one
-     * <p>
-     * Graphql fragments mean that for any give logical field can have one or more {@link Field} values associated with it
-     * in the query, hence the fieldList.  However, the first entry is representative of the field for most purposes.
-     *
-     * @param executionContext contains the top level execution parameters
-     * @param parameters       contains the parameters holding the fields to be executed and source object
-     *
-     * @return a {@link CompletableFuture} promise to an {@link Object} or the materialized {@link Object}
-     *
-     * @throws NonNullableFieldWasNullException in the future if a non-null field resolved to a null value
-     */
-    @SuppressWarnings("unchecked")
-    @DuckTyped(shape = " CompletableFuture<Object> | Object")
-    protected Object resolveField(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
-        Object fieldWithInfo = resolveFieldWithInfo(executionContext, parameters);
-        if (fieldWithInfo instanceof CompletableFuture) {
-            return ((CompletableFuture<FieldValueInfo>) fieldWithInfo).thenCompose(FieldValueInfo::getFieldValueFuture);
-        } else {
-            return ((FieldValueInfo) fieldWithInfo).getFieldValueObject();
-        }
-    }
-
-    /**
      * Called to fetch a value for a field and its extra runtime info and resolve it further in terms of the graphql query.  This will call
      * #fetchField followed by #completeField and the completed {@link graphql.execution.FieldValueInfo} is returned.
      * <p>

--- a/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionStrategyTest.groovy
@@ -541,7 +541,7 @@ class ExecutionStrategyTest extends Specification {
         DataFetchingEnvironment environment
 
         when:
-        executionStrategy.resolveField(executionContext, parameters)
+        executionStrategy.resolveFieldWithInfo(executionContext, parameters)
 
         then:
         1 * dataFetcher.get(_,_,_) >> { environment = (it[2] as Supplier<DataFetchingEnvironment>).get() }
@@ -636,7 +636,7 @@ class ExecutionStrategyTest extends Specification {
         }
 
         when:
-        overridingStrategy.resolveField(executionContext, parameters)
+        overridingStrategy.resolveFieldWithInfo(executionContext, parameters)
 
         then:
         handlerCalled == true
@@ -646,29 +646,6 @@ class ExecutionStrategyTest extends Specification {
         exceptionWhileDataFetching.getMessage().contains('This is the exception you are looking for')
     }
 
-    def "test that the old legacy method is still useful for those who derive new execution strategies"() {
-
-        def expectedException = new UnsupportedOperationException("This is the exception you are looking for")
-
-        //noinspection GroovyAssignabilityCheck,GroovyUnusedAssignment
-        def (ExecutionContext executionContext, GraphQLFieldDefinition fieldDefinition, ResultPath expectedPath, ExecutionStrategyParameters parameters, Field field, SourceLocation sourceLocation) = exceptionSetupFixture(expectedException)
-
-
-        ExecutionStrategy overridingStrategy = new ExecutionStrategy() {
-            @Override
-            CompletableFuture<ExecutionResult> execute(ExecutionContext ec, ExecutionStrategyParameters p) throws NonNullableFieldWasNullException {
-                null
-            }
-        }
-
-        when:
-        overridingStrategy.resolveField(executionContext, parameters)
-
-        then:
-        executionContext.errors.size() == 1
-        def exceptionWhileDataFetching = executionContext.errors[0] as ExceptionWhileDataFetching
-        exceptionWhileDataFetching.getMessage().contains('This is the exception you are looking for')
-    }
 
     def "#2519 data fetcher errors for a given field appear in FetchedResult within instrumentation"() {
         def expectedException = new UnsupportedOperationException("This is the exception you are looking for")
@@ -700,7 +677,7 @@ class ExecutionStrategyTest extends Specification {
         }
 
         when:
-        overridingStrategy.resolveField(instrumentedExecutionContext, params)
+        overridingStrategy.resolveFieldWithInfo(instrumentedExecutionContext, params)
 
         then:
         FetchedValue fetchedValue = instrumentation.fetchedValues.get("someField")
@@ -761,7 +738,8 @@ class ExecutionStrategyTest extends Specification {
                 .build()
 
         when:
-        executionStrategy.resolveField(executionContext, parameters).join()
+        FieldValueInfo fieldValueInfo = (executionStrategy.resolveFieldWithInfo(executionContext, parameters) as CompletableFuture).join()
+        (fieldValueInfo.fieldValueObject as CompletableFuture).join()
 
         then:
         thrown(CompletionException)


### PR DESCRIPTION
This is a breaking change as the ExecutionStrategy is public (unfortunately :-) ) .

