### PR TITLE
support variable forward-references in directives

### DIFF
--- a/src/test/groovy/graphql/validation/rules/NoUndefinedVariablesTest.groovy
+++ b/src/test/groovy/graphql/validation/rules/NoUndefinedVariablesTest.groovy
@@ -181,4 +181,37 @@ class NoUndefinedVariablesTest extends Specification {
         errorCollector.containsValidationError(ValidationErrorType.UndefinedVariable)
         errorCollector.getErrors()[0].message == "Validation error (UndefinedVariable@[A/field]) : Undefined variable 'a'"
     }
+
+    def "variable-directive back-reference"() {
+        given:
+        def query = "query (\$v1: Int, \$v2: Int @dir(arg: \$v1)) { __typename }"
+
+        when:
+        traverse(query)
+
+        then:
+        errorCollector.errors.isEmpty()
+    }
+
+    def "variable-directive self-reference"() {
+        given:
+        def query = "query (\$v1: Int @dir(arg: \$v1)) { __typename }"
+
+        when:
+        traverse(query)
+
+        then:
+        errorCollector.errors.isEmpty()
+    }
+
+    def "variable-directive forward-reference"() {
+        given:
+        def query = "query (\$v1: Int @dir(arg: \$v2), \$v2: Int) { __typename }"
+
+        when:
+        traverse(query)
+
+        then:
+        errorCollector.errors.isEmpty()
+    }
 }


### PR DESCRIPTION
This PR is a repro of a potential issue, filed at #3927

The potential issue is related to variable reference validation when variables are used in directives that are applied to other variable definitions 🤪

See line comments in diff.