### PR TITLE
Added UAT for EscapeUtil 

### DIFF
--- a/src/test/groovy/graphql/util/EscapeUtilTest.groovy
+++ b/src/test/groovy/graphql/util/EscapeUtilTest.groovy
@@ -28,4 +28,24 @@ class EscapeUtilTest extends Specification {
         '''"{"operator":"eq", "operands": []}"''' | '''\\"{\\"operator\\":\\"eq\\", \\"operands\\": []}\\"'''
     }
 
+    def "escapeJsonStringTo produces correct escaped output"() {
+        given:
+        def strValue = new StringBuilder()
+
+        when:
+        EscapeUtil.escapeJsonStringTo(strValue, input)
+
+        then:
+        strValue.toString() == expected
+
+        where:
+        input                                       | expected
+        ''                                          | ''
+        'plain'                                     | 'plain'
+        'quote-"and\\'                              | 'quote-\\"and\\\\'
+        'tab\tnewline\n'                            | 'tab\\tnewline\\n'
+        'combo-"\\\b\f\n\r\t'                       | 'combo-\\"\\\\\\b\\f\\n\\r\\t'
+    }
+
+
 }


### PR DESCRIPTION
### Context

This PR adds the missing test case for [EscapeUtil](https://github.com/graphql-java/graphql-java/blob/master/src/main/java/graphql/util/EscapeUtil.java). 

### Test Plan

> ./gradlew :test

<img width="668" alt="Screenshot 2025-07-02 at 5 43 56 PM" src="https://github.com/user-attachments/assets/fabf30ed-ed89-4a1a-9d14-1729fcf15850" />

### Next Steps

1. Add more missing test cases to make this codebase more resilient. 