### PR TITLE
Update to DataLoader 5.0.2 - backport for 24.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,7 @@ tasks.withType(GroovyCompile) {
 }
 dependencies {
     implementation 'org.antlr:antlr4-runtime:' + antlrVersion
-    api 'com.graphql-java:java-dataloader:5.0.0'
+    api 'com.graphql-java:java-dataloader:5.0.2'
     api 'org.reactivestreams:reactive-streams:' + reactiveStreamsVersion
     api "org.jspecify:jspecify:1.0.0"
     antlr 'org.antlr:antlr4:' + antlrVersion


### PR DESCRIPTION
Update DataLoader with nullability annotation fixes. Backport to prepare for 24.2 release

We released 5.0.2, which is 5.0.1 plus one more nullability fix

Note that the 5.0.1 upgrade on master looks different https://github.com/graphql-java/graphql-java/pull/4043 that's because Chained DataLoaders are in master, but not 24.x