### PR TITLE
Prohibit JMH tests from having more than 2 forks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -144,7 +144,7 @@ dependencies {
 
     testImplementation 'org.testng:testng:7.11.0' // use for reactive streams test inheritance
     testImplementation "com.tngtech.archunit:archunit-junit5:1.4.1"
-    testImplementation 'org.openjdk.jmh:jmh-core:1.37' // for ArchUnit tests that check JMH annotations
+    testImplementation 'org.openjdk.jmh:jmh-core:1.37' // required for ArchUnit to check JMH tests
 
     antlr 'org.antlr:antlr4:' + antlrVersion
 

--- a/build.gradle
+++ b/build.gradle
@@ -309,7 +309,8 @@ artifacts {
 
 List<TestDescriptor> failedTests = []
 
-test {
+tasks.withType(Test) {
+
     useJUnitPlatform()
     testLogging {
         events "FAILED", "SKIPPED"
@@ -327,33 +328,10 @@ tasks.register('testWithJava17', Test) {
     javaLauncher = javaToolchains.launcherFor {
         languageVersion = JavaLanguageVersion.of(17)
     }
-    useJUnitPlatform()
-    testLogging {
-        events "FAILED", "SKIPPED"
-        exceptionFormat = "FULL"
-    }
-
-    afterTest { TestDescriptor descriptor, TestResult result ->
-        if (result.getFailedTestCount() > 0) {
-            failedTests.add(descriptor)
-        }
-    }
-
 }
 tasks.register('testWithJava11', Test) {
     javaLauncher = javaToolchains.launcherFor {
         languageVersion = JavaLanguageVersion.of(11)
-    }
-    useJUnitPlatform()
-    testLogging {
-        events "FAILED", "SKIPPED"
-        exceptionFormat = "FULL"
-    }
-
-    afterTest { TestDescriptor descriptor, TestResult result ->
-        if (result.getFailedTestCount() > 0) {
-            failedTests.add(descriptor)
-        }
     }
 }
 test.dependsOn testWithJava17

--- a/build.gradle
+++ b/build.gradle
@@ -144,6 +144,7 @@ dependencies {
 
     testImplementation 'org.testng:testng:7.11.0' // use for reactive streams test inheritance
     testImplementation "com.tngtech.archunit:archunit-junit5:1.4.1"
+    testImplementation 'org.openjdk.jmh:jmh-core:1.37' // for ArchUnit tests that check JMH annotations
 
     antlr 'org.antlr:antlr4:' + antlrVersion
 
@@ -310,12 +311,15 @@ artifacts {
 List<TestDescriptor> failedTests = []
 
 tasks.withType(Test) {
-
     useJUnitPlatform()
     testLogging {
         events "FAILED", "SKIPPED"
         exceptionFormat = "FULL"
     }
+
+    // Required for JMH ArchUnit tests
+    classpath += sourceSets.jmh.output
+    dependsOn "jmhClasses"
 
     afterTest { TestDescriptor descriptor, TestResult result ->
         if (result.getFailedTestCount() > 0) {

--- a/src/jmh/java/benchmark/AssertBenchmark.java
+++ b/src/jmh/java/benchmark/AssertBenchmark.java
@@ -18,7 +18,7 @@ import java.util.concurrent.TimeUnit;
 
 @Warmup(iterations = 2, time = 5, batchSize = 50)
 @Measurement(iterations = 3, batchSize = 50)
-@Fork(3)
+@Fork(2)
 public class AssertBenchmark {
 
     private static final int LOOPS = 100;

--- a/src/jmh/java/benchmark/AstPrinterBenchmark.java
+++ b/src/jmh/java/benchmark/AstPrinterBenchmark.java
@@ -16,7 +16,7 @@ import java.util.concurrent.TimeUnit;
 
 @Warmup(iterations = 2, time = 5)
 @Measurement(iterations = 3, time = 10)
-@Fork(3)
+@Fork(2)
 public class AstPrinterBenchmark {
     /**
      * Note: this query is a redacted version of a real query

--- a/src/jmh/java/benchmark/ChainedInstrumentationBenchmark.java
+++ b/src/jmh/java/benchmark/ChainedInstrumentationBenchmark.java
@@ -35,7 +35,7 @@ import static graphql.schema.GraphQLObjectType.newObject;
 @State(Scope.Benchmark)
 @Warmup(iterations = 2, time = 5)
 @Measurement(iterations = 3)
-@Fork(3)
+@Fork(2)
 public class ChainedInstrumentationBenchmark {
 
     @Param({"0", "1", "10"})

--- a/src/jmh/java/benchmark/CompletableFuturesBenchmark.java
+++ b/src/jmh/java/benchmark/CompletableFuturesBenchmark.java
@@ -23,7 +23,7 @@ import java.util.concurrent.CompletableFuture;
 @State(Scope.Benchmark)
 @Warmup(iterations = 2, time = 1)
 @Measurement(iterations = 3, time = 10, batchSize = 10)
-@Fork(3)
+@Fork(2)
 public class CompletableFuturesBenchmark {
 
 

--- a/src/jmh/java/benchmark/CreateExtendedSchemaBenchmark.java
+++ b/src/jmh/java/benchmark/CreateExtendedSchemaBenchmark.java
@@ -27,7 +27,7 @@ import static benchmark.BenchmarkUtils.runInToolingForSomeTimeThenExit;
  */
 @Warmup(iterations = 2, time = 5)
 @Measurement(iterations = 3)
-@Fork(3)
+@Fork(2)
 public class CreateExtendedSchemaBenchmark {
 
     private static final String SDL = mkSDL();

--- a/src/jmh/java/benchmark/CreateSchemaBenchmark.java
+++ b/src/jmh/java/benchmark/CreateSchemaBenchmark.java
@@ -18,7 +18,7 @@ import java.util.concurrent.TimeUnit;
 
 @Warmup(iterations = 2, time = 5)
 @Measurement(iterations = 3)
-@Fork(3)
+@Fork(2)
 public class CreateSchemaBenchmark {
 
     static String largeSDL = BenchmarkUtils.loadResource("large-schema-3.graphqls");

--- a/src/jmh/java/benchmark/GetterAccessBenchmark.java
+++ b/src/jmh/java/benchmark/GetterAccessBenchmark.java
@@ -13,7 +13,7 @@ import java.util.function.Function;
 
 @Warmup(iterations = 2, time = 5, batchSize = 500)
 @Measurement(iterations = 3, batchSize = 500)
-@Fork(3)
+@Fork(2)
 public class GetterAccessBenchmark {
 
     public static class Pojo {

--- a/src/jmh/java/benchmark/IntMapBenchmark.java
+++ b/src/jmh/java/benchmark/IntMapBenchmark.java
@@ -15,7 +15,7 @@ import java.util.Map;
 @State(Scope.Benchmark)
 @Warmup(iterations = 2, time = 5)
 @Measurement(iterations = 3)
-@Fork(3)
+@Fork(2)
 public class IntMapBenchmark {
 
     @Benchmark

--- a/src/jmh/java/benchmark/IntrospectionBenchmark.java
+++ b/src/jmh/java/benchmark/IntrospectionBenchmark.java
@@ -21,7 +21,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @State(Scope.Benchmark)
 @Warmup(iterations = 2, time = 5)
 @Measurement(iterations = 3)
-@Fork(3)
+@Fork(2)
 public class IntrospectionBenchmark {
 
     @Benchmark

--- a/src/jmh/java/benchmark/MapBenchmark.java
+++ b/src/jmh/java/benchmark/MapBenchmark.java
@@ -25,7 +25,7 @@ import java.util.Random;
 @State(Scope.Benchmark)
 @Warmup(iterations = 2, time = 1)
 @Measurement(iterations = 3, time = 1, batchSize = 1000)
-@Fork(3)
+@Fork(2)
 public class MapBenchmark {
 
     @Param({"10", "50", "300"})

--- a/src/jmh/java/benchmark/OverlappingFieldValidationBenchmark.java
+++ b/src/jmh/java/benchmark/OverlappingFieldValidationBenchmark.java
@@ -35,7 +35,7 @@ import static graphql.Assert.assertTrue;
 @State(Scope.Benchmark)
 @Warmup(iterations = 2, time = 5)
 @Measurement(iterations = 3)
-@Fork(3)
+@Fork(2)
 public class OverlappingFieldValidationBenchmark {
 
     @State(Scope.Benchmark)

--- a/src/jmh/java/benchmark/PropertyFetcherBenchMark.java
+++ b/src/jmh/java/benchmark/PropertyFetcherBenchMark.java
@@ -16,7 +16,7 @@ import java.util.concurrent.TimeUnit;
 
 @Warmup(iterations = 2, time = 5, batchSize = 50)
 @Measurement(iterations = 3, batchSize = 50)
-@Fork(3)
+@Fork(2)
 public class PropertyFetcherBenchMark {
 
     @Benchmark

--- a/src/jmh/java/benchmark/SchemaTransformerBenchmark.java
+++ b/src/jmh/java/benchmark/SchemaTransformerBenchmark.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
 @BenchmarkMode(Mode.AverageTime)
 @Warmup(iterations = 2, time = 5)
 @Measurement(iterations = 3, time = 10)
-@Fork(3)
+@Fork(2)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class SchemaTransformerBenchmark {
 

--- a/src/jmh/java/benchmark/SimpleQueryBenchmark.java
+++ b/src/jmh/java/benchmark/SimpleQueryBenchmark.java
@@ -28,7 +28,7 @@ import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring;
 
 @Warmup(iterations = 2, time = 5)
 @Measurement(iterations = 3)
-@Fork(3)
+@Fork(2)
 public class SimpleQueryBenchmark {
 
     private static final int NUMBER_OF_FRIENDS = 10 * 100;

--- a/src/jmh/java/benchmark/TwitterBenchmark.java
+++ b/src/jmh/java/benchmark/TwitterBenchmark.java
@@ -35,7 +35,7 @@ import static graphql.Scalars.GraphQLString;
 
 @Warmup(iterations = 2, time = 5)
 @Measurement(iterations = 3)
-@Fork(3)
+@Fork(2)
 public class TwitterBenchmark {
     private static final int BREADTH = 150;
     private static final int DEPTH = 150;

--- a/src/jmh/java/benchmark/TypeDefinitionParserVersusSerializeBenchmark.java
+++ b/src/jmh/java/benchmark/TypeDefinitionParserVersusSerializeBenchmark.java
@@ -21,7 +21,7 @@ import static benchmark.BenchmarkUtils.asRTE;
 
 @Warmup(iterations = 2, time = 5)
 @Measurement(iterations = 3)
-@Fork(3)
+@Fork(2)
 public class TypeDefinitionParserVersusSerializeBenchmark {
 
     static SchemaParser schemaParser = new SchemaParser();

--- a/src/jmh/java/benchmark/ValidatorBenchmark.java
+++ b/src/jmh/java/benchmark/ValidatorBenchmark.java
@@ -28,7 +28,7 @@ import static graphql.Assert.assertTrue;
 @BenchmarkMode(Mode.AverageTime)
 @Warmup(iterations = 2, time = 5)
 @Measurement(iterations = 3)
-@Fork(3)
+@Fork(2)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class ValidatorBenchmark {
 

--- a/src/test/groovy/graphql/archunit/JMHForkArchRuleTest.groovy
+++ b/src/test/groovy/graphql/archunit/JMHForkArchRuleTest.groovy
@@ -1,0 +1,50 @@
+package graphql.archunit
+
+import com.tngtech.archunit.core.domain.JavaClass
+import com.tngtech.archunit.core.importer.ClassFileImporter
+import com.tngtech.archunit.lang.ArchCondition
+import com.tngtech.archunit.lang.ConditionEvents
+import com.tngtech.archunit.lang.EvaluationResult
+import com.tngtech.archunit.lang.SimpleConditionEvent
+import org.openjdk.jmh.annotations.Fork
+import spock.lang.Specification
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes
+
+class JMHForkArchRuleTest extends Specification {
+
+    def "JMH benchmarks on classes should not have a fork value greater than 2"() {
+        given:
+        def importedClasses = new ClassFileImporter()
+                .importPackages("benchmark", "performance", "graphql.execution")
+
+        def rule = classes()
+                .that().areAnnotatedWith(Fork.class)
+                .and().areTopLevelClasses()
+                .should(haveForkValueNotGreaterThan(2))
+
+        when:
+        EvaluationResult result = rule.evaluate(importedClasses)
+
+        then:
+        !result.hasViolation()
+
+        cleanup:
+        if (result.hasViolation()) {
+            println result.getFailureReport().toString()
+        }
+    }
+
+    private static ArchCondition<JavaClass> haveForkValueNotGreaterThan(int maxFork) {
+        return new ArchCondition<JavaClass>("have a @Fork value of at most $maxFork") {
+            @Override
+            void check(JavaClass javaClass, ConditionEvents events) {
+                def forkAnnotation = javaClass.getAnnotationOfType(Fork.class)
+                if (forkAnnotation.value() > maxFork) {
+                    def message = "Class ${javaClass.name} has a @Fork value of ${forkAnnotation.value()} which is > $maxFork"
+                    events.add(SimpleConditionEvent.violated(javaClass, message))
+                }
+            }
+        }
+    }
+}

--- a/src/test/groovy/graphql/archunit/NullabilityAnnotationUsageTest.groovy
+++ b/src/test/groovy/graphql/archunit/NullabilityAnnotationUsageTest.groovy
@@ -1,4 +1,4 @@
-package graphql
+package graphql.archunit
 
 import com.tngtech.archunit.core.domain.JavaClasses
 import com.tngtech.archunit.core.importer.ClassFileImporter


### PR DESCRIPTION
Fixes #4010. Adds an ArchUnit test to prohibit JMH tests that use more than 2 forks. This is to save time in our automated testing pipeline, because extra forks don't add much value.

I had to update our test config because our JMH benchmarks are not in the usual package as everything else. ArchUnit reads .class files. Without this configuration change, ArchUnit can't read any JMH tests.

While I'm here I also: 
* Tidied up the test config, to reduce repetition
* Changed all offending JMH tests to 2 forks, even if they don't run in the automated pipeline (in `performance`), because I'd rather we apply this rule equally to all benchmarks
* Created a new home for ArchUnit tests, make it easier to find

Sample error output
```
Architecture Violation [Priority: MEDIUM] - Rule 'classes that are annotated with @Fork and are top level classes should have a @Fork value of at most 2' was violated (17 times):
Class benchmark.AssertBenchmark has a @Fork value of 3 which is > 2
Class benchmark.AstPrinterBenchmark has a @Fork value of 3 which is > 2
Class benchmark.ChainedInstrumentationBenchmark has a @Fork value of 3 which is > 2
Class benchmark.CompletableFuturesBenchmark has a @Fork value of 3 which is > 2
Class benchmark.CreateExtendedSchemaBenchmark has a @Fork value of 3 which is > 2
Class benchmark.CreateSchemaBenchmark has a @Fork value of 3 which is > 2
Class benchmark.GetterAccessBenchmark has a @Fork value of 3 which is > 2
Class benchmark.IntMapBenchmark has a @Fork value of 3 which is > 2
Class benchmark.IntrospectionBenchmark has a @Fork value of 3 which is > 2
Class benchmark.MapBenchmark has a @Fork value of 3 which is > 2
Class benchmark.OverlappingFieldValidationBenchmark has a @Fork value of 3 which is > 2
Class benchmark.PropertyFetcherBenchMark has a @Fork value of 3 which is > 2
Class benchmark.SchemaTransformerBenchmark has a @Fork value of 3 which is > 2
Class benchmark.SimpleQueryBenchmark has a @Fork value of 3 which is > 2
Class benchmark.TwitterBenchmark has a @Fork value of 3 which is > 2
Class benchmark.TypeDefinitionParserVersusSerializeBenchmark has a @Fork value of 3 which is > 2
Class benchmark.ValidatorBenchmark has a @Fork value of 3 which is > 2
```