### PR TITLE
OSGI - Make org.jspecify.* imports optional

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -176,7 +176,7 @@ shadowJar {
     bnd('''
 -exportcontents: graphql.*
 -removeheaders: Private-Package
-Import-Package: !android.os.*,!com.google.*,!org.checkerframework.*,!javax.annotation.*,!graphql.com.google.*,!org.antlr.*,!graphql.org.antlr.*,!sun.misc.*,*
+Import-Package: !android.os.*,!com.google.*,!org.checkerframework.*,!javax.annotation.*,!graphql.com.google.*,!org.antlr.*,!graphql.org.antlr.*,!sun.misc.*,org.jspecify.*;resolution:=optional,*
 ''')
 }
 


### PR DESCRIPTION
Since org.specify import is not necessarily needed at runtime, can we make it optional?