### PR TITLE
Retriveing singleton property fetchers will not create DataFetcherFactoryEnvironment objects

### DIFF
--- a/src/main/java/graphql/schema/SingletonPropertyDataFetcher.java
+++ b/src/main/java/graphql/schema/SingletonPropertyDataFetcher.java
@@ -15,7 +15,18 @@ public class SingletonPropertyDataFetcher<T> implements LightDataFetcher<T> {
 
     private static final SingletonPropertyDataFetcher<Object> SINGLETON_FETCHER = new SingletonPropertyDataFetcher<>();
 
-    private static final DataFetcherFactory<?> SINGLETON_FETCHER_FACTORY = environment -> SINGLETON_FETCHER;
+    private static final DataFetcherFactory<?> SINGLETON_FETCHER_FACTORY = new DataFetcherFactory<Object>() {
+        @SuppressWarnings("deprecation")
+        @Override
+        public DataFetcher<Object> get(DataFetcherFactoryEnvironment environment) {
+            return SINGLETON_FETCHER;
+        }
+
+        @Override
+        public DataFetcher<Object> get(GraphQLFieldDefinition fieldDefinition) {
+            return SINGLETON_FETCHER;
+        }
+    };
 
     /**
      * This returns the same singleton {@link LightDataFetcher} that fetches property values


### PR DESCRIPTION
This was always the intention here when we created https://github.com/graphql-java/graphql-java/pull/3754 to have a singleton property fetcher instance

However we didnt do the factory right and hence `DataFetcherFactoryEnvironment` are created when they dont need to be

This fixes on of the items found in https://github.com/graphql-java/graphql-java/issues/3939

Namely why was "graphql.schema.DataFetcherFactoryEnvironment"  being 2% of objects allocated

This fixes that

re : https://github.com/graphql-java/graphql-java/issues/3941