### PR TITLE
Caching parse and validate by default

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,6 +126,12 @@ dependencies {
     implementation 'org.antlr:antlr4-runtime:' + antlrVersion
     implementation 'com.google.guava:guava:' + guavaVersion
 
+    // we can compile against caffeine but its not shipped as a runtime dependency
+    compileOnly 'com.github.ben-manes.caffeine:caffeine:3.1.8'
+    // we need caffeine to write tests however
+    testImplementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
+
+
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
     testImplementation 'net.bytebuddy:byte-buddy:1.17.7'

--- a/src/jmh/java/benchmark/CachingDocumentBenchmark.java
+++ b/src/jmh/java/benchmark/CachingDocumentBenchmark.java
@@ -1,0 +1,83 @@
+package benchmark;
+
+import graphql.GraphQL;
+import graphql.StarWarsSchema;
+import graphql.execution.preparsed.NoOpPreparsedDocumentProvider;
+import graphql.execution.preparsed.PreparsedDocumentProvider;
+import graphql.execution.preparsed.caching.CachingDocumentProvider;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@Warmup(iterations = 2, time = 5)
+@Measurement(iterations = 3)
+@Fork(2)
+public class CachingDocumentBenchmark {
+
+    @Param({"50", "500", "5000"})
+    public int querySize;
+
+    @Param({"10", "50", "500"})
+    public int queryCount;
+
+    @Setup(Level.Trial)
+    public void setUp() {
+    }
+
+    private static final GraphQL GRAPHQL_CACHING_ON = buildGraphQL(true);
+    private static final GraphQL GRAPHQL_CACHING_OFF = buildGraphQL(true);
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public void benchMarkCachingOnAvgTime() {
+        executeQuery(true);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public void benchMarkCachingOffAvgTime() {
+        executeQuery(false);
+    }
+
+    public void executeQuery(boolean cachingOn) {
+        String query = buildQuery(querySize);
+        GraphQL graphQL = cachingOn ? GRAPHQL_CACHING_ON : GRAPHQL_CACHING_OFF;
+
+        for (int i = 0; i < queryCount; i++) {
+            graphQL.execute(query);
+        }
+    }
+
+    private static String buildQuery(int howManyAliases) {
+        StringBuilder query = new StringBuilder("query q { hero { \n");
+        for (int i = 0; i < howManyAliases; i++) {
+            query.append("nameAlias").append(i).append(" : name\n");
+        }
+        query.append("}}");
+        return query.toString();
+    }
+
+    private static GraphQL buildGraphQL(boolean cachingOn) {
+        PreparsedDocumentProvider documentProvider = NoOpPreparsedDocumentProvider.INSTANCE;
+        if (cachingOn) {
+            documentProvider = new CachingDocumentProvider();
+        }
+        return GraphQL.newGraphQL(StarWarsSchema.starWarsSchema)
+                .preparsedDocumentProvider(documentProvider)
+                .build();
+    }
+}

--- a/src/jmh/java/benchmark/CachingDocumentBenchmark.java
+++ b/src/jmh/java/benchmark/CachingDocumentBenchmark.java
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit;
 
 @State(Scope.Benchmark)
 @Warmup(iterations = 2, time = 5)
-@Measurement(iterations = 3)
+@Measurement(iterations = 3, time = 2)
 @Fork(2)
 public class CachingDocumentBenchmark {
 
@@ -37,7 +37,7 @@ public class CachingDocumentBenchmark {
     }
 
     private static final GraphQL GRAPHQL_CACHING_ON = buildGraphQL(true);
-    private static final GraphQL GRAPHQL_CACHING_OFF = buildGraphQL(true);
+    private static final GraphQL GRAPHQL_CACHING_OFF = buildGraphQL(false);
 
     @Benchmark
     @BenchmarkMode(Mode.AverageTime)

--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -20,9 +20,9 @@ import graphql.execution.instrumentation.SimplePerformantInstrumentation;
 import graphql.execution.instrumentation.parameters.InstrumentationCreateStateParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationValidationParameters;
-import graphql.execution.preparsed.NoOpPreparsedDocumentProvider;
 import graphql.execution.preparsed.PreparsedDocumentEntry;
 import graphql.execution.preparsed.PreparsedDocumentProvider;
+import graphql.execution.preparsed.caching.CachingDocumentProvider;
 import graphql.language.Document;
 import graphql.schema.GraphQLSchema;
 import graphql.validation.ValidationError;
@@ -279,7 +279,7 @@ public class GraphQL {
         private DataFetcherExceptionHandler defaultExceptionHandler = new SimpleDataFetcherExceptionHandler();
         private ExecutionIdProvider idProvider = DEFAULT_EXECUTION_ID_PROVIDER;
         private Instrumentation instrumentation = null; // deliberate default here
-        private PreparsedDocumentProvider preparsedDocumentProvider = NoOpPreparsedDocumentProvider.INSTANCE;
+        private PreparsedDocumentProvider preparsedDocumentProvider = new CachingDocumentProvider();
         private boolean doNotAutomaticallyDispatchDataLoader = false;
         private ValueUnboxer valueUnboxer = ValueUnboxer.DEFAULT;
 

--- a/src/main/java/graphql/execution/preparsed/NoOpPreparsedDocumentProvider.java
+++ b/src/main/java/graphql/execution/preparsed/NoOpPreparsedDocumentProvider.java
@@ -2,12 +2,17 @@ package graphql.execution.preparsed;
 
 
 import graphql.ExecutionInput;
-import graphql.Internal;
+import graphql.PublicApi;
+import org.jspecify.annotations.NullMarked;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
-@Internal
+/**
+ * A {@link PreparsedDocumentProvider that does nothing}
+ */
+@PublicApi
+@NullMarked
 public class NoOpPreparsedDocumentProvider implements PreparsedDocumentProvider {
     public static final NoOpPreparsedDocumentProvider INSTANCE = new NoOpPreparsedDocumentProvider();
 

--- a/src/main/java/graphql/execution/preparsed/caching/CachingDocumentProvider.java
+++ b/src/main/java/graphql/execution/preparsed/caching/CachingDocumentProvider.java
@@ -1,0 +1,56 @@
+package graphql.execution.preparsed.caching;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import graphql.ExecutionInput;
+import graphql.PublicApi;
+import graphql.execution.preparsed.PreparsedDocumentEntry;
+import graphql.execution.preparsed.PreparsedDocumentProvider;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+/**
+ * By default, graphql-java will cache the parsed {@link PreparsedDocumentEntry} that represents
+ * a parsed and validated graphql query IF {@link Caffeine} is present on the class path
+ * at runtime.  If it's not then no caching takes place.
+ */
+@PublicApi
+@NullMarked
+public class CachingDocumentProvider implements PreparsedDocumentProvider {
+    private final DocumentCache documentCache;
+
+    /**
+     * By default, it will try to use a {@link Caffeine} backed implementation if it's on the class
+     * path otherwise it will become a non caching mechanism.
+     */
+    public CachingDocumentProvider() {
+        this(new CaffeineDocumentCache());
+    }
+
+    /**
+     * You can use your own cache implementation and provide that to this class to use
+     *
+     * @param documentCache the cache to use
+     */
+    public CachingDocumentProvider(DocumentCache documentCache) {
+        this.documentCache = documentCache;
+    }
+
+    @Override
+    public CompletableFuture<PreparsedDocumentEntry> getDocumentAsync(ExecutionInput executionInput, Function<ExecutionInput, PreparsedDocumentEntry> parseAndValidateFunction) {
+        if (documentCache.isNoop()) {
+            // saves creating keys and doing a lookup that will just call this function anyway
+            return CompletableFuture.completedFuture(parseAndValidateFunction.apply(executionInput));
+        }
+        DocumentCache.DocumentCacheKey cacheKey = new DocumentCache.DocumentCacheKey(executionInput.getQuery(), executionInput.getOperationName());
+        PreparsedDocumentEntry cacheEntry = documentCache.get(cacheKey, missFunction(executionInput, parseAndValidateFunction));
+        return CompletableFuture.completedFuture(cacheEntry);
+    }
+
+    private static Function<DocumentCache.DocumentCacheKey, PreparsedDocumentEntry> missFunction(ExecutionInput executionInput, Function<ExecutionInput, PreparsedDocumentEntry> parseAndValidateFunction) {
+        return key -> {
+            return parseAndValidateFunction.apply(executionInput);
+        };
+    }
+}

--- a/src/main/java/graphql/execution/preparsed/caching/CachingDocumentProvider.java
+++ b/src/main/java/graphql/execution/preparsed/caching/CachingDocumentProvider.java
@@ -43,7 +43,7 @@ public class CachingDocumentProvider implements PreparsedDocumentProvider {
             // saves creating keys and doing a lookup that will just call this function anyway
             return CompletableFuture.completedFuture(parseAndValidateFunction.apply(executionInput));
         }
-        DocumentCache.DocumentCacheKey cacheKey = new DocumentCache.DocumentCacheKey(executionInput.getQuery(), executionInput.getOperationName());
+        DocumentCache.DocumentCacheKey cacheKey = new DocumentCache.DocumentCacheKey(executionInput.getQuery(), executionInput.getOperationName(), executionInput.getLocale());
         PreparsedDocumentEntry cacheEntry = documentCache.get(cacheKey, key -> parseAndValidateFunction.apply(executionInput));
         return CompletableFuture.completedFuture(cacheEntry);
     }

--- a/src/main/java/graphql/execution/preparsed/caching/CachingDocumentProvider.java
+++ b/src/main/java/graphql/execution/preparsed/caching/CachingDocumentProvider.java
@@ -11,9 +11,15 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 /**
+ * The CachingDocumentProvider allows previously parsed and validated operations to be cached and
+ * hence re-used.  This can lead to significant time savings, especially for large operations.
+ * <p>
  * By default, graphql-java will cache the parsed {@link PreparsedDocumentEntry} that represents
  * a parsed and validated graphql query IF {@link Caffeine} is present on the class path
  * at runtime.  If it's not then no caching takes place.
+ * <p>
+ * You can provide your own {@link DocumentCache} implementation and hence use any cache
+ * technology you like.
  */
 @PublicApi
 @NullMarked
@@ -23,6 +29,8 @@ public class CachingDocumentProvider implements PreparsedDocumentProvider {
     /**
      * By default, it will try to use a {@link Caffeine} backed implementation if it's on the class
      * path otherwise it will become a non caching mechanism.
+     *
+     * @see CaffeineDocumentCache
      */
     public CachingDocumentProvider() {
         this(new CaffeineDocumentCache());
@@ -35,6 +43,13 @@ public class CachingDocumentProvider implements PreparsedDocumentProvider {
      */
     public CachingDocumentProvider(DocumentCache documentCache) {
         this.documentCache = documentCache;
+    }
+
+    /**
+     * @return the {@link DocumentCache} being used
+     */
+    public DocumentCache getDocumentCache() {
+        return documentCache;
     }
 
     @Override

--- a/src/main/java/graphql/execution/preparsed/caching/CachingDocumentProvider.java
+++ b/src/main/java/graphql/execution/preparsed/caching/CachingDocumentProvider.java
@@ -44,13 +44,8 @@ public class CachingDocumentProvider implements PreparsedDocumentProvider {
             return CompletableFuture.completedFuture(parseAndValidateFunction.apply(executionInput));
         }
         DocumentCache.DocumentCacheKey cacheKey = new DocumentCache.DocumentCacheKey(executionInput.getQuery(), executionInput.getOperationName());
-        PreparsedDocumentEntry cacheEntry = documentCache.get(cacheKey, missFunction(executionInput, parseAndValidateFunction));
+        PreparsedDocumentEntry cacheEntry = documentCache.get(cacheKey, key -> parseAndValidateFunction.apply(executionInput));
         return CompletableFuture.completedFuture(cacheEntry);
     }
 
-    private static Function<DocumentCache.DocumentCacheKey, PreparsedDocumentEntry> missFunction(ExecutionInput executionInput, Function<ExecutionInput, PreparsedDocumentEntry> parseAndValidateFunction) {
-        return key -> {
-            return parseAndValidateFunction.apply(executionInput);
-        };
-    }
 }

--- a/src/main/java/graphql/execution/preparsed/caching/CachingDocumentProvider.java
+++ b/src/main/java/graphql/execution/preparsed/caching/CachingDocumentProvider.java
@@ -10,6 +10,8 @@ import org.jspecify.annotations.NullMarked;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
+import static graphql.execution.Async.toCompletableFuture;
+
 /**
  * The CachingDocumentProvider allows previously parsed and validated operations to be cached and
  * hence re-used.  This can lead to significant time savings, especially for large operations.
@@ -56,11 +58,11 @@ public class CachingDocumentProvider implements PreparsedDocumentProvider {
     public CompletableFuture<PreparsedDocumentEntry> getDocumentAsync(ExecutionInput executionInput, Function<ExecutionInput, PreparsedDocumentEntry> parseAndValidateFunction) {
         if (documentCache.isNoop()) {
             // saves creating keys and doing a lookup that will just call this function anyway
-            return CompletableFuture.completedFuture(parseAndValidateFunction.apply(executionInput));
+            return toCompletableFuture(parseAndValidateFunction.apply(executionInput));
         }
         DocumentCache.DocumentCacheKey cacheKey = new DocumentCache.DocumentCacheKey(executionInput.getQuery(), executionInput.getOperationName(), executionInput.getLocale());
-        PreparsedDocumentEntry cacheEntry = documentCache.get(cacheKey, key -> parseAndValidateFunction.apply(executionInput));
-        return CompletableFuture.completedFuture(cacheEntry);
+        Object cacheEntry = documentCache.get(cacheKey, key -> parseAndValidateFunction.apply(executionInput));
+        return toCompletableFuture(cacheEntry);
     }
 
 }

--- a/src/main/java/graphql/execution/preparsed/caching/CaffeineDocumentCache.java
+++ b/src/main/java/graphql/execution/preparsed/caching/CaffeineDocumentCache.java
@@ -1,0 +1,72 @@
+package graphql.execution.preparsed.caching;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import graphql.PublicApi;
+import graphql.execution.preparsed.PreparsedDocumentEntry;
+import graphql.util.ClassKit;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.function.Function;
+
+import static java.util.Objects.requireNonNull;
+
+@PublicApi
+@NullMarked
+public class CaffeineDocumentCache implements DocumentCache {
+
+    private final static boolean isCaffeineAvailable = ClassKit.isClassAvailable("com.github.benmanes.caffeine.cache.Caffeine");
+
+    @Nullable
+    private final Object caffeineCacheObj;
+
+    CaffeineDocumentCache(boolean isCaffeineAvailable) {
+        if (isCaffeineAvailable) {
+            CaffeineDocumentCacheOptions options = CaffeineDocumentCacheOptions.getDefaultJvmOptions();
+            caffeineCacheObj = Caffeine.newBuilder()
+                    .expireAfterAccess(options.getExpireAfterAccess())
+                    .maximumSize(options.getMaxSize())
+                    .build();
+        } else {
+            caffeineCacheObj = null;
+        }
+    }
+
+    public CaffeineDocumentCache() {
+        this(isCaffeineAvailable);
+    }
+
+    /**
+     * If you want to control the {@link Caffeine} configuration, using this constructor and pass in your own {@link Caffeine} cache
+     *
+     * @param caffeineCache the custom {@link Caffeine} cache to use
+     */
+    public CaffeineDocumentCache(Cache<DocumentCache.DocumentCacheKey, PreparsedDocumentEntry> caffeineCache) {
+        this.caffeineCacheObj = caffeineCache;
+    }
+
+    @Override
+    public PreparsedDocumentEntry get(DocumentCacheKey key, Function<DocumentCacheKey, PreparsedDocumentEntry> mappingFunction) {
+        if (isNoop()) {
+            return mappingFunction.apply(key);
+        }
+        return cache().get(key, mappingFunction);
+    }
+
+    private Cache<DocumentCache.DocumentCacheKey, PreparsedDocumentEntry> cache() {
+        //noinspection unchecked
+        return (Cache<DocumentCacheKey, PreparsedDocumentEntry>) requireNonNull(caffeineCacheObj);
+    }
+
+    @Override
+    public boolean isNoop() {
+        return caffeineCacheObj == null;
+    }
+
+    public void clear() {
+        if (!isNoop()) {
+            cache().invalidateAll();
+        }
+    }
+}

--- a/src/main/java/graphql/execution/preparsed/caching/CaffeineDocumentCache.java
+++ b/src/main/java/graphql/execution/preparsed/caching/CaffeineDocumentCache.java
@@ -33,6 +33,10 @@ public class CaffeineDocumentCache implements DocumentCache {
         }
     }
 
+    /**
+     * Creates a cache that works if Caffeine is on the class path otherwise its
+     * a no op.
+     */
     public CaffeineDocumentCache() {
         this(isCaffeineAvailable);
     }
@@ -64,7 +68,8 @@ public class CaffeineDocumentCache implements DocumentCache {
         return caffeineCacheObj == null;
     }
 
-    public void clear() {
+    @Override
+    public void invalidateAll() {
         if (!isNoop()) {
             cache().invalidateAll();
         }

--- a/src/main/java/graphql/execution/preparsed/caching/CaffeineDocumentCacheOptions.java
+++ b/src/main/java/graphql/execution/preparsed/caching/CaffeineDocumentCacheOptions.java
@@ -5,18 +5,21 @@ import org.jspecify.annotations.NullMarked;
 
 import java.time.Duration;
 
+/**
+ * This controls the default options that get use in the {@link CaffeineDocumentCache} creation
+ */
 @PublicApi
 @NullMarked
 public class CaffeineDocumentCacheOptions {
 
     /**
-     * By default, we cache documents for 5 minutes
+     * By default, we expire documents after 5 minutes if they are not accessed
      */
     public static final Duration EXPIRED_AFTER_ACCESS = Duration.ofMinutes(5);
     /**
-     * By default, we hold 1000 entries
+     * By default, we hold 500 operations
      */
-    public static final int MAX_SIZE = 1000;
+    public static final int MAX_SIZE = 500;
 
     private static CaffeineDocumentCacheOptions defaultJvmOptions = newOptions()
             .expireAfterAccess(EXPIRED_AFTER_ACCESS)
@@ -35,7 +38,7 @@ public class CaffeineDocumentCacheOptions {
     /**
      * This sets new JVM wide default options for the {@link CaffeineDocumentCache}
      *
-     * @param jvmOptions
+     * @param jvmOptions the options to use
      */
     public static void setDefaultJvmOptions(CaffeineDocumentCacheOptions jvmOptions) {
         defaultJvmOptions = jvmOptions;

--- a/src/main/java/graphql/execution/preparsed/caching/CaffeineDocumentCacheOptions.java
+++ b/src/main/java/graphql/execution/preparsed/caching/CaffeineDocumentCacheOptions.java
@@ -1,0 +1,82 @@
+package graphql.execution.preparsed.caching;
+
+import graphql.PublicApi;
+import org.jspecify.annotations.NullMarked;
+
+import java.time.Duration;
+
+@PublicApi
+@NullMarked
+public class CaffeineDocumentCacheOptions {
+
+    /**
+     * By default, we cache documents for 5 minutes
+     */
+    public static final Duration EXPIRED_AFTER_ACCESS = Duration.ofMinutes(5);
+    /**
+     * By default, we hold 1000 entries
+     */
+    public static final int MAX_SIZE = 1000;
+
+    private static CaffeineDocumentCacheOptions defaultJvmOptions = newOptions()
+            .expireAfterAccess(EXPIRED_AFTER_ACCESS)
+            .maxSize(MAX_SIZE)
+            .build();
+
+    /**
+     * This returns the JVM wide default options for the {@link CaffeineDocumentCache}
+     *
+     * @return the JVM wide default options
+     */
+    public static CaffeineDocumentCacheOptions getDefaultJvmOptions() {
+        return defaultJvmOptions;
+    }
+
+    /**
+     * This sets new JVM wide default options for the {@link CaffeineDocumentCache}
+     *
+     * @param jvmOptions
+     */
+    public static void setDefaultJvmOptions(CaffeineDocumentCacheOptions jvmOptions) {
+        defaultJvmOptions = jvmOptions;
+    }
+
+    private final Duration expireAfterAccess;
+    private final int maxSize;
+
+    private CaffeineDocumentCacheOptions(Builder builder) {
+        this.expireAfterAccess = builder.expireAfterAccess;
+        this.maxSize = builder.maxSize;
+    }
+
+    public Duration getExpireAfterAccess() {
+        return expireAfterAccess;
+    }
+
+    public int getMaxSize() {
+        return maxSize;
+    }
+
+    public static Builder newOptions() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        Duration expireAfterAccess = Duration.ofMinutes(5);
+        int maxSize = 1000;
+
+        public Builder maxSize(int maxSize) {
+            this.maxSize = maxSize;
+            return this;
+        }
+
+        public Builder expireAfterAccess(Duration expireAfterAccess) {
+            this.expireAfterAccess = expireAfterAccess;
+            return this;
+        }
+
+        CaffeineDocumentCacheOptions build() {
+            return new CaffeineDocumentCacheOptions(this);
+        }
+    }
+}

--- a/src/main/java/graphql/execution/preparsed/caching/DocumentCache.java
+++ b/src/main/java/graphql/execution/preparsed/caching/DocumentCache.java
@@ -1,0 +1,66 @@
+package graphql.execution.preparsed.caching;
+
+import graphql.execution.preparsed.PreparsedDocumentEntry;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * This represents a cache interface to get a document from a cache key.  You can use your own cache implementation
+ * to back the caching of parsed graphql documents.
+ */
+@NullMarked
+public interface DocumentCache {
+    /**
+     * Called to get a document that has previously been parsed ad validated.
+     *
+     * @param key             the cache key
+     * @param mappingFunction if the value is missing in cache this function can be called to create a value
+     *
+     * @return a non null document entry
+     */
+    PreparsedDocumentEntry get(DocumentCacheKey key, Function<DocumentCacheKey, PreparsedDocumentEntry> mappingFunction);
+
+    /**
+     * @return true if the cache in fact does no caching otherwise false.  This helps the implementation optimise how the cache is used or not.
+     */
+    boolean isNoop();
+
+    /**
+     * This represents the key to the document cache
+     */
+    class DocumentCacheKey {
+        private final String query;
+        @Nullable
+        private final String operationName;
+
+        DocumentCacheKey(String query, @Nullable String operationName) {
+            this.query = query;
+            this.operationName = operationName;
+        }
+
+        public String getQuery() {
+            return query;
+        }
+
+        public @Nullable String getOperationName() {
+            return operationName;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            DocumentCacheKey cacheKey = (DocumentCacheKey) o;
+            return Objects.equals(query, cacheKey.query) && Objects.equals(operationName, cacheKey.operationName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(query, operationName);
+        }
+    }
+}

--- a/src/main/java/graphql/execution/preparsed/caching/DocumentCache.java
+++ b/src/main/java/graphql/execution/preparsed/caching/DocumentCache.java
@@ -1,5 +1,6 @@
 package graphql.execution.preparsed.caching;
 
+import graphql.PublicApi;
 import graphql.execution.preparsed.PreparsedDocumentEntry;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -11,6 +12,7 @@ import java.util.function.Function;
  * This represents a cache interface to get a document from a cache key.  You can use your own cache implementation
  * to back the caching of parsed graphql documents.
  */
+@PublicApi
 @NullMarked
 public interface DocumentCache {
     /**

--- a/src/main/java/graphql/execution/preparsed/caching/DocumentCache.java
+++ b/src/main/java/graphql/execution/preparsed/caching/DocumentCache.java
@@ -5,6 +5,7 @@ import graphql.execution.preparsed.PreparsedDocumentEntry;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
+import java.util.Locale;
 import java.util.Objects;
 import java.util.function.Function;
 
@@ -37,10 +38,12 @@ public interface DocumentCache {
         private final String query;
         @Nullable
         private final String operationName;
+        private final Locale locale;
 
-        DocumentCacheKey(String query, @Nullable String operationName) {
+        DocumentCacheKey(String query, @Nullable String operationName, Locale locale) {
             this.query = query;
             this.operationName = operationName;
+            this.locale = locale;
         }
 
         public String getQuery() {
@@ -51,18 +54,24 @@ public interface DocumentCache {
             return operationName;
         }
 
+        public Locale getLocale() {
+            return locale;
+        }
+
         @Override
         public boolean equals(Object o) {
             if (o == null || getClass() != o.getClass()) {
                 return false;
             }
             DocumentCacheKey cacheKey = (DocumentCacheKey) o;
-            return Objects.equals(query, cacheKey.query) && Objects.equals(operationName, cacheKey.operationName);
+            return Objects.equals(query, cacheKey.query) &&
+                    Objects.equals(operationName, cacheKey.operationName) &&
+                    Objects.equals(locale, cacheKey.locale);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(query, operationName);
+            return Objects.hash(query, operationName, locale);
         }
     }
 }

--- a/src/main/java/graphql/execution/preparsed/caching/DocumentCache.java
+++ b/src/main/java/graphql/execution/preparsed/caching/DocumentCache.java
@@ -32,6 +32,10 @@ public interface DocumentCache {
     boolean isNoop();
 
     /**
+     * Called to clear the cache.  If your implementation doesn't support this, then just no op the method
+     */
+    void invalidateAll();
+    /**
      * This represents the key to the document cache
      */
     class DocumentCacheKey {

--- a/src/main/java/graphql/execution/preparsed/caching/DocumentCache.java
+++ b/src/main/java/graphql/execution/preparsed/caching/DocumentCache.java
@@ -1,5 +1,6 @@
 package graphql.execution.preparsed.caching;
 
+import graphql.DuckTyped;
 import graphql.PublicApi;
 import graphql.execution.preparsed.PreparsedDocumentEntry;
 import org.jspecify.annotations.NullMarked;
@@ -17,14 +18,18 @@ import java.util.function.Function;
 @NullMarked
 public interface DocumentCache {
     /**
-     * Called to get a document that has previously been parsed ad validated.
+     * Called to get a document that has previously been parsed ad validated.  The return value of this method
+     * can be either a {@link PreparsedDocumentEntry} or a {@link java.util.concurrent.CompletableFuture} promise
+     * to a {@link PreparsedDocumentEntry}.  This allows caches that are in memory to return direct values OR
+     * if the cache is distributed, it can return a promise to a value.
      *
      * @param key             the cache key
      * @param mappingFunction if the value is missing in cache this function can be called to create a value
      *
-     * @return a non null document entry
+     * @return a non-null {@link PreparsedDocumentEntry} or a promise to one via a {@link java.util.concurrent.CompletableFuture}
      */
-    PreparsedDocumentEntry get(DocumentCacheKey key, Function<DocumentCacheKey, PreparsedDocumentEntry> mappingFunction);
+    @DuckTyped(shape = "PreparsedDocumentEntry | CompletableFuture<PreparsedDocumentEntry")
+    Object get(DocumentCacheKey key, Function<DocumentCacheKey, PreparsedDocumentEntry> mappingFunction);
 
     /**
      * @return true if the cache in fact does no caching otherwise false.  This helps the implementation optimise how the cache is used or not.
@@ -35,6 +40,7 @@ public interface DocumentCache {
      * Called to clear the cache.  If your implementation doesn't support this, then just no op the method
      */
     void invalidateAll();
+
     /**
      * This represents the key to the document cache
      */

--- a/src/main/java/graphql/util/ClassKit.java
+++ b/src/main/java/graphql/util/ClassKit.java
@@ -1,0 +1,13 @@
+package graphql.util;
+
+public class ClassKit {
+    public static boolean isClassAvailable(String className) {
+        ClassLoader classLoader = ClassKit.class.getClassLoader();
+        Class<?> caffieneClass = null;
+        try {
+            caffieneClass = classLoader.loadClass(className);
+        } catch (ClassNotFoundException ignored) {
+        }
+        return caffieneClass != null;
+    }
+}

--- a/src/test/groovy/graphql/GraphQLTest.groovy
+++ b/src/test/groovy/graphql/GraphQLTest.groovy
@@ -19,7 +19,7 @@ import graphql.execution.instrumentation.Instrumentation
 import graphql.execution.instrumentation.InstrumentationState
 import graphql.execution.instrumentation.SimplePerformantInstrumentation
 import graphql.execution.instrumentation.parameters.InstrumentationCreateStateParameters
-import graphql.execution.preparsed.NoOpPreparsedDocumentProvider
+import graphql.execution.preparsed.caching.CachingDocumentProvider
 import graphql.language.SourceLocation
 import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironment
@@ -1414,7 +1414,7 @@ many lines''']
         graphQL.getGraphQLSchema() == StarWarsSchema.starWarsSchema
         graphQL.getIdProvider() == ExecutionIdProvider.DEFAULT_EXECUTION_ID_PROVIDER
         graphQL.getValueUnboxer() == ValueUnboxer.DEFAULT
-        graphQL.getPreparsedDocumentProvider() == NoOpPreparsedDocumentProvider.INSTANCE
+        graphQL.getPreparsedDocumentProvider() instanceof CachingDocumentProvider
         graphQL.getInstrumentation() instanceof Instrumentation
         graphQL.getQueryStrategy() instanceof AsyncExecutionStrategy
         graphQL.getMutationStrategy() instanceof AsyncSerialExecutionStrategy

--- a/src/test/groovy/graphql/ParseAndValidateTest.groovy
+++ b/src/test/groovy/graphql/ParseAndValidateTest.groovy
@@ -1,5 +1,6 @@
 package graphql
 
+import graphql.execution.preparsed.NoOpPreparsedDocumentProvider
 import graphql.language.Document
 import graphql.language.SourceLocation
 import graphql.parser.InvalidSyntaxException
@@ -121,7 +122,9 @@ class ParseAndValidateTest extends Specification {
     def "can use the graphql context to stop certain validation rules"() {
 
         def sdl = '''type Query { foo : ID } '''
-        def graphQL = TestUtil.graphQL(sdl).build()
+        // if you use validation rule predicates - then you cant use caching
+        def graphQL = TestUtil.graphQL(sdl)
+                .preparsedDocumentProvider(NoOpPreparsedDocumentProvider.INSTANCE).build()
 
         Predicate<Class<?>> predicate = new Predicate<Class<?>>() {
             @Override

--- a/src/test/groovy/graphql/execution/preparsed/caching/CachingDocumentProviderTest.groovy
+++ b/src/test/groovy/graphql/execution/preparsed/caching/CachingDocumentProviderTest.groovy
@@ -1,0 +1,147 @@
+package graphql.execution.preparsed.caching
+
+import graphql.ExecutionInput
+import graphql.GraphQL
+import graphql.StarWarsSchema
+import graphql.execution.preparsed.PreparsedDocumentEntry
+import graphql.parser.Parser
+import spock.lang.Specification
+
+import java.util.function.Function
+
+class CachingDocumentProviderTest extends Specification {
+    private String heroQuery1
+
+    void setup() {
+        heroQuery1 = """        
+            query HeroNameQuery {
+              hero {
+                name
+              }
+            }
+        """
+    }
+
+    def "basic integration test"() {
+
+        def cachingDocumentProvider = new CachingDocumentProvider()
+        GraphQL graphQL = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema)
+                .preparsedDocumentProvider(cachingDocumentProvider)
+                .build()
+
+        when:
+        def executionInput = ExecutionInput.newExecutionInput(heroQuery1)
+                .operationName("HeroNameQuery").build()
+
+        def er = graphQL.execute(executionInput)
+
+        then:
+        er.errors.isEmpty()
+        er.data == [hero: [name: "R2-D2"]]
+    }
+
+    def "integration still works when caffeine is not on the class path"() {
+        // we fake out the test here saying its NOT on the classpath
+        def cache = new CaffeineDocumentCache(false)
+        def cachingDocumentProvider = new CachingDocumentProvider(cache)
+        GraphQL graphQL = GraphQL.newGraphQL(StarWarsSchema.starWarsSchema)
+                .preparsedDocumentProvider(cachingDocumentProvider)
+                .build()
+        when:
+        def executionInput = ExecutionInput.newExecutionInput(heroQuery1)
+                .operationName("HeroNameQuery").build()
+
+        def er = graphQL.execute(executionInput)
+
+        then:
+        er.errors.isEmpty()
+        er.data == [hero: [name: "R2-D2"]]
+    }
+
+    class CountingDocProvider implements Function<ExecutionInput, PreparsedDocumentEntry> {
+        int count = 0
+
+        @Override
+        PreparsedDocumentEntry apply(ExecutionInput executionInput) {
+            count++
+            def document = Parser.parse(executionInput.query)
+            return new PreparsedDocumentEntry(document)
+        }
+    }
+
+    def "caching happens and the parse and validated function is avoided"() {
+        def cache = new CaffeineDocumentCache(true)
+        def cachingDocumentProvider = new CachingDocumentProvider(cache)
+
+        def ei = ExecutionInput.newExecutionInput("query q { f }").build()
+        def callback = new CountingDocProvider()
+
+        when:
+        def cf = cachingDocumentProvider.getDocumentAsync(ei, callback)
+        def documentEntry = cf.join()
+
+        then:
+        !documentEntry.hasErrors()
+        documentEntry.document != null
+        callback.count == 1
+
+        when:
+        cf = cachingDocumentProvider.getDocumentAsync(ei, callback)
+        documentEntry = cf.join()
+
+        then:
+        !documentEntry.hasErrors()
+        documentEntry.document != null
+        // cached
+        callback.count == 1
+
+        when:
+        cache.clear()
+        cf = cachingDocumentProvider.getDocumentAsync(ei, callback)
+        documentEntry = cf.join()
+
+        then:
+        !documentEntry.hasErrors()
+        documentEntry.document != null
+        // after cleared cached
+        callback.count == 2
+
+    }
+
+    def "when caching is not present then parse and validated function is always called"() {
+        def cache = new CaffeineDocumentCache(false)
+        def cachingDocumentProvider = new CachingDocumentProvider(cache)
+
+        def ei = ExecutionInput.newExecutionInput("query q { f }").build()
+        def callback = new CountingDocProvider()
+
+        when:
+        def cf = cachingDocumentProvider.getDocumentAsync(ei, callback)
+        def documentEntry = cf.join()
+
+        then:
+        !documentEntry.hasErrors()
+        documentEntry.document != null
+        callback.count == 1
+
+        when:
+        cf = cachingDocumentProvider.getDocumentAsync(ei, callback)
+        documentEntry = cf.join()
+
+        then:
+        !documentEntry.hasErrors()
+        documentEntry.document != null
+        // not cached
+        callback.count == 2
+
+        when:
+        cache.clear()
+        cf = cachingDocumentProvider.getDocumentAsync(ei, callback)
+        documentEntry = cf.join()
+
+        then:
+        !documentEntry.hasErrors()
+        documentEntry.document != null
+        callback.count == 3
+    }
+}


### PR DESCRIPTION
This is some early work to cache parsed and validated documents by default.

This is discussed in more detailed here https://github.com/graphql-java/graphql-java/issues/4107