### PR TITLE
POC An example of how we might fix the schema transformer

### DIFF
--- a/src/test/groovy/graphql/schema/SchemaTransformerTest.groovy
+++ b/src/test/groovy/graphql/schema/SchemaTransformerTest.groovy
@@ -1056,13 +1056,13 @@ type Query {
         """
 
         def schema = TestUtil.schema(sdl)
-        schema = schema.transform { builder ->
-            for (def type : schema.getTypeMap().values()) {
-                if (type != schema.getQueryType() && type != schema.getMutationType() && type != schema.getSubscriptionType()) {
-                    builder.additionalType(type)
-                }
-            }
-        }
+//        schema = schema.transform { builder ->
+//            for (def type : schema.getTypeMap().values()) {
+//                if (type != schema.getQueryType() && type != schema.getMutationType() && type != schema.getSubscriptionType()) {
+//                    builder.additionalType(type)
+//                }
+//            }
+//        }
 
 
         def visitor = new GraphQLTypeVisitorStub() {


### PR DESCRIPTION
This is a quick suggestion - it could even be put into the GraphqlSchema however I cant think og a time when you would want `schema.getAllTypesExceptOpTypes` other than in this SchemaTransformer case and hence I think it should be just in this class