### PR TITLE
Removed more .streams() with our filterAndMap code

### DIFF
--- a/src/main/java/graphql/collect/ImmutableKit.java
+++ b/src/main/java/graphql/collect/ImmutableKit.java
@@ -185,4 +185,27 @@ public final class ImmutableKit {
         return newSet.build();
     }
 
+
+    /**
+     * Filters a variable args array to a list
+     *
+     * @param filter the predicate the filter with
+     * @param args   the variable args
+     * @param <T>    fot two
+     *
+     * @return a filtered list
+     */
+    @SafeVarargs
+    public static <T> List<T> filterVarArgs(Predicate<? super T> filter, T... args) {
+        if (args.length == 0) {
+            return ImmutableList.of();
+        }
+        ImmutableList.Builder<T> builder = ImmutableList.builderWithExpectedSize(args.length);
+        for (T arg : args) {
+            if (filter.test(arg)) {
+                builder.add(arg);
+            }
+        }
+        return builder.build();
+    }
 }

--- a/src/main/java/graphql/introspection/Introspection.java
+++ b/src/main/java/graphql/introspection/Introspection.java
@@ -7,6 +7,7 @@ import graphql.ExecutionResult;
 import graphql.GraphQLContext;
 import graphql.Internal;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 import graphql.execution.ExecutionContext;
 import graphql.execution.MergedField;
 import graphql.execution.MergedSelectionSet;
@@ -48,7 +49,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static graphql.Assert.assertTrue;
 import static graphql.Scalars.GraphQLBoolean;
@@ -356,9 +356,8 @@ public class Introspection {
             Object type = environment.getSource();
             GraphQLFieldDefinition fieldDef = (GraphQLFieldDefinition) type;
             Boolean includeDeprecated = environment.getArgument("includeDeprecated");
-            return fieldDef.getArguments().stream()
-                    .filter(arg -> includeDeprecated || !arg.isDeprecated())
-                    .collect(Collectors.toList());
+            return ImmutableKit.filter(fieldDef.getArguments(),
+                    arg -> includeDeprecated || !arg.isDeprecated());
         };
         register(__Field, "name", nameDataFetcher);
         register(__Field, "description", descriptionDataFetcher);
@@ -406,9 +405,8 @@ public class Introspection {
             if (includeDeprecated) {
                 return fieldDefinitions;
             }
-            return fieldDefinitions.stream()
-                    .filter(field -> !field.isDeprecated())
-                    .collect(Collectors.toList());
+            return ImmutableKit.filter(fieldDefinitions,
+                    field -> !field.isDeprecated());
         }
         return null;
     };
@@ -444,9 +442,8 @@ public class Introspection {
             if (includeDeprecated) {
                 return values;
             }
-            return values.stream()
-                    .filter(enumValue -> !enumValue.isDeprecated())
-                    .collect(Collectors.toList());
+            return ImmutableKit.filter(values,
+                    enumValue -> !enumValue.isDeprecated());
         }
         return null;
     };
@@ -463,9 +460,8 @@ public class Introspection {
             if (includeDeprecated) {
                 return inputFields;
             }
-            return inputFields
-                    .stream().filter(inputField -> !inputField.isDeprecated())
-                    .collect(Collectors.toList());
+            return ImmutableKit.filter(inputFields,
+                    inputField -> !inputField.isDeprecated());
         }
         return null;
     };
@@ -650,9 +646,8 @@ public class Introspection {
         IntrospectionDataFetcher<?> argsDataFetcher = environment -> {
             GraphQLDirective directive = environment.getSource();
             Boolean includeDeprecated = environment.getArgument("includeDeprecated");
-            return directive.getArguments().stream()
-                    .filter(arg -> includeDeprecated || !arg.isDeprecated())
-                    .collect(Collectors.toList());
+            return ImmutableKit.filter(directive.getArguments(),
+                    arg -> includeDeprecated || !arg.isDeprecated());
         };
         register(__Directive, "name", nameDataFetcher);
         register(__Directive, "description", descriptionDataFetcher);

--- a/src/main/java/graphql/introspection/IntrospectionQueryBuilder.java
+++ b/src/main/java/graphql/introspection/IntrospectionQueryBuilder.java
@@ -2,13 +2,13 @@ package graphql.introspection;
 
 import com.google.common.collect.ImmutableList;
 import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
 import graphql.language.AstPrinter;
 import graphql.language.BooleanValue;
 import graphql.language.Document;
 import graphql.language.OperationDefinition;
 import graphql.language.SelectionSet;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
@@ -20,7 +20,6 @@ import static graphql.language.FragmentSpread.newFragmentSpread;
 import static graphql.language.OperationDefinition.newOperationDefinition;
 import static graphql.language.SelectionSet.newSelectionSet;
 import static graphql.language.TypeName.newTypeName;
-import static java.util.stream.Collectors.toList;
 
 /**
  * {@link IntrospectionQueryBuilder} allows you to build introspection queries controlled
@@ -152,6 +151,7 @@ public class IntrospectionQueryBuilder {
                     this.inputValueDeprecation,
                     this.typeRefFragmentDepth);
         }
+
         /**
          * This will allow you to include the `isRepeatable` field for directives in the introspection query.
          *
@@ -223,7 +223,7 @@ public class IntrospectionQueryBuilder {
 
     @SafeVarargs
     private static <T> List<T> filter(T... args) {
-        return Arrays.stream(args).filter(Objects::nonNull).collect(toList());
+        return ImmutableKit.filterVarArgs(Objects::nonNull, args);
     }
 
     /**

--- a/src/main/java/graphql/introspection/IntrospectionWithDirectivesSupport.java
+++ b/src/main/java/graphql/introspection/IntrospectionWithDirectivesSupport.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import graphql.DirectivesUtil;
 import graphql.PublicApi;
 import graphql.PublicSpi;
+import graphql.collect.ImmutableKit;
 import graphql.execution.ValuesResolver;
 import graphql.language.AstPrinter;
 import graphql.language.Node;
@@ -41,7 +42,6 @@ import static graphql.schema.GraphQLList.list;
 import static graphql.schema.GraphQLNonNull.nonNull;
 import static graphql.schema.GraphQLObjectType.newObject;
 import static graphql.util.TraversalControl.CONTINUE;
-import static java.util.stream.Collectors.toList;
 
 /**
  * The graphql specification does not allow you to retrieve the directives and their argument values that
@@ -171,9 +171,9 @@ public class IntrospectionWithDirectivesSupport {
     }
 
     private GraphQLSchema addDirectiveDefinitionFilter(GraphQLSchema schema) {
-        DataFetcher<?>  df = env -> {
+        DataFetcher<?> df = env -> {
             List<GraphQLDirective> definedDirectives = env.getGraphQLSchema().getDirectives();
-            return filterDirectives(schema,true, null, definedDirectives);
+            return filterDirectives(schema, true, null, definedDirectives);
         };
         GraphQLCodeRegistry codeRegistry = schema.getCodeRegistry().transform(bld ->
                 bld.dataFetcher(coordinates(__Schema, "directives"), df));
@@ -199,8 +199,8 @@ public class IntrospectionWithDirectivesSupport {
         DataFetcher<?> argsDF = env -> {
             final GraphQLAppliedDirective directive = env.getSource();
             // we only show directive arguments that have values set on them
-            return directive.getArguments().stream()
-                    .filter(arg -> arg.getArgumentValue().isSet());
+            return ImmutableKit.filter(directive.getArguments(),
+                    arg -> arg.getArgumentValue().isSet());
         };
         DataFetcher<?> argValueDF = env -> {
             final GraphQLAppliedDirectiveArgument argument = env.getSource();
@@ -225,17 +225,19 @@ public class IntrospectionWithDirectivesSupport {
     }
 
     private List<GraphQLDirective> filterDirectives(GraphQLSchema schema, boolean isDefinedDirective, GraphQLDirectiveContainer container, List<GraphQLDirective> directives) {
-        return directives.stream().filter(directive -> {
-            DirectivePredicateEnvironment env = buildDirectivePredicateEnv(schema, isDefinedDirective, container, directive.getName());
-            return directivePredicate.isDirectiveIncluded(env);
-        }).collect(toList());
+        return ImmutableKit.filter(directives,
+                directive -> {
+                    DirectivePredicateEnvironment env = buildDirectivePredicateEnv(schema, isDefinedDirective, container, directive.getName());
+                    return directivePredicate.isDirectiveIncluded(env);
+                });
     }
 
     private List<GraphQLAppliedDirective> filterAppliedDirectives(GraphQLSchema schema, boolean isDefinedDirective, GraphQLDirectiveContainer container, List<GraphQLAppliedDirective> directives) {
-        return directives.stream().filter(directive -> {
-            DirectivePredicateEnvironment env = buildDirectivePredicateEnv(schema, isDefinedDirective, container, directive.getName());
-            return directivePredicate.isDirectiveIncluded(env);
-        }).collect(toList());
+        return ImmutableKit.filter(directives,
+                directive -> {
+                    DirectivePredicateEnvironment env = buildDirectivePredicateEnv(schema, isDefinedDirective, container, directive.getName());
+                    return directivePredicate.isDirectiveIncluded(env);
+                });
     }
 
     @NonNull

--- a/src/main/java/graphql/schema/idl/SchemaParseOrder.java
+++ b/src/main/java/graphql/schema/idl/SchemaParseOrder.java
@@ -1,6 +1,7 @@
 package graphql.schema.idl;
 
 import com.google.common.collect.ImmutableMap;
+import graphql.collect.ImmutableKit;
 import graphql.language.SDLDefinition;
 import graphql.language.SDLNamedDefinition;
 import graphql.language.SourceLocation;
@@ -21,7 +22,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
-import java.util.stream.Collectors;
 
 import static java.util.Optional.ofNullable;
 
@@ -53,10 +53,9 @@ public class SchemaParseOrder implements Serializable {
     public Map<String, List<SDLNamedDefinition<?>>> getInNameOrder() {
         Map<String, List<SDLNamedDefinition<?>>> named = new LinkedHashMap<>();
         definitionOrder.forEach((location, def) -> {
-            List<SDLNamedDefinition<?>> namedDefs = def.stream()
-                    .filter(d -> d instanceof SDLNamedDefinition)
-                    .map(d -> (SDLNamedDefinition<?>) d)
-                    .collect(Collectors.toList());
+            List<SDLNamedDefinition<?>> namedDefs = ImmutableKit.filterAndMap(def,
+                    d -> d instanceof SDLNamedDefinition,
+                    d -> (SDLNamedDefinition<?>) d);
             named.put(location, namedDefs);
         });
         return named;

--- a/src/main/java/graphql/schema/idl/SchemaTypeChecker.java
+++ b/src/main/java/graphql/schema/idl/SchemaTypeChecker.java
@@ -130,12 +130,8 @@ public class SchemaTypeChecker {
         List<InputObjectTypeDefinition> inputTypes = filterTo(typesMap, InputObjectTypeDefinition.class);
         inputTypes.forEach(inputType -> {
             List<InputValueDefinition> inputValueDefinitions = inputType.getInputValueDefinitions();
-            List<Type> inputValueTypes = inputValueDefinitions.stream()
-                    .map(InputValueDefinition::getType)
-                    .collect(toList());
-
+            List<Type> inputValueTypes = ImmutableKit.map(inputValueDefinitions, InputValueDefinition::getType);
             inputValueTypes.forEach(checkTypeExists("input value", typeRegistry, errors, inputType));
-
         });
     }
 
@@ -149,10 +145,7 @@ public class SchemaTypeChecker {
             checkNamedUniqueness(errors, arguments, InputValueDefinition::getName,
                     (name, arg) -> new NonUniqueNameError(directiveDefinition, arg));
 
-            List<Type> inputValueTypes = arguments.stream()
-                    .map(InputValueDefinition::getType)
-                    .collect(toList());
-
+            List<Type> inputValueTypes = ImmutableKit.map(arguments, InputValueDefinition::getType);
             inputValueTypes.forEach(
                     checkTypeExists(typeRegistry, errors, "directive definition", directiveDefinition, directiveDefinition.getName())
             );
@@ -316,7 +309,7 @@ public class SchemaTypeChecker {
     }
 
     private void checkFieldTypesPresent(TypeDefinitionRegistry typeRegistry, List<GraphQLError> errors, TypeDefinition typeDefinition, List<FieldDefinition> fields) {
-        List<Type> fieldTypes = fields.stream().map(FieldDefinition::getType).collect(toList());
+        List<Type> fieldTypes = ImmutableKit.map(fields, FieldDefinition::getType);
         fieldTypes.forEach(checkTypeExists("field", typeRegistry, errors, typeDefinition));
 
         List<Type> fieldInputValues = fields.stream()
@@ -363,9 +356,7 @@ public class SchemaTypeChecker {
     }
 
     private <T extends TypeDefinition> List<T> filterTo(Map<String, TypeDefinition> types, Class<? extends T> clazz) {
-        return types.values().stream()
-                .filter(t -> clazz.equals(t.getClass()))
-                .map(clazz::cast)
-                .collect(toList());
+        return ImmutableKit.filterAndMap(types.values(), t -> clazz.equals(t.getClass()),
+                clazz::cast);
     }
 }

--- a/src/main/java/graphql/schema/idl/SchemaTypeDirectivesChecker.java
+++ b/src/main/java/graphql/schema/idl/SchemaTypeDirectivesChecker.java
@@ -2,6 +2,7 @@ package graphql.schema.idl;
 
 import graphql.GraphQLError;
 import graphql.Internal;
+import graphql.collect.ImmutableKit;
 import graphql.introspection.Introspection.DirectiveLocation;
 import graphql.language.Argument;
 import graphql.language.Directive;
@@ -34,7 +35,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static graphql.introspection.Introspection.DirectiveLocation.ARGUMENT_DEFINITION;
 import static graphql.introspection.Introspection.DirectiveLocation.ENUM;
@@ -149,11 +149,8 @@ class SchemaTypeDirectivesChecker {
     }
 
     private boolean inRightLocation(DirectiveLocation expectedLocation, DirectiveDefinition directiveDefinition) {
-        List<String> names = directiveDefinition.getDirectiveLocations()
-                .stream().map(graphql.language.DirectiveLocation::getName)
-                .map(String::toUpperCase)
-                .collect(Collectors.toList());
-
+        List<String> names = ImmutableKit.map(directiveDefinition.getDirectiveLocations(),
+                it -> it.getName().toUpperCase());
         return names.contains(expectedLocation.name().toUpperCase());
     }
 

--- a/src/test/groovy/graphql/collect/ImmutableKitTest.groovy
+++ b/src/test/groovy/graphql/collect/ImmutableKitTest.groovy
@@ -74,4 +74,21 @@ class ImmutableKitTest extends Specification {
         then:
         flatList == ["A", "B", "C", "D", "E",]
     }
+
+    def "can filter variable args"() {
+        when:
+        def list = ImmutableKit.filterVarArgs({ String s -> s.endsWith("x") }, "a", "b", "ax", "bx", "c")
+        then:
+        list == ["ax", "bx"]
+
+        when:
+        list = ImmutableKit.filterVarArgs({ String s -> s.startsWith("Z") }, "a", "b", "ax", "bx", "c")
+        then:
+        list == []
+
+        when:
+        list = ImmutableKit.filterVarArgs({ String s -> s.startsWith("x") })
+        then:
+        list == []
+    }
 }


### PR DESCRIPTION
Die `.stream()` die

  We still have some left but they tend to be .findFirst() or flatMap and hence harder to replace in a straight forward manner