### PR TITLE
avoid wrapping materialized fieldValueObject in a CompletableFuture

### DIFF
--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -635,10 +635,13 @@ public abstract class ExecutionStrategy {
         );
 
         FieldValueInfo fieldValueInfo = completeValue(executionContext, newParameters);
-
-        CompletableFuture<Object> executionResultFuture = fieldValueInfo.getFieldValueFuture();
         ctxCompleteField.onDispatched();
-        executionResultFuture.whenComplete(ctxCompleteField::onCompleted);
+        if (fieldValueInfo.isFutureValue()) {
+            CompletableFuture<Object> executionResultFuture = fieldValueInfo.getFieldValueFuture();
+            executionResultFuture.whenComplete(ctxCompleteField::onCompleted);
+        } else {
+            ctxCompleteField.onCompleted(fieldValueInfo.getFieldValueObject(), null);
+        }
         return fieldValueInfo;
     }
 


### PR DESCRIPTION
While updating graphql-kotlin to graphql-java 23 found that `completeField` is still wrapping `FieldValueInfo.fieldValueObject` in a `CompletableFuture` for objects already materialized / in memory

this might be considered a follow up of the `Completable Future wrapping` change set that came in graphql-java 22
https://github.com/graphql-java/graphql-java/releases/tag/v22.0

I don't think this is a breaking change.