### PR TITLE
Fix error: Unusable type signature for overload of graphql.schema.SchemaTraverser::depthFirst #4147

### DIFF
--- a/src/main/java/graphql/schema/SchemaTraverser.java
+++ b/src/main/java/graphql/schema/SchemaTraverser.java
@@ -83,9 +83,9 @@ public class SchemaTraverser {
 
 
     public TraverserResult depthFirst(final Traverser<GraphQLSchemaElement> traverser,
-                                      final TraverserDelegateVisitor traverserDelegateVisitor,
+                                      final TraverserVisitor<GraphQLSchemaElement> traverserVisitor,
                                       Collection<? extends GraphQLSchemaElement> roots) {
-        return doTraverse(traverser, roots, traverserDelegateVisitor);
+        return doTraverse(traverser, roots, traverserVisitor);
     }
 
     private Traverser<GraphQLSchemaElement> initTraverser() {
@@ -94,8 +94,8 @@ public class SchemaTraverser {
 
     private TraverserResult doTraverse(Traverser<GraphQLSchemaElement> traverser,
                                        Collection<? extends GraphQLSchemaElement> roots,
-                                       TraverserDelegateVisitor traverserDelegateVisitor) {
-        return traverser.traverse(roots, traverserDelegateVisitor);
+                                       TraverserVisitor<GraphQLSchemaElement> traverserVisitor) {
+        return traverser.traverse(roots, traverserVisitor);
     }
 
     private static class TraverserDelegateVisitor implements TraverserVisitor<GraphQLSchemaElement> {


### PR DESCRIPTION
I found the problematic overload in SchemaTraverser and updated its public API to accept the correct visitor type, ensuring it’s usable outside the class.

This removes the unusable public signature that referenced the private TraverserDelegateVisitor type. All existing internal calls (which pass new TraverserDelegateVisitor(...)) still work because that class implements TraverserVisitor<GraphQLSchemaElement>.

Summary:
- Changed SchemaTraverser.depthFirst(Traverser, TraverserDelegateVisitor, ...) to use TraverserVisitor<GraphQLSchemaElement> instead, and adjusted the helper accordingly.
- Public API is now usable by callers without referencing a private inner class; no behavior change for existing internal usage.

Contribution by Gittensor, learn more at https://gittensor.io/