### PR TITLE
Fix sizing of some maps and collections

### DIFF
--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -1,6 +1,7 @@
 package graphql.execution;
 
 
+import com.google.common.collect.Maps;
 import graphql.GraphQLContext;
 import graphql.Internal;
 import graphql.collect.ImmutableKit;
@@ -109,7 +110,7 @@ public class ValuesResolver {
             Locale locale
     ) {
         GraphqlFieldVisibility fieldVisibility = schema.getCodeRegistry().getFieldVisibility();
-        Map<String, NormalizedInputValue> result = new LinkedHashMap<>();
+        Map<String, NormalizedInputValue> result = Maps.newLinkedHashMapWithExpectedSize(variableDefinitions.size());
         for (VariableDefinition variableDefinition : variableDefinitions) {
             String variableName = variableDefinition.getName();
             GraphQLType variableType = TypeFromAST.getTypeFromAST(schema, variableDefinition.getType());
@@ -330,7 +331,7 @@ public class ValuesResolver {
             return ImmutableKit.emptyMap();
         }
 
-        Map<String, Object> coercedValues = new LinkedHashMap<>();
+        Map<String, Object> coercedValues = Maps.newLinkedHashMapWithExpectedSize(arguments.size());
         Map<String, Argument> argumentMap = argumentMap(arguments);
         for (GraphQLArgument argumentDefinition : argumentTypes) {
             GraphQLInputType argumentType = argumentDefinition.getType();
@@ -384,7 +385,7 @@ public class ValuesResolver {
     }
 
     private static Map<String, Argument> argumentMap(List<Argument> arguments) {
-        Map<String, Argument> result = new LinkedHashMap<>(arguments.size());
+        Map<String, Argument> result = Maps.newLinkedHashMapWithExpectedSize(arguments.size());
         for (Argument argument : arguments) {
             result.put(argument.getName(), argument);
         }
@@ -463,8 +464,9 @@ public class ValuesResolver {
                                                                 Value value,
                                                                 Map<String, NormalizedInputValue> normalizedVariables) {
         if (value instanceof ArrayValue) {
-            List<Object> result = new ArrayList<>();
-            for (Value valueInArray : ((ArrayValue) value).getValues()) {
+            List<Value> values = ((ArrayValue) value).getValues();
+            List<Object> result = new ArrayList<>(values.size());
+            for (Value valueInArray : values) {
                 Object normalisedValue = literalToNormalizedValue(
                         fieldVisibility,
                         type.getWrappedType(),

--- a/src/main/java/graphql/execution/incremental/DeferredExecutionSupport.java
+++ b/src/main/java/graphql/execution/incremental/DeferredExecutionSupport.java
@@ -3,6 +3,7 @@ package graphql.execution.incremental;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.Internal;
@@ -117,7 +118,8 @@ public interface DeferredExecutionSupport {
         @Override
         public Set<IncrementalCall<? extends IncrementalPayload>> createCalls() {
             ImmutableSet<DeferredExecution> deferredExecutions = deferredExecutionToFields.keySet();
-            Set<IncrementalCall<? extends IncrementalPayload>> set = new HashSet<>(deferredExecutions.size());
+            Set<IncrementalCall<? extends IncrementalPayload>> set = Sets.newHashSetWithExpectedSize(deferredExecutions.size());
+
             for (DeferredExecution deferredExecution : deferredExecutions) {
                 set.add(this.createDeferredFragmentCall(deferredExecution));
             }

--- a/src/main/java/graphql/schema/DataLoaderWithContext.java
+++ b/src/main/java/graphql/schema/DataLoaderWithContext.java
@@ -1,5 +1,6 @@
 package graphql.schema;
 
+import com.google.common.collect.Maps;
 import graphql.Internal;
 import graphql.execution.Async;
 import graphql.execution.incremental.AlternativeCallContext;
@@ -66,7 +67,7 @@ public class DataLoaderWithContext<K, V> extends DelegatingDataLoader<K, V> {
         assertNotNull(keysAndContexts);
 
         CompletableFuture<Map<K, V>> result;
-        Map<K, CompletableFuture<V>> collect = new HashMap<>(keysAndContexts.size());
+        Map<K, CompletableFuture<V>> collect = Maps.newHashMapWithExpectedSize(keysAndContexts.size());
         for (Map.Entry<K, ?> entry : keysAndContexts.entrySet()) {
             K key = entry.getKey();
             Object keyContext = entry.getValue();

--- a/src/main/java/graphql/validation/rules/UniqueVariableNames.java
+++ b/src/main/java/graphql/validation/rules/UniqueVariableNames.java
@@ -1,5 +1,6 @@
 package graphql.validation.rules;
 
+import com.google.common.collect.Sets;
 import graphql.Internal;
 import graphql.language.OperationDefinition;
 import graphql.language.VariableDefinition;
@@ -32,7 +33,7 @@ public class UniqueVariableNames extends AbstractRule {
             return;
         }
 
-        Set<String> variableNameList = new LinkedHashSet<>(variableDefinitions.size());
+        Set<String> variableNameList = Sets.newLinkedHashSetWithExpectedSize(variableDefinitions.size());
 
 
         for (VariableDefinition variableDefinition : variableDefinitions) {


### PR DESCRIPTION
Address a few places where maps and sets were pre-sized incorrectly by supplying a capacity without regard to the load factor. Use the Guava helpers that take load factor into account.

Additionally pre-size some collections in places where it's straightforward.