### PR TITLE
Fix testWithJava21 task running zero tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -361,6 +361,11 @@ tasks.register('testWithJava21', Test) {
     javaLauncher = javaToolchains.launcherFor {
         languageVersion = JavaLanguageVersion.of(21)
     }
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    classpath += sourceSets.jmh.output
+    dependsOn "jmhClasses"
+    dependsOn tasks.named('testClasses')
 }
 
 tasks.register('testWithJava17', Test) {


### PR DESCRIPTION
## Summary

- The `testWithJava21` Gradle task was missing `testClassesDirs`, `classpath`, and `dependsOn` configuration, causing it to discover zero test classes and silently succeed with **0 tests executed**
- CI logs confirm: `testWithJava21` completed in ~2 minutes with "0 tests run in 0 ms" while `testWithJava17` and `testWithJava11` each ran 5336 tests in ~7 minutes
- Added the same configuration that `testWithJava17` and `testWithJava11` already have

## Test plan

- [ ] Verify the `testWithJava21` CI job now reports 5336 tests (matching Java 11 and Java 17)
- [ ] Verify the `testWithJava21` CI job duration is ~7 minutes (matching Java 11 and Java 17), no longer ~2 minutes
- [ ] Verify all other CI matrix jobs still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)