### PR TITLE
Add JSpecify nullability annotations to DataFetcherResult

### DIFF
--- a/src/main/java/graphql/execution/DataFetcherResult.java
+++ b/src/main/java/graphql/execution/DataFetcherResult.java
@@ -6,6 +6,8 @@ import graphql.GraphQLError;
 import graphql.Internal;
 import graphql.PublicApi;
 import graphql.schema.DataFetcher;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,14 +34,15 @@ import static graphql.Assert.assertNotNull;
  * @param <T> The type of the data fetched
  */
 @PublicApi
+@NullMarked
 public class DataFetcherResult<T> {
 
-    private final T data;
+    private final @Nullable T data;
     private final List<GraphQLError> errors;
-    private final Object localContext;
-    private final Map<Object, Object> extensions;
+    private final @Nullable Object localContext;
+    private final @Nullable Map<Object, Object> extensions;
 
-    private DataFetcherResult(T data, List<GraphQLError> errors, Object localContext, Map<Object, Object> extensions) {
+    private DataFetcherResult(@Nullable T data, List<GraphQLError> errors, @Nullable Object localContext, @Nullable Map<Object, Object> extensions) {
         this.data = data;
         this.errors = ImmutableList.copyOf(assertNotNull(errors));
         this.localContext = localContext;
@@ -49,7 +52,7 @@ public class DataFetcherResult<T> {
     /**
      * @return The data fetched. May be null.
      */
-    public T getData() {
+    public @Nullable T getData() {
         return data;
     }
 
@@ -72,7 +75,7 @@ public class DataFetcherResult<T> {
      *
      * @return a local context object
      */
-    public Object getLocalContext() {
+    public @Nullable Object getLocalContext() {
         return localContext;
     }
 
@@ -88,7 +91,7 @@ public class DataFetcherResult<T> {
      * @see graphql.extensions.ExtensionsBuilder
      * @see graphql.extensions.ExtensionsMerger
      */
-    public Map<Object, Object> getExtensions() {
+    public @Nullable Map<Object, Object> getExtensions() {
         return extensions;
     }
 
@@ -115,7 +118,7 @@ public class DataFetcherResult<T> {
      *
      * @return a new instance with where the data value has been transformed
      */
-    public <R> DataFetcherResult<R> map(Function<T, R> transformation) {
+    public <R> DataFetcherResult<R> map(Function<@Nullable T, @Nullable R> transformation) {
         return new Builder<>(transformation.apply(this.data))
                 .errors(this.errors)
                 .extensions(this.extensions)
@@ -135,10 +138,10 @@ public class DataFetcherResult<T> {
     }
 
     public static class Builder<T> {
-        private T data;
-        private Object localContext;
+        private @Nullable T data;
+        private @Nullable Object localContext;
         private final List<GraphQLError> errors = new ArrayList<>();
-        private Map<Object, Object> extensions;
+        private @Nullable Map<Object, Object> extensions;
 
         public Builder(DataFetcherResult<T> existing) {
             data = existing.getData();
@@ -147,14 +150,14 @@ public class DataFetcherResult<T> {
             extensions = existing.extensions;
         }
 
-        public Builder(T data) {
+        public Builder(@Nullable T data) {
             this.data = data;
         }
 
         public Builder() {
         }
 
-        public Builder<T> data(T data) {
+        public Builder<T> data(@Nullable T data) {
             this.data = data;
             return this;
         }
@@ -181,12 +184,12 @@ public class DataFetcherResult<T> {
             return !errors.isEmpty();
         }
 
-        public Builder<T> localContext(Object localContext) {
+        public Builder<T> localContext(@Nullable Object localContext) {
             this.localContext = localContext;
             return this;
         }
 
-        public Builder<T> extensions(Map<Object, Object> extensions) {
+        public Builder<T> extensions(@Nullable Map<Object, Object> extensions) {
             this.extensions = extensions;
             return this;
         }


### PR DESCRIPTION
I made a classic NPE mistake because I forgot to check if `data` was null while writing a DataFetcher

With JSpecify, we can detect NPEs like this at compile time rather than run time.

Have a look at the documentation for `@NullMarked` https://jspecify.dev/docs/user-guide/#nullmarked

This is the first PR to add JSpecify to an existing class so let's have a discussion.