### PR TITLE
Try revert this shadow change with JMH debugging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
     id 'maven-publish'
     id 'antlr'
     id 'signing'
-    id "com.gradleup.shadow" version "9.0.2"
+    id "com.gradleup.shadow" version "8.3.8"
     id "biz.aQute.bnd.builder" version "6.4.0"
     id "io.github.gradle-nexus.publish-plugin" version "2.0.0"
     id "groovy"


### PR DESCRIPTION
We're getting an unusual error message on our JMH pipeline, and I'm trying to eliminate options. It mysteriously stops after this dependabot update https://github.com/graphql-java/graphql-java/commit/0b5c7629f345194923c3278f1c8994f1085e4f5d