### PR TITLE
Draft - Update to Shadow 9.x and configure special task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 import net.ltgt.gradle.errorprone.CheckSeverity
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 import java.text.SimpleDateFormat
 
@@ -10,7 +11,7 @@ plugins {
     id 'maven-publish'
     id 'antlr'
     id 'signing'
-    id "com.gradleup.shadow" version "8.3.8"
+    id "com.gradleup.shadow" version "9.0.2"
     id "biz.aQute.bnd.builder" version "6.4.0"
     id "io.github.gradle-nexus.publish-plugin" version "2.0.0"
     id "groovy"
@@ -455,5 +456,11 @@ tasks.withType(GenerateModuleMetadata) {
     enabled = false
 }
 
+
+// Special Shadow 9.x configuration for JMH jar
+tasks.named('jmhJar', ShadowJar) {
+    configurations = [project.configurations.jmh]
+    archiveClassifier = 'jmh-all'
+}
 
 


### PR DESCRIPTION
With the major Shadow 9.x update, the fat JAR didn't seem to get created for jmh. Found that out when our jmh pipeline failed, being unable to find the main class to start the tests

This might be the config to set it right. I'll come back to this later