### PR TITLE
A more memory efficient directives container

### DIFF
--- a/src/main/java/graphql/language/DirectivesContainer.java
+++ b/src/main/java/graphql/language/DirectivesContainer.java
@@ -34,20 +34,16 @@ public interface DirectivesContainer<T extends DirectivesContainer> extends Node
      *
      * @return a map of all directives by directive name
      */
-    default Map<String, List<Directive>> getDirectivesByName() {
-        return ImmutableMap.copyOf(allDirectivesByName(getDirectives()));
-    }
+    Map<String, List<Directive>> getDirectivesByName();
 
     /**
-     * Returns all of the directives with the provided name, including repeatable and non repeatable directives.
+     * Returns all the directives with the provided name, including repeatable and non repeatable directives.
      *
      * @param directiveName the name of the directives to retrieve
      *
      * @return the directives or empty list if there is not one with that name
      */
-    default List<Directive> getDirectives(String directiveName) {
-        return getDirectivesByName().getOrDefault(directiveName, emptyList());
-    }
+    List<Directive> getDirectives(String directiveName);
 
     /**
      * This returns true if the AST node contains one or more directives by the specified name
@@ -56,7 +52,5 @@ public interface DirectivesContainer<T extends DirectivesContainer> extends Node
      *
      * @return true if the AST node contains one or more directives by the specified name
      */
-    default boolean hasDirective(String directiveName) {
-        return !getDirectives(directiveName).isEmpty();
-    }
+    boolean hasDirective(String directiveName);
 }

--- a/src/main/java/graphql/language/EnumTypeDefinition.java
+++ b/src/main/java/graphql/language/EnumTypeDefinition.java
@@ -23,7 +23,7 @@ import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 public class EnumTypeDefinition extends AbstractDescribedNode<EnumTypeDefinition> implements TypeDefinition<EnumTypeDefinition>, DirectivesContainer<EnumTypeDefinition>, NamedNode<EnumTypeDefinition> {
     private final String name;
     private final ImmutableList<EnumValueDefinition> enumValueDefinitions;
-    private final ImmutableList<Directive> directives;
+    private final NodeUtil.DirectivesHolder directives;
 
     public static final String CHILD_ENUM_VALUE_DEFINITIONS = "enumValueDefinitions";
     public static final String CHILD_DIRECTIVES = "directives";
@@ -38,7 +38,7 @@ public class EnumTypeDefinition extends AbstractDescribedNode<EnumTypeDefinition
                                  IgnoredChars ignoredChars, Map<String, String> additionalData) {
         super(sourceLocation, comments, ignoredChars, additionalData, description);
         this.name = name;
-        this.directives = ImmutableKit.nonNullCopyOf(directives);
+        this.directives = NodeUtil.DirectivesHolder.of(directives);
         this.enumValueDefinitions = ImmutableKit.nonNullCopyOf(enumValueDefinitions);
     }
 
@@ -57,7 +57,22 @@ public class EnumTypeDefinition extends AbstractDescribedNode<EnumTypeDefinition
 
     @Override
     public List<Directive> getDirectives() {
-        return directives;
+        return directives.getDirectives();
+    }
+
+    @Override
+    public Map<String, List<Directive>> getDirectivesByName() {
+        return directives.getDirectivesByName();
+    }
+
+    @Override
+    public List<Directive> getDirectives(String directiveName) {
+        return directives.getDirectives(directiveName);
+    }
+
+    @Override
+    public boolean hasDirective(String directiveName) {
+        return directives.hasDirective(directiveName);
     }
 
     @Override
@@ -69,7 +84,7 @@ public class EnumTypeDefinition extends AbstractDescribedNode<EnumTypeDefinition
     public List<Node> getChildren() {
         List<Node> result = new ArrayList<>();
         result.addAll(enumValueDefinitions);
-        result.addAll(directives);
+        result.addAll(directives.getDirectives());
         return result;
     }
 
@@ -77,7 +92,7 @@ public class EnumTypeDefinition extends AbstractDescribedNode<EnumTypeDefinition
     public NodeChildrenContainer getNamedChildren() {
         return newNodeChildrenContainer()
                 .children(CHILD_ENUM_VALUE_DEFINITIONS, enumValueDefinitions)
-                .children(CHILD_DIRECTIVES, directives)
+                .children(CHILD_DIRECTIVES, directives.getDirectives())
                 .build();
     }
 
@@ -107,7 +122,7 @@ public class EnumTypeDefinition extends AbstractDescribedNode<EnumTypeDefinition
     public EnumTypeDefinition deepCopy() {
         return new EnumTypeDefinition(name,
                 deepCopy(enumValueDefinitions),
-                deepCopy(directives),
+                deepCopy(directives.getDirectives()),
                 description,
                 getSourceLocation(),
                 getComments(),

--- a/src/main/java/graphql/language/EnumValueDefinition.java
+++ b/src/main/java/graphql/language/EnumValueDefinition.java
@@ -17,13 +17,12 @@ import java.util.function.Consumer;
 import static graphql.Assert.assertNotNull;
 import static graphql.collect.ImmutableKit.emptyList;
 import static graphql.collect.ImmutableKit.emptyMap;
-import static graphql.collect.ImmutableKit.nonNullCopyOf;
 import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 
 @PublicApi
 public class EnumValueDefinition extends AbstractDescribedNode<EnumValueDefinition> implements DirectivesContainer<EnumValueDefinition>, NamedNode<EnumValueDefinition> {
     private final String name;
-    private final ImmutableList<Directive> directives;
+    private final NodeUtil.DirectivesHolder directives;
 
     public static final String CHILD_DIRECTIVES = "directives";
 
@@ -36,7 +35,7 @@ public class EnumValueDefinition extends AbstractDescribedNode<EnumValueDefiniti
                                   IgnoredChars ignoredChars, Map<String, String> additionalData) {
         super(sourceLocation, comments, ignoredChars, additionalData, description);
         this.name = name;
-        this.directives = nonNullCopyOf(directives);
+        this.directives = NodeUtil.DirectivesHolder.of(directives);
     }
 
     /**
@@ -65,18 +64,33 @@ public class EnumValueDefinition extends AbstractDescribedNode<EnumValueDefiniti
 
     @Override
     public List<Directive> getDirectives() {
-        return directives;
+        return directives.getDirectives();
+    }
+
+    @Override
+    public Map<String, List<Directive>> getDirectivesByName() {
+        return directives.getDirectivesByName();
+    }
+
+    @Override
+    public List<Directive> getDirectives(String directiveName) {
+        return directives.getDirectives(directiveName);
+    }
+
+    @Override
+    public boolean hasDirective(String directiveName) {
+        return directives.hasDirective(directiveName);
     }
 
     @Override
     public List<Node> getChildren() {
-        return ImmutableList.copyOf(directives);
+        return ImmutableList.copyOf(directives.getDirectives());
     }
 
     @Override
     public NodeChildrenContainer getNamedChildren() {
         return newNodeChildrenContainer()
-                .children(CHILD_DIRECTIVES, directives)
+                .children(CHILD_DIRECTIVES, directives.getDirectives())
                 .build();
     }
 
@@ -104,7 +118,7 @@ public class EnumValueDefinition extends AbstractDescribedNode<EnumValueDefiniti
 
     @Override
     public EnumValueDefinition deepCopy() {
-        return new EnumValueDefinition(name, deepCopy(directives), description, getSourceLocation(), getComments(), getIgnoredChars(), getAdditionalData());
+        return new EnumValueDefinition(name, deepCopy(directives.getDirectives()), description, getSourceLocation(), getComments(), getIgnoredChars(), getAdditionalData());
     }
 
     @Override

--- a/src/main/java/graphql/language/Field.java
+++ b/src/main/java/graphql/language/Field.java
@@ -32,7 +32,7 @@ public class Field extends AbstractNode<Field> implements Selection<Field>, Sele
     private final String name;
     private final String alias;
     private final ImmutableList<Argument> arguments;
-    private final ImmutableList<Directive> directives;
+    private final NodeUtil.DirectivesHolder directives;
     private final SelectionSet selectionSet;
 
     public static final String CHILD_ARGUMENTS = "arguments";
@@ -54,7 +54,7 @@ public class Field extends AbstractNode<Field> implements Selection<Field>, Sele
         this.name = name == null ? null : Interning.intern(name);
         this.alias = alias;
         this.arguments = ImmutableList.copyOf(arguments);
-        this.directives = ImmutableList.copyOf(directives);
+        this.directives = NodeUtil.DirectivesHolder.of(directives);
         this.selectionSet = selectionSet;
     }
 
@@ -103,7 +103,7 @@ public class Field extends AbstractNode<Field> implements Selection<Field>, Sele
     public List<Node> getChildren() {
         List<Node> result = new ArrayList<>();
         result.addAll(arguments);
-        result.addAll(directives);
+        result.addAll(directives.getDirectives());
         if (selectionSet != null) {
             result.add(selectionSet);
         }
@@ -114,7 +114,7 @@ public class Field extends AbstractNode<Field> implements Selection<Field>, Sele
     public NodeChildrenContainer getNamedChildren() {
         return NodeChildrenContainer.newNodeChildrenContainer()
                 .children(CHILD_ARGUMENTS, arguments)
-                .children(CHILD_DIRECTIVES, directives)
+                .children(CHILD_DIRECTIVES, directives.getDirectives())
                 .child(CHILD_SELECTION_SET, selectionSet)
                 .build();
     }
@@ -147,7 +147,22 @@ public class Field extends AbstractNode<Field> implements Selection<Field>, Sele
 
     @Override
     public List<Directive> getDirectives() {
-        return directives;
+        return directives.getDirectives();
+    }
+
+    @Override
+    public Map<String, List<Directive>> getDirectivesByName() {
+        return directives.getDirectivesByName();
+    }
+
+    @Override
+    public List<Directive> getDirectives(String directiveName) {
+        return directives.getDirectives(directiveName);
+    }
+
+    @Override
+    public boolean hasDirective(String directiveName) {
+        return directives.hasDirective(directiveName);
     }
 
     @Override
@@ -175,7 +190,7 @@ public class Field extends AbstractNode<Field> implements Selection<Field>, Sele
         return new Field(name,
                 alias,
                 deepCopy(arguments),
-                deepCopy(directives),
+                deepCopy(directives.getDirectives()),
                 deepCopy(selectionSet),
                 getSourceLocation(),
                 getComments(),

--- a/src/main/java/graphql/language/FieldDefinition.java
+++ b/src/main/java/graphql/language/FieldDefinition.java
@@ -25,7 +25,7 @@ public class FieldDefinition extends AbstractDescribedNode<FieldDefinition> impl
     private final String name;
     private final Type type;
     private final ImmutableList<InputValueDefinition> inputValueDefinitions;
-    private final ImmutableList<Directive> directives;
+    private final NodeUtil.DirectivesHolder directives;
 
     public static final String CHILD_TYPE = "type";
     public static final String CHILD_INPUT_VALUE_DEFINITION = "inputValueDefinition";
@@ -45,7 +45,7 @@ public class FieldDefinition extends AbstractDescribedNode<FieldDefinition> impl
         this.name = name;
         this.type = type;
         this.inputValueDefinitions = ImmutableList.copyOf(inputValueDefinitions);
-        this.directives = ImmutableList.copyOf(directives);
+        this.directives = NodeUtil.DirectivesHolder.of(directives);
     }
 
     public FieldDefinition(String name,
@@ -68,7 +68,22 @@ public class FieldDefinition extends AbstractDescribedNode<FieldDefinition> impl
 
     @Override
     public List<Directive> getDirectives() {
-        return directives;
+        return directives.getDirectives();
+    }
+
+    @Override
+    public Map<String, List<Directive>> getDirectivesByName() {
+        return directives.getDirectivesByName();
+    }
+
+    @Override
+    public List<Directive> getDirectives(String directiveName) {
+        return directives.getDirectives(directiveName);
+    }
+
+    @Override
+    public boolean hasDirective(String directiveName) {
+        return directives.hasDirective(directiveName);
     }
 
     @Override
@@ -76,7 +91,7 @@ public class FieldDefinition extends AbstractDescribedNode<FieldDefinition> impl
         List<Node> result = new ArrayList<>();
         result.add(type);
         result.addAll(inputValueDefinitions);
-        result.addAll(directives);
+        result.addAll(directives.getDirectives());
         return result;
     }
 
@@ -85,7 +100,7 @@ public class FieldDefinition extends AbstractDescribedNode<FieldDefinition> impl
         return newNodeChildrenContainer()
                 .child(CHILD_TYPE, type)
                 .children(CHILD_INPUT_VALUE_DEFINITION, inputValueDefinitions)
-                .children(CHILD_DIRECTIVES, directives)
+                .children(CHILD_DIRECTIVES, directives.getDirectives())
                 .build();
     }
 
@@ -117,7 +132,7 @@ public class FieldDefinition extends AbstractDescribedNode<FieldDefinition> impl
         return new FieldDefinition(name,
                 deepCopy(type),
                 deepCopy(inputValueDefinitions),
-                deepCopy(directives),
+                deepCopy(directives.getDirectives()),
                 description,
                 getSourceLocation(),
                 getComments(),

--- a/src/main/java/graphql/language/FragmentDefinition.java
+++ b/src/main/java/graphql/language/FragmentDefinition.java
@@ -27,7 +27,7 @@ public class FragmentDefinition extends AbstractNode<FragmentDefinition> impleme
 
     private final String name;
     private final TypeName typeCondition;
-    private final ImmutableList<Directive> directives;
+    private final NodeUtil.DirectivesHolder directives;
     private final SelectionSet selectionSet;
 
     public static final String CHILD_TYPE_CONDITION = "typeCondition";
@@ -46,7 +46,7 @@ public class FragmentDefinition extends AbstractNode<FragmentDefinition> impleme
         super(sourceLocation, comments, ignoredChars, additionalData);
         this.name = name;
         this.typeCondition = typeCondition;
-        this.directives = ImmutableList.copyOf(directives);
+        this.directives = NodeUtil.DirectivesHolder.of(directives);
         this.selectionSet = selectionSet;
     }
 
@@ -62,9 +62,23 @@ public class FragmentDefinition extends AbstractNode<FragmentDefinition> impleme
 
     @Override
     public List<Directive> getDirectives() {
-        return directives;
+        return directives.getDirectives();
     }
 
+    @Override
+    public Map<String, List<Directive>> getDirectivesByName() {
+        return directives.getDirectivesByName();
+    }
+
+    @Override
+    public List<Directive> getDirectives(String directiveName) {
+        return directives.getDirectives(directiveName);
+    }
+
+    @Override
+    public boolean hasDirective(String directiveName) {
+        return directives.hasDirective(directiveName);
+    }
 
     @Override
     public SelectionSet getSelectionSet() {
@@ -75,7 +89,7 @@ public class FragmentDefinition extends AbstractNode<FragmentDefinition> impleme
     public List<Node> getChildren() {
         List<Node> result = new ArrayList<>();
         result.add(typeCondition);
-        result.addAll(directives);
+        result.addAll(directives.getDirectives());
         result.add(selectionSet);
         return result;
     }
@@ -84,7 +98,7 @@ public class FragmentDefinition extends AbstractNode<FragmentDefinition> impleme
     public NodeChildrenContainer getNamedChildren() {
         return newNodeChildrenContainer()
                 .child(CHILD_TYPE_CONDITION, typeCondition)
-                .children(CHILD_DIRECTIVES, directives)
+                .children(CHILD_DIRECTIVES, directives.getDirectives())
                 .child(CHILD_SELECTION_SET, selectionSet)
                 .build();
     }
@@ -116,7 +130,7 @@ public class FragmentDefinition extends AbstractNode<FragmentDefinition> impleme
     public FragmentDefinition deepCopy() {
         return new FragmentDefinition(name,
                 deepCopy(typeCondition),
-                deepCopy(directives),
+                deepCopy(directives.getDirectives()),
                 deepCopy(selectionSet),
                 getSourceLocation(),
                 getComments(),

--- a/src/main/java/graphql/language/FragmentSpread.java
+++ b/src/main/java/graphql/language/FragmentSpread.java
@@ -23,7 +23,7 @@ import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 public class FragmentSpread extends AbstractNode<FragmentSpread> implements Selection<FragmentSpread>, DirectivesContainer<FragmentSpread>, NamedNode<FragmentSpread> {
 
     private final String name;
-    private final ImmutableList<Directive> directives;
+    private final NodeUtil.DirectivesHolder directives;
 
     public static final String CHILD_DIRECTIVES = "directives";
 
@@ -31,7 +31,7 @@ public class FragmentSpread extends AbstractNode<FragmentSpread> implements Sele
     protected FragmentSpread(String name, List<Directive> directives, SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars, Map<String, String> additionalData) {
         super(sourceLocation, comments, ignoredChars, additionalData);
         this.name = name;
-        this.directives = ImmutableList.copyOf(directives);
+        this.directives = NodeUtil.DirectivesHolder.of(directives);
     }
 
     /**
@@ -50,7 +50,22 @@ public class FragmentSpread extends AbstractNode<FragmentSpread> implements Sele
 
     @Override
     public List<Directive> getDirectives() {
-        return directives;
+        return directives.getDirectives();
+    }
+
+    @Override
+    public Map<String, List<Directive>> getDirectivesByName() {
+        return directives.getDirectivesByName();
+    }
+
+    @Override
+    public List<Directive> getDirectives(String directiveName) {
+        return directives.getDirectives(directiveName);
+    }
+
+    @Override
+    public boolean hasDirective(String directiveName) {
+        return directives.hasDirective(directiveName);
     }
 
     @Override
@@ -70,13 +85,13 @@ public class FragmentSpread extends AbstractNode<FragmentSpread> implements Sele
 
     @Override
     public List<Node> getChildren() {
-        return ImmutableList.copyOf(directives);
+        return ImmutableList.copyOf(directives.getDirectives());
     }
 
     @Override
     public NodeChildrenContainer getNamedChildren() {
         return newNodeChildrenContainer()
-                .children(CHILD_DIRECTIVES, directives)
+                .children(CHILD_DIRECTIVES, directives.getDirectives())
                 .build();
     }
 
@@ -89,7 +104,7 @@ public class FragmentSpread extends AbstractNode<FragmentSpread> implements Sele
 
     @Override
     public FragmentSpread deepCopy() {
-        return new FragmentSpread(name, deepCopy(directives), getSourceLocation(), getComments(), getIgnoredChars(), getAdditionalData());
+        return new FragmentSpread(name, deepCopy(directives.getDirectives()), getSourceLocation(), getComments(), getIgnoredChars(), getAdditionalData());
     }
 
     @Override

--- a/src/main/java/graphql/language/InlineFragment.java
+++ b/src/main/java/graphql/language/InlineFragment.java
@@ -22,7 +22,7 @@ import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 @PublicApi
 public class InlineFragment extends AbstractNode<InlineFragment> implements Selection<InlineFragment>, SelectionSetContainer<InlineFragment>, DirectivesContainer<InlineFragment> {
     private final TypeName typeCondition;
-    private final ImmutableList<Directive> directives;
+    private final NodeUtil.DirectivesHolder directives;
     private final SelectionSet selectionSet;
 
     public static final String CHILD_TYPE_CONDITION = "typeCondition";
@@ -39,7 +39,7 @@ public class InlineFragment extends AbstractNode<InlineFragment> implements Sele
                              Map<String, String> additionalData) {
         super(sourceLocation, comments, ignoredChars, additionalData);
         this.typeCondition = typeCondition;
-        this.directives = ImmutableList.copyOf(directives);
+        this.directives = NodeUtil.DirectivesHolder.of(directives);
         this.selectionSet = selectionSet;
     }
 
@@ -66,8 +66,24 @@ public class InlineFragment extends AbstractNode<InlineFragment> implements Sele
         return typeCondition;
     }
 
+    @Override
     public List<Directive> getDirectives() {
-        return directives;
+        return directives.getDirectives();
+    }
+
+    @Override
+    public Map<String, List<Directive>> getDirectivesByName() {
+        return directives.getDirectivesByName();
+    }
+
+    @Override
+    public List<Directive> getDirectives(String directiveName) {
+        return directives.getDirectives(directiveName);
+    }
+
+    @Override
+    public boolean hasDirective(String directiveName) {
+        return directives.hasDirective(directiveName);
     }
 
     @Override
@@ -81,7 +97,7 @@ public class InlineFragment extends AbstractNode<InlineFragment> implements Sele
         if (typeCondition != null) {
             result.add(typeCondition);
         }
-        result.addAll(directives);
+        result.addAll(directives.getDirectives());
         result.add(selectionSet);
         return result;
     }
@@ -90,7 +106,7 @@ public class InlineFragment extends AbstractNode<InlineFragment> implements Sele
     public NodeChildrenContainer getNamedChildren() {
         return newNodeChildrenContainer()
                 .child(CHILD_TYPE_CONDITION, typeCondition)
-                .children(CHILD_DIRECTIVES, directives)
+                .children(CHILD_DIRECTIVES, directives.getDirectives())
                 .child(CHILD_SELECTION_SET, selectionSet)
                 .build();
     }
@@ -116,7 +132,7 @@ public class InlineFragment extends AbstractNode<InlineFragment> implements Sele
     public InlineFragment deepCopy() {
         return new InlineFragment(
                 deepCopy(typeCondition),
-                deepCopy(directives),
+                deepCopy(directives.getDirectives()),
                 deepCopy(selectionSet),
                 getSourceLocation(),
                 getComments(),

--- a/src/main/java/graphql/language/InputObjectTypeDefinition.java
+++ b/src/main/java/graphql/language/InputObjectTypeDefinition.java
@@ -23,7 +23,7 @@ import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 public class InputObjectTypeDefinition extends AbstractDescribedNode<InputObjectTypeDefinition> implements TypeDefinition<InputObjectTypeDefinition>, DirectivesContainer<InputObjectTypeDefinition>, NamedNode<InputObjectTypeDefinition> {
 
     private final String name;
-    private final ImmutableList<Directive> directives;
+    private final NodeUtil.DirectivesHolder directives;
     private final ImmutableList<InputValueDefinition> inputValueDefinitions;
 
     public static final String CHILD_DIRECTIVES = "directives";
@@ -40,13 +40,28 @@ public class InputObjectTypeDefinition extends AbstractDescribedNode<InputObject
                                         Map<String, String> additionalData) {
         super(sourceLocation, comments, ignoredChars, additionalData, description);
         this.name = name;
-        this.directives = ImmutableList.copyOf(directives);
+        this.directives = NodeUtil.DirectivesHolder.of(directives);
         this.inputValueDefinitions = ImmutableList.copyOf(inputValueDefinitions);
     }
 
     @Override
     public List<Directive> getDirectives() {
-        return directives;
+        return directives.getDirectives();
+    }
+
+    @Override
+    public Map<String, List<Directive>> getDirectivesByName() {
+        return directives.getDirectivesByName();
+    }
+
+    @Override
+    public List<Directive> getDirectives(String directiveName) {
+        return directives.getDirectives(directiveName);
+    }
+
+    @Override
+    public boolean hasDirective(String directiveName) {
+        return directives.hasDirective(directiveName);
     }
 
     public List<InputValueDefinition> getInputValueDefinitions() {
@@ -61,7 +76,7 @@ public class InputObjectTypeDefinition extends AbstractDescribedNode<InputObject
     @Override
     public List<Node> getChildren() {
         List<Node> result = new ArrayList<>();
-        result.addAll(directives);
+        result.addAll(directives.getDirectives());
         result.addAll(inputValueDefinitions);
         return result;
     }
@@ -69,7 +84,7 @@ public class InputObjectTypeDefinition extends AbstractDescribedNode<InputObject
     @Override
     public NodeChildrenContainer getNamedChildren() {
         return newNodeChildrenContainer()
-                .children(CHILD_DIRECTIVES, directives)
+                .children(CHILD_DIRECTIVES, directives.getDirectives())
                 .children(CHILD_INPUT_VALUES_DEFINITIONS, inputValueDefinitions)
                 .build();
     }
@@ -99,7 +114,7 @@ public class InputObjectTypeDefinition extends AbstractDescribedNode<InputObject
     @Override
     public InputObjectTypeDefinition deepCopy() {
         return new InputObjectTypeDefinition(name,
-                deepCopy(directives),
+                deepCopy(directives.getDirectives()),
                 deepCopy(inputValueDefinitions),
                 description,
                 getSourceLocation(),

--- a/src/main/java/graphql/language/InputValueDefinition.java
+++ b/src/main/java/graphql/language/InputValueDefinition.java
@@ -25,7 +25,7 @@ public class InputValueDefinition extends AbstractDescribedNode<InputValueDefini
     private final String name;
     private final Type type;
     private final Value defaultValue;
-    private final ImmutableList<Directive> directives;
+    private final NodeUtil.DirectivesHolder directives;
 
     public static final String CHILD_TYPE = "type";
     public static final String CHILD_DEFAULT_VALUE = "defaultValue";
@@ -45,7 +45,7 @@ public class InputValueDefinition extends AbstractDescribedNode<InputValueDefini
         this.name = name;
         this.type = type;
         this.defaultValue = defaultValue;
-        this.directives = ImmutableList.copyOf(directives);
+        this.directives = NodeUtil.DirectivesHolder.of(directives);
     }
 
     /**
@@ -88,8 +88,24 @@ public class InputValueDefinition extends AbstractDescribedNode<InputValueDefini
         return defaultValue;
     }
 
+    @Override
     public List<Directive> getDirectives() {
-        return directives;
+        return directives.getDirectives();
+    }
+
+    @Override
+    public Map<String, List<Directive>> getDirectivesByName() {
+        return directives.getDirectivesByName();
+    }
+
+    @Override
+    public List<Directive> getDirectives(String directiveName) {
+        return directives.getDirectives(directiveName);
+    }
+
+    @Override
+    public boolean hasDirective(String directiveName) {
+        return directives.hasDirective(directiveName);
     }
 
     @Override
@@ -99,7 +115,7 @@ public class InputValueDefinition extends AbstractDescribedNode<InputValueDefini
         if (defaultValue != null) {
             result.add(defaultValue);
         }
-        result.addAll(directives);
+        result.addAll(directives.getDirectives());
         return result;
     }
 
@@ -108,7 +124,7 @@ public class InputValueDefinition extends AbstractDescribedNode<InputValueDefini
         return newNodeChildrenContainer()
                 .child(CHILD_TYPE, type)
                 .child(CHILD_DEFAULT_VALUE, defaultValue)
-                .children(CHILD_DIRECTIVES, directives)
+                .children(CHILD_DIRECTIVES, directives.getDirectives())
                 .build();
     }
 
@@ -141,7 +157,7 @@ public class InputValueDefinition extends AbstractDescribedNode<InputValueDefini
         return new InputValueDefinition(name,
                 deepCopy(type),
                 deepCopy(defaultValue),
-                deepCopy(directives),
+                deepCopy(directives.getDirectives()),
                 description,
                 getSourceLocation(),
                 getComments(),

--- a/src/main/java/graphql/language/InterfaceTypeDefinition.java
+++ b/src/main/java/graphql/language/InterfaceTypeDefinition.java
@@ -26,7 +26,7 @@ public class InterfaceTypeDefinition extends AbstractDescribedNode<InterfaceType
     private final String name;
     private final ImmutableList<Type> implementz;
     private final ImmutableList<FieldDefinition> definitions;
-    private final ImmutableList<Directive> directives;
+    private final NodeUtil.DirectivesHolder directives;
 
     public static final String CHILD_IMPLEMENTZ = "implementz";
     public static final String CHILD_DEFINITIONS = "definitions";
@@ -46,7 +46,7 @@ public class InterfaceTypeDefinition extends AbstractDescribedNode<InterfaceType
         this.name = name;
         this.implementz = ImmutableList.copyOf(implementz);
         this.definitions = ImmutableList.copyOf(definitions);
-        this.directives = ImmutableList.copyOf(directives);
+        this.directives = NodeUtil.DirectivesHolder.of(directives);
     }
 
     /**
@@ -70,7 +70,22 @@ public class InterfaceTypeDefinition extends AbstractDescribedNode<InterfaceType
 
     @Override
     public List<Directive> getDirectives() {
-        return directives;
+        return directives.getDirectives();
+    }
+
+    @Override
+    public Map<String, List<Directive>> getDirectivesByName() {
+        return directives.getDirectivesByName();
+    }
+
+    @Override
+    public List<Directive> getDirectives(String directiveName) {
+        return directives.getDirectives(directiveName);
+    }
+
+    @Override
+    public boolean hasDirective(String directiveName) {
+        return directives.hasDirective(directiveName);
     }
 
     @Override
@@ -83,7 +98,7 @@ public class InterfaceTypeDefinition extends AbstractDescribedNode<InterfaceType
         List<Node> result = new ArrayList<>();
         result.addAll(implementz);
         result.addAll(definitions);
-        result.addAll(directives);
+        result.addAll(directives.getDirectives());
         return result;
     }
 
@@ -92,7 +107,7 @@ public class InterfaceTypeDefinition extends AbstractDescribedNode<InterfaceType
         return newNodeChildrenContainer()
                 .children(CHILD_IMPLEMENTZ, implementz)
                 .children(CHILD_DEFINITIONS, definitions)
-                .children(CHILD_DIRECTIVES, directives)
+                .children(CHILD_DIRECTIVES, directives.getDirectives())
                 .build();
     }
 
@@ -124,7 +139,7 @@ public class InterfaceTypeDefinition extends AbstractDescribedNode<InterfaceType
         return new InterfaceTypeDefinition(name,
                 deepCopy(implementz),
                 deepCopy(definitions),
-                deepCopy(directives),
+                deepCopy(directives.getDirectives()),
                 description,
                 getSourceLocation(),
                 getComments(),

--- a/src/main/java/graphql/language/ObjectTypeDefinition.java
+++ b/src/main/java/graphql/language/ObjectTypeDefinition.java
@@ -24,7 +24,7 @@ import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 public class ObjectTypeDefinition extends AbstractDescribedNode<ObjectTypeDefinition> implements ImplementingTypeDefinition<ObjectTypeDefinition>, DirectivesContainer<ObjectTypeDefinition>, NamedNode<ObjectTypeDefinition> {
     private final String name;
     private final ImmutableList<Type> implementz;
-    private final ImmutableList<Directive> directives;
+    private final NodeUtil.DirectivesHolder directives;
     private final ImmutableList<FieldDefinition> fieldDefinitions;
 
     public static final String CHILD_IMPLEMENTZ = "implementz";
@@ -44,7 +44,7 @@ public class ObjectTypeDefinition extends AbstractDescribedNode<ObjectTypeDefini
         super(sourceLocation, comments, ignoredChars, additionalData, description);
         this.name = name;
         this.implementz = ImmutableList.copyOf(implementz);
-        this.directives = ImmutableList.copyOf(directives);
+        this.directives = NodeUtil.DirectivesHolder.of(directives);
         this.fieldDefinitions = ImmutableList.copyOf(fieldDefinitions);
     }
 
@@ -62,9 +62,23 @@ public class ObjectTypeDefinition extends AbstractDescribedNode<ObjectTypeDefini
         return implementz;
     }
 
-    @Override
     public List<Directive> getDirectives() {
-        return directives;
+        return directives.getDirectives();
+    }
+
+    @Override
+    public Map<String, List<Directive>> getDirectivesByName() {
+        return directives.getDirectivesByName();
+    }
+
+    @Override
+    public List<Directive> getDirectives(String directiveName) {
+        return directives.getDirectives(directiveName);
+    }
+
+    @Override
+    public boolean hasDirective(String directiveName) {
+        return directives.hasDirective(directiveName);
     }
 
     @Override
@@ -81,7 +95,7 @@ public class ObjectTypeDefinition extends AbstractDescribedNode<ObjectTypeDefini
     public List<Node> getChildren() {
         List<Node> result = new ArrayList<>();
         result.addAll(implementz);
-        result.addAll(directives);
+        result.addAll(directives.getDirectives());
         result.addAll(fieldDefinitions);
         return result;
     }
@@ -90,7 +104,7 @@ public class ObjectTypeDefinition extends AbstractDescribedNode<ObjectTypeDefini
     public NodeChildrenContainer getNamedChildren() {
         return newNodeChildrenContainer()
                 .children(CHILD_IMPLEMENTZ, implementz)
-                .children(CHILD_DIRECTIVES, directives)
+                .children(CHILD_DIRECTIVES, directives.getDirectives())
                 .children(CHILD_FIELD_DEFINITIONS, fieldDefinitions)
                 .build();
     }
@@ -120,7 +134,7 @@ public class ObjectTypeDefinition extends AbstractDescribedNode<ObjectTypeDefini
     public ObjectTypeDefinition deepCopy() {
         return new ObjectTypeDefinition(name,
                 deepCopy(implementz),
-                deepCopy(directives),
+                deepCopy(directives.getDirectives()),
                 deepCopy(fieldDefinitions),
                 description,
                 getSourceLocation(),

--- a/src/main/java/graphql/language/OperationDefinition.java
+++ b/src/main/java/graphql/language/OperationDefinition.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
 import graphql.collect.ImmutableKit;
+import graphql.language.NodeUtil.DirectivesHolder;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
@@ -31,7 +32,7 @@ public class OperationDefinition extends AbstractNode<OperationDefinition> imple
 
     private final Operation operation;
     private final ImmutableList<VariableDefinition> variableDefinitions;
-    private final ImmutableList<Directive> directives;
+    private final DirectivesHolder directives;
     private final SelectionSet selectionSet;
 
     public static final String CHILD_VARIABLE_DEFINITIONS = "variableDefinitions";
@@ -52,7 +53,7 @@ public class OperationDefinition extends AbstractNode<OperationDefinition> imple
         this.name = name;
         this.operation = operation;
         this.variableDefinitions = ImmutableList.copyOf(variableDefinitions);
-        this.directives = ImmutableList.copyOf(directives);
+        this.directives = DirectivesHolder.of(directives);
         this.selectionSet = selectionSet;
     }
 
@@ -69,7 +70,7 @@ public class OperationDefinition extends AbstractNode<OperationDefinition> imple
     public List<Node> getChildren() {
         List<Node> result = new ArrayList<>();
         result.addAll(variableDefinitions);
-        result.addAll(directives);
+        result.addAll(directives.getDirectives());
         result.add(selectionSet);
         return result;
     }
@@ -78,7 +79,7 @@ public class OperationDefinition extends AbstractNode<OperationDefinition> imple
     public NodeChildrenContainer getNamedChildren() {
         return newNodeChildrenContainer()
                 .children(CHILD_VARIABLE_DEFINITIONS, variableDefinitions)
-                .children(CHILD_DIRECTIVES, directives)
+                .children(CHILD_DIRECTIVES, directives.getDirectives())
                 .child(CHILD_SELECTION_SET, selectionSet)
                 .build();
     }
@@ -105,7 +106,22 @@ public class OperationDefinition extends AbstractNode<OperationDefinition> imple
     }
 
     public List<Directive> getDirectives() {
-        return directives;
+        return directives.getDirectives();
+    }
+
+    @Override
+    public Map<String, List<Directive>> getDirectivesByName() {
+        return directives.getDirectivesByName();
+    }
+
+    @Override
+    public List<Directive> getDirectives(String directiveName) {
+        return directives.getDirectives(directiveName);
+    }
+
+    @Override
+    public boolean hasDirective(String directiveName) {
+        return directives.hasDirective(directiveName);
     }
 
     @Override
@@ -133,7 +149,7 @@ public class OperationDefinition extends AbstractNode<OperationDefinition> imple
         return new OperationDefinition(name,
                 operation,
                 deepCopy(variableDefinitions),
-                deepCopy(directives),
+                deepCopy(directives.getDirectives()),
                 deepCopy(selectionSet),
                 getSourceLocation(),
                 getComments(),
@@ -234,6 +250,7 @@ public class OperationDefinition extends AbstractNode<OperationDefinition> imple
             this.directives = ImmutableKit.addToList(directives, directive);
             return this;
         }
+
         public Builder selectionSet(SelectionSet selectionSet) {
             this.selectionSet = selectionSet;
             return this;

--- a/src/main/java/graphql/language/ScalarTypeDefinition.java
+++ b/src/main/java/graphql/language/ScalarTypeDefinition.java
@@ -23,7 +23,7 @@ import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 public class ScalarTypeDefinition extends AbstractDescribedNode<ScalarTypeDefinition> implements TypeDefinition<ScalarTypeDefinition>, DirectivesContainer<ScalarTypeDefinition>, NamedNode<ScalarTypeDefinition> {
 
     private final String name;
-    private final ImmutableList<Directive> directives;
+    private final NodeUtil.DirectivesHolder directives;
 
     public static final String CHILD_DIRECTIVES = "directives";
 
@@ -37,7 +37,7 @@ public class ScalarTypeDefinition extends AbstractDescribedNode<ScalarTypeDefini
                                    Map<String, String> additionalData) {
         super(sourceLocation, comments, ignoredChars, additionalData, description);
         this.name = name;
-        this.directives = ImmutableList.copyOf(directives);
+        this.directives = NodeUtil.DirectivesHolder.of(directives);
     }
 
     /**
@@ -51,7 +51,22 @@ public class ScalarTypeDefinition extends AbstractDescribedNode<ScalarTypeDefini
 
     @Override
     public List<Directive> getDirectives() {
-        return directives;
+        return directives.getDirectives();
+    }
+
+    @Override
+    public Map<String, List<Directive>> getDirectivesByName() {
+        return directives.getDirectivesByName();
+    }
+
+    @Override
+    public List<Directive> getDirectives(String directiveName) {
+        return directives.getDirectives(directiveName);
+    }
+
+    @Override
+    public boolean hasDirective(String directiveName) {
+        return directives.hasDirective(directiveName);
     }
 
     @Override
@@ -61,13 +76,13 @@ public class ScalarTypeDefinition extends AbstractDescribedNode<ScalarTypeDefini
 
     @Override
     public List<Node> getChildren() {
-        return ImmutableList.copyOf(directives);
+        return ImmutableList.copyOf(directives.getDirectives());
     }
 
     @Override
     public NodeChildrenContainer getNamedChildren() {
         return newNodeChildrenContainer()
-                .children(CHILD_DIRECTIVES, directives)
+                .children(CHILD_DIRECTIVES, directives.getDirectives())
                 .build();
     }
 
@@ -94,7 +109,7 @@ public class ScalarTypeDefinition extends AbstractDescribedNode<ScalarTypeDefini
 
     @Override
     public ScalarTypeDefinition deepCopy() {
-        return new ScalarTypeDefinition(name, deepCopy(directives), description, getSourceLocation(), getComments(), getIgnoredChars(), getAdditionalData());
+        return new ScalarTypeDefinition(name, deepCopy(directives.getDirectives()), description, getSourceLocation(), getComments(), getIgnoredChars(), getAdditionalData());
     }
 
     @Override

--- a/src/main/java/graphql/language/SchemaDefinition.java
+++ b/src/main/java/graphql/language/SchemaDefinition.java
@@ -21,7 +21,7 @@ import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 @PublicApi
 public class SchemaDefinition extends AbstractDescribedNode<SchemaDefinition> implements SDLDefinition<SchemaDefinition>, DirectivesContainer<SchemaDefinition> {
 
-    private final ImmutableList<Directive> directives;
+    private final NodeUtil.DirectivesHolder directives;
     private final ImmutableList<OperationTypeDefinition> operationTypeDefinitions;
 
     public static final String CHILD_DIRECTIVES = "directives";
@@ -37,12 +37,28 @@ public class SchemaDefinition extends AbstractDescribedNode<SchemaDefinition> im
                                Map<String, String> additionalData,
                                Description description) {
         super(sourceLocation, comments, ignoredChars, additionalData, description);
-        this.directives = ImmutableList.copyOf(directives);
+        this.directives = NodeUtil.DirectivesHolder.of(directives);
         this.operationTypeDefinitions = ImmutableList.copyOf(operationTypeDefinitions);
     }
 
+    @Override
     public List<Directive> getDirectives() {
-        return directives;
+        return directives.getDirectives();
+    }
+
+    @Override
+    public Map<String, List<Directive>> getDirectivesByName() {
+        return directives.getDirectivesByName();
+    }
+
+    @Override
+    public List<Directive> getDirectives(String directiveName) {
+        return directives.getDirectives(directiveName);
+    }
+
+    @Override
+    public boolean hasDirective(String directiveName) {
+        return directives.hasDirective(directiveName);
     }
 
     public List<OperationTypeDefinition> getOperationTypeDefinitions() {
@@ -56,7 +72,7 @@ public class SchemaDefinition extends AbstractDescribedNode<SchemaDefinition> im
     @Override
     public List<Node> getChildren() {
         List<Node> result = new ArrayList<>();
-        result.addAll(directives);
+        result.addAll(directives.getDirectives());
         result.addAll(operationTypeDefinitions);
         return result;
     }
@@ -64,7 +80,7 @@ public class SchemaDefinition extends AbstractDescribedNode<SchemaDefinition> im
     @Override
     public NodeChildrenContainer getNamedChildren() {
         return newNodeChildrenContainer()
-                .children(CHILD_DIRECTIVES, directives)
+                .children(CHILD_DIRECTIVES, directives.getDirectives())
                 .children(CHILD_OPERATION_TYPE_DEFINITIONS, operationTypeDefinitions)
                 .build();
     }
@@ -90,7 +106,7 @@ public class SchemaDefinition extends AbstractDescribedNode<SchemaDefinition> im
 
     @Override
     public SchemaDefinition deepCopy() {
-        return new SchemaDefinition(deepCopy(directives), deepCopy(operationTypeDefinitions), getSourceLocation(), getComments(),
+        return new SchemaDefinition(deepCopy(directives.getDirectives()), deepCopy(operationTypeDefinitions), getSourceLocation(), getComments(),
                 getIgnoredChars(), getAdditionalData(), description);
     }
 

--- a/src/main/java/graphql/language/UnionTypeDefinition.java
+++ b/src/main/java/graphql/language/UnionTypeDefinition.java
@@ -24,7 +24,7 @@ import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 public class UnionTypeDefinition extends AbstractDescribedNode<UnionTypeDefinition> implements TypeDefinition<UnionTypeDefinition>, DirectivesContainer<UnionTypeDefinition>, NamedNode<UnionTypeDefinition> {
 
     private final String name;
-    private final ImmutableList<Directive> directives;
+    private final NodeUtil.DirectivesHolder directives;
     private final ImmutableList<Type> memberTypes;
 
     public static final String CHILD_DIRECTIVES = "directives";
@@ -40,7 +40,7 @@ public class UnionTypeDefinition extends AbstractDescribedNode<UnionTypeDefiniti
                                   IgnoredChars ignoredChars, Map<String, String> additionalData) {
         super(sourceLocation, comments, ignoredChars, additionalData, description);
         this.name = name;
-        this.directives = ImmutableList.copyOf(directives);
+        this.directives = NodeUtil.DirectivesHolder.of(directives);
         this.memberTypes = ImmutableList.copyOf(memberTypes);
     }
 
@@ -66,7 +66,22 @@ public class UnionTypeDefinition extends AbstractDescribedNode<UnionTypeDefiniti
 
     @Override
     public List<Directive> getDirectives() {
-        return directives;
+        return directives.getDirectives();
+    }
+
+    @Override
+    public Map<String, List<Directive>> getDirectivesByName() {
+        return directives.getDirectivesByName();
+    }
+
+    @Override
+    public List<Directive> getDirectives(String directiveName) {
+        return directives.getDirectives(directiveName);
+    }
+
+    @Override
+    public boolean hasDirective(String directiveName) {
+        return directives.hasDirective(directiveName);
     }
 
     public List<Type> getMemberTypes() {
@@ -81,7 +96,7 @@ public class UnionTypeDefinition extends AbstractDescribedNode<UnionTypeDefiniti
     @Override
     public List<Node> getChildren() {
         List<Node> result = new ArrayList<>();
-        result.addAll(directives);
+        result.addAll(directives.getDirectives());
         result.addAll(memberTypes);
         return result;
     }
@@ -89,7 +104,7 @@ public class UnionTypeDefinition extends AbstractDescribedNode<UnionTypeDefiniti
     @Override
     public NodeChildrenContainer getNamedChildren() {
         return newNodeChildrenContainer()
-                .children(CHILD_DIRECTIVES, directives)
+                .children(CHILD_DIRECTIVES, directives.getDirectives())
                 .children(CHILD_MEMBER_TYPES, memberTypes)
                 .build();
     }
@@ -119,7 +134,7 @@ public class UnionTypeDefinition extends AbstractDescribedNode<UnionTypeDefiniti
     @Override
     public UnionTypeDefinition deepCopy() {
         return new UnionTypeDefinition(name,
-                deepCopy(directives),
+                deepCopy(directives.getDirectives()),
                 deepCopy(memberTypes),
                 description,
                 getSourceLocation(),

--- a/src/main/java/graphql/language/VariableDefinition.java
+++ b/src/main/java/graphql/language/VariableDefinition.java
@@ -26,7 +26,7 @@ public class VariableDefinition extends AbstractNode<VariableDefinition> impleme
     private final String name;
     private final Type type;
     private final Value defaultValue;
-    private final ImmutableList<Directive> directives;
+    private final NodeUtil.DirectivesHolder directives;
 
     public static final String CHILD_TYPE = "type";
     public static final String CHILD_DEFAULT_VALUE = "defaultValue";
@@ -45,7 +45,7 @@ public class VariableDefinition extends AbstractNode<VariableDefinition> impleme
         this.name = name;
         this.type = type;
         this.defaultValue = defaultValue;
-        this.directives = ImmutableList.copyOf(directives);
+        this.directives = NodeUtil.DirectivesHolder.of(directives);
     }
 
     /**
@@ -86,7 +86,22 @@ public class VariableDefinition extends AbstractNode<VariableDefinition> impleme
 
     @Override
     public List<Directive> getDirectives() {
-        return directives;
+        return directives.getDirectives();
+    }
+
+    @Override
+    public Map<String, List<Directive>> getDirectivesByName() {
+        return directives.getDirectivesByName();
+    }
+
+    @Override
+    public List<Directive> getDirectives(String directiveName) {
+        return directives.getDirectives(directiveName);
+    }
+
+    @Override
+    public boolean hasDirective(String directiveName) {
+        return directives.hasDirective(directiveName);
     }
 
     @Override
@@ -96,7 +111,7 @@ public class VariableDefinition extends AbstractNode<VariableDefinition> impleme
         if (defaultValue != null) {
             result.add(defaultValue);
         }
-        result.addAll(directives);
+        result.addAll(directives.getDirectives());
         return result;
     }
 
@@ -105,7 +120,7 @@ public class VariableDefinition extends AbstractNode<VariableDefinition> impleme
         return newNodeChildrenContainer()
                 .child(CHILD_TYPE, type)
                 .child(CHILD_DEFAULT_VALUE, defaultValue)
-                .children(CHILD_DIRECTIVES, directives)
+                .children(CHILD_DIRECTIVES, directives.getDirectives())
                 .build();
     }
 
@@ -138,7 +153,7 @@ public class VariableDefinition extends AbstractNode<VariableDefinition> impleme
         return new VariableDefinition(name,
                 deepCopy(type),
                 deepCopy(defaultValue),
-                deepCopy(directives),
+                deepCopy(directives.getDirectives()),
                 getSourceLocation(),
                 getComments(),
                 getIgnoredChars(),


### PR DESCRIPTION
When we wrote the `graphql.language.DirectivesContainer` we put default methods on it to save code in each language element that implemented it

But because interfaces cant have state, then it we doing a per "group by" etc... when each call was made.

This introduces a `DirectivesHolder` helper class (like we do in the runtime via `graphql.DirectivesUtil.DirectivesHolder`) that holds the immutable state and helps each implementing class implement the `DirectivesContainer` methods

So while there is more code in each, it more efficient than the `default` interface methods