### PR TITLE
Added support for Flow publishers coming back from the subscription field data fetcher

### DIFF
--- a/src/test/groovy/graphql/execution/SubscriptionExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/SubscriptionExecutionStrategyTest.groovy
@@ -1,5 +1,6 @@
 package graphql.execution
 
+import graphql.AssertException
 import graphql.ErrorType
 import graphql.ExecutionInput
 import graphql.ExecutionResult
@@ -12,6 +13,7 @@ import graphql.execution.instrumentation.InstrumentationState
 import graphql.execution.instrumentation.LegacyTestingInstrumentation
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters
 import graphql.execution.pubsub.CapturingSubscriber
+import graphql.execution.pubsub.FlowMessagePublisher
 import graphql.execution.pubsub.Message
 import graphql.execution.pubsub.ReactiveStreamsMessagePublisher
 import graphql.execution.pubsub.ReactiveStreamsObjectPublisher
@@ -138,7 +140,7 @@ class SubscriptionExecutionStrategyTest extends Specification {
     def "subscription query sends out a stream of events using the '#why' implementation"() {
 
         given:
-        Publisher<Object> publisher = eventStreamPublisher
+        Object publisher = eventStreamPublisher
 
         DataFetcher newMessageDF = new DataFetcher() {
             @Override
@@ -181,6 +183,7 @@ class SubscriptionExecutionStrategyTest extends Specification {
         why                       | eventStreamPublisher
         'reactive streams stream' | new ReactiveStreamsMessagePublisher(10)
         'rxjava stream'           | new RxJavaMessagePublisher(10)
+        'flow stream'             | new FlowMessagePublisher(10)
 
     }
 
@@ -188,7 +191,7 @@ class SubscriptionExecutionStrategyTest extends Specification {
     def "subscription alias is correctly used in response messages using '#why' implementation"() {
 
         given:
-        Publisher<Object> publisher = eventStreamPublisher
+        Object publisher = eventStreamPublisher
 
         DataFetcher newMessageDF = new DataFetcher() {
             @Override
@@ -227,6 +230,7 @@ class SubscriptionExecutionStrategyTest extends Specification {
         why                       | eventStreamPublisher
         'reactive streams stream' | new ReactiveStreamsMessagePublisher(1)
         'rxjava stream'           | new RxJavaMessagePublisher(1)
+        'flow stream'             | new FlowMessagePublisher(1)
     }
 
 
@@ -238,7 +242,7 @@ class SubscriptionExecutionStrategyTest extends Specification {
         // capability and it costs us little to support it, lets have a test for it.
         //
         given:
-        Publisher<Object> publisher = eventStreamPublisher
+        Object publisher = eventStreamPublisher
 
         DataFetcher newMessageDF = new DataFetcher() {
             @Override
@@ -279,7 +283,7 @@ class SubscriptionExecutionStrategyTest extends Specification {
         why                       | eventStreamPublisher
         'reactive streams stream' | new ReactiveStreamsMessagePublisher(10)
         'rxjava stream'           | new RxJavaMessagePublisher(10)
-
+        'flow stream'             | new FlowMessagePublisher(10)
     }
 
 
@@ -310,6 +314,33 @@ class SubscriptionExecutionStrategyTest extends Specification {
         executionResult != null
         executionResult.data == null
         executionResult.errors.size() == 1
+    }
+
+    def "if you dont return a Publisher we will assert"() {
+
+        DataFetcher newMessageDF = new DataFetcher() {
+            @Override
+            Object get(DataFetchingEnvironment environment) {
+                return "Not a Publisher"
+            }
+        }
+
+        GraphQL graphQL = buildSubscriptionQL(newMessageDF)
+
+        def executionInput = ExecutionInput.newExecutionInput().query("""
+            subscription NewMessages {
+              newMessage(roomId: 123) {
+                sender
+                text
+              }
+            }
+        """).build()
+
+        when:
+        graphQL.execute(executionInput)
+
+        then:
+        thrown(AssertException)
     }
 
     def "subscription query will surface event stream exceptions"() {

--- a/src/test/groovy/graphql/execution/pubsub/CommonMessagePublisher.java
+++ b/src/test/groovy/graphql/execution/pubsub/CommonMessagePublisher.java
@@ -1,0 +1,44 @@
+package graphql.execution.pubsub;
+
+import org.reactivestreams.example.unicast.AsyncIterablePublisher;
+
+import java.util.Iterator;
+import java.util.concurrent.ForkJoinPool;
+import java.util.function.Function;
+
+class CommonMessagePublisher {
+
+    protected final AsyncIterablePublisher<Message> iterablePublisher;
+
+    protected CommonMessagePublisher(final int count) {
+        Iterable<Message> iterable = mkIterable(count, at -> {
+            Message message = new Message("sender" + at, "text" + at);
+            return examineMessage(message, at);
+        });
+        iterablePublisher = new AsyncIterablePublisher<>(iterable, ForkJoinPool.commonPool());
+    }
+
+    @SuppressWarnings("unused")
+    protected Message examineMessage(Message message, Integer at) {
+        return message;
+    }
+
+    private static Iterable<Message> mkIterable(int count, Function<Integer, Message> msgMaker) {
+        return () -> new Iterator<>() {
+            private int at = 0;
+
+            @Override
+            public boolean hasNext() {
+                return at < count;
+            }
+
+            @Override
+            public Message next() {
+                Message message = msgMaker.apply(at);
+                at++;
+                return message;
+            }
+        };
+    }
+
+}

--- a/src/test/groovy/graphql/execution/pubsub/FlowMessagePublisher.java
+++ b/src/test/groovy/graphql/execution/pubsub/FlowMessagePublisher.java
@@ -1,0 +1,22 @@
+package graphql.execution.pubsub;
+
+import org.reactivestreams.FlowAdapters;
+
+import java.util.concurrent.Flow;
+
+/**
+ * This example publisher will create count "messages" and then terminate. It
+ * uses the reactive streams TCK as its implementation but presents itself
+ * as a {@link Flow.Publisher}
+ */
+public class FlowMessagePublisher extends CommonMessagePublisher implements Flow.Publisher<Message> {
+
+    public FlowMessagePublisher(int count) {
+        super(count);
+    }
+
+    @Override
+    public void subscribe(Flow.Subscriber<? super Message> s) {
+        iterablePublisher.subscribe(FlowAdapters.toSubscriber(s));
+    }
+}

--- a/src/test/groovy/graphql/execution/pubsub/ReactiveStreamsMessagePublisher.java
+++ b/src/test/groovy/graphql/execution/pubsub/ReactiveStreamsMessagePublisher.java
@@ -2,54 +2,20 @@ package graphql.execution.pubsub;
 
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
-import org.reactivestreams.example.unicast.AsyncIterablePublisher;
-
-import java.util.Iterator;
-import java.util.concurrent.ForkJoinPool;
-import java.util.function.Function;
 
 /**
  * This example publisher will create count "messages" and then terminate. It
  * uses the reactive streams TCK as its implementation
  */
-public class ReactiveStreamsMessagePublisher implements Publisher<Message> {
-
-    private final AsyncIterablePublisher<Message> iterablePublisher;
+public class ReactiveStreamsMessagePublisher extends CommonMessagePublisher implements Publisher<Message> {
 
     public ReactiveStreamsMessagePublisher(final int count) {
-        Iterable<Message> iterable = mkIterable(count, at -> {
-            Message message = new Message("sender" + at, "text" + at);
-            return examineMessage(message, at);
-        });
-        iterablePublisher = new AsyncIterablePublisher<>(iterable, ForkJoinPool.commonPool());
+        super(count);
     }
 
     @Override
     public void subscribe(Subscriber<? super Message> s) {
         iterablePublisher.subscribe(s);
     }
-
-    @SuppressWarnings("unused")
-    protected Message examineMessage(Message message, Integer at) {
-        return message;
-    }
-
-    private static Iterable<Message> mkIterable(int count, Function<Integer, Message> msgMaker) {
-        return () -> new Iterator<Message>() {
-            private int at = 0;
-
-            @Override
-            public boolean hasNext() {
-                return at < count;
-            }
-
-            @Override
-            public Message next() {
-                Message message = msgMaker.apply(at);
-                at++;
-                return message;
-            }
-        };
-    }
-
 }
+


### PR DESCRIPTION
This allows an implementation to return a `Flow.Publisher` in their data fetcher

It will be converted to a reactive streams publisher when it comes back out of the ExecutionResult.