### PR TITLE
filter out null error location in toSpecification

### DIFF
--- a/src/main/java/graphql/GraphqlErrorHelper.java
+++ b/src/main/java/graphql/GraphqlErrorHelper.java
@@ -65,6 +65,9 @@ public class GraphqlErrorHelper {
      * @return a value for source location of the error
      */
     public static Object location(SourceLocation location) {
+        if (location == null) {
+            return null;
+        }
         int line = location.getLine();
         int column = location.getColumn();
         if (line < 1 || column < 1) {

--- a/src/test/groovy/graphql/GraphQLErrorTest.groovy
+++ b/src/test/groovy/graphql/GraphQLErrorTest.groovy
@@ -94,6 +94,26 @@ class GraphQLErrorTest extends Specification {
         error.toSpecification() == expectedMap
     }
 
+    def "toSpecification filters out null error locations"() {
+        given:
+        def error = ValidationError.newValidationError()
+                .validationErrorType(ValidationErrorType.UnknownType)
+                .sourceLocations([null, mkLocation(333, 1)])
+                .description("Test ValidationError")
+                .build()
+
+        def expectedMap = [
+                locations: [
+                        [line: 333, column: 1]
+                ],
+                message: "Test ValidationError",
+                extensions: [classification:"ValidationError"]
+        ]
+
+        expect:
+        error.toSpecification() == expectedMap
+    }
+
     class CustomException extends RuntimeException implements GraphQLError {
         private LinkedHashMap<String, String> map
 


### PR DESCRIPTION
A fix for https://github.com/graphql-java/graphql-java/issues/3885

I felt that changing `GraphQLErrorHelper.location()`, rather than `BaseError.getLocations()`, was the least intrusive approach. However, there may be other places, in the present or in the future, where NPEs could show up due to null error locations, so maybe the change to `BaseError.getLocations()` outlined in https://github.com/graphql-java/graphql-java/issues/3885 would be a better option. Maybe both changes? It's at the discretion of the reviewer.