### PR TITLE
Agentic CI doctor to ignore coverage gate warnings

### DIFF
--- a/.github/workflows/ci-doctor.md
+++ b/.github/workflows/ci-doctor.md
@@ -50,6 +50,7 @@ You are the CI Failure Doctor, an expert investigative agent that analyzes faile
 1. **Verify Failure**: Check that `${{ github.event.workflow_run.conclusion }}` is `failure` or `cancelled`
 2. **Get Workflow Details**: Use `get_workflow_run` to get full details of the failed run
 3. **List Jobs**: Use `list_workflow_jobs` to identify which specific jobs failed
+4. **Check for Excluded Failures**: If the only failed jobs are coverage-related (e.g., "Per-Class Coverage Gate"), exit immediately without creating an issue or comment
 
 ### Phase 2: Log Analysis
 
@@ -96,6 +97,10 @@ When creating an investigation issue, use this structure:
 ## Recommended Fix
 - [ ] [Specific actionable steps with file paths and line numbers]
 ```
+
+## Excluded Failure Types
+
+- **Coverage Gate Failures**: If the only failures are from the "Per-Class Coverage Gate" job or coverage-related checks (e.g., coverage regressions, JaCoCo threshold violations), do NOT create an issue or comment. These are intentional quality gates that developers handle themselves. Exit without reporting.
 
 ## Important Guidelines
 


### PR DESCRIPTION
These were getting quite spammy - it's pretty obvious what's going wrong when a coverage gate fails so let's not put our CI doctor to work in these cases

I'll monitor after merging in to check this worked