### PR TITLE
WIP Cancel support attempt 2

### DIFF
--- a/src/main/java/graphql/ExecutionInput.java
+++ b/src/main/java/graphql/ExecutionInput.java
@@ -29,7 +29,6 @@ public class ExecutionInput {
     private final DataLoaderRegistry dataLoaderRegistry;
     private final ExecutionId executionId;
     private final Locale locale;
-    // this is currently not used but we want it back soon after the v23 release
     private final AtomicBoolean cancelled;
 
 
@@ -140,6 +139,28 @@ public class ExecutionInput {
      */
     public Map<String, Object> getExtensions() {
         return extensions;
+    }
+
+
+    /**
+     * The graphql engine will check this frequently and if that is true, it will
+     * throw a {@link graphql.execution.AbortExecutionException} to cancel the execution.
+     * <p>
+     * This is a cooperative cancellation.  Some asynchronous data fetching code may still continue to
+     * run but there will be no more efforts run future field fetches say.
+     *
+     * @return true if the execution should be cancelled
+     */
+    public boolean isCancelled() {
+        return cancelled.get();
+    }
+
+    /**
+     * This can be called to cancel the graphql execution.  Remember this is a cooperative cancellation
+     * and the graphql engine needs to be running on a thread to allow is to respect this flag.
+     */
+    public void cancel() {
+        cancelled.set(true);
     }
 
     /**

--- a/src/main/java/graphql/execution/EngineRunningObserver.java
+++ b/src/main/java/graphql/execution/EngineRunningObserver.java
@@ -1,5 +1,6 @@
 package graphql.execution;
 
+import graphql.ExecutionInput;
 import graphql.ExperimentalApi;
 import graphql.GraphQLContext;
 import org.jspecify.annotations.NullMarked;
@@ -8,6 +9,8 @@ import org.jspecify.annotations.NullMarked;
  * This class lets you observe the running state of the graphql-java engine.  As it processes and dispatches graphql fields,
  * the engine moves in and out of a running and not running state.  As it does this, the callback is called with information telling you the current
  * state.
+ * <p>
+ * If the engine is cancelled via {@link ExecutionInput#cancel()} then the observer will also be called to indicate that.
  */
 @ExperimentalApi
 @NullMarked
@@ -22,6 +25,10 @@ public interface EngineRunningObserver {
          * Represents that the engine code is asynchronously waiting for fetching to happen
          */
         NOT_RUNNING,
+        /**
+         * Represents that the engine code has been cancelled via {@link ExecutionInput#cancel()}
+         */
+        CANCELLED
     }
 
 

--- a/src/test/groovy/graphql/execution/SubscriptionExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/SubscriptionExecutionStrategyTest.groovy
@@ -710,6 +710,49 @@ class SubscriptionExecutionStrategyTest extends Specification {
         }
     }
 
+    def "we can cancel the operation and the upstream publisher is told"() {
+        List<Runnable> promises = []
+        RxJavaMessagePublisher publisher = new RxJavaMessagePublisher(10)
+
+        DataFetcher newMessageDF = { env -> return publisher }
+        DataFetcher senderDF = dfThatDoesNotComplete("sender", promises)
+        DataFetcher textDF = PropertyDataFetcher.fetching("text")
+
+        GraphQL graphQL = buildSubscriptionQL(newMessageDF, senderDF, textDF)
+
+        def executionInput = ExecutionInput.newExecutionInput().query("""
+            subscription NewMessages {
+              newMessage(roomId: 123) {
+                sender
+                text
+              }
+            }
+        """).graphQLContext([(SubscriptionExecutionStrategy.KEEP_SUBSCRIPTION_EVENTS_ORDERED): true]).build()
+
+        def executionResult = graphQL.execute(executionInput)
+
+        when:
+        Publisher<ExecutionResult> msgStream = executionResult.getData()
+        def capturingSubscriber = new CapturingSubscriber<ExecutionResult>(1)
+        msgStream.subscribe(capturingSubscriber)
+
+        // now cancel the operation
+        executionInput.cancel()
+
+        // make things over the subscription
+        promises.forEach {it.run()}
+
+
+        then:
+        Awaitility.await().untilTrue(capturingSubscriber.isDone())
+
+        def messages = capturingSubscriber.events
+        messages.size() == 1
+        def error = messages[0].errors[0]
+        assert error.message == "Execution has been asked to be cancelled"
+        publisher.counter == 2
+    }
+
     private static DataFetcher<?> dfThatDoesNotComplete(String propertyName, List<Runnable> promises) {
         { env ->
             def df = PropertyDataFetcher.fetching(propertyName)


### PR DESCRIPTION
WIP

This is the second attempt at operation cancellation

At this stage it can still lock up. The "random" tests show this happening locally but only occasionally

I think its to do with CompletableFutures and how we give back a different CF to the CF we check the abort in.

This needs more investigation

But candidate stack traces are

```
graphql.execution.AbortExecutionException: Execution has been asked to be cancelled
	at graphql.execution.ExecutionContext.checkIsCancelled(ExecutionContext.java:455)
	at graphql.execution.ExecutionContext.checkIsCancelled(ExecutionContext.java:445)
	at graphql.execution.ExecutionContext.incrementRunning(ExecutionContext.java:380)
	at graphql.execution.ExecutionContext.lambda$incrementRunning$4(ExecutionContext.java:398)
	at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:859)
	at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:837)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1705)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.exec(CompletableFuture.java:1692)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
graphql.execution.AbortExecutionException: Execution has been asked to be cancelled
	at graphql.execution.ExecutionContext.checkIsCancelled(ExecutionContext.java:455)
	at graphql.execution.ExecutionContext.checkIsCancelled(ExecutionContext.java:445)
	at graphql.execution.ExecutionContext.incrementRunning(ExecutionContext.java:380)
	at graphql.execution.ExecutionContext.call(ExecutionContext.java:417)
	at graphql.execution.ExecutionStrategy.lambda$fetchField$16(ExecutionStrategy.java:491)
	at java.base/java.util.concurrent.CompletableFuture.uniHandle(CompletableFuture.java:930)
	at java.base/java.util.concurrent.CompletableFuture$UniHandle.tryFire(CompletableFuture.java:907)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
```

and

```
graphql.execution.AbortExecutionException: Execution has been asked to be cancelled
	at graphql.execution.ExecutionContext.checkIsCancelled(ExecutionContext.java:455)
	at graphql.execution.ExecutionContext.checkIsCancelled(ExecutionContext.java:445)
	at graphql.execution.ExecutionContext.incrementRunning(ExecutionContext.java:380)
	at graphql.execution.ExecutionContext.run(ExecutionContext.java:432)
	at graphql.execution.AbstractAsyncExecutionStrategy.lambda$handleResults$1(AbstractAsyncExecutionStrategy.java:25)
	at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:859)
	at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:837)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
	at java.base/java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2079)
	at graphql.execution.Async$Many.lambda$await$0(Async.java:226)
	at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:859)
	at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:837)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
	at java.base/java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2079)
	at graphql.execution.ExecutionStrategy.handleValueException(ExecutionStrategy.java:854)
	at graphql.execution.ExecutionStrategy.lambda$buildFieldValueMap$5(ExecutionStrategy.java:285)
	at graphql.execution.ExecutionContext.run(ExecutionContext.java:434)
	at graphql.execution.ExecutionStrategy.lambda$buildFieldValueMap$6(ExecutionStrategy.java:283)
	at graphql.execution.ExecutionStrategy.lambda$executeObject$0(ExecutionStrategy.java:231)
	at graphql.execution.ExecutionContext.run(ExecutionContext.java:434)
	at graphql.execution.ExecutionStrategy.lambda$executeObject$1(ExecutionStrategy.java:229)
```

