### PR TITLE
fix: treat empty operation name the same as null

### DIFF
--- a/src/main/java/graphql/language/NodeUtil.java
+++ b/src/main/java/graphql/language/NodeUtil.java
@@ -73,12 +73,13 @@ public class NodeUtil {
                 fragmentsByName.put(fragmentDefinition.getName(), fragmentDefinition);
             }
         }
-        if (operationName == null && operationsByName.size() > 1) {
+        boolean operationNameProvided = operationName != null && !operationName.isEmpty();
+        if (!operationNameProvided && operationsByName.size() > 1) {
             throw new UnknownOperationException("Must provide operation name if query contains multiple operations.");
         }
         OperationDefinition operation;
 
-        if (operationName == null || operationName.isEmpty()) {
+        if (!operationNameProvided) {
             operation = operationsByName.values().iterator().next();
         } else {
             operation = operationsByName.get(operationName);

--- a/src/test/groovy/graphql/language/NodeUtilTest.groovy
+++ b/src/test/groovy/graphql/language/NodeUtilTest.groovy
@@ -15,11 +15,14 @@ class NodeUtilTest extends Specification {
         ''')
 
         when:
-        NodeUtil.getOperation(doc, null)
+        NodeUtil.getOperation(doc, operationName)
 
         then:
         def ex = thrown(UnknownOperationException)
         ex.message == "Must provide operation name if query contains multiple operations."
+
+        where:
+        operationName << [null, '']
     }
 
     def "getOperation: when multiple operations are defined in the query and operation name doesn't match any of the query operations then it should throw UnknownOperationException"() {


### PR DESCRIPTION
if an empty operation name is given and multiple
operations are provided in the query, then the first operation is
 returned. not entirely sure why this would be the desired behaviour,
 when an exception is thrown for any other value that doesn't
 match an existing operation in the query.
