### PR TITLE
Avoid no-op field fetch adapter allocation

### DIFF
--- a/src/main/java/graphql/execution/instrumentation/Instrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/Instrumentation.java
@@ -241,6 +241,9 @@ public interface Instrumentation {
     @Nullable
     default FieldFetchingInstrumentationContext beginFieldFetching(InstrumentationFieldFetchParameters parameters, InstrumentationState state) {
         InstrumentationContext<Object> ctx = beginFieldFetch(parameters, state);
+        if (ctx == noOp()) {
+            return FieldFetchingInstrumentationContext.NOOP;
+        }
         return FieldFetchingInstrumentationContext.adapter(ctx);
     }
 

--- a/src/test/groovy/graphql/execution/instrumentation/InstrumentationDefaultMethodsTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/InstrumentationDefaultMethodsTest.groovy
@@ -1,0 +1,72 @@
+package graphql.execution.instrumentation
+
+import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters
+import spock.lang.Specification
+
+class InstrumentationDefaultMethodsTest extends Specification {
+
+    def "default begin field fetching does not allocate an adapter for inherited no-op"() {
+        given:
+        def instrumentation = new Instrumentation() {}
+
+        when:
+        def context = instrumentation.beginFieldFetching(null, null)
+
+        then:
+        context.is(FieldFetchingInstrumentationContext.NOOP)
+    }
+
+    def "simple performant instrumentation begin field fetching does not allocate an adapter for inherited no-op"() {
+        when:
+        def context = SimplePerformantInstrumentation.INSTANCE.beginFieldFetching(null, null)
+
+        then:
+        context.is(FieldFetchingInstrumentationContext.NOOP)
+    }
+
+    def "default begin field fetching does not allocate an adapter when deprecated override returns no-op"() {
+        given:
+        def instrumentation = new Instrumentation() {
+            @Override
+            InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters, InstrumentationState state) {
+                return SimpleInstrumentationContext.noOp()
+            }
+        }
+
+        when:
+        def context = instrumentation.beginFieldFetching(null, null)
+
+        then:
+        context.is(FieldFetchingInstrumentationContext.NOOP)
+    }
+
+    def "default begin field fetching still adapts deprecated begin field fetch overrides"() {
+        given:
+        def events = []
+        def instrumentation = new Instrumentation() {
+            @Override
+            InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters, InstrumentationState state) {
+                return new InstrumentationContext<Object>() {
+                    @Override
+                    void onDispatched() {
+                        events.add("dispatched")
+                    }
+
+                    @Override
+                    void onCompleted(Object result, Throwable t) {
+                        events.add(result)
+                    }
+                }
+            }
+        }
+
+        when:
+        def context = instrumentation.beginFieldFetching(null, null)
+        context.onDispatched()
+        context.onFetchedValue("ignored")
+        context.onCompleted("completed", null)
+
+        then:
+        events == ["dispatched", "completed"]
+    }
+}


### PR DESCRIPTION
## Problem

`beginFieldFetching` keeps older `beginFieldFetch` implementations working by
calling the deprecated method and adapting the returned `InstrumentationContext`.
For instrumentations that inherit the default/no-op `beginFieldFetch`, that means
adapting `SimpleInstrumentationContext.noOp()` into a new anonymous
`FieldFetchingInstrumentationContext`.

That adapter allocation happens once per field fetch. In a `ChainedInstrumentation`
with multiple legacy/no-op field-fetch instrumentations, each instrumentation can
pay that allocation for every field even though all callbacks are no-ops.

## Fix

When the legacy hook returns the canonical `SimpleInstrumentationContext.noOp()`
instance, return the canonical `FieldFetchingInstrumentationContext.NOOP` directly
instead of allocating an adapter.

Real legacy `beginFieldFetch` overrides are still adapted normally, and
instrumentations that override `beginFieldFetching` themselves are unaffected.

## Tests

Added coverage for:

- default `Instrumentation` no-op field fetching
- `SimplePerformantInstrumentation` inherited no-op field fetching
- deprecated overrides that explicitly return `noOp()`
- deprecated overrides that return a real context and still need adaptation

Validated with:

```bash
./gradlew test --tests graphql.execution.instrumentation.InstrumentationDefaultMethodsTest --no-build-cache
```