### PR TITLE
Avoid rare TCK test failure

### DIFF
--- a/src/test/groovy/graphql/execution/reactive/tck/CompletionStageMappingPublisherTckVerificationTest.java
+++ b/src/test/groovy/graphql/execution/reactive/tck/CompletionStageMappingPublisherTckVerificationTest.java
@@ -10,6 +10,7 @@ import org.testng.annotations.Test;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executors;
 import java.util.function.Function;
 
 /**
@@ -31,7 +32,7 @@ public class CompletionStageMappingPublisherTckVerificationTest extends Publishe
     @Override
     public Publisher<String> createPublisher(long elements) {
         Publisher<Integer> publisher = Flowable.range(0, (int) elements);
-        Function<Integer, CompletionStage<String>> mapper = i -> CompletableFuture.supplyAsync(() -> i + "!");
+        Function<Integer, CompletionStage<String>> mapper = i -> CompletableFuture.supplyAsync(() -> i + "!", Executors.newSingleThreadExecutor());
         return new CompletionStageMappingPublisher<>(publisher, mapper);
     }
 


### PR DESCRIPTION
use always a new thread for the tck verification as the TCK uses thread locals to track things, which can cause tests failure in rare cases