### PR TITLE
Iterate over implementations in isPossibleType

### DIFF
--- a/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java
+++ b/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java
@@ -623,9 +623,17 @@ public class TypeDefinitionRegistry implements Serializable {
             return false;
         } else {
             InterfaceTypeDefinition iFace = (InterfaceTypeDefinition) abstractTypeDef;
-            List<ImplementingTypeDefinition> implementingTypeDefinitions = getAllImplementationsOf(iFace);
-            return implementingTypeDefinitions.stream()
-                    .anyMatch(od -> od.getName().equals(targetObjectTypeDef.getName()));
+
+            return types.values().stream()
+                    .filter(ImplementingTypeDefinition.class::isInstance)
+                    .filter(t -> t.getName().equals(targetObjectTypeDef.getName()))
+                    .map(td -> (ImplementingTypeDefinition<?>) td)
+                    .anyMatch(itd -> itd.getImplements()
+                            .stream()
+                            .map(TypeInfo::getTypeName)
+                            .map(tn -> types.get(tn.getName()))
+                            .anyMatch(td -> td.getName().equals(iFace.getName()))
+                    );
         }
     }
 

--- a/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java
+++ b/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java
@@ -624,16 +624,24 @@ public class TypeDefinitionRegistry implements Serializable {
         } else {
             InterfaceTypeDefinition iFace = (InterfaceTypeDefinition) abstractTypeDef;
 
-            return types.values().stream()
-                    .filter(ImplementingTypeDefinition.class::isInstance)
-                    .filter(t -> t.getName().equals(targetObjectTypeDef.getName()))
-                    .map(td -> (ImplementingTypeDefinition<?>) td)
-                    .anyMatch(itd -> itd.getImplements()
-                            .stream()
-                            .map(TypeInfo::getTypeName)
-                            .map(tn -> types.get(tn.getName()))
-                            .anyMatch(td -> td.getName().equals(iFace.getName()))
-                    );
+            for (TypeDefinition<?> t : types.values()) {
+                if (t instanceof ImplementingTypeDefinition) {
+                    if (t.getName().equals(targetObjectTypeDef.getName())) {
+                        ImplementingTypeDefinition<?> itd = (ImplementingTypeDefinition<?>) t;
+
+                        for (Type impl : itd.getImplements()) {
+                            TypeName typeName = TypeInfo.getTypeName(impl);
+                            TypeDefinition<?> matchingInterface = types.get(typeName.getName());
+
+                            if (matchingInterface != null && matchingInterface.getName().equals(iFace.getName())) {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+
+            return false;
         }
     }
 

--- a/src/main/java/graphql/schema/idl/TypeInfo.java
+++ b/src/main/java/graphql/schema/idl/TypeInfo.java
@@ -26,6 +26,13 @@ public class TypeInfo {
         return new TypeInfo(type);
     }
 
+    /**
+     * Gets the type name of a [Type], unwrapping any lists or non-null decorations
+     *
+     * @param type the Type
+     *
+     * @return the inner TypeName for this type
+     */
     public static TypeName getTypeName(Type type) {
         while (!(type instanceof TypeName)) {
             if (type instanceof NonNullType) {

--- a/src/main/java/graphql/schema/idl/TypeInfo.java
+++ b/src/main/java/graphql/schema/idl/TypeInfo.java
@@ -26,6 +26,18 @@ public class TypeInfo {
         return new TypeInfo(type);
     }
 
+    public static TypeName getTypeName(Type type) {
+        while (!(type instanceof TypeName)) {
+            if (type instanceof NonNullType) {
+                type = ((NonNullType) type).getType();
+            }
+            if (type instanceof ListType) {
+                type = ((ListType) type).getType();
+            }
+        }
+        return (TypeName) type;
+    }
+
     private final Type rawType;
     private final TypeName typeName;
     private final Deque<Class<?>> decoration = new ArrayDeque<>();

--- a/src/test/groovy/graphql/schema/idl/TypeInfoTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/TypeInfoTest.groovy
@@ -136,4 +136,21 @@ class TypeInfoTest extends Specification {
         "[named!]!"   | "[newName!]!"
         "[[named!]!]" | "[[newName!]!]"
     }
+
+    def "test getTypeName gets to the inner type"() {
+
+        expect:
+        Type actualType = TestUtil.parseType(actual)
+        def typeName = TypeInfo.getTypeName(actualType)
+        typeName.getName() == expected
+
+        where:
+        actual        | expected
+        "named"       | "named"
+        "named!"      | "named"
+        "[named]"     | "named"
+        "[named!]"    | "named"
+        "[named!]!"   | "named"
+        "[[named!]!]" | "named"
+    }
 }


### PR DESCRIPTION
See https://github.com/graphql-java/graphql-java/pull/4021#issuecomment-3026354864 for more context.

Current `isPossibleType` needs to go through two expensive things for what seems like a simple check,  due. to the fact it calls `getAllImplementationsOf` first.

1. `getTypes` gets called by `getAllImplementationsOf` to collect all `ImplementingTypeDefinition`s. [(src)](https://github.com/graphql-java/graphql-java/blob/master/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java#L563)
2. For every implementation, a `TypeInfo` object is created to get name.

This PR tries to avoid both these things, and try to keep to a single iteration of types/impls.

