### PR TITLE
Shadow 9.0 upgrade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 import net.ltgt.gradle.errorprone.CheckSeverity
+import org.gradle.api.file.DuplicatesStrategy
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
@@ -10,7 +11,7 @@ plugins {
     id 'maven-publish'
     id 'antlr'
     id 'signing'
-    id "com.gradleup.shadow" version "8.3.8"
+    id "com.gradleup.shadow" version "9.0.0"
     id "biz.aQute.bnd.builder" version "6.4.0"
     id "io.github.gradle-nexus.publish-plugin" version "2.0.0"
     id "groovy"
@@ -206,6 +207,15 @@ shadowJar {
 -removeheaders: Private-Package
 Import-Package: !android.os.*,!com.google.*,!org.checkerframework.*,!graphql.com.google.*,!org.antlr.*,!graphql.org.antlr.*,!sun.misc.*,org.jspecify.annotations;resolution:=optional,*
 ''')
+}
+
+tasks.named('jmhJar') {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    from {
+        project.configurations.jmhRuntimeClasspath
+                .filter { it.exists() }
+                .collect { it.isDirectory() ? it : zipTree(it) }
+    }
 }
 
 


### PR DESCRIPTION
Shadow 9.0 is a major breaking change and a total rewrite, which has meant our JMH jar didn't work in our performance pipeline

This tries to re-create the old behaviour of creating a fat JAR

I've confirmed this works by running the performance pipeline on this branch. You can see the results checked in here: https://github.com/graphql-java/graphql-java/commit/dcafe231399167a6f1ebe5bfc28375770514bf31

Shadow 9.0 is not the latest version, trying to keep the version difference small for this bump