### PR TITLE
Allows creating mock schemas where there are default values on custom schemas

### DIFF
--- a/src/main/java/graphql/schema/idl/MockedWiringFactory.java
+++ b/src/main/java/graphql/schema/idl/MockedWiringFactory.java
@@ -1,6 +1,20 @@
 package graphql.schema.idl;
 
+import graphql.Assert;
+import graphql.GraphQLContext;
 import graphql.PublicApi;
+import graphql.execution.CoercedVariables;
+import graphql.language.ArrayValue;
+import graphql.language.BooleanValue;
+import graphql.language.EnumValue;
+import graphql.language.FloatValue;
+import graphql.language.IntValue;
+import graphql.language.NullValue;
+import graphql.language.ObjectField;
+import graphql.language.ObjectValue;
+import graphql.language.StringValue;
+import graphql.language.Value;
+import graphql.language.VariableReference;
 import graphql.schema.Coercing;
 import graphql.schema.CoercingParseLiteralException;
 import graphql.schema.CoercingParseValueException;
@@ -9,8 +23,26 @@ import graphql.schema.DataFetcher;
 import graphql.schema.GraphQLScalarType;
 import graphql.schema.SingletonPropertyDataFetcher;
 import graphql.schema.TypeResolver;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * This is a {@link WiringFactory} which provides mocked types resolver
+ * and scalars. It is useful for testing only, for example for creating schemas
+ * that can be inspected but not executed on.
+ * <p>
+ * See {@link RuntimeWiring#MOCKED_WIRING} for example usage
+ */
 @PublicApi
+@NullMarked
+@SuppressWarnings("rawtypes")
 public class MockedWiringFactory implements WiringFactory {
 
     @Override
@@ -43,34 +75,79 @@ public class MockedWiringFactory implements WiringFactory {
     }
 
     @Override
-    public DataFetcher getDataFetcher(FieldWiringEnvironment environment) {
+    public DataFetcher<?> getDataFetcher(FieldWiringEnvironment environment) {
         return SingletonPropertyDataFetcher.singleton();
     }
 
     @Override
     public boolean providesScalar(ScalarWiringEnvironment environment) {
-        if (ScalarInfo.isGraphqlSpecifiedScalar(environment.getScalarTypeDefinition().getName())) {
-            return false;
-        }
-        return true;
+        return !ScalarInfo.isGraphqlSpecifiedScalar(environment.getScalarTypeDefinition().getName());
     }
 
     public GraphQLScalarType getScalar(ScalarWiringEnvironment environment) {
-        return GraphQLScalarType.newScalar().name(environment.getScalarTypeDefinition().getName()).coercing(new Coercing() {
+        return GraphQLScalarType.newScalar().name(environment.getScalarTypeDefinition().getName()).coercing(new Coercing<>() {
+            @Nullable
             @Override
-            public Object serialize(Object dataFetcherResult) throws CoercingSerializeException {
+            public Object serialize(@NonNull Object dataFetcherResult, @NonNull GraphQLContext graphQLContext, @NonNull Locale locale) throws CoercingSerializeException {
                 throw new UnsupportedOperationException("Not implemented...this is only a mocked wiring");
             }
 
+            @Nullable
             @Override
-            public Object parseValue(Object input) throws CoercingParseValueException {
+            public Object parseValue(@NonNull Object input, @NonNull GraphQLContext graphQLContext, @NonNull Locale locale) throws CoercingParseValueException {
                 throw new UnsupportedOperationException("Not implemented...this is only a mocked wiring");
             }
 
+            @Nullable
             @Override
-            public Object parseLiteral(Object input) throws CoercingParseLiteralException {
-                throw new UnsupportedOperationException("Not implemented...this is only a mocked wiring");
+            public Object parseLiteral(@NonNull Value input, @NonNull CoercedVariables variables, @NonNull GraphQLContext graphQLContext, @NonNull Locale locale) throws CoercingParseLiteralException {
+                return parseLiteralImpl(input, variables, graphQLContext, locale);
             }
+
+            @Nullable
+            private Object parseLiteralImpl(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) {
+                if (input instanceof NullValue) {
+                    return null;
+                }
+                if (input instanceof FloatValue) {
+                    return ((FloatValue) input).getValue();
+                }
+                if (input instanceof StringValue) {
+                    return ((StringValue) input).getValue();
+                }
+                if (input instanceof IntValue) {
+                    return ((IntValue) input).getValue();
+                }
+                if (input instanceof BooleanValue) {
+                    return ((BooleanValue) input).isValue();
+                }
+                if (input instanceof EnumValue) {
+                    return ((EnumValue) input).getName();
+                }
+                if (input instanceof VariableReference) {
+                    String varName = ((VariableReference) input).getName();
+                    return variables.get(varName);
+                }
+                if (input instanceof ArrayValue) {
+                    List<Value> values = ((ArrayValue) input).getValues();
+                    return values.stream()
+                            .map(v -> parseLiteral(v, variables, graphQLContext, locale))
+                            .collect(Collectors.toList());
+                }
+                if (input instanceof ObjectValue) {
+                    List<ObjectField> values = ((ObjectValue) input).getObjectFields();
+                    Map<String, Object> parsedValues = new LinkedHashMap<>();
+                    values.forEach(fld -> {
+                        Object parsedValue = parseLiteral(fld.getValue(), variables, graphQLContext, locale);
+                        if (parsedValue != null) {
+                            parsedValues.put(fld.getName(), parsedValue);
+                        }
+                    });
+                    return parsedValues;
+                }
+                return Assert.assertShouldNeverHappen("We have covered all Value types");
+            }
+
         }).build();
     }
 }

--- a/src/main/java/graphql/schema/idl/RuntimeWiring.java
+++ b/src/main/java/graphql/schema/idl/RuntimeWiring.java
@@ -42,7 +42,8 @@ public class RuntimeWiring {
 
     /**
      * This is a Runtime wiring which provides mocked types resolver
-     * and scalars. Useful for testing only.
+     * and scalars. It is useful for testing only, for example for creating schemas
+     * that can be inspected but not executed on.
      */
     public static final RuntimeWiring MOCKED_WIRING = RuntimeWiring
             .newRuntimeWiring()

--- a/src/test/groovy/graphql/schema/idl/MockedWiringFactoryTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/MockedWiringFactoryTest.groovy
@@ -1,0 +1,49 @@
+package graphql.schema.idl
+
+
+import spock.lang.Specification
+
+class MockedWiringFactoryTest extends Specification {
+
+    def "mock wiring factory can be used for any schema"() {
+        def sdl = """
+            type Query {
+                foo : Foo
+            }
+            
+            scalar SomeScalar
+            scalar SomeOtherScalar
+            
+            type Foo {
+                bar( 
+                    arg1 : SomeScalar! = 666, 
+                    arg2 : Int! = 777, 
+                    arg3 : SomeOtherScalar = { x : [{ y : 1, z : "s"}] } ) : Bar
+            }
+            
+            interface Bar {
+                baz : String
+            }
+            
+            type BarBar implements Bar {
+                baz : String
+            }
+
+            type BlackSheep implements Bar {
+                baz : String
+            }
+        """
+
+        when:
+        def registry = new SchemaParser().parse(sdl)
+        def schema = new SchemaGenerator().makeExecutableSchema(registry, RuntimeWiring.MOCKED_WIRING)
+
+        then:
+        schema != null
+        schema.getType("Query") != null
+        schema.getType("Foo") != null
+        schema.getType("Bar") != null
+        schema.getType("BarBar") != null
+        schema.getType("BlackSheep") != null
+    }
+}


### PR DESCRIPTION
If a schema has a default value on a custom scalar then the current MockWiringFactory will not fake it out well enough to create the schema

You get

```
java.lang.UnsupportedOperationException: Not implemented...this is only a mocked wiring

	at graphql.schema.idl.MockedWiringFactory$1.parseLiteral(MockedWiringFactory.java:72)
	at graphql.schema.Coercing.parseLiteral(Coercing.java:176)
	at graphql.schema.Coercing.parseLiteral(Coercing.java:205)
	at graphql.validation.ValidationUtil.parseLiteral(ValidationUtil.java:128)
	at graphql.validation.ValidationUtil.isValidLiteralValue(ValidationUtil.java:100)
	at graphql.schema.validation.DefaultValuesAreValid.visitGraphQLArgument(DefaultValuesAreValid.java:70)
	at graphql.schema.GraphQLArgument.accept(GraphQLArgument.java:301)
	at graphql.schema.SchemaTraverser$TraverserDelegateListVisitor.enter(SchemaTraverser.java:136)
	at graphql.util.Traverser.traverse(Traverser.java:144)
	at graphql.schema.SchemaTraverser.depthFirstFullSchema(SchemaTraverser.java:73)
	at graphql.schema.validation.SchemaValidator.validateSchema(SchemaValidator.java:41)
```

This changes it so it returns a value from the literal.  Its still not an executable schema (there is no true data fetchers or type resolves) but the schema will be created ok