### PR TITLE
Benchmark introspection against multiple large schemas

### DIFF
--- a/src/jmh/java/benchmark/IntrospectionBenchmark.java
+++ b/src/jmh/java/benchmark/IntrospectionBenchmark.java
@@ -8,9 +8,13 @@ import graphql.schema.idl.SchemaGenerator;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.runner.Runner;
@@ -18,14 +22,44 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
+import java.util.concurrent.TimeUnit;
+
 @State(Scope.Benchmark)
 @Warmup(iterations = 2, time = 5)
 @Measurement(iterations = 3)
 @Fork(2)
 public class IntrospectionBenchmark {
 
+    @Param({
+            "large-schema-2.graphqls",
+            "large-schema-3.graphqls",
+            "large-schema-4.graphqls",
+            "large-schema-5.graphqls",
+            "large-schema-federated-1.graphqls"
+    })
+    String schemaFile;
+
+    private GraphQL graphQL;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        String schema = loadSchema(schemaFile);
+        GraphQLSchema graphQLSchema = SchemaGenerator.createdMockedSchema(schema);
+        graphQL = GraphQL.newGraphQL(graphQLSchema).build();
+    }
+
+    private static String loadSchema(String schemaFile) {
+        if (schemaFile.equals("large-schema-5.graphqls")) {
+            // This schema is split across two files due to its size (11.3 MB)
+            return BenchmarkUtils.loadResource("large-schema-5.graphqls.part1")
+                    + BenchmarkUtils.loadResource("large-schema-5.graphqls.part2");
+        }
+        return BenchmarkUtils.loadResource(schemaFile);
+    }
+
     @Benchmark
     @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
     public ExecutionResult benchMarkIntrospectionAvgTime() {
         return graphQL.execute(IntrospectionQuery.INTROSPECTION_QUERY);
     }
@@ -34,16 +68,6 @@ public class IntrospectionBenchmark {
     @BenchmarkMode(Mode.Throughput)
     public ExecutionResult benchMarkIntrospectionThroughput() {
         return graphQL.execute(IntrospectionQuery.INTROSPECTION_QUERY);
-    }
-
-    private final GraphQL graphQL;
-
-
-    public IntrospectionBenchmark() {
-        String largeSchema = BenchmarkUtils.loadResource("large-schema-4.graphqls");
-        GraphQLSchema graphQLSchema = SchemaGenerator.createdMockedSchema(largeSchema);
-        graphQL = GraphQL.newGraphQL(graphQLSchema)
-                .build();
     }
 
     public static void main(String[] args) throws RunnerException {


### PR DESCRIPTION
## Summary
- Enhanced `IntrospectionBenchmark` to use JMH `@Param` to run against 5 schemas of increasing size instead of only `large-schema-4.graphqls`
- Schemas tested: `large-schema-2` (medium), `large-schema-3` (large), `large-schema-4` (very large), `large-schema-5` (split, ~11 MB), `large-schema-federated-1` (largest federated)
- Added `@OutputTimeUnit(TimeUnit.MILLISECONDS)` for average time readability

## Baseline results (2 warmup iterations, 3 measurement iterations, 2 forks)

```
Benchmark                                                                     (schemaFile)   Mode  Cnt    Score    Error  Units
IntrospectionBenchmark.benchMarkIntrospectionThroughput            large-schema-2.graphqls  thrpt    6   35.257 ±  0.502  ops/s
IntrospectionBenchmark.benchMarkIntrospectionThroughput            large-schema-3.graphqls  thrpt    6   11.138 ±  3.687  ops/s
IntrospectionBenchmark.benchMarkIntrospectionThroughput            large-schema-4.graphqls  thrpt    6    3.067 ±  0.268  ops/s
IntrospectionBenchmark.benchMarkIntrospectionThroughput            large-schema-5.graphqls  thrpt    6    2.546 ±  0.145  ops/s
IntrospectionBenchmark.benchMarkIntrospectionThroughput  large-schema-federated-1.graphqls  thrpt    6    1.716 ±  0.312  ops/s
IntrospectionBenchmark.benchMarkIntrospectionAvgTime               large-schema-2.graphqls   avgt    6   22.628 ±  1.697  ms/op
IntrospectionBenchmark.benchMarkIntrospectionAvgTime               large-schema-3.graphqls   avgt    6   79.248 ±  2.164  ms/op
IntrospectionBenchmark.benchMarkIntrospectionAvgTime               large-schema-4.graphqls   avgt    6  331.683 ± 27.475  ms/op
IntrospectionBenchmark.benchMarkIntrospectionAvgTime               large-schema-5.graphqls   avgt    6  388.928 ± 66.078  ms/op
IntrospectionBenchmark.benchMarkIntrospectionAvgTime     large-schema-federated-1.graphqls   avgt    6  614.070 ± 20.609  ms/op
```

| Schema | Avg Time (ms/op) | Throughput (ops/s) |
|---|---|---|
| large-schema-2 | 22.6 | 35.3 |
| large-schema-3 | 79.2 | 11.1 |
| large-schema-4 | 331.7 | 3.1 |
| large-schema-5 | 388.9 | 2.5 |
| large-schema-federated-1 | 614.1 | 1.7 |

## Test plan
- [x] `./gradlew jmhClasses` compiles successfully
- [x] Full benchmark run with 2 warmups, 3 iterations, 2 forks produces 10 rows (5 schemas × 2 modes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)