### PR TITLE
Add ArchUnit rule to ban javax & JetBrains nullability annotations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -176,7 +176,7 @@ shadowJar {
     bnd('''
 -exportcontents: graphql.*
 -removeheaders: Private-Package
-Import-Package: !android.os.*,!com.google.*,!org.checkerframework.*,!javax.annotation.*,!graphql.com.google.*,!org.antlr.*,!graphql.org.antlr.*,!sun.misc.*,org.jspecify.annotations;resolution:=optional,*
+Import-Package: !android.os.*,!com.google.*,!org.checkerframework.*,!graphql.com.google.*,!org.antlr.*,!graphql.org.antlr.*,!sun.misc.*,org.jspecify.annotations;resolution:=optional,*
 ''')
 }
 

--- a/src/test/groovy/graphql/AnnotationUsageTest.groovy
+++ b/src/test/groovy/graphql/AnnotationUsageTest.groovy
@@ -1,0 +1,40 @@
+package graphql
+
+import com.tngtech.archunit.core.domain.JavaClasses
+import com.tngtech.archunit.core.importer.ClassFileImporter
+import com.tngtech.archunit.core.importer.ImportOption
+import com.tngtech.archunit.lang.ArchRule
+import com.tngtech.archunit.lang.EvaluationResult
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition
+import spock.lang.Specification
+
+class AnnotationUsageTest extends Specification {
+
+    private static final JavaClasses importedClasses = new ClassFileImporter()
+            .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+            .importPackages("graphql")
+
+    def "should only use JSpecify nullability annotations"() {
+        given:
+        ArchRule dependencyRule = ArchRuleDefinition.noClasses()
+                .should()
+                .dependOnClassesThat()
+                .resideInAnyPackage(
+                        "javax.annotation",
+                        "org.jetbrains.annotations"
+                )
+                .because("We are using JSpecify nullability annotations only. Please change to use JSpecify.")
+
+        when:
+        EvaluationResult result = dependencyRule.evaluate(importedClasses)
+
+        then:
+        if (result.hasViolation()) {
+            println "We are using JSpecify nullability annotations only. Please change the following to use JSpecify instead:"
+            result.getFailureReport().getDetails().each { violation ->
+                println "- ${violation}"
+            }
+        }
+        !result.hasViolation()
+    }
+} 


### PR DESCRIPTION
Going forward we will be using JSpecify Nullability annotations.

It's possible to accidentally pull in the old javax Nullability annotations because this doesn't need any changes to our build.gradle dependencies.

While it's unlikely someone would accidentally add JetBrains Nullability annotations, because these require a new dependency to be added, I have also banned them.

Sample test output when a banned usage is found:
```
We are using JSpecify nullability annotations only. Please change the following to use JSpecify instead:
- Parameter <java.util.concurrent.CompletableFuture<T>> of method <graphql.execution.Async.orNullCompletedFuture(java.util.concurrent.CompletableFuture)> is annotated with <javax.annotation.Nullable> in (Async.java:0)
```