### PR TITLE
deterministic SourceLocation serialization

### DIFF
--- a/src/main/java/graphql/GraphqlErrorHelper.java
+++ b/src/main/java/graphql/GraphqlErrorHelper.java
@@ -73,7 +73,10 @@ public class GraphqlErrorHelper {
         if (line < 1 || column < 1) {
             return null;
         }
-        return Map.of("line", line, "column", column);
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>(2);
+        map.put("line", line);
+        map.put("column", column);
+        return map;
     }
 
     static List<GraphQLError> fromSpecification(List<Map<String, Object>> specificationMaps) {

--- a/src/test/groovy/graphql/GraphqlErrorHelperTest.groovy
+++ b/src/test/groovy/graphql/GraphqlErrorHelperTest.groovy
@@ -3,6 +3,7 @@ package graphql
 import graphql.language.SourceLocation
 import graphql.validation.ValidationError
 import graphql.validation.ValidationErrorType
+import spock.lang.RepeatUntilFailure
 import spock.lang.Specification
 
 class GraphqlErrorHelperTest extends Specification {
@@ -120,7 +121,7 @@ class GraphqlErrorHelperTest extends Specification {
 
         when:
         rawError = [message: "m"]
-        graphQLError = GraphQLError.fromSpecification(rawError) // just so we reference the public method
+        graphQLError = GraphQLError.fromSpecification(rawError) // vso we reference the public method
         then:
         graphQLError.getMessage() == "m"
         graphQLError.getErrorType() == ErrorType.DataFetchingException // default from error builder
@@ -153,5 +154,16 @@ class GraphqlErrorHelperTest extends Specification {
             assert gErr.getPath() == null
             assert gErr.getExtensions() == null
         }
+    }
+
+    @RepeatUntilFailure(maxAttempts = 1_000)
+    def "can deterministically serialize SourceLocation"() {
+        when:
+        def specMap = GraphqlErrorHelper.toSpecification(new TestError())
+
+        then:
+        def location = specMap["locations"][0] as Map<String, Object>
+        def keys = location.keySet().toList()
+        keys == ["line", "column"]
     }
 }

--- a/src/test/groovy/graphql/GraphqlErrorHelperTest.groovy
+++ b/src/test/groovy/graphql/GraphqlErrorHelperTest.groovy
@@ -121,7 +121,7 @@ class GraphqlErrorHelperTest extends Specification {
 
         when:
         rawError = [message: "m"]
-        graphQLError = GraphQLError.fromSpecification(rawError) // vso we reference the public method
+        graphQLError = GraphQLError.fromSpecification(rawError) // just so we reference the public method
         then:
         graphQLError.getMessage() == "m"
         graphQLError.getErrorType() == ErrorType.DataFetchingException // default from error builder


### PR DESCRIPTION
In upgrading from 22.3 to 24.0, some of our tests that make assertions on serialized responses started failing.

I think this was probably caused by [#3753](https://github.com/graphql-java/graphql-java/pull/3753/files#r1855350447), which changed the serialized representation from a LinkedHashMap to a `Map.of`, which has [randomized iteration order](https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/util/ImmutableCollections.java#L62-L68). This PR brings back the LinkedHashMap serialization format.

I'd appreciate some feedback on this! While the spec doesn't describe how the fields of an error should be ordered, non-deterministic ordering can make it difficult to build reliable tests that interact with GraphQL errors. 
