### PR TITLE
ExecutionStepInfo now has a direct transform without a Builder

### DIFF
--- a/src/jmh/java/graphql/execution/ExecutionStepInfoBenchmark.java
+++ b/src/jmh/java/graphql/execution/ExecutionStepInfoBenchmark.java
@@ -1,0 +1,86 @@
+package graphql.execution;
+
+import graphql.Scalars;
+import graphql.language.Field;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.concurrent.TimeUnit;
+
+import static graphql.execution.ExecutionStepInfo.newExecutionStepInfo;
+
+@State(Scope.Benchmark)
+@Warmup(iterations = 2, time = 5)
+@Measurement(iterations = 2)
+@Fork(2)
+public class ExecutionStepInfoBenchmark {
+    @Param({"1000000", "2000000"})
+    int howManyItems = 1000000;
+
+    @Setup(Level.Trial)
+    public void setUp() {
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+    }
+
+
+    MergedField mergedField = MergedField.newMergedField().addField(Field.newField("f").build()).build();
+
+    ResultPath path = ResultPath.rootPath().segment("f");
+    ExecutionStepInfo rootStepInfo = newExecutionStepInfo()
+            .path(path).type(Scalars.GraphQLString)
+            .field(mergedField)
+            .build();
+
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public void benchMarkDirectConstructorThroughput(Blackhole blackhole) {
+        for (int i = 0; i < howManyItems; i++) {
+            ResultPath newPath = path.segment(1);
+            ExecutionStepInfo newOne = rootStepInfo.transform(Scalars.GraphQLInt, rootStepInfo, newPath);
+            blackhole.consume(newOne);
+        }
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public void benchMarkBuilderThroughput(Blackhole blackhole) {
+        for (int i = 0; i < howManyItems; i++) {
+            ResultPath newPath = path.segment(1);
+            ExecutionStepInfo newOne = newExecutionStepInfo(rootStepInfo).parentInfo(rootStepInfo)
+                    .type(Scalars.GraphQLInt).path(newPath).build();
+            blackhole.consume(newOne);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        Options opt = new OptionsBuilder()
+                .include("graphql.execution.ExecutionStepInfoBenchmark")
+                .addProfiler(GCProfiler.class)
+                .build();
+
+        new Runner(opt).run();
+    }
+
+}

--- a/src/main/java/graphql/execution/ExecutionStepInfo.java
+++ b/src/main/java/graphql/execution/ExecutionStepInfo.java
@@ -1,5 +1,6 @@
 package graphql.execution;
 
+import graphql.Internal;
 import graphql.PublicApi;
 import graphql.collect.ImmutableMapWithNullValues;
 import graphql.schema.GraphQLFieldDefinition;
@@ -75,6 +76,19 @@ public class ExecutionStepInfo {
         this.type = assertNotNull(builder.type, () -> "you must provide a graphql type");
         this.arguments = builder.arguments;
         this.fieldContainer = builder.fieldContainer;
+    }
+
+    /*
+     * This constructor allows for a slightly ( 1% ish) faster transformation without an intermediate Builder object
+     */
+    private ExecutionStepInfo(GraphQLOutputType type, ResultPath path, ExecutionStepInfo parent, MergedField field, GraphQLFieldDefinition fieldDefinition, GraphQLObjectType fieldContainer, Supplier<ImmutableMapWithNullValues<String, Object>> arguments) {
+        this.type = assertNotNull(type, () -> "you must provide a graphql type");
+        this.path = path;
+        this.parent = parent;
+        this.field = field;
+        this.fieldDefinition = fieldDefinition;
+        this.fieldContainer = fieldContainer;
+        this.arguments = arguments;
     }
 
     /**
@@ -193,12 +207,11 @@ public class ExecutionStepInfo {
     public ExecutionStepInfo changeTypeWithPreservedNonNull(GraphQLOutputType newType) {
         assertTrue(!GraphQLTypeUtil.isNonNull(newType), () -> "newType can't be non null");
         if (isNonNullType()) {
-            return newExecutionStepInfo(this).type(GraphQLNonNull.nonNull(newType)).build();
+            return transform(GraphQLNonNull.nonNull(newType));
         } else {
-            return newExecutionStepInfo(this).type(newType).build();
+            return transform(newType);
         }
     }
-
 
     /**
      * @return the type in graphql SDL format, eg [typeName!]!
@@ -214,6 +227,16 @@ public class ExecutionStepInfo {
                 ", type=" + type +
                 ", fieldDefinition=" + fieldDefinition +
                 '}';
+    }
+
+    @Internal
+    ExecutionStepInfo transform(GraphQLOutputType type) {
+        return new ExecutionStepInfo(type, path, parent, field, fieldDefinition, fieldContainer, arguments);
+    }
+
+    @Internal
+    ExecutionStepInfo transform(GraphQLOutputType type, ExecutionStepInfo parent, ResultPath path) {
+        return new ExecutionStepInfo(type, path, parent, field, fieldDefinition, fieldContainer, arguments);
     }
 
     public ExecutionStepInfo transform(Consumer<Builder> builderConsumer) {

--- a/src/main/java/graphql/execution/ExecutionStepInfo.java
+++ b/src/main/java/graphql/execution/ExecutionStepInfo.java
@@ -81,7 +81,13 @@ public class ExecutionStepInfo {
     /*
      * This constructor allows for a slightly ( 1% ish) faster transformation without an intermediate Builder object
      */
-    private ExecutionStepInfo(GraphQLOutputType type, ResultPath path, ExecutionStepInfo parent, MergedField field, GraphQLFieldDefinition fieldDefinition, GraphQLObjectType fieldContainer, Supplier<ImmutableMapWithNullValues<String, Object>> arguments) {
+    private ExecutionStepInfo(GraphQLOutputType type,
+                              ResultPath path,
+                              ExecutionStepInfo parent,
+                              MergedField field,
+                              GraphQLFieldDefinition fieldDefinition,
+                              GraphQLObjectType fieldContainer,
+                              Supplier<ImmutableMapWithNullValues<String, Object>> arguments) {
         this.type = assertNotNull(type, () -> "you must provide a graphql type");
         this.path = path;
         this.parent = parent;

--- a/src/main/java/graphql/execution/ExecutionStepInfoFactory.java
+++ b/src/main/java/graphql/execution/ExecutionStepInfoFactory.java
@@ -1,19 +1,92 @@
 package graphql.execution;
 
 import graphql.Internal;
+import graphql.collect.ImmutableMapWithNullValues;
+import graphql.language.Argument;
+import graphql.schema.GraphQLArgument;
+import graphql.schema.GraphQLCodeRegistry;
+import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLList;
+import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLOutputType;
+import graphql.util.FpKit;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static graphql.execution.ExecutionStepInfo.newExecutionStepInfo;
 
 @Internal
+@NullMarked
 public class ExecutionStepInfoFactory {
 
     public ExecutionStepInfo newExecutionStepInfoForListElement(ExecutionStepInfo executionInfo, ResultPath indexedPath) {
         GraphQLList fieldType = (GraphQLList) executionInfo.getUnwrappedNonNullType();
         GraphQLOutputType typeInList = (GraphQLOutputType) fieldType.getWrappedType();
-        return executionInfo.transform(builder -> builder
-                .parentInfo(executionInfo)
-                .type(typeInList)
-                .path(indexedPath));
+        return executionInfo.transform(typeInList, executionInfo, indexedPath);
     }
+
+    /**
+     * Builds the type info hierarchy for the current field
+     *
+     * @param executionContext the execution context  in play
+     * @param parameters       contains the parameters holding the fields to be executed and source object
+     * @param fieldDefinition  the field definition to build type info for
+     * @param fieldContainer   the field container
+     *
+     * @return a new type info
+     */
+    public ExecutionStepInfo createExecutionStepInfo(ExecutionContext executionContext,
+                                                        ExecutionStrategyParameters parameters,
+                                                        GraphQLFieldDefinition fieldDefinition,
+                                                        @Nullable GraphQLObjectType fieldContainer) {
+        MergedField field = parameters.getField();
+        ExecutionStepInfo parentStepInfo = parameters.getExecutionStepInfo();
+        GraphQLOutputType fieldType = fieldDefinition.getType();
+        List<GraphQLArgument> fieldArgDefs = fieldDefinition.getArguments();
+        Supplier<ImmutableMapWithNullValues<String, Object>> argumentValues = ImmutableMapWithNullValues::emptyMap;
+        //
+        // no need to create args at all if there are none on the field def
+        //
+        if (!fieldArgDefs.isEmpty()) {
+            argumentValues = getArgumentValues(executionContext, fieldArgDefs, field.getArguments());
+        }
+
+
+        return newExecutionStepInfo()
+                .type(fieldType)
+                .fieldDefinition(fieldDefinition)
+                .fieldContainer(fieldContainer)
+                .field(field)
+                .path(parameters.getPath())
+                .parentInfo(parentStepInfo)
+                .arguments(argumentValues)
+                .build();
+    }
+
+    @NonNull
+    private static Supplier<ImmutableMapWithNullValues<String, Object>> getArgumentValues(ExecutionContext executionContext,
+                                                                                          List<GraphQLArgument> fieldArgDefs,
+                                                                                          List<Argument> fieldArgs) {
+        Supplier<ImmutableMapWithNullValues<String, Object>> argumentValues;
+        GraphQLCodeRegistry codeRegistry = executionContext.getGraphQLSchema().getCodeRegistry();
+        Supplier<ImmutableMapWithNullValues<String, Object>> argValuesSupplier = () -> {
+            Map<String, Object> resolvedValues = ValuesResolver.getArgumentValues(codeRegistry,
+                    fieldArgDefs,
+                    fieldArgs,
+                    executionContext.getCoercedVariables(),
+                    executionContext.getGraphQLContext(),
+                    executionContext.getLocale());
+
+            return ImmutableMapWithNullValues.copyOf(resolvedValues);
+        };
+        argumentValues = FpKit.intraThreadMemoize(argValuesSupplier);
+        return argumentValues;
+    }
+
 
 }

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -14,7 +14,6 @@ import graphql.SerializationError;
 import graphql.TrivialDataFetcher;
 import graphql.TypeMismatchError;
 import graphql.UnresolvedTypeError;
-import graphql.collect.ImmutableMapWithNullValues;
 import graphql.execution.directives.QueryDirectives;
 import graphql.execution.directives.QueryDirectivesImpl;
 import graphql.execution.incremental.DeferredExecutionSupport;
@@ -29,7 +28,6 @@ import graphql.execution.instrumentation.parameters.InstrumentationFieldParamete
 import graphql.execution.reactive.ReactiveSupport;
 import graphql.extensions.ExtensionsBuilder;
 import graphql.introspection.Introspection;
-import graphql.language.Argument;
 import graphql.language.Field;
 import graphql.normalized.ExecutableNormalizedField;
 import graphql.normalized.ExecutableNormalizedOperation;
@@ -38,12 +36,10 @@ import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.DataFetchingFieldSelectionSet;
 import graphql.schema.DataFetchingFieldSelectionSetImpl;
-import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLCodeRegistry;
 import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLObjectType;
-import graphql.schema.GraphQLOutputType;
 import graphql.schema.GraphQLScalarType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
@@ -64,7 +60,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static graphql.execution.Async.exceptionallyCompletedFuture;
-import static graphql.execution.ExecutionStepInfo.newExecutionStepInfo;
 import static graphql.execution.FieldCollectorParameters.newParameters;
 import static graphql.execution.FieldValueInfo.CompleteValueType.ENUM;
 import static graphql.execution.FieldValueInfo.CompleteValueType.LIST;
@@ -1091,48 +1086,10 @@ public abstract class ExecutionStrategy {
                                                         ExecutionStrategyParameters parameters,
                                                         GraphQLFieldDefinition fieldDefinition,
                                                         GraphQLObjectType fieldContainer) {
-        MergedField field = parameters.getField();
-        ExecutionStepInfo parentStepInfo = parameters.getExecutionStepInfo();
-        GraphQLOutputType fieldType = fieldDefinition.getType();
-        List<GraphQLArgument> fieldArgDefs = fieldDefinition.getArguments();
-        Supplier<ImmutableMapWithNullValues<String, Object>> argumentValues = ImmutableMapWithNullValues::emptyMap;
-        //
-        // no need to create args at all if there are none on the field def
-        //
-        if (!fieldArgDefs.isEmpty()) {
-            argumentValues = getArgumentValues(executionContext, fieldArgDefs, field.getArguments());
-        }
-
-
-        return newExecutionStepInfo()
-                .type(fieldType)
-                .fieldDefinition(fieldDefinition)
-                .fieldContainer(fieldContainer)
-                .field(field)
-                .path(parameters.getPath())
-                .parentInfo(parentStepInfo)
-                .arguments(argumentValues)
-                .build();
-    }
-
-    @NonNull
-    private static Supplier<ImmutableMapWithNullValues<String, Object>> getArgumentValues(ExecutionContext executionContext,
-                                                                                          List<GraphQLArgument> fieldArgDefs,
-                                                                                          List<Argument> fieldArgs) {
-        Supplier<ImmutableMapWithNullValues<String, Object>> argumentValues;
-        GraphQLCodeRegistry codeRegistry = executionContext.getGraphQLSchema().getCodeRegistry();
-        Supplier<ImmutableMapWithNullValues<String, Object>> argValuesSupplier = () -> {
-            Map<String, Object> resolvedValues = ValuesResolver.getArgumentValues(codeRegistry,
-                    fieldArgDefs,
-                    fieldArgs,
-                    executionContext.getCoercedVariables(),
-                    executionContext.getGraphQLContext(),
-                    executionContext.getLocale());
-
-            return ImmutableMapWithNullValues.copyOf(resolvedValues);
-        };
-        argumentValues = FpKit.intraThreadMemoize(argValuesSupplier);
-        return argumentValues;
+        return executionStepInfoFactory.createExecutionStepInfo(executionContext,
+                parameters,
+                fieldDefinition,
+                fieldContainer);
     }
 
     // Errors that result from the execution of deferred fields are kept in the deferred context only.


### PR DESCRIPTION
This is really 1% stuff.  Its debatably faster BUT it uses (slightly) less memory and thats a good thing at scale

```
Benchmark                                                        (howManyItems)   Mode  Cnt    Score    Error  Units
ExecutionStepInfoBenchmark.benchMarkBuilderThroughput                   1000000  thrpt    4  376.814 ±  7.136  ops/s
ExecutionStepInfoBenchmark.benchMarkBuilderThroughput                   2000000  thrpt    4  188.889 ±  2.585  ops/s
ExecutionStepInfoBenchmark.benchMarkDirectConstructorThroughput         1000000  thrpt    4  379.725 ± 13.369  ops/s
ExecutionStepInfoBenchmark.benchMarkDirectConstructorThroughput         2000000  thrpt    4  191.496 ±  1.785  ops/s
```

