### PR TITLE
Add unified allBuildAndTestSuccessful CI check

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -188,6 +188,34 @@ jobs:
           distribution: 'corretto'
       - name: Verify Javadoc
         run: ./gradlew javadoc --info --stacktrace
+  allBuildAndTestSuccessful:
+    if: always()
+    needs:
+      - buildAndTest
+      - update-baseline
+      - javadoc
+      - publishToMavenCentral
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all jobs passed
+        run: |
+          if [ "${{ needs.buildAndTest.result }}" != "success" ]; then
+            echo "buildAndTest failed with result: ${{ needs.buildAndTest.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.update-baseline.result }}" != "success" ]; then
+            echo "update-baseline failed with result: ${{ needs.update-baseline.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.javadoc.result }}" != "success" ]; then
+            echo "javadoc failed with result: ${{ needs.javadoc.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.publishToMavenCentral.result }}" != "success" ]; then
+            echo "publishToMavenCentral failed with result: ${{ needs.publishToMavenCentral.result }}"
+            exit 1
+          fi
+          echo "All build and test jobs passed successfully."
   publishToMavenCentral:
     needs: buildAndTest
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -396,3 +396,26 @@ jobs:
           distribution: 'corretto'
       - name: Verify Javadoc
         run: ./gradlew javadoc --info --stacktrace
+  allBuildAndTestSuccessful:
+    if: always()
+    needs:
+      - buildAndTest
+      - test-summary
+      - javadoc
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all jobs passed
+        run: |
+          if [ "${{ needs.buildAndTest.result }}" != "success" ]; then
+            echo "buildAndTest failed with result: ${{ needs.buildAndTest.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.test-summary.result }}" != "success" ] && [ "${{ needs.test-summary.result }}" != "skipped" ]; then
+            echo "test-summary failed with result: ${{ needs.test-summary.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.javadoc.result }}" != "success" ]; then
+            echo "javadoc failed with result: ${{ needs.javadoc.result }}"
+            exit 1
+          fi
+          echo "All build and test jobs passed successfully."


### PR DESCRIPTION
## Summary
- Adds a new `allBuildAndTestSuccessful` job to both `pull_request.yml` and `master.yml` workflows
- The job depends on all other build/test jobs and fails if any dependency failed, providing a single unified green/red status check
- This can be configured as the sole required status check in branch protection rules, simplifying merge gating

## Details

**pull_request.yml** — `allBuildAndTestSuccessful` depends on:
- `buildAndTest` (matrix: check, java11, java17, java21, java25)
- `test-summary` (allowed to be skipped on non-PR push events)
- `javadoc`

**master.yml** — `allBuildAndTestSuccessful` depends on:
- `buildAndTest` (matrix: check, java11, java17, java21, java25)
- `update-baseline`
- `javadoc`
- `publishToMavenCentral`

The job uses `if: always()` to ensure it runs even when dependencies fail, and explicitly checks each dependency's result to produce a clear pass/fail.

## Test plan
- [ ] Verify the workflow YAML is valid by checking the Actions tab after push
- [ ] Confirm `allBuildAndTestSuccessful` appears as a status check on this PR
- [ ] Optionally configure branch protection to require `allBuildAndTestSuccessful`

https://claude.ai/code/session_01353Dv2D47pHrj45ExnLxmc