### PR TITLE
Flyweight support of key re-used objects

### DIFF
--- a/src/jmh/java/benchmark/BenchmarkUtils.java
+++ b/src/jmh/java/benchmark/BenchmarkUtils.java
@@ -1,5 +1,7 @@
 package benchmark;
 
+import org.openjdk.jmh.infra.Blackhole;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -81,4 +83,7 @@ public class BenchmarkUtils {
         }
     }
 
+    public static Blackhole blackHole() {
+        return new Blackhole("Today's password is swordfish. I understand instantiating Blackholes directly is dangerous.");
+    }
 }

--- a/src/jmh/java/graphql/schema/FlyWeightBenchmark.java
+++ b/src/jmh/java/graphql/schema/FlyWeightBenchmark.java
@@ -1,0 +1,119 @@
+package graphql.schema;
+
+import benchmark.BenchmarkUtils;
+import graphql.util.flyweight.FlyweightKit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 2, time = 5, batchSize = 50)
+@Measurement(iterations = 3, batchSize = 50)
+@Fork(3)
+public class FlyWeightBenchmark {
+
+    private static final int LOOPS = 10;
+
+    static FlyweightKit.BiKeyMap<String, String, FieldCoordinates> flyweightFieldCoordinates = new FlyweightKit.BiKeyMap<>();
+    static FlyweightKit.TriKeyMap<ClassLoader, String, String, PropertyFetchingImpl.CacheKey> FLYWEIGHT_CACHE = new FlyweightKit.TriKeyMap<>();
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public void benchMarkDirectInstantiationThroughput(Blackhole blackhole) {
+        directInstantiation(blackhole);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public void benchMarkDirectInstantiationAvgTime(Blackhole blackhole) {
+        directInstantiation(blackhole);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public void benchMarkUsingFlyweightsThroughput(Blackhole blackhole) {
+        flyweights(blackhole);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public void benchMarkUsingFlyweightsAveTime(Blackhole blackhole) {
+        flyweights(blackhole);
+    }
+
+    private void directInstantiation(Blackhole blackhole) {
+        for (int i = 0; i < LOOPS; i++) {
+            FieldCoordinates fieldCoordinates = FieldCoordinates.coordinates(
+                    mkName("t", i),
+                    "f");
+            blackhole.consume(fieldCoordinates);
+
+            PropertyFetchingImpl.CacheKey cacheKey = new PropertyFetchingImpl.CacheKey(
+                    getClass().getClassLoader(),
+                    mkName("c", i),
+                    "f");
+            blackhole.consume(cacheKey);
+        }
+    }
+
+    private void flyweights(Blackhole blackhole) {
+        for (int i = 0; i < LOOPS; i++) {
+            FieldCoordinates fieldCoordinates = flyweightFieldCoordinates.computeIfAbsent(
+                    mkName("t", i),
+                    "f",
+                    FieldCoordinates::coordinates);
+            blackhole.consume(fieldCoordinates);
+
+            PropertyFetchingImpl.CacheKey cacheKey = FLYWEIGHT_CACHE.computeIfAbsent(
+                    getClass().getClassLoader(),
+                    mkName("c", i),
+                    "f",
+                    PropertyFetchingImpl.CacheKey::new);
+            blackhole.consume(cacheKey);
+        }
+    }
+
+    private String mkName(String s, int i) {
+        return s + "_" + (i % 2 == 0);
+    }
+
+
+    public static void main(String[] args) throws RunnerException {
+        runAtStartup();
+        Options opt = new OptionsBuilder()
+                .include("graphql.schema.FlyWeightBenchmark")
+                .addProfiler(GCProfiler.class)
+                .build();
+
+        new Runner(opt).run();
+    }
+
+    private static void runAtStartup() {
+        FlyWeightBenchmark benchMark = new FlyWeightBenchmark();
+        Blackhole blackhole = BenchmarkUtils.blackHole();
+
+        BenchmarkUtils.runInToolingForSomeTimeThenExit(
+                () -> {
+                },
+                () -> benchMark.benchMarkUsingFlyweightsThroughput(blackhole),
+                () -> {
+                }
+
+        );
+    }
+}

--- a/src/main/java/graphql/schema/PropertyFetchingImpl.java
+++ b/src/main/java/graphql/schema/PropertyFetchingImpl.java
@@ -401,12 +401,12 @@ public class PropertyFetchingImpl {
         return FLYWEIGHT_CACHEKEY_CACHE.computeIfAbsent(classLoader, clazz.getName(), propertyName, CacheKey::new);
     }
 
-    private static final class CacheKey {
+    static final class CacheKey {
         private final ClassLoader classLoader;
         private final String className;
         private final String propertyName;
 
-        private CacheKey(ClassLoader classLoader, String className, String propertyName) {
+        CacheKey(ClassLoader classLoader, String className, String propertyName) {
             this.classLoader = classLoader;
             this.className = className;
             this.propertyName = propertyName;

--- a/src/main/java/graphql/util/flyweight/FlyweightKit.java
+++ b/src/main/java/graphql/util/flyweight/FlyweightKit.java
@@ -1,0 +1,79 @@
+package graphql.util.flyweight;
+
+import graphql.Internal;
+import graphql.util.LockKit;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+@Internal
+@NullMarked
+public class FlyweightKit {
+
+    public static class BiKeyMap<K1, K2, T> {
+        private final Map<K1, Map<K2, T>> map;
+        private final LockKit.ReentrantLock lock;
+
+
+        public BiKeyMap() {
+            map = new HashMap<>();
+            lock = new LockKit.ReentrantLock();
+        }
+
+        public T computeIfAbsent(K1 key1, K2 key2, BiFunction<K1, K2, T> computeFunc) {
+            lock.lock();
+            try {
+                Map<K2, T> k2Map = map.computeIfAbsent(key1, k1 -> new HashMap<>());
+                return k2Map.computeIfAbsent(key2, k2 -> computeFunc.apply(key1, k2));
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        public void clear() {
+            clearMap(map, lock);
+        }
+    }
+
+    public interface TriFunction<K1, K2, K3, T> {
+        T apply(K1 k1, K2 k2, K3 k3);
+    }
+
+    public static class TriKeyMap<K1, K2, K3, T> {
+        private final Map<K1, Map<K2, Map<K3, T>>> map;
+        private final LockKit.ReentrantLock lock;
+
+        public TriKeyMap() {
+            map = new HashMap<>();
+            lock = new LockKit.ReentrantLock();
+        }
+
+        public T computeIfAbsent(K1 key1, K2 key2, K3 key3, TriFunction<K1, K2, K3, T> computeFunc) {
+            lock.lock();
+            try {
+                Map<K2, Map<K3, T>> k2Map = map.computeIfAbsent(key1, k1 -> new HashMap<>());
+                Map<K3, T> k3Map = k2Map.computeIfAbsent(key2, k2 -> new HashMap<>());
+                return k3Map.computeIfAbsent(key3, k3 -> computeFunc.apply(key1, key2, k3));
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        public void clear() {
+            clearMap(map, lock);
+        }
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static void clearMap(Map map, LockKit.ReentrantLock lock) {
+        lock.lock();
+        try {
+            map.clear();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+}

--- a/src/test/groovy/graphql/util/flyweight/FlyweightKitTest.groovy
+++ b/src/test/groovy/graphql/util/flyweight/FlyweightKitTest.groovy
@@ -1,0 +1,103 @@
+package graphql.util.flyweight
+
+import spock.lang.Specification
+
+class FlyweightKitTest extends Specification {
+
+    class CacheKey {
+        private String className;
+        private String propertyName;
+
+        CacheKey(String className, String propertyName) {
+            this.className = className
+            this.propertyName = propertyName
+        }
+
+        String getClassName() {
+            return className
+        }
+
+        String getPropertyName() {
+            return propertyName
+        }
+    }
+
+    def "can compute objects with a 2 key map"() {
+        def flyweightMap = new FlyweightKit.BiKeyMap<String, String, CacheKey>()
+        when:
+        def cacheKey1 = flyweightMap.computeIfAbsent("classX", "foo", { k1, k2 -> new CacheKey(k1, k2) })
+
+        then:
+        cacheKey1.getClassName() == "classX"
+        cacheKey1.getPropertyName() == "foo"
+
+        when:
+        def cacheKey2 = flyweightMap.computeIfAbsent("classX", "foo", { k1, k2 -> new CacheKey(k1, k2) })
+
+        then:
+        cacheKey2 === cacheKey1
+
+        when:
+        def cacheKey3 = flyweightMap.computeIfAbsent("classY", "foo", { k1, k2 -> new CacheKey(k1, k2) })
+
+        then:
+        cacheKey3 !== cacheKey1
+        cacheKey3.getClassName() == "classY"
+        cacheKey3.getPropertyName() == "foo"
+
+        when:
+        def cacheKey4 = flyweightMap.computeIfAbsent("classY", "bar", { k1, k2 -> new CacheKey(k1, k2) })
+
+        then:
+        cacheKey4 !== cacheKey3
+        cacheKey4.getClassName() == "classY"
+        cacheKey4.getPropertyName() == "bar"
+
+        when:
+        def cacheKey5 = flyweightMap.computeIfAbsent("classY", "bar", { k1, k2 -> new CacheKey(k1, k2) })
+
+        then:
+        cacheKey5 === cacheKey4
+    }
+
+    def "can compute objects with a 3 key map"() {
+        def flyweightMap = new FlyweightKit.TriKeyMap<String, String, Integer, String>()
+
+        when:
+        def value1 = flyweightMap.computeIfAbsent("a", "x", 1, { k1, k2, k3 -> "$k1:$k2:$k3" })
+
+        then:
+        value1 == "a:x:1"
+
+        when:
+        def value2 = flyweightMap.computeIfAbsent("a", "x", 1, { k1, k2, k3 -> "$k1:$k2:$k3" })
+
+        then:
+        value2 == "a:x:1"
+        value2 === value1
+
+        when:
+        def value3 = flyweightMap.computeIfAbsent("a", "x", 2, { k1, k2, k3 -> "$k1:$k2:$k3" })
+
+        then:
+        value3 == "a:x:2"
+
+        when:
+        def value4 = flyweightMap.computeIfAbsent("b", "x", 1, { k1, k2, k3 -> "$k1:$k2:$k3" })
+
+        then:
+        value4 == "b:x:1"
+
+        when:
+        def value5 = flyweightMap.computeIfAbsent("b", "x", 2, { k1, k2, k3 -> "$k1:$k2:$k3" })
+
+        then:
+        value5 == "b:x:2"
+
+        when:
+        def value6 = flyweightMap.computeIfAbsent("b", "x", 2, { k1, k2, k3 -> "$k1:$k2:$k3" })
+
+        then:
+        value6 === value5
+    }
+}


### PR DESCRIPTION
I wanted to see if flyweight objects could be used for two very commonly created "cache key" objects, namely `CacheKey` and `FieldCoordinates`

This results in WAY less objects being allocated when they are used over and over with the same values.  So this is a nett saving in memory in a a called system that is loading the same logical objects over and over.  And this is likely to always be the case.

HOWEVER the thing happening here in terms of speed is

* how fast can Java allocate a new object
* vs
* how fast can it do 2 or 3 map lookups

And the answer to that is that new Java objects are **361%** faster than map lookups.

So this becomes a trade off between objects being allocated and cpu throughput

And its not worth taking - we should not merge this PR

However I wanted to create the PR to show my working


```
Benchmark                                                                      Mode  Cnt      Score     Error   Units
FlyWeightBenchmark.benchMarkDirectInstantiationThroughput                     thrpt    9    134.741 ±   0.299  ops/ms

FlyWeightBenchmark.benchMarkDirectInstantiationThroughput:gc.alloc.rate       thrpt    9   9251.771 ±  20.519  MB/sec
FlyWeightBenchmark.benchMarkDirectInstantiationThroughput:gc.alloc.rate.norm  thrpt    9  72000.029 ±   0.023    B/op
FlyWeightBenchmark.benchMarkDirectInstantiationThroughput:gc.count            thrpt    9   1400.000            counts
FlyWeightBenchmark.benchMarkDirectInstantiationThroughput:gc.time             thrpt    9    692.000                ms

FlyWeightBenchmark.benchMarkUsingFlyweightsThroughput                         thrpt    9     29.223 ±   0.761  ops/ms

FlyWeightBenchmark.benchMarkUsingFlyweightsThroughput:gc.alloc.rate           thrpt    9   2006.581 ±  52.273  MB/sec
FlyWeightBenchmark.benchMarkUsingFlyweightsThroughput:gc.alloc.rate.norm      thrpt    9  72000.132 ±   0.121    B/op
FlyWeightBenchmark.benchMarkUsingFlyweightsThroughput:gc.count                thrpt    9    596.000            counts
FlyWeightBenchmark.benchMarkUsingFlyweightsThroughput:gc.time                 thrpt    9    238.000                ms

FlyWeightBenchmark.benchMarkDirectInstantiationAvgTime                         avgt    9      0.008 ±   0.001   ms/op

FlyWeightBenchmark.benchMarkDirectInstantiationAvgTime:gc.alloc.rate           avgt    9   9071.949 ± 245.016  MB/sec
FlyWeightBenchmark.benchMarkDirectInstantiationAvgTime:gc.alloc.rate.norm      avgt    9  72000.042 ±   0.018    B/op
FlyWeightBenchmark.benchMarkDirectInstantiationAvgTime:gc.count                avgt    9   1154.000            counts
FlyWeightBenchmark.benchMarkDirectInstantiationAvgTime:gc.time                 avgt    9    805.000                ms

FlyWeightBenchmark.benchMarkUsingFlyweightsAveTime                             avgt    9      0.035 ±   0.001   ms/op

FlyWeightBenchmark.benchMarkUsingFlyweightsAveTime:gc.alloc.rate               avgt    9   1974.576 ±  72.272  MB/sec
FlyWeightBenchmark.benchMarkUsingFlyweightsAveTime:gc.alloc.rate.norm          avgt    9  72000.123 ±   0.133    B/op
FlyWeightBenchmark.benchMarkUsingFlyweightsAveTime:gc.count                    avgt    9    586.000            counts
FlyWeightBenchmark.benchMarkUsingFlyweightsAveTime:gc.time                     avgt    9    287.000                ms
```


Note here how its much slower in cpu terms but much more efficient in memory terms with a lot less GC happening