### PR TITLE
avoid allocating in hasDirective

### DIFF
--- a/src/main/java/graphql/language/DirectivesContainer.java
+++ b/src/main/java/graphql/language/DirectivesContainer.java
@@ -57,6 +57,11 @@ public interface DirectivesContainer<T extends DirectivesContainer> extends Node
      * @return true if the AST node contains one or more directives by the specified name
      */
     default boolean hasDirective(String directiveName) {
-        return !getDirectives(directiveName).isEmpty();
+        for (Directive d : getDirectives()) {
+            if (d.getName().equals(directiveName)) {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
`hasDirective` on `DirectivesContainer` sounds cheap but actually allocates/copies/does a groupingBy on every call. There is no need to group by in this case, and we can cheaply iterate over `getDirectives` instead, which does not copy/allocate anything. 