### PR TITLE
OneOf Inhabitability

### DIFF
--- a/src/main/java/graphql/schema/validation/OneOfInputObjectRules.java
+++ b/src/main/java/graphql/schema/validation/OneOfInputObjectRules.java
@@ -4,10 +4,15 @@ import graphql.ExperimentalApi;
 import graphql.schema.GraphQLInputObjectField;
 import graphql.schema.GraphQLInputObjectType;
 import graphql.schema.GraphQLSchemaElement;
+import graphql.schema.GraphQLType;
 import graphql.schema.GraphQLTypeUtil;
 import graphql.schema.GraphQLTypeVisitorStub;
+import graphql.schema.GraphQLUnmodifiedType;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 import static java.lang.String.format;
 
@@ -18,6 +23,45 @@ import static java.lang.String.format;
  */
 @ExperimentalApi
 public class OneOfInputObjectRules extends GraphQLTypeVisitorStub {
+
+    @Override
+    public TraversalControl visitGraphQLInputObjectType(GraphQLInputObjectType inputObjectType, TraverserContext<GraphQLSchemaElement> context) {
+        if (!inputObjectType.isOneOf()) {
+            return TraversalControl.CONTINUE;
+        }
+        SchemaValidationErrorCollector errorCollector = context.getVarFromParents(SchemaValidationErrorCollector.class);
+        if (!canBeProvidedAFiniteValue(inputObjectType, new LinkedHashSet<>())) {
+            String message = format("OneOf Input Object %s must be inhabited but all fields recursively reference only other OneOf Input Objects forming an unresolvable cycle.", inputObjectType.getName());
+            errorCollector.addError(new SchemaValidationError(SchemaValidationErrorType.OneOfNotInhabited, message));
+        }
+        return TraversalControl.CONTINUE;
+    }
+
+    private boolean canBeProvidedAFiniteValue(GraphQLInputObjectType oneOfInputObject, Set<GraphQLInputObjectType> visited) {
+        if (visited.contains(oneOfInputObject)) {
+            return false;
+        }
+        Set<GraphQLInputObjectType> nextVisited = new LinkedHashSet<>(visited);
+        nextVisited.add(oneOfInputObject);
+        for (GraphQLInputObjectField field : oneOfInputObject.getFieldDefinitions()) {
+            GraphQLType fieldType = field.getType();
+            if (GraphQLTypeUtil.isList(fieldType)) {
+                return true;
+            }
+            GraphQLUnmodifiedType namedFieldType = GraphQLTypeUtil.unwrapAll(fieldType);
+            if (!(namedFieldType instanceof GraphQLInputObjectType)) {
+                return true;
+            }
+            GraphQLInputObjectType inputFieldType = (GraphQLInputObjectType) namedFieldType;
+            if (!inputFieldType.isOneOf()) {
+                return true;
+            }
+            if (canBeProvidedAFiniteValue(inputFieldType, nextVisited)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     @Override
     public TraversalControl visitGraphQLInputObjectField(GraphQLInputObjectField inputObjectField, TraverserContext<GraphQLSchemaElement> context) {

--- a/src/main/java/graphql/schema/validation/SchemaValidationErrorType.java
+++ b/src/main/java/graphql/schema/validation/SchemaValidationErrorType.java
@@ -22,6 +22,7 @@ public enum SchemaValidationErrorType implements SchemaValidationErrorClassifica
     InputTypeUsedInOutputTypeContext,
     OneOfDefaultValueOnField,
     OneOfNonNullableField,
+    OneOfNotInhabited,
     RequiredInputFieldCannotBeDeprecated,
     RequiredFieldArgumentCannotBeDeprecated,
     RequiredDirectiveArgumentCannotBeDeprecated

--- a/src/test/groovy/graphql/schema/validation/OneOfInputObjectRulesTest.groovy
+++ b/src/test/groovy/graphql/schema/validation/OneOfInputObjectRulesTest.groovy
@@ -33,4 +33,158 @@ class OneOfInputObjectRulesTest extends Specification {
         schemaProblem.errors[1].description == "OneOf input field OneOfInputType.badDefaulted cannot have a default value."
         schemaProblem.errors[1].classification == SchemaValidationErrorType.OneOfDefaultValueOnField
     }
+
+    def "oneOf with scalar fields is inhabited"() {
+        def sdl = """
+            type Query { f(arg: A): String }
+            input A @oneOf { a: String, b: Int }
+        """
+
+        when:
+        def registry = new SchemaParser().parse(sdl)
+        new SchemaGenerator().makeExecutableSchema(registry, TestUtil.getMockRuntimeWiring())
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "oneOf with enum field is inhabited"() {
+        def sdl = """
+            type Query { f(arg: A): String }
+            enum Color { RED GREEN BLUE }
+            input A @oneOf { a: Color }
+        """
+
+        when:
+        def registry = new SchemaParser().parse(sdl)
+        new SchemaGenerator().makeExecutableSchema(registry, TestUtil.getMockRuntimeWiring())
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "oneOf with list field is inhabited"() {
+        def sdl = """
+            type Query { f(arg: A): String }
+            input A @oneOf { a: [A] }
+        """
+
+        when:
+        def registry = new SchemaParser().parse(sdl)
+        new SchemaGenerator().makeExecutableSchema(registry, TestUtil.getMockRuntimeWiring())
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "oneOf referencing non-oneOf input is inhabited"() {
+        def sdl = """
+            type Query { f(arg: A): String }
+            input A @oneOf { a: RegularInput }
+            input RegularInput { x: String }
+        """
+
+        when:
+        def registry = new SchemaParser().parse(sdl)
+        new SchemaGenerator().makeExecutableSchema(registry, TestUtil.getMockRuntimeWiring())
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "oneOf with escape field is inhabited"() {
+        def sdl = """
+            type Query { f(arg: A): String }
+            input A @oneOf { b: B, escape: String }
+            input B @oneOf { a: A }
+        """
+
+        when:
+        def registry = new SchemaParser().parse(sdl)
+        new SchemaGenerator().makeExecutableSchema(registry, TestUtil.getMockRuntimeWiring())
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "mutually referencing oneOf types with scalar escape is inhabited"() {
+        def sdl = """
+            type Query { f(arg: A): String }
+            input A @oneOf { b: B }
+            input B @oneOf { a: A, escape: Int }
+        """
+
+        when:
+        def registry = new SchemaParser().parse(sdl)
+        new SchemaGenerator().makeExecutableSchema(registry, TestUtil.getMockRuntimeWiring())
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "oneOf referencing non-oneOf with back-reference is inhabited"() {
+        def sdl = """
+            type Query { f(arg: A): String }
+            input A @oneOf { b: RegularInput }
+            input RegularInput { back: A }
+        """
+
+        when:
+        def registry = new SchemaParser().parse(sdl)
+        new SchemaGenerator().makeExecutableSchema(registry, TestUtil.getMockRuntimeWiring())
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "multiple fields with chained oneOf escape is inhabited"() {
+        def sdl = """
+            type Query { f(arg: A): String }
+            input A @oneOf { b: B, c: C }
+            input B @oneOf { a: A }
+            input C @oneOf { a: A, escape: String }
+        """
+
+        when:
+        def registry = new SchemaParser().parse(sdl)
+        new SchemaGenerator().makeExecutableSchema(registry, TestUtil.getMockRuntimeWiring())
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "single oneOf self-reference cycle is not inhabited"() {
+        def sdl = """
+            type Query { f(arg: A): String }
+            input A @oneOf { self: A }
+        """
+
+        when:
+        def registry = new SchemaParser().parse(sdl)
+        new SchemaGenerator().makeExecutableSchema(registry, TestUtil.getMockRuntimeWiring())
+
+        then:
+        def schemaProblem = thrown(InvalidSchemaException)
+        schemaProblem.errors.size() == 1
+        schemaProblem.errors[0].description == "OneOf Input Object A must be inhabited but all fields recursively reference only other OneOf Input Objects forming an unresolvable cycle."
+        schemaProblem.errors[0].classification == SchemaValidationErrorType.OneOfNotInhabited
+    }
+
+    def "multiple oneOf types forming cycle are not inhabited"() {
+        def sdl = """
+            type Query { f(arg: A): String }
+            input A @oneOf { b: B }
+            input B @oneOf { c: C }
+            input C @oneOf { a: A }
+        """
+
+        when:
+        def registry = new SchemaParser().parse(sdl)
+        new SchemaGenerator().makeExecutableSchema(registry, TestUtil.getMockRuntimeWiring())
+
+        then:
+        def schemaProblem = thrown(InvalidSchemaException)
+        schemaProblem.errors.size() == 3
+        schemaProblem.errors.every { it.classification == SchemaValidationErrorType.OneOfNotInhabited }
+    }
 }


### PR DESCRIPTION
This PR implements the validation described at https://github.com/graphql/graphql-spec/pull/1211

More discussion is at the link above, but the core issue is around uninhabited OneOf types -- the property that a type can be defined in a way that a value cannot be generated for it.

The simplest example of an uninhabited type is this recursive OneOf:
```
input A @oneOf { a:A }
```

While this type definition is currently valid by the rules of OneOf types and circular input types, it violates the spirit of the [Circular References](https://spec.graphql.org/draft/#sec-Input-Objects.Circular-References) because it does not allow construction of a finite value. This uninhabitation property applies to any closed subgraph of OneOf types.

This PR adds a new validator for OneOf inhabitation. I've tried to follow the existing conventions, but any feedback on style or substance is welcome.

 
