### PR TITLE
Support null query when running APQ request

### DIFF
--- a/src/main/java/graphql/ExecutionInput.java
+++ b/src/main/java/graphql/ExecutionInput.java
@@ -3,6 +3,7 @@ package graphql;
 import graphql.collect.ImmutableKit;
 import graphql.execution.ExecutionId;
 import graphql.execution.RawVariables;
+import graphql.execution.preparsed.persisted.PersistedQuerySupport;
 import org.dataloader.DataLoaderRegistry;
 
 import java.util.Locale;
@@ -34,7 +35,7 @@ public class ExecutionInput {
 
     @Internal
     private ExecutionInput(Builder builder) {
-        this.query = assertNotNull(builder.query, () -> "query can't be null");
+        this.query = assertQuery(builder);
         this.operationName = builder.operationName;
         this.context = builder.context;
         this.graphQLContext = assertNotNull(builder.graphQLContext);
@@ -46,6 +47,14 @@ public class ExecutionInput {
         this.localContext = builder.localContext;
         this.extensions = builder.extensions;
         this.cancelled = builder.cancelled;
+    }
+
+    private static String assertQuery(Builder builder) {
+        if ((builder.query == null || builder.query.isEmpty()) && builder.extensions.containsKey("persistedQuery")) {
+            return PersistedQuerySupport.PERSISTED_QUERY_MARKER;
+        }
+
+        return assertNotNull(builder.query, () -> "query can't be null");
     }
 
     /**
@@ -252,7 +261,7 @@ public class ExecutionInput {
         }
 
         public Builder query(String query) {
-            this.query = assertNotNull(query, () -> "query can't be null");
+            this.query = query;
             return this;
         }
 
@@ -312,7 +321,7 @@ public class ExecutionInput {
             return this;
         }
 
-         /**
+        /**
          * This will give you a builder of {@link GraphQLContext} and any values you set will be copied
          * into the underlying {@link GraphQLContext} of this execution input
          *


### PR DESCRIPTION
Support null query when running APQ request. This is upstream merge of our commit made by @joshjcarrier

#4008

This pull request modifies the ExecutionInput logic to return a persisted query marker when a null or empty query is provided along with a persistedQuery extension, ensuring graceful handling of APQ requests.
- `src/main/java/graphql/ExecutionInput.java`: Introduces a new static method (`assertQuery`) to check for null/empty queries and returns a persisted query marker if appropriate; also removes the strict non-null assertion in the builder.
- `src/test/groovy/graphql/ExecutionInputTest.groovy`: Adds a test case validating that a null query with the persistedQuery extension returns the expected persisted query marker.