### PR TITLE
assert with constants where possible

### DIFF
--- a/src/main/java/graphql/Assert.java
+++ b/src/main/java/graphql/Assert.java
@@ -21,6 +21,13 @@ public class Assert {
         throw new NullPointerException(msg.get());
     }
 
+    public static <T> T assertNotNullWithNPE(T object, String constantMsg) {
+        if (object != null) {
+            return object;
+        }
+        throw new NullPointerException(constantMsg);
+    }
+
     @Contract("null -> fail")
     public static <T> T assertNotNull(@Nullable T object) {
         if (object != null) {
@@ -78,6 +85,14 @@ public class Assert {
         throwAssert(msg.get());
     }
 
+    @Contract("!null,_ -> fail")
+    public static <T> void assertNull(@Nullable T object, String constantMsg) {
+        if (object == null) {
+            return;
+        }
+        throwAssert(constantMsg);
+    }
+
     @Contract("!null -> fail")
     public static <T> void assertNull(@Nullable Object object) {
         if (object == null) {
@@ -112,6 +127,13 @@ public class Assert {
     public static <T> Collection<T> assertNotEmpty(Collection<T> collection, Supplier<String> msg) {
         if (collection == null || collection.isEmpty()) {
             throwAssert(msg.get());
+        }
+        return collection;
+    }
+
+    public static <T> Collection<T> assertNotEmpty(Collection<T> collection, String constantMsg) {
+        if (collection == null || collection.isEmpty()) {
+            throwAssert(constantMsg);
         }
         return collection;
     }

--- a/src/main/java/graphql/DirectivesUtil.java
+++ b/src/main/java/graphql/DirectivesUtil.java
@@ -64,16 +64,16 @@ public class DirectivesUtil {
 
     @Deprecated(since = "2022-02-24") // use GraphQLAppliedDirectives eventually
     public static List<GraphQLDirective> add(List<GraphQLDirective> targetList, GraphQLDirective newDirective) {
-        assertNotNull(targetList, () -> "directive list can't be null");
-        assertNotNull(newDirective, () -> "directive can't be null");
+        assertNotNull(targetList, "directive list can't be null");
+        assertNotNull(newDirective, "directive can't be null");
         targetList.add(newDirective);
         return targetList;
     }
 
     @Deprecated(since = "2022-02-24") // use GraphQLAppliedDirectives eventually
     public static List<GraphQLDirective> addAll(List<GraphQLDirective> targetList, List<GraphQLDirective> newDirectives) {
-        assertNotNull(targetList, () -> "directive list can't be null");
-        assertNotNull(newDirectives, () -> "directive list can't be null");
+        assertNotNull(targetList, "directive list can't be null");
+        assertNotNull(newDirectives, "directive list can't be null");
         targetList.addAll(newDirectives);
         return targetList;
     }

--- a/src/main/java/graphql/ExecutionInput.java
+++ b/src/main/java/graphql/ExecutionInput.java
@@ -69,7 +69,7 @@ public class ExecutionInput {
             return PERSISTED_QUERY_MARKER;
         }
 
-        return assertNotNull(builder.query, () -> "query can't be null");
+        return assertNotNull(builder.query, "query can't be null");
     }
 
     /**
@@ -432,13 +432,13 @@ public class ExecutionInput {
          * @return this builder
          */
         public Builder variables(Map<String, Object> rawVariables) {
-            assertNotNull(rawVariables, () -> "variables map can't be null");
+            assertNotNull(rawVariables, "variables map can't be null");
             this.rawVariables = RawVariables.of(rawVariables);
             return this;
         }
 
         public Builder extensions(Map<String, Object> extensions) {
-            this.extensions = assertNotNull(extensions, () -> "extensions map can't be null");
+            this.extensions = assertNotNull(extensions, "extensions map can't be null");
             return this;
         }
 

--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -164,14 +164,14 @@ public class GraphQL {
 
 
     private GraphQL(Builder builder) {
-        this.graphQLSchema = assertNotNull(builder.graphQLSchema, () -> "graphQLSchema must be non null");
-        this.queryStrategy = assertNotNull(builder.queryExecutionStrategy, () -> "queryStrategy must not be null");
-        this.mutationStrategy = assertNotNull(builder.mutationExecutionStrategy, () -> "mutationStrategy must not be null");
-        this.subscriptionStrategy = assertNotNull(builder.subscriptionExecutionStrategy, () -> "subscriptionStrategy must not be null");
-        this.idProvider = assertNotNull(builder.idProvider, () -> "idProvider must be non null");
-        this.instrumentation = assertNotNull(builder.instrumentation, () -> "instrumentation must not be null");
-        this.preparsedDocumentProvider = assertNotNull(builder.preparsedDocumentProvider, () -> "preparsedDocumentProvider must be non null");
-        this.valueUnboxer = assertNotNull(builder.valueUnboxer, () -> "valueUnboxer must not be null");
+        this.graphQLSchema = assertNotNull(builder.graphQLSchema, "graphQLSchema must be non null");
+        this.queryStrategy = assertNotNull(builder.queryExecutionStrategy, "queryStrategy must not be null");
+        this.mutationStrategy = assertNotNull(builder.mutationExecutionStrategy, "mutationStrategy must not be null");
+        this.subscriptionStrategy = assertNotNull(builder.subscriptionExecutionStrategy, "subscriptionStrategy must not be null");
+        this.idProvider = assertNotNull(builder.idProvider, "idProvider must be non null");
+        this.instrumentation = assertNotNull(builder.instrumentation, "instrumentation must not be null");
+        this.preparsedDocumentProvider = assertNotNull(builder.preparsedDocumentProvider, "preparsedDocumentProvider must be non null");
+        this.valueUnboxer = assertNotNull(builder.valueUnboxer, "valueUnboxer must not be null");
         this.doNotAutomaticallyDispatchDataLoader = builder.doNotAutomaticallyDispatchDataLoader;
     }
 
@@ -288,22 +288,22 @@ public class GraphQL {
         }
 
         public Builder schema(GraphQLSchema graphQLSchema) {
-            this.graphQLSchema = assertNotNull(graphQLSchema, () -> "GraphQLSchema must be non null");
+            this.graphQLSchema = assertNotNull(graphQLSchema, "GraphQLSchema must be non null");
             return this;
         }
 
         public Builder queryExecutionStrategy(ExecutionStrategy executionStrategy) {
-            this.queryExecutionStrategy = assertNotNull(executionStrategy, () -> "Query ExecutionStrategy must be non null");
+            this.queryExecutionStrategy = assertNotNull(executionStrategy, "Query ExecutionStrategy must be non null");
             return this;
         }
 
         public Builder mutationExecutionStrategy(ExecutionStrategy executionStrategy) {
-            this.mutationExecutionStrategy = assertNotNull(executionStrategy, () -> "Mutation ExecutionStrategy must be non null");
+            this.mutationExecutionStrategy = assertNotNull(executionStrategy, "Mutation ExecutionStrategy must be non null");
             return this;
         }
 
         public Builder subscriptionExecutionStrategy(ExecutionStrategy executionStrategy) {
-            this.subscriptionExecutionStrategy = assertNotNull(executionStrategy, () -> "Subscription ExecutionStrategy must be non null");
+            this.subscriptionExecutionStrategy = assertNotNull(executionStrategy, "Subscription ExecutionStrategy must be non null");
             return this;
         }
 
@@ -316,22 +316,22 @@ public class GraphQL {
          * @return this builder
          */
         public Builder defaultDataFetcherExceptionHandler(DataFetcherExceptionHandler dataFetcherExceptionHandler) {
-            this.defaultExceptionHandler = assertNotNull(dataFetcherExceptionHandler, () -> "The DataFetcherExceptionHandler must be non null");
+            this.defaultExceptionHandler = assertNotNull(dataFetcherExceptionHandler, "The DataFetcherExceptionHandler must be non null");
             return this;
         }
 
         public Builder instrumentation(Instrumentation instrumentation) {
-            this.instrumentation = assertNotNull(instrumentation, () -> "Instrumentation must be non null");
+            this.instrumentation = assertNotNull(instrumentation, "Instrumentation must be non null");
             return this;
         }
 
         public Builder preparsedDocumentProvider(PreparsedDocumentProvider preparsedDocumentProvider) {
-            this.preparsedDocumentProvider = assertNotNull(preparsedDocumentProvider, () -> "PreparsedDocumentProvider must be non null");
+            this.preparsedDocumentProvider = assertNotNull(preparsedDocumentProvider, "PreparsedDocumentProvider must be non null");
             return this;
         }
 
         public Builder executionIdProvider(ExecutionIdProvider executionIdProvider) {
-            this.idProvider = assertNotNull(executionIdProvider, () -> "ExecutionIdProvider must be non null");
+            this.idProvider = assertNotNull(executionIdProvider, "ExecutionIdProvider must be non null");
             return this;
         }
 

--- a/src/main/java/graphql/GraphqlErrorBuilder.java
+++ b/src/main/java/graphql/GraphqlErrorBuilder.java
@@ -129,7 +129,7 @@ public class GraphqlErrorBuilder<B extends GraphqlErrorBuilder<B>> implements Gr
      * @return a newly built GraphqlError
      */
     public GraphQLError build() {
-        assertNotNull(message, () -> "You must provide error message");
+        assertNotNull(message, "You must provide error message");
         return new GraphqlErrorImpl(message, locations, errorType, path, extensions);
     }
 

--- a/src/main/java/graphql/analysis/MaxQueryComplexityInstrumentation.java
+++ b/src/main/java/graphql/analysis/MaxQueryComplexityInstrumentation.java
@@ -74,7 +74,7 @@ public class MaxQueryComplexityInstrumentation extends SimplePerformantInstrumen
     public MaxQueryComplexityInstrumentation(int maxComplexity, FieldComplexityCalculator fieldComplexityCalculator,
                                              Function<QueryComplexityInfo, Boolean> maxQueryComplexityExceededFunction) {
         this.maxComplexity = maxComplexity;
-        this.fieldComplexityCalculator = assertNotNull(fieldComplexityCalculator, () -> "calculator can't be null");
+        this.fieldComplexityCalculator = assertNotNull(fieldComplexityCalculator, "calculator can't be null");
         this.maxQueryComplexityExceededFunction = maxQueryComplexityExceededFunction;
     }
 

--- a/src/main/java/graphql/analysis/QueryComplexityCalculator.java
+++ b/src/main/java/graphql/analysis/QueryComplexityCalculator.java
@@ -25,10 +25,10 @@ public class QueryComplexityCalculator {
     private final CoercedVariables variables;
 
     public QueryComplexityCalculator(Builder builder) {
-        this.fieldComplexityCalculator = assertNotNull(builder.fieldComplexityCalculator, () -> "fieldComplexityCalculator can't be null");
-        this.schema = assertNotNull(builder.schema, () -> "schema can't be null");
-        this.document = assertNotNull(builder.document, () -> "document can't be null");
-        this.variables = assertNotNull(builder.variables, () -> "variables can't be null");
+        this.fieldComplexityCalculator = assertNotNull(builder.fieldComplexityCalculator, "fieldComplexityCalculator can't be null");
+        this.schema = assertNotNull(builder.schema, "schema can't be null");
+        this.document = assertNotNull(builder.document, "document can't be null");
+        this.variables = assertNotNull(builder.variables, "variables can't be null");
         this.operationName = builder.operationName;
     }
 

--- a/src/main/java/graphql/analysis/QueryTransformer.java
+++ b/src/main/java/graphql/analysis/QueryTransformer.java
@@ -47,12 +47,12 @@ public class QueryTransformer {
                              Map<String, FragmentDefinition> fragmentsByName,
                              Map<String, Object> variables,
                              QueryTraversalOptions options) {
-        this.schema = assertNotNull(schema, () -> "schema can't be null");
-        this.variables = assertNotNull(variables, () -> "variables can't be null");
-        this.root = assertNotNull(root, () -> "root can't be null");
+        this.schema = assertNotNull(schema, "schema can't be null");
+        this.variables = assertNotNull(variables, "variables can't be null");
+        this.root = assertNotNull(root, "root can't be null");
         this.rootParentType = assertNotNull(rootParentType);
-        this.fragmentsByName = assertNotNull(fragmentsByName, () -> "fragmentsByName can't be null");
-        this.options = assertNotNull(options, () -> "options can't be null");
+        this.fragmentsByName = assertNotNull(fragmentsByName, "fragmentsByName can't be null");
+        this.options = assertNotNull(options, "options can't be null");
     }
 
     /**
@@ -177,7 +177,7 @@ public class QueryTransformer {
          * @return this builder
          */
         public Builder options(QueryTraversalOptions options) {
-            this.options = assertNotNull(options, () -> "options can't be null");
+            this.options = assertNotNull(options, "options can't be null");
             return this;
         }
 

--- a/src/main/java/graphql/analysis/QueryTraverser.java
+++ b/src/main/java/graphql/analysis/QueryTraverser.java
@@ -238,7 +238,7 @@ public class QueryTraverser {
          * @return this builder
          */
         public Builder schema(GraphQLSchema schema) {
-            this.schema = assertNotNull(schema, () -> "schema can't be null");
+            this.schema = assertNotNull(schema, "schema can't be null");
             return this;
         }
 
@@ -264,7 +264,7 @@ public class QueryTraverser {
          * @return this builder
          */
         public Builder document(Document document) {
-            this.document = assertNotNull(document, () -> "document can't be null");
+            this.document = assertNotNull(document, "document can't be null");
             return this;
         }
 
@@ -276,7 +276,7 @@ public class QueryTraverser {
          * @return this builder
          */
         public Builder variables(Map<String, Object> variables) {
-            assertNotNull(variables, () -> "variables can't be null");
+            assertNotNull(variables, "variables can't be null");
             this.rawVariables = RawVariables.of(variables);
             return this;
         }
@@ -289,7 +289,7 @@ public class QueryTraverser {
          * @return this builder
          */
         public Builder coercedVariables(CoercedVariables coercedVariables) {
-            assertNotNull(coercedVariables, () -> "coercedVariables can't be null");
+            assertNotNull(coercedVariables, "coercedVariables can't be null");
             this.coercedVariables = coercedVariables;
             return this;
         }
@@ -303,7 +303,7 @@ public class QueryTraverser {
          * @return this builder
          */
         public Builder root(Node root) {
-            this.root = assertNotNull(root, () -> "root can't be null");
+            this.root = assertNotNull(root, "root can't be null");
             return this;
         }
 
@@ -315,7 +315,7 @@ public class QueryTraverser {
          * @return this builder
          */
         public Builder rootParentType(GraphQLCompositeType rootParentType) {
-            this.rootParentType = assertNotNull(rootParentType, () -> "rootParentType can't be null");
+            this.rootParentType = assertNotNull(rootParentType, "rootParentType can't be null");
             return this;
         }
 
@@ -327,7 +327,7 @@ public class QueryTraverser {
          * @return this builder
          */
         public Builder fragmentsByName(Map<String, FragmentDefinition> fragmentsByName) {
-            this.fragmentsByName = assertNotNull(fragmentsByName, () -> "fragmentsByName can't be null");
+            this.fragmentsByName = assertNotNull(fragmentsByName, "fragmentsByName can't be null");
             return this;
         }
 
@@ -338,7 +338,7 @@ public class QueryTraverser {
          * @return this builder
          */
         public Builder options(QueryTraversalOptions options) {
-            this.options = assertNotNull(options, () -> "options can't be null");
+            this.options = assertNotNull(options, "options can't be null");
             return this;
         }
 

--- a/src/main/java/graphql/analysis/values/ValueTraverser.java
+++ b/src/main/java/graphql/analysis/values/ValueTraverser.java
@@ -220,7 +220,7 @@ public class ValueTraverser {
 
     private static Object visitObjectValue(Object coercedValue, GraphQLInputObjectType inputObjectType, InputElements containingElements, ValueVisitor visitor) {
         if (coercedValue != null) {
-            assertTrue(coercedValue instanceof Map, () -> "A input object type MUST have an Map<String,Object> value");
+            assertTrue(coercedValue instanceof Map, "A input object type MUST have an Map<String,Object> value");
         }
         @SuppressWarnings("unchecked")
         Map<String, Object> map = (Map<String, Object>) coercedValue;
@@ -265,7 +265,7 @@ public class ValueTraverser {
 
     private static Object visitListValue(Object coercedValue, GraphQLList listInputType, InputElements containingElements, ValueVisitor visitor) {
         if (coercedValue != null) {
-            assertTrue(coercedValue instanceof List, () -> "A list type MUST have an List value");
+            assertTrue(coercedValue instanceof List, "A list type MUST have an List value");
         }
         @SuppressWarnings("unchecked")
         List<Object> list = (List<Object>) coercedValue;

--- a/src/main/java/graphql/execution/ExecutionContextBuilder.java
+++ b/src/main/java/graphql/execution/ExecutionContextBuilder.java
@@ -249,7 +249,7 @@ public class ExecutionContextBuilder {
 
     public ExecutionContext build() {
         // preconditions
-        assertNotNull(executionId, () -> "You must provide a query identifier");
+        assertNotNull(executionId, "You must provide a query identifier");
         return new ExecutionContext(this);
     }
 

--- a/src/main/java/graphql/execution/ExecutionId.java
+++ b/src/main/java/graphql/execution/ExecutionId.java
@@ -33,7 +33,7 @@ public class ExecutionId {
     private final String id;
 
     private ExecutionId(String id) {
-        Assert.assertNotNull(id, () -> "You must provided a non null id");
+        Assert.assertNotNull(id, "You must provided a non null id");
         this.id = id;
     }
 

--- a/src/main/java/graphql/execution/ExecutionStepInfo.java
+++ b/src/main/java/graphql/execution/ExecutionStepInfo.java
@@ -73,7 +73,7 @@ public class ExecutionStepInfo {
         this.field = builder.field;
         this.path = builder.path;
         this.parent = builder.parentInfo;
-        this.type = assertNotNull(builder.type, () -> "you must provide a graphql type");
+        this.type = assertNotNull(builder.type, "you must provide a graphql type");
         this.arguments = builder.arguments;
         this.fieldContainer = builder.fieldContainer;
     }
@@ -88,7 +88,7 @@ public class ExecutionStepInfo {
                               GraphQLFieldDefinition fieldDefinition,
                               GraphQLObjectType fieldContainer,
                               Supplier<ImmutableMapWithNullValues<String, Object>> arguments) {
-        this.type = assertNotNull(type, () -> "you must provide a graphql type");
+        this.type = assertNotNull(type, "you must provide a graphql type");
         this.path = path;
         this.parent = parent;
         this.field = field;
@@ -223,7 +223,7 @@ public class ExecutionStepInfo {
      * @return a new type info with the same
      */
     public ExecutionStepInfo changeTypeWithPreservedNonNull(GraphQLOutputType newType) {
-        assertTrue(!GraphQLTypeUtil.isNonNull(newType), () -> "newType can't be non null");
+        assertTrue(!GraphQLTypeUtil.isNonNull(newType), "newType can't be non null");
         if (isNonNullType()) {
             return transform(GraphQLNonNull.nonNull(newType));
         } else {

--- a/src/main/java/graphql/execution/ExecutionStrategyParameters.java
+++ b/src/main/java/graphql/execution/ExecutionStrategyParameters.java
@@ -34,11 +34,11 @@ public class ExecutionStrategyParameters {
                                         ExecutionStrategyParameters parent,
                                         AlternativeCallContext alternativeCallContext) {
 
-        this.executionStepInfo = assertNotNull(executionStepInfo, () -> "executionStepInfo is null");
+        this.executionStepInfo = assertNotNull(executionStepInfo, "executionStepInfo is null");
         this.localContext = localContext;
-        this.fields = assertNotNull(fields, () -> "fields is null");
+        this.fields = assertNotNull(fields, "fields is null");
         this.source = source;
-        this.nonNullableFieldValidator = assertNotNull(nonNullableFieldValidator, () -> "requires a NonNullValidator");;
+        this.nonNullableFieldValidator = assertNotNull(nonNullableFieldValidator, "requires a NonNullValidator");;
         this.path = path;
         this.currentField = currentField;
         this.parent = parent;
@@ -275,7 +275,7 @@ public class ExecutionStrategyParameters {
         }
 
         public Builder nonNullFieldValidator(NonNullableFieldValidator nonNullableFieldValidator) {
-            this.nonNullableFieldValidator = assertNotNull(nonNullableFieldValidator, () -> "requires a NonNullValidator");
+            this.nonNullableFieldValidator = assertNotNull(nonNullableFieldValidator, "requires a NonNullValidator");
             return this;
         }
 

--- a/src/main/java/graphql/execution/FieldCollectorParameters.java
+++ b/src/main/java/graphql/execution/FieldCollectorParameters.java
@@ -92,7 +92,7 @@ public class FieldCollectorParameters {
         }
 
         public FieldCollectorParameters build() {
-            Assert.assertNotNull(graphQLSchema, () -> "You must provide a schema");
+            Assert.assertNotNull(graphQLSchema, "You must provide a schema");
             return new FieldCollectorParameters(this);
         }
 

--- a/src/main/java/graphql/execution/MergedField.java
+++ b/src/main/java/graphql/execution/MergedField.java
@@ -428,7 +428,7 @@ public class MergedField {
             if (this.singleField != null && this.fields == null) {
                 return new MergedField(singleField, deferredExecutions);
             }
-            ImmutableList<Field> fields = assertNotNull(this.fields, () -> "You MUST add at least one field via the builder").build();
+            ImmutableList<Field> fields = assertNotNull(this.fields, "You MUST add at least one field via the builder").build();
             assertNotEmpty(fields);
             return new MultiMergedField(fields, deferredExecutions);
         }

--- a/src/main/java/graphql/execution/ResultPath.java
+++ b/src/main/java/graphql/execution/ResultPath.java
@@ -49,14 +49,14 @@ public class ResultPath {
     }
 
     private ResultPath(ResultPath parent, String segment) {
-        this.parent = assertNotNull(parent, () -> "Must provide a parent path");
-        this.segment = assertNotNull(segment, () -> "Must provide a sub path");
+        this.parent = assertNotNull(parent, "Must provide a parent path");
+        this.segment = assertNotNull(segment, "Must provide a sub path");
         this.toStringValue = initString();
         this.level = parent.level + 1;
     }
 
     private ResultPath(ResultPath parent, int segment) {
-        this.parent = assertNotNull(parent, () -> "Must provide a parent path");
+        this.parent = assertNotNull(parent, "Must provide a parent path");
         this.segment = segment;
         this.toStringValue = initString();
         this.level = parent.level;
@@ -134,13 +134,13 @@ public class ResultPath {
         while (st.hasMoreTokens()) {
             String token = st.nextToken();
             if ("/".equals(token)) {
-                assertTrue(st.hasMoreTokens(), () -> String.format(mkErrMsg(), finalPathString));
+                assertTrue(st.hasMoreTokens(), mkErrMsg(), finalPathString);
                 path = path.segment(st.nextToken());
             } else if ("[".equals(token)) {
-                assertTrue(st.countTokens() >= 2, () -> String.format(mkErrMsg(), finalPathString));
+                assertTrue(st.countTokens() >= 2, mkErrMsg(), finalPathString);
                 path = path.segment(Integer.parseInt(st.nextToken()));
                 String closingBrace = st.nextToken();
-                assertTrue(closingBrace.equals("]"), () -> String.format(mkErrMsg(), finalPathString));
+                assertTrue(closingBrace.equals("]"), mkErrMsg(), finalPathString);
             } else {
                 throw new AssertException(format(mkErrMsg(), pathString));
             }
@@ -217,7 +217,7 @@ public class ResultPath {
      * @return a new path with the last segment replaced
      */
     public ResultPath replaceSegment(int segment) {
-        assertTrue(!ROOT_PATH.equals(this), () -> "You MUST not call this with the root path");
+        assertTrue(!ROOT_PATH.equals(this), "You MUST not call this with the root path");
         return new ResultPath(parent, segment);
     }
 
@@ -230,7 +230,7 @@ public class ResultPath {
      * @return a new path with the last segment replaced
      */
     public ResultPath replaceSegment(String segment) {
-        assertTrue(!ROOT_PATH.equals(this), () -> "You MUST not call this with the root path");
+        assertTrue(!ROOT_PATH.equals(this), "You MUST not call this with the root path");
         return new ResultPath(parent, segment);
     }
 

--- a/src/main/java/graphql/execution/directives/QueryAppliedDirective.java
+++ b/src/main/java/graphql/execution/directives/QueryAppliedDirective.java
@@ -41,7 +41,7 @@ public class QueryAppliedDirective {
 
     private QueryAppliedDirective(String name, Directive definition, Collection<QueryAppliedDirectiveArgument> arguments) {
         assertValidName(name);
-        assertNotNull(arguments, () -> "arguments can't be null");
+        assertNotNull(arguments, "arguments can't be null");
         this.name = name;
         this.arguments = ImmutableList.copyOf(arguments);
         this.definition = definition;
@@ -122,13 +122,13 @@ public class QueryAppliedDirective {
         }
 
         public Builder argument(QueryAppliedDirectiveArgument argument) {
-            assertNotNull(argument, () -> "argument must not be null");
+            assertNotNull(argument,"argument must not be null");
             arguments.put(argument.getName(), argument);
             return this;
         }
 
         public Builder replaceArguments(List<QueryAppliedDirectiveArgument> arguments) {
-            assertNotNull(arguments, () -> "arguments must not be null");
+            assertNotNull(arguments, "arguments must not be null");
             this.arguments.clear();
             for (QueryAppliedDirectiveArgument argument : arguments) {
                 this.arguments.put(argument.getName(), argument);

--- a/src/main/java/graphql/execution/reactive/CompletionStageMappingPublisher.java
+++ b/src/main/java/graphql/execution/reactive/CompletionStageMappingPublisher.java
@@ -35,7 +35,7 @@ public class CompletionStageMappingPublisher<D, U> implements Publisher<D> {
 
     @Override
     public void subscribe(Subscriber<? super D> downstreamSubscriber) {
-        assertNotNullWithNPE(downstreamSubscriber, () -> "Subscriber passed to subscribe must not be null");
+        assertNotNullWithNPE(downstreamSubscriber, "Subscriber passed to subscribe must not be null");
         upstreamPublisher.subscribe(createSubscriber(downstreamSubscriber));
     }
 

--- a/src/main/java/graphql/execution/reactive/NonBlockingMutexExecutor.java
+++ b/src/main/java/graphql/execution/reactive/NonBlockingMutexExecutor.java
@@ -38,7 +38,7 @@ class NonBlockingMutexExecutor implements Executor {
 
     @Override
     public void execute(final @NonNull Runnable command) {
-        final RunNode newNode = new RunNode(assertNotNull(command, () -> "Runnable must not be null"));
+        final RunNode newNode = new RunNode(assertNotNull(command,  "Runnable must not be null"));
         final RunNode prevLast = last.getAndSet(newNode);
         if (prevLast != null) {
             prevLast.lazySet(newNode);

--- a/src/main/java/graphql/execution/reactive/SingleSubscriberPublisher.java
+++ b/src/main/java/graphql/execution/reactive/SingleSubscriberPublisher.java
@@ -102,7 +102,7 @@ public class SingleSubscriberPublisher<T> implements Publisher<T> {
 
     @Override
     public void subscribe(Subscriber<? super T> subscriber) {
-        assertNotNullWithNPE(subscriber, () -> "Subscriber passed to subscribe must not be null");
+        assertNotNullWithNPE(subscriber, "Subscriber passed to subscribe must not be null");
         mutex.execute(() -> {
             if (this.subscriber == null) {
                 this.subscriber = subscriber;

--- a/src/main/java/graphql/extensions/ExtensionsBuilder.java
+++ b/src/main/java/graphql/extensions/ExtensionsBuilder.java
@@ -106,7 +106,7 @@ public class ExtensionsBuilder {
         Map<Object, Object> outMap = new LinkedHashMap<>(firstChange);
         for (int i = 1; i < changes.size(); i++) {
             Map<Object, Object> newMap = extensionsMerger.merge(outMap, changes.get(i));
-            assertNotNull(outMap, () -> "You MUST provide a non null Map from ExtensionsMerger.merge()");
+            assertNotNull(outMap, "You MUST provide a non null Map from ExtensionsMerger.merge()");
             outMap = newMap;
         }
         return outMap;

--- a/src/main/java/graphql/introspection/IntrospectionResultToSchema.java
+++ b/src/main/java/graphql/introspection/IntrospectionResultToSchema.java
@@ -73,12 +73,11 @@ public class IntrospectionResultToSchema {
      */
     @SuppressWarnings("unchecked")
     public Document createSchemaDefinition(Map<String, Object> introspectionResult) {
-        assertTrue(introspectionResult.get("__schema") != null, () -> "__schema expected");
         Map<String, Object> schema = (Map<String, Object>) introspectionResult.get("__schema");
-
+        assertNotNull(schema, "__schema expected");
 
         Map<String, Object> queryType = (Map<String, Object>) schema.get("queryType");
-        assertNotNull(queryType, () -> "queryType expected");
+        assertNotNull(queryType, "queryType expected");
         TypeName query = TypeName.newTypeName().name((String) queryType.get("name")).build();
         boolean nonDefaultQueryName = !"Query".equals(query.getName());
 
@@ -155,8 +154,8 @@ public class IntrospectionResultToSchema {
     }
 
     private List<DirectiveLocation> createDirectiveLocations(List<Object> locations) {
-        assertNotEmpty(locations, () -> "the locations of directive should not be empty.");
-        ArrayList<DirectiveLocation> result = new ArrayList<>();
+        assertNotEmpty(locations, "the locations of directive should not be empty.");
+        List<DirectiveLocation> result = new ArrayList<>(locations.size());
         for (Object location : locations) {
             DirectiveLocation directiveLocation = DirectiveLocation.newDirectiveLocation().name(location.toString()).build();
             result.add(directiveLocation);
@@ -202,7 +201,7 @@ public class IntrospectionResultToSchema {
 
     @SuppressWarnings("unchecked")
     UnionTypeDefinition createUnion(Map<String, Object> input) {
-        assertTrue(input.get("kind").equals("UNION"), () -> "wrong input");
+        assertTrue(input.get("kind").equals("UNION"), "wrong input");
 
         UnionTypeDefinition.Builder unionTypeDefinition = UnionTypeDefinition.newUnionTypeDefinition();
         unionTypeDefinition.name((String) input.get("name"));
@@ -220,7 +219,7 @@ public class IntrospectionResultToSchema {
 
     @SuppressWarnings("unchecked")
     EnumTypeDefinition createEnum(Map<String, Object> input) {
-        assertTrue(input.get("kind").equals("ENUM"), () -> "wrong input");
+        assertTrue(input.get("kind").equals("ENUM"), "wrong input");
 
         EnumTypeDefinition.Builder enumTypeDefinition = EnumTypeDefinition.newEnumTypeDefinition().name((String) input.get("name"));
         enumTypeDefinition.description(toDescription(input));
@@ -242,7 +241,7 @@ public class IntrospectionResultToSchema {
 
     @SuppressWarnings("unchecked")
     InterfaceTypeDefinition createInterface(Map<String, Object> input) {
-        assertTrue(input.get("kind").equals("INTERFACE"), () -> "wrong input");
+        assertTrue(input.get("kind").equals("INTERFACE"), "wrong input");
 
         InterfaceTypeDefinition.Builder interfaceTypeDefinition = InterfaceTypeDefinition.newInterfaceTypeDefinition().name((String) input.get("name"));
         interfaceTypeDefinition.description(toDescription(input));
@@ -263,7 +262,7 @@ public class IntrospectionResultToSchema {
 
     @SuppressWarnings("unchecked")
     InputObjectTypeDefinition createInputObject(Map<String, Object> input) {
-        assertTrue(input.get("kind").equals("INPUT_OBJECT"), () -> "wrong input");
+        assertTrue(input.get("kind").equals("INPUT_OBJECT"), "wrong input");
 
         InputObjectTypeDefinition.Builder inputObjectTypeDefinition = InputObjectTypeDefinition.newInputObjectDefinition()
                 .name((String) input.get("name"))
@@ -278,7 +277,7 @@ public class IntrospectionResultToSchema {
 
     @SuppressWarnings("unchecked")
     ObjectTypeDefinition createObject(Map<String, Object> input) {
-        assertTrue(input.get("kind").equals("OBJECT"), () -> "wrong input");
+        assertTrue(input.get("kind").equals("OBJECT"), "wrong input");
 
         ObjectTypeDefinition.Builder objectTypeDefinition = ObjectTypeDefinition.newObjectTypeDefinition().name((String) input.get("name"));
         objectTypeDefinition.description(toDescription(input));
@@ -295,7 +294,7 @@ public class IntrospectionResultToSchema {
     }
 
     private List<FieldDefinition> createFields(List<Map<String, Object>> fields) {
-        List<FieldDefinition> result = new ArrayList<>();
+        List<FieldDefinition> result = new ArrayList<>(fields.size());
         for (Map<String, Object> field : fields) {
             FieldDefinition.Builder fieldDefinition = FieldDefinition.newFieldDefinition().name((String) field.get("name"));
             fieldDefinition.description(toDescription(field));
@@ -312,7 +311,6 @@ public class IntrospectionResultToSchema {
     }
 
     private void createDeprecatedDirective(Map<String, Object> field, NodeDirectivesBuilder nodeDirectivesBuilder) {
-        List<Directive> directives = new ArrayList<>();
         if (Boolean.TRUE.equals(field.get("isDeprecated"))) {
             String reason = (String) field.get("deprecationReason");
             if (reason == null) {
@@ -320,14 +318,13 @@ public class IntrospectionResultToSchema {
             }
             Argument reasonArg = Argument.newArgument().name("reason").value(StringValue.newStringValue().value(reason).build()).build();
             Directive deprecated = Directive.newDirective().name("deprecated").arguments(Collections.singletonList(reasonArg)).build();
-            directives.add(deprecated);
+            nodeDirectivesBuilder.directive(deprecated);
         }
-        nodeDirectivesBuilder.directives(directives);
     }
 
     @SuppressWarnings("unchecked")
     private List<InputValueDefinition> createInputValueDefinitions(List<Map<String, Object>> args) {
-        List<InputValueDefinition> result = new ArrayList<>();
+        List<InputValueDefinition> result = new ArrayList<>(args.size());
         for (Map<String, Object> arg : args) {
             Type argType = createTypeIndirection((Map<String, Object>) arg.get("type"));
             InputValueDefinition.Builder inputValueDefinition = InputValueDefinition.newInputValueDefinition().name((String) arg.get("name")).type(argType);

--- a/src/main/java/graphql/language/AbstractNode.java
+++ b/src/main/java/graphql/language/AbstractNode.java
@@ -28,9 +28,9 @@ public abstract class AbstractNode<T extends Node> implements Node<T> {
     }
 
     public AbstractNode(@Nullable SourceLocation sourceLocation, List<Comment> comments, IgnoredChars ignoredChars, Map<String, String> additionalData) {
-        Assert.assertNotNull(comments, () -> "comments can't be null");
-        Assert.assertNotNull(ignoredChars, () -> "ignoredChars can't be null");
-        Assert.assertNotNull(additionalData, () -> "additionalData can't be null");
+        Assert.assertNotNull(comments, "comments can't be null");
+        Assert.assertNotNull(ignoredChars, "ignoredChars can't be null");
+        Assert.assertNotNull(additionalData, "additionalData can't be null");
 
         this.sourceLocation = sourceLocation;
         this.additionalData = ImmutableMap.copyOf(additionalData);

--- a/src/main/java/graphql/language/AstPrinter.java
+++ b/src/main/java/graphql/language/AstPrinter.java
@@ -574,7 +574,7 @@ public class AstPrinter {
 
     private void node(StringBuilder out, Node<?> node, Class<?> startClass) {
         if (startClass != null) {
-            assertTrue(startClass.isInstance(node), () -> "The starting class must be in the inherit tree");
+            assertTrue(startClass.isInstance(node), "The starting class must be in the inherit tree");
         }
         NodePrinter<Node<?>> printer = _findPrinter(node, startClass);
         printer.print(out, node);

--- a/src/main/java/graphql/language/NodeParentTree.java
+++ b/src/main/java/graphql/language/NodeParentTree.java
@@ -29,14 +29,14 @@ public class NodeParentTree<T extends Node> {
 
     @Internal
     public NodeParentTree(Deque<T> nodeStack) {
-        assertNotNull(nodeStack, () -> "You MUST have a non null stack of nodes");
-        assertTrue(!nodeStack.isEmpty(), () -> "You MUST have a non empty stack of nodes");
+        assertNotNull(nodeStack, "You MUST have a non null stack of nodes");
+        assertTrue(!nodeStack.isEmpty(), "You MUST have a non empty stack of nodes");
 
         Deque<T> copy = new ArrayDeque<>(nodeStack);
         path = mkPath(copy);
         node = copy.pop();
         if (!copy.isEmpty()) {
-            parent = new NodeParentTree<T>(copy);
+            parent = new NodeParentTree<>(copy);
         } else {
             parent = null;
         }
@@ -88,8 +88,6 @@ public class NodeParentTree<T extends Node> {
 
     @Override
     public String toString() {
-        return String.valueOf(node) +
-                " - parent : " +
-                parent;
+        return node + " - parent : " + parent;
     }
 }

--- a/src/main/java/graphql/language/PrettyAstPrinter.java
+++ b/src/main/java/graphql/language/PrettyAstPrinter.java
@@ -220,7 +220,7 @@ public class PrettyAstPrinter extends AstPrinter {
 
     private String node(Node node, Class startClass) {
         if (startClass != null) {
-            assertTrue(startClass.isInstance(node), () -> "The starting class must be in the inherit tree");
+            assertTrue(startClass.isInstance(node), "The starting class must be in the inherit tree");
         }
         StringBuilder builder = new StringBuilder();
 

--- a/src/main/java/graphql/normalized/ExecutableNormalizedField.java
+++ b/src/main/java/graphql/normalized/ExecutableNormalizedField.java
@@ -183,7 +183,7 @@ public class ExecutableNormalizedField {
     public GraphQLOutputType getType(GraphQLSchema schema) {
         List<GraphQLFieldDefinition> fieldDefinitions = getFieldDefinitions(schema);
         Set<String> fieldTypes = fieldDefinitions.stream().map(fd -> simplePrint(fd.getType())).collect(toSet());
-        assertTrue(fieldTypes.size() == 1, () -> "More than one type ... use getTypes");
+        assertTrue(fieldTypes.size() == 1, "More than one type ... use getTypes");
         return fieldDefinitions.get(0).getType();
     }
 
@@ -436,8 +436,8 @@ public class ExecutableNormalizedField {
     }
 
     public List<ExecutableNormalizedField> getChildren(int includingRelativeLevel) {
+        assertTrue(includingRelativeLevel >= 1, "relative level must be >= 1");
         List<ExecutableNormalizedField> result = new ArrayList<>();
-        assertTrue(includingRelativeLevel >= 1, () -> "relative level must be >= 1");
 
         this.getChildren().forEach(child -> {
             traverseImpl(child, result::add, 1, includingRelativeLevel);

--- a/src/main/java/graphql/normalized/NormalizedInputValue.java
+++ b/src/main/java/graphql/normalized/NormalizedInputValue.java
@@ -100,7 +100,7 @@ public class NormalizedInputValue {
 
     private String unwrapOne(String typeName) {
         assertNotNull(typeName);
-        Assert.assertTrue(typeName.trim().length() > 0, () -> "We have an empty type name unwrapped");
+        Assert.assertTrue(!typeName.trim().isEmpty(), "We have an empty type name unwrapped");
         if (typeName.endsWith("!")) {
             return typeName.substring(0, typeName.length() - 1);
         }

--- a/src/main/java/graphql/normalized/nf/NormalizedField.java
+++ b/src/main/java/graphql/normalized/nf/NormalizedField.java
@@ -182,7 +182,7 @@ public class NormalizedField {
     public GraphQLOutputType getType(GraphQLSchema schema) {
         List<GraphQLFieldDefinition> fieldDefinitions = getFieldDefinitions(schema);
         Set<String> fieldTypes = fieldDefinitions.stream().map(fd -> simplePrint(fd.getType())).collect(toSet());
-        assertTrue(fieldTypes.size() == 1, () -> "More than one type ... use getTypes");
+        assertTrue(fieldTypes.size() == 1, "More than one type ... use getTypes");
         return fieldDefinitions.get(0).getType();
     }
 
@@ -429,8 +429,8 @@ public class NormalizedField {
     }
 
     public List<NormalizedField> getChildren(int includingRelativeLevel) {
+        assertTrue(includingRelativeLevel >= 1, "relative level must be >= 1");
         List<NormalizedField> result = new ArrayList<>();
-        assertTrue(includingRelativeLevel >= 1, () -> "relative level must be >= 1");
 
         this.getChildren().forEach(child -> {
             traverseImpl(child, result::add, 1, includingRelativeLevel);

--- a/src/main/java/graphql/relay/DefaultConnection.java
+++ b/src/main/java/graphql/relay/DefaultConnection.java
@@ -27,8 +27,8 @@ public class DefaultConnection<T> implements Connection<T> {
      * @throws IllegalArgumentException if edges or page info is null. use {@link Collections#emptyList()} for empty edges.
      */
     public DefaultConnection(List<Edge<T>> edges, PageInfo pageInfo) {
-        this.edges = ImmutableList.copyOf(assertNotNull(edges, () -> "edges cannot be null"));
-        this.pageInfo = assertNotNull(pageInfo, () -> "page info cannot be null");
+        this.edges = ImmutableList.copyOf(assertNotNull(edges, "edges cannot be null"));
+        this.pageInfo = assertNotNull(pageInfo, "page info cannot be null");
     }
 
     @Override

--- a/src/main/java/graphql/relay/DefaultConnectionCursor.java
+++ b/src/main/java/graphql/relay/DefaultConnectionCursor.java
@@ -11,7 +11,7 @@ public class DefaultConnectionCursor implements ConnectionCursor {
     private final String value;
 
     public DefaultConnectionCursor(String value) {
-        Assert.assertTrue(value != null && !value.isEmpty(), () -> "connection value cannot be null or empty");
+        Assert.assertTrue(value != null && !value.isEmpty(), "connection value cannot be null or empty");
         this.value = value;
     }
 

--- a/src/main/java/graphql/relay/DefaultEdge.java
+++ b/src/main/java/graphql/relay/DefaultEdge.java
@@ -13,7 +13,7 @@ public class DefaultEdge<T> implements Edge<T> {
     private final ConnectionCursor cursor;
 
     public DefaultEdge(T node, ConnectionCursor cursor) {
-        this.cursor = assertNotNull(cursor, () -> "cursor cannot be null");
+        this.cursor = assertNotNull(cursor, "cursor cannot be null");
         this.node = node;
     }
 

--- a/src/main/java/graphql/relay/SimpleListConnection.java
+++ b/src/main/java/graphql/relay/SimpleListConnection.java
@@ -8,6 +8,7 @@ import graphql.schema.DataFetchingEnvironment;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static graphql.Assert.assertNotNull;
@@ -24,8 +25,8 @@ public class SimpleListConnection<T> implements DataFetcher<Connection<T>>, Triv
     private final List<T> data;
 
     public SimpleListConnection(List<T> data, String prefix) {
-        this.data = assertNotNull(data, () -> " data cannot be null");
-        assertTrue(prefix != null && !prefix.isEmpty(), () -> "prefix cannot be null or empty");
+        this.data = assertNotNull(data, " data cannot be null");
+        assertTrue(prefix != null && !prefix.isEmpty(), "prefix cannot be null or empty");
         this.prefix = prefix;
     }
 
@@ -34,7 +35,10 @@ public class SimpleListConnection<T> implements DataFetcher<Connection<T>>, Triv
     }
 
     private List<Edge<T>> buildEdges() {
-        List<Edge<T>> edges = new ArrayList<>();
+        if (data.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<Edge<T>> edges = new ArrayList<>(data.size());
         int ix = 0;
         for (T object : data) {
             edges.add(new DefaultEdge<>(object, new DefaultConnectionCursor(createCursor(ix++))));
@@ -47,7 +51,7 @@ public class SimpleListConnection<T> implements DataFetcher<Connection<T>>, Triv
 
         List<Edge<T>> edges = buildEdges();
 
-        if (edges.size() == 0) {
+        if (edges.isEmpty()) {
             return emptyConnection();
         }
 
@@ -64,7 +68,7 @@ public class SimpleListConnection<T> implements DataFetcher<Connection<T>>, Triv
         }
 
         edges = edges.subList(begin, end);
-        if (edges.size() == 0) {
+        if (edges.isEmpty()) {
             return emptyConnection();
         }
 

--- a/src/main/java/graphql/schema/AsyncDataFetcher.java
+++ b/src/main/java/graphql/schema/AsyncDataFetcher.java
@@ -67,8 +67,8 @@ public class AsyncDataFetcher<T> implements DataFetcher<CompletableFuture<T>> {
     }
 
     public AsyncDataFetcher(DataFetcher<T> wrappedDataFetcher, Executor executor) {
-        this.wrappedDataFetcher = assertNotNull(wrappedDataFetcher, () -> "wrappedDataFetcher can't be null");
-        this.executor = assertNotNull(executor, () -> "executor can't be null");
+        this.wrappedDataFetcher = assertNotNull(wrappedDataFetcher, "wrappedDataFetcher can't be null");
+        this.executor = assertNotNull(executor, "executor can't be null");
     }
 
     @Override

--- a/src/main/java/graphql/schema/DefaultGraphqlTypeComparatorRegistry.java
+++ b/src/main/java/graphql/schema/DefaultGraphqlTypeComparatorRegistry.java
@@ -129,9 +129,9 @@ public class DefaultGraphqlTypeComparatorRegistry implements GraphqlTypeComparat
          * @return The {@code Builder} instance to allow chaining.
          */
         public <T extends GraphQLType> Builder addComparator(GraphqlTypeComparatorEnvironment environment, Class<T> comparatorClass, Comparator<? super T> comparator) {
-            assertNotNull(environment, () -> "environment can't be null");
-            assertNotNull(comparatorClass, () -> "comparatorClass can't be null");
-            assertNotNull(comparator, () -> "comparator can't be null");
+            assertNotNull(environment, "environment can't be null");
+            assertNotNull(comparatorClass, "comparatorClass can't be null");
+            assertNotNull(comparator, "comparator can't be null");
             registry.put(environment, comparator);
             return this;
         }
@@ -150,7 +150,7 @@ public class DefaultGraphqlTypeComparatorRegistry implements GraphqlTypeComparat
          */
         public <T extends GraphQLType> Builder addComparator(UnaryOperator<GraphqlTypeComparatorEnvironment.Builder> builderFunction,
                                                              Class<T> comparatorClass, Comparator<? super T> comparator) {
-            assertNotNull(builderFunction, () -> "builderFunction can't be null");
+            assertNotNull(builderFunction, "builderFunction can't be null");
 
             GraphqlTypeComparatorEnvironment environment = builderFunction.apply(newEnvironment()).build();
             return addComparator(environment, comparatorClass, comparator);

--- a/src/main/java/graphql/schema/GraphQLAppliedDirective.java
+++ b/src/main/java/graphql/schema/GraphQLAppliedDirective.java
@@ -41,7 +41,7 @@ public class GraphQLAppliedDirective implements GraphQLNamedSchemaElement {
 
     private GraphQLAppliedDirective(String name, Directive definition, List<GraphQLAppliedDirectiveArgument> arguments) {
         assertValidName(name);
-        assertNotNull(arguments, () -> "arguments can't be null");
+        assertNotNull(arguments, "arguments can't be null");
         this.name = name;
         this.arguments = ImmutableList.copyOf(arguments);
         this.definition = definition;
@@ -167,13 +167,13 @@ public class GraphQLAppliedDirective implements GraphQLNamedSchemaElement {
         }
 
         public Builder argument(GraphQLAppliedDirectiveArgument argument) {
-            assertNotNull(argument, () -> "argument must not be null");
+            assertNotNull(argument, "argument must not be null");
             arguments.put(argument.getName(), argument);
             return this;
         }
 
         public Builder replaceArguments(List<GraphQLAppliedDirectiveArgument> arguments) {
-            assertNotNull(arguments, () -> "arguments must not be null");
+            assertNotNull(arguments, "arguments must not be null");
             this.arguments.clear();
             for (GraphQLAppliedDirectiveArgument argument : arguments) {
                 this.arguments.put(argument.getName(), argument);

--- a/src/main/java/graphql/schema/GraphQLArgument.java
+++ b/src/main/java/graphql/schema/GraphQLArgument.java
@@ -74,7 +74,7 @@ public class GraphQLArgument implements GraphQLNamedSchemaElement, GraphQLInputV
                             List<GraphQLAppliedDirective> appliedDirectives,
                             String deprecationReason) {
         assertValidName(name);
-        assertNotNull(type, () -> "type can't be null");
+        assertNotNull(type, "type can't be null");
         this.name = name;
         this.description = description;
         this.originalType = type;
@@ -500,7 +500,7 @@ public class GraphQLArgument implements GraphQLNamedSchemaElement, GraphQLInputV
         }
 
         public GraphQLArgument build() {
-            assertNotNull(type, () -> "type can't be null");
+            assertNotNull(type, "type can't be null");
 
             return new GraphQLArgument(
                     name,

--- a/src/main/java/graphql/schema/GraphQLDirective.java
+++ b/src/main/java/graphql/schema/GraphQLDirective.java
@@ -52,8 +52,8 @@ public class GraphQLDirective implements GraphQLNamedSchemaElement {
                              List<GraphQLArgument> arguments,
                              DirectiveDefinition definition) {
         assertValidName(name);
-        assertNotNull(arguments, () -> "arguments can't be null");
-        assertNotEmpty(locations, () -> "locations can't be empty");
+        assertNotNull(arguments, "arguments can't be null");
+        assertNotEmpty(locations, "locations can't be empty");
         this.name = name;
         this.description = description;
         this.repeatable = repeatable;
@@ -231,13 +231,13 @@ public class GraphQLDirective implements GraphQLNamedSchemaElement {
         }
 
         public Builder argument(GraphQLArgument argument) {
-            assertNotNull(argument, () -> "argument must not be null");
+            assertNotNull(argument, "argument must not be null");
             arguments.put(argument.getName(), argument);
             return this;
         }
 
         public Builder replaceArguments(List<GraphQLArgument> arguments) {
-            assertNotNull(arguments, () -> "arguments must not be null");
+            assertNotNull(arguments, "arguments must not be null");
             this.arguments.clear();
             for (GraphQLArgument argument : arguments) {
                 this.arguments.put(argument.getName(), argument);

--- a/src/main/java/graphql/schema/GraphQLEnumType.java
+++ b/src/main/java/graphql/schema/GraphQLEnumType.java
@@ -60,7 +60,7 @@ public class GraphQLEnumType implements GraphQLNamedInputType, GraphQLNamedOutpu
                             EnumTypeDefinition definition,
                             List<EnumTypeExtensionDefinition> extensionDefinitions) {
         assertValidName(name);
-        assertNotNull(directives, () -> "directives cannot be null");
+        assertNotNull(directives, "directives cannot be null");
 
         this.name = name;
         this.description = description;
@@ -365,7 +365,7 @@ public class GraphQLEnumType implements GraphQLNamedInputType, GraphQLNamedOutpu
         }
 
         public Builder value(String name, Object value) {
-            assertNotNull(value, () -> "value can't be null");
+            assertNotNull(value, "value can't be null");
             return value(newEnumValueDefinition().name(name)
                     .value(value).build());
         }
@@ -388,7 +388,7 @@ public class GraphQLEnumType implements GraphQLNamedInputType, GraphQLNamedOutpu
         }
 
         public Builder value(GraphQLEnumValueDefinition enumValueDefinition) {
-            assertNotNull(enumValueDefinition, () -> "enumValueDefinition can't be null");
+            assertNotNull(enumValueDefinition, "enumValueDefinition can't be null");
             values.put(enumValueDefinition.getName(), enumValueDefinition);
             return this;
         }

--- a/src/main/java/graphql/schema/GraphQLEnumValueDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLEnumValueDefinition.java
@@ -43,7 +43,7 @@ public class GraphQLEnumValueDefinition implements GraphQLNamedSchemaElement, Gr
                                        List<GraphQLAppliedDirective> appliedDirectives,
                                        EnumValueDefinition definition) {
         assertValidName(name);
-        assertNotNull(directives, () -> "directives cannot be null");
+        assertNotNull(directives, "directives cannot be null");
 
         this.name = name;
         this.description = description;

--- a/src/main/java/graphql/schema/GraphQLFieldDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLFieldDefinition.java
@@ -61,8 +61,8 @@ public class GraphQLFieldDefinition implements GraphQLNamedSchemaElement, GraphQ
                                    List<GraphQLAppliedDirective> appliedDirectives,
                                    FieldDefinition definition) {
         assertValidName(name);
-        assertNotNull(type, () -> "type can't be null");
-        assertNotNull(arguments, () -> "arguments can't be null");
+        assertNotNull(type, "type can't be null");
+        assertNotNull(arguments, "arguments can't be null");
         this.name = Interning.intern(name);
         this.description = description;
         this.originalType = type;
@@ -313,7 +313,7 @@ public class GraphQLFieldDefinition implements GraphQLNamedSchemaElement, GraphQ
          */
         @Deprecated(since = "2018-12-03")
         public Builder dataFetcher(DataFetcher<?> dataFetcher) {
-            assertNotNull(dataFetcher, () -> "dataFetcher must be not null");
+            assertNotNull(dataFetcher, "dataFetcher must be not null");
             this.dataFetcherFactory = DataFetcherFactories.useDataFetcher(dataFetcher);
             return this;
         }
@@ -329,7 +329,7 @@ public class GraphQLFieldDefinition implements GraphQLNamedSchemaElement, GraphQ
          */
         @Deprecated(since = "2018-12-03")
         public Builder dataFetcherFactory(DataFetcherFactory<?> dataFetcherFactory) {
-            assertNotNull(dataFetcherFactory, () -> "dataFetcherFactory must be not null");
+            assertNotNull(dataFetcherFactory, "dataFetcherFactory must be not null");
             this.dataFetcherFactory = dataFetcherFactory;
             return this;
         }
@@ -350,7 +350,7 @@ public class GraphQLFieldDefinition implements GraphQLNamedSchemaElement, GraphQ
         }
 
         public Builder argument(GraphQLArgument argument) {
-            assertNotNull(argument, () -> "argument can't be null");
+            assertNotNull(argument, "argument can't be null");
             this.arguments.put(argument.getName(), argument);
             return this;
         }
@@ -409,7 +409,7 @@ public class GraphQLFieldDefinition implements GraphQLNamedSchemaElement, GraphQ
          * @return this
          */
         public Builder arguments(List<GraphQLArgument> arguments) {
-            assertNotNull(arguments, () -> "arguments can't be null");
+            assertNotNull(arguments, "arguments can't be null");
             for (GraphQLArgument argument : arguments) {
                 argument(argument);
             }
@@ -417,7 +417,7 @@ public class GraphQLFieldDefinition implements GraphQLNamedSchemaElement, GraphQ
         }
 
         public Builder replaceArguments(List<GraphQLArgument> arguments) {
-            assertNotNull(arguments, () -> "arguments can't be null");
+            assertNotNull(arguments, "arguments can't be null");
             this.arguments.clear();
             for (GraphQLArgument argument : arguments) {
                 argument(argument);

--- a/src/main/java/graphql/schema/GraphQLInputObjectField.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectField.java
@@ -56,8 +56,8 @@ public class GraphQLInputObjectField implements GraphQLNamedSchemaElement, Graph
             InputValueDefinition definition,
             String deprecationReason) {
         assertValidName(name);
-        assertNotNull(type, () -> "type can't be null");
-        assertNotNull(directives, () -> "directives cannot be null");
+        assertNotNull(type, "type can't be null");
+        assertNotNull(directives, "directives cannot be null");
 
         this.name = name;
         this.originalType = type;
@@ -375,7 +375,7 @@ public class GraphQLInputObjectField implements GraphQLNamedSchemaElement, Graph
         }
 
         public GraphQLInputObjectField build() {
-            assertNotNull(type, () -> "type can't be null");
+            assertNotNull(type, "type can't be null");
             return new GraphQLInputObjectField(
                     name,
                     description,

--- a/src/main/java/graphql/schema/GraphQLInputObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectType.java
@@ -56,8 +56,8 @@ public class GraphQLInputObjectType implements GraphQLNamedInputType, GraphQLUnm
                                    InputObjectTypeDefinition definition,
                                    List<InputObjectTypeExtensionDefinition> extensionDefinitions) {
         assertValidName(name);
-        assertNotNull(fields, () -> "fields can't be null");
-        assertNotNull(directives, () -> "directives cannot be null");
+        assertNotNull(fields, "fields can't be null");
+        assertNotNull(directives, "directives cannot be null");
 
         this.name = name;
         this.description = description;
@@ -283,7 +283,7 @@ public class GraphQLInputObjectType implements GraphQLNamedInputType, GraphQLUnm
         }
 
         public Builder field(GraphQLInputObjectField field) {
-            assertNotNull(field, () -> "field can't be null");
+            assertNotNull(field, "field can't be null");
             fields.put(field.getName(), field);
             return this;
         }
@@ -302,7 +302,7 @@ public class GraphQLInputObjectType implements GraphQLNamedInputType, GraphQLUnm
          * @return this
          */
         public Builder field(UnaryOperator<GraphQLInputObjectField.Builder> builderFunction) {
-            assertNotNull(builderFunction, () -> "builderFunction should not be null");
+            assertNotNull(builderFunction, "builderFunction should not be null");
             GraphQLInputObjectField.Builder builder = GraphQLInputObjectField.newInputObjectField();
             builder = builderFunction.apply(builder);
             return field(builder);

--- a/src/main/java/graphql/schema/GraphQLInterfaceType.java
+++ b/src/main/java/graphql/schema/GraphQLInterfaceType.java
@@ -67,8 +67,8 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLCompositeT
                                  List<GraphQLNamedOutputType> interfaces,
                                  Comparator<? super GraphQLSchemaElement> interfaceComparator) {
         assertValidName(name);
-        assertNotNull(fieldDefinitions, () -> "fieldDefinitions can't null");
-        assertNotNull(directives, () -> "directives cannot be null");
+        assertNotNull(fieldDefinitions, "fieldDefinitions can't null");
+        assertNotNull(directives, "directives cannot be null");
 
         this.name = name;
         this.description = description;
@@ -292,7 +292,7 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLCompositeT
         }
 
         public Builder field(GraphQLFieldDefinition fieldDefinition) {
-            assertNotNull(fieldDefinition, () -> "fieldDefinition can't be null");
+            assertNotNull(fieldDefinition, "fieldDefinition can't be null");
             this.fields.put(fieldDefinition.getName(), fieldDefinition);
             return this;
         }
@@ -311,7 +311,7 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLCompositeT
          * @return this
          */
         public Builder field(UnaryOperator<GraphQLFieldDefinition.Builder> builderFunction) {
-            assertNotNull(builderFunction, () -> "builderFunction can't be null");
+            assertNotNull(builderFunction, "builderFunction can't be null");
             GraphQLFieldDefinition.Builder builder = GraphQLFieldDefinition.newFieldDefinition();
             builder = builderFunction.apply(builder);
             return field(builder);
@@ -330,13 +330,13 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLCompositeT
         }
 
         public Builder fields(List<GraphQLFieldDefinition> fieldDefinitions) {
-            assertNotNull(fieldDefinitions, () -> "fieldDefinitions can't be null");
+            assertNotNull(fieldDefinitions, "fieldDefinitions can't be null");
             fieldDefinitions.forEach(this::field);
             return this;
         }
 
         public Builder replaceFields(List<GraphQLFieldDefinition> fieldDefinitions) {
-            assertNotNull(fieldDefinitions, () -> "fieldDefinitions can't be null");
+            assertNotNull(fieldDefinitions, "fieldDefinitions can't be null");
             this.fields.clear();
             fieldDefinitions.forEach(this::field);
             return this;
@@ -374,7 +374,7 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLCompositeT
         }
 
         public Builder replaceInterfacesOrReferences(List<? extends GraphQLNamedOutputType> interfacesOrReferences) {
-            assertNotNull(interfacesOrReferences, () -> "interfaces can't be null");
+            assertNotNull(interfacesOrReferences, "interfaces can't be null");
             this.interfaces.clear();
             for (GraphQLNamedOutputType schemaElement : interfacesOrReferences) {
                 if (schemaElement instanceof GraphQLInterfaceType || schemaElement instanceof GraphQLTypeReference) {
@@ -387,13 +387,13 @@ public class GraphQLInterfaceType implements GraphQLNamedType, GraphQLCompositeT
         }
 
         public Builder withInterface(GraphQLInterfaceType interfaceType) {
-            assertNotNull(interfaceType, () -> "interfaceType can't be null");
+            assertNotNull(interfaceType, "interfaceType can't be null");
             this.interfaces.put(interfaceType.getName(), interfaceType);
             return this;
         }
 
         public Builder withInterface(GraphQLTypeReference reference) {
-            assertNotNull(reference, () -> "reference can't be null");
+            assertNotNull(reference, "reference can't be null");
             this.interfaces.put(reference.getName(), reference);
             return this;
         }

--- a/src/main/java/graphql/schema/GraphQLList.java
+++ b/src/main/java/graphql/schema/GraphQLList.java
@@ -41,7 +41,7 @@ public class GraphQLList implements GraphQLType, GraphQLInputType, GraphQLOutput
 
 
     public GraphQLList(GraphQLType wrappedType) {
-        assertNotNull(wrappedType, () -> "wrappedType can't be null");
+        assertNotNull(wrappedType, "wrappedType can't be null");
         this.originalWrappedType = wrappedType;
     }
 

--- a/src/main/java/graphql/schema/GraphQLNonNull.java
+++ b/src/main/java/graphql/schema/GraphQLNonNull.java
@@ -40,7 +40,7 @@ public class GraphQLNonNull implements GraphQLType, GraphQLInputType, GraphQLOut
 
 
     public GraphQLNonNull(GraphQLType wrappedType) {
-        assertNotNull(wrappedType, () -> "wrappedType can't be null");
+        assertNotNull(wrappedType, "wrappedType can't be null");
         assertNonNullWrapping(wrappedType);
         this.originalWrappedType = wrappedType;
     }

--- a/src/main/java/graphql/schema/GraphQLObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLObjectType.java
@@ -65,8 +65,8 @@ public class GraphQLObjectType implements GraphQLNamedOutputType, GraphQLComposi
                               List<ObjectTypeExtensionDefinition> extensionDefinitions,
                               Comparator<? super GraphQLSchemaElement> interfaceComparator) {
         assertValidName(name);
-        assertNotNull(fieldDefinitions, () -> "fieldDefinitions can't be null");
-        assertNotNull(interfaces, () -> "interfaces can't be null");
+        assertNotNull(fieldDefinitions, "fieldDefinitions can't be null");
+        assertNotNull(interfaces, "interfaces can't be null");
         this.name = name;
         this.description = description;
         this.interfaceComparator = interfaceComparator;
@@ -279,7 +279,7 @@ public class GraphQLObjectType implements GraphQLNamedOutputType, GraphQLComposi
         }
 
         public Builder field(GraphQLFieldDefinition fieldDefinition) {
-            assertNotNull(fieldDefinition, () -> "fieldDefinition can't be null");
+            assertNotNull(fieldDefinition, "fieldDefinition can't be null");
             this.fields.put(fieldDefinition.getName(), fieldDefinition);
             return this;
         }
@@ -298,7 +298,7 @@ public class GraphQLObjectType implements GraphQLNamedOutputType, GraphQLComposi
          * @return this
          */
         public Builder field(UnaryOperator<GraphQLFieldDefinition.Builder> builderFunction) {
-            assertNotNull(builderFunction, () -> "builderFunction can't be null");
+            assertNotNull(builderFunction, "builderFunction can't be null");
             GraphQLFieldDefinition.Builder builder = GraphQLFieldDefinition.newFieldDefinition();
             builder = builderFunction.apply(builder);
             return field(builder.build());
@@ -317,13 +317,13 @@ public class GraphQLObjectType implements GraphQLNamedOutputType, GraphQLComposi
         }
 
         public Builder fields(List<GraphQLFieldDefinition> fieldDefinitions) {
-            assertNotNull(fieldDefinitions, () -> "fieldDefinitions can't be null");
+            assertNotNull(fieldDefinitions, "fieldDefinitions can't be null");
             fieldDefinitions.forEach(this::field);
             return this;
         }
 
         public Builder replaceFields(List<GraphQLFieldDefinition> fieldDefinitions) {
-            assertNotNull(fieldDefinitions, () -> "fieldDefinitions can't be null");
+            assertNotNull(fieldDefinitions, "fieldDefinitions can't be null");
             this.fields.clear();
             fieldDefinitions.forEach(this::field);
             return this;
@@ -345,13 +345,13 @@ public class GraphQLObjectType implements GraphQLNamedOutputType, GraphQLComposi
 
 
         public Builder withInterface(GraphQLInterfaceType interfaceType) {
-            assertNotNull(interfaceType, () -> "interfaceType can't be null");
+            assertNotNull(interfaceType, "interfaceType can't be null");
             this.interfaces.put(interfaceType.getName(), interfaceType);
             return this;
         }
 
         public Builder replaceInterfaces(List<? extends GraphQLNamedOutputType> interfaces) {
-            assertNotNull(interfaces, () -> "interfaces can't be null");
+            assertNotNull(interfaces, "interfaces can't be null");
             this.interfaces.clear();
             for (GraphQLNamedOutputType schemaElement : interfaces) {
                 if (schemaElement instanceof GraphQLInterfaceType || schemaElement instanceof GraphQLTypeReference) {
@@ -364,7 +364,7 @@ public class GraphQLObjectType implements GraphQLNamedOutputType, GraphQLComposi
         }
 
         public Builder withInterface(GraphQLTypeReference reference) {
-            assertNotNull(reference, () -> "reference can't be null");
+            assertNotNull(reference, "reference can't be null");
             this.interfaces.put(reference.getName(), reference);
             return this;
         }

--- a/src/main/java/graphql/schema/GraphQLScalarType.java
+++ b/src/main/java/graphql/schema/GraphQLScalarType.java
@@ -58,8 +58,8 @@ GraphQLScalarType implements GraphQLNamedInputType, GraphQLNamedOutputType, Grap
                               List<ScalarTypeExtensionDefinition> extensionDefinitions,
                               String specifiedByUrl) {
         assertValidName(name);
-        assertNotNull(coercing, () -> "coercing can't be null");
-        assertNotNull(directives, () -> "directives can't be null");
+        assertNotNull(coercing, "coercing can't be null");
+        assertNotNull(directives, "directives can't be null");
 
         this.name = name;
         this.description = description;

--- a/src/main/java/graphql/schema/GraphQLSchema.java
+++ b/src/main/java/graphql/schema/GraphQLSchema.java
@@ -78,10 +78,10 @@ public class GraphQLSchema {
      */
     @Internal
     private GraphQLSchema(Builder builder) {
-        assertNotNull(builder.additionalTypes, () -> "additionalTypes can't be null");
-        assertNotNull(builder.queryType, () -> "queryType can't be null");
-        assertNotNull(builder.additionalDirectives, () -> "directives can't be null");
-        assertNotNull(builder.codeRegistry, () -> "codeRegistry can't be null");
+        assertNotNull(builder.additionalTypes, "additionalTypes can't be null");
+        assertNotNull(builder.queryType, "queryType can't be null");
+        assertNotNull(builder.additionalDirectives, "directives can't be null");
+        assertNotNull(builder.codeRegistry, "codeRegistry can't be null");
 
         this.queryType = builder.queryType;
         this.mutationType = builder.mutationType;
@@ -112,7 +112,7 @@ public class GraphQLSchema {
                          ImmutableMap<String, GraphQLNamedType> typeMap,
                          ImmutableMap<String, ImmutableList<GraphQLObjectType>> interfaceNameToObjectTypes
     ) {
-        assertNotNull(codeRegistry, () -> "codeRegistry can't be null");
+        assertNotNull(codeRegistry, "codeRegistry can't be null");
 
         this.queryType = existingSchema.queryType;
         this.mutationType = existingSchema.mutationType;
@@ -137,7 +137,7 @@ public class GraphQLSchema {
      */
     @Internal
     public GraphQLSchema(BuilderWithoutTypes builder) {
-        assertNotNull(builder.codeRegistry, () -> "codeRegistry can't be null");
+        assertNotNull(builder.codeRegistry, "codeRegistry can't be null");
 
         GraphQLSchema existingSchema = builder.existingSchema;
 
@@ -768,7 +768,7 @@ public class GraphQLSchema {
         }
 
         public Builder withSchemaDirective(GraphQLDirective directive) {
-            assertNotNull(directive, () -> "directive can't be null");
+            assertNotNull(directive, "directive can't be null");
             schemaDirectives.add(directive);
             return this;
         }
@@ -792,7 +792,7 @@ public class GraphQLSchema {
         }
 
         public Builder withSchemaAppliedDirective(GraphQLAppliedDirective appliedDirective) {
-            assertNotNull(appliedDirective, () -> "directive can't be null");
+            assertNotNull(appliedDirective, "directive can't be null");
             schemaAppliedDirectives.add(appliedDirective);
             return this;
         }
@@ -842,8 +842,8 @@ public class GraphQLSchema {
         }
 
         private GraphQLSchema buildImpl() {
-            assertNotNull(additionalTypes, () -> "additionalTypes can't be null");
-            assertNotNull(additionalDirectives, () -> "additionalDirectives can't be null");
+            assertNotNull(additionalTypes, "additionalTypes can't be null");
+            assertNotNull(additionalDirectives, "additionalDirectives can't be null");
 
             // schemas built via the schema generator have the deprecated directive BUT we want it present for hand built
             // schemas - it's inherently part of the spec!

--- a/src/main/java/graphql/schema/GraphQLTypeUtil.java
+++ b/src/main/java/graphql/schema/GraphQLTypeUtil.java
@@ -26,7 +26,7 @@ public class GraphQLTypeUtil {
      * @return the type in graphql SDL format, eg [typeName!]!
      */
     public static String simplePrint(GraphQLType type) {
-        Assert.assertNotNull(type, () -> "type can't be null");
+        Assert.assertNotNull(type, "type can't be null");
         if (isNonNull(type)) {
             return simplePrint(unwrapOne(type)) + "!";
         } else if (isList(type)) {

--- a/src/main/java/graphql/schema/GraphQLUnionType.java
+++ b/src/main/java/graphql/schema/GraphQLUnionType.java
@@ -60,9 +60,9 @@ public class GraphQLUnionType implements GraphQLNamedOutputType, GraphQLComposit
                              UnionTypeDefinition definition,
                              List<UnionTypeExtensionDefinition> extensionDefinitions) {
         assertValidName(name);
-        assertNotNull(types, () -> "types can't be null");
-        assertNotEmpty(types, () -> "A Union type must define one or more member types.");
-        assertNotNull(directives, () -> "directives cannot be null");
+        assertNotNull(types, "types can't be null");
+        assertNotEmpty(types, "A Union type must define one or more member types.");
+        assertNotNull(directives, "directives cannot be null");
 
         this.name = name;
         this.description = description;
@@ -294,13 +294,13 @@ public class GraphQLUnionType implements GraphQLNamedOutputType, GraphQLComposit
         }
 
         public Builder possibleType(GraphQLObjectType type) {
-            assertNotNull(type, () -> "possible type can't be null");
+            assertNotNull(type, "possible type can't be null");
             types.put(type.getName(), type);
             return this;
         }
 
         public Builder possibleType(GraphQLTypeReference reference) {
-            assertNotNull(reference, () -> "reference can't be null");
+            assertNotNull(reference, "reference can't be null");
             types.put(reference.getName(), reference);
             return this;
         }

--- a/src/main/java/graphql/schema/GraphqlDirectivesContainerTypeBuilder.java
+++ b/src/main/java/graphql/schema/GraphqlDirectivesContainerTypeBuilder.java
@@ -14,7 +14,7 @@ public abstract class GraphqlDirectivesContainerTypeBuilder<B extends GraphqlDir
     protected final List<GraphQLDirective> directives = new ArrayList<>();
 
     public B replaceAppliedDirectives(List<GraphQLAppliedDirective> directives) {
-        assertNotNull(directives, () -> "directive can't be null");
+        assertNotNull(directives, "directive can't be null");
         this.appliedDirectives.clear();
         this.appliedDirectives.addAll(directives);
         return (B) this;
@@ -26,7 +26,7 @@ public abstract class GraphqlDirectivesContainerTypeBuilder<B extends GraphqlDir
      * @return this builder
      */
     public B withAppliedDirectives(GraphQLAppliedDirective... directives) {
-        assertNotNull(directives, () -> "directives can't be null");
+        assertNotNull(directives, "directives can't be null");
         for (GraphQLAppliedDirective directive : directives) {
             withAppliedDirective(directive);
         }
@@ -39,7 +39,7 @@ public abstract class GraphqlDirectivesContainerTypeBuilder<B extends GraphqlDir
      * @return this builder
      */
     public B withAppliedDirective(GraphQLAppliedDirective directive) {
-        assertNotNull(directive, () -> "directive can't be null");
+        assertNotNull(directive, "directive can't be null");
         this.appliedDirectives.add(directive);
         return (B) this;
     }
@@ -62,7 +62,7 @@ public abstract class GraphqlDirectivesContainerTypeBuilder<B extends GraphqlDir
      */
     @Deprecated(since = "2022-02-24")
     public B replaceDirectives(List<GraphQLDirective> directives) {
-        assertNotNull(directives, () -> "directive can't be null");
+        assertNotNull(directives, "directive can't be null");
         this.directives.clear();
         this.directives.addAll(directives);
         return (B) this;
@@ -77,7 +77,7 @@ public abstract class GraphqlDirectivesContainerTypeBuilder<B extends GraphqlDir
      */
     @Deprecated(since = "2022-02-24")
     public B withDirectives(GraphQLDirective... directives) {
-        assertNotNull(directives, () -> "directives can't be null");
+        assertNotNull(directives, "directives can't be null");
         for (GraphQLDirective directive : directives) {
             withDirective(directive);
         }
@@ -93,7 +93,7 @@ public abstract class GraphqlDirectivesContainerTypeBuilder<B extends GraphqlDir
      */
     @Deprecated(since = "2022-02-24")
     public B withDirective(GraphQLDirective directive) {
-        assertNotNull(directive, () -> "directive can't be null");
+        assertNotNull(directive, "directive can't be null");
         this.directives.add(directive);
         return (B) this;
     }

--- a/src/main/java/graphql/schema/GraphqlElementParentTree.java
+++ b/src/main/java/graphql/schema/GraphqlElementParentTree.java
@@ -25,8 +25,8 @@ public class GraphqlElementParentTree {
 
     @Internal
     public GraphqlElementParentTree(Deque<GraphQLSchemaElement> nodeStack) {
-        assertNotNull(nodeStack, () -> "You MUST have a non null stack of elements");
-        assertTrue(!nodeStack.isEmpty(), () -> "You MUST have a non empty stack of element");
+        assertNotNull(nodeStack, "You MUST have a non null stack of elements");
+        assertTrue(!nodeStack.isEmpty(), "You MUST have a non empty stack of element");
 
         Deque<GraphQLSchemaElement> copy = new ArrayDeque<>(nodeStack);
         element = copy.pop();
@@ -69,8 +69,6 @@ public class GraphqlElementParentTree {
 
     @Override
     public String toString() {
-        return String.valueOf(element) +
-                " - parent : " +
-                parent;
+        return element + " - parent : " + parent;
     }
 }

--- a/src/main/java/graphql/schema/InputValueWithState.java
+++ b/src/main/java/graphql/schema/InputValueWithState.java
@@ -45,7 +45,7 @@ public class InputValueWithState {
     public static final InputValueWithState NOT_SET = new InputValueWithState(State.NOT_SET, null);
 
     public static InputValueWithState newLiteralValue(@NonNull Value value) {
-        assertNotNull(value, () -> "value literal can't be null");
+        assertNotNull(value, "value literal can't be null");
         return new InputValueWithState(State.LITERAL, value);
     }
 

--- a/src/main/java/graphql/schema/SchemaTransformer.java
+++ b/src/main/java/graphql/schema/SchemaTransformer.java
@@ -433,12 +433,12 @@ public class SchemaTransformer {
             GraphQLSchemaElement parent,
             Map<NodeZipper<GraphQLSchemaElement>, Breadcrumb<GraphQLSchemaElement>> sameParentsZipper) {
         Set<NodeZipper<GraphQLSchemaElement>> sameParent = sameParentsZipper.keySet();
-        assertNotEmpty(sameParent, () -> "expected at least one zipper");
+        assertNotEmpty(sameParent, "expected at least one zipper");
 
         Map<String, List<GraphQLSchemaElement>> childrenMap = new HashMap<>(SCHEMA_ELEMENT_ADAPTER.getNamedChildren(parent));
         Map<String, Integer> indexCorrection = new HashMap<>();
 
-        List<ZipperWithOneParent> zipperWithOneParents = new ArrayList<>();
+        List<ZipperWithOneParent> zipperWithOneParents = new ArrayList<>(sameParent.size());
         for (NodeZipper<GraphQLSchemaElement> zipper : sameParent) {
             Breadcrumb<GraphQLSchemaElement> breadcrumb = sameParentsZipper.get(zipper);
             zipperWithOneParents.add(new ZipperWithOneParent(zipper, breadcrumb));

--- a/src/main/java/graphql/schema/diff/DiffSet.java
+++ b/src/main/java/graphql/schema/diff/DiffSet.java
@@ -69,7 +69,7 @@ public class DiffSet {
     private static Map<String, Object> introspect(GraphQLSchema schema) {
         GraphQL gql = GraphQL.newGraphQL(schema).build();
         ExecutionResult result = gql.execute(IntrospectionQuery.INTROSPECTION_QUERY);
-        Assert.assertTrue(result.getErrors().size() == 0, () -> "The schema has errors during Introspection");
+        Assert.assertTrue(result.getErrors().isEmpty(), "The schema has errors during Introspection");
         return result.getData();
     }
 }

--- a/src/main/java/graphql/schema/diff/SchemaDiffSet.java
+++ b/src/main/java/graphql/schema/diff/SchemaDiffSet.java
@@ -128,7 +128,7 @@ public class SchemaDiffSet {
     private static Map<String, Object> introspect(GraphQLSchema schema) {
         GraphQL gql = GraphQL.newGraphQL(schema).build();
         ExecutionResult result = gql.execute(IntrospectionQuery.INTROSPECTION_QUERY);
-        Assert.assertTrue(result.getErrors().size() == 0, () -> "The schema has errors during Introspection");
+        Assert.assertTrue(result.getErrors().isEmpty(), "The schema has errors during Introspection");
         return result.getData();
     }
 }

--- a/src/main/java/graphql/schema/idl/CombinedWiringFactory.java
+++ b/src/main/java/graphql/schema/idl/CombinedWiringFactory.java
@@ -21,7 +21,7 @@ public class CombinedWiringFactory implements WiringFactory {
     private final List<WiringFactory> factories;
 
     public CombinedWiringFactory(List<WiringFactory> factories) {
-        assertNotNull(factories, () -> "You must provide a list of wiring factories");
+        assertNotNull(factories, "You must provide a list of wiring factories");
         this.factories = new ArrayList<>(factories);
     }
 

--- a/src/main/java/graphql/schema/idl/MapEnumValuesProvider.java
+++ b/src/main/java/graphql/schema/idl/MapEnumValuesProvider.java
@@ -12,7 +12,7 @@ public class MapEnumValuesProvider implements EnumValuesProvider {
     private final Map<String, Object> values;
 
     public MapEnumValuesProvider(Map<String, Object> values) {
-        Assert.assertNotNull(values, () -> "values can't be null");
+        Assert.assertNotNull(values, "values can't be null");
         this.values = values;
     }
 

--- a/src/main/java/graphql/schema/idl/NaturalEnumValuesProvider.java
+++ b/src/main/java/graphql/schema/idl/NaturalEnumValuesProvider.java
@@ -13,7 +13,7 @@ public class NaturalEnumValuesProvider<T extends Enum<T>> implements EnumValuesP
     private final Class<T> enumType;
 
     public NaturalEnumValuesProvider(Class<T> enumType) {
-        Assert.assertNotNull(enumType, () -> "enumType can't be null");
+        Assert.assertNotNull(enumType, "enumType can't be null");
         this.enumType = enumType;
     }
 

--- a/src/main/java/graphql/schema/idl/RuntimeWiring.java
+++ b/src/main/java/graphql/schema/idl/RuntimeWiring.java
@@ -226,7 +226,7 @@ public class RuntimeWiring {
          * @return this outer builder
          */
         public Builder wiringFactory(WiringFactory wiringFactory) {
-            assertNotNull(wiringFactory, () -> "You must provide a wiring factory");
+            assertNotNull(wiringFactory, "You must provide a wiring factory");
             this.wiringFactory = wiringFactory;
             return this;
         }

--- a/src/main/java/graphql/schema/idl/SchemaDirectiveWiringEnvironmentImpl.java
+++ b/src/main/java/graphql/schema/idl/SchemaDirectiveWiringEnvironmentImpl.java
@@ -128,15 +128,15 @@ public class SchemaDirectiveWiringEnvironmentImpl<T extends GraphQLDirectiveCont
 
     @Override
     public DataFetcher<?> getFieldDataFetcher() {
-        assertNotNull(fieldDefinition, () -> "An output field must be in context to call this method");
-        assertNotNull(fieldsContainer, () -> "An output field container must be in context to call this method");
+        assertNotNull(fieldDefinition, "An output field must be in context to call this method");
+        assertNotNull(fieldsContainer, "An output field container must be in context to call this method");
         return codeRegistry.getDataFetcher(FieldCoordinates.coordinates(fieldsContainer, fieldDefinition), fieldDefinition);
     }
 
     @Override
     public GraphQLFieldDefinition setFieldDataFetcher(DataFetcher<?> newDataFetcher) {
-        assertNotNull(fieldDefinition, () -> "An output field must be in context to call this method");
-        assertNotNull(fieldsContainer, () -> "An output field container must be in context to call this method");
+        assertNotNull(fieldDefinition, "An output field must be in context to call this method");
+        assertNotNull(fieldsContainer, "An output field container must be in context to call this method");
 
         FieldCoordinates coordinates = FieldCoordinates.coordinates(fieldsContainer, fieldDefinition);
         codeRegistry.dataFetcher(coordinates, newDataFetcher);

--- a/src/main/java/graphql/schema/idl/SchemaExtensionsChecker.java
+++ b/src/main/java/graphql/schema/idl/SchemaExtensionsChecker.java
@@ -30,7 +30,7 @@ public class SchemaExtensionsChecker {
     static Map<String, OperationTypeDefinition> gatherOperationDefs(TypeDefinitionRegistry typeRegistry) {
         List<GraphQLError> noErrors = new ArrayList<>();
         Map<String, OperationTypeDefinition> operationTypeDefinitionMap = gatherOperationDefs(noErrors, typeRegistry.schemaDefinition().orElse(null), typeRegistry.getSchemaExtensionDefinitions());
-        Assert.assertTrue(noErrors.isEmpty(), () -> "If you call this method it MUST have previously been error checked");
+        Assert.assertTrue(noErrors.isEmpty(), "If you call this method it MUST have previously been error checked");
         return operationTypeDefinitionMap;
     }
 
@@ -89,7 +89,7 @@ public class SchemaExtensionsChecker {
     static List<Directive> gatherSchemaDirectives(TypeDefinitionRegistry typeRegistry) {
         List<GraphQLError> noErrors = new ArrayList<>();
         List<Directive> directiveList = gatherSchemaDirectives(typeRegistry, noErrors);
-        Assert.assertTrue(noErrors.isEmpty(), () -> "If you call this method it MUST have previously been error checked");
+        Assert.assertTrue(noErrors.isEmpty(), "If you call this method it MUST have previously been error checked");
         return directiveList;
     }
 

--- a/src/main/java/graphql/schema/idl/SchemaGeneratorDirectiveHelper.java
+++ b/src/main/java/graphql/schema/idl/SchemaGeneratorDirectiveHelper.java
@@ -455,7 +455,7 @@ public class SchemaGeneratorDirectiveHelper {
         // wiring factory is last (if present)
         env = envBuilder.apply(outputObject, allDirectives, allAppliedDirectives, null, null);
         if (wiringFactory.providesSchemaDirectiveWiring(env)) {
-            schemaDirectiveWiring = assertNotNull(wiringFactory.getSchemaDirectiveWiring(env), () -> "Your WiringFactory MUST provide a non null SchemaDirectiveWiring");
+            schemaDirectiveWiring = assertNotNull(wiringFactory.getSchemaDirectiveWiring(env), "Your WiringFactory MUST provide a non null SchemaDirectiveWiring");
             outputObject = invokeWiring(outputObject, invoker, schemaDirectiveWiring, env);
         }
 

--- a/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
+++ b/src/main/java/graphql/schema/idl/SchemaGeneratorHelper.java
@@ -505,7 +505,7 @@ public class SchemaGeneratorHelper {
 
         if (wiringFactory.providesTypeResolver(environment)) {
             typeResolver = wiringFactory.getTypeResolver(environment);
-            assertNotNull(typeResolver, () -> "The WiringFactory indicated it provides a interface type resolver but then returned null");
+            assertNotNull(typeResolver, "The WiringFactory indicated it provides a interface type resolver but then returned null");
 
         } else {
             typeResolver = wiring.getTypeResolvers().get(interfaceType.getName());
@@ -527,7 +527,7 @@ public class SchemaGeneratorHelper {
 
         if (wiringFactory.providesTypeResolver(environment)) {
             typeResolver = wiringFactory.getTypeResolver(environment);
-            assertNotNull(typeResolver, () -> "The WiringFactory indicated it union provides a type resolver but then returned null");
+            assertNotNull(typeResolver, "The WiringFactory indicated it union provides a type resolver but then returned null");
 
         } else {
             typeResolver = wiring.getTypeResolvers().get(unionType.getName());
@@ -835,14 +835,14 @@ public class SchemaGeneratorHelper {
         DataFetcherFactory<?> dataFetcherFactory;
         if (wiringFactory.providesDataFetcherFactory(wiringEnvironment)) {
             dataFetcherFactory = wiringFactory.getDataFetcherFactory(wiringEnvironment);
-            assertNotNull(dataFetcherFactory, () -> "The WiringFactory indicated it provides a data fetcher factory but then returned null");
+            assertNotNull(dataFetcherFactory, "The WiringFactory indicated it provides a data fetcher factory but then returned null");
         } else {
             //
             // ok they provide a data fetcher directly
             DataFetcher<?> dataFetcher;
             if (wiringFactory.providesDataFetcher(wiringEnvironment)) {
                 dataFetcher = wiringFactory.getDataFetcher(wiringEnvironment);
-                assertNotNull(dataFetcher, () -> "The WiringFactory indicated it provides a data fetcher but then returned null");
+                assertNotNull(dataFetcher, "The WiringFactory indicated it provides a data fetcher but then returned null");
             } else {
                 dataFetcher = runtimeWiring.getDataFetchersForType(parentTypeName).get(fieldName);
                 if (dataFetcher == null) {

--- a/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java
+++ b/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java
@@ -316,7 +316,7 @@ public class TypeDefinitionRegistry implements Serializable {
      * @param definition the definition to remove
      */
     public void remove(SDLDefinition definition) {
-        assertNotNull(definition, () -> "definition to remove can't be null");
+        assertNotNull(definition, "definition to remove can't be null");
         schemaParseOrder.removeDefinition(definition);
         if (definition instanceof ObjectTypeExtensionDefinition) {
             removeFromList(objectTypeExtensions, (TypeDefinition) definition);
@@ -364,8 +364,8 @@ public class TypeDefinitionRegistry implements Serializable {
      * @param definition the definition to remove
      */
     public void remove(String key, SDLDefinition definition) {
-        assertNotNull(definition, () -> "definition to remove can't be null");
-        assertNotNull(key, () -> "key to remove can't be null");
+        assertNotNull(definition, "definition to remove can't be null");
+        assertNotNull(key, "key to remove can't be null");
         schemaParseOrder.removeDefinition(definition);
         if (definition instanceof ObjectTypeExtensionDefinition) {
             removeFromMap(objectTypeExtensions, key);

--- a/src/main/java/graphql/schema/idl/TypeInfo.java
+++ b/src/main/java/graphql/schema/idl/TypeInfo.java
@@ -31,7 +31,7 @@ public class TypeInfo {
     private final Deque<Class<?>> decoration = new ArrayDeque<>();
 
     private TypeInfo(Type type) {
-        this.rawType = assertNotNull(type, () -> "type must not be null");
+        this.rawType = assertNotNull(type, "type must not be null");
         while (!(type instanceof TypeName)) {
             if (type instanceof NonNullType) {
                 decoration.push(NonNullType.class);

--- a/src/main/java/graphql/schema/idl/TypeRuntimeWiring.java
+++ b/src/main/java/graphql/schema/idl/TypeRuntimeWiring.java
@@ -64,7 +64,7 @@ public class TypeRuntimeWiring {
      * @return the builder
      */
     public static Builder newTypeWiring(String typeName) {
-        assertNotNull(typeName, () -> "You must provide a type name");
+        assertNotNull(typeName, "You must provide a type name");
         return new Builder().typeName(typeName);
     }
 
@@ -154,8 +154,8 @@ public class TypeRuntimeWiring {
          * @return the current type wiring
          */
         public Builder dataFetcher(String fieldName, DataFetcher dataFetcher) {
-            assertNotNull(dataFetcher, () -> "you must provide a data fetcher");
-            assertNotNull(fieldName, () -> "you must tell us what field");
+            assertNotNull(dataFetcher, "you must provide a data fetcher");
+            assertNotNull(fieldName, "you must tell us what field");
             if (strictMode) {
                 assertFieldStrictly(fieldName);
             }
@@ -171,7 +171,7 @@ public class TypeRuntimeWiring {
          * @return the current type wiring
          */
         public Builder dataFetchers(Map<String, DataFetcher> dataFetchersMap) {
-            assertNotNull(dataFetchersMap, () -> "you must provide a data fetchers map");
+            assertNotNull(dataFetchersMap, "you must provide a data fetchers map");
             if (strictMode) {
                 dataFetchersMap.forEach((fieldName, df) -> {
                     assertFieldStrictly(fieldName);
@@ -213,13 +213,13 @@ public class TypeRuntimeWiring {
          * @return the current type wiring
          */
         public Builder typeResolver(TypeResolver typeResolver) {
-            assertNotNull(typeResolver, () -> "you must provide a type resolver");
+            assertNotNull(typeResolver, "you must provide a type resolver");
             this.typeResolver = typeResolver;
             return this;
         }
 
         public Builder enumValues(EnumValuesProvider enumValuesProvider) {
-            assertNotNull(enumValuesProvider, () -> "you must provide an enum values provider");
+            assertNotNull(enumValuesProvider, "you must provide an enum values provider");
             this.enumValuesProvider = enumValuesProvider;
             return this;
         }
@@ -228,7 +228,7 @@ public class TypeRuntimeWiring {
          * @return the built type wiring
          */
         public TypeRuntimeWiring build() {
-            assertNotNull(typeName, () -> "you must provide a type name");
+            assertNotNull(typeName, "you must provide a type name");
             return new TypeRuntimeWiring(typeName, defaultDataFetcher, fieldDataFetchers, typeResolver, enumValuesProvider);
         }
     }

--- a/src/main/java/graphql/schema/validation/SchemaValidationError.java
+++ b/src/main/java/graphql/schema/validation/SchemaValidationError.java
@@ -13,8 +13,8 @@ public class SchemaValidationError {
     private final String description;
 
     public SchemaValidationError(SchemaValidationErrorType errorClassification, String description) {
-        assertNotNull(errorClassification, () -> "error classification can not be null");
-        assertNotNull(description, () -> "error description can not be null");
+        assertNotNull(errorClassification, "error classification can not be null");
+        assertNotNull(description, "error description can not be null");
         this.errorClassification = errorClassification;
         this.description = description;
     }

--- a/src/main/java/graphql/util/Anonymizer.java
+++ b/src/main/java/graphql/util/Anonymizer.java
@@ -146,7 +146,7 @@ public class Anonymizer {
     }
 
     public static AnonymizeResult anonymizeSchemaAndQueries(GraphQLSchema schema, List<String> queries, Map<String, Object> variables) {
-        assertNotNull(queries, () -> "queries can't be null");
+        assertNotNull(queries, "queries can't be null");
 
         AtomicInteger defaultStringValueCounter = new AtomicInteger(1);
         AtomicInteger defaultIntValueCounter = new AtomicInteger(1);

--- a/src/main/java/graphql/util/DefaultTraverserContext.java
+++ b/src/main/java/graphql/util/DefaultTraverserContext.java
@@ -74,7 +74,7 @@ public class DefaultTraverserContext<T> implements TraverserContext<T> {
 
     @Override
     public T thisNode() {
-        assertFalse(this.nodeDeleted, () -> "node is deleted");
+        assertFalse(this.nodeDeleted, "node is deleted");
         if (newNode != null) {
             return newNode;
         }
@@ -89,15 +89,15 @@ public class DefaultTraverserContext<T> implements TraverserContext<T> {
     @Override
     public void changeNode(T newNode) {
         assertNotNull(newNode);
-        assertFalse(this.nodeDeleted, () -> "node is deleted");
+        assertFalse(this.nodeDeleted, "node is deleted");
         this.newNode = newNode;
     }
 
 
     @Override
     public void deleteNode() {
-        assertNull(this.newNode, () -> "node is already changed");
-        assertFalse(this.nodeDeleted, () -> "node is already deleted");
+        assertNull(this.newNode, "node is already changed");
+        assertFalse(this.nodeDeleted, "node is already deleted");
         this.nodeDeleted = true;
     }
 
@@ -223,14 +223,14 @@ public class DefaultTraverserContext<T> implements TraverserContext<T> {
      * PRIVATE: Used by {@link Traverser}
      */
     void setChildrenContexts(Map<String, List<TraverserContext<T>>> children) {
-        assertTrue(this.children == null, () -> "children already set");
+        assertTrue(this.children == null, "children already set");
         this.children = children;
     }
 
 
     @Override
     public Map<String, List<TraverserContext<T>>> getChildrenContexts() {
-        assertNotNull(children, () -> "children not available");
+        assertNotNull(children, "children not available");
         return children;
     }
 

--- a/src/main/java/graphql/util/NodeMultiZipper.java
+++ b/src/main/java/graphql/util/NodeMultiZipper.java
@@ -72,7 +72,7 @@ public class NodeMultiZipper<T> {
             curZippers.removeAll(deepestZippers);
             curZippers.addAll(newZippers);
         }
-        assertTrue(curZippers.size() == 1, () -> "unexpected state: all zippers must share the same root node");
+        assertTrue(curZippers.size() == 1, "unexpected state: all zippers must share the same root node");
         return curZippers.iterator().next().toRoot();
     }
 
@@ -105,7 +105,7 @@ public class NodeMultiZipper<T> {
 
     public NodeMultiZipper<T> withReplacedZipper(NodeZipper<T> oldZipper, NodeZipper<T> newZipper) {
         int index = zippers.indexOf(oldZipper);
-        assertTrue(index >= 0, () -> "oldZipper not found");
+        assertTrue(index >= 0, "oldZipper not found");
         List<NodeZipper<T>> newZippers = new ArrayList<>(zippers);
         newZippers.set(index, newZipper);
         return new NodeMultiZipper<>(commonRoot, newZippers, this.nodeAdapter);
@@ -113,7 +113,7 @@ public class NodeMultiZipper<T> {
 
     public NodeMultiZipper<T> withReplacedZipperForNode(T currentNode, T newNode) {
         int index = FpKit.findIndex(zippers, zipper -> zipper.getCurNode() == currentNode);
-        assertTrue(index >= 0, () -> "No current zipper found for provided node");
+        assertTrue(index >= 0, "No current zipper found for provided node");
         NodeZipper<T> newZipper = zippers.get(index).withNewNode(newNode);
         List<NodeZipper<T>> newZippers = new ArrayList<>(zippers);
         newZippers.set(index, newZipper);
@@ -129,7 +129,7 @@ public class NodeMultiZipper<T> {
     }
 
     private NodeZipper<T> moveUp(T parent, List<NodeZipper<T>> sameParent) {
-        assertNotEmpty(sameParent, () -> "expected at least one zipper");
+        assertNotEmpty(sameParent, "expected at least one zipper");
 
         Map<String, List<T>> childrenMap = new HashMap<>(nodeAdapter.getNamedChildren(parent));
         Map<String, Integer> indexCorrection = new HashMap<>();

--- a/src/main/java/graphql/util/Traverser.java
+++ b/src/main/java/graphql/util/Traverser.java
@@ -112,8 +112,8 @@ public class Traverser<T> {
                 currentContext.setPhase(TraverserContext.Phase.LEAVE);
                 TraversalControl traversalControl = visitor.leave(currentContext);
                 currentAccValue = currentContext.getNewAccumulate();
-                assertNotNull(traversalControl, () -> "result of leave must not be null");
-                assertTrue(CONTINUE_OR_QUIT.contains(traversalControl), () -> "result can only return CONTINUE or QUIT");
+                assertNotNull(traversalControl, "result of leave must not be null");
+                assertTrue(CONTINUE_OR_QUIT.contains(traversalControl), "result can only return CONTINUE or QUIT");
 
                 switch (traversalControl) {
                     case QUIT:
@@ -132,8 +132,8 @@ public class Traverser<T> {
                 currentContext.setPhase(TraverserContext.Phase.BACKREF);
                 TraversalControl traversalControl = visitor.backRef(currentContext);
                 currentAccValue = currentContext.getNewAccumulate();
-                assertNotNull(traversalControl, () -> "result of backRef must not be null");
-                assertTrue(CONTINUE_OR_QUIT.contains(traversalControl), () -> "backRef can only return CONTINUE or QUIT");
+                assertNotNull(traversalControl,"result of backRef must not be null");
+                assertTrue(CONTINUE_OR_QUIT.contains(traversalControl), "backRef can only return CONTINUE or QUIT");
                 if (traversalControl == QUIT) {
                     break traverseLoop;
                 }
@@ -143,7 +143,7 @@ public class Traverser<T> {
                 currentContext.setPhase(TraverserContext.Phase.ENTER);
                 TraversalControl traversalControl = visitor.enter(currentContext);
                 currentAccValue = currentContext.getNewAccumulate();
-                assertNotNull(traversalControl, () -> "result of enter must not be null");
+                assertNotNull(traversalControl, "result of enter must not be null");
                 this.traverserState.addVisited((T) nodeBeforeEnter);
                 switch (traversalControl) {
                     case QUIT:

--- a/src/main/java/graphql/util/TreeParallelTransformer.java
+++ b/src/main/java/graphql/util/TreeParallelTransformer.java
@@ -31,7 +31,7 @@ public class TreeParallelTransformer<T> {
     private final NodeAdapter<T> nodeAdapter;
 
 
-    private Object sharedContextData;
+    private final Object sharedContextData;
 
 
     private TreeParallelTransformer(Object sharedContextData,
@@ -101,8 +101,8 @@ public class TreeParallelTransformer<T> {
             currentContext.setPhase(TraverserContext.Phase.ENTER);
             currentContext.setVar(List.class, myZippers);
             TraversalControl traversalControl = visitor.enter(currentContext);
-            assertNotNull(traversalControl, () -> "result of enter must not be null");
-            assertTrue(QUIT != traversalControl, () -> "can't return QUIT for parallel traversing");
+            assertNotNull(traversalControl, "result of enter must not be null");
+            assertTrue(QUIT != traversalControl, "can't return QUIT for parallel traversing");
             if (traversalControl == ABORT) {
                 this.children = ImmutableKit.emptyList();
                 tryComplete();
@@ -151,7 +151,7 @@ public class TreeParallelTransformer<T> {
         }
 
         private NodeZipper<T> moveUp(T parent, List<NodeZipper<T>> sameParent) {
-            assertNotEmpty(sameParent, () -> "expected at least one zipper");
+            assertNotEmpty(sameParent, "expected at least one zipper");
 
             Map<String, List<T>> childrenMap = new HashMap<>(nodeAdapter.getNamedChildren(parent));
             Map<String, Integer> indexCorrection = new HashMap<>();

--- a/src/main/java/graphql/util/TreeParallelTraverser.java
+++ b/src/main/java/graphql/util/TreeParallelTraverser.java
@@ -131,8 +131,8 @@ public class TreeParallelTraverser<T> {
         public void compute() {
             currentContext.setPhase(TraverserContext.Phase.ENTER);
             TraversalControl traversalControl = visitor.enter(currentContext);
-            assertNotNull(traversalControl, () -> "result of enter must not be null");
-            assertTrue(QUIT != traversalControl, () -> "can't return QUIT for parallel traversing");
+            assertNotNull(traversalControl, "result of enter must not be null");
+            assertTrue(QUIT != traversalControl, "can't return QUIT for parallel traversing");
             if (traversalControl == ABORT) {
                 tryComplete();
                 return;

--- a/src/main/java/graphql/util/TreeTransformerUtil.java
+++ b/src/main/java/graphql/util/TreeTransformerUtil.java
@@ -50,7 +50,7 @@ public class TreeTransformerUtil {
 
     private static <T> void replaceZipperForNode(List<NodeZipper<T>> zippers, T currentNode, T newNode) {
         int index = FpKit.findIndex(zippers, zipper -> zipper.getCurNode() == currentNode);
-        assertTrue(index >= 0, () -> "No current zipper found for provided node");
+        assertTrue(index >= 0, "No current zipper found for provided node");
         NodeZipper<T> newZipper = zippers.get(index).withNewNode(newNode);
         zippers.set(index, newZipper);
     }


### PR DESCRIPTION
Lots of places were asserting with a supplier of a constant String; switch to just using the assert methods that take the constant String directly. While the lambdas were cached / inlined, we can avoid even the small overhead of the lambda existing and needing the JIT to inline.