### PR TITLE
Make JSpecify optional import more specific

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -176,7 +176,7 @@ shadowJar {
     bnd('''
 -exportcontents: graphql.*
 -removeheaders: Private-Package
-Import-Package: !android.os.*,!com.google.*,!org.checkerframework.*,!javax.annotation.*,!graphql.com.google.*,!org.antlr.*,!graphql.org.antlr.*,!sun.misc.*,org.jspecify.*;resolution:=optional,*
+Import-Package: !android.os.*,!com.google.*,!org.checkerframework.*,!javax.annotation.*,!graphql.com.google.*,!org.antlr.*,!graphql.org.antlr.*,!sun.misc.*,org.jspecify.annotations;resolution:=optional,*
 ''')
 }
 


### PR DESCRIPTION
Small change to bring this library in line with a recent change in DataLoader https://github.com/graphql-java/java-dataloader/pull/194/files