### PR TITLE
Optimize GraphqlTypeComparators

### DIFF
--- a/src/main/java/graphql/schema/GraphqlTypeComparators.java
+++ b/src/main/java/graphql/schema/GraphqlTypeComparators.java
@@ -3,13 +3,16 @@ package graphql.schema;
 import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 
 @Internal
 public class GraphqlTypeComparators {
+
+    private static final Comparator<? super GraphQLSchemaElement> BY_NAME_ASCENDING =
+            Comparator.comparing(graphQLSchemaElement ->
+                    ((GraphQLNamedSchemaElement) graphQLSchemaElement).getName());
 
     /**
      * This sorts the list of {@link graphql.schema.GraphQLType} objects (by name) and allocates a new sorted
@@ -22,9 +25,7 @@ public class GraphqlTypeComparators {
      * @return a new allocated list of sorted things
      */
     public static <T extends GraphQLSchemaElement> List<T> sortTypes(Comparator<? super GraphQLSchemaElement> comparator, Collection<T> types) {
-        List<T> sorted = new ArrayList<>(types);
-        sorted.sort(comparator);
-        return ImmutableList.copyOf(sorted);
+        return ImmutableList.sortedCopyOf(comparator, types);
     }
 
     /**
@@ -42,7 +43,7 @@ public class GraphqlTypeComparators {
      * @return a comparator that compares {@link graphql.schema.GraphQLType} objects by ascending name
      */
     public static Comparator<? super GraphQLSchemaElement> byNameAsc() {
-        return Comparator.comparing(graphQLSchemaElement -> ((GraphQLNamedSchemaElement) graphQLSchemaElement).getName());
+        return BY_NAME_ASCENDING;
     }
 
 }


### PR DESCRIPTION
- Return singleton Comparator from byNameAsc
- Use ImmutableList.sortedCopyOf to avoid extra List allocation in sortTypes