### PR TITLE
Added UAT for Pair.java

### DIFF
--- a/src/test/groovy/graphql/util/PairTest.groovy
+++ b/src/test/groovy/graphql/util/PairTest.groovy
@@ -1,0 +1,31 @@
+package graphql.util
+
+import spock.lang.Specification
+
+class PairTest extends Specification {
+    def "constructor initializes fields correctly"() {
+        when:
+        def pair = new Pair<>("hello", 123)
+
+        then:
+        pair.first == "hello"
+        pair.second == 123
+    }
+
+    def "static pair method creates Pair instance"() {
+        when:
+        def pair = Pair.pair("foo", "bar")
+
+        then:
+        pair instanceof Pair
+        pair.first == "foo"
+        pair.second == "bar"
+    }
+
+    def "toString returns formatted string"() {
+        expect:
+        new Pair<>(1, 2).toString() == "(1, 2)"
+        Pair.pair("a", "b").toString() == "(a, b)"
+        new Pair<>(null, null).toString() == "(null, null)"
+    }
+}


### PR DESCRIPTION
### Context

This PR adds the missing test case for [Pair](https://github.com/graphql-java/graphql-java/blob/master/src/main/java/graphql/util/Pair.java). 

### Test Plan

> ./gradlew :test

<img width="670" alt="Screenshot 2025-07-02 at 5 55 48 PM" src="https://github.com/user-attachments/assets/b710c378-7df8-4a2b-bb30-c720343a130e" />

### Next Steps

1. Add more missing test cases to make this codebase more resilient. 