### PR TITLE
New Exhaustion based data loader dispatching strategy

### DIFF
--- a/src/jmh/java/performance/DataLoaderPerformance.java
+++ b/src/jmh/java/performance/DataLoaderPerformance.java
@@ -483,6 +483,11 @@ public class DataLoaderPerformance {
     static BatchLoader<String, Owner> ownerBatchLoader = list -> {
         List<Owner> collect = list.stream().map(key -> {
             Owner owner = owners.get(key);
+            try {
+                Thread.sleep(50);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
             return owner;
         }).collect(Collectors.toList());
         return CompletableFuture.completedFuture(collect);
@@ -490,6 +495,11 @@ public class DataLoaderPerformance {
     static BatchLoader<String, Pet> petBatchLoader = list -> {
         List<Pet> collect = list.stream().map(key -> {
             Pet owner = pets.get(key);
+            try {
+                Thread.sleep(5);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
             return owner;
         }).collect(Collectors.toList());
         return CompletableFuture.completedFuture(collect);
@@ -532,20 +542,20 @@ public class DataLoaderPerformance {
                 });
                 DataFetcher petsDf = (env -> {
                     Owner owner = env.getSource();
-                    return env.getDataLoader(petDLName).loadMany((List) owner.petIds)
-                            .thenCompose((result) -> CompletableFuture.supplyAsync(() -> null).thenApply((__) -> result));
+                    return env.getDataLoader(petDLName).loadMany((List) owner.petIds);
+//                            .thenCompose((result) -> CompletableFuture.supplyAsync(() -> null).thenApply((__) -> result));
                 });
 
                 DataFetcher petFriendsDF = (env -> {
                     Pet pet = env.getSource();
-                    return env.getDataLoader(petDLName).loadMany((List) pet.friendsIds)
-                            .thenCompose((result) -> CompletableFuture.supplyAsync(() -> null).thenApply((__) -> result));
+                    return env.getDataLoader(petDLName).loadMany((List) pet.friendsIds);
+//                            .thenCompose((result) -> CompletableFuture.supplyAsync(() -> null).thenApply((__) -> result));
                 });
 
                 DataFetcher petOwnerDF = (env -> {
                     Pet pet = env.getSource();
-                    return env.getDataLoader(ownerDLName).load(pet.ownerId)
-                            .thenCompose((result) -> CompletableFuture.supplyAsync(() -> null).thenApply((__) -> result));
+                    return env.getDataLoader(ownerDLName).load(pet.ownerId);
+//                            .thenCompose((result) -> CompletableFuture.supplyAsync(() -> null).thenApply((__) -> result));
                 });
 
 

--- a/src/main/java/graphql/GraphQLUnusualConfiguration.java
+++ b/src/main/java/graphql/GraphQLUnusualConfiguration.java
@@ -7,6 +7,7 @@ import graphql.schema.PropertyDataFetcherHelper;
 
 import static graphql.Assert.assertNotNull;
 import static graphql.execution.instrumentation.dataloader.DataLoaderDispatchingContextKeys.ENABLE_DATA_LOADER_CHAINING;
+import static graphql.execution.instrumentation.dataloader.DataLoaderDispatchingContextKeys.ENABLE_DATA_LOADER_EXHAUSTED_DISPATCHING;
 
 /**
  * This allows you to control "unusual" aspects of the GraphQL system
@@ -344,10 +345,14 @@ public class GraphQLUnusualConfiguration {
         }
 
         /**
-         * @return true if @defer and @stream behaviour is enabled for this execution.
+         * returns true if chained data loader dispatching is enabled
          */
         public boolean isDataLoaderChainingEnabled() {
             return contextConfig.getBoolean(ENABLE_DATA_LOADER_CHAINING);
+        }
+
+        public boolean isDataLoaderExhaustedDispatchingEnabled() {
+            return contextConfig.get(ENABLE_DATA_LOADER_EXHAUSTED_DISPATCHING);
         }
 
         /**
@@ -358,6 +363,17 @@ public class GraphQLUnusualConfiguration {
             contextConfig.put(ENABLE_DATA_LOADER_CHAINING, enable);
             return this;
         }
+
+        /**
+         * Enables a dispatching strategy that will dispatch as long as there is no
+         * other data fetcher or batch loader running.
+         */
+        @ExperimentalApi
+        public DataloaderConfig enableDataLoaderExhaustedDispatching(boolean enable) {
+            contextConfig.put(ENABLE_DATA_LOADER_EXHAUSTED_DISPATCHING, enable);
+            return this;
+        }
+
 
     }
 

--- a/src/main/java/graphql/execution/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncExecutionStrategy.java
@@ -55,8 +55,9 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
         DeferredExecutionSupport deferredExecutionSupport = createDeferredExecutionSupport(executionContext, parameters);
 
         dataLoaderDispatcherStrategy.executionStrategy(executionContext, parameters, deferredExecutionSupport.getNonDeferredFieldNames(fieldNames).size());
-
         Async.CombinedBuilder<FieldValueInfo> futures = getAsyncFieldValueInfo(executionContext, parameters, deferredExecutionSupport);
+        dataLoaderDispatcherStrategy.finishedFetching(executionContext, parameters);
+
 
         CompletableFuture<ExecutionResult> overallResult = new CompletableFuture<>();
         executionStrategyCtx.onDispatched();

--- a/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncSerialExecutionStrategy.java
@@ -71,6 +71,7 @@ public class AsyncSerialExecutionStrategy extends AbstractAsyncExecutionStrategy
         dataLoaderDispatcherStrategy.executionSerialStrategy(executionContext, newParameters);
 
         Object fieldWithInfo = resolveFieldWithInfo(executionContext, newParameters);
+        dataLoaderDispatcherStrategy.finishedFetching(executionContext, newParameters);
         if (fieldWithInfo instanceof CompletableFuture) {
             //noinspection unchecked
             return ((CompletableFuture<FieldValueInfo>) fieldWithInfo).thenCompose(fvi -> {

--- a/src/main/java/graphql/execution/DataLoaderDispatchStrategy.java
+++ b/src/main/java/graphql/execution/DataLoaderDispatchStrategy.java
@@ -64,4 +64,8 @@ public interface DataLoaderDispatchStrategy {
     default void subscriptionEventCompletionDone(AlternativeCallContext alternativeCallContext) {
 
     }
+
+    default void finishedFetching(ExecutionContext executionContext, ExecutionStrategyParameters newParameters) {
+
+    }
 }

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -15,7 +15,7 @@ import graphql.execution.incremental.IncrementalCallState;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.InstrumentationState;
-import graphql.execution.instrumentation.dataloader.PerLevelDataLoaderDispatchStrategy;
+import graphql.execution.instrumentation.dataloader.ExhaustedDataLoaderDispatchStrategy;
 import graphql.execution.instrumentation.parameters.InstrumentationExecuteOperationParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
 import graphql.extensions.ExtensionsBuilder;
@@ -262,7 +262,8 @@ public class Execution {
         if (executionContext.getDataLoaderRegistry() == EMPTY_DATALOADER_REGISTRY || doNotAutomaticallyDispatchDataLoader) {
             return DataLoaderDispatchStrategy.NO_OP;
         }
-        return new PerLevelDataLoaderDispatchStrategy(executionContext);
+//        return new PerLevelDataLoaderDispatchStrategy(executionContext);
+        return new ExhaustedDataLoaderDispatchStrategy(executionContext);
     }
 
 

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -210,6 +210,7 @@ public abstract class ExecutionStrategy {
         List<String> fieldsExecutedOnInitialResult = deferredExecutionSupport.getNonDeferredFieldNames(fieldNames);
         dataLoaderDispatcherStrategy.executeObject(executionContext, parameters, fieldsExecutedOnInitialResult.size());
         Async.CombinedBuilder<FieldValueInfo> resolvedFieldFutures = getAsyncFieldValueInfo(executionContext, parameters, deferredExecutionSupport);
+        dataLoaderDispatcherStrategy.finishedFetching(executionContext, parameters);
 
         CompletableFuture<Map<String, Object>> overallResult = new CompletableFuture<>();
         BiConsumer<List<Object>, Throwable> handleResultsConsumer = buildFieldValueMap(fieldsExecutedOnInitialResult, overallResult, executionContext);

--- a/src/main/java/graphql/execution/instrumentation/dataloader/DataLoaderDispatchingContextKeys.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/DataLoaderDispatchingContextKeys.java
@@ -26,12 +26,28 @@ public final class DataLoaderDispatchingContextKeys {
 
 
     /**
+     * Enabled a different dispatching strategy that mimics the JS event loop based one:
+     * DataLoader will be dispatched as soon as there is no data fetcher or batch loader currently running.
+     *
+     */
+    public static final String ENABLE_DATA_LOADER_EXHAUSTED_DISPATCHING = "__GJ_enable_data_loader_exhausted_dispatching";
+
+    /**
      * Enables the ability that chained DataLoaders are dispatched automatically.
      *
      * @param graphQLContext
      */
     public static void setEnableDataLoaderChaining(GraphQLContext graphQLContext, boolean enabled) {
         graphQLContext.put(ENABLE_DATA_LOADER_CHAINING, enabled);
+    }
+
+    /**
+     * Enables the ability that chained DataLoaders are dispatched automatically.
+     *
+     * @param graphQLContext
+     */
+    public static void setEnableDataLoaderExhaustedDispatching(GraphQLContext graphQLContext, boolean enabled) {
+        graphQLContext.put(ENABLE_DATA_LOADER_EXHAUSTED_DISPATCHING, enabled);
     }
 
 

--- a/src/main/java/graphql/execution/instrumentation/dataloader/ExhaustedDataLoaderDispatchStrategy.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/ExhaustedDataLoaderDispatchStrategy.java
@@ -1,0 +1,271 @@
+package graphql.execution.instrumentation.dataloader;
+
+import graphql.Assert;
+import graphql.Internal;
+import graphql.Profiler;
+import graphql.execution.DataLoaderDispatchStrategy;
+import graphql.execution.ExecutionContext;
+import graphql.execution.ExecutionStrategyParameters;
+import graphql.execution.FieldValueInfo;
+import graphql.execution.incremental.AlternativeCallContext;
+import org.dataloader.DataLoader;
+import org.dataloader.DataLoaderRegistry;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+@Internal
+@NullMarked
+public class ExhaustedDataLoaderDispatchStrategy implements DataLoaderDispatchStrategy {
+
+    private final CallStack initialCallStack;
+    private final ExecutionContext executionContext;
+
+    private final Profiler profiler;
+
+    private final Map<AlternativeCallContext, CallStack> alternativeCallContextMap = new ConcurrentHashMap<>();
+
+
+    private static class CallStack {
+
+
+        static class State {
+            final int objectRunningCount;
+            final boolean dataLoaderToDispatch;
+            final boolean currentlyDispatching;
+
+            State(int objectRunningCount, boolean dataLoaderToDispatch, boolean currentlyDispatching) {
+                this.objectRunningCount = objectRunningCount;
+                this.dataLoaderToDispatch = dataLoaderToDispatch;
+                this.currentlyDispatching = currentlyDispatching;
+            }
+
+            public State copy() {
+                return new State(objectRunningCount, dataLoaderToDispatch, currentlyDispatching);
+            }
+
+            public State incrementObjectRunningCount() {
+                return new State(objectRunningCount + 1, dataLoaderToDispatch, currentlyDispatching);
+            }
+
+            public State decrementObjetRunningCount() {
+                return new State(objectRunningCount - 1, dataLoaderToDispatch, currentlyDispatching);
+            }
+
+            public State dataLoaderToDispatch() {
+                return new State(objectRunningCount, true, currentlyDispatching);
+            }
+
+            public State startDispatching() {
+                return new State(objectRunningCount, false, true);
+            }
+
+            public State stopDispatching() {
+                return new State(objectRunningCount, false, false);
+            }
+
+
+            @Override
+            public String toString() {
+                return "State{" +
+                       "objectRunningCount=" + objectRunningCount +
+                       ", dataLoaderToDispatch=" + dataLoaderToDispatch +
+                       '}';
+            }
+        }
+
+        private final AtomicLong state = new AtomicLong();
+        private final AtomicReference<State> stateRef = new AtomicReference<>(new State(0, false, false));
+
+        public State getState() {
+            return Assert.assertNotNull(stateRef.get());
+        }
+
+        public boolean tryUpdateState(State oldState, State newState) {
+            System.out.println("updateState: " + oldState + " -> " + newState);
+            return stateRef.compareAndSet(oldState, newState);
+        }
+
+        private final AtomicInteger deferredFragmentRootFieldsCompleted = new AtomicInteger();
+
+        public CallStack() {
+        }
+
+
+        public void clear() {
+            deferredFragmentRootFieldsCompleted.set(0);
+            stateRef.set(new State(0, false, false));
+        }
+    }
+
+    public ExhaustedDataLoaderDispatchStrategy(ExecutionContext executionContext) {
+        this.initialCallStack = new CallStack();
+        this.executionContext = executionContext;
+
+        this.profiler = executionContext.getProfiler();
+    }
+
+
+    @Override
+    public void executionStrategy(ExecutionContext executionContext, ExecutionStrategyParameters parameters, int fieldCount) {
+        Assert.assertTrue(parameters.getExecutionStepInfo().getPath().isRootPath());
+        // no concurrency access happening
+        CallStack.State state = initialCallStack.getState();
+        Assert.assertTrue(initialCallStack.tryUpdateState(state, state.incrementObjectRunningCount()));
+    }
+
+    @Override
+    public void finishedFetching(ExecutionContext executionContext, ExecutionStrategyParameters newParameters) {
+        CallStack callStack = getCallStack(newParameters);
+        decrementObjectRunningAndMaybeDispatch(callStack);
+    }
+
+    @Override
+    public void executionSerialStrategy(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
+        CallStack callStack = getCallStack(parameters);
+        callStack.clear();
+        CallStack.State state = callStack.getState();
+        // no concurrency access happening
+        Assert.assertTrue(callStack.tryUpdateState(state, state.incrementObjectRunningCount()));
+    }
+
+
+    @Override
+    public void executeObject(ExecutionContext executionContext, ExecutionStrategyParameters parameters, int fieldCount) {
+        CallStack callStack = getCallStack(parameters);
+        while (true) {
+            CallStack.State state = callStack.getState();
+            if (callStack.tryUpdateState(state, state.incrementObjectRunningCount())) {
+                break;
+            }
+        }
+    }
+
+
+    @Override
+    public void newSubscriptionExecution(AlternativeCallContext alternativeCallContext) {
+        CallStack callStack = new CallStack();
+        alternativeCallContextMap.put(alternativeCallContext, callStack);
+    }
+
+    @Override
+    public void deferredOnFieldValue(String resultKey, FieldValueInfo fieldValueInfo, Throwable throwable, ExecutionStrategyParameters parameters) {
+        CallStack callStack = getCallStack(parameters);
+        int deferredFragmentRootFieldsCompleted = callStack.deferredFragmentRootFieldsCompleted.incrementAndGet();
+        Assert.assertNotNull(parameters.getDeferredCallContext());
+        if (deferredFragmentRootFieldsCompleted == parameters.getDeferredCallContext().getFields()) {
+            decrementObjectRunningAndMaybeDispatch(callStack);
+        }
+
+    }
+
+    private CallStack getCallStack(ExecutionStrategyParameters parameters) {
+        return getCallStack(parameters.getDeferredCallContext());
+    }
+
+    private CallStack getCallStack(@Nullable AlternativeCallContext alternativeCallContext) {
+        if (alternativeCallContext == null) {
+            return this.initialCallStack;
+        } else {
+            return alternativeCallContextMap.computeIfAbsent(alternativeCallContext, k -> {
+                /*
+                  This is only for handling deferred cases. Subscription cases will also get a new callStack, but
+                  it is explicitly created in `newSubscriptionExecution`.
+                  The reason we are doing this lazily is, because we don't have explicit startDeferred callback.
+                 */
+                CallStack callStack = new CallStack();
+                return callStack;
+            });
+        }
+    }
+
+
+    private void decrementObjectRunningAndMaybeDispatch(CallStack callStack) {
+        CallStack.State oldState;
+        CallStack.State newState;
+        while (true) {
+            oldState = callStack.getState();
+            newState = oldState.decrementObjetRunningCount();
+            if (callStack.tryUpdateState(oldState, newState)) {
+                break;
+            }
+        }
+        // this means we have not fetching running and we can execute
+        if (newState.objectRunningCount == 0 && !newState.currentlyDispatching) {
+            dispatchImpl(callStack);
+        }
+    }
+
+    private void newDataLoaderInvocationMaybeDispatch(CallStack callStack) {
+        CallStack.State oldState;
+        CallStack.State newState;
+        while (true) {
+            oldState = callStack.getState();
+            newState = oldState.dataLoaderToDispatch();
+            if (callStack.tryUpdateState(oldState, newState)) {
+                break;
+            }
+        }
+//        System.out.println("new data loader invocation maybe with state: " + newState);
+        // this means we are not waiting for some fetching to be finished and we need to dispatch
+        if (newState.objectRunningCount == 0 && !newState.currentlyDispatching) {
+            dispatchImpl(callStack);
+        }
+
+    }
+
+
+    private void dispatchImpl(CallStack callStack) {
+
+        CallStack.State oldState;
+        while (true) {
+            oldState = callStack.getState();
+            if (!oldState.dataLoaderToDispatch) {
+                CallStack.State newState = oldState.stopDispatching();
+                if (callStack.tryUpdateState(oldState, newState)) {
+                    return;
+                }
+            }
+            CallStack.State newState = oldState.startDispatching();
+            if (callStack.tryUpdateState(oldState, newState)) {
+                break;
+            }
+        }
+
+        DataLoaderRegistry dataLoaderRegistry = executionContext.getDataLoaderRegistry();
+        List<DataLoader<?, ?>> dataLoaders = dataLoaderRegistry.getDataLoaders();
+        List<CompletableFuture<? extends List<?>>> allDispatchedCFs = new ArrayList<>();
+        for (DataLoader<?, ?> dataLoader : dataLoaders) {
+            CompletableFuture<? extends List<?>> dispatch = dataLoader.dispatch();
+            allDispatchedCFs.add(dispatch);
+        }
+        CompletableFuture.allOf(allDispatchedCFs.toArray(new CompletableFuture[0]))
+                .whenComplete((unused, throwable) -> {
+                    dispatchImpl(callStack);
+                });
+
+    }
+
+
+    public void newDataLoaderInvocation(String resultPath,
+                                        int level,
+                                        DataLoader dataLoader,
+                                        String dataLoaderName,
+                                        Object key,
+                                        @Nullable AlternativeCallContext alternativeCallContext) {
+//        DataLoaderInvocation dataLoaderInvocation = new DataLoaderInvocation(resultPath, level, dataLoader, dataLoaderName, key);
+        CallStack callStack = getCallStack(alternativeCallContext);
+        newDataLoaderInvocationMaybeDispatch(callStack);
+    }
+
+
+}
+

--- a/src/main/java/graphql/execution/instrumentation/dataloader/ExhaustedDataLoaderDispatchStrategy.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/ExhaustedDataLoaderDispatchStrategy.java
@@ -265,13 +265,7 @@ public class ExhaustedDataLoaderDispatchStrategy implements DataLoaderDispatchSt
     }
 
 
-    public void newDataLoaderInvocation(String resultPath,
-                                        int level,
-                                        DataLoader dataLoader,
-                                        String dataLoaderName,
-                                        Object key,
-                                        @Nullable AlternativeCallContext alternativeCallContext) {
-//        DataLoaderInvocation dataLoaderInvocation = new DataLoaderInvocation(resultPath, level, dataLoader, dataLoaderName, key);
+    public void newDataLoaderInvocation(@Nullable AlternativeCallContext alternativeCallContext) {
         CallStack callStack = getCallStack(alternativeCallContext);
         newDataLoaderInvocationMaybeDispatch(callStack);
     }

--- a/src/main/java/graphql/execution/instrumentation/dataloader/PerLevelDataLoaderDispatchStrategy.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/PerLevelDataLoaderDispatchStrategy.java
@@ -391,8 +391,7 @@ public class PerLevelDataLoaderDispatchStrategy implements DataLoaderDispatchStr
     }
 
     @Override
-    public void deferredOnFieldValue(String resultKey, FieldValueInfo fieldValueInfo, Throwable
-            throwable, ExecutionStrategyParameters parameters) {
+    public void deferredOnFieldValue(String resultKey, FieldValueInfo fieldValueInfo, Throwable throwable, ExecutionStrategyParameters parameters) {
         CallStack callStack = getCallStack(parameters);
         int deferredFragmentRootFieldsCompleted = callStack.deferredFragmentRootFieldsCompleted.incrementAndGet();
         Assert.assertNotNull(parameters.getDeferredCallContext());

--- a/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
@@ -15,6 +15,7 @@ import graphql.execution.ExecutionStepInfo;
 import graphql.execution.MergedField;
 import graphql.execution.directives.QueryDirectives;
 import graphql.execution.incremental.AlternativeCallContext;
+import graphql.execution.instrumentation.dataloader.DataLoaderDispatchingContextKeys;
 import graphql.language.Document;
 import graphql.language.Field;
 import graphql.language.FragmentDefinition;
@@ -232,9 +233,10 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
         if (dataLoader == null) {
             return null;
         }
-//        if (!graphQLContext.getBoolean(DataLoaderDispatchingContextKeys.ENABLE_DATA_LOADER_CHAINING, false)) {
-//            return dataLoader;
-//        }
+        if (!graphQLContext.getBoolean(DataLoaderDispatchingContextKeys.ENABLE_DATA_LOADER_CHAINING, false)
+            && !graphQLContext.getBoolean(DataLoaderDispatchingContextKeys.ENABLE_DATA_LOADER_EXHAUSTED_DISPATCHING, false)) {
+            return dataLoader;
+        }
         return new DataLoaderWithContext<>(this, dataLoaderName, dataLoader);
     }
 
@@ -272,8 +274,8 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
     @Override
     public String toString() {
         return "DataFetchingEnvironmentImpl{" +
-                "executionStepInfo=" + executionStepInfo +
-                '}';
+               "executionStepInfo=" + executionStepInfo +
+               '}';
     }
 
     @NullUnmarked

--- a/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
@@ -15,7 +15,6 @@ import graphql.execution.ExecutionStepInfo;
 import graphql.execution.MergedField;
 import graphql.execution.directives.QueryDirectives;
 import graphql.execution.incremental.AlternativeCallContext;
-import graphql.execution.instrumentation.dataloader.DataLoaderDispatchingContextKeys;
 import graphql.language.Document;
 import graphql.language.Field;
 import graphql.language.FragmentDefinition;
@@ -233,9 +232,9 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
         if (dataLoader == null) {
             return null;
         }
-        if (!graphQLContext.getBoolean(DataLoaderDispatchingContextKeys.ENABLE_DATA_LOADER_CHAINING, false)) {
-            return dataLoader;
-        }
+//        if (!graphQLContext.getBoolean(DataLoaderDispatchingContextKeys.ENABLE_DATA_LOADER_CHAINING, false)) {
+//            return dataLoader;
+//        }
         return new DataLoaderWithContext<>(this, dataLoaderName, dataLoader);
     }
 

--- a/src/main/java/graphql/schema/DataLoaderWithContext.java
+++ b/src/main/java/graphql/schema/DataLoaderWithContext.java
@@ -3,6 +3,7 @@ package graphql.schema;
 import graphql.Internal;
 import graphql.execution.incremental.AlternativeCallContext;
 import graphql.execution.instrumentation.dataloader.ExhaustedDataLoaderDispatchStrategy;
+import graphql.execution.instrumentation.dataloader.PerLevelDataLoaderDispatchStrategy;
 import org.dataloader.DataLoader;
 import org.dataloader.DelegatingDataLoader;
 import org.jspecify.annotations.NonNull;
@@ -32,11 +33,14 @@ public class DataLoaderWithContext<K, V> extends DelegatingDataLoader<K, V> {
         DataFetchingEnvironmentImpl dfeImpl = (DataFetchingEnvironmentImpl) dfe;
         DataFetchingEnvironmentImpl.DFEInternalState dfeInternalState = (DataFetchingEnvironmentImpl.DFEInternalState) dfeImpl.toInternal();
         dfeInternalState.getProfiler().dataLoaderUsed(dataLoaderName);
-        if (dfeInternalState.getDataLoaderDispatchStrategy() instanceof ExhaustedDataLoaderDispatchStrategy) {
+        if (dfeInternalState.getDataLoaderDispatchStrategy() instanceof PerLevelDataLoaderDispatchStrategy) {
             AlternativeCallContext alternativeCallContext = dfeInternalState.getDeferredCallContext();
             int level = dfe.getExecutionStepInfo().getPath().getLevel();
             String path = dfe.getExecutionStepInfo().getPath().toString();
-            ((ExhaustedDataLoaderDispatchStrategy) dfeInternalState.dataLoaderDispatchStrategy).newDataLoaderInvocation(path, level, delegate, dataLoaderName, key, alternativeCallContext);
+            ((PerLevelDataLoaderDispatchStrategy) dfeInternalState.dataLoaderDispatchStrategy).newDataLoaderInvocation(path, level, delegate, dataLoaderName, key, alternativeCallContext);
+        } else if (dfeInternalState.getDataLoaderDispatchStrategy() instanceof ExhaustedDataLoaderDispatchStrategy) {
+            AlternativeCallContext alternativeCallContext = dfeInternalState.getDeferredCallContext();
+            ((ExhaustedDataLoaderDispatchStrategy) dfeInternalState.dataLoaderDispatchStrategy).newDataLoaderInvocation(alternativeCallContext);
         }
         return result;
     }

--- a/src/main/java/graphql/schema/DataLoaderWithContext.java
+++ b/src/main/java/graphql/schema/DataLoaderWithContext.java
@@ -2,7 +2,7 @@ package graphql.schema;
 
 import graphql.Internal;
 import graphql.execution.incremental.AlternativeCallContext;
-import graphql.execution.instrumentation.dataloader.PerLevelDataLoaderDispatchStrategy;
+import graphql.execution.instrumentation.dataloader.ExhaustedDataLoaderDispatchStrategy;
 import org.dataloader.DataLoader;
 import org.dataloader.DelegatingDataLoader;
 import org.jspecify.annotations.NonNull;
@@ -32,11 +32,11 @@ public class DataLoaderWithContext<K, V> extends DelegatingDataLoader<K, V> {
         DataFetchingEnvironmentImpl dfeImpl = (DataFetchingEnvironmentImpl) dfe;
         DataFetchingEnvironmentImpl.DFEInternalState dfeInternalState = (DataFetchingEnvironmentImpl.DFEInternalState) dfeImpl.toInternal();
         dfeInternalState.getProfiler().dataLoaderUsed(dataLoaderName);
-        if (dfeInternalState.getDataLoaderDispatchStrategy() instanceof PerLevelDataLoaderDispatchStrategy) {
+        if (dfeInternalState.getDataLoaderDispatchStrategy() instanceof ExhaustedDataLoaderDispatchStrategy) {
             AlternativeCallContext alternativeCallContext = dfeInternalState.getDeferredCallContext();
             int level = dfe.getExecutionStepInfo().getPath().getLevel();
             String path = dfe.getExecutionStepInfo().getPath().toString();
-            ((PerLevelDataLoaderDispatchStrategy) dfeInternalState.dataLoaderDispatchStrategy).newDataLoaderInvocation(path, level, delegate, dataLoaderName, key, alternativeCallContext);
+            ((ExhaustedDataLoaderDispatchStrategy) dfeInternalState.dataLoaderDispatchStrategy).newDataLoaderInvocation(path, level, delegate, dataLoaderName, key, alternativeCallContext);
         }
         return result;
     }


### PR DESCRIPTION
This PR introduces an alternative data loader strategy that mimics in some way how the JS event loop Data Loader dispatcher works:

Instead of dispatching per Level (the current default) this strategy dispatches as soon as the engine is not "busy" anymore.

Busy here means specifically: 

- No sub selection is currently being fetched (on any level)
- No Data Loader is currently dispatched


This also handles "chained data loaders": data loaders being used after another data loader inside one DataFetcher.

This new dispatching strategy can be enabled by setting

```java
  graphQLContext.put(DataLoaderDispatchingContextKeys.ENABLE_DATA_LOADER_EXHAUSTED_DISPATCHING, true);
```
  
or 
```java
 GraphQL.unusualConfiguration(graphqlContext).dataloaderConfig().enableDataLoaderExhaustedDispatching(true)

```
