### PR TITLE
Improve FpKit.concat, presize collections / maps

### DIFF
--- a/src/main/java/graphql/GraphqlErrorHelper.java
+++ b/src/main/java/graphql/GraphqlErrorHelper.java
@@ -1,5 +1,6 @@
 package graphql;
 
+import com.google.common.collect.Maps;
 import graphql.language.SourceLocation;
 import graphql.util.FpKit;
 
@@ -20,7 +21,7 @@ import static graphql.collect.ImmutableKit.mapAndDropNulls;
 public class GraphqlErrorHelper {
 
     public static Map<String, Object> toSpecification(GraphQLError error) {
-        Map<String, Object> errorMap = new LinkedHashMap<>();
+        Map<String, Object> errorMap = Maps.newLinkedHashMapWithExpectedSize(4);
         errorMap.put("message", error.getMessage());
         if (error.getLocations() != null) {
             errorMap.put("locations", locations(error.getLocations()));
@@ -73,7 +74,7 @@ public class GraphqlErrorHelper {
         if (line < 1 || column < 1) {
             return null;
         }
-        LinkedHashMap<String, Object> map = new LinkedHashMap<>(2);
+        Map<String, Object> map = Maps.newLinkedHashMapWithExpectedSize(2);
         map.put("line", line);
         map.put("column", column);
         return map;
@@ -120,7 +121,7 @@ public class GraphqlErrorHelper {
     private static void extractLocations(GraphQLError.Builder<?> errorBuilder, Map<String, Object> rawError) {
         List<Object> locations = (List<Object>) rawError.get("locations");
         if (locations != null) {
-            List<SourceLocation> sourceLocations = new ArrayList<>();
+            List<SourceLocation> sourceLocations = new ArrayList<>(locations.size());
             for (Object locationObj : locations) {
                 Map<String, Object> location = (Map<String, Object>) locationObj;
                 if (location != null) {

--- a/src/main/java/graphql/util/FpKit.java
+++ b/src/main/java/graphql/util/FpKit.java
@@ -3,6 +3,7 @@ package graphql.util;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import graphql.Internal;
 import org.jspecify.annotations.NonNull;
@@ -25,7 +26,6 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import static java.util.Collections.singletonList;
 
 @Internal
 public class FpKit {
@@ -39,7 +39,7 @@ public class FpKit {
     //
     // From a collection of keyed things, get a map of them by key, merging them according to the merge function
     public static <T, NewKey> Map<NewKey, T> toMap(Collection<T> collection, Function<T, NewKey> keyFunction, BinaryOperator<T> mergeFunc) {
-        Map<NewKey, T> resultMap = new LinkedHashMap<>();
+        Map<NewKey, T> resultMap = Maps.newLinkedHashMapWithExpectedSize(collection.size());
         for (T obj : collection) {
             NewKey key = keyFunction.apply(obj);
             if (resultMap.containsKey(key)) {
@@ -250,7 +250,10 @@ public class FpKit {
      * @return a <strong>new</strong> list composed of the first list elements and the new element
      */
     public static <T> List<T> concat(List<T> l, T t) {
-        return concat(l, singletonList(t));
+        List<T> list = new ArrayList<>(l.size() + 1);
+        list.addAll(l);
+        list.add(t);
+        return list;
     }
 
     /**
@@ -263,9 +266,9 @@ public class FpKit {
      * @return a <strong>new</strong> list composed of the two concatenated lists elements
      */
     public static <T> List<T> concat(List<T> l1, List<T> l2) {
-        ArrayList<T> l = new ArrayList<>(l1);
+        List<T> l = new ArrayList<>(l1.size() + l2.size());
+        l.addAll(l1);
         l.addAll(l2);
-        l.trimToSize();
         return l;
     }
 

--- a/src/test/java/graphql/schema/scalars/ObjectScalar.java
+++ b/src/test/java/graphql/schema/scalars/ObjectScalar.java
@@ -1,5 +1,6 @@
 package graphql.schema.scalars;
 
+import com.google.common.collect.Maps;
 import graphql.Assert;
 import graphql.Internal;
 import graphql.language.ArrayValue;
@@ -92,7 +93,7 @@ public class ObjectScalar {
             }
             if (input instanceof ObjectValue) {
                 List<ObjectField> values = ((ObjectValue) input).getObjectFields();
-                Map<String, Object> parsedValues = new LinkedHashMap<>();
+                Map<String, Object> parsedValues = Maps.newLinkedHashMapWithExpectedSize(values.size());
                 values.forEach(fld -> {
                     Object parsedValue = parseLiteral(fld.getValue(), variables);
                     parsedValues.put(fld.getName(), parsedValue);


### PR DESCRIPTION
FpKit.concat now sizes the resulting ArrayLists precisely. Additionally, update some more locations where we can easily presize Maps.