### PR TITLE
Call onExceptionHandled in ChainedInstrumentation

### DIFF
--- a/src/main/java/graphql/execution/instrumentation/ChainedInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/ChainedInstrumentation.java
@@ -6,6 +6,7 @@ import graphql.ExecutionResult;
 import graphql.ExperimentalApi;
 import graphql.PublicApi;
 import graphql.execution.Async;
+import graphql.execution.DataFetcherResult;
 import graphql.execution.ExecutionContext;
 import graphql.execution.FieldValueInfo;
 import graphql.execution.instrumentation.parameters.InstrumentationCreateStateParameters;
@@ -378,6 +379,11 @@ public class ChainedInstrumentation implements Instrumentation {
         @Override
         public void onFetchedValue(Object fetchedValue) {
             contexts.forEach(context -> context.onFetchedValue(fetchedValue));
+        }
+
+        @Override
+        public void onExceptionHandled(DataFetcherResult<Object> dataFetcherResult) {
+            contexts.forEach(context -> context.onExceptionHandled(dataFetcherResult));
         }
 
         @Override

--- a/src/test/groovy/graphql/execution/instrumentation/TestingFieldFetchingInstrumentationContext.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/TestingFieldFetchingInstrumentationContext.groovy
@@ -1,9 +1,16 @@
 package graphql.execution.instrumentation
 
+import graphql.execution.DataFetcherResult
+
 class TestingFieldFetchingInstrumentationContext extends TestingInstrumentContext<Object> implements FieldFetchingInstrumentationContext {
 
     TestingFieldFetchingInstrumentationContext(Object op, Object executionList, Object throwableList, Boolean useOnDispatch) {
         super(op, executionList, throwableList, useOnDispatch)
+    }
+
+    @Override
+    void onExceptionHandled(DataFetcherResult<Object> dataFetcherResult) {
+        executionList << "onExceptionHandled:$op"
     }
 }
 

--- a/src/test/groovy/graphql/execution/instrumentation/TestingInstrumentContext.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/TestingInstrumentContext.groovy
@@ -1,7 +1,5 @@
 package graphql.execution.instrumentation
 
-import java.util.concurrent.CompletableFuture
-
 class TestingInstrumentContext<T> implements InstrumentationContext<T> {
     def op
     def start = System.currentTimeMillis()


### PR DESCRIPTION
This is a miss from PR #4206, we needed to ensure that the new hook is being properly delegated to each instrumentation within a `ChainedInstrumentation`