### PR TITLE
Improved access speed of isPossibleType

### DIFF
--- a/src/main/java/graphql/schema/idl/TypeInfo.java
+++ b/src/main/java/graphql/schema/idl/TypeInfo.java
@@ -139,6 +139,25 @@ public class TypeInfo {
         return unwrapOne().getRawType();
     }
 
+    /**
+     * Gets the type name of a [Type], unwrapping any lists or non-null decorations
+     *
+     * @param type the Type
+     *
+     * @return the inner TypeName for this type
+     */
+    public static TypeName getTypeName(Type<?> type) {
+        while (!(type instanceof TypeName)) {
+            if (type instanceof NonNullType) {
+                type = ((NonNullType) type).getType();
+            }
+            if (type instanceof ListType) {
+                type = ((ListType) type).getType();
+            }
+        }
+        return (TypeName) type;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/test/groovy/graphql/schema/idl/ImmutableTypeDefinitionRegistryTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/ImmutableTypeDefinitionRegistryTest.groovy
@@ -1,5 +1,6 @@
 package graphql.schema.idl
 
+import graphql.language.InterfaceTypeDefinition
 import graphql.language.TypeDefinition
 import spock.lang.Specification
 
@@ -169,6 +170,64 @@ class ImmutableTypeDefinitionRegistryTest extends Specification {
         immutableRegistry.remove("key", someDef)
         then:
         thrown(UnsupportedOperationException)
+    }
+
+    def "get implementations of"() {
+        def sdl = serializableSchema + """
+            interface IType {
+                i : String
+            }
+            
+            interface DerivedIType implements IType {
+                i : String
+                d : String                
+            } 
+            
+        """
+        for (int i = 0; i < 10; i++) {
+            sdl += """
+                type OT$i implements IType {
+                    i : String
+                }
+                """
+
+        }
+        for (int i = 0; i < 5; i++) {
+            sdl += """
+            type DT$i implements DerivedIType {
+                i : String
+                d : String                
+            } 
+                """
+
+        }
+        def immutableRegistry = new SchemaParser().parse(sdl).readOnly()
+
+        Map<String, InterfaceTypeDefinition> interfaces = immutableRegistry.getTypesMap(InterfaceTypeDefinition.class)
+
+        when:
+        def iFieldType = interfaces.get("IType")
+        def allImplementationsOf = immutableRegistry.getAllImplementationsOf(iFieldType)
+        def implementationsOf = immutableRegistry.getImplementationsOf(iFieldType)
+
+        then:
+        allImplementationsOf.size() == 11
+        allImplementationsOf.collect({ it.getName() }).every { it.startsWith("OT") || it == "DerivedIType" }
+
+        implementationsOf.size() == 10
+        implementationsOf.collect({ it.getName() }).every { it.startsWith("OT") }
+
+        when:
+        def iDerivedType = interfaces.get("DerivedIType")
+        allImplementationsOf = immutableRegistry.getAllImplementationsOf(iDerivedType)
+        implementationsOf = immutableRegistry.getImplementationsOf(iDerivedType)
+
+        then:
+        allImplementationsOf.size() == 5
+        allImplementationsOf.collect({ it.getName() }).every { it.startsWith("DT") }
+
+        implementationsOf.size() == 5
+        implementationsOf.collect({ it.getName() }).every { it.startsWith("DT") }
 
     }
 

--- a/src/test/groovy/graphql/schema/idl/SchemaTypeCheckerTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaTypeCheckerTest.groovy
@@ -32,7 +32,7 @@ import static java.lang.String.format
 class SchemaTypeCheckerTest extends Specification {
 
     static TypeDefinitionRegistry parseSDL(String spec) {
-        new SchemaParser().parse(spec)
+        new SchemaParser().parse(spec).readOnly()
     }
 
     def resolver = new TypeResolver() {

--- a/src/test/groovy/graphql/schema/idl/TypeInfoTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/TypeInfoTest.groovy
@@ -136,4 +136,22 @@ class TypeInfoTest extends Specification {
         "[named!]!"   | "[newName!]!"
         "[[named!]!]" | "[[newName!]!]"
     }
+
+    @Unroll
+    def "test getTypeName gets to the inner type"() {
+
+        expect:
+        Type actualType = TestUtil.parseType(actual)
+        def typeName = TypeInfo.getTypeName(actualType)
+        typeName.getName() == expected
+
+        where:
+        actual        | expected
+        "named"       | "named"
+        "named!"      | "named"
+        "[named]"     | "named"
+        "[named!]"    | "named"
+        "[named!]!"   | "named"
+        "[[named!]!]" | "named"
+    }
 }


### PR DESCRIPTION
This builds on https://github.com/graphql-java/graphql-java/pull/4033/ but it creates a cache in the ImmutableTypeRegistry so that we don't need to iterate all types on each call