### PR TITLE
ExecutionStrategyParameters now has a direct transform without a Builder

### DIFF
--- a/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
@@ -52,11 +52,9 @@ public class AsyncSerialExecutionStrategy extends AbstractAsyncExecutionStrategy
         CompletableFuture<List<Object>> resultsFuture = Async.eachSequentially(fieldNames, (fieldName, prevResults) -> {
             MergedField currentField = fields.getSubField(fieldName);
             ResultPath fieldPath = parameters.getPath().segment(mkNameForPath(currentField));
-            ExecutionStrategyParameters newParameters = parameters
-                    .transform(builder -> builder.field(currentField).path(fieldPath));
+            ExecutionStrategyParameters newParameters = parameters.transform(currentField, fieldPath);
 
-            Object resolveSerialField = resolveSerialField(executionContext, dataLoaderDispatcherStrategy, newParameters);
-            return resolveSerialField;
+            return resolveSerialField(executionContext, dataLoaderDispatcherStrategy, newParameters);
         });
 
         CompletableFuture<ExecutionResult> overallResult = new CompletableFuture<>();

--- a/src/main/java/graphql/execution/ExecutionStrategyParameters.java
+++ b/src/main/java/graphql/execution/ExecutionStrategyParameters.java
@@ -1,5 +1,6 @@
 package graphql.execution;
 
+import graphql.Internal;
 import graphql.PublicApi;
 import graphql.execution.incremental.DeferredCallContext;
 import org.jspecify.annotations.Nullable;
@@ -113,6 +114,31 @@ public class ExecutionStrategyParameters {
      */
     public MergedField getField() {
         return currentField;
+    }
+
+    @Internal
+    ExecutionStrategyParameters transform(MergedField currentField, ResultPath path) {
+        return new ExecutionStrategyParameters(executionStepInfo, source, localContext, fields, nonNullableFieldValidator, path, currentField, parent, deferredCallContext);
+    }
+
+    @Internal
+    ExecutionStrategyParameters transform(ExecutionStepInfo executionStepInfo, NonNullableFieldValidator nonNullableFieldValidator, MergedSelectionSet fields, Object source) {
+        return new ExecutionStrategyParameters(executionStepInfo, source, localContext, fields, nonNullableFieldValidator, path, currentField, parent, deferredCallContext);
+    }
+
+    @Internal
+    ExecutionStrategyParameters transform(ExecutionStepInfo executionStepInfo, NonNullableFieldValidator nonNullableFieldValidator, ResultPath path, Object localContext, Object source) {
+        return new ExecutionStrategyParameters(executionStepInfo, source, localContext, fields, nonNullableFieldValidator, path, currentField, parent, deferredCallContext);
+    }
+
+    @Internal
+    ExecutionStrategyParameters transform(ExecutionStepInfo executionStepInfo, NonNullableFieldValidator nonNullableFieldValidator, Object localContext, Object source) {
+        return new ExecutionStrategyParameters(executionStepInfo, source, localContext, fields, nonNullableFieldValidator, path, currentField, parent, deferredCallContext);
+    }
+
+    @Internal
+    ExecutionStrategyParameters transform(MergedField currentField, ResultPath path, ExecutionStrategyParameters parent) {
+        return new ExecutionStrategyParameters(executionStepInfo, source, localContext, fields, nonNullableFieldValidator, path, currentField, parent, deferredCallContext);
     }
 
     public ExecutionStrategyParameters transform(Consumer<Builder> builderConsumer) {

--- a/src/main/java/graphql/execution/ExecutionStrategyParameters.java
+++ b/src/main/java/graphql/execution/ExecutionStrategyParameters.java
@@ -117,28 +117,81 @@ public class ExecutionStrategyParameters {
     }
 
     @Internal
-    ExecutionStrategyParameters transform(MergedField currentField, ResultPath path) {
-        return new ExecutionStrategyParameters(executionStepInfo, source, localContext, fields, nonNullableFieldValidator, path, currentField, parent, deferredCallContext);
+    ExecutionStrategyParameters transform(MergedField currentField,
+                                          ResultPath path) {
+        return new ExecutionStrategyParameters(executionStepInfo,
+                source,
+                localContext,
+                fields,
+                nonNullableFieldValidator,
+                path,
+                currentField,
+                parent,
+                deferredCallContext);
     }
 
     @Internal
-    ExecutionStrategyParameters transform(ExecutionStepInfo executionStepInfo, NonNullableFieldValidator nonNullableFieldValidator, MergedSelectionSet fields, Object source) {
-        return new ExecutionStrategyParameters(executionStepInfo, source, localContext, fields, nonNullableFieldValidator, path, currentField, parent, deferredCallContext);
+    ExecutionStrategyParameters transform(ExecutionStepInfo executionStepInfo,
+                                          NonNullableFieldValidator nonNullableFieldValidator,
+                                          MergedSelectionSet fields,
+                                          Object source) {
+        return new ExecutionStrategyParameters(executionStepInfo,
+                source,
+                localContext,
+                fields,
+                nonNullableFieldValidator,
+                path,
+                currentField,
+                parent,
+                deferredCallContext);
     }
 
     @Internal
-    ExecutionStrategyParameters transform(ExecutionStepInfo executionStepInfo, NonNullableFieldValidator nonNullableFieldValidator, ResultPath path, Object localContext, Object source) {
-        return new ExecutionStrategyParameters(executionStepInfo, source, localContext, fields, nonNullableFieldValidator, path, currentField, parent, deferredCallContext);
+    ExecutionStrategyParameters transform(ExecutionStepInfo executionStepInfo,
+                                          NonNullableFieldValidator nonNullableFieldValidator,
+                                          ResultPath path,
+                                          Object localContext,
+                                          Object source) {
+        return new ExecutionStrategyParameters(executionStepInfo,
+                source,
+                localContext,
+                fields,
+                nonNullableFieldValidator,
+                path,
+                currentField,
+                parent,
+                deferredCallContext);
     }
 
     @Internal
-    ExecutionStrategyParameters transform(ExecutionStepInfo executionStepInfo, NonNullableFieldValidator nonNullableFieldValidator, Object localContext, Object source) {
-        return new ExecutionStrategyParameters(executionStepInfo, source, localContext, fields, nonNullableFieldValidator, path, currentField, parent, deferredCallContext);
+    ExecutionStrategyParameters transform(ExecutionStepInfo executionStepInfo,
+                                          NonNullableFieldValidator nonNullableFieldValidator,
+                                          Object localContext,
+                                          Object source) {
+        return new ExecutionStrategyParameters(executionStepInfo,
+                source,
+                localContext,
+                fields,
+                nonNullableFieldValidator,
+                path,
+                currentField,
+                parent,
+                deferredCallContext);
     }
 
     @Internal
-    ExecutionStrategyParameters transform(MergedField currentField, ResultPath path, ExecutionStrategyParameters parent) {
-        return new ExecutionStrategyParameters(executionStepInfo, source, localContext, fields, nonNullableFieldValidator, path, currentField, parent, deferredCallContext);
+    ExecutionStrategyParameters transform(MergedField currentField,
+                                          ResultPath path,
+                                          ExecutionStrategyParameters parent) {
+        return new ExecutionStrategyParameters(executionStepInfo,
+                source,
+                localContext,
+                fields,
+                nonNullableFieldValidator,
+                path,
+                currentField,
+                parent,
+                deferredCallContext);
     }
 
     public ExecutionStrategyParameters transform(Consumer<Builder> builderConsumer) {

--- a/src/main/java/graphql/execution/SubscriptionExecutionStrategy.java
+++ b/src/main/java/graphql/execution/SubscriptionExecutionStrategy.java
@@ -184,7 +184,7 @@ public class SubscriptionExecutionStrategy extends ExecutionStrategy {
         MergedField firstField = fields.getSubField(fields.getKeys().get(0));
 
         ResultPath fieldPath = parameters.getPath().segment(mkNameForPath(firstField.getSingleField()));
-        return parameters.transform(builder -> builder.field(firstField).path(fieldPath));
+        return parameters.transform(firstField,fieldPath);
     }
 
     private ExecutionStepInfo createSubscribedFieldStepInfo(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {

--- a/src/main/java/graphql/execution/incremental/DeferredExecutionSupport.java
+++ b/src/main/java/graphql/execution/incremental/DeferredExecutionSupport.java
@@ -11,6 +11,7 @@ import graphql.execution.ExecutionStrategyParameters;
 import graphql.execution.FieldValueInfo;
 import graphql.execution.MergedField;
 import graphql.execution.MergedSelectionSet;
+import graphql.execution.ResultPath;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.incremental.IncrementalPayload;
 import graphql.util.FpKit;
@@ -139,10 +140,11 @@ public interface DeferredExecutionSupport {
             ExecutionStrategyParameters callParameters = parameters.transform(builder ->
                     {
                         MergedSelectionSet mergedSelectionSet = MergedSelectionSet.newMergedSelectionSet().subFields(fields).build();
+                        ResultPath path = parameters.getPath().segment(currentField.getResultKey());
                         builder.deferredCallContext(deferredCallContext)
                                 .field(currentField)
                                 .fields(mergedSelectionSet)
-                                .path(parameters.getPath().segment(currentField.getResultKey()))
+                                .path(path)
                                 .parent(null); // this is a break in the parent -> child chain - it's a new start effectively
                     }
             );


### PR DESCRIPTION
This is really 1% stuff. Its debatably faster BUT it uses (slightly) less memory and thats a good thing at scale