### PR TITLE
WIP Profiler tweaks

### DIFF
--- a/src/main/java/graphql/ProfilerResult.java
+++ b/src/main/java/graphql/ProfilerResult.java
@@ -273,7 +273,7 @@ public class ProfilerResult {
 
     public Map<String, Object> shortSummaryMap() {
         Map<String, Object> result = new LinkedHashMap<>();
-        result.put("executionId", Assert.assertNotNull(executionId));
+        result.put("executionId", Assert.assertNotNull(executionId).toString());
         result.put("operation", operationType + ":" + operationName);
         result.put("startTime", startTime);
         result.put("endTime", endTime);


### PR DESCRIPTION
We're putting the finishing touches on the Profiler

First tweak: `ExecutionId` is better cast to a string for the output map, otherwise a logger can complain it doesn't know how to serialise this type to JSON

WIP, testing now and likely to find more improvements