### PR TITLE
Fixed deferred support to have proper Instrumentation

### DIFF
--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -292,7 +292,8 @@ public abstract class ExecutionStrategy {
                         fields,
                         parameters,
                         executionContext,
-                        (ec, esp) -> Async.toCompletableFuture(resolveFieldWithInfo(ec, esp))
+                        (ec, esp) -> Async.toCompletableFuture(resolveFieldWithInfo(ec, esp)),
+                        this::createExecutionStepInfo
                 ) : DeferredExecutionSupport.NOOP;
 
     }
@@ -1094,6 +1095,11 @@ public abstract class ExecutionStrategy {
                 parameters,
                 fieldDefinition,
                 fieldContainer);
+    }
+
+    private Supplier<ExecutionStepInfo> createExecutionStepInfo(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
+        GraphQLFieldDefinition fieldDef = getFieldDef(executionContext, parameters, parameters.getField().getSingleField());
+        return FpKit.intraThreadMemoize(() -> createExecutionStepInfo(executionContext, parameters, fieldDef, null));
     }
 
     // Errors that result from the execution of deferred fields are kept in the deferred context only.

--- a/src/main/java/graphql/execution/incremental/DeferredExecutionSupport.java
+++ b/src/main/java/graphql/execution/incremental/DeferredExecutionSupport.java
@@ -18,7 +18,7 @@ import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldParameters;
 import graphql.incremental.IncrementalPayload;
 import graphql.util.FpKit;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -162,8 +162,6 @@ public interface DeferredExecutionSupport {
                     }
             );
 
-
-
             // todo: handle cached computations
             return dfCache.computeIfAbsent(
                     currentField.getResultKey(),
@@ -174,7 +172,7 @@ public interface DeferredExecutionSupport {
             );
         }
 
-        @NotNull
+        @NonNull
         private Supplier<CompletableFuture<DeferredFragmentCall.FieldWithExecutionResult>> resolveDeferredFieldValue(MergedField currentField, ExecutionContext executionContext, ExecutionStrategyParameters executionStrategyParameters) {
             return () -> {
 

--- a/src/main/java/graphql/execution/incremental/DeferredExecutionSupport.java
+++ b/src/main/java/graphql/execution/incremental/DeferredExecutionSupport.java
@@ -7,14 +7,18 @@ import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.Internal;
 import graphql.execution.ExecutionContext;
+import graphql.execution.ExecutionStepInfo;
 import graphql.execution.ExecutionStrategyParameters;
 import graphql.execution.FieldValueInfo;
 import graphql.execution.MergedField;
 import graphql.execution.MergedSelectionSet;
 import graphql.execution.ResultPath;
 import graphql.execution.instrumentation.Instrumentation;
+import graphql.execution.instrumentation.InstrumentationContext;
+import graphql.execution.instrumentation.parameters.InstrumentationFieldParameters;
 import graphql.incremental.IncrementalPayload;
 import graphql.util.FpKit;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -26,6 +30,8 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
+
+import static graphql.execution.instrumentation.SimpleInstrumentationContext.nonNullCtx;
 
 /**
  * The purpose of this class hierarchy is to encapsulate most of the logic for deferring field execution, thus
@@ -59,16 +65,19 @@ public interface DeferredExecutionSupport {
         private final ExecutionStrategyParameters parameters;
         private final ExecutionContext executionContext;
         private final BiFunction<ExecutionContext, ExecutionStrategyParameters, CompletableFuture<FieldValueInfo>> resolveFieldWithInfoFn;
+        private final BiFunction<ExecutionContext, ExecutionStrategyParameters, Supplier<ExecutionStepInfo>> executionStepInfoFn;
         private final Map<String, Supplier<CompletableFuture<DeferredFragmentCall.FieldWithExecutionResult>>> dfCache = new HashMap<>();
 
         public DeferredExecutionSupportImpl(
                 MergedSelectionSet mergedSelectionSet,
                 ExecutionStrategyParameters parameters,
                 ExecutionContext executionContext,
-                BiFunction<ExecutionContext, ExecutionStrategyParameters, CompletableFuture<FieldValueInfo>> resolveFieldWithInfoFn
+                BiFunction<ExecutionContext, ExecutionStrategyParameters, CompletableFuture<FieldValueInfo>> resolveFieldWithInfoFn,
+                BiFunction<ExecutionContext, ExecutionStrategyParameters, Supplier<ExecutionStepInfo>> executionStepInfoFn
         ) {
             this.executionContext = executionContext;
             this.resolveFieldWithInfoFn = resolveFieldWithInfoFn;
+            this.executionStepInfoFn = executionStepInfoFn;
             ImmutableListMultimap.Builder<DeferredExecution, MergedField> deferredExecutionToFieldsBuilder = ImmutableListMultimap.builder();
             ImmutableSet.Builder<MergedField> deferredFieldsBuilder = ImmutableSet.builder();
             ImmutableList.Builder<String> nonDeferredFieldNamesBuilder = ImmutableList.builder();
@@ -154,36 +163,47 @@ public interface DeferredExecutionSupport {
             );
 
 
-            Instrumentation instrumentation = executionContext.getInstrumentation();
-
-            instrumentation.beginDeferredField(executionContext.getInstrumentationState());
 
             // todo: handle cached computations
             return dfCache.computeIfAbsent(
                     currentField.getResultKey(),
                     // The same field can be associated with multiple defer executions, so
                     // we memoize the field resolution to avoid multiple calls to the same data fetcher
-                    key -> FpKit.interThreadMemoize(() -> {
-                        CompletableFuture<FieldValueInfo> fieldValueResult = resolveFieldWithInfoFn.apply(executionContext, executionStrategyParameters);
-
-                        fieldValueResult.whenComplete((fieldValueInfo, throwable) -> {
-                            executionContext.getDataLoaderDispatcherStrategy().deferredOnFieldValue(currentField.getResultKey(), fieldValueInfo, throwable, executionStrategyParameters);
-                        });
-
-
-                                CompletableFuture<ExecutionResult> executionResultCF = fieldValueResult
-                                        .thenCompose(fvi -> fvi
-                                                .getFieldValueFuture()
-                                                .thenApply(fv -> ExecutionResultImpl.newExecutionResult().data(fv).build())
-                                        );
-
-                                return executionResultCF
-                                        .thenApply(executionResult ->
-                                                new DeferredFragmentCall.FieldWithExecutionResult(currentField.getResultKey(), executionResult)
-                                        );
-                            }
+                    key -> FpKit.interThreadMemoize(resolveDeferredFieldValue(currentField, executionContext, executionStrategyParameters)
                     )
             );
+        }
+
+        @NotNull
+        private Supplier<CompletableFuture<DeferredFragmentCall.FieldWithExecutionResult>> resolveDeferredFieldValue(MergedField currentField, ExecutionContext executionContext, ExecutionStrategyParameters executionStrategyParameters) {
+            return () -> {
+
+                Instrumentation instrumentation = executionContext.getInstrumentation();
+                Supplier<ExecutionStepInfo> executionStepInfo = executionStepInfoFn.apply(executionContext, executionStrategyParameters);
+                InstrumentationFieldParameters fieldParameters = new InstrumentationFieldParameters(executionContext, executionStepInfo);
+                InstrumentationContext<Object> deferredFieldCtx = nonNullCtx(instrumentation.beginDeferredField(fieldParameters, executionContext.getInstrumentationState()));
+
+                CompletableFuture<FieldValueInfo> fieldValueResult = resolveFieldWithInfoFn.apply(this.executionContext, executionStrategyParameters);
+
+                deferredFieldCtx.onDispatched();
+
+                fieldValueResult.whenComplete((fieldValueInfo, throwable) -> {
+                    this.executionContext.getDataLoaderDispatcherStrategy().deferredOnFieldValue(currentField.getResultKey(), fieldValueInfo, throwable, executionStrategyParameters);
+                    deferredFieldCtx.onCompleted(fieldValueInfo, throwable);
+                });
+
+
+                CompletableFuture<ExecutionResult> executionResultCF = fieldValueResult
+                        .thenCompose(fvi -> fvi
+                                .getFieldValueFuture()
+                                .thenApply(fv -> ExecutionResultImpl.newExecutionResult().data(fv).build())
+                        );
+
+                return executionResultCF
+                        .thenApply(executionResult ->
+                                new DeferredFragmentCall.FieldWithExecutionResult(currentField.getResultKey(), executionResult)
+                        );
+            };
         }
     }
 

--- a/src/main/java/graphql/execution/instrumentation/ChainedInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/ChainedInstrumentation.java
@@ -166,10 +166,9 @@ public class ChainedInstrumentation implements Instrumentation {
 
     @ExperimentalApi
     @Override
-    public InstrumentationContext<Object> beginDeferredField(InstrumentationState instrumentationState) {
-        return new ChainedDeferredExecutionStrategyInstrumentationContext(chainedMapAndDropNulls(instrumentationState, Instrumentation::beginDeferredField));
+    public InstrumentationContext<Object> beginDeferredField(InstrumentationFieldParameters parameters, InstrumentationState state) {
+        return chainedCtx(state, (instrumentation, specificState) -> instrumentation.beginDeferredField(parameters, specificState));
     }
-
 
     @Override
     public InstrumentationContext<ExecutionResult> beginSubscribedFieldEvent(InstrumentationFieldParameters parameters, InstrumentationState state) {

--- a/src/main/java/graphql/execution/instrumentation/Instrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/Instrumentation.java
@@ -153,12 +153,13 @@ public interface Instrumentation {
      * <p>
      * This is an EXPERIMENTAL instrumentation callback. The method signature will definitely change.
      *
-     * @param state the state created during the call to {@link #createStateAsync(InstrumentationCreateStateParameters)}
+     * @param parameters the parameters to this step
+     * @param state      the state created during the call to {@link #createStateAsync(InstrumentationCreateStateParameters)}
      *
-     * @return a nullable {@link ExecutionStrategyInstrumentationContext} object that will be called back when the step ends (assuming it's not null)
+     * @return a nullable {@link InstrumentationContext} object that will be called back when the step ends (assuming it's not null)
      */
     @ExperimentalApi
-    default InstrumentationContext<Object> beginDeferredField(InstrumentationState state) {
+    default InstrumentationContext<Object> beginDeferredField(InstrumentationFieldParameters parameters, InstrumentationState state) {
         return noOp();
     }
 

--- a/src/main/java/graphql/execution/instrumentation/NoContextChainedInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/NoContextChainedInstrumentation.java
@@ -84,6 +84,11 @@ public class NoContextChainedInstrumentation extends ChainedInstrumentation {
     }
 
     @Override
+    public InstrumentationContext<Object> beginDeferredField(InstrumentationFieldParameters parameters, InstrumentationState state) {
+        return runAll(state, (instrumentation, specificState) -> instrumentation.beginDeferredField(parameters, specificState));
+    }
+
+    @Override
     public InstrumentationContext<ExecutionResult> beginSubscribedFieldEvent(InstrumentationFieldParameters parameters, InstrumentationState state) {
         return runAll(state, (instrumentation, specificState) -> instrumentation.beginSubscribedFieldEvent(parameters, specificState));
     }

--- a/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/InstrumentationTest.groovy
@@ -506,9 +506,7 @@ class InstrumentationTest extends Specification {
         def query = """
         {
             hero {
-                ... @defer(label: "id") {
-                    id
-                }
+                id
                 ... @defer(label: "name") {
                     name
                 }
@@ -551,6 +549,13 @@ class InstrumentationTest extends Specification {
                                           "end:fetch-hero",
                                           "start:complete-hero",
                                           "start:execute-object",
+                                          "start:field-id",
+                                          "start:fetch-id",
+                                          "end:fetch-id",
+                                          "start:complete-id",
+                                          "end:complete-id",
+                                          "end:field-id",
+
                                           "end:execute-object",
                                           "end:complete-hero",
                                           "end:field-hero",
@@ -559,14 +564,6 @@ class InstrumentationTest extends Specification {
                                           "end:execution",
                                           //
                                           // the deferred field resolving now happens after the operation has come back
-                                          "start:deferred-field-id",
-                                          "start:field-id",
-                                          "start:fetch-id",
-                                          "end:fetch-id",
-                                          "start:complete-id",
-                                          "end:complete-id",
-                                          "end:field-id",
-                                          "end:deferred-field-id",
                                           "start:deferred-field-name",
                                           "start:field-name",
                                           "start:fetch-name",

--- a/src/test/groovy/graphql/execution/instrumentation/ModernTestingInstrumentation.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/ModernTestingInstrumentation.groovy
@@ -104,6 +104,12 @@ class ModernTestingInstrumentation implements Instrumentation {
     }
 
     @Override
+    InstrumentationContext<Object> beginDeferredField(InstrumentationFieldParameters parameters, InstrumentationState state) {
+        assert state == instrumentationState
+        return new TestingInstrumentContext("deferred-field-$parameters.field.name", executionList, throwableList, useOnDispatch)
+    }
+
+    @Override
     ExecutionInput instrumentExecutionInput(ExecutionInput executionInput, InstrumentationExecutionParameters parameters, InstrumentationState state) {
         assert state == instrumentationState
         return executionInput


### PR DESCRIPTION
The current deferred field Instrumentation is broken - it has no arguments and its context is never called back.

This implements it more properly.  It calls beingDeferredField each time a field actually gets started - eg after the main operation has finished and we begin to drain the deferred queue