### PR TITLE
bugfix: fix mutations data loading dispatching when defer is enabled

### DIFF
--- a/src/main/java/graphql/execution/instrumentation/dataloader/PerLevelDataLoaderDispatchStrategyWithDeferAlwaysDispatch.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/PerLevelDataLoaderDispatchStrategyWithDeferAlwaysDispatch.java
@@ -44,46 +44,72 @@ public class PerLevelDataLoaderDispatchStrategyWithDeferAlwaysDispatch implement
         private final LockKit.ReentrantLock lock = new LockKit.ReentrantLock();
         private final LevelMap expectedFetchCountPerLevel = new LevelMap();
         private final LevelMap fetchCountPerLevel = new LevelMap();
-        private final LevelMap expectedStrategyCallsPerLevel = new LevelMap();
-        private final LevelMap happenedStrategyCallsPerLevel = new LevelMap();
+
+        private final LevelMap expectedExecuteObjectCallsPerLevel = new LevelMap();
+        private final LevelMap happenedExecuteObjectCallsPerLevel = new LevelMap();
+
         private final LevelMap happenedOnFieldValueCallsPerLevel = new LevelMap();
 
         private final Set<Integer> dispatchedLevels = new LinkedHashSet<>();
 
         public CallStack() {
-            expectedStrategyCallsPerLevel.set(1, 1);
+            expectedExecuteObjectCallsPerLevel.set(1, 1);
         }
 
         void increaseExpectedFetchCount(int level, int count) {
             expectedFetchCountPerLevel.increment(level, count);
         }
 
+        void clearExpectedFetchCount() {
+            expectedFetchCountPerLevel.clear();
+        }
+
         void increaseFetchCount(int level) {
             fetchCountPerLevel.increment(level, 1);
         }
 
-        void increaseExpectedStrategyCalls(int level, int count) {
-            expectedStrategyCallsPerLevel.increment(level, count);
+        void clearFetchCount() {
+            fetchCountPerLevel.clear();
         }
 
-        void increaseHappenedStrategyCalls(int level) {
-            happenedStrategyCallsPerLevel.increment(level, 1);
+        void increaseExpectedExecuteObjectCalls(int level, int count) {
+            expectedExecuteObjectCallsPerLevel.increment(level, count);
+        }
+
+        void clearExpectedObjectCalls() {
+            expectedExecuteObjectCallsPerLevel.clear();
+        }
+
+        void increaseHappenedExecuteObjectCalls(int level) {
+            happenedExecuteObjectCallsPerLevel.increment(level, 1);
+        }
+
+        void clearHappenedExecuteObjectCalls() {
+            happenedExecuteObjectCallsPerLevel.clear();
         }
 
         void increaseHappenedOnFieldValueCalls(int level) {
             happenedOnFieldValueCallsPerLevel.increment(level, 1);
         }
 
-        boolean allStrategyCallsHappened(int level) {
-            return happenedStrategyCallsPerLevel.get(level) == expectedStrategyCallsPerLevel.get(level);
+        void clearHappenedOnFieldValueCalls() {
+            happenedOnFieldValueCallsPerLevel.clear();
+        }
+
+        boolean allExecuteObjectCallsHappened(int level) {
+            return happenedExecuteObjectCallsPerLevel.get(level) == expectedExecuteObjectCallsPerLevel.get(level);
         }
 
         boolean allOnFieldCallsHappened(int level) {
-            return happenedOnFieldValueCallsPerLevel.get(level) == expectedStrategyCallsPerLevel.get(level);
+            return happenedOnFieldValueCallsPerLevel.get(level) == expectedExecuteObjectCallsPerLevel.get(level);
         }
 
         boolean allFetchesHappened(int level) {
             return fetchCountPerLevel.get(level) == expectedFetchCountPerLevel.get(level);
+        }
+
+        void clearDispatchLevels() {
+            dispatchedLevels.clear();
         }
 
         @Override
@@ -91,8 +117,8 @@ public class PerLevelDataLoaderDispatchStrategyWithDeferAlwaysDispatch implement
             return "CallStack{" +
                     "expectedFetchCountPerLevel=" + expectedFetchCountPerLevel +
                     ", fetchCountPerLevel=" + fetchCountPerLevel +
-                    ", expectedStrategyCallsPerLevel=" + expectedStrategyCallsPerLevel +
-                    ", happenedStrategyCallsPerLevel=" + happenedStrategyCallsPerLevel +
+                    ", expectedExecuteObjectCallsPerLevel=" + expectedExecuteObjectCallsPerLevel +
+                    ", happenedExecuteObjectCallsPerLevel=" + happenedExecuteObjectCallsPerLevel +
                     ", happenedOnFieldValueCallsPerLevel=" + happenedOnFieldValueCallsPerLevel +
                     ", dispatchedLevels" + dispatchedLevels +
                     '}';
@@ -125,16 +151,14 @@ public class PerLevelDataLoaderDispatchStrategyWithDeferAlwaysDispatch implement
             return;
         }
         int curLevel = parameters.getExecutionStepInfo().getPath().getLevel() + 1;
-        increaseCallCounts(curLevel, parameters);
+        increaseHappenedExecuteObjectAndIncreaseExpectedFetchCount(curLevel, parameters);
+
     }
 
     @Override
-    public void executeObject(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
-        if (this.startedDeferredExecution.get()) {
-            return;
-        }
-        int curLevel = parameters.getExecutionStepInfo().getPath().getLevel() + 1;
-        increaseCallCounts(curLevel, parameters);
+    public void executionSerialStrategy(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
+        resetCallStack();
+        increaseHappenedExecuteObjectAndIncreaseExpectedFetchCount(1, 1);
     }
 
     @Override
@@ -145,12 +169,23 @@ public class PerLevelDataLoaderDispatchStrategyWithDeferAlwaysDispatch implement
         onFieldValuesInfoDispatchIfNeeded(fieldValueInfoList, 1);
     }
 
-    @Override
     public void executionStrategyOnFieldValuesException(Throwable t) {
         callStack.lock.runLocked(() ->
                 callStack.increaseHappenedOnFieldValueCalls(1)
         );
     }
+
+
+    @Override
+    public void executeObject(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
+        if (this.startedDeferredExecution.get()) {
+            return;
+        }
+        int curLevel = parameters.getExecutionStepInfo().getPath().getLevel() + 1;
+        increaseHappenedExecuteObjectAndIncreaseExpectedFetchCount(curLevel, parameters);
+    }
+
+
 
     @Override
     public void executeObjectOnFieldValuesInfo(List<FieldValueInfo> fieldValueInfoList, ExecutionStrategyParameters parameters) {
@@ -170,45 +205,34 @@ public class PerLevelDataLoaderDispatchStrategyWithDeferAlwaysDispatch implement
         );
     }
 
-    @Override
-    public void fieldFetched(ExecutionContext executionContext,
-                             ExecutionStrategyParameters parameters,
-                             DataFetcher<?> dataFetcher,
-                             Object fetchedValue) {
-
-        final boolean dispatchNeeded;
-
-        if (parameters.getField().isDeferred() || this.startedDeferredExecution.get()) {
-            this.startedDeferredExecution.set(true);
-            dispatchNeeded = true;
-        } else {
-            int level = parameters.getPath().getLevel();
-            dispatchNeeded = callStack.lock.callLocked(() -> {
-                callStack.increaseFetchCount(level);
-                return dispatchIfNeeded(level);
-            });
-        }
-
-        if (dispatchNeeded) {
-            dispatch();
-        }
-
-    }
-
-    private void increaseCallCounts(int curLevel, ExecutionStrategyParameters parameters) {
-        int count = 0;
+    private void increaseHappenedExecuteObjectAndIncreaseExpectedFetchCount(int curLevel, ExecutionStrategyParameters parameters) {
+        int nonDeferredFields = 0;
         for (MergedField field : parameters.getFields().getSubFieldsList()) {
             if (!field.isDeferred()) {
-                count++;
+                nonDeferredFields++;
             }
         }
-        int nonDeferredFieldCount = count;
+        increaseHappenedExecuteObjectAndIncreaseExpectedFetchCount(curLevel, nonDeferredFields);
+    }
+
+    private void increaseHappenedExecuteObjectAndIncreaseExpectedFetchCount(int curLevel, int fieldCount) {
         callStack.lock.runLocked(() -> {
-            callStack.increaseExpectedFetchCount(curLevel, nonDeferredFieldCount);
-            callStack.increaseHappenedStrategyCalls(curLevel);
+            callStack.increaseHappenedExecuteObjectCalls(curLevel);
+            callStack.increaseExpectedFetchCount(curLevel, fieldCount);
         });
     }
 
+    private void resetCallStack() {
+        callStack.lock.runLocked(() -> {
+            callStack.clearDispatchLevels();
+            callStack.clearExpectedObjectCalls();
+            callStack.clearExpectedFetchCount();
+            callStack.clearFetchCount();
+            callStack.clearHappenedExecuteObjectCalls();
+            callStack.clearHappenedOnFieldValueCalls();
+            callStack.expectedExecuteObjectCallsPerLevel.set(1, 1);
+        });
+    }
     private void onFieldValuesInfoDispatchIfNeeded(List<FieldValueInfo> fieldValueInfoList, int curLevel) {
         boolean dispatchNeeded = callStack.lock.callLocked(() ->
                 handleOnFieldValuesInfo(fieldValueInfoList, curLevel)
@@ -223,22 +247,52 @@ public class PerLevelDataLoaderDispatchStrategyWithDeferAlwaysDispatch implement
     //
     private boolean handleOnFieldValuesInfo(List<FieldValueInfo> fieldValueInfos, int curLevel) {
         callStack.increaseHappenedOnFieldValueCalls(curLevel);
-        int expectedStrategyCalls = getCountForList(fieldValueInfos);
-        callStack.increaseExpectedStrategyCalls(curLevel + 1, expectedStrategyCalls);
+        int expectedStrategyCalls = getObjectCountForList(fieldValueInfos);
+        callStack.increaseExpectedExecuteObjectCalls(curLevel + 1, expectedStrategyCalls);
         return dispatchIfNeeded(curLevel + 1);
     }
 
-    private int getCountForList(List<FieldValueInfo> fieldValueInfos) {
+    /**
+     * the amount of (non nullable) objects that will require an execute object call
+     */
+    private int getObjectCountForList(List<FieldValueInfo> fieldValueInfos) {
         int result = 0;
         for (FieldValueInfo fieldValueInfo : fieldValueInfos) {
             if (fieldValueInfo.getCompleteValueType() == FieldValueInfo.CompleteValueType.OBJECT) {
                 result += 1;
             } else if (fieldValueInfo.getCompleteValueType() == FieldValueInfo.CompleteValueType.LIST) {
-                result += getCountForList(fieldValueInfo.getFieldValueInfos());
+                result += getObjectCountForList(fieldValueInfo.getFieldValueInfos());
             }
         }
         return result;
     }
+
+
+    @Override
+    public void fieldFetched(ExecutionContext executionContext,
+                             ExecutionStrategyParameters executionStrategyParameters,
+                             DataFetcher<?> dataFetcher,
+                             Object fetchedValue) {
+
+        final boolean dispatchNeeded;
+
+        if (executionStrategyParameters.getField().isDeferred() || this.startedDeferredExecution.get()) {
+            this.startedDeferredExecution.set(true);
+            dispatchNeeded = true;
+        } else {
+            int level = executionStrategyParameters.getPath().getLevel();
+            dispatchNeeded = callStack.lock.callLocked(() -> {
+                callStack.increaseFetchCount(level);
+                return dispatchIfNeeded(level);
+            });
+        }
+
+        if (dispatchNeeded) {
+            dispatch();
+        }
+
+    }
+
 
     //
     // thread safety : called with callStack.lock
@@ -260,7 +314,7 @@ public class PerLevelDataLoaderDispatchStrategyWithDeferAlwaysDispatch implement
             return callStack.allFetchesHappened(1);
         }
         if (levelReady(level - 1) && callStack.allOnFieldCallsHappened(level - 1)
-                && callStack.allStrategyCallsHappened(level) && callStack.allFetchesHappened(level)) {
+                && callStack.allExecuteObjectCallsHappened(level) && callStack.allFetchesHappened(level)) {
 
             return true;
         }


### PR DESCRIPTION
This is a port of the mutation data loading #3737 for the case when defer is enabled.

When defer is enabled and dataloading is used for mutations the execution will hang and the dataloader will not be dispatched. Important that defer only needs to be enabled, even when there is no defer used, this bug occurs. 

This is a special fix for 24: On master (next release of GJ) we will not have any separate dispatching strategy anymore for defer and this bug doesn't exist.