### PR TITLE
Remove incorrect @Nullable from GraphQLSchema.getCodeRegistry()

### DIFF
--- a/src/main/java/graphql/schema/GraphQLSchema.java
+++ b/src/main/java/graphql/schema/GraphQLSchema.java
@@ -69,7 +69,7 @@ public class GraphQLSchema {
     private final @Nullable SchemaDefinition definition;
     private final ImmutableList<SchemaExtensionDefinition> extensionDefinitions;
     private final @Nullable String description;
-    private final @Nullable GraphQLCodeRegistry codeRegistry;
+    private final GraphQLCodeRegistry codeRegistry;
 
     private final ImmutableMap<String, GraphQLNamedType> typeMap;
     private final ImmutableMap<String, ImmutableList<GraphQLObjectType>> interfaceNameToObjectTypes;
@@ -77,7 +77,7 @@ public class GraphQLSchema {
 
     /*
      * This constructs partial GraphQL schema object which has the schema (query / mutation / subscription) trees
-     * in it but it does not have the collected types, code registry nor the type references replaced
+     * in it but it does not have the collected types, the correct code registry nor the type references replaced
      *
      * But it can be traversed to discover all that and filled out later via another constructor.
      *
@@ -102,7 +102,7 @@ public class GraphQLSchema {
         this.extensionDefinitions = nonNullCopyOf(builder.extensionDefinitions);
         this.description = builder.description;
 
-        this.codeRegistry = null;
+        this.codeRegistry = builder.codeRegistry;
         this.typeMap = ImmutableKit.emptyMap();
         this.interfaceNameToObjectTypes = ImmutableKit.emptyMap();
         this.interfaceNameToObjectTypeNames = ImmutableKit.emptyMap();
@@ -254,7 +254,7 @@ public class GraphQLSchema {
         return map.build();
     }
 
-    public @Nullable GraphQLCodeRegistry getCodeRegistry() {
+    public GraphQLCodeRegistry getCodeRegistry() {
         return codeRegistry;
     }
 


### PR DESCRIPTION
## Summary

- Remove `@Nullable` annotation from `GraphQLSchema.codeRegistry` field and `getCodeRegistry()` return type
- Fix first-pass constructor to use `builder.codeRegistry` instead of discarding it and setting the field to `null`

## Why

The field was annotated `@Nullable` and the first-pass constructor (`private GraphQLSchema(Builder)`) set `this.codeRegistry = null` — despite asserting `builder.codeRegistry` was non-null on the line above. All three constructors require a non-null codeRegistry, and no fully-constructed schema ever exposes a null value.

The `@Nullable` annotation was misleading and caused downstream code to add unnecessary null checks (e.g. `schema.getCodeRegistry() != null` guards in validation).

## Test plan

- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)