### PR TITLE
Performance issue in `makeSchema` with schemas containing a lot of extensions

### DIFF
--- a/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
+++ b/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
@@ -112,6 +112,7 @@ public class SchemaGeneratorHelper {
      */
     static class BuildContext {
         private final TypeDefinitionRegistry typeRegistry;
+        private final Map<String, List<ObjectTypeExtensionDefinition>> objectTypeExtensions;
         private final RuntimeWiring wiring;
         private final Deque<String> typeStack = new ArrayDeque<>();
 
@@ -125,6 +126,7 @@ public class SchemaGeneratorHelper {
 
         BuildContext(TypeDefinitionRegistry typeRegistry, RuntimeWiring wiring, Map<String, OperationTypeDefinition> operationTypeDefinitions, SchemaGenerator.Options options) {
             this.typeRegistry = typeRegistry;
+            this.objectTypeExtensions = typeRegistry.objectTypeExtensions();
             this.wiring = wiring;
             this.codeRegistry = GraphQLCodeRegistry.newCodeRegistry(wiring.getCodeRegistry());
             this.operationTypeDefs = operationTypeDefinitions;
@@ -981,7 +983,7 @@ public class SchemaGeneratorHelper {
     }
 
     List<ObjectTypeExtensionDefinition> objectTypeExtensions(ObjectTypeDefinition typeDefinition, BuildContext buildCtx) {
-        return buildCtx.getTypeRegistry().objectTypeExtensions().getOrDefault(typeDefinition.getName(), emptyList());
+        return buildCtx.objectTypeExtensions.getOrDefault(typeDefinition.getName(), emptyList());
     }
 
     List<UnionTypeExtensionDefinition> unionTypeExtensions(UnionTypeDefinition typeDefinition, BuildContext buildCtx) {


### PR DESCRIPTION
For schemas with a large amount of object extensions, `makeSchema` can allocate a lot of memory due to the immutable nature of `TypeRegistry.*extensions()`.

The main culprit is `src/main/java/graphql/schema/idl/ImplementingTypesChecker.java` which repeatedly calls `objectTypeExtensions` and `interfaceTypeExtensions`. (first commit)

`buildObjectType` is also an issue. (second commit).

First commit fix on `ImplementingTypesChecker` should make a lot of sense, but for `buildObjectType`, I'd love your opinions. I can cache all kinds of extensions on `BuildContext` (only did object type for now, as that was our issue).

Can also discuss if there should be cheaper getters on `TypeRegistry`. I welcome your thoughts!