### PR TITLE
Fix ExecutableNormalizedField to respect GraphqlFieldVisibility

### DIFF
--- a/src/test/groovy/graphql/normalized/ExecutableNormalizedFieldTest.groovy
+++ b/src/test/groovy/graphql/normalized/ExecutableNormalizedFieldTest.groovy
@@ -59,4 +59,85 @@ class ExecutableNormalizedFieldTest extends Specification {
         dogFields.collect { it.name } == ["id", "name", "woof"]
     }
 
+    def "forEachFieldDefinition respects custom GraphqlFieldVisibility"() {
+        // This test verifies that ExecutableNormalizedField.forEachFieldDefinition() uses
+        // GraphqlFieldVisibility to look up fields. This is important for federated subgraphs
+        // where the supergraph may have fields that don't exist in the local schema, but
+        // a custom visibility can provide placeholder field definitions.
+        String schema = """
+        type Query{ 
+            pet: Pet
+        }
+        type Pet {
+            id: ID
+            name: String
+        }
+        """
+        
+        // Create a custom visibility that provides a "virtual" field that doesn't exist on the type
+        def customVisibility = new graphql.schema.visibility.GraphqlFieldVisibility() {
+            @Override
+            List<graphql.schema.GraphQLFieldDefinition> getFieldDefinitions(graphql.schema.GraphQLFieldsContainer fieldsContainer) {
+                def fields = new ArrayList<>(fieldsContainer.getFieldDefinitions())
+                // Add a virtual "age" field for Pet type
+                if (fieldsContainer.name == "Pet") {
+                    fields.add(graphql.schema.GraphQLFieldDefinition.newFieldDefinition()
+                        .name("age")
+                        .type(graphql.Scalars.GraphQLInt)
+                        .build())
+                }
+                return fields
+            }
+            
+            @Override
+            graphql.schema.GraphQLFieldDefinition getFieldDefinition(graphql.schema.GraphQLFieldsContainer fieldsContainer, String fieldName) {
+                // First check if the field exists on the type
+                def field = fieldsContainer.getFieldDefinition(fieldName)
+                if (field != null) {
+                    return field
+                }
+                // Provide virtual "age" field for Pet type
+                if (fieldsContainer.name == "Pet" && fieldName == "age") {
+                    return graphql.schema.GraphQLFieldDefinition.newFieldDefinition()
+                        .name("age")
+                        .type(graphql.Scalars.GraphQLInt)
+                        .build()
+                }
+                return null
+            }
+        }
+        
+        GraphQLSchema graphQLSchema = TestUtil.schema(schema)
+        
+        // Rebuild schema with custom visibility
+        def codeRegistry = graphql.schema.GraphQLCodeRegistry.newCodeRegistry(graphQLSchema.getCodeRegistry())
+            .fieldVisibility(customVisibility)
+            .build()
+        graphQLSchema = graphQLSchema.transform { builder -> builder.codeRegistry(codeRegistry) }
+
+        // Query that includes the "virtual" age field that exists only through visibility
+        String query = """
+        {
+            pet {
+                id
+                name
+                age
+            }
+        }
+        """
+        Document document = TestUtil.parseQuery(query)
+
+        when:
+        // This should succeed because the visibility provides the "age" field
+        def normalizedOperation = ExecutableNormalizedOperationFactory.createExecutableNormalizedOperation(
+            graphQLSchema, document, null, CoercedVariables.emptyVariables())
+        def pet = normalizedOperation.getTopLevelFields()[0]
+        def fieldNames = pet.getChildren().collect { it.name }
+
+        then:
+        // The age field should be found via the custom visibility
+        fieldNames.contains("age")
+        fieldNames.containsAll(["id", "name", "age"])
+    }
+
 }


### PR DESCRIPTION
## Problem

`ExecutableNormalizedField.forEachFieldDefinition()` and `getOneFieldDefinition()` call `type.getField(fieldName)` directly, bypassing the schema's configured `GraphqlFieldVisibility`.

This is inconsistent with other parts of graphql-java (validation, execution) that respect field visibility, and causes issues when:

- A custom GraphqlFieldVisibility provides field definitions that differ from what's in the schema type (e.g., placeholder fields, virtual fields, or dynamically-computed fields)
- Application code accesses DataFetchingEnvironment.getSelectionSet().getFields() in a DataFetcher
- Normalization fails with "No field X found for type Y" because it bypasses the visibility

### Reproduction

1. Configure a custom `GraphqlFieldVisibility` that provides virtual/placeholder fields
2. Execute a query that includes a field only available through the visibility
3. Access `DataFetchingEnvironment.getSelectionSet().getFields()` in a DataFetcher
4. Normalization fails because `ExecutableNormalizedField.forEachFieldDefinition()` calls `type.getField()` directly

## Solution

Change the field lookup to use the schema's field visibility:

```java
// Before
type.getField(fieldName)

// After  
schema.getCodeRegistry().getFieldVisibility().getFieldDefinition(type, fieldName)