### PR TITLE
Adding Instrumentation for reactive results and when they finish

### DIFF
--- a/src/main/java/graphql/execution/SubscriptionExecutionStrategy.java
+++ b/src/main/java/graphql/execution/SubscriptionExecutionStrategy.java
@@ -12,6 +12,7 @@ import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionStrategyParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationReactiveResultsParameters;
 import graphql.execution.reactive.SubscriptionPublisher;
 import graphql.language.Field;
 import graphql.schema.GraphQLFieldDefinition;
@@ -77,7 +78,13 @@ public class SubscriptionExecutionStrategy extends ExecutionStrategy {
             }
             Function<Object, CompletionStage<ExecutionResult>> mapperFunction = eventPayload -> executeSubscriptionEvent(executionContext, parameters, eventPayload);
             boolean keepOrdered = keepOrdered(executionContext.getGraphQLContext());
-            SubscriptionPublisher mapSourceToResponse = new SubscriptionPublisher(publisher, mapperFunction, keepOrdered);
+
+            InstrumentationReactiveResultsParameters instrumentationReactiveResultsParameters = new InstrumentationReactiveResultsParameters(executionContext, InstrumentationReactiveResultsParameters.ResultType.DEFER);
+            InstrumentationContext<Void> reactiveCtx = nonNullCtx(executionContext.getInstrumentation().beginReactiveResults(instrumentationReactiveResultsParameters, executionContext.getInstrumentationState()));
+            reactiveCtx.onDispatched();
+
+            SubscriptionPublisher mapSourceToResponse = new SubscriptionPublisher(publisher, mapperFunction, keepOrdered,
+                    throwable -> reactiveCtx.onCompleted(null, throwable));
             return new ExecutionResultImpl(mapSourceToResponse, executionContext.getErrors());
         });
 

--- a/src/main/java/graphql/execution/instrumentation/Instrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/Instrumentation.java
@@ -12,6 +12,7 @@ import graphql.execution.instrumentation.parameters.InstrumentationExecutionStra
 import graphql.execution.instrumentation.parameters.InstrumentationFieldCompleteParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationReactiveResultsParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationValidationParameters;
 import graphql.language.Document;
 import graphql.schema.DataFetcher;
@@ -117,6 +118,21 @@ public interface Instrumentation {
      */
     @Nullable
     default InstrumentationContext<ExecutionResult> beginExecuteOperation(InstrumentationExecuteOperationParameters parameters, InstrumentationState state) {
+        return noOp();
+    }
+
+    /**
+     * This is called just before the execution of any reactive results, namely incremental deferred results or subscriptions.  When the {@link org.reactivestreams.Publisher}
+     * finally ends (with either a {@link Throwable} or none) then the {@link InstrumentationContext} wil be called back to say the reactive results
+     * have finished.
+     *
+     * @param parameters the parameters to this step
+     * @param state      the state created during the call to {@link #createStateAsync(InstrumentationCreateStateParameters)}
+     *
+     * @return a nullable {@link InstrumentationContext} object that will be called back when the step ends (assuming it's not null)
+     */
+    @Nullable
+    default InstrumentationContext<Void> beginReactiveResults(InstrumentationReactiveResultsParameters parameters, InstrumentationState state) {
         return noOp();
     }
 

--- a/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationReactiveResultsParameters.java
+++ b/src/main/java/graphql/execution/instrumentation/parameters/InstrumentationReactiveResultsParameters.java
@@ -1,0 +1,37 @@
+package graphql.execution.instrumentation.parameters;
+
+import graphql.PublicApi;
+import graphql.execution.ExecutionContext;
+import graphql.execution.instrumentation.Instrumentation;
+
+/**
+ * Parameters sent to {@link Instrumentation} methods
+ */
+@SuppressWarnings("TypeParameterUnusedInFormals")
+@PublicApi
+public class InstrumentationReactiveResultsParameters {
+
+    /**
+     * What type of reactive results was the {@link org.reactivestreams.Publisher}
+     */
+    public enum ResultType {
+        DEFER, SUBSCRIPTION
+    }
+
+    private final ExecutionContext executionContext;
+    private final ResultType resultType;
+
+    public InstrumentationReactiveResultsParameters(ExecutionContext executionContext, ResultType resultType) {
+        this.executionContext = executionContext;
+        this.resultType = resultType;
+    }
+
+
+    public ExecutionContext getExecutionContext() {
+        return executionContext;
+    }
+
+    public ResultType getResultType() {
+        return resultType;
+    }
+}


### PR DESCRIPTION
**This is not finished yet - it needs more testing of the Instrumentation but I want the other PR about deferred Instrumentation to be merged first**

This adds Insrtrumentation support for reactive results - namely defer Publishers and Subscription Publisher.

When the Publisher is finished (throwable or not error) then the Instrumentation context is considered finished and called.