### PR TITLE
implement a new checkForTypeExtensionFieldUniqueness

### DIFF
--- a/src/main/java/graphql/schema/idl/SchemaTypeExtensionsChecker.java
+++ b/src/main/java/graphql/schema/idl/SchemaTypeExtensionsChecker.java
@@ -24,10 +24,13 @@ import graphql.schema.idl.errors.TypeExtensionFieldRedefinitionError;
 import graphql.schema.idl.errors.TypeExtensionMissingBaseTypeError;
 import graphql.util.FpKit;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static graphql.schema.idl.SchemaTypeChecker.checkNamedUniqueness;
@@ -81,12 +84,13 @@ class SchemaTypeExtensionsChecker {
                                         checkNamedUniqueness(errors, directive.getArguments(), Argument::getName,
                                                 (argumentName, argument) -> new NonUniqueArgumentError(extension, fld, argumentName))));
 
-                                //
                                 // fields must be unique within a type extension
-                                forEachBut(extension, extensions,
-                                        otherTypeExt -> checkForFieldRedefinition(errors, otherTypeExt, otherTypeExt.getFieldDefinitions(), fieldDefinitions));
+                                checkForTypeExtensionFieldUniqueness(
+                                        errors,
+                                        extensions,
+                                        ObjectTypeDefinition::getFieldDefinitions
+                                );
 
-                                //
                                 // then check for field re-defs from the base type
                                 Optional<ObjectTypeDefinition> baseTypeOpt = typeRegistry.getType(extension.getName(), ObjectTypeDefinition.class);
                                 baseTypeOpt.ifPresent(baseTypeDef -> checkForFieldRedefinition(errors, extension, fieldDefinitions, baseTypeDef.getFieldDefinitions()));
@@ -125,10 +129,12 @@ class SchemaTypeExtensionsChecker {
                                 checkNamedUniqueness(errors, directive.getArguments(), Argument::getName,
                                         (argumentName, argument) -> new NonUniqueArgumentError(extension, fld, argumentName))));
 
-                        //
                         // fields must be unique within a type extension
-                        forEachBut(extension, extensions,
-                                otherTypeExt -> checkForFieldRedefinition(errors, otherTypeExt, otherTypeExt.getFieldDefinitions(), fieldDefinitions));
+                        checkForTypeExtensionFieldUniqueness(
+                                errors,
+                                extensions,
+                                InterfaceTypeDefinition::getFieldDefinitions
+                        );
 
                         //
                         // then check for field re-defs from the base type
@@ -136,6 +142,24 @@ class SchemaTypeExtensionsChecker {
                         baseTypeOpt.ifPresent(baseTypeDef -> checkForFieldRedefinition(errors, extension, fieldDefinitions, baseTypeDef.getFieldDefinitions()));
                     });
                 });
+    }
+
+    private <T extends TypeDefinition<?>> void checkForTypeExtensionFieldUniqueness(
+            List<GraphQLError> errors,
+            List<T> extensions,
+            Function<T, List<FieldDefinition>> getFieldDefinitions
+    ) {
+        Set<String> seenFields = new HashSet<>();
+
+        for (T extension : extensions) {
+            for (FieldDefinition field : getFieldDefinitions.apply(extension)) {
+                if (seenFields.contains(field.getName())) {
+                    errors.add(new TypeExtensionFieldRedefinitionError(extension, field));
+                } else {
+                    seenFields.add(field.getName());
+                }
+            }
+        }
     }
 
     /*


### PR DESCRIPTION
I'm afraid this might not be backward compatible /  a suitable user experience. But curious on your thoughts. This check is very, very expensive on large schemas (containing a lot of extensions such as federated schemas).

This proposed solution is not quite the same as before. The current check compares. each extension against each other extension. This means that if two types define `a`, we get two errors for `a`.

Could we get away with calling out redefinitions only once?
