### PR TITLE
Re-add GraphQLSchema.Builder.clearDirectives()

### DIFF
--- a/src/main/java/graphql/schema/GraphQLSchema.java
+++ b/src/main/java/graphql/schema/GraphQLSchema.java
@@ -931,6 +931,30 @@ public class GraphQLSchema {
             return this;
         }
 
+        /**
+         * Clears all directives from this builder, including any that were previously added
+         * via {@link #additionalDirective(GraphQLDirective)} or {@link #additionalDirectives(Set)}.
+         * Built-in directives ({@code @include}, {@code @skip}, {@code @deprecated}, etc.) will
+         * always be added back automatically at build time by {@code ensureBuiltInDirectives()}.
+         * <p>
+         * This is useful when transforming a schema to replace all non-built-in directives:
+         * <pre>{@code
+         * schema.transform(builder -> {
+         *     List<GraphQLDirective> nonBuiltIns = schema.getDirectives().stream()
+         *         .filter(d -> !Directives.isBuiltInDirective(d))
+         *         .collect(toList());
+         *     builder.clearDirectives()
+         *         .additionalDirectives(transform(nonBuiltIns));
+         * })
+         * }</pre>
+         *
+         * @return this builder
+         */
+        public Builder clearDirectives() {
+            this.additionalDirectives.clear();
+            return this;
+        }
+
         public Builder withSchemaDirectives(GraphQLDirective... directives) {
             for (GraphQLDirective directive : directives) {
                 withSchemaDirective(directive);


### PR DESCRIPTION
## Summary

PR #4229 removed `clearDirectives()` from `GraphQLSchema.Builder` as part of unifying built-in directive handling. As noted in issue #4259, this method is useful in practice: a common pattern when using `GraphQLSchema.transform` is to collect the non-built-in directives from the source schema, call `clearDirectives()` on the builder, and then add back transformed versions of those directives.

This PR re-adds `clearDirectives()` with semantics that are consistent with the approach introduced in #4229:

- Clears `additionalDirectives` entirely (including any explicitly-added built-ins)
- Built-in directives are always re-added automatically at build time by `ensureBuiltInDirectives()`, so they cannot be permanently removed — all built-ins are treated uniformly

## Changes

- Re-adds `Builder.clearDirectives()` to `GraphQLSchema` with Javadoc illustrating the transform use case
- Adds tests covering:
  - `clearDirectives()` followed by `build()` still yields all 7 built-in directives
  - `clearDirectives()` followed by adding a custom directive yields the expected set
  - The primary use case: using `clearDirectives()` in a `schema.transform()` to replace non-built-in directives
  - Ordering behavior: unoverridden built-ins sort first, then user-supplied directives in insertion order; customized built-ins retain their custom properties

## Related

Fixes #4259. See also #4229.