### PR TITLE
Fix SchemaTransformerBenchmark to pass schema validation

### DIFF
--- a/src/jmh/java/benchmark/SchemaTransformerBenchmark.java
+++ b/src/jmh/java/benchmark/SchemaTransformerBenchmark.java
@@ -1,5 +1,6 @@
 package benchmark;
 
+import graphql.introspection.Introspection.DirectiveLocation;
 import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLObjectType;
@@ -42,6 +43,8 @@ public class SchemaTransformerBenchmark {
 
         GraphQLDirective infoDirective = GraphQLDirective.newDirective()
                 .name("Info")
+                .validLocation(DirectiveLocation.FIELD_DEFINITION)
+                .validLocation(DirectiveLocation.OBJECT)
                 .build();
         GraphQLTypeVisitor directiveAdder = new GraphQLTypeVisitorStub() {
             @Override
@@ -94,6 +97,8 @@ public class SchemaTransformerBenchmark {
             try {
                 String schemaString = BenchmarkUtils.loadResource("large-schema-3.graphqls");
                 schema = SchemaGenerator.createdMockedSchema(schemaString);
+                // Declare the Info directive on the schema so validation passes after transformation
+                schema = schema.transform(builder -> builder.additionalDirective(infoDirective));
                 txSchema = SchemaTransformer.transformSchema(schema, directiveAdder);
             } catch (Exception e) {
                 throw new RuntimeException(e);


### PR DESCRIPTION
## Summary
- The benchmark's `infoDirective` lacked valid locations (`FIELD_DEFINITION`, `OBJECT`), and the directive was not declared on the schema — so `transformSchema` was hitting validation errors rather than measuring the real transformation cost
- Added valid locations and declared the directive on the schema before transformation

## Test plan
- [x] Verified benchmark runs cleanly: `./gradlew jmh -PjmhInclude="SchemaTransformerBenchmark" -PjmhIterations=3 -PjmhWarmupIterations=2 -PjmhFork=2`
- [x] Full test suite passes: `./gradlew test -x testWithJava21 -x testWithJava17 -x testWithJava11 -x testng`

🤖 Generated with [Claude Code](https://claude.com/claude-code)