### PR TITLE
Specify nullness for some `graphql.schema.idl` classes

### DIFF
--- a/src/main/java/graphql/Assert.java
+++ b/src/main/java/graphql/Assert.java
@@ -1,7 +1,6 @@
 package graphql;
 
 import org.jspecify.annotations.NullMarked;
-import org.jspecify.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.function.Supplier;
@@ -14,49 +13,49 @@ import static java.lang.String.format;
 @NullMarked
 public class Assert {
 
-    public static <T> T assertNotNullWithNPE(@Nullable T object, Supplier<String> msg) {
+    public static <T> T assertNotNullWithNPE(T object, Supplier<String> msg) {
         if (object != null) {
             return object;
         }
         throw new NullPointerException(msg.get());
     }
 
-    public static <T> T assertNotNull(@Nullable T object) {
+    public static <T> T assertNotNull(T object) {
         if (object != null) {
             return object;
         }
         return throwAssert("Object required to be not null");
     }
 
-    public static <T> T assertNotNull(@Nullable T object, Supplier<String> msg) {
+    public static <T> T assertNotNull(T object, Supplier<String> msg) {
         if (object != null) {
             return object;
         }
         return throwAssert(msg.get());
     }
 
-    public static <T> T assertNotNull(@Nullable T object, String constantMsg) {
+    public static <T> T assertNotNull(T object, String constantMsg) {
         if (object != null) {
             return object;
         }
         return throwAssert(constantMsg);
     }
 
-    public static <T> T assertNotNull(@Nullable T object, String msgFmt, Object arg1) {
+    public static <T> T assertNotNull(T object, String msgFmt, Object arg1) {
         if (object != null) {
             return object;
         }
         return throwAssert(msgFmt, arg1);
     }
 
-    public static <T> T assertNotNull(@Nullable T object, String msgFmt, Object arg1, Object arg2) {
+    public static <T> T assertNotNull(T object, String msgFmt, Object arg1, Object arg2) {
         if (object != null) {
             return object;
         }
         return throwAssert(msgFmt, arg1, arg2);
     }
 
-    public static <T> T assertNotNull(@Nullable T object, String msgFmt, Object arg1, Object arg2, Object arg3) {
+    public static <T> T assertNotNull(T object, String msgFmt, Object arg1, Object arg2, Object arg3) {
         if (object != null) {
             return object;
         }
@@ -64,14 +63,14 @@ public class Assert {
     }
 
 
-    public static <T> void assertNull(@Nullable T object, Supplier<String> msg) {
+    public static <T> void assertNull(T object, Supplier<String> msg) {
         if (object == null) {
             return;
         }
         throwAssert(msg.get());
     }
 
-    public static <T> void assertNull(@Nullable T object) {
+    public static <T> void assertNull(T object) {
         if (object == null) {
             return;
         }
@@ -90,14 +89,14 @@ public class Assert {
         return throwAssert("Internal error: should never happen");
     }
 
-    public static <T> Collection<T> assertNotEmpty(@Nullable Collection<T> collection) {
+    public static <T> Collection<T> assertNotEmpty(Collection<T> collection) {
         if (collection == null || collection.isEmpty()) {
             throwAssert("collection must be not null and not empty");
         }
         return collection;
     }
 
-    public static <T> Collection<T> assertNotEmpty(@Nullable Collection<T> collection, Supplier<String> msg) {
+    public static <T> Collection<T> assertNotEmpty(Collection<T> collection, Supplier<String> msg) {
         if (collection == null || collection.isEmpty()) {
             throwAssert(msg.get());
         }
@@ -200,14 +199,14 @@ public class Assert {
      *
      * @return the name if valid, or AssertException if invalid.
      */
-    public static String assertValidName(@Nullable String name) {
+    public static String assertValidName(String name) {
         if (name != null && !name.isEmpty() && validNamePattern.matcher(name).matches()) {
             return name;
         }
         return throwAssert(invalidNameErrorMessage, name);
     }
 
-    private static <T> T throwAssert(String format, @Nullable Object... args) {
+    private static <T> T throwAssert(String format, Object... args) {
         throw new AssertException(format(format, args));
     }
 }

--- a/src/main/java/graphql/Assert.java
+++ b/src/main/java/graphql/Assert.java
@@ -1,5 +1,8 @@
 package graphql;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
 import java.util.Collection;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
@@ -8,51 +11,52 @@ import static java.lang.String.format;
 
 @SuppressWarnings("TypeParameterUnusedInFormals")
 @Internal
+@NullMarked
 public class Assert {
 
-    public static <T> T assertNotNullWithNPE(T object, Supplier<String> msg) {
+    public static <T> T assertNotNullWithNPE(@Nullable T object, Supplier<String> msg) {
         if (object != null) {
             return object;
         }
         throw new NullPointerException(msg.get());
     }
 
-    public static <T> T assertNotNull(T object) {
+    public static <T> T assertNotNull(@Nullable T object) {
         if (object != null) {
             return object;
         }
         return throwAssert("Object required to be not null");
     }
 
-    public static <T> T assertNotNull(T object, Supplier<String> msg) {
+    public static <T> T assertNotNull(@Nullable T object, Supplier<String> msg) {
         if (object != null) {
             return object;
         }
         return throwAssert(msg.get());
     }
 
-    public static <T> T assertNotNull(T object, String constantMsg) {
+    public static <T> T assertNotNull(@Nullable T object, String constantMsg) {
         if (object != null) {
             return object;
         }
         return throwAssert(constantMsg);
     }
 
-    public static <T> T assertNotNull(T object, String msgFmt, Object arg1) {
+    public static <T> T assertNotNull(@Nullable T object, String msgFmt, Object arg1) {
         if (object != null) {
             return object;
         }
         return throwAssert(msgFmt, arg1);
     }
 
-    public static <T> T assertNotNull(T object, String msgFmt, Object arg1, Object arg2) {
+    public static <T> T assertNotNull(@Nullable T object, String msgFmt, Object arg1, Object arg2) {
         if (object != null) {
             return object;
         }
         return throwAssert(msgFmt, arg1, arg2);
     }
 
-    public static <T> T assertNotNull(T object, String msgFmt, Object arg1, Object arg2, Object arg3) {
+    public static <T> T assertNotNull(@Nullable T object, String msgFmt, Object arg1, Object arg2, Object arg3) {
         if (object != null) {
             return object;
         }
@@ -60,14 +64,14 @@ public class Assert {
     }
 
 
-    public static <T> void assertNull(T object, Supplier<String> msg) {
+    public static <T> void assertNull(@Nullable T object, Supplier<String> msg) {
         if (object == null) {
             return;
         }
         throwAssert(msg.get());
     }
 
-    public static <T> void assertNull(T object) {
+    public static <T> void assertNull(@Nullable T object) {
         if (object == null) {
             return;
         }
@@ -86,14 +90,14 @@ public class Assert {
         return throwAssert("Internal error: should never happen");
     }
 
-    public static <T> Collection<T> assertNotEmpty(Collection<T> collection) {
+    public static <T> Collection<T> assertNotEmpty(@Nullable Collection<T> collection) {
         if (collection == null || collection.isEmpty()) {
             throwAssert("collection must be not null and not empty");
         }
         return collection;
     }
 
-    public static <T> Collection<T> assertNotEmpty(Collection<T> collection, Supplier<String> msg) {
+    public static <T> Collection<T> assertNotEmpty(@Nullable Collection<T> collection, Supplier<String> msg) {
         if (collection == null || collection.isEmpty()) {
             throwAssert(msg.get());
         }
@@ -196,14 +200,14 @@ public class Assert {
      *
      * @return the name if valid, or AssertException if invalid.
      */
-    public static String assertValidName(String name) {
+    public static String assertValidName(@Nullable String name) {
         if (name != null && !name.isEmpty() && validNamePattern.matcher(name).matches()) {
             return name;
         }
         return throwAssert(invalidNameErrorMessage, name);
     }
 
-    private static <T> T throwAssert(String format, Object... args) {
+    private static <T> T throwAssert(String format, @Nullable Object... args) {
         throw new AssertException(format(format, args));
     }
 }

--- a/src/main/java/graphql/schema/idl/FieldWiringEnvironment.java
+++ b/src/main/java/graphql/schema/idl/FieldWiringEnvironment.java
@@ -6,10 +6,12 @@ import graphql.language.TypeDefinition;
 import graphql.schema.GraphQLAppliedDirective;
 import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLOutputType;
+import org.jspecify.annotations.NullMarked;
 
 import java.util.List;
 
 @PublicApi
+@NullMarked
 public class FieldWiringEnvironment extends WiringEnvironment {
 
     private final FieldDefinition fieldDefinition;

--- a/src/main/java/graphql/schema/idl/InterfaceWiringEnvironment.java
+++ b/src/main/java/graphql/schema/idl/InterfaceWiringEnvironment.java
@@ -2,8 +2,10 @@ package graphql.schema.idl;
 
 import graphql.PublicApi;
 import graphql.language.InterfaceTypeDefinition;
+import org.jspecify.annotations.NullMarked;
 
 @PublicApi
+@NullMarked
 public class InterfaceWiringEnvironment extends WiringEnvironment {
 
     private final InterfaceTypeDefinition interfaceTypeDefinition;

--- a/src/main/java/graphql/schema/idl/ScalarInfo.java
+++ b/src/main/java/graphql/schema/idl/ScalarInfo.java
@@ -6,6 +6,7 @@ import graphql.PublicApi;
 import graphql.Scalars;
 import graphql.language.ScalarTypeDefinition;
 import graphql.schema.GraphQLScalarType;
+import org.jspecify.annotations.NullMarked;
 
 import java.util.List;
 import java.util.Map;
@@ -14,6 +15,7 @@ import java.util.Map;
  * Info on all the standard scalar objects provided by graphql-java
  */
 @PublicApi
+@NullMarked
 public class ScalarInfo {
 
     /**

--- a/src/main/java/graphql/schema/idl/ScalarWiringEnvironment.java
+++ b/src/main/java/graphql/schema/idl/ScalarWiringEnvironment.java
@@ -3,10 +3,12 @@ package graphql.schema.idl;
 import graphql.PublicApi;
 import graphql.language.ScalarTypeDefinition;
 import graphql.language.ScalarTypeExtensionDefinition;
+import org.jspecify.annotations.NullMarked;
 
 import java.util.List;
 
 @PublicApi
+@NullMarked
 public class ScalarWiringEnvironment extends WiringEnvironment {
 
     private final ScalarTypeDefinition scalarTypeDefinition;

--- a/src/main/java/graphql/schema/idl/SchemaParser.java
+++ b/src/main/java/graphql/schema/idl/SchemaParser.java
@@ -12,6 +12,8 @@ import graphql.parser.ParserEnvironment;
 import graphql.parser.ParserOptions;
 import graphql.schema.idl.errors.NonSDLDefinitionError;
 import graphql.schema.idl.errors.SchemaProblem;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;
@@ -32,6 +34,7 @@ import static java.nio.charset.Charset.defaultCharset;
  * definitions ready to be placed into {@link SchemaGenerator} say
  */
 @PublicApi
+@NullMarked
 public class SchemaParser {
 
     /**
@@ -87,7 +90,7 @@ public class SchemaParser {
      *
      * @throws SchemaProblem if there are problems compiling the schema definitions
      */
-    public TypeDefinitionRegistry parse(Reader reader, ParserOptions parserOptions) throws SchemaProblem {
+    public TypeDefinitionRegistry parse(Reader reader, @Nullable ParserOptions parserOptions) throws SchemaProblem {
         try (Reader input = reader) {
             return parseImpl(input, parserOptions);
         } catch (IOException e) {
@@ -113,7 +116,7 @@ public class SchemaParser {
         return parseImpl(schemaInput, null);
     }
 
-    private TypeDefinitionRegistry parseImpl(Reader schemaInput, ParserOptions parseOptions) {
+    private TypeDefinitionRegistry parseImpl(Reader schemaInput, @Nullable ParserOptions parseOptions) {
         try {
             if (parseOptions == null) {
                 parseOptions = ParserOptions.getDefaultSdlParserOptions();

--- a/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java
+++ b/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java
@@ -28,6 +28,7 @@ import graphql.schema.idl.errors.SchemaRedefinitionError;
 import graphql.schema.idl.errors.TypeRedefinitionError;
 import graphql.util.FpKit;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -63,7 +64,7 @@ public class TypeDefinitionRegistry implements Serializable {
     private final Map<String, TypeDefinition> types = new LinkedHashMap<>();
     private final Map<String, ScalarTypeDefinition> scalarTypes = new LinkedHashMap<>();
     private final Map<String, DirectiveDefinition> directiveDefinitions = new LinkedHashMap<>();
-    private SchemaDefinition schema;
+    private @Nullable SchemaDefinition schema;
     private final List<SchemaExtensionDefinition> schemaExtensionDefinitions = new ArrayList<>();
     private final SchemaParseOrder schemaParseOrder = new SchemaParseOrder();
 

--- a/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java
+++ b/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java
@@ -27,6 +27,7 @@ import graphql.schema.idl.errors.SchemaProblem;
 import graphql.schema.idl.errors.SchemaRedefinitionError;
 import graphql.schema.idl.errors.TypeRedefinitionError;
 import graphql.util.FpKit;
+import org.jspecify.annotations.NullMarked;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -49,6 +50,7 @@ import static java.util.Optional.ofNullable;
  */
 @SuppressWarnings("rawtypes")
 @PublicApi
+@NullMarked
 public class TypeDefinitionRegistry implements Serializable {
 
     private final Map<String, List<ObjectTypeExtensionDefinition>> objectTypeExtensions = new LinkedHashMap<>();

--- a/src/main/java/graphql/schema/idl/UnionWiringEnvironment.java
+++ b/src/main/java/graphql/schema/idl/UnionWiringEnvironment.java
@@ -2,8 +2,10 @@ package graphql.schema.idl;
 
 import graphql.PublicApi;
 import graphql.language.UnionTypeDefinition;
+import org.jspecify.annotations.NullMarked;
 
 @PublicApi
+@NullMarked
 public class UnionWiringEnvironment extends WiringEnvironment {
 
     private final UnionTypeDefinition unionTypeDefinition;

--- a/src/main/java/graphql/schema/idl/WiringEnvironment.java
+++ b/src/main/java/graphql/schema/idl/WiringEnvironment.java
@@ -2,8 +2,10 @@ package graphql.schema.idl;
 
 
 import graphql.PublicApi;
+import org.jspecify.annotations.NullMarked;
 
 @PublicApi
+@NullMarked
 abstract class WiringEnvironment {
 
     private final TypeDefinitionRegistry registry;


### PR DESCRIPTION
Related https://github.com/graphql-java/graphql-java/issues/3878

I applied `@NullMarked` on the classes:
* `graphql.Assert`
* `graphql.schema.idl.FieldWiringEnvironment`
* `graphql.schema.idl.InterfaceWiringEnvironment`
* `graphql.schema.idl.ScalarInfo`
* `graphql.schema.idl.ScalarWiringEnvironment`
* `graphql.schema.idl.SchemaParser`
* `graphql.schema.idl.TypeDefinitionRegistry`
* `graphql.schema.idl.UnionWiringEnvironment`
* `graphql.schema.idl.WiringEnvironment`