### PR TITLE
Possibility to run JMH benchmarks without JAR build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,6 +150,7 @@ dependencies {
     // this is needed for the idea jmh plugin to work correctly
     jmh 'org.openjdk.jmh:jmh-core:1.37'
     jmh 'org.openjdk.jmh:jmh-generator-annprocess:1.37'
+    jmhAnnotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess:1.37'
 
     errorprone 'com.uber.nullaway:nullaway:0.12.7'
     errorprone 'com.google.errorprone:error_prone_core:2.40.0'


### PR DESCRIPTION
It is very handy to start a benchmark directly from within IntelliJ:
<img width="854" height="303" alt="image" src="https://github.com/user-attachments/assets/a0b1e70d-31fb-4398-9f84-04f39a13bc6f" />

Without this configuration, I get the following error "Unable to find the resource: /META-INF/BenchmarkList"
@bbakerman  @andimarek  @dondonz 