### PR TITLE
Fix FpKit.concat parameters

### DIFF
--- a/src/main/java/graphql/language/InputObjectTypeDefinition.java
+++ b/src/main/java/graphql/language/InputObjectTypeDefinition.java
@@ -1,14 +1,13 @@
 package graphql.language;
 
-
 import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
 import graphql.collect.ImmutableKit;
+import graphql.util.FpKit;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -75,10 +74,7 @@ public class InputObjectTypeDefinition extends AbstractDescribedNode<InputObject
 
     @Override
     public List<Node> getChildren() {
-        List<Node> result = new ArrayList<>();
-        result.addAll(directives.getDirectives());
-        result.addAll(inputValueDefinitions);
-        return result;
+        return FpKit.concat(directives.getDirectives(), inputValueDefinitions);
     }
 
     @Override

--- a/src/main/java/graphql/language/SchemaDefinition.java
+++ b/src/main/java/graphql/language/SchemaDefinition.java
@@ -5,10 +5,10 @@ import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
 import graphql.collect.ImmutableKit;
+import graphql.util.FpKit;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -71,10 +71,7 @@ public class SchemaDefinition extends AbstractDescribedNode<SchemaDefinition> im
 
     @Override
     public List<Node> getChildren() {
-        List<Node> result = new ArrayList<>();
-        result.addAll(directives.getDirectives());
-        result.addAll(operationTypeDefinitions);
-        return result;
+        return FpKit.concat(directives.getDirectives(), operationTypeDefinitions);
     }
 
     @Override

--- a/src/main/java/graphql/language/UnionTypeDefinition.java
+++ b/src/main/java/graphql/language/UnionTypeDefinition.java
@@ -5,10 +5,10 @@ import com.google.common.collect.ImmutableList;
 import graphql.Internal;
 import graphql.PublicApi;
 import graphql.collect.ImmutableKit;
+import graphql.util.FpKit;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -95,10 +95,7 @@ public class UnionTypeDefinition extends AbstractDescribedNode<UnionTypeDefiniti
 
     @Override
     public List<Node> getChildren() {
-        List<Node> result = new ArrayList<>();
-        result.addAll(directives.getDirectives());
-        result.addAll(memberTypes);
-        return result;
+        return FpKit.concat(directives.getDirectives(), memberTypes);
     }
 
     @Override

--- a/src/main/java/graphql/util/FpKit.java
+++ b/src/main/java/graphql/util/FpKit.java
@@ -265,7 +265,7 @@ public class FpKit {
      *
      * @return a <strong>new</strong> list composed of the two concatenated lists elements
      */
-    public static <T> List<T> concat(List<T> l1, List<T> l2) {
+    public static <T> List<T> concat(List<? extends T> l1, List<? extends T> l2) {
         List<T> l = new ArrayList<>(l1.size() + l2.size());
         l.addAll(l1);
         l.addAll(l2);


### PR DESCRIPTION
Make FpKit.concat parameters contravariant, so that it can be used in more call-sites; update a few such places that didn't work before in various Definition classes.