### PR TITLE
comment out the processor by default

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,7 +150,9 @@ dependencies {
     // this is needed for the idea jmh plugin to work correctly
     jmh 'org.openjdk.jmh:jmh-core:1.37'
     jmh 'org.openjdk.jmh:jmh-generator-annprocess:1.37'
-    jmhAnnotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess:1.37'
+
+    // comment this in if you want to run JMH benchmarks from idea
+//    jmhAnnotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess:1.37'
 
     errorprone 'com.uber.nullaway:nullaway:0.12.7'
     errorprone 'com.google.errorprone:error_prone_core:2.41.0'


### PR DESCRIPTION
Hey @dfa1 @bbakerman ,

unfortunately this really breaks idea rebuild/build functionality. We need to keep this commented out by default and put it back in if we want to run JMH tests from idea.

If you find another solution that would be great ... I spend some time finding one, but could not . 😢 