### PR TITLE
Fix IncrementalExecutionResult.transform() to preserve incremental fields

### DIFF
--- a/src/main/java/graphql/incremental/IncrementalExecutionResultImpl.java
+++ b/src/main/java/graphql/incremental/IncrementalExecutionResultImpl.java
@@ -52,9 +52,13 @@ public class IncrementalExecutionResultImpl extends ExecutionResultImpl implemen
         return new Builder().from(executionResult);
     }
 
+    public static Builder fromIncrementalExecutionResult(IncrementalExecutionResult executionResult) {
+        return new Builder().from(executionResult);
+    }
+
     @Override
     public IncrementalExecutionResult transform(Consumer<ExecutionResult.Builder<?>> builderConsumer) {
-        var builder = fromExecutionResult(this);
+        var builder = fromIncrementalExecutionResult(this);
         builderConsumer.accept(builder);
         return builder.build();
     }

--- a/src/test/groovy/graphql/incremental/IncrementalExecutionResultTest.groovy
+++ b/src/test/groovy/graphql/incremental/IncrementalExecutionResultTest.groovy
@@ -121,7 +121,15 @@ class IncrementalExecutionResultTest extends Specification {
 
     def "transform returns IncrementalExecutionResult"() {
         when:
-        def initial = newIncrementalExecutionResult().hasNext(true).build()
+        def defer = newDeferredItem()
+                .label("homeWorldDefer")
+                .path(ResultPath.parse("/person"))
+                .data([homeWorld: "Tatooine"])
+                .build()
+        def initial = newIncrementalExecutionResult()
+                .hasNext(true)
+                .incremental([defer])
+                .build()
 
         then:
         def transformed = initial.transform { b ->
@@ -130,6 +138,7 @@ class IncrementalExecutionResultTest extends Specification {
         }
         transformed instanceof IncrementalExecutionResult
         transformed.extensions == ["ext-key": "ext-value"]
+        transformed.incremental == initial.incremental
         transformed.hasNext == false
     }
 }


### PR DESCRIPTION
## Summary
Fixes the `transform()` method in `IncrementalExecutionResultImpl` to return an `IncrementalExecutionResult` that preserves all incremental-specific field values instead of losing them.

## Changes
- Updated `IncrementalExecutionResultImpl.transform()` to preserve `incremental`, `hasNext`, and `incrementalPublisher` fields
- Improved `IncrementalExecutionResultTest` with comprehensive test coverage for the transform behavior

Fixes #4072