### PR TITLE
Fix jar file naming when branch contains slashes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ def getDevelopmentVersion() {
     def gitRevParseError = new StringBuilder()
     def gitRevParse = ["git", "-C", projectDir.toString(), "rev-parse", "--abbrev-ref", "HEAD"].execute()
     gitRevParse.waitForProcessOutput(gitRevParseOutput, gitRevParseError)
-    def branchName = gitRevParseOutput.toString().trim()
+    def branchName = gitRevParseOutput.toString().trim().replaceAll('[/\\\\]', '-')
 
     return makeDevelopmentVersion(["0.0.0", branchName, "SNAPSHOT"])
 }


### PR DESCRIPTION
## Summary
- Branch names containing `/` (e.g. `feature/my-change`) are used directly in the development version string, producing jar file names like `graphql-java-0.0.0-feature/my-change-SNAPSHOT.jar`
- The `/` in the file name breaks file paths and build tooling
- Fixed by replacing `/` and `\` characters in the branch name with `-` before constructing the version string

## Test plan
- [ ] Check out a branch with `/` in the name (e.g. `feature/test`) and run `./gradlew jar` — the jar file should have `-` instead of `/` in its name
- [ ] Verify normal branch names (no slashes) are unaffected

https://claude.ai/code/session_016vUi9axZU9DGXryxPWiwwT