### PR TITLE
Validate directive definition cycles

### DIFF
--- a/src/main/java/graphql/schema/idl/SchemaTypeDirectivesChecker.java
+++ b/src/main/java/graphql/schema/idl/SchemaTypeDirectivesChecker.java
@@ -7,9 +7,11 @@ import graphql.language.Argument;
 import graphql.language.Directive;
 import graphql.language.DirectiveDefinition;
 import graphql.language.EnumTypeDefinition;
+import graphql.language.EnumTypeExtensionDefinition;
 import graphql.language.EnumValueDefinition;
 import graphql.language.FieldDefinition;
 import graphql.language.InputObjectTypeDefinition;
+import graphql.language.InputObjectTypeExtensionDefinition;
 import graphql.language.InputValueDefinition;
 import graphql.language.InterfaceTypeDefinition;
 import graphql.language.NamedNode;
@@ -17,6 +19,7 @@ import graphql.language.Node;
 import graphql.language.NonNullType;
 import graphql.language.ObjectTypeDefinition;
 import graphql.language.ScalarTypeDefinition;
+import graphql.language.ScalarTypeExtensionDefinition;
 import graphql.language.SchemaDefinition;
 import graphql.language.TypeDefinition;
 import graphql.language.TypeName;
@@ -30,10 +33,14 @@ import graphql.schema.idl.errors.IllegalNameError;
 import graphql.schema.idl.errors.MissingTypeError;
 import graphql.schema.idl.errors.NotAnInputTypeError;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static graphql.introspection.Introspection.DirectiveLocation.ARGUMENT_DEFINITION;
 import static graphql.introspection.Introspection.DirectiveLocation.ENUM;
@@ -184,14 +191,203 @@ class SchemaTypeDirectivesChecker {
     private void commonCheck(Collection<DirectiveDefinition> directiveDefinitions, List<GraphQLError> errors) {
         directiveDefinitions.forEach(directiveDefinition -> {
             assertTypeName(directiveDefinition, errors);
-            directiveDefinition.getInputValueDefinitions().forEach(inputValueDefinition -> {
+            boolean hasDirectSelfReference = false;
+            for (InputValueDefinition inputValueDefinition : directiveDefinition.getInputValueDefinitions()) {
                 assertTypeName(inputValueDefinition, errors);
                 assertExistAndIsInputType(inputValueDefinition, errors);
                 if (inputValueDefinition.hasDirective(directiveDefinition.getName())) {
                     errors.add(new DirectiveIllegalReferenceError(directiveDefinition, inputValueDefinition));
+                    hasDirectSelfReference = true;
                 }
-            });
+            }
+            if (hasDirectSelfReference) {
+                return;
+            }
+
+            String cycle = findDirectiveCycle(directiveDefinition);
+            if (cycle != null) {
+                errors.add(new DirectiveIllegalReferenceError(directiveDefinition, cycle));
+            }
         });
+    }
+
+    private String findDirectiveCycle(DirectiveDefinition directiveDefinition) {
+        List<String> path = new ArrayList<>();
+        path.add(directiveName(directiveDefinition.getName()));
+
+        Set<String> visited = new LinkedHashSet<>();
+        visited.add(directiveName(directiveDefinition.getName()));
+
+        return findCycleFromInputValueDefinitions(directiveDefinition.getInputValueDefinitions(), directiveDefinition.getName(), path, visited);
+    }
+
+    private String findCycleFromInputValueDefinitions(List<InputValueDefinition> inputValueDefinitions, String startDirectiveName, List<String> path, Set<String> visited) {
+        for (InputValueDefinition inputValueDefinition : inputValueDefinitions) {
+            String cycle = findCycleFromDirectives(inputValueDefinition.getDirectives(), startDirectiveName, path, visited);
+            if (cycle != null) {
+                return cycle;
+            }
+
+            cycle = findCycleFromInputType(inputValueDefinition.getType(), startDirectiveName, path, visited);
+            if (cycle != null) {
+                return cycle;
+            }
+        }
+        return null;
+    }
+
+    private String findCycleFromDirectives(List<Directive> directives, String startDirectiveName, List<String> path, Set<String> visited) {
+        for (Directive directive : directives) {
+            String cycle = findCycleFromDirectiveReference(directive.getName(), startDirectiveName, path, visited);
+            if (cycle != null) {
+                return cycle;
+            }
+        }
+        return null;
+    }
+
+    private String findCycleFromDirectiveReference(String directiveName, String startDirectiveName, List<String> path, Set<String> visited) {
+        String displayName = directiveName(directiveName);
+        if (directiveName.equals(startDirectiveName)) {
+            return cyclePath(path, displayName);
+        }
+        if (visited.contains(displayName)) {
+            return null;
+        }
+
+        Optional<DirectiveDefinition> directiveDefinition = typeRegistry.getDirectiveDefinition(directiveName);
+        if (directiveDefinition.isEmpty()) {
+            return null;
+        }
+
+        return findCycleFromInputValueDefinitions(
+                directiveDefinition.get().getInputValueDefinitions(),
+                startDirectiveName,
+                addToPath(path, displayName),
+                addToVisited(visited, displayName)
+        );
+    }
+
+    private String findCycleFromInputType(graphql.language.Type<?> type, String startDirectiveName, List<String> path, Set<String> visited) {
+        TypeDefinition<?> typeDefinition = findTypeDefFromRegistry(TypeUtil.unwrapAll(type).getName(), typeRegistry);
+        if (typeDefinition == null) {
+            return null;
+        }
+        if (visited.contains(typeDefinition.getName())) {
+            return null;
+        }
+
+        List<String> nextPath = addToPath(path, typeDefinition.getName());
+        Set<String> nextVisited = addToVisited(visited, typeDefinition.getName());
+
+        if (typeDefinition instanceof ScalarTypeDefinition) {
+            return findCycleFromScalarType((ScalarTypeDefinition) typeDefinition, startDirectiveName, nextPath, nextVisited);
+        }
+        if (typeDefinition instanceof EnumTypeDefinition) {
+            return findCycleFromEnumType((EnumTypeDefinition) typeDefinition, startDirectiveName, nextPath, nextVisited);
+        }
+        if (typeDefinition instanceof InputObjectTypeDefinition) {
+            return findCycleFromInputObjectType((InputObjectTypeDefinition) typeDefinition, startDirectiveName, nextPath, nextVisited);
+        }
+        return null;
+    }
+
+    private String findCycleFromScalarType(ScalarTypeDefinition typeDefinition, String startDirectiveName, List<String> path, Set<String> visited) {
+        String cycle = findCycleFromDirectives(typeDefinition.getDirectives(), startDirectiveName, path, visited);
+        if (cycle != null) {
+            return cycle;
+        }
+
+        List<ScalarTypeExtensionDefinition> extensions = typeRegistry.scalarTypeExtensions().getOrDefault(typeDefinition.getName(), Collections.emptyList());
+        for (ScalarTypeExtensionDefinition extension : extensions) {
+            cycle = findCycleFromDirectives(extension.getDirectives(), startDirectiveName, path, visited);
+            if (cycle != null) {
+                return cycle;
+            }
+        }
+        return null;
+    }
+
+    private String findCycleFromEnumType(EnumTypeDefinition typeDefinition, String startDirectiveName, List<String> path, Set<String> visited) {
+        String cycle = findCycleFromDirectives(typeDefinition.getDirectives(), startDirectiveName, path, visited);
+        if (cycle != null) {
+            return cycle;
+        }
+
+        cycle = findCycleFromEnumValues(typeDefinition.getEnumValueDefinitions(), startDirectiveName, path, visited);
+        if (cycle != null) {
+            return cycle;
+        }
+
+        List<EnumTypeExtensionDefinition> extensions = typeRegistry.enumTypeExtensions().getOrDefault(typeDefinition.getName(), Collections.emptyList());
+        for (EnumTypeExtensionDefinition extension : extensions) {
+            cycle = findCycleFromDirectives(extension.getDirectives(), startDirectiveName, path, visited);
+            if (cycle != null) {
+                return cycle;
+            }
+
+            cycle = findCycleFromEnumValues(extension.getEnumValueDefinitions(), startDirectiveName, path, visited);
+            if (cycle != null) {
+                return cycle;
+            }
+        }
+        return null;
+    }
+
+    private String findCycleFromEnumValues(List<EnumValueDefinition> enumValueDefinitions, String startDirectiveName, List<String> path, Set<String> visited) {
+        for (EnumValueDefinition enumValueDefinition : enumValueDefinitions) {
+            String cycle = findCycleFromDirectives(enumValueDefinition.getDirectives(), startDirectiveName, path, visited);
+            if (cycle != null) {
+                return cycle;
+            }
+        }
+        return null;
+    }
+
+    private String findCycleFromInputObjectType(InputObjectTypeDefinition typeDefinition, String startDirectiveName, List<String> path, Set<String> visited) {
+        String cycle = findCycleFromDirectives(typeDefinition.getDirectives(), startDirectiveName, path, visited);
+        if (cycle != null) {
+            return cycle;
+        }
+
+        cycle = findCycleFromInputValueDefinitions(typeDefinition.getInputValueDefinitions(), startDirectiveName, path, visited);
+        if (cycle != null) {
+            return cycle;
+        }
+
+        List<InputObjectTypeExtensionDefinition> extensions = typeRegistry.inputObjectTypeExtensions().getOrDefault(typeDefinition.getName(), Collections.emptyList());
+        for (InputObjectTypeExtensionDefinition extension : extensions) {
+            cycle = findCycleFromDirectives(extension.getDirectives(), startDirectiveName, path, visited);
+            if (cycle != null) {
+                return cycle;
+            }
+
+            cycle = findCycleFromInputValueDefinitions(extension.getInputValueDefinitions(), startDirectiveName, path, visited);
+            if (cycle != null) {
+                return cycle;
+            }
+        }
+        return null;
+    }
+
+    private List<String> addToPath(List<String> path, String element) {
+        List<String> nextPath = new ArrayList<>(path);
+        nextPath.add(element);
+        return nextPath;
+    }
+
+    private Set<String> addToVisited(Set<String> visited, String element) {
+        Set<String> nextVisited = new LinkedHashSet<>(visited);
+        nextVisited.add(element);
+        return nextVisited;
+    }
+
+    private String cyclePath(List<String> path, String cycleElement) {
+        return String.join(" -> ", addToPath(path, cycleElement));
+    }
+
+    private String directiveName(String directiveName) {
+        return "@" + directiveName;
     }
 
     private static void assertTypeName(NamedNode<?> node, List<GraphQLError> errors) {

--- a/src/main/java/graphql/schema/idl/errors/DirectiveIllegalReferenceError.java
+++ b/src/main/java/graphql/schema/idl/errors/DirectiveIllegalReferenceError.java
@@ -12,4 +12,11 @@ public class DirectiveIllegalReferenceError extends BaseError {
                         directive.getName(), location.getName(), lineCol(location)
                 ));
     }
+
+    public DirectiveIllegalReferenceError(DirectiveDefinition directive, String cycle) {
+        super(directive,
+                String.format("'%s' must not form a circular reference: %s",
+                        directive.getName(), cycle
+                ));
+    }
 }

--- a/src/main/java/graphql/schema/validation/DirectiveCycleDetector.java
+++ b/src/main/java/graphql/schema/validation/DirectiveCycleDetector.java
@@ -70,13 +70,9 @@ public class DirectiveCycleDetector {
     }
 
     private String findCycleFromDirectiveReference(String directiveName, String startDirectiveName, List<String> path, Set<String> visited) {
-        if (directiveName.equals(startDirectiveName) && path.size() == 1) {
-            return null;
-        }
-
         String displayName = directiveName(directiveName);
         if (directiveName.equals(startDirectiveName)) {
-            return canonicalize(addToPath(path, displayName));
+            return cyclePath(path, displayName);
         }
         if (visited.contains(displayName)) {
             return null;
@@ -164,28 +160,8 @@ public class DirectiveCycleDetector {
         return nextVisited;
     }
 
-    private String canonicalize(List<String> cyclePath) {
-        List<String> cycle = cyclePath.subList(0, cyclePath.size() - 1);
-        String best = null;
-        int bestIndex = 0;
-
-        for (int i = 0; i < cycle.size(); i++) {
-            String candidate = rotate(cycle, i);
-            if (best == null || candidate.compareTo(best) < 0) {
-                best = candidate;
-                bestIndex = i;
-            }
-        }
-
-        return best + " -> " + cycle.get(bestIndex);
-    }
-
-    private String rotate(List<String> cycle, int offset) {
-        List<String> rotated = new ArrayList<>(cycle.size());
-        for (int i = 0; i < cycle.size(); i++) {
-            rotated.add(cycle.get((i + offset) % cycle.size()));
-        }
-        return String.join(" -> ", rotated);
+    private String cyclePath(List<String> path, String cycleElement) {
+        return String.join(" -> ", addToPath(path, cycleElement));
     }
 
     private String directiveName(String directiveName) {

--- a/src/main/java/graphql/schema/validation/DirectiveCycleDetector.java
+++ b/src/main/java/graphql/schema/validation/DirectiveCycleDetector.java
@@ -1,0 +1,194 @@
+package graphql.schema.validation;
+
+import graphql.DirectivesUtil;
+import graphql.Internal;
+import graphql.schema.GraphQLDirective;
+import graphql.schema.GraphQLDirectiveContainer;
+import graphql.schema.GraphQLEnumType;
+import graphql.schema.GraphQLEnumValueDefinition;
+import graphql.schema.GraphQLInputObjectType;
+import graphql.schema.GraphQLInputType;
+import graphql.schema.GraphQLInputValueDefinition;
+import graphql.schema.GraphQLScalarType;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLType;
+import graphql.schema.GraphQLTypeReference;
+import graphql.schema.GraphQLTypeUtil;
+import graphql.schema.GraphQLUnmodifiedType;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+@Internal
+public class DirectiveCycleDetector {
+
+    private final GraphQLSchema schema;
+
+    public DirectiveCycleDetector(GraphQLSchema schema) {
+        this.schema = schema;
+    }
+
+    public String findCycle(GraphQLDirective directive) {
+        List<String> path = new ArrayList<>();
+        path.add(directiveName(directive.getName()));
+
+        Set<String> visited = new LinkedHashSet<>();
+        visited.add(directiveName(directive.getName()));
+
+        return findCycleFromDirective(directive, directive.getName(), path, visited);
+    }
+
+    private String findCycleFromDirective(GraphQLDirective directive, String startDirectiveName, List<String> path, Set<String> visited) {
+        return findCycleFromInputValueDefinitions(directive.getArguments(), startDirectiveName, path, visited);
+    }
+
+    private String findCycleFromInputValueDefinitions(List<? extends GraphQLInputValueDefinition> inputValueDefinitions, String startDirectiveName, List<String> path, Set<String> visited) {
+        for (GraphQLInputValueDefinition inputValueDefinition : inputValueDefinitions) {
+            String cycle = findCycleFromDirectiveContainer(inputValueDefinition, startDirectiveName, path, visited);
+            if (cycle != null) {
+                return cycle;
+            }
+
+            cycle = findCycleFromType(inputValueDefinition.getType(), startDirectiveName, path, visited);
+            if (cycle != null) {
+                return cycle;
+            }
+        }
+        return null;
+    }
+
+    private String findCycleFromDirectiveContainer(GraphQLDirectiveContainer directiveContainer, String startDirectiveName, List<String> path, Set<String> visited) {
+        for (graphql.schema.GraphQLAppliedDirective directive : DirectivesUtil.toAppliedDirectives(directiveContainer)) {
+            String cycle = findCycleFromDirectiveReference(directive.getName(), startDirectiveName, path, visited);
+            if (cycle != null) {
+                return cycle;
+            }
+        }
+        return null;
+    }
+
+    private String findCycleFromDirectiveReference(String directiveName, String startDirectiveName, List<String> path, Set<String> visited) {
+        if (directiveName.equals(startDirectiveName) && path.size() == 1) {
+            return null;
+        }
+
+        String displayName = directiveName(directiveName);
+        if (directiveName.equals(startDirectiveName)) {
+            return canonicalize(addToPath(path, displayName));
+        }
+        if (visited.contains(displayName)) {
+            return null;
+        }
+
+        GraphQLDirective directive = schema.getDirective(directiveName);
+        if (directive == null) {
+            return null;
+        }
+
+        return findCycleFromDirective(
+                directive,
+                startDirectiveName,
+                addToPath(path, displayName),
+                addToVisited(visited, displayName)
+        );
+    }
+
+    private String findCycleFromType(GraphQLInputType inputType, String startDirectiveName, List<String> path, Set<String> visited) {
+        GraphQLUnmodifiedType unwrappedType = GraphQLTypeUtil.unwrapAll(inputType);
+        GraphQLType resolvedType = resolveType(unwrappedType);
+        if (resolvedType == null) {
+            return null;
+        }
+
+        String displayName = ((graphql.schema.GraphQLNamedSchemaElement) resolvedType).getName();
+        if (visited.contains(displayName)) {
+            return null;
+        }
+
+        List<String> nextPath = addToPath(path, displayName);
+        Set<String> nextVisited = addToVisited(visited, displayName);
+
+        if (resolvedType instanceof GraphQLScalarType) {
+            return findCycleFromDirectiveContainer((GraphQLScalarType) resolvedType, startDirectiveName, nextPath, nextVisited);
+        }
+        if (resolvedType instanceof GraphQLEnumType) {
+            return findCycleFromEnumType((GraphQLEnumType) resolvedType, startDirectiveName, nextPath, nextVisited);
+        }
+        if (resolvedType instanceof GraphQLInputObjectType) {
+            return findCycleFromInputObjectType((GraphQLInputObjectType) resolvedType, startDirectiveName, nextPath, nextVisited);
+        }
+        return null;
+    }
+
+    private String findCycleFromEnumType(GraphQLEnumType enumType, String startDirectiveName, List<String> path, Set<String> visited) {
+        String cycle = findCycleFromDirectiveContainer(enumType, startDirectiveName, path, visited);
+        if (cycle != null) {
+            return cycle;
+        }
+
+        for (GraphQLEnumValueDefinition enumValueDefinition : enumType.getValues()) {
+            cycle = findCycleFromDirectiveContainer(enumValueDefinition, startDirectiveName, path, visited);
+            if (cycle != null) {
+                return cycle;
+            }
+        }
+        return null;
+    }
+
+    private String findCycleFromInputObjectType(GraphQLInputObjectType inputObjectType, String startDirectiveName, List<String> path, Set<String> visited) {
+        String cycle = findCycleFromDirectiveContainer(inputObjectType, startDirectiveName, path, visited);
+        if (cycle != null) {
+            return cycle;
+        }
+        return findCycleFromInputValueDefinitions(inputObjectType.getFieldDefinitions(), startDirectiveName, path, visited);
+    }
+
+    private GraphQLType resolveType(GraphQLType type) {
+        if (!(type instanceof GraphQLTypeReference)) {
+            return type;
+        }
+        return schema.getType(((GraphQLTypeReference) type).getName());
+    }
+
+    private List<String> addToPath(List<String> path, String element) {
+        List<String> nextPath = new ArrayList<>(path);
+        nextPath.add(element);
+        return nextPath;
+    }
+
+    private Set<String> addToVisited(Set<String> visited, String element) {
+        Set<String> nextVisited = new LinkedHashSet<>(visited);
+        nextVisited.add(element);
+        return nextVisited;
+    }
+
+    private String canonicalize(List<String> cyclePath) {
+        List<String> cycle = cyclePath.subList(0, cyclePath.size() - 1);
+        String best = null;
+        int bestIndex = 0;
+
+        for (int i = 0; i < cycle.size(); i++) {
+            String candidate = rotate(cycle, i);
+            if (best == null || candidate.compareTo(best) < 0) {
+                best = candidate;
+                bestIndex = i;
+            }
+        }
+
+        return best + " -> " + cycle.get(bestIndex);
+    }
+
+    private String rotate(List<String> cycle, int offset) {
+        List<String> rotated = new ArrayList<>(cycle.size());
+        for (int i = 0; i < cycle.size(); i++) {
+            rotated.add(cycle.get((i + offset) % cycle.size()));
+        }
+        return String.join(" -> ", rotated);
+    }
+
+    private String directiveName(String directiveName) {
+        return "@" + directiveName;
+    }
+}

--- a/src/main/java/graphql/schema/validation/DirectiveReferencesAreValid.java
+++ b/src/main/java/graphql/schema/validation/DirectiveReferencesAreValid.java
@@ -1,0 +1,35 @@
+package graphql.schema.validation;
+
+import graphql.Internal;
+import graphql.schema.GraphQLDirective;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLSchemaElement;
+import graphql.schema.GraphQLTypeVisitorStub;
+import graphql.util.TraversalControl;
+import graphql.util.TraverserContext;
+
+import static java.lang.String.format;
+
+@Internal
+public class DirectiveReferencesAreValid extends GraphQLTypeVisitorStub {
+
+    @Override
+    public TraversalControl visitGraphQLDirective(GraphQLDirective directive, TraverserContext<GraphQLSchemaElement> context) {
+        if (context.getParentNode() != null) {
+            return TraversalControl.CONTINUE;
+        }
+
+        GraphQLSchema schema = context.getVarFromParents(GraphQLSchema.class);
+        SchemaValidationErrorCollector errorCollector = context.getVarFromParents(SchemaValidationErrorCollector.class);
+        DirectiveCycleDetector detector = new DirectiveCycleDetector(schema);
+        String cycle = detector.findCycle(directive);
+
+        if (cycle == null) {
+            return TraversalControl.CONTINUE;
+        }
+
+        String message = format("The directive cycle '%s' is invalid", cycle);
+        errorCollector.addError(new SchemaValidationError(SchemaValidationErrorType.InvalidDirectiveDefinition, message));
+        return TraversalControl.CONTINUE;
+    }
+}

--- a/src/main/java/graphql/schema/validation/SchemaValidationErrorType.java
+++ b/src/main/java/graphql/schema/validation/SchemaValidationErrorType.java
@@ -18,6 +18,7 @@ public enum SchemaValidationErrorType implements SchemaValidationErrorClassifica
     InvalidDefaultValue,
     InvalidAppliedDirectiveArgument,
     InvalidAppliedDirective,
+    InvalidDirectiveDefinition,
     OutputTypeUsedInInputTypeContext,
     InputTypeUsedInOutputTypeContext,
     OneOfDefaultValueOnField,

--- a/src/main/java/graphql/schema/validation/SchemaValidator.java
+++ b/src/main/java/graphql/schema/validation/SchemaValidator.java
@@ -23,6 +23,7 @@ public class SchemaValidator {
         rules.add(new TypeAndFieldRule());
         rules.add(new DefaultValuesAreValid());
         rules.add(new AppliedDirectivesAreValid());
+        rules.add(new DirectiveReferencesAreValid());
         rules.add(new AppliedDirectiveArgumentsAreValid());
         rules.add(new InputAndOutputTypesUsedAppropriately());
         rules.add(new OneOfInputObjectRules());

--- a/src/test/groovy/graphql/schema/idl/SchemaTypeDirectivesCheckerTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaTypeDirectivesCheckerTest.groovy
@@ -5,6 +5,7 @@ import graphql.schema.GraphQLScalarType
 import graphql.schema.idl.errors.DirectiveIllegalLocationError
 import graphql.schema.idl.errors.DirectiveIllegalReferenceError
 import graphql.schema.idl.errors.DirectiveMissingNonNullArgumentError
+import graphql.schema.idl.errors.SchemaProblem
 import graphql.schema.idl.errors.DirectiveUndeclaredError
 import graphql.schema.idl.errors.DirectiveUnknownArgumentError
 import graphql.schema.idl.errors.IllegalNameError
@@ -230,6 +231,77 @@ class SchemaTypeDirectivesCheckerTest extends Specification {
         errors.size() == 1
         errors.get(0) instanceof DirectiveIllegalReferenceError
         errors.get(0).getMessage() == "'invalidExample' must not reference itself on 'arg''[@2:39]'"
+    }
+
+    def "directive must not participate in a cycle through other directives"() {
+        given:
+        def spec = '''
+            directive @first(arg: String @second) on ARGUMENT_DEFINITION
+            directive @second(arg: String @first) on ARGUMENT_DEFINITION
+
+            type Query {
+                hello: String
+            }
+        '''
+        def registry = parse(spec)
+        def errors = []
+
+        when:
+        new SchemaTypeDirectivesChecker(registry, RuntimeWiring.newRuntimeWiring().build()).checkTypeDirectives(errors)
+
+        then:
+        errors.size() == 2
+        errors.every { it instanceof DirectiveIllegalReferenceError }
+        errors.every { it.message.contains("first") }
+        errors.every { it.message.contains("second") }
+    }
+
+    def "directive must not participate in a cycle through input types"() {
+        given:
+        def spec = '''
+            directive @first(arg: Filter) on ARGUMENT_DEFINITION
+            directive @second(arg: Int @first) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+
+            input Filter {
+                field: Int @second(arg: 1)
+            }
+
+            type Query {
+                hello: String
+            }
+        '''
+        def registry = parse(spec)
+        def errors = []
+
+        when:
+        new SchemaTypeDirectivesChecker(registry, RuntimeWiring.newRuntimeWiring().build()).checkTypeDirectives(errors)
+
+        then:
+        errors.size() == 2
+        errors.every { it instanceof DirectiveIllegalReferenceError }
+        errors.every { it.message.contains("Filter") }
+        errors*.message.any { it.contains("first") }
+        errors*.message.any { it.contains("second") }
+    }
+
+    def "schema generator rejects directive cycles before schema construction recurses"() {
+        given:
+        def spec = '''
+            directive @first(arg: String @second) on ARGUMENT_DEFINITION
+            directive @second(arg: String @first) on ARGUMENT_DEFINITION
+
+            type Query {
+                hello: String
+            }
+        '''
+
+        when:
+        new SchemaGenerator().makeExecutableSchema(parse(spec), RuntimeWiring.newRuntimeWiring().build())
+
+        then:
+        def error = thrown(SchemaProblem)
+        error.message.contains("first")
+        error.message.contains("second")
     }
 
     def "directive must not begin with '__'"() {

--- a/src/test/groovy/graphql/schema/validation/DirectiveReferencesAreValidTest.groovy
+++ b/src/test/groovy/graphql/schema/validation/DirectiveReferencesAreValidTest.groovy
@@ -1,0 +1,114 @@
+package graphql.schema.validation
+
+import graphql.schema.GraphQLDirective
+import graphql.schema.GraphQLTypeReference
+import spock.lang.Specification
+
+import static graphql.Scalars.GraphQLInt
+import static graphql.Scalars.GraphQLString
+import static graphql.introspection.Introspection.DirectiveLocation.ARGUMENT_DEFINITION
+import static graphql.introspection.Introspection.DirectiveLocation.INPUT_FIELD_DEFINITION
+import static graphql.schema.GraphQLArgument.newArgument
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
+import static graphql.schema.GraphQLInputObjectField.newInputObjectField
+import static graphql.schema.GraphQLInputObjectType.newInputObject
+import static graphql.schema.GraphQLObjectType.newObject
+import static graphql.schema.GraphQLSchema.newSchema
+
+class DirectiveReferencesAreValidTest extends Specification {
+
+    def "programmatic schemas reject directive cycles through directives"() {
+        given:
+        def first = GraphQLDirective.newDirective()
+                .name("first")
+                .validLocation(ARGUMENT_DEFINITION)
+                .build()
+        def second = GraphQLDirective.newDirective()
+                .name("second")
+                .validLocation(ARGUMENT_DEFINITION)
+                .argument(newArgument()
+                        .name("arg")
+                        .type(GraphQLString)
+                        .withAppliedDirective(first.toAppliedDirective())
+                        .build())
+                .build()
+        first = first.transform { builder ->
+            builder.argument(newArgument()
+                    .name("arg")
+                    .type(GraphQLString)
+                    .withAppliedDirective(second.toAppliedDirective())
+                    .build())
+        }
+
+        when:
+        newSchema()
+                .query(newObject()
+                        .name("Query")
+                        .field(newFieldDefinition()
+                                .name("hello")
+                                .type(GraphQLString)
+                                .build())
+                        .build())
+                .additionalDirective(first)
+                .additionalDirective(second)
+                .build()
+
+        then:
+        def error = thrown(InvalidSchemaException)
+        error.message.contains("first")
+        error.message.contains("second")
+    }
+
+    def "programmatic schemas reject directive cycles through input types"() {
+        given:
+        def first = GraphQLDirective.newDirective()
+                .name("first")
+                .validLocation(ARGUMENT_DEFINITION)
+                .argument(newArgument()
+                        .name("arg")
+                        .type(GraphQLTypeReference.typeRef("Filter"))
+                        .build())
+                .build()
+        def second = GraphQLDirective.newDirective()
+                .name("second")
+                .validLocations(ARGUMENT_DEFINITION, INPUT_FIELD_DEFINITION)
+                .argument(newArgument()
+                        .name("arg")
+                        .type(GraphQLInt)
+                        .withAppliedDirective(first.toAppliedDirective())
+                        .build())
+                .build()
+        def filterType = newInputObject()
+                .name("Filter")
+                .field(newInputObjectField()
+                        .name("field")
+                        .type(GraphQLInt)
+                        .withAppliedDirective(second.toAppliedDirective())
+                        .build())
+                .build()
+
+        when:
+        newSchema()
+                .query(newObject()
+                        .name("Query")
+                        .field(newFieldDefinition()
+                                .name("hello")
+                                .type(GraphQLString)
+                                .argument(newArgument()
+                                        .name("filter")
+                                        .type(filterType)
+                                        .build())
+                                .build())
+                        .build())
+                .additionalType(filterType)
+                .additionalDirective(first)
+                .additionalDirective(second)
+                .build()
+
+        then:
+        def error = thrown(InvalidSchemaException)
+        error.message.contains("first")
+        error.message.contains("Filter")
+        error.message.contains("second")
+    }
+}

--- a/src/test/groovy/graphql/schema/validation/DirectiveReferencesAreValidTest.groovy
+++ b/src/test/groovy/graphql/schema/validation/DirectiveReferencesAreValidTest.groovy
@@ -17,6 +17,37 @@ import static graphql.schema.GraphQLSchema.newSchema
 
 class DirectiveReferencesAreValidTest extends Specification {
 
+    def "programmatic schemas reject direct self-referential directives"() {
+        given:
+        def invalid = GraphQLDirective.newDirective()
+                .name("invalid")
+                .validLocation(ARGUMENT_DEFINITION)
+                .build()
+        invalid = invalid.transform { builder ->
+            builder.argument(newArgument()
+                    .name("arg")
+                    .type(GraphQLString)
+                    .withAppliedDirective(invalid.toAppliedDirective())
+                    .build())
+        }
+
+        when:
+        newSchema()
+                .query(newObject()
+                        .name("Query")
+                        .field(newFieldDefinition()
+                                .name("hello")
+                                .type(GraphQLString)
+                                .build())
+                        .build())
+                .additionalDirective(invalid)
+                .build()
+
+        then:
+        def error = thrown(InvalidSchemaException)
+        error.message.contains("@invalid -> @invalid")
+    }
+
     def "programmatic schemas reject directive cycles through directives"() {
         given:
         def first = GraphQLDirective.newDirective()

--- a/src/test/groovy/graphql/schema/validation/SchemaValidatorTest.groovy
+++ b/src/test/groovy/graphql/schema/validation/SchemaValidatorTest.groovy
@@ -11,15 +11,16 @@ class SchemaValidatorTest extends Specification {
         def validator = new SchemaValidator()
         def rules = validator.rules
         then:
-        rules.size() == 9
+        rules.size() == 10
         rules[0] instanceof NoUnbrokenInputCycles
         rules[1] instanceof TypesImplementInterfaces
         rules[2] instanceof TypeAndFieldRule
         rules[3] instanceof DefaultValuesAreValid
         rules[4] instanceof AppliedDirectivesAreValid
-        rules[5] instanceof AppliedDirectiveArgumentsAreValid
-        rules[6] instanceof InputAndOutputTypesUsedAppropriately
-        rules[7] instanceof OneOfInputObjectRules
-        rules[8] instanceof DeprecatedInputObjectAndArgumentsAreValid
+        rules[5] instanceof DirectiveReferencesAreValid
+        rules[6] instanceof AppliedDirectiveArgumentsAreValid
+        rules[7] instanceof InputAndOutputTypesUsedAppropriately
+        rules[8] instanceof OneOfInputObjectRules
+        rules[9] instanceof DeprecatedInputObjectAndArgumentsAreValid
     }
 }


### PR DESCRIPTION
## Summary
- add schema validation for directive definition cycles, including indirect cycles through input types
- keep a minimal SDL pre-check to stop recursive directive construction before schema validation can run
- add SDL and programmatic schema tests covering direct and indirect directive cycles

## Testing
- ./gradlew test --tests graphql.schema.idl.SchemaTypeDirectivesCheckerTest --tests graphql.schema.validation.DirectiveReferencesAreValidTest --tests graphql.schema.validation.SchemaValidatorTest
- ./gradlew clean test (run locally with a temporary init-script workaround to remove duplicate main output directories from the test classpath; vanilla `./gradlew test` in this workspace currently hits an unrelated ArchUnit classpath issue)