### PR TITLE
Adding a built-in profiler 

### DIFF
--- a/src/main/java/graphql/ExecutionInput.java
+++ b/src/main/java/graphql/ExecutionInput.java
@@ -32,6 +32,7 @@ public class ExecutionInput {
     // this is currently not used but we want it back soon after the v23 release
     private final AtomicBoolean cancelled;
 
+    private final boolean profileExecution;
 
     @Internal
     private ExecutionInput(Builder builder) {
@@ -47,6 +48,7 @@ public class ExecutionInput {
         this.localContext = builder.localContext;
         this.extensions = builder.extensions;
         this.cancelled = builder.cancelled;
+        this.profileExecution = builder.profileExecution;
     }
 
     /**
@@ -142,6 +144,10 @@ public class ExecutionInput {
         return extensions;
     }
 
+    public boolean isProfileExecution() {
+        return profileExecution;
+    }
+
     /**
      * This helps you transform the current ExecutionInput object into another one by starting a builder with all
      * the current values and allows you to transform it how you want.
@@ -163,7 +169,9 @@ public class ExecutionInput {
                 .variables(this.rawVariables.toMap())
                 .extensions(this.extensions)
                 .executionId(this.executionId)
-                .locale(this.locale);
+                .locale(this.locale)
+                .profileExecution(this.profileExecution);
+
 
         builderConsumer.accept(builder);
 
@@ -221,6 +229,7 @@ public class ExecutionInput {
         private Locale locale = Locale.getDefault();
         private ExecutionId executionId;
         private AtomicBoolean cancelled = new AtomicBoolean(false);
+        private boolean profileExecution;
 
         public Builder query(String query) {
             this.query = assertNotNull(query, () -> "query can't be null");
@@ -357,6 +366,11 @@ public class ExecutionInput {
          */
         public Builder dataLoaderRegistry(DataLoaderRegistry dataLoaderRegistry) {
             this.dataLoaderRegistry = assertNotNull(dataLoaderRegistry);
+            return this;
+        }
+
+        public Builder profileExecution(boolean profileExecution) {
+            this.profileExecution = profileExecution;
             return this;
         }
 

--- a/src/main/java/graphql/Profiler.java
+++ b/src/main/java/graphql/Profiler.java
@@ -1,0 +1,29 @@
+package graphql;
+
+import graphql.schema.DataFetcher;
+import org.jspecify.annotations.NullMarked;
+
+@Internal
+@NullMarked
+public interface Profiler {
+
+    Profiler NO_OP = new Profiler() {
+    };
+
+    default void start() {
+
+    }
+
+
+    default void rootFieldCount(int size) {
+
+    }
+
+    default void subSelectionCount(int size) {
+
+    }
+
+    default void fieldFetched(Object fetchedObject, DataFetcher<?> dataFetcher) {
+
+    }
+}

--- a/src/main/java/graphql/ProfilerImpl.java
+++ b/src/main/java/graphql/ProfilerImpl.java
@@ -1,0 +1,37 @@
+package graphql;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.PropertyDataFetcher;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Internal
+@NullMarked
+public class ProfilerImpl implements Profiler {
+
+    volatile long startTime;
+    volatile int rootFieldCount;
+
+    AtomicInteger fieldCount;
+    AtomicInteger propertyDataFetcherCount;
+
+    @Override
+    public void start() {
+        startTime = System.nanoTime();
+    }
+
+
+    @Override
+    public void rootFieldCount(int count) {
+        this.rootFieldCount = count;
+    }
+
+    @Override
+    public void fieldFetched(Object fetchedObject, DataFetcher<?> dataFetcher) {
+        fieldCount.incrementAndGet();
+        if (dataFetcher instanceof PropertyDataFetcher) {
+            propertyDataFetcherCount.incrementAndGet();
+        }
+    }
+}

--- a/src/main/java/graphql/execution/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncExecutionStrategy.java
@@ -62,6 +62,7 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
 
             futures.await().whenComplete((completeValueInfos, throwable) -> {
                 executionContext.run(throwable,() -> {
+                    executionContext.getProfiler().rootFieldCount(completeValueInfos.size());
                     List<String> fieldsExecutedOnInitialResult = deferredExecutionSupport.getNonDeferredFieldNames(fieldNames);
 
                     BiConsumer<List<Object>, Throwable> handleResultsConsumer = handleResults(executionContext, fieldsExecutedOnInitialResult, overallResult);

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -9,6 +9,7 @@ import graphql.ExperimentalApi;
 import graphql.GraphQLContext;
 import graphql.GraphQLError;
 import graphql.Internal;
+import graphql.Profiler;
 import graphql.execution.incremental.IncrementalCallState;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationContext;
@@ -57,19 +58,22 @@ public class Execution {
     private final Instrumentation instrumentation;
     private final ValueUnboxer valueUnboxer;
     private final boolean doNotAutomaticallyDispatchDataLoader;
+    private final Profiler profiler;
 
     public Execution(ExecutionStrategy queryStrategy,
                      ExecutionStrategy mutationStrategy,
                      ExecutionStrategy subscriptionStrategy,
                      Instrumentation instrumentation,
                      ValueUnboxer valueUnboxer,
-                     boolean doNotAutomaticallyDispatchDataLoader) {
+                     boolean doNotAutomaticallyDispatchDataLoader,
+                     Profiler profiler) {
         this.queryStrategy = queryStrategy != null ? queryStrategy : new AsyncExecutionStrategy();
         this.mutationStrategy = mutationStrategy != null ? mutationStrategy : new AsyncSerialExecutionStrategy();
         this.subscriptionStrategy = subscriptionStrategy != null ? subscriptionStrategy : new AsyncExecutionStrategy();
         this.instrumentation = instrumentation;
         this.valueUnboxer = valueUnboxer;
         this.doNotAutomaticallyDispatchDataLoader = doNotAutomaticallyDispatchDataLoader;
+        this.profiler = profiler;
     }
 
     public CompletableFuture<ExecutionResult> execute(Document document, GraphQLSchema graphQLSchema, ExecutionId executionId, ExecutionInput executionInput, InstrumentationState instrumentationState) {
@@ -115,6 +119,7 @@ public class Execution {
                 .executionInput(executionInput)
                 .propagapropagateErrorsOnNonNullContractFailureeErrors(propagateErrorsOnNonNullContractFailure)
                 .engineRunningObserver(engineRunningObserver)
+                .profiler(profiler)
                 .build();
 
         executionContext.getGraphQLContext().put(ResultNodesInfo.RESULT_NODES_INFO, executionContext.getResultNodesInfo());

--- a/src/main/java/graphql/execution/ExecutionContext.java
+++ b/src/main/java/graphql/execution/ExecutionContext.java
@@ -8,6 +8,7 @@ import graphql.ExperimentalApi;
 import graphql.GraphQLContext;
 import graphql.GraphQLError;
 import graphql.Internal;
+import graphql.Profiler;
 import graphql.PublicApi;
 import graphql.collect.ImmutableKit;
 import graphql.execution.EngineRunningObserver.RunningState;
@@ -78,6 +79,7 @@ public class ExecutionContext {
 
     private final ResultNodesInfo resultNodesInfo = new ResultNodesInfo();
     private final EngineRunningObserver engineRunningObserver;
+    private final Profiler profiler;
 
     ExecutionContext(ExecutionContextBuilder builder) {
         this.graphQLSchema = builder.graphQLSchema;
@@ -105,6 +107,7 @@ public class ExecutionContext {
         this.queryTree = FpKit.interThreadMemoize(() -> ExecutableNormalizedOperationFactory.createExecutableNormalizedOperation(graphQLSchema, operationDefinition, fragmentsByName, coercedVariables));
         this.propagateErrorsOnNonNullContractFailure = builder.propagateErrorsOnNonNullContractFailure;
         this.engineRunningObserver = builder.engineRunningObserver;
+        this.profiler = builder.profiler;
     }
 
 
@@ -439,5 +442,9 @@ public class ExecutionContext {
         if (engineRunningObserver != null) {
             engineRunningObserver.runningStateChanged(executionId, graphQLContext, runningState);
         }
+    }
+
+    public Profiler getProfiler() {
+        return profiler;
     }
 }

--- a/src/main/java/graphql/execution/ExecutionContextBuilder.java
+++ b/src/main/java/graphql/execution/ExecutionContextBuilder.java
@@ -7,6 +7,7 @@ import graphql.ExperimentalApi;
 import graphql.GraphQLContext;
 import graphql.GraphQLError;
 import graphql.Internal;
+import graphql.Profiler;
 import graphql.collect.ImmutableKit;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationState;
@@ -51,6 +52,7 @@ public class ExecutionContextBuilder {
     DataLoaderDispatchStrategy dataLoaderDispatcherStrategy = DataLoaderDispatchStrategy.NO_OP;
     boolean propagateErrorsOnNonNullContractFailure = true;
     EngineRunningObserver engineRunningObserver;
+    Profiler profiler;
 
     /**
      * @return a new builder of {@link graphql.execution.ExecutionContext}s
@@ -99,6 +101,7 @@ public class ExecutionContextBuilder {
         dataLoaderDispatcherStrategy = other.getDataLoaderDispatcherStrategy();
         propagateErrorsOnNonNullContractFailure = other.propagateErrorsOnNonNullContractFailure();
         engineRunningObserver = other.getEngineRunningObserver();
+        profiler = other.getProfiler();
     }
 
     public ExecutionContextBuilder instrumentation(Instrumentation instrumentation) {
@@ -243,6 +246,11 @@ public class ExecutionContextBuilder {
 
     public ExecutionContextBuilder engineRunningObserver(EngineRunningObserver engineRunningObserver) {
         this.engineRunningObserver = engineRunningObserver;
+        return this;
+    }
+
+    public ExecutionContextBuilder profiler(Profiler profiler) {
+        this.profiler = profiler;
         return this;
     }
 }

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -226,6 +226,7 @@ public abstract class ExecutionStrategy {
             if (fieldValueInfosResult instanceof CompletableFuture) {
                 CompletableFuture<List<FieldValueInfo>> fieldValueInfos = (CompletableFuture<List<FieldValueInfo>>) fieldValueInfosResult;
                 fieldValueInfos.whenComplete((completeValueInfos, throwable) -> {
+                    executionContext.getProfiler().subSelectionCount(completeValueInfos.size());
                     executionContext.run(throwable, () -> {
                         if (throwable != null) {
                             handleResultsConsumer.accept(null, throwable);
@@ -250,6 +251,7 @@ public abstract class ExecutionStrategy {
                 return overallResult;
             } else {
                 List<FieldValueInfo> completeValueInfos = (List<FieldValueInfo>) fieldValueInfosResult;
+                executionContext.getProfiler().subSelectionCount(completeValueInfos.size());
 
                 Async.CombinedBuilder<Object> resultFutures = fieldValuesCombinedBuilder(completeValueInfos);
                 dataLoaderDispatcherStrategy.executeObjectOnFieldValuesInfo(completeValueInfos, parameters);
@@ -478,6 +480,7 @@ public abstract class ExecutionStrategy {
         executionContext.getDataLoaderDispatcherStrategy().fieldFetched(executionContext, parameters, dataFetcher, fetchedObject);
         fetchCtx.onDispatched();
         fetchCtx.onFetchedValue(fetchedObject);
+        executionContext.getProfiler().fieldFetched(fetchedObject, dataFetcher);
         // if it's a subscription, leave any reactive objects alone
         if (!executionContext.isSubscriptionOperation()) {
             // possible convert reactive objects into CompletableFutures

--- a/src/test/groovy/graphql/execution/ExecutionTest.groovy
+++ b/src/test/groovy/graphql/execution/ExecutionTest.groovy
@@ -35,7 +35,7 @@ class ExecutionTest extends Specification {
     def subscriptionStrategy = new CountingExecutionStrategy()
     def mutationStrategy = new CountingExecutionStrategy()
     def queryStrategy = new CountingExecutionStrategy()
-    def execution = new Execution(queryStrategy, mutationStrategy, subscriptionStrategy, SimplePerformantInstrumentation.INSTANCE, ValueUnboxer.DEFAULT, false)
+    def execution = new Execution(queryStrategy, mutationStrategy, subscriptionStrategy, SimplePerformantInstrumentation.INSTANCE, ValueUnboxer.DEFAULT, false, profiler)
     def emptyExecutionInput = ExecutionInput.newExecutionInput().query("query").build()
     def instrumentationState = new InstrumentationState() {}
 
@@ -124,7 +124,7 @@ class ExecutionTest extends Specification {
             }
         }
 
-        def execution = new Execution(queryStrategy, mutationStrategy, subscriptionStrategy, instrumentation, ValueUnboxer.DEFAULT, false)
+        def execution = new Execution(queryStrategy, mutationStrategy, subscriptionStrategy, instrumentation, ValueUnboxer.DEFAULT, false, profiler)
 
 
         when:

--- a/src/test/groovy/graphql/execution/instrumentation/fieldvalidation/FieldValidationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/fieldvalidation/FieldValidationTest.groovy
@@ -12,8 +12,6 @@ import graphql.execution.ExecutionId
 import graphql.execution.ResultPath
 import graphql.execution.ValueUnboxer
 import graphql.execution.instrumentation.ChainedInstrumentation
-import graphql.execution.instrumentation.SimplePerformantInstrumentation
-import graphql.execution.instrumentation.parameters.InstrumentationCreateStateParameters
 import spock.lang.Specification
 
 import java.util.concurrent.CompletableFuture
@@ -307,7 +305,7 @@ class FieldValidationTest extends Specification {
         def document = TestUtil.parseQuery(query)
         def strategy = new AsyncExecutionStrategy()
         def instrumentation = new FieldValidationInstrumentation(validation)
-        def execution = new Execution(strategy, strategy, strategy, instrumentation, ValueUnboxer.DEFAULT, false)
+        def execution = new Execution(strategy, strategy, strategy, instrumentation, ValueUnboxer.DEFAULT, false, profiler)
 
         def executionInput = ExecutionInput.newExecutionInput().query(query).variables(variables).build()
         execution.execute(document, schema, ExecutionId.generate(), executionInput, null)


### PR DESCRIPTION
While we recently added a Java agent to profile a GraphQL Java application the following things became clear:

- Java agents are not the future of the JVM: soon a dynamic loading will be forbidden. See https://openjdk.org/jeps/451
- We added the ability to track the engine running state 
- We added the ability to chain DataLoaders, which as a side effect allow for tracking which dataloaders are used by which field / DataFetcher

Together this means Java agents are not really future proof + they are not needed anymore, as we have all the abilities now inside GraphQL Java directly itself.

The goal is to remove the Java agent eventually and offer a better alternative in form of this PRs: a built-in Profiler in GraphQL Java.

A Profiler is enabled per execution (request) and will collect with very minimal overhead all relevant informations to understand the performance and execution. The result will be made available via GraphQLContext.

This PR is just a draft at the moment. Once https://github.com/graphql-java/graphql-java/pull/3872 it can be fully developed.
