### PR TITLE
Fix NullAway 0.13.1 compatibility

### DIFF
--- a/src/main/java/graphql/execution/MergedField.java
+++ b/src/main/java/graphql/execution/MergedField.java
@@ -16,7 +16,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotEmpty;
-import static graphql.Assert.assertNotNull;
+
 
 /**
  * This represents all Fields in a query which overlap and are merged into one.
@@ -428,7 +428,11 @@ public class MergedField {
             if (this.singleField != null && this.fields == null) {
                 return new MergedField(singleField, deferredExecutions);
             }
-            ImmutableList<Field> fields = assertNotNull(this.fields, "You MUST add at least one field via the builder").build();
+            ImmutableList.Builder<Field> fieldsBuilder = this.fields;
+            if (fieldsBuilder == null) {
+                throw new AssertionError("You MUST add at least one field via the builder");
+            }
+            ImmutableList<Field> fields = fieldsBuilder.build();
             assertNotEmpty(fields);
             return new MultiMergedField(fields, deferredExecutions);
         }

--- a/src/main/java/graphql/language/ArrayValue.java
+++ b/src/main/java/graphql/language/ArrayValue.java
@@ -91,8 +91,7 @@ public class ArrayValue extends AbstractNode<ArrayValue> implements Value<ArrayV
 
     @Override
     public ArrayValue deepCopy() {
-        List<Value> copiedValues = assertNotNull(deepCopy(values));
-        return new ArrayValue(copiedValues, getSourceLocation(), getComments(), getIgnoredChars(), getAdditionalData());
+        return new ArrayValue(assertNotNull(deepCopy(values)), getSourceLocation(), getComments(), getIgnoredChars(), getAdditionalData());
     }
 
     @Override

--- a/src/main/java/graphql/language/ObjectValue.java
+++ b/src/main/java/graphql/language/ObjectValue.java
@@ -81,8 +81,7 @@ public class ObjectValue extends AbstractNode<ObjectValue> implements Value<Obje
 
     @Override
     public ObjectValue deepCopy() {
-        List<ObjectField> copiedFields = assertNotNull(deepCopy(objectFields));
-        return new ObjectValue(copiedFields, getSourceLocation(), getComments(), getIgnoredChars(), getAdditionalData());
+        return new ObjectValue(assertNotNull(deepCopy(objectFields)), getSourceLocation(), getComments(), getIgnoredChars(), getAdditionalData());
     }
 
 


### PR DESCRIPTION
## Summary
- Fix 3 NullAway errors that occur with NullAway 0.13.1 (blocking PR #4317)
- `ArrayValue.deepCopy()` / `ObjectValue.deepCopy()`: inline `assertNotNull(deepCopy(...))` to avoid `@Nullable` local variable being passed where `@NonNull` is required
- `MergedField.Builder.build()`: replace `assertNotNull` on `@Nullable` Builder field with explicit null check

## Test plan
- [x] Verified compilation passes with NullAway 0.12.10
- [x] Verified compilation passes with NullAway 0.13.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)