### PR TITLE
A few adjustments in the QueryGenerator util

### DIFF
--- a/src/main/java/graphql/util/querygenerator/QueryGenerator.java
+++ b/src/main/java/graphql/util/querygenerator/QueryGenerator.java
@@ -8,6 +8,8 @@ import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLOutputType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLUnionType;
+import graphql.util.querygenerator.QueryGeneratorFieldSelection.FieldSelection;
+import graphql.util.querygenerator.QueryGeneratorFieldSelection.FieldSelectionResult;
 import org.jspecify.annotations.Nullable;
 
 import java.util.stream.Stream;
@@ -29,6 +31,18 @@ public class QueryGenerator {
     private final GraphQLSchema schema;
     private final QueryGeneratorFieldSelection fieldSelectionGenerator;
     private final QueryGeneratorPrinter printer;
+
+
+    /**
+     * Constructor for QueryGenerator using default options.
+     *
+     * @param schema the GraphQL schema
+     */
+    public QueryGenerator(GraphQLSchema schema) {
+        this.schema = schema;
+        this.fieldSelectionGenerator = new QueryGeneratorFieldSelection(schema, QueryGeneratorOptions.newBuilder().build());
+        this.printer = new QueryGeneratorPrinter();
+    }
 
     /**
      * Constructor for QueryGenerator.
@@ -54,22 +68,22 @@ public class QueryGenerator {
      * <p>
      * arguments are optional. When passed, the generated query will contain that value in the arguments.
      * <p>
-     * typeClassifier is optional. It should not be passed in when the field in the path is an object type, and it
+     * typeName is optional. It should not be passed in when the field in the path is an object type, and it
      * **should** be passed when the field in the path is an interface or union type. In the latter case, its value
      * should be an object type that is part of the union or implements the interface.
      *
      * @param operationFieldPath the operation field path (e.g., "Query.user", "Mutation.createUser", "Subscription.userCreated")
      * @param operationName optional: the operation name (e.g., "getUser")
      * @param arguments optional: the arguments for the operation in a plain text form (e.g., "(id: 1)")
-     * @param typeClassifier optional: the type classifier for union or interface types (e.g., "FirstPartyUser")
+     * @param typeName optional: the type name for when operationFieldPath points to a field of union or interface types (e.g., "FirstPartyUser")
      *
-     * @return the generated GraphQL query string
+     * @return a QueryGeneratorResult containing the generated query string and additional information
      */
-    public String generateQuery(
+    public QueryGeneratorResult generateQuery(
             String operationFieldPath,
             @Nullable String operationName,
             @Nullable String arguments,
-            @Nullable String typeClassifier
+            @Nullable String typeName
     ) {
         String[] fieldParts = operationFieldPath.split("\\.");
         String operation = fieldParts[0];
@@ -109,23 +123,23 @@ public class QueryGenerator {
         final GraphQLFieldsContainer lastFieldContainer;
 
         if (lastType instanceof GraphQLObjectType) {
-            if (typeClassifier != null) {
-                throw new IllegalArgumentException("typeClassifier should be used only with interface or union types");
+            if (typeName != null) {
+                throw new IllegalArgumentException("typeName should be used only with interface or union types");
             }
             lastFieldContainer = (GraphQLObjectType) lastType;
         } else if (lastType instanceof GraphQLUnionType) {
-            if (typeClassifier == null) {
-                throw new IllegalArgumentException("typeClassifier is required for union types");
+            if (typeName == null) {
+                throw new IllegalArgumentException("typeName is required for union types");
             }
             lastFieldContainer = ((GraphQLUnionType) lastType).getTypes().stream()
                     .filter(GraphQLFieldsContainer.class::isInstance)
                     .map(GraphQLFieldsContainer.class::cast)
-                    .filter(type -> type.getName().equals(typeClassifier))
+                    .filter(type -> type.getName().equals(typeName))
                     .findFirst()
-                    .orElseThrow(() -> new IllegalArgumentException("Type " + typeClassifier + " not found in union " + ((GraphQLUnionType) lastType).getName()));
+                    .orElseThrow(() -> new IllegalArgumentException("Type " + typeName + " not found in union " + ((GraphQLUnionType) lastType).getName()));
         } else if (lastType instanceof GraphQLInterfaceType) {
-            if (typeClassifier == null) {
-                throw new IllegalArgumentException("typeClassifier is required for interface types");
+            if (typeName == null) {
+                throw new IllegalArgumentException("typeName is required for interface types");
             }
             Stream<GraphQLFieldsContainer> fieldsContainerStream = Stream.concat(
                     Stream.of((GraphQLInterfaceType) lastType),
@@ -133,15 +147,23 @@ public class QueryGenerator {
             );
 
             lastFieldContainer = fieldsContainerStream
-                    .filter(type -> type.getName().equals(typeClassifier))
+                    .filter(type -> type.getName().equals(typeName))
                     .findFirst()
-                    .orElseThrow(() -> new IllegalArgumentException("Type " + typeClassifier + " not found in interface " + ((GraphQLInterfaceType) lastType).getName()));
+                    .orElseThrow(() -> new IllegalArgumentException("Type " + typeName + " not found in interface " + ((GraphQLInterfaceType) lastType).getName()));
         } else {
             throw new IllegalArgumentException("Type " + lastType + " is not a field container");
         }
 
-        QueryGeneratorFieldSelection.FieldSelection rootFieldSelection = fieldSelectionGenerator.buildFields(lastFieldContainer);
+        FieldSelectionResult fieldSelectionResult = fieldSelectionGenerator.buildFields(lastFieldContainer);
+        FieldSelection rootFieldSelection = fieldSelectionResult.rootFieldSelection;
 
-        return printer.print(operationFieldPath, operationName, arguments, rootFieldSelection);
+        String query = printer.print(operationFieldPath, operationName, arguments, rootFieldSelection);
+
+        return new QueryGeneratorResult(
+                query,
+                lastFieldContainer.getName(),
+                fieldSelectionResult.totalFieldCount,
+                fieldSelectionResult.reachedMaxFieldCount
+        );
     }
 }

--- a/src/main/java/graphql/util/querygenerator/QueryGenerator.java
+++ b/src/main/java/graphql/util/querygenerator/QueryGenerator.java
@@ -7,6 +7,7 @@ import graphql.schema.GraphQLInterfaceType;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLOutputType;
 import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLTypeUtil;
 import graphql.schema.GraphQLUnionType;
 import graphql.util.querygenerator.QueryGeneratorFieldSelection.FieldSelection;
 import graphql.util.querygenerator.QueryGeneratorFieldSelection.FieldSelectionResult;
@@ -118,7 +119,7 @@ public class QueryGenerator {
         }
 
         // last field may be an object, interface or union type
-        GraphQLOutputType lastType = lastFieldDefinition.getType();
+        GraphQLOutputType lastType = GraphQLTypeUtil.unwrapAllAs(lastFieldDefinition.getType());
 
         final GraphQLFieldsContainer lastFieldContainer;
 

--- a/src/main/java/graphql/util/querygenerator/QueryGeneratorResult.java
+++ b/src/main/java/graphql/util/querygenerator/QueryGeneratorResult.java
@@ -42,10 +42,20 @@ public class QueryGeneratorResult {
         return usedType;
     }
 
+    /**
+     * Returns the total number of fields that were considered during query generation.
+     *
+     * @return the total field count
+     */
     public int getTotalFieldCount() {
         return totalFieldCount;
     }
 
+    /**
+     * Indicates whether the maximum field count was reached during query generation.
+     *
+     * @return true if the maximum field count was reached, false otherwise
+     */
     public boolean isReachedMaxFieldCount() {
         return reachedMaxFieldCount;
     }

--- a/src/main/java/graphql/util/querygenerator/QueryGeneratorResult.java
+++ b/src/main/java/graphql/util/querygenerator/QueryGeneratorResult.java
@@ -1,0 +1,52 @@
+package graphql.util.querygenerator;
+
+import graphql.ExperimentalApi;
+
+/**
+ * Represents the result of a query generation process.
+ */
+@ExperimentalApi
+public class QueryGeneratorResult {
+    private final String query;
+    private final String usedType;
+    private final int totalFieldCount;
+    private final boolean reachedMaxFieldCount;
+
+    public QueryGeneratorResult(
+            String query,
+            String usedType,
+            int totalFieldCount,
+            boolean reachedMaxFieldCount
+    ) {
+        this.query = query;
+        this.usedType = usedType;
+        this.totalFieldCount = totalFieldCount;
+        this.reachedMaxFieldCount = reachedMaxFieldCount;
+    }
+
+    /**
+     * Returns the generated query string.
+     *
+     * @return the query string
+     */
+    public String getQuery() {
+        return query;
+    }
+
+    /**
+     * Returns the type that ultimately was used to generate the query.
+     *
+     * @return the used type
+     */
+    public String getUsedType() {
+        return usedType;
+    }
+
+    public int getTotalFieldCount() {
+        return totalFieldCount;
+    }
+
+    public boolean isReachedMaxFieldCount() {
+        return reachedMaxFieldCount;
+    }
+}

--- a/src/test/groovy/graphql/util/querygenerator/QueryGeneratorTest.groovy
+++ b/src/test/groovy/graphql/util/querygenerator/QueryGeneratorTest.groovy
@@ -84,6 +84,69 @@ query barTestOperation {
         assertNotNull(result)
     }
 
+
+    def "generate query field of list type"() {
+        given:
+        def schema = """
+        type Query {
+            allBars: [Bar]
+        }
+        
+        type Bar {
+           id: ID!
+           name: String
+        }
+"""
+
+        def fieldPath = "Query.allBars"
+        when:
+        def expectedNoOperation = """
+{
+  allBars {
+    ... on Bar {
+      id
+      name
+    }
+  }
+}"""
+
+        def result = executeTest(schema, fieldPath, expectedNoOperation)
+
+        then:
+        assertNotNull(result)
+    }
+
+    def "generate query field of non-nullable type"() {
+        given:
+        def schema = """
+        type Query {
+            bar: Bar 
+        }
+        
+        type Bar {
+           id: ID!
+           name: String
+        }
+"""
+
+        def fieldPath = "Query.bar"
+        when:
+        def expectedNoOperation = """
+{
+  bar {
+    ... on Bar {
+      id
+      name
+    }
+  }
+}"""
+
+        def result = executeTest(schema, fieldPath, expectedNoOperation)
+
+        then:
+        assertNotNull(result)
+    }
+
     def "generate query for type with nested type"() {
         given:
         def schema = """


### PR DESCRIPTION
- add constructor with default options
- rename `typeClassifier` to `typeName`
- return data structure containing the generated query + useful information about the execution