### PR TITLE
Add input-aware AST signatures

### DIFF
--- a/src/main/java/graphql/language/AstSignature.java
+++ b/src/main/java/graphql/language/AstSignature.java
@@ -1,7 +1,27 @@
 package graphql.language;
 
+import graphql.Scalars;
 import graphql.PublicApi;
 import graphql.collect.ImmutableKit;
+import graphql.execution.CoercedVariables;
+import graphql.execution.TypeFromAST;
+import graphql.introspection.Introspection;
+import graphql.schema.GraphQLArgument;
+import graphql.schema.GraphQLCompositeType;
+import graphql.schema.GraphQLDirective;
+import graphql.schema.GraphQLEnumType;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLInputObjectField;
+import graphql.schema.GraphQLInputObjectType;
+import graphql.schema.GraphQLInputType;
+import graphql.schema.GraphQLList;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLOutputType;
+import graphql.schema.GraphQLScalarType;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLType;
+import graphql.schema.GraphQLUnmodifiedType;
+import graphql.schema.visibility.GraphqlFieldVisibility;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 import org.jspecify.annotations.NullMarked;
@@ -9,11 +29,18 @@ import org.jspecify.annotations.Nullable;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static graphql.Assert.assertNotNull;
+import static graphql.schema.GraphQLTypeUtil.isList;
+import static graphql.schema.GraphQLTypeUtil.isNonNull;
+import static graphql.schema.GraphQLTypeUtil.unwrapAll;
+import static graphql.schema.GraphQLTypeUtil.unwrapOne;
 import static graphql.util.TreeTransformerUtil.changeNode;
 
 /**
@@ -66,6 +93,579 @@ public class AstSignature {
                         hideLiterals(false,
                                 dropUnusedQueryDefinitions(document, operationName)))
         );
+    }
+
+    /**
+     * This can produce a "signature" AST that preserves the shape of arguments and input object fields while redacting
+     * all concrete values.  Unlike {@link AstSignature#signatureQuery(Document, String)}, input object fields are retained
+     * recursively and variable references are resolved against the provided coerced variable values.
+     *
+     * Omitted arguments and omitted input object fields stay omitted.  This means two operations with different input
+     * shapes can be categorised differently without exposing the values that were supplied.
+     *
+     * @param document      the document to make a signature query from
+     * @param operationName the name of the operation to do it for (since only one query can be run at a time)
+     * @param schema        the schema used to resolve field, directive, argument and input object types
+     * @param variables     the coerced variables for the operation
+     *
+     * @return the signature query in document form
+     */
+    public Document signatureWithInput(Document document, @Nullable String operationName, GraphQLSchema schema, CoercedVariables variables) {
+        Map<String, String> variableRemapping = new HashMap<>();
+        AtomicInteger variableCount = new AtomicInteger();
+        Document wantedDocument = dropUnusedQueryDefinitions(document, operationName);
+        Document signatureDocument = redactInputValues(wantedDocument, operationName, schema, variables, variableRemapping, variableCount);
+        return sortAST(removeAliases(signatureDocument));
+    }
+
+    private Document redactInputValues(Document document,
+                                       @Nullable String operationName,
+                                       GraphQLSchema schema,
+                                       CoercedVariables variables,
+                                       Map<String, String> variableRemapping,
+                                       AtomicInteger variableCount) {
+        OperationDefinition operationDefinition = findOperationDefinition(document, operationName);
+        Map<String, GraphQLInputType> variableTypes = variableTypes(operationDefinition, schema);
+        List<Definition> definitions = new ArrayList<>(document.getDefinitions().size());
+        for (Definition definition : document.getDefinitions()) {
+            definitions.add(redactDefinition(definition, schema, variables, variableTypes, variableRemapping, variableCount));
+        }
+        return document.transform(builder -> builder.definitions(definitions));
+    }
+
+    private Definition redactDefinition(Definition definition,
+                                        GraphQLSchema schema,
+                                        CoercedVariables variables,
+                                        Map<String, GraphQLInputType> variableTypes,
+                                        Map<String, String> variableRemapping,
+                                        AtomicInteger variableCount) {
+        if (definition instanceof OperationDefinition) {
+            return redactOperationDefinition((OperationDefinition) definition, schema, variables, variableTypes, variableRemapping, variableCount);
+        }
+        if (definition instanceof FragmentDefinition) {
+            return redactFragmentDefinition((FragmentDefinition) definition, schema, variables, variableTypes, variableRemapping, variableCount);
+        }
+        return definition;
+    }
+
+    private OperationDefinition redactOperationDefinition(OperationDefinition operationDefinition,
+                                                         GraphQLSchema schema,
+                                                         CoercedVariables variables,
+                                                         Map<String, GraphQLInputType> variableTypes,
+                                                         Map<String, String> variableRemapping,
+                                                         AtomicInteger variableCount) {
+        GraphQLOutputType rootType = operationRootType(operationDefinition, schema);
+        return operationDefinition.transform(builder -> {
+            builder.variableDefinitions(redactVariableDefinitions(operationDefinition.getVariableDefinitions(), schema, variables, variableTypes, variableRemapping, variableCount));
+            builder.directives(redactDirectives(operationDefinition.getDirectives(), schema, variables, variableTypes, variableRemapping, variableCount));
+            builder.selectionSet(redactSelectionSet(operationDefinition.getSelectionSet(), rootType, schema, variables, variableTypes, variableRemapping, variableCount));
+        });
+    }
+
+    private FragmentDefinition redactFragmentDefinition(FragmentDefinition fragmentDefinition,
+                                                       GraphQLSchema schema,
+                                                       CoercedVariables variables,
+                                                       Map<String, GraphQLInputType> variableTypes,
+                                                       Map<String, String> variableRemapping,
+                                                       AtomicInteger variableCount) {
+        GraphQLOutputType outputType = outputType(schema, fragmentDefinition.getTypeCondition());
+        if (outputType == null) {
+            return fragmentDefinition;
+        }
+        return fragmentDefinition.transform(builder -> {
+            builder.directives(redactDirectives(fragmentDefinition.getDirectives(), schema, variables, variableTypes, variableRemapping, variableCount));
+            builder.selectionSet(redactSelectionSet(fragmentDefinition.getSelectionSet(), outputType, schema, variables, variableTypes, variableRemapping, variableCount));
+        });
+    }
+
+    private List<VariableDefinition> redactVariableDefinitions(List<VariableDefinition> variableDefinitions,
+                                                               GraphQLSchema schema,
+                                                               CoercedVariables variables,
+                                                               Map<String, GraphQLInputType> variableTypes,
+                                                               Map<String, String> variableRemapping,
+                                                               AtomicInteger variableCount) {
+        List<VariableDefinition> result = new ArrayList<>(variableDefinitions.size());
+        for (VariableDefinition variableDefinition : variableDefinitions) {
+            result.add(redactVariableDefinition(variableDefinition, schema, variables, variableTypes, variableRemapping, variableCount));
+        }
+        return result;
+    }
+
+    private VariableDefinition redactVariableDefinition(VariableDefinition variableDefinition,
+                                                       GraphQLSchema schema,
+                                                       CoercedVariables variables,
+                                                       Map<String, GraphQLInputType> variableTypes,
+                                                       Map<String, String> variableRemapping,
+                                                       AtomicInteger variableCount) {
+        Value defaultValue = variableDefinition.getDefaultValue();
+        GraphQLInputType variableType = variableTypes.get(variableDefinition.getName());
+        Value redactedDefaultValue = defaultValue == null || variableType == null
+                ? defaultValue
+                : redactValue(defaultValue, variableType, schema, variables, variableRemapping, variableCount);
+        return variableDefinition.transform(builder -> {
+            builder.name(remapVariable(variableDefinition.getName(), variableRemapping, variableCount));
+            builder.defaultValue(redactedDefaultValue);
+            builder.directives(redactDirectives(variableDefinition.getDirectives(), schema, variables, variableTypes, variableRemapping, variableCount));
+        });
+    }
+
+    private SelectionSet redactSelectionSet(SelectionSet selectionSet,
+                                            GraphQLOutputType parentType,
+                                            GraphQLSchema schema,
+                                            CoercedVariables variables,
+                                            Map<String, GraphQLInputType> variableTypes,
+                                            Map<String, String> variableRemapping,
+                                            AtomicInteger variableCount) {
+        List<Selection> selections = new ArrayList<>(selectionSet.getSelections().size());
+        for (Selection selection : selectionSet.getSelections()) {
+            selections.add(redactSelection(selection, parentType, schema, variables, variableTypes, variableRemapping, variableCount));
+        }
+        return selectionSet.transform(builder -> builder.selections(selections));
+    }
+
+    private Selection redactSelection(Selection selection,
+                                      GraphQLOutputType parentType,
+                                      GraphQLSchema schema,
+                                      CoercedVariables variables,
+                                      Map<String, GraphQLInputType> variableTypes,
+                                      Map<String, String> variableRemapping,
+                                      AtomicInteger variableCount) {
+        if (selection instanceof Field) {
+            return redactField((Field) selection, parentType, schema, variables, variableTypes, variableRemapping, variableCount);
+        }
+        if (selection instanceof InlineFragment) {
+            return redactInlineFragment((InlineFragment) selection, parentType, schema, variables, variableTypes, variableRemapping, variableCount);
+        }
+        if (selection instanceof FragmentSpread) {
+            return redactFragmentSpread((FragmentSpread) selection, schema, variables, variableTypes, variableRemapping, variableCount);
+        }
+        return selection;
+    }
+
+    private Field redactField(Field field,
+                              GraphQLOutputType parentType,
+                              GraphQLSchema schema,
+                              CoercedVariables variables,
+                              Map<String, GraphQLInputType> variableTypes,
+                              Map<String, String> variableRemapping,
+                              AtomicInteger variableCount) {
+        GraphQLCompositeType compositeType = (GraphQLCompositeType) unwrapAll(parentType);
+        GraphQLFieldDefinition fieldDefinition = Introspection.getFieldDef(schema, compositeType, field.getName());
+        return field.transform(builder -> {
+            builder.arguments(redactArguments(field.getArguments(), fieldDefinition.getArguments(), schema, variables, variableTypes, variableRemapping, variableCount));
+            builder.directives(redactDirectives(field.getDirectives(), schema, variables, variableTypes, variableRemapping, variableCount));
+            builder.selectionSet(redactFieldSelectionSet(field, fieldDefinition.getType(), schema, variables, variableTypes, variableRemapping, variableCount));
+        });
+    }
+
+    private @Nullable SelectionSet redactFieldSelectionSet(Field field,
+                                                           GraphQLOutputType fieldType,
+                                                           GraphQLSchema schema,
+                                                           CoercedVariables variables,
+                                                           Map<String, GraphQLInputType> variableTypes,
+                                                           Map<String, String> variableRemapping,
+                                                           AtomicInteger variableCount) {
+        SelectionSet selectionSet = field.getSelectionSet();
+        if (selectionSet == null) {
+            return null;
+        }
+        GraphQLUnmodifiedType unmodifiedType = unwrapAll(fieldType);
+        if (!(unmodifiedType instanceof GraphQLOutputType)) {
+            return selectionSet;
+        }
+        return redactSelectionSet(selectionSet, (GraphQLOutputType) unmodifiedType, schema, variables, variableTypes, variableRemapping, variableCount);
+    }
+
+    private InlineFragment redactInlineFragment(InlineFragment inlineFragment,
+                                                GraphQLOutputType parentType,
+                                                GraphQLSchema schema,
+                                                CoercedVariables variables,
+                                                Map<String, GraphQLInputType> variableTypes,
+                                                Map<String, String> variableRemapping,
+                                                AtomicInteger variableCount) {
+        GraphQLOutputType outputType = inlineFragment.getTypeCondition() == null
+                ? parentType
+                : outputType(schema, inlineFragment.getTypeCondition());
+        if (outputType == null) {
+            return inlineFragment;
+        }
+        return inlineFragment.transform(builder -> {
+            builder.directives(redactDirectives(inlineFragment.getDirectives(), schema, variables, variableTypes, variableRemapping, variableCount));
+            builder.selectionSet(redactSelectionSet(inlineFragment.getSelectionSet(), outputType, schema, variables, variableTypes, variableRemapping, variableCount));
+        });
+    }
+
+    private FragmentSpread redactFragmentSpread(FragmentSpread fragmentSpread,
+                                                GraphQLSchema schema,
+                                                CoercedVariables variables,
+                                                Map<String, GraphQLInputType> variableTypes,
+                                                Map<String, String> variableRemapping,
+                                                AtomicInteger variableCount) {
+        return fragmentSpread.transform(builder -> {
+            builder.directives(redactDirectives(fragmentSpread.getDirectives(), schema, variables, variableTypes, variableRemapping, variableCount));
+        });
+    }
+
+    private List<Directive> redactDirectives(List<Directive> directives,
+                                             GraphQLSchema schema,
+                                             CoercedVariables variables,
+                                             Map<String, GraphQLInputType> variableTypes,
+                                             Map<String, String> variableRemapping,
+                                             AtomicInteger variableCount) {
+        List<Directive> result = new ArrayList<>(directives.size());
+        for (Directive directive : directives) {
+            GraphQLDirective directiveDefinition = schema.getDirective(directive.getName());
+            result.add(redactDirective(directive, directiveDefinition, schema, variables, variableTypes, variableRemapping, variableCount));
+        }
+        return result;
+    }
+
+    private Directive redactDirective(Directive directive,
+                                      @Nullable GraphQLDirective directiveDefinition,
+                                      GraphQLSchema schema,
+                                      CoercedVariables variables,
+                                      Map<String, GraphQLInputType> variableTypes,
+                                      Map<String, String> variableRemapping,
+                                      AtomicInteger variableCount) {
+        if (directiveDefinition == null) {
+            return directive.transform(builder -> builder.arguments(redactArgumentsWithoutTypes(directive.getArguments(), schema, variables, variableTypes, variableRemapping, variableCount)));
+        }
+        return directive.transform(builder -> {
+            builder.arguments(redactArguments(directive.getArguments(), directiveDefinition.getArguments(), schema, variables, variableTypes, variableRemapping, variableCount));
+        });
+    }
+
+    private List<Argument> redactArguments(List<Argument> arguments,
+                                           List<GraphQLArgument> argumentDefinitions,
+                                           GraphQLSchema schema,
+                                           CoercedVariables variables,
+                                           Map<String, GraphQLInputType> variableTypes,
+                                           Map<String, String> variableRemapping,
+                                           AtomicInteger variableCount) {
+        Map<String, GraphQLArgument> argumentDefinitionByName = argumentDefinitionByName(argumentDefinitions);
+        List<Argument> result = new ArrayList<>(arguments.size());
+        for (Argument argument : arguments) {
+            Argument redactedArgument = redactArgument(argument, argumentDefinitionByName.get(argument.getName()), schema, variables, variableTypes, variableRemapping, variableCount);
+            if (redactedArgument != null) {
+                result.add(redactedArgument);
+            }
+        }
+        return result;
+    }
+
+    private List<Argument> redactArgumentsWithoutTypes(List<Argument> arguments,
+                                                       GraphQLSchema schema,
+                                                       CoercedVariables variables,
+                                                       Map<String, GraphQLInputType> variableTypes,
+                                                       Map<String, String> variableRemapping,
+                                                       AtomicInteger variableCount) {
+        List<Argument> result = new ArrayList<>(arguments.size());
+        for (Argument argument : arguments) {
+            Value value = redactValueWithoutType(argument.getValue(), schema, variables, variableTypes, variableRemapping, variableCount);
+            result.add(argument.transform(builder -> builder.value(value)));
+        }
+        return result;
+    }
+
+    private @Nullable Argument redactArgument(Argument argument,
+                                              @Nullable GraphQLArgument argumentDefinition,
+                                              GraphQLSchema schema,
+                                              CoercedVariables variables,
+                                              Map<String, GraphQLInputType> variableTypes,
+                                              Map<String, String> variableRemapping,
+                                              AtomicInteger variableCount) {
+        if (isAbsentVariableReference(argument.getValue(), variables)) {
+            return null;
+        }
+        if (argumentDefinition == null) {
+            Value value = redactValueWithoutType(argument.getValue(), schema, variables, variableTypes, variableRemapping, variableCount);
+            return argument.transform(builder -> builder.value(value));
+        }
+        Value redactedValue = redactValue(argument.getValue(), argumentDefinition.getType(), schema, variables, variableRemapping, variableCount);
+        return argument.transform(builder -> builder.value(redactedValue));
+    }
+
+    private Value redactValue(Value value,
+                              GraphQLInputType inputType,
+                              GraphQLSchema schema,
+                              CoercedVariables variables,
+                              Map<String, String> variableRemapping,
+                              AtomicInteger variableCount) {
+        if (value instanceof VariableReference) {
+            return redactVariableReference((VariableReference) value, inputType, schema, variables);
+        }
+        if (value instanceof NullValue) {
+            return NullValue.of();
+        }
+        if (isNonNull(inputType)) {
+            return redactValue(value, (GraphQLInputType) unwrapOne(inputType), schema, variables, variableRemapping, variableCount);
+        }
+        if (isList(inputType)) {
+            return redactListValue(value, (GraphQLList) inputType, schema, variables, variableRemapping, variableCount);
+        }
+        if (inputType instanceof GraphQLInputObjectType && value instanceof ObjectValue) {
+            return redactObjectValue((ObjectValue) value, (GraphQLInputObjectType) inputType, schema, variables, variableRemapping, variableCount);
+        }
+        if (inputType instanceof GraphQLEnumType) {
+            return EnumValue.of("REDACTED");
+        }
+        if (inputType instanceof GraphQLScalarType) {
+            return redactedScalarValue((GraphQLScalarType) inputType);
+        }
+        return redactValueWithoutType(value, schema, variables, Collections.emptyMap(), variableRemapping, variableCount);
+    }
+
+    private Value redactVariableReference(VariableReference variableReference,
+                                          GraphQLInputType inputType,
+                                          GraphQLSchema schema,
+                                          CoercedVariables variables) {
+        if (!variables.containsKey(variableReference.getName())) {
+            return NullValue.of();
+        }
+        return redactExternalValue(variables.get(variableReference.getName()), inputType, schema);
+    }
+
+    private Value redactListValue(Value value,
+                                  GraphQLList listType,
+                                  GraphQLSchema schema,
+                                  CoercedVariables variables,
+                                  Map<String, String> variableRemapping,
+                                  AtomicInteger variableCount) {
+        GraphQLInputType wrappedType = (GraphQLInputType) listType.getWrappedType();
+        if (!(value instanceof ArrayValue)) {
+            return redactValue(value, wrappedType, schema, variables, variableRemapping, variableCount);
+        }
+        ArrayValue arrayValue = (ArrayValue) value;
+        List<Value> values = new ArrayList<>(arrayValue.getValues().size());
+        for (Value item : arrayValue.getValues()) {
+            values.add(redactValue(item, wrappedType, schema, variables, variableRemapping, variableCount));
+        }
+        return arrayValue.transform(builder -> builder.values(values));
+    }
+
+    private ObjectValue redactObjectValue(ObjectValue objectValue,
+                                          GraphQLInputObjectType inputObjectType,
+                                          GraphQLSchema schema,
+                                          CoercedVariables variables,
+                                          Map<String, String> variableRemapping,
+                                          AtomicInteger variableCount) {
+        Map<String, GraphQLInputObjectField> fieldDefinitionByName = inputObjectFieldDefinitionByName(inputObjectType, schema);
+        List<ObjectField> objectFields = new ArrayList<>(objectValue.getObjectFields().size());
+        for (ObjectField objectField : objectValue.getObjectFields()) {
+            ObjectField redactedObjectField = redactObjectField(objectField, fieldDefinitionByName.get(objectField.getName()), schema, variables, variableRemapping, variableCount);
+            if (redactedObjectField != null) {
+                objectFields.add(redactedObjectField);
+            }
+        }
+        return objectValue.transform(builder -> builder.objectFields(objectFields));
+    }
+
+    private @Nullable ObjectField redactObjectField(ObjectField objectField,
+                                                    @Nullable GraphQLInputObjectField fieldDefinition,
+                                                    GraphQLSchema schema,
+                                                    CoercedVariables variables,
+                                                    Map<String, String> variableRemapping,
+                                                    AtomicInteger variableCount) {
+        if (isAbsentVariableReference(objectField.getValue(), variables)) {
+            return null;
+        }
+        if (fieldDefinition == null) {
+            Value redactedValue = redactValueWithoutType(objectField.getValue(), schema, variables, Collections.emptyMap(), variableRemapping, variableCount);
+            return objectField.transform(builder -> builder.value(redactedValue));
+        }
+        Value redactedValue = redactValue(objectField.getValue(), fieldDefinition.getType(), schema, variables, variableRemapping, variableCount);
+        return objectField.transform(builder -> builder.value(redactedValue));
+    }
+
+    private Value redactExternalValue(@Nullable Object value, GraphQLInputType inputType, GraphQLSchema schema) {
+        if (value == null) {
+            return NullValue.of();
+        }
+        if (isNonNull(inputType)) {
+            return redactExternalValue(value, (GraphQLInputType) unwrapOne(inputType), schema);
+        }
+        if (inputType instanceof GraphQLList) {
+            return redactExternalListValue(value, (GraphQLList) inputType, schema);
+        }
+        if (inputType instanceof GraphQLInputObjectType) {
+            return redactExternalObjectValue(value, (GraphQLInputObjectType) inputType, schema);
+        }
+        if (inputType instanceof GraphQLEnumType) {
+            return EnumValue.of("REDACTED");
+        }
+        if (inputType instanceof GraphQLScalarType) {
+            return redactedScalarValue((GraphQLScalarType) inputType);
+        }
+        return StringValue.of("");
+    }
+
+    private ArrayValue redactExternalListValue(Object value, GraphQLList listType, GraphQLSchema schema) {
+        GraphQLInputType wrappedType = (GraphQLInputType) listType.getWrappedType();
+        List<?> values = value instanceof List<?> ? (List<?>) value : Collections.singletonList(value);
+        List<Value> redactedValues = new ArrayList<>(values.size());
+        for (Object item : values) {
+            redactedValues.add(redactExternalValue(item, wrappedType, schema));
+        }
+        return ArrayValue.newArrayValue().values(redactedValues).build();
+    }
+
+    private Value redactExternalObjectValue(Object value, GraphQLInputObjectType inputObjectType, GraphQLSchema schema) {
+        if (!(value instanceof Map<?, ?>)) {
+            return ObjectValue.newObjectValue().build();
+        }
+        Map<?, ?> inputMap = (Map<?, ?>) value;
+        GraphqlFieldVisibility fieldVisibility = schema.getCodeRegistry().getFieldVisibility();
+        List<ObjectField> objectFields = new ArrayList<>();
+        for (GraphQLInputObjectField fieldDefinition : fieldVisibility.getFieldDefinitions(inputObjectType)) {
+            String fieldName = fieldDefinition.getName();
+            if (inputMap.containsKey(fieldName)) {
+                Value redactedValue = redactExternalValue(inputMap.get(fieldName), fieldDefinition.getType(), schema);
+                objectFields.add(ObjectField.newObjectField().name(fieldName).value(redactedValue).build());
+            }
+        }
+        return ObjectValue.newObjectValue().objectFields(objectFields).build();
+    }
+
+    private Value redactedScalarValue(GraphQLScalarType scalarType) {
+        if (Scalars.GraphQLInt.getName().equals(scalarType.getName())) {
+            return IntValue.of(0);
+        }
+        if (Scalars.GraphQLFloat.getName().equals(scalarType.getName())) {
+            return FloatValue.newFloatValue(BigDecimal.ZERO).build();
+        }
+        if (Scalars.GraphQLBoolean.getName().equals(scalarType.getName())) {
+            return BooleanValue.of(false);
+        }
+        return StringValue.of("");
+    }
+
+    private Value redactValueWithoutType(Value value,
+                                         GraphQLSchema schema,
+                                         CoercedVariables variables,
+                                         Map<String, GraphQLInputType> variableTypes,
+                                         Map<String, String> variableRemapping,
+                                         AtomicInteger variableCount) {
+        if (value instanceof VariableReference) {
+            VariableReference variableReference = (VariableReference) value;
+            GraphQLInputType variableType = variableTypes.get(variableReference.getName());
+            if (variableType != null) {
+                return redactVariableReference(variableReference, variableType, schema, variables);
+            }
+            return variableReference.transform(builder -> builder.name(remapVariable(variableReference.getName(), variableRemapping, variableCount)));
+        }
+        if (value instanceof ArrayValue) {
+            return redactArrayValueWithoutType((ArrayValue) value, schema, variables, variableTypes, variableRemapping, variableCount);
+        }
+        if (value instanceof ObjectValue) {
+            return redactObjectValueWithoutType((ObjectValue) value, schema, variables, variableTypes, variableRemapping, variableCount);
+        }
+        if (value instanceof IntValue) {
+            return IntValue.of(0);
+        }
+        if (value instanceof FloatValue) {
+            return FloatValue.newFloatValue(BigDecimal.ZERO).build();
+        }
+        if (value instanceof StringValue) {
+            return StringValue.of("");
+        }
+        if (value instanceof BooleanValue) {
+            return BooleanValue.of(false);
+        }
+        if (value instanceof EnumValue) {
+            return EnumValue.of("REDACTED");
+        }
+        return NullValue.of();
+    }
+
+    private ArrayValue redactArrayValueWithoutType(ArrayValue arrayValue,
+                                                   GraphQLSchema schema,
+                                                   CoercedVariables variables,
+                                                   Map<String, GraphQLInputType> variableTypes,
+                                                   Map<String, String> variableRemapping,
+                                                   AtomicInteger variableCount) {
+        List<Value> values = new ArrayList<>(arrayValue.getValues().size());
+        for (Value item : arrayValue.getValues()) {
+            values.add(redactValueWithoutType(item, schema, variables, variableTypes, variableRemapping, variableCount));
+        }
+        return arrayValue.transform(builder -> builder.values(values));
+    }
+
+    private ObjectValue redactObjectValueWithoutType(ObjectValue objectValue,
+                                                     GraphQLSchema schema,
+                                                     CoercedVariables variables,
+                                                     Map<String, GraphQLInputType> variableTypes,
+                                                     Map<String, String> variableRemapping,
+                                                     AtomicInteger variableCount) {
+        List<ObjectField> objectFields = new ArrayList<>(objectValue.getObjectFields().size());
+        for (ObjectField objectField : objectValue.getObjectFields()) {
+            Value value = redactValueWithoutType(objectField.getValue(), schema, variables, variableTypes, variableRemapping, variableCount);
+            objectFields.add(objectField.transform(builder -> builder.value(value)));
+        }
+        return objectValue.transform(builder -> builder.objectFields(objectFields));
+    }
+
+    private boolean isAbsentVariableReference(Value value, CoercedVariables variables) {
+        if (!(value instanceof VariableReference)) {
+            return false;
+        }
+        VariableReference variableReference = (VariableReference) value;
+        return !variables.containsKey(variableReference.getName());
+    }
+
+    private Map<String, GraphQLArgument> argumentDefinitionByName(List<GraphQLArgument> argumentDefinitions) {
+        Map<String, GraphQLArgument> result = new HashMap<>();
+        for (GraphQLArgument argumentDefinition : argumentDefinitions) {
+            result.put(argumentDefinition.getName(), argumentDefinition);
+        }
+        return result;
+    }
+
+    private Map<String, GraphQLInputObjectField> inputObjectFieldDefinitionByName(GraphQLInputObjectType inputObjectType, GraphQLSchema schema) {
+        GraphqlFieldVisibility fieldVisibility = schema.getCodeRegistry().getFieldVisibility();
+        Map<String, GraphQLInputObjectField> result = new HashMap<>();
+        for (GraphQLInputObjectField fieldDefinition : fieldVisibility.getFieldDefinitions(inputObjectType)) {
+            result.put(fieldDefinition.getName(), fieldDefinition);
+        }
+        return result;
+    }
+
+    private Map<String, GraphQLInputType> variableTypes(@Nullable OperationDefinition operationDefinition, GraphQLSchema schema) {
+        if (operationDefinition == null) {
+            return Collections.emptyMap();
+        }
+        Map<String, GraphQLInputType> result = new HashMap<>();
+        for (VariableDefinition variableDefinition : operationDefinition.getVariableDefinitions()) {
+            GraphQLType graphQLType = TypeFromAST.getTypeFromAST(schema, variableDefinition.getType());
+            if (graphQLType instanceof GraphQLInputType) {
+                result.put(variableDefinition.getName(), (GraphQLInputType) graphQLType);
+            }
+        }
+        return result;
+    }
+
+    private @Nullable OperationDefinition findOperationDefinition(Document document, @Nullable String operationName) {
+        for (Definition definition : document.getDefinitions()) {
+            if (definition instanceof OperationDefinition && isThisOperation((OperationDefinition) definition, operationName)) {
+                return (OperationDefinition) definition;
+            }
+        }
+        return null;
+    }
+
+    private GraphQLOutputType operationRootType(OperationDefinition operationDefinition, GraphQLSchema schema) {
+        if (operationDefinition.getOperation() == OperationDefinition.Operation.MUTATION) {
+            return assertNotNull(schema.getMutationType(), "mutation root type must be present");
+        }
+        if (operationDefinition.getOperation() == OperationDefinition.Operation.SUBSCRIPTION) {
+            return assertNotNull(schema.getSubscriptionType(), "subscription root type must be present");
+        }
+        GraphQLObjectType queryType = schema.getQueryType();
+        return assertNotNull(queryType, "query root type must be present");
+    }
+
+    private @Nullable GraphQLOutputType outputType(GraphQLSchema schema, TypeName typeName) {
+        GraphQLType graphQLType = schema.getType(typeName.getName());
+        return graphQLType instanceof GraphQLOutputType ? (GraphQLOutputType) graphQLType : null;
     }
 
     private Document hideLiterals(boolean signatureMode, Document document) {

--- a/src/main/java/graphql/language/AstSignature.java
+++ b/src/main/java/graphql/language/AstSignature.java
@@ -1,7 +1,7 @@
 package graphql.language;
 
-import graphql.Scalars;
 import graphql.PublicApi;
+import graphql.Scalars;
 import graphql.collect.ImmutableKit;
 import graphql.execution.CoercedVariables;
 import graphql.execution.TypeFromAST;
@@ -20,7 +20,6 @@ import graphql.schema.GraphQLOutputType;
 import graphql.schema.GraphQLScalarType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
-import graphql.schema.GraphQLUnmodifiedType;
 import graphql.schema.visibility.GraphqlFieldVisibility;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
@@ -128,24 +127,13 @@ public class AstSignature {
         Map<String, GraphQLInputType> variableTypes = variableTypes(operationDefinition, schema);
         List<Definition> definitions = new ArrayList<>(document.getDefinitions().size());
         for (Definition definition : document.getDefinitions()) {
-            definitions.add(redactDefinition(definition, schema, variables, variableTypes, variableRemapping, variableCount));
+            if (definition instanceof OperationDefinition) {
+                definitions.add(redactOperationDefinition((OperationDefinition) definition, schema, variables, variableTypes, variableRemapping, variableCount));
+                continue;
+            }
+            definitions.add(redactFragmentDefinition((FragmentDefinition) definition, schema, variables, variableTypes, variableRemapping, variableCount));
         }
         return document.transform(builder -> builder.definitions(definitions));
-    }
-
-    private Definition redactDefinition(Definition definition,
-                                        GraphQLSchema schema,
-                                        CoercedVariables variables,
-                                        Map<String, GraphQLInputType> variableTypes,
-                                        Map<String, String> variableRemapping,
-                                        AtomicInteger variableCount) {
-        if (definition instanceof OperationDefinition) {
-            return redactOperationDefinition((OperationDefinition) definition, schema, variables, variableTypes, variableRemapping, variableCount);
-        }
-        if (definition instanceof FragmentDefinition) {
-            return redactFragmentDefinition((FragmentDefinition) definition, schema, variables, variableTypes, variableRemapping, variableCount);
-        }
-        return definition;
     }
 
     private OperationDefinition redactOperationDefinition(OperationDefinition operationDefinition,
@@ -236,10 +224,7 @@ public class AstSignature {
         if (selection instanceof InlineFragment) {
             return redactInlineFragment((InlineFragment) selection, parentType, schema, variables, variableTypes, variableRemapping, variableCount);
         }
-        if (selection instanceof FragmentSpread) {
-            return redactFragmentSpread((FragmentSpread) selection, schema, variables, variableTypes, variableRemapping, variableCount);
-        }
-        return selection;
+        return redactFragmentSpread((FragmentSpread) selection, schema, variables, variableTypes, variableRemapping, variableCount);
     }
 
     private Field redactField(Field field,
@@ -269,11 +254,8 @@ public class AstSignature {
         if (selectionSet == null) {
             return null;
         }
-        GraphQLUnmodifiedType unmodifiedType = unwrapAll(fieldType);
-        if (!(unmodifiedType instanceof GraphQLOutputType)) {
-            return selectionSet;
-        }
-        return redactSelectionSet(selectionSet, (GraphQLOutputType) unmodifiedType, schema, variables, variableTypes, variableRemapping, variableCount);
+        GraphQLOutputType unmodifiedType = (GraphQLOutputType) unwrapAll(fieldType);
+        return redactSelectionSet(selectionSet, unmodifiedType, schema, variables, variableTypes, variableRemapping, variableCount);
     }
 
     private InlineFragment redactInlineFragment(InlineFragment inlineFragment,
@@ -493,10 +475,11 @@ public class AstSignature {
         if (inputType instanceof GraphQLEnumType) {
             return EnumValue.of("REDACTED");
         }
+        GraphQLScalarType scalarType = Scalars.GraphQLString;
         if (inputType instanceof GraphQLScalarType) {
-            return redactedScalarValue((GraphQLScalarType) inputType);
+            scalarType = (GraphQLScalarType) inputType;
         }
-        return StringValue.of("");
+        return redactedScalarValue(scalarType);
     }
 
     private ArrayValue redactExternalListValue(Object value, GraphQLList listType, GraphQLSchema schema) {

--- a/src/test/groovy/graphql/language/AstSignatureTest.groovy
+++ b/src/test/groovy/graphql/language/AstSignatureTest.groovy
@@ -188,6 +188,72 @@ fragment X on SomeType {
 '''
     }
 
+    def "signature with input redacts literal single values supplied to list arguments"() {
+        expect:
+        signatureWithInput('''
+            query Test {
+                search(ids: "abc") {
+                    id
+                }
+            }
+        ''') == '''query Test {
+  search(ids: "") {
+    id
+  }
+}
+'''
+    }
+
+    def "signature with input keeps literal null values"() {
+        expect:
+        signatureWithInput('''
+            query Test {
+                search(term: null) {
+                    id
+                }
+            }
+        ''') == '''query Test {
+  search(term: null) {
+    id
+  }
+}
+'''
+    }
+
+    def "signature with input redacts malformed input object literals without schema shape"() {
+        expect:
+        signatureWithInput('''
+            query Test {
+                search(filter: "secret") {
+                    id
+                }
+            }
+        ''') == '''query Test {
+  search(filter: "") {
+    id
+  }
+}
+'''
+    }
+
+    def "signature with input redacts non null argument and variable values"() {
+        expect:
+        signatureWithInput('''
+            query Test($filter: FilterInput!) {
+                search(requiredFilter: $filter, requiredTerm: "secret") {
+                    id
+                }
+            }
+        ''', [
+                filter: [term: "secret"]
+        ]) == '''query Test($var1: FilterInput!) {
+  search(requiredFilter: {term : ""}, requiredTerm: "") {
+    id
+  }
+}
+'''
+    }
+
     def "signature with input omits an argument when its variable is absent"() {
         expect:
         signatureWithInput('''
@@ -220,6 +286,24 @@ fragment X on SomeType {
 '''
     }
 
+    def "signature with input redacts null variables as explicit null values"() {
+        expect:
+        signatureWithInput('''
+            query Test($term: String) {
+                search(term: $term) {
+                    id
+                }
+            }
+        ''', [
+                term: null
+        ]) == '''query Test($var1: String) {
+  search(term: null) {
+    id
+  }
+}
+'''
+    }
+
     def "signature with input expands variable values into redacted input shapes"() {
         expect:
         signatureWithInput('''
@@ -246,6 +330,42 @@ fragment X on SomeType {
 '''
     }
 
+    def "signature with input expands singleton variable values into list shapes"() {
+        expect:
+        signatureWithInput('''
+            query Test($ids: [ID]) {
+                search(ids: $ids) {
+                    id
+                }
+            }
+        ''', [
+                ids: "abc"
+        ]) == '''query Test($var1: [ID]) {
+  search(ids: [""]) {
+    id
+  }
+}
+'''
+    }
+
+    def "signature with input redacts invalid input object variable values as empty object shapes"() {
+        expect:
+        signatureWithInput('''
+            query Test($filter: FilterInput) {
+                search(filter: $filter) {
+                    id
+                }
+            }
+        ''', [
+                filter: "not a map"
+        ]) == '''query Test($var1: FilterInput) {
+  search(filter: {}) {
+    id
+  }
+}
+'''
+    }
+
     def "signature with input redacts variable default values"() {
         expect:
         signatureWithInput('''
@@ -258,6 +378,150 @@ fragment X on SomeType {
                 filter: [term: "default", nested: [min: 1]]
         ]) == '''query Test($var1: FilterInput = {nested : {min : 0}, term : ""}) {
   search(filter: {nested : {min : 0}, term : ""}) {
+    id
+  }
+}
+'''
+    }
+
+    def "signature with input redacts unknown arguments and unknown input object fields without schema types"() {
+        expect:
+        signatureWithInput('''
+            query Test {
+                search(filter: { term: "secret", unknownField: "secret" }, unknownArg: { inner: "secret" }) {
+                    id
+                }
+            }
+        ''') == '''query Test {
+  search(filter: {term : "", unknownField : ""}, unknownArg: {inner : ""}) {
+    id
+  }
+}
+'''
+    }
+
+    def "signature with input redacts unknown directive arguments without schema types"() {
+        expect:
+        signatureWithInput('''
+            query Test($known: FilterInput) {
+                search @unknown(
+                    array: [1, 2.5, "secret", true, DESC, null, { inner: "secret" }]
+                    known: $known
+                    unknown: $unknown
+                ) {
+                    id
+                }
+            }
+        ''', [
+                known: [term: "secret"]
+        ]) == '''query Test($var1: FilterInput) {
+  search @unknown(array: [0, 0, "", false, REDACTED, null, {inner : ""}], known: {term : ""}, unknown: $var2) {
+    id
+  }
+}
+'''
+    }
+
+    def "signature with input redacts absent typed variables in unknown directive arguments as null"() {
+        expect:
+        signatureWithInput('''
+            query Test($term: String) {
+                search @unknown(term: $term) {
+                    id
+                }
+            }
+        ''') == '''query Test($var1: String) {
+  search @unknown(term: null) {
+    id
+  }
+}
+'''
+    }
+
+    def "signature with input handles mutation and subscription root operation types"() {
+        expect:
+        signatureWithInput(query) == expectedQuery
+
+        where:
+        query                                                                   | expectedQuery
+        '''mutation Test { update(term: "secret") { id } }'''                  | '''mutation Test {
+  update(term: "") {
+    id
+  }
+}
+'''
+        '''subscription Test { updates(term: "secret") { id } }'''             | '''subscription Test {
+  updates(term: "") {
+    id
+  }
+}
+'''
+    }
+
+    def "signature with input handles inline fragments without type conditions"() {
+        expect:
+        signatureWithInput('''
+            query Test {
+                search(term: "root") {
+                    ... {
+                        child(filter: { term: "secret" }) {
+                            id
+                        }
+                    }
+                }
+            }
+        ''') == '''query Test {
+  search(term: "") {
+    ... {
+      child(filter: {term : ""}) {
+        id
+      }
+    }
+  }
+}
+'''
+    }
+
+    def "signature with input leaves unknown inline fragment type conditions unchanged"() {
+        expect:
+        signatureWithInput('''
+            query Test {
+                node(filter: { term: "root" }) {
+                    ... on MissingType {
+                        child(filter: { term: "secret" }) {
+                            id
+                        }
+                    }
+                }
+            }
+        ''') == '''query Test {
+  node(filter: {term : ""}) {
+    ... on MissingType {
+      child(filter: {term : "secret"}) {
+        id
+      }
+    }
+  }
+}
+'''
+    }
+
+    def "signature with input can retain fragments when no operation matches"() {
+        expect:
+        signatureWithInput('''
+            query Test {
+                search(term: "not selected") {
+                    id
+                }
+            }
+
+            fragment MissingFields on MissingType {
+                child(filter: { term: "secret" }) {
+                    id
+                }
+            }
+        ''', [:], "DoesNotExist") == '''fragment MissingFields on MissingType {
+  child(filter: {term : "secret"}) {
     id
   }
 }
@@ -311,8 +575,12 @@ fragment ResultFields on SearchResult {
     }
 
     def signatureWithInput(String query, Map<String, Object> variables = [:], String operationName = "Test") {
+        signatureWithInput(query, variables, operationName, inputSignatureSchema())
+    }
+
+    def signatureWithInput(String query, Map<String, Object> variables, String operationName, def schema) {
         def doc = TestUtil.parseQuery(query)
-        def newDoc = new AstSignature().signatureWithInput(doc, operationName, inputSignatureSchema(), CoercedVariables.of(variables))
+        def newDoc = new AstSignature().signatureWithInput(doc, operationName, schema, CoercedVariables.of(variables))
         printAst(newDoc)
     }
 
@@ -349,8 +617,18 @@ fragment ResultFields on SearchResult {
                     enumArg: Sort
                     ids: [ID]
                     raw: JSON
+                    requiredTerm: String!
+                    requiredFilter: FilterInput!
                 ): SearchResult
                 node(filter: FilterInput): Node
+            }
+
+            type Mutation {
+                update(term: String): SearchResult
+            }
+
+            type Subscription {
+                updates(term: String): SearchResult
             }
 
             input FilterInput {

--- a/src/test/groovy/graphql/language/AstSignatureTest.groovy
+++ b/src/test/groovy/graphql/language/AstSignatureTest.groovy
@@ -1,7 +1,9 @@
 package graphql.language
 
 import graphql.TestUtil
+import graphql.execution.CoercedVariables
 import spock.lang.Specification
+import spock.lang.Unroll
 
 import static graphql.language.AstPrinter.printAst
 
@@ -125,5 +127,247 @@ fragment X on SomeType {
         printAst(newDoc) == expectedQuery
 
 
+    }
+
+    @Unroll
+    def "signature with input redacts #argumentDescription argument"() {
+        expect:
+        signatureWithInput("""
+            query Test {
+                search($argumentSource) {
+                    id
+                }
+            }
+        """) == """query Test {
+  search($expectedArgument) {
+    id
+  }
+}
+"""
+
+        where:
+        argumentDescription | argumentSource                    | expectedArgument
+        "String"            | 'term: "secret"'                  | 'term: ""'
+        "Int"               | 'count: 123'                      | 'count: 0'
+        "Float"             | 'ratio: 123.45'                   | 'ratio: 0'
+        "Boolean"           | 'flag: true'                      | 'flag: false'
+        "enum"              | 'enumArg: ASC'                    | 'enumArg: REDACTED'
+        "ID list"           | 'ids: ["abc", "def"]'             | 'ids: ["", ""]'
+        "custom scalar"     | 'raw: { secret: "not inspected" }' | 'raw: ""'
+    }
+
+    def "signature with input keeps only supplied input object fields"() {
+        expect:
+        signatureWithInput('''
+            query Test {
+                search(filter: { term: "secret", nested: { min: 1 } }) {
+                    id
+                }
+            }
+        ''') == '''query Test {
+  search(filter: {nested : {min : 0}, term : ""}) {
+    id
+  }
+}
+'''
+    }
+
+    def "signature with input preserves list item shapes"() {
+        expect:
+        signatureWithInput('''
+            query Test {
+                search(filters: [{ term: "one" }, { nested: { flag: true } }]) {
+                    id
+                }
+            }
+        ''') == '''query Test {
+  search(filters: [{term : ""}, {nested : {flag : false}}]) {
+    id
+  }
+}
+'''
+    }
+
+    def "signature with input omits an argument when its variable is absent"() {
+        expect:
+        signatureWithInput('''
+            query Test($term: String) {
+                search(count: 1, term: $term) {
+                    id
+                }
+            }
+        ''') == '''query Test($var1: String) {
+  search(count: 0) {
+    id
+  }
+}
+'''
+    }
+
+    def "signature with input omits an input object field when its variable is absent"() {
+        expect:
+        signatureWithInput('''
+            query Test($term: String) {
+                search(filter: { nested: { min: 1 }, term: $term }) {
+                    id
+                }
+            }
+        ''') == '''query Test($var1: String) {
+  search(filter: {nested : {min : 0}}) {
+    id
+  }
+}
+'''
+    }
+
+    def "signature with input expands variable values into redacted input shapes"() {
+        expect:
+        signatureWithInput('''
+            query Test($filter: FilterInput, $filters: [FilterInput]) {
+                search(filter: $filter, filters: $filters) {
+                    id
+                }
+            }
+        ''', [
+                filter : [
+                        term  : "secret",
+                        ranges: [[min: 1], [flag: true]],
+                        sort  : "DESC"
+                ],
+                filters: [
+                        [term: "one"],
+                        [nested: [child: [term: "two"]]]
+                ]
+        ]) == '''query Test($var1: FilterInput, $var2: [FilterInput]) {
+  search(filter: {ranges : [{min : 0}, {flag : false}], sort : REDACTED, term : ""}, filters: [{term : ""}, {nested : {child : {term : ""}}}]) {
+    id
+  }
+}
+'''
+    }
+
+    def "signature with input redacts variable default values"() {
+        expect:
+        signatureWithInput('''
+            query Test($filter: FilterInput = { term: "default", nested: { min: 1 } }) {
+                search(filter: $filter) {
+                    id
+                }
+            }
+        ''', [
+                filter: [term: "default", nested: [min: 1]]
+        ]) == '''query Test($var1: FilterInput = {nested : {min : 0}, term : ""}) {
+  search(filter: {nested : {min : 0}, term : ""}) {
+    id
+  }
+}
+'''
+    }
+
+    def "signature with input handles directives fragments aliases and operation pruning together"() {
+        expect:
+        signatureWithInput('''
+            query Test($filter: FilterInput) @searchMeta(meta: { term: "operation" }, enabled: true) {
+                alias: node(filter: { term: "root" }) {
+                    ...ResultFields @searchMeta(meta: { term: "spread" })
+                    ... on SearchResult @searchMeta(meta: { term: "inline" }) {
+                        child(filter: $filter) @searchMeta(meta: { nested: { min: 1 } }, enabled: false) {
+                            id
+                        }
+                    }
+                }
+            }
+
+            query Other {
+                search(term: "not selected") {
+                    id
+                }
+            }
+
+            fragment ResultFields on SearchResult {
+                child(filter: { nested: { min: 1 } }) {
+                    id
+                }
+            }
+        ''', [
+                filter: [nested: [child: [term: "variable"]]]
+        ]) == '''query Test($var1: FilterInput) @searchMeta(enabled: false, meta: {term : ""}) {
+  node(filter: {term : ""}) {
+    ...ResultFields@searchMeta(meta: {term : ""})
+    ... on SearchResult @searchMeta(meta: {term : ""}) {
+      child(filter: {nested : {child : {term : ""}}}) @searchMeta(enabled: false, meta: {nested : {min : 0}}) {
+        id
+      }
+    }
+  }
+}
+
+fragment ResultFields on SearchResult {
+  child(filter: {nested : {min : 0}}) {
+    id
+  }
+}
+'''
+    }
+
+    def signatureWithInput(String query, Map<String, Object> variables = [:], String operationName = "Test") {
+        def doc = TestUtil.parseQuery(query)
+        def newDoc = new AstSignature().signatureWithInput(doc, operationName, inputSignatureSchema(), CoercedVariables.of(variables))
+        printAst(newDoc)
+    }
+
+    def inputSignatureSchema() {
+        TestUtil.schema('''
+            directive @searchMeta(meta: FilterInput, enabled: Boolean) on FIELD | QUERY | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+            scalar JSON
+
+            enum Sort {
+                ASC
+                DESC
+            }
+
+            interface Node {
+                id: ID
+            }
+
+            type SearchResult implements Node {
+                id: ID
+                child(filter: FilterInput): SearchResult
+            }
+
+            type Query {
+                search(
+                    filter: FilterInput
+                    filters: [FilterInput]
+                    fallback: FilterInput
+                    term: String
+                    optional: String
+                    count: Int
+                    ratio: Float
+                    flag: Boolean
+                    enumArg: Sort
+                    ids: [ID]
+                    raw: JSON
+                ): SearchResult
+                node(filter: FilterInput): Node
+            }
+
+            input FilterInput {
+                term: String
+                nested: NestedInput
+                tags: [String]
+                ranges: [NestedInput]
+                sort: Sort
+                optional: String
+            }
+
+            input NestedInput {
+                min: Int
+                max: Int
+                flag: Boolean
+                child: FilterInput
+            }
+        ''')
     }
 }


### PR DESCRIPTION
## Summary
- add `AstSignature.signatureWithInput(Document, @Nullable String, GraphQLSchema, CoercedVariables)`
- preserve supplied argument and input object field shapes while redacting concrete values
- expand coerced variable values recursively and keep omitted arguments/input fields omitted
- add focused Spock coverage for scalar redaction, variables, defaults, directives, fragments, and recursive inputs

## Testing
- `./gradlew test --tests graphql.language.AstSignatureTest`
- `git diff --check`