### PR TITLE
Added a read only copy of a type registry for performance reasons

### DIFF
--- a/src/main/java/graphql/schema/idl/ImmutableTypeDefinitionRegistry.java
+++ b/src/main/java/graphql/schema/idl/ImmutableTypeDefinitionRegistry.java
@@ -1,0 +1,132 @@
+package graphql.schema.idl;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import graphql.GraphQLError;
+import graphql.PublicApi;
+import graphql.language.DirectiveDefinition;
+import graphql.language.EnumTypeExtensionDefinition;
+import graphql.language.InputObjectTypeExtensionDefinition;
+import graphql.language.InterfaceTypeExtensionDefinition;
+import graphql.language.ObjectTypeExtensionDefinition;
+import graphql.language.SDLDefinition;
+import graphql.language.ScalarTypeDefinition;
+import graphql.language.ScalarTypeExtensionDefinition;
+import graphql.language.SchemaExtensionDefinition;
+import graphql.language.TypeDefinition;
+import graphql.language.UnionTypeExtensionDefinition;
+import graphql.schema.idl.errors.SchemaProblem;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.collect.ImmutableMap.copyOf;
+
+/**
+ * A {@link ImmutableTypeDefinitionRegistry} contains an immutable set of type definitions that come from compiling
+ * a graphql schema definition file via {@link SchemaParser#parse(String)} and is more performant because it
+ * uses {@link ImmutableMap} structures.
+ */
+@SuppressWarnings("rawtypes")
+@PublicApi
+@NullMarked
+public class ImmutableTypeDefinitionRegistry extends TypeDefinitionRegistry {
+    ImmutableTypeDefinitionRegistry(TypeDefinitionRegistry registry) {
+        super(
+                copyOf(registry.objectTypeExtensions),
+                copyOf(registry.interfaceTypeExtensions),
+                copyOf(registry.unionTypeExtensions),
+                copyOf(registry.enumTypeExtensions),
+                copyOf(registry.scalarTypeExtensions),
+                copyOf(registry.inputObjectTypeExtensions),
+                copyOf(registry.types),
+                copyOf(registry.scalars()), // has an extra side effect
+                copyOf(registry.directiveDefinitions),
+                ImmutableList.copyOf(registry.schemaExtensionDefinitions),
+                registry.schema,
+                registry.schemaParseOrder
+        );
+    }
+
+    private UnsupportedOperationException unsupportedOperationException() {
+        return new UnsupportedOperationException("The TypeDefinitionRegistry is in read only mode");
+    }
+
+    @Override
+    public TypeDefinitionRegistry merge(TypeDefinitionRegistry typeRegistry) throws SchemaProblem {
+        throw unsupportedOperationException();
+    }
+
+    @Override
+    public Optional<GraphQLError> addAll(Collection<SDLDefinition> definitions) {
+        throw unsupportedOperationException();
+    }
+
+    @Override
+    public Optional<GraphQLError> add(SDLDefinition definition) {
+        throw unsupportedOperationException();
+    }
+
+    @Override
+    public void remove(SDLDefinition definition) {
+        throw unsupportedOperationException();
+    }
+
+    @Override
+    public void remove(String key, SDLDefinition definition) {
+        throw unsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, TypeDefinition> types() {
+        return types;
+    }
+
+    @Override
+    public Map<String, ScalarTypeDefinition> scalars() {
+        return scalarTypes;
+    }
+
+    @Override
+    public Map<String, List<ObjectTypeExtensionDefinition>> objectTypeExtensions() {
+        return objectTypeExtensions;
+    }
+
+    @Override
+    public Map<String, List<InterfaceTypeExtensionDefinition>> interfaceTypeExtensions() {
+        return interfaceTypeExtensions;
+    }
+
+    @Override
+    public Map<String, List<UnionTypeExtensionDefinition>> unionTypeExtensions() {
+        return unionTypeExtensions;
+    }
+
+    @Override
+    public Map<String, List<EnumTypeExtensionDefinition>> enumTypeExtensions() {
+        return enumTypeExtensions;
+    }
+
+    @Override
+    public Map<String, List<ScalarTypeExtensionDefinition>> scalarTypeExtensions() {
+        return scalarTypeExtensions;
+    }
+
+    @Override
+    public Map<String, List<InputObjectTypeExtensionDefinition>> inputObjectTypeExtensions() {
+        return inputObjectTypeExtensions;
+    }
+
+    @Override
+    public List<SchemaExtensionDefinition> getSchemaExtensionDefinitions() {
+        return schemaExtensionDefinitions;
+    }
+
+    @Override
+    public Map<String, DirectiveDefinition> getDirectiveDefinitions() {
+        return directiveDefinitions;
+    }
+}

--- a/src/main/java/graphql/schema/idl/SchemaGenerator.java
+++ b/src/main/java/graphql/schema/idl/SchemaGenerator.java
@@ -103,17 +103,19 @@ public class SchemaGenerator {
 
         schemaGeneratorHelper.addDirectivesIncludedByDefault(typeRegistryCopy);
 
-        List<GraphQLError> errors = typeChecker.checkTypeRegistry(typeRegistryCopy, wiring);
+        // by making it read only all the traversal and checks run faster
+        ImmutableTypeDefinitionRegistry fasterImmutableRegistry = typeRegistryCopy.readOnly();
+        List<GraphQLError> errors = typeChecker.checkTypeRegistry(fasterImmutableRegistry, wiring);
         if (!errors.isEmpty()) {
             throw new SchemaProblem(errors);
         }
 
-        Map<String, OperationTypeDefinition> operationTypeDefinitions = SchemaExtensionsChecker.gatherOperationDefs(typeRegistry);
+        Map<String, OperationTypeDefinition> operationTypeDefinitions = SchemaExtensionsChecker.gatherOperationDefs(fasterImmutableRegistry);
 
-        return makeExecutableSchemaImpl(typeRegistryCopy, wiring, operationTypeDefinitions, options);
+        return makeExecutableSchemaImpl(fasterImmutableRegistry, wiring, operationTypeDefinitions, options);
     }
 
-    private GraphQLSchema makeExecutableSchemaImpl(TypeDefinitionRegistry typeRegistry,
+    private GraphQLSchema makeExecutableSchemaImpl(ImmutableTypeDefinitionRegistry typeRegistry,
                                                    RuntimeWiring wiring,
                                                    Map<String, OperationTypeDefinition> operationTypeDefinitions,
                                                    Options options) {

--- a/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
+++ b/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
@@ -111,7 +111,7 @@ public class SchemaGeneratorHelper {
      * it gives us helper functions
      */
     static class BuildContext {
-        private final TypeDefinitionRegistry typeRegistry;
+        private final ImmutableTypeDefinitionRegistry typeRegistry;
         private final RuntimeWiring wiring;
         private final Deque<String> typeStack = new ArrayDeque<>();
 
@@ -123,7 +123,7 @@ public class SchemaGeneratorHelper {
         public final SchemaGenerator.Options options;
         public boolean directiveWiringRequired;
 
-        BuildContext(TypeDefinitionRegistry typeRegistry, RuntimeWiring wiring, Map<String, OperationTypeDefinition> operationTypeDefinitions, SchemaGenerator.Options options) {
+        BuildContext(ImmutableTypeDefinitionRegistry typeRegistry, RuntimeWiring wiring, Map<String, OperationTypeDefinition> operationTypeDefinitions, SchemaGenerator.Options options) {
             this.typeRegistry = typeRegistry;
             this.wiring = wiring;
             this.codeRegistry = GraphQLCodeRegistry.newCodeRegistry(wiring.getCodeRegistry());

--- a/src/main/java/graphql/schema/idl/SchemaTypeChecker.java
+++ b/src/main/java/graphql/schema/idl/SchemaTypeChecker.java
@@ -52,7 +52,7 @@ import static java.util.stream.Collectors.toList;
 @Internal
 public class SchemaTypeChecker {
 
-    public List<GraphQLError> checkTypeRegistry(TypeDefinitionRegistry typeRegistry, RuntimeWiring wiring) throws SchemaProblem {
+    public List<GraphQLError> checkTypeRegistry(ImmutableTypeDefinitionRegistry typeRegistry, RuntimeWiring wiring) throws SchemaProblem {
         List<GraphQLError> errors = new ArrayList<>();
         checkForMissingTypes(errors, typeRegistry);
 

--- a/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java
+++ b/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java
@@ -54,20 +54,70 @@ import static java.util.Optional.ofNullable;
 @NullMarked
 public class TypeDefinitionRegistry implements Serializable {
 
-    private final Map<String, List<ObjectTypeExtensionDefinition>> objectTypeExtensions = new LinkedHashMap<>();
-    private final Map<String, List<InterfaceTypeExtensionDefinition>> interfaceTypeExtensions = new LinkedHashMap<>();
-    private final Map<String, List<UnionTypeExtensionDefinition>> unionTypeExtensions = new LinkedHashMap<>();
-    private final Map<String, List<EnumTypeExtensionDefinition>> enumTypeExtensions = new LinkedHashMap<>();
-    private final Map<String, List<ScalarTypeExtensionDefinition>> scalarTypeExtensions = new LinkedHashMap<>();
-    private final Map<String, List<InputObjectTypeExtensionDefinition>> inputObjectTypeExtensions = new LinkedHashMap<>();
+    protected final Map<String, List<ObjectTypeExtensionDefinition>> objectTypeExtensions;
+    protected final Map<String, List<InterfaceTypeExtensionDefinition>> interfaceTypeExtensions;
+    protected final Map<String, List<UnionTypeExtensionDefinition>> unionTypeExtensions;
+    protected final Map<String, List<EnumTypeExtensionDefinition>> enumTypeExtensions;
+    protected final Map<String, List<ScalarTypeExtensionDefinition>> scalarTypeExtensions;
+    protected final Map<String, List<InputObjectTypeExtensionDefinition>> inputObjectTypeExtensions;
 
-    private final Map<String, TypeDefinition> types = new LinkedHashMap<>();
-    private final Map<String, ScalarTypeDefinition> scalarTypes = new LinkedHashMap<>();
-    private final Map<String, DirectiveDefinition> directiveDefinitions = new LinkedHashMap<>();
-    private @Nullable SchemaDefinition schema;
-    private final List<SchemaExtensionDefinition> schemaExtensionDefinitions = new ArrayList<>();
-    private final SchemaParseOrder schemaParseOrder = new SchemaParseOrder();
+    protected final Map<String, TypeDefinition> types;
+    protected final Map<String, ScalarTypeDefinition> scalarTypes;
+    protected final Map<String, DirectiveDefinition> directiveDefinitions;
+    protected @Nullable SchemaDefinition schema;
+    protected final List<SchemaExtensionDefinition> schemaExtensionDefinitions;
+    protected final SchemaParseOrder schemaParseOrder;
 
+    public TypeDefinitionRegistry() {
+        objectTypeExtensions = new LinkedHashMap<>();
+        interfaceTypeExtensions = new LinkedHashMap<>();
+        unionTypeExtensions = new LinkedHashMap<>();
+        enumTypeExtensions = new LinkedHashMap<>();
+        scalarTypeExtensions = new LinkedHashMap<>();
+        inputObjectTypeExtensions = new LinkedHashMap<>();
+        types = new LinkedHashMap<>();
+        scalarTypes = new LinkedHashMap<>();
+        directiveDefinitions = new LinkedHashMap<>();
+        schemaExtensionDefinitions = new ArrayList<>();
+        schemaParseOrder = new SchemaParseOrder();
+    }
+
+    protected TypeDefinitionRegistry(Map<String, List<ObjectTypeExtensionDefinition>> objectTypeExtensions,
+                                  Map<String, List<InterfaceTypeExtensionDefinition>> interfaceTypeExtensions,
+                                  Map<String, List<UnionTypeExtensionDefinition>> unionTypeExtensions,
+                                  Map<String, List<EnumTypeExtensionDefinition>> enumTypeExtensions,
+                                  Map<String, List<ScalarTypeExtensionDefinition>> scalarTypeExtensions,
+                                  Map<String, List<InputObjectTypeExtensionDefinition>> inputObjectTypeExtensions,
+                                  Map<String, TypeDefinition> types,
+                                  Map<String, ScalarTypeDefinition> scalarTypes,
+                                  Map<String, DirectiveDefinition> directiveDefinitions,
+                                  List<SchemaExtensionDefinition> schemaExtensionDefinitions,
+                                  @Nullable SchemaDefinition schema,
+                                  SchemaParseOrder schemaParseOrder) {
+        this.objectTypeExtensions = objectTypeExtensions;
+        this.interfaceTypeExtensions = interfaceTypeExtensions;
+        this.unionTypeExtensions = unionTypeExtensions;
+        this.enumTypeExtensions = enumTypeExtensions;
+        this.scalarTypeExtensions = scalarTypeExtensions;
+        this.inputObjectTypeExtensions = inputObjectTypeExtensions;
+        this.types = types;
+        this.scalarTypes = scalarTypes;
+        this.directiveDefinitions = directiveDefinitions;
+        this.schemaExtensionDefinitions = schemaExtensionDefinitions;
+        this.schema = schema;
+        this.schemaParseOrder = schemaParseOrder;
+    }
+
+    /**
+     * @return an immutable view of this {@link TypeDefinitionRegistry} that is more performant
+     * when in read only mode.
+     */
+    public ImmutableTypeDefinitionRegistry readOnly() {
+        if (this instanceof ImmutableTypeDefinitionRegistry) {
+            return (ImmutableTypeDefinitionRegistry) this;
+        }
+        return new ImmutableTypeDefinitionRegistry(this);
+    }
 
     /**
      * @return the order in which {@link SDLDefinition}s were parsed

--- a/src/test/groovy/graphql/schema/idl/ImmutableTypeDefinitionRegistryTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/ImmutableTypeDefinitionRegistryTest.groovy
@@ -1,0 +1,196 @@
+package graphql.schema.idl
+
+import graphql.language.TypeDefinition
+import spock.lang.Specification
+
+class ImmutableTypeDefinitionRegistryTest extends Specification {
+
+    def serializableSchema = '''
+            "the schema"
+            schema {
+                query : Q
+            }
+            
+            "the query type"
+            type Q {
+                field( arg : String! = "default") : FieldType @deprecated(reason : "no good")
+            }
+            
+            interface FieldType {
+                f : UnionType
+            }
+            
+            type FieldTypeImpl implements FieldType {
+                f : UnionType
+            }
+            
+            union UnionType = Foo | Bar
+            
+            type Foo {
+                foo : String
+            }
+
+            type Bar {
+                bar : String
+            }
+            
+            scalar MyScalar
+            
+            input InputType {
+                in : String
+            }
+        '''
+
+    def "immutable registry can be serialized and hence cacheable"() {
+        def registryOut = new SchemaParser().parse(serializableSchema).readOnly()
+
+        when:
+
+        TypeDefinitionRegistry registryIn = serialise(registryOut).readOnly()
+
+        then:
+
+        TypeDefinition typeIn = registryIn.getType(typeName).get()
+        TypeDefinition typeOut = registryOut.getType(typeName).get()
+        typeIn.isEqualTo(typeOut)
+
+        where:
+        typeName        | _
+        "Q"             | _
+        "FieldType"     | _
+        "FieldTypeImpl" | _
+        "UnionType"     | _
+        "Foo"           | _
+        "Bar"           | _
+    }
+
+    def "immutable registry is a perfect copy of the starting registry"() {
+        when:
+        def mutableRegistry = new SchemaParser().parse(serializableSchema)
+        def immutableRegistry = mutableRegistry.readOnly()
+
+        then:
+
+        containsSameObjects(mutableRegistry.types(), immutableRegistry.types())
+
+        TypeDefinition typeIn = mutableRegistry.getType(typeName).get()
+        TypeDefinition typeOut = immutableRegistry.getType(typeName).get()
+        typeIn.isEqualTo(typeOut)
+
+        where:
+        typeName        | _
+        "Q"             | _
+        "FieldType"     | _
+        "FieldTypeImpl" | _
+        "UnionType"     | _
+        "Foo"           | _
+        "Bar"           | _
+    }
+
+    def "extensions are also present in immutable copy"() {
+        def sdl = serializableSchema + """
+            extend type FieldTypeImpl {
+                extra : String
+            }
+            
+            extend input InputType {
+                out : String
+            }
+ 
+            extend scalar MyScalar @specifiedBy(url: "myUrl.example")
+            
+            extend union UnionType @deprecated
+
+            extend interface FieldType @deprecated
+
+        """
+
+        when:
+        def mutableRegistry = new SchemaParser().parse(sdl)
+        def immutableRegistry = mutableRegistry.readOnly()
+
+        then:
+
+        containsSameObjects(mutableRegistry.types(), immutableRegistry.types())
+        containsSameObjects(mutableRegistry.objectTypeExtensions(), immutableRegistry.objectTypeExtensions())
+        containsSameObjects(mutableRegistry.inputObjectTypeExtensions(), immutableRegistry.inputObjectTypeExtensions())
+        containsSameObjects(mutableRegistry.interfaceTypeExtensions(), immutableRegistry.interfaceTypeExtensions())
+        containsSameObjects(mutableRegistry.unionTypeExtensions(), immutableRegistry.unionTypeExtensions())
+        containsSameObjects(mutableRegistry.scalarTypeExtensions(), immutableRegistry.scalarTypeExtensions())
+
+    }
+
+    def "readonly is aware if itself"() {
+        when:
+        def mutableRegistry = new SchemaParser().parse(serializableSchema)
+        def immutableRegistry1 = mutableRegistry.readOnly()
+
+        then:
+        mutableRegistry !== immutableRegistry1
+
+        when:
+        def immutableRegistry2 = immutableRegistry1.readOnly()
+
+        then:
+        immutableRegistry2 === immutableRegistry1
+
+
+    }
+
+    def "is in read only mode"() {
+        when:
+        def mutableRegistry = new SchemaParser().parse(serializableSchema)
+        def immutableRegistry = mutableRegistry.readOnly()
+
+        immutableRegistry.merge(mutableRegistry)
+
+        then:
+        thrown(UnsupportedOperationException)
+
+        when:
+        immutableRegistry.addAll([])
+        then:
+        thrown(UnsupportedOperationException)
+
+
+        def someDef = mutableRegistry.getTypes(TypeDefinition.class)[0]
+
+        when:
+        immutableRegistry.add(someDef)
+        then:
+        thrown(UnsupportedOperationException)
+
+        when:
+        immutableRegistry.remove(someDef)
+        then:
+        thrown(UnsupportedOperationException)
+
+        when:
+        immutableRegistry.remove("key", someDef)
+        then:
+        thrown(UnsupportedOperationException)
+
+    }
+
+    void containsSameObjects(Map<String, Object> leftMap, Map<String, Object> rightMap) {
+        assert leftMap.size() > 0, "The map must have some entries"
+        assert leftMap.size() == rightMap.size(), "The maps are not the same size"
+        for (String leftKey : leftMap.keySet()) {
+            def leftVal = leftMap.get(leftKey)
+            def rightVal = rightMap.get(leftKey)
+            assert leftVal === rightVal, "$leftKey :  $leftVal dont not strictly equal $rightVal"
+        }
+    }
+
+    static TypeDefinitionRegistry serialise(TypeDefinitionRegistry registryOut) {
+        ByteArrayOutputStream baOS = new ByteArrayOutputStream()
+        ObjectOutputStream oos = new ObjectOutputStream(baOS)
+
+        oos.writeObject(registryOut)
+
+        ByteArrayInputStream baIS = new ByteArrayInputStream(baOS.toByteArray())
+        ObjectInputStream ois = new ObjectInputStream(baIS)
+
+        ois.readObject() as TypeDefinitionRegistry
+    }
+}

--- a/src/test/groovy/graphql/schema/idl/SchemaTypeCheckerTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaTypeCheckerTest.groovy
@@ -139,7 +139,7 @@ class SchemaTypeCheckerTest extends Specification {
         for (String name : resolvingNames) {
             runtimeBuilder.type(TypeRuntimeWiring.newTypeWiring(name).typeResolver(resolver))
         }
-        return new SchemaTypeChecker().checkTypeRegistry(types, runtimeBuilder.build())
+        return new SchemaTypeChecker().checkTypeRegistry(types.readOnly(), runtimeBuilder.build())
     }
 
     def "test missing type in object"() {


### PR DESCRIPTION
The `graphql.schema.idl.TypeDefinitionRegistry` is very mutable and we cant break its mutability at this stage of its life.

So we have added a `.readOnly()` mechanism that returns a `graphql.schema.idl.ImmutableTypeDefinitionRegistry` that is a `TypeDefinitionRegistry`

So code that is read only like the SchemaGenerator and TypeCheckers can be faster because they dont allocate copies all the time