### PR TITLE
Collect references from input-aware AST signatures

### DIFF
--- a/src/main/java/graphql/language/AstSignature.java
+++ b/src/main/java/graphql/language/AstSignature.java
@@ -9,11 +9,13 @@ import graphql.introspection.Introspection;
 import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLCompositeType;
 import graphql.schema.GraphQLDirective;
+import graphql.schema.GraphQLFieldsContainer;
 import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLInputObjectField;
 import graphql.schema.GraphQLInputObjectType;
 import graphql.schema.GraphQLInputType;
+import graphql.schema.GraphQLInterfaceType;
 import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLOutputType;
@@ -33,6 +35,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static graphql.Assert.assertNotNull;
@@ -107,14 +110,24 @@ public class AstSignature {
      * @param schema        the schema used to resolve field, directive, argument and input object types
      * @param variables     the coerced variables for the operation
      *
-     * @return the signature query in document form
+     * @return the signature query in document form and the coordinates referenced by it
      */
-    public Document signatureWithInput(Document document, @Nullable String operationName, GraphQLSchema schema, CoercedVariables variables) {
+    public AstSignatureWithInputResult signatureWithInput(Document document, @Nullable String operationName, GraphQLSchema schema, CoercedVariables variables) {
         Map<String, String> variableRemapping = new HashMap<>();
         AtomicInteger variableCount = new AtomicInteger();
         Document wantedDocument = dropUnusedQueryDefinitions(document, operationName);
-        Document signatureDocument = redactInputValues(wantedDocument, operationName, schema, variables, variableRemapping, variableCount);
-        return sortAST(removeAliases(signatureDocument));
+        AstSignatureReferenceCollector referenceCollector = new AstSignatureReferenceCollector();
+        Document signatureDocument = redactInputValues(wantedDocument, operationName, schema, variables, variableRemapping, variableCount, referenceCollector);
+        Document sortedDocument = sortAST(removeAliases(signatureDocument));
+        AstSignatureInputReferences references = referenceCollector.toReferences();
+        return AstSignatureWithInputResult.newAstSignatureWithInputResult()
+                .document(sortedDocument)
+                .fieldCoordinates(references.getFieldCoordinates())
+                .usedDirectives(references.getUsedDirectives())
+                .fieldArgumentCoordinates(references.getFieldArgumentCoordinates())
+                .directiveArgumentCoordinates(references.getDirectiveArgumentCoordinates())
+                .inputObjectFieldCoordinates(references.getInputObjectFieldCoordinates())
+                .build();
     }
 
     private Document redactInputValues(Document document,
@@ -122,16 +135,36 @@ public class AstSignature {
                                        GraphQLSchema schema,
                                        CoercedVariables variables,
                                        Map<String, String> variableRemapping,
-                                       AtomicInteger variableCount) {
+                                       AtomicInteger variableCount,
+                                       AstSignatureReferenceCollector referenceCollector) {
         OperationDefinition operationDefinition = findOperationDefinition(document, operationName);
         Map<String, GraphQLInputType> variableTypes = variableTypes(operationDefinition, schema);
         List<Definition> definitions = new ArrayList<>(document.getDefinitions().size());
         for (Definition definition : document.getDefinitions()) {
             if (definition instanceof OperationDefinition) {
-                definitions.add(redactOperationDefinition((OperationDefinition) definition, schema, variables, variableTypes, variableRemapping, variableCount));
+                definitions.add(redactOperationDefinition(
+                        (OperationDefinition) definition,
+                        schema,
+                        variables,
+                        variableTypes,
+                        variableRemapping,
+                        variableCount,
+                        referenceCollector.getOperationReferences(),
+                        referenceCollector.getOperationFragmentSpreads()
+                ));
                 continue;
             }
-            definitions.add(redactFragmentDefinition((FragmentDefinition) definition, schema, variables, variableTypes, variableRemapping, variableCount));
+            FragmentDefinition fragmentDefinition = (FragmentDefinition) definition;
+            definitions.add(redactFragmentDefinition(
+                    fragmentDefinition,
+                    schema,
+                    variables,
+                    variableTypes,
+                    variableRemapping,
+                    variableCount,
+                    referenceCollector.getFragmentReferences(fragmentDefinition.getName()),
+                    referenceCollector.getFragmentSpreads(fragmentDefinition.getName())
+            ));
         }
         return document.transform(builder -> builder.definitions(definitions));
     }
@@ -141,12 +174,14 @@ public class AstSignature {
                                                          CoercedVariables variables,
                                                          Map<String, GraphQLInputType> variableTypes,
                                                          Map<String, String> variableRemapping,
-                                                         AtomicInteger variableCount) {
+                                                         AtomicInteger variableCount,
+                                                         AstSignatureInputReferences references,
+                                                         Set<String> fragmentSpreads) {
         GraphQLOutputType rootType = operationRootType(operationDefinition, schema);
         return operationDefinition.transform(builder -> {
-            builder.variableDefinitions(redactVariableDefinitions(operationDefinition.getVariableDefinitions(), schema, variables, variableTypes, variableRemapping, variableCount));
-            builder.directives(redactDirectives(operationDefinition.getDirectives(), schema, variables, variableTypes, variableRemapping, variableCount));
-            builder.selectionSet(redactSelectionSet(operationDefinition.getSelectionSet(), rootType, schema, variables, variableTypes, variableRemapping, variableCount));
+            builder.variableDefinitions(redactVariableDefinitions(operationDefinition.getVariableDefinitions(), schema, variables, variableTypes, variableRemapping, variableCount, references));
+            builder.directives(redactDirectives(operationDefinition.getDirectives(), schema, variables, variableTypes, variableRemapping, variableCount, references));
+            builder.selectionSet(redactSelectionSet(operationDefinition.getSelectionSet(), rootType, schema, variables, variableTypes, variableRemapping, variableCount, references, fragmentSpreads));
         });
     }
 
@@ -155,14 +190,16 @@ public class AstSignature {
                                                        CoercedVariables variables,
                                                        Map<String, GraphQLInputType> variableTypes,
                                                        Map<String, String> variableRemapping,
-                                                       AtomicInteger variableCount) {
+                                                       AtomicInteger variableCount,
+                                                       AstSignatureInputReferences references,
+                                                       Set<String> fragmentSpreads) {
         GraphQLOutputType outputType = outputType(schema, fragmentDefinition.getTypeCondition());
         if (outputType == null) {
             return fragmentDefinition;
         }
         return fragmentDefinition.transform(builder -> {
-            builder.directives(redactDirectives(fragmentDefinition.getDirectives(), schema, variables, variableTypes, variableRemapping, variableCount));
-            builder.selectionSet(redactSelectionSet(fragmentDefinition.getSelectionSet(), outputType, schema, variables, variableTypes, variableRemapping, variableCount));
+            builder.directives(redactDirectives(fragmentDefinition.getDirectives(), schema, variables, variableTypes, variableRemapping, variableCount, references));
+            builder.selectionSet(redactSelectionSet(fragmentDefinition.getSelectionSet(), outputType, schema, variables, variableTypes, variableRemapping, variableCount, references, fragmentSpreads));
         });
     }
 
@@ -171,10 +208,11 @@ public class AstSignature {
                                                                CoercedVariables variables,
                                                                Map<String, GraphQLInputType> variableTypes,
                                                                Map<String, String> variableRemapping,
-                                                               AtomicInteger variableCount) {
+                                                               AtomicInteger variableCount,
+                                                               AstSignatureInputReferences references) {
         List<VariableDefinition> result = new ArrayList<>(variableDefinitions.size());
         for (VariableDefinition variableDefinition : variableDefinitions) {
-            result.add(redactVariableDefinition(variableDefinition, schema, variables, variableTypes, variableRemapping, variableCount));
+            result.add(redactVariableDefinition(variableDefinition, schema, variables, variableTypes, variableRemapping, variableCount, references));
         }
         return result;
     }
@@ -184,16 +222,17 @@ public class AstSignature {
                                                        CoercedVariables variables,
                                                        Map<String, GraphQLInputType> variableTypes,
                                                        Map<String, String> variableRemapping,
-                                                       AtomicInteger variableCount) {
+                                                       AtomicInteger variableCount,
+                                                       AstSignatureInputReferences references) {
         Value defaultValue = variableDefinition.getDefaultValue();
         GraphQLInputType variableType = variableTypes.get(variableDefinition.getName());
         Value redactedDefaultValue = defaultValue == null || variableType == null
                 ? defaultValue
-                : redactValue(defaultValue, variableType, schema, variables, variableRemapping, variableCount);
+                : redactValue(defaultValue, variableType, schema, variables, variableRemapping, variableCount, references);
         return variableDefinition.transform(builder -> {
             builder.name(remapVariable(variableDefinition.getName(), variableRemapping, variableCount));
             builder.defaultValue(redactedDefaultValue);
-            builder.directives(redactDirectives(variableDefinition.getDirectives(), schema, variables, variableTypes, variableRemapping, variableCount));
+            builder.directives(redactDirectives(variableDefinition.getDirectives(), schema, variables, variableTypes, variableRemapping, variableCount, references));
         });
     }
 
@@ -203,10 +242,12 @@ public class AstSignature {
                                             CoercedVariables variables,
                                             Map<String, GraphQLInputType> variableTypes,
                                             Map<String, String> variableRemapping,
-                                            AtomicInteger variableCount) {
+                                            AtomicInteger variableCount,
+                                            AstSignatureInputReferences references,
+                                            Set<String> fragmentSpreads) {
         List<Selection> selections = new ArrayList<>(selectionSet.getSelections().size());
         for (Selection selection : selectionSet.getSelections()) {
-            selections.add(redactSelection(selection, parentType, schema, variables, variableTypes, variableRemapping, variableCount));
+            selections.add(redactSelection(selection, parentType, schema, variables, variableTypes, variableRemapping, variableCount, references, fragmentSpreads));
         }
         return selectionSet.transform(builder -> builder.selections(selections));
     }
@@ -217,14 +258,16 @@ public class AstSignature {
                                       CoercedVariables variables,
                                       Map<String, GraphQLInputType> variableTypes,
                                       Map<String, String> variableRemapping,
-                                      AtomicInteger variableCount) {
+                                      AtomicInteger variableCount,
+                                      AstSignatureInputReferences references,
+                                      Set<String> fragmentSpreads) {
         if (selection instanceof Field) {
-            return redactField((Field) selection, parentType, schema, variables, variableTypes, variableRemapping, variableCount);
+            return redactField((Field) selection, parentType, schema, variables, variableTypes, variableRemapping, variableCount, references, fragmentSpreads);
         }
         if (selection instanceof InlineFragment) {
-            return redactInlineFragment((InlineFragment) selection, parentType, schema, variables, variableTypes, variableRemapping, variableCount);
+            return redactInlineFragment((InlineFragment) selection, parentType, schema, variables, variableTypes, variableRemapping, variableCount, references, fragmentSpreads);
         }
-        return redactFragmentSpread((FragmentSpread) selection, schema, variables, variableTypes, variableRemapping, variableCount);
+        return redactFragmentSpread((FragmentSpread) selection, schema, variables, variableTypes, variableRemapping, variableCount, references, fragmentSpreads);
     }
 
     private Field redactField(Field field,
@@ -233,14 +276,28 @@ public class AstSignature {
                               CoercedVariables variables,
                               Map<String, GraphQLInputType> variableTypes,
                               Map<String, String> variableRemapping,
-                              AtomicInteger variableCount) {
+                              AtomicInteger variableCount,
+                              AstSignatureInputReferences references,
+                              Set<String> fragmentSpreads) {
         GraphQLCompositeType compositeType = (GraphQLCompositeType) unwrapAll(parentType);
         GraphQLFieldDefinition fieldDefinition = Introspection.getFieldDef(schema, compositeType, field.getName());
         return field.transform(builder -> {
-            builder.arguments(redactArguments(field.getArguments(), fieldDefinition.getArguments(), schema, variables, variableTypes, variableRemapping, variableCount));
-            builder.directives(redactDirectives(field.getDirectives(), schema, variables, variableTypes, variableRemapping, variableCount));
-            builder.selectionSet(redactFieldSelectionSet(field, fieldDefinition.getType(), schema, variables, variableTypes, variableRemapping, variableCount));
+            String fieldCoordinate = fieldCoordinate(compositeType, field);
+            if (fieldCoordinate != null) {
+                references.addFieldCoordinate(fieldCoordinate);
+            }
+            builder.arguments(redactFieldArguments(fieldCoordinate, field.getArguments(), fieldDefinition.getArguments(), schema, variables, variableTypes, variableRemapping, variableCount, references));
+            builder.directives(redactDirectives(field.getDirectives(), schema, variables, variableTypes, variableRemapping, variableCount, references));
+            builder.selectionSet(redactFieldSelectionSet(field, fieldDefinition.getType(), schema, variables, variableTypes, variableRemapping, variableCount, references, fragmentSpreads));
         });
+    }
+
+    private @Nullable String fieldCoordinate(GraphQLCompositeType compositeType, Field field) {
+        if (field.getName().startsWith("__")) {
+            return null;
+        }
+        GraphQLFieldsContainer fieldsContainer = (GraphQLFieldsContainer) compositeType;
+        return fieldsContainer.getName() + "." + field.getName();
     }
 
     private @Nullable SelectionSet redactFieldSelectionSet(Field field,
@@ -249,13 +306,15 @@ public class AstSignature {
                                                            CoercedVariables variables,
                                                            Map<String, GraphQLInputType> variableTypes,
                                                            Map<String, String> variableRemapping,
-                                                           AtomicInteger variableCount) {
+                                                           AtomicInteger variableCount,
+                                                           AstSignatureInputReferences references,
+                                                           Set<String> fragmentSpreads) {
         SelectionSet selectionSet = field.getSelectionSet();
         if (selectionSet == null) {
             return null;
         }
         GraphQLOutputType unmodifiedType = (GraphQLOutputType) unwrapAll(fieldType);
-        return redactSelectionSet(selectionSet, unmodifiedType, schema, variables, variableTypes, variableRemapping, variableCount);
+        return redactSelectionSet(selectionSet, unmodifiedType, schema, variables, variableTypes, variableRemapping, variableCount, references, fragmentSpreads);
     }
 
     private InlineFragment redactInlineFragment(InlineFragment inlineFragment,
@@ -264,7 +323,9 @@ public class AstSignature {
                                                 CoercedVariables variables,
                                                 Map<String, GraphQLInputType> variableTypes,
                                                 Map<String, String> variableRemapping,
-                                                AtomicInteger variableCount) {
+                                                AtomicInteger variableCount,
+                                                AstSignatureInputReferences references,
+                                                Set<String> fragmentSpreads) {
         GraphQLOutputType outputType = inlineFragment.getTypeCondition() == null
                 ? parentType
                 : outputType(schema, inlineFragment.getTypeCondition());
@@ -272,8 +333,8 @@ public class AstSignature {
             return inlineFragment;
         }
         return inlineFragment.transform(builder -> {
-            builder.directives(redactDirectives(inlineFragment.getDirectives(), schema, variables, variableTypes, variableRemapping, variableCount));
-            builder.selectionSet(redactSelectionSet(inlineFragment.getSelectionSet(), outputType, schema, variables, variableTypes, variableRemapping, variableCount));
+            builder.directives(redactDirectives(inlineFragment.getDirectives(), schema, variables, variableTypes, variableRemapping, variableCount, references));
+            builder.selectionSet(redactSelectionSet(inlineFragment.getSelectionSet(), outputType, schema, variables, variableTypes, variableRemapping, variableCount, references, fragmentSpreads));
         });
     }
 
@@ -282,9 +343,12 @@ public class AstSignature {
                                                 CoercedVariables variables,
                                                 Map<String, GraphQLInputType> variableTypes,
                                                 Map<String, String> variableRemapping,
-                                                AtomicInteger variableCount) {
+                                                AtomicInteger variableCount,
+                                                AstSignatureInputReferences references,
+                                                Set<String> fragmentSpreads) {
+        fragmentSpreads.add(fragmentSpread.getName());
         return fragmentSpread.transform(builder -> {
-            builder.directives(redactDirectives(fragmentSpread.getDirectives(), schema, variables, variableTypes, variableRemapping, variableCount));
+            builder.directives(redactDirectives(fragmentSpread.getDirectives(), schema, variables, variableTypes, variableRemapping, variableCount, references));
         });
     }
 
@@ -293,11 +357,12 @@ public class AstSignature {
                                              CoercedVariables variables,
                                              Map<String, GraphQLInputType> variableTypes,
                                              Map<String, String> variableRemapping,
-                                             AtomicInteger variableCount) {
+                                             AtomicInteger variableCount,
+                                             AstSignatureInputReferences references) {
         List<Directive> result = new ArrayList<>(directives.size());
         for (Directive directive : directives) {
             GraphQLDirective directiveDefinition = schema.getDirective(directive.getName());
-            result.add(redactDirective(directive, directiveDefinition, schema, variables, variableTypes, variableRemapping, variableCount));
+            result.add(redactDirective(directive, directiveDefinition, schema, variables, variableTypes, variableRemapping, variableCount, references));
         }
         return result;
     }
@@ -308,31 +373,101 @@ public class AstSignature {
                                       CoercedVariables variables,
                                       Map<String, GraphQLInputType> variableTypes,
                                       Map<String, String> variableRemapping,
-                                      AtomicInteger variableCount) {
+                                      AtomicInteger variableCount,
+                                      AstSignatureInputReferences references) {
         if (directiveDefinition == null) {
             return directive.transform(builder -> builder.arguments(redactArgumentsWithoutTypes(directive.getArguments(), schema, variables, variableTypes, variableRemapping, variableCount)));
         }
+        String usedDirective = "@" + directive.getName();
+        references.addUsedDirective(usedDirective);
         return directive.transform(builder -> {
-            builder.arguments(redactArguments(directive.getArguments(), directiveDefinition.getArguments(), schema, variables, variableTypes, variableRemapping, variableCount));
+            builder.arguments(redactDirectiveArguments(usedDirective, directive.getArguments(), directiveDefinition.getArguments(), schema, variables, variableTypes, variableRemapping, variableCount, references));
         });
     }
 
-    private List<Argument> redactArguments(List<Argument> arguments,
+    private List<Argument> redactFieldArguments(@Nullable String fieldCoordinate,
+                                                List<Argument> arguments,
+                                                List<GraphQLArgument> argumentDefinitions,
+                                                GraphQLSchema schema,
+                                                CoercedVariables variables,
+                                                Map<String, GraphQLInputType> variableTypes,
+                                                Map<String, String> variableRemapping,
+                                                AtomicInteger variableCount,
+                                                AstSignatureInputReferences references) {
+        return redactArguments(
+                fieldCoordinate,
+                null,
+                arguments,
+                argumentDefinitions,
+                schema,
+                variables,
+                variableTypes,
+                variableRemapping,
+                variableCount,
+                references
+        );
+    }
+
+    private List<Argument> redactDirectiveArguments(String usedDirective,
+                                                    List<Argument> arguments,
+                                                    List<GraphQLArgument> argumentDefinitions,
+                                                    GraphQLSchema schema,
+                                                    CoercedVariables variables,
+                                                    Map<String, GraphQLInputType> variableTypes,
+                                                    Map<String, String> variableRemapping,
+                                                    AtomicInteger variableCount,
+                                                    AstSignatureInputReferences references) {
+        return redactArguments(
+                null,
+                usedDirective,
+                arguments,
+                argumentDefinitions,
+                schema,
+                variables,
+                variableTypes,
+                variableRemapping,
+                variableCount,
+                references
+        );
+    }
+
+    private List<Argument> redactArguments(@Nullable String fieldCoordinate,
+                                           @Nullable String usedDirective,
+                                           List<Argument> arguments,
                                            List<GraphQLArgument> argumentDefinitions,
                                            GraphQLSchema schema,
                                            CoercedVariables variables,
                                            Map<String, GraphQLInputType> variableTypes,
                                            Map<String, String> variableRemapping,
-                                           AtomicInteger variableCount) {
+                                           AtomicInteger variableCount,
+                                           AstSignatureInputReferences references) {
         Map<String, GraphQLArgument> argumentDefinitionByName = argumentDefinitionByName(argumentDefinitions);
         List<Argument> result = new ArrayList<>(arguments.size());
         for (Argument argument : arguments) {
-            Argument redactedArgument = redactArgument(argument, argumentDefinitionByName.get(argument.getName()), schema, variables, variableTypes, variableRemapping, variableCount);
+            GraphQLArgument argumentDefinition = argumentDefinitionByName.get(argument.getName());
+            Argument redactedArgument = redactArgument(argument, argumentDefinition, schema, variables, variableTypes, variableRemapping, variableCount, references);
             if (redactedArgument != null) {
+                collectArgumentReference(fieldCoordinate, usedDirective, redactedArgument, argumentDefinition, references);
                 result.add(redactedArgument);
             }
         }
         return result;
+    }
+
+    private void collectArgumentReference(@Nullable String fieldCoordinate,
+                                          @Nullable String usedDirective,
+                                          Argument argument,
+                                          @Nullable GraphQLArgument argumentDefinition,
+                                          AstSignatureInputReferences references) {
+        if (argumentDefinition == null) {
+            return;
+        }
+        if (fieldCoordinate != null) {
+            references.addFieldArgumentCoordinate(fieldCoordinate + "(" + argument.getName() + ":)");
+        }
+        if (usedDirective != null) {
+            references.addDirectiveArgumentCoordinate(usedDirective + "(" + argument.getName() + ":)");
+        }
     }
 
     private List<Argument> redactArgumentsWithoutTypes(List<Argument> arguments,
@@ -355,7 +490,8 @@ public class AstSignature {
                                               CoercedVariables variables,
                                               Map<String, GraphQLInputType> variableTypes,
                                               Map<String, String> variableRemapping,
-                                              AtomicInteger variableCount) {
+                                              AtomicInteger variableCount,
+                                              AstSignatureInputReferences references) {
         if (isAbsentVariableReference(argument.getValue(), variables)) {
             return null;
         }
@@ -363,7 +499,7 @@ public class AstSignature {
             Value value = redactValueWithoutType(argument.getValue(), schema, variables, variableTypes, variableRemapping, variableCount);
             return argument.transform(builder -> builder.value(value));
         }
-        Value redactedValue = redactValue(argument.getValue(), argumentDefinition.getType(), schema, variables, variableRemapping, variableCount);
+        Value redactedValue = redactValue(argument.getValue(), argumentDefinition.getType(), schema, variables, variableRemapping, variableCount, references);
         return argument.transform(builder -> builder.value(redactedValue));
     }
 
@@ -372,21 +508,22 @@ public class AstSignature {
                               GraphQLSchema schema,
                               CoercedVariables variables,
                               Map<String, String> variableRemapping,
-                              AtomicInteger variableCount) {
+                              AtomicInteger variableCount,
+                              AstSignatureInputReferences references) {
         if (value instanceof VariableReference) {
-            return redactVariableReference((VariableReference) value, inputType, schema, variables);
+            return redactVariableReference((VariableReference) value, inputType, schema, variables, references);
         }
         if (value instanceof NullValue) {
             return NullValue.of();
         }
         if (isNonNull(inputType)) {
-            return redactValue(value, (GraphQLInputType) unwrapOne(inputType), schema, variables, variableRemapping, variableCount);
+            return redactValue(value, (GraphQLInputType) unwrapOne(inputType), schema, variables, variableRemapping, variableCount, references);
         }
         if (isList(inputType)) {
-            return redactListValue(value, (GraphQLList) inputType, schema, variables, variableRemapping, variableCount);
+            return redactListValue(value, (GraphQLList) inputType, schema, variables, variableRemapping, variableCount, references);
         }
         if (inputType instanceof GraphQLInputObjectType && value instanceof ObjectValue) {
-            return redactObjectValue((ObjectValue) value, (GraphQLInputObjectType) inputType, schema, variables, variableRemapping, variableCount);
+            return redactObjectValue((ObjectValue) value, (GraphQLInputObjectType) inputType, schema, variables, variableRemapping, variableCount, references);
         }
         if (inputType instanceof GraphQLEnumType) {
             return EnumValue.of("REDACTED");
@@ -400,11 +537,12 @@ public class AstSignature {
     private Value redactVariableReference(VariableReference variableReference,
                                           GraphQLInputType inputType,
                                           GraphQLSchema schema,
-                                          CoercedVariables variables) {
+                                          CoercedVariables variables,
+                                          AstSignatureInputReferences references) {
         if (!variables.containsKey(variableReference.getName())) {
             return NullValue.of();
         }
-        return redactExternalValue(variables.get(variableReference.getName()), inputType, schema);
+        return redactExternalValue(variables.get(variableReference.getName()), inputType, schema, references);
     }
 
     private Value redactListValue(Value value,
@@ -412,15 +550,16 @@ public class AstSignature {
                                   GraphQLSchema schema,
                                   CoercedVariables variables,
                                   Map<String, String> variableRemapping,
-                                  AtomicInteger variableCount) {
+                                  AtomicInteger variableCount,
+                                  AstSignatureInputReferences references) {
         GraphQLInputType wrappedType = (GraphQLInputType) listType.getWrappedType();
         if (!(value instanceof ArrayValue)) {
-            return redactValue(value, wrappedType, schema, variables, variableRemapping, variableCount);
+            return redactValue(value, wrappedType, schema, variables, variableRemapping, variableCount, references);
         }
         ArrayValue arrayValue = (ArrayValue) value;
         List<Value> values = new ArrayList<>(arrayValue.getValues().size());
         for (Value item : arrayValue.getValues()) {
-            values.add(redactValue(item, wrappedType, schema, variables, variableRemapping, variableCount));
+            values.add(redactValue(item, wrappedType, schema, variables, variableRemapping, variableCount, references));
         }
         return arrayValue.transform(builder -> builder.values(values));
     }
@@ -430,11 +569,12 @@ public class AstSignature {
                                           GraphQLSchema schema,
                                           CoercedVariables variables,
                                           Map<String, String> variableRemapping,
-                                          AtomicInteger variableCount) {
+                                          AtomicInteger variableCount,
+                                          AstSignatureInputReferences references) {
         Map<String, GraphQLInputObjectField> fieldDefinitionByName = inputObjectFieldDefinitionByName(inputObjectType, schema);
         List<ObjectField> objectFields = new ArrayList<>(objectValue.getObjectFields().size());
         for (ObjectField objectField : objectValue.getObjectFields()) {
-            ObjectField redactedObjectField = redactObjectField(objectField, fieldDefinitionByName.get(objectField.getName()), schema, variables, variableRemapping, variableCount);
+            ObjectField redactedObjectField = redactObjectField(objectField, inputObjectType, fieldDefinitionByName.get(objectField.getName()), schema, variables, variableRemapping, variableCount, references);
             if (redactedObjectField != null) {
                 objectFields.add(redactedObjectField);
             }
@@ -443,11 +583,13 @@ public class AstSignature {
     }
 
     private @Nullable ObjectField redactObjectField(ObjectField objectField,
+                                                    GraphQLInputObjectType inputObjectType,
                                                     @Nullable GraphQLInputObjectField fieldDefinition,
                                                     GraphQLSchema schema,
                                                     CoercedVariables variables,
                                                     Map<String, String> variableRemapping,
-                                                    AtomicInteger variableCount) {
+                                                    AtomicInteger variableCount,
+                                                    AstSignatureInputReferences references) {
         if (isAbsentVariableReference(objectField.getValue(), variables)) {
             return null;
         }
@@ -455,22 +597,26 @@ public class AstSignature {
             Value redactedValue = redactValueWithoutType(objectField.getValue(), schema, variables, Collections.emptyMap(), variableRemapping, variableCount);
             return objectField.transform(builder -> builder.value(redactedValue));
         }
-        Value redactedValue = redactValue(objectField.getValue(), fieldDefinition.getType(), schema, variables, variableRemapping, variableCount);
+        references.addInputObjectFieldCoordinate(inputObjectType.getName() + "." + objectField.getName());
+        Value redactedValue = redactValue(objectField.getValue(), fieldDefinition.getType(), schema, variables, variableRemapping, variableCount, references);
         return objectField.transform(builder -> builder.value(redactedValue));
     }
 
-    private Value redactExternalValue(@Nullable Object value, GraphQLInputType inputType, GraphQLSchema schema) {
+    private Value redactExternalValue(@Nullable Object value,
+                                      GraphQLInputType inputType,
+                                      GraphQLSchema schema,
+                                      AstSignatureInputReferences references) {
         if (value == null) {
             return NullValue.of();
         }
         if (isNonNull(inputType)) {
-            return redactExternalValue(value, (GraphQLInputType) unwrapOne(inputType), schema);
+            return redactExternalValue(value, (GraphQLInputType) unwrapOne(inputType), schema, references);
         }
         if (inputType instanceof GraphQLList) {
-            return redactExternalListValue(value, (GraphQLList) inputType, schema);
+            return redactExternalListValue(value, (GraphQLList) inputType, schema, references);
         }
         if (inputType instanceof GraphQLInputObjectType) {
-            return redactExternalObjectValue(value, (GraphQLInputObjectType) inputType, schema);
+            return redactExternalObjectValue(value, (GraphQLInputObjectType) inputType, schema, references);
         }
         if (inputType instanceof GraphQLEnumType) {
             return EnumValue.of("REDACTED");
@@ -482,17 +628,23 @@ public class AstSignature {
         return redactedScalarValue(scalarType);
     }
 
-    private ArrayValue redactExternalListValue(Object value, GraphQLList listType, GraphQLSchema schema) {
+    private ArrayValue redactExternalListValue(Object value,
+                                               GraphQLList listType,
+                                               GraphQLSchema schema,
+                                               AstSignatureInputReferences references) {
         GraphQLInputType wrappedType = (GraphQLInputType) listType.getWrappedType();
         List<?> values = value instanceof List<?> ? (List<?>) value : Collections.singletonList(value);
         List<Value> redactedValues = new ArrayList<>(values.size());
         for (Object item : values) {
-            redactedValues.add(redactExternalValue(item, wrappedType, schema));
+            redactedValues.add(redactExternalValue(item, wrappedType, schema, references));
         }
         return ArrayValue.newArrayValue().values(redactedValues).build();
     }
 
-    private Value redactExternalObjectValue(Object value, GraphQLInputObjectType inputObjectType, GraphQLSchema schema) {
+    private Value redactExternalObjectValue(Object value,
+                                            GraphQLInputObjectType inputObjectType,
+                                            GraphQLSchema schema,
+                                            AstSignatureInputReferences references) {
         if (!(value instanceof Map<?, ?>)) {
             return ObjectValue.newObjectValue().build();
         }
@@ -502,7 +654,8 @@ public class AstSignature {
         for (GraphQLInputObjectField fieldDefinition : fieldVisibility.getFieldDefinitions(inputObjectType)) {
             String fieldName = fieldDefinition.getName();
             if (inputMap.containsKey(fieldName)) {
-                Value redactedValue = redactExternalValue(inputMap.get(fieldName), fieldDefinition.getType(), schema);
+                references.addInputObjectFieldCoordinate(inputObjectType.getName() + "." + fieldName);
+                Value redactedValue = redactExternalValue(inputMap.get(fieldName), fieldDefinition.getType(), schema, references);
                 objectFields.add(ObjectField.newObjectField().name(fieldName).value(redactedValue).build());
             }
         }
@@ -532,7 +685,7 @@ public class AstSignature {
             VariableReference variableReference = (VariableReference) value;
             GraphQLInputType variableType = variableTypes.get(variableReference.getName());
             if (variableType != null) {
-                return redactVariableReference(variableReference, variableType, schema, variables);
+                return redactVariableReference(variableReference, variableType, schema, variables, new AstSignatureInputReferences());
             }
             return variableReference.transform(builder -> builder.name(remapVariable(variableReference.getName(), variableRemapping, variableCount)));
         }

--- a/src/main/java/graphql/language/AstSignatureInputReferences.java
+++ b/src/main/java/graphql/language/AstSignatureInputReferences.java
@@ -1,0 +1,68 @@
+package graphql.language;
+
+import graphql.Internal;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+@Internal
+@NullMarked
+public class AstSignatureInputReferences {
+
+    private final Set<String> fieldCoordinates = new TreeSet<>();
+    private final Set<String> usedDirectives = new TreeSet<>();
+    private final Set<String> fieldArgumentCoordinates = new TreeSet<>();
+    private final Set<String> directiveArgumentCoordinates = new TreeSet<>();
+    private final Set<String> inputObjectFieldCoordinates = new TreeSet<>();
+
+    public void addFieldCoordinate(String fieldCoordinate) {
+        fieldCoordinates.add(fieldCoordinate);
+    }
+
+    public void addUsedDirective(String usedDirective) {
+        usedDirectives.add(usedDirective);
+    }
+
+    public void addFieldArgumentCoordinate(String fieldArgumentCoordinate) {
+        fieldArgumentCoordinates.add(fieldArgumentCoordinate);
+    }
+
+    public void addDirectiveArgumentCoordinate(String directiveArgumentCoordinate) {
+        directiveArgumentCoordinates.add(directiveArgumentCoordinate);
+    }
+
+    public void addInputObjectFieldCoordinate(String inputObjectFieldCoordinate) {
+        inputObjectFieldCoordinates.add(inputObjectFieldCoordinate);
+    }
+
+    public void addAll(AstSignatureInputReferences references) {
+        fieldCoordinates.addAll(references.fieldCoordinates);
+        usedDirectives.addAll(references.usedDirectives);
+        fieldArgumentCoordinates.addAll(references.fieldArgumentCoordinates);
+        directiveArgumentCoordinates.addAll(references.directiveArgumentCoordinates);
+        inputObjectFieldCoordinates.addAll(references.inputObjectFieldCoordinates);
+    }
+
+    public List<String> getFieldCoordinates() {
+        return new ArrayList<>(fieldCoordinates);
+    }
+
+    public List<String> getUsedDirectives() {
+        return new ArrayList<>(usedDirectives);
+    }
+
+    public List<String> getFieldArgumentCoordinates() {
+        return new ArrayList<>(fieldArgumentCoordinates);
+    }
+
+    public List<String> getDirectiveArgumentCoordinates() {
+        return new ArrayList<>(directiveArgumentCoordinates);
+    }
+
+    public List<String> getInputObjectFieldCoordinates() {
+        return new ArrayList<>(inputObjectFieldCoordinates);
+    }
+}

--- a/src/main/java/graphql/language/AstSignatureReferenceCollector.java
+++ b/src/main/java/graphql/language/AstSignatureReferenceCollector.java
@@ -1,0 +1,68 @@
+package graphql.language;
+
+import graphql.Internal;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+@Internal
+@NullMarked
+public class AstSignatureReferenceCollector {
+
+    private final AstSignatureInputReferences operationReferences = new AstSignatureInputReferences();
+    private final Set<String> operationFragmentSpreads = new LinkedHashSet<>();
+    private final Map<String, AstSignatureInputReferences> fragmentReferencesByName = new LinkedHashMap<>();
+    private final Map<String, Set<String>> fragmentSpreadsByName = new LinkedHashMap<>();
+
+    public AstSignatureInputReferences getOperationReferences() {
+        return operationReferences;
+    }
+
+    public Set<String> getOperationFragmentSpreads() {
+        return operationFragmentSpreads;
+    }
+
+    public AstSignatureInputReferences getFragmentReferences(String fragmentName) {
+        return fragmentReferencesByName.computeIfAbsent(fragmentName, ignored -> new AstSignatureInputReferences());
+    }
+
+    public Set<String> getFragmentSpreads(String fragmentName) {
+        return fragmentSpreadsByName.computeIfAbsent(fragmentName, ignored -> new LinkedHashSet<>());
+    }
+
+    public AstSignatureInputReferences toReferences() {
+        AstSignatureInputReferences references = new AstSignatureInputReferences();
+        references.addAll(operationReferences);
+        addFragmentReferences(operationFragmentSpreads, references, new LinkedHashSet<>());
+        return references;
+    }
+
+    private void addFragmentReferences(Set<String> fragmentNames,
+                                       AstSignatureInputReferences references,
+                                       Set<String> visitedFragmentNames) {
+        for (String fragmentName : fragmentNames) {
+            addFragmentReference(fragmentName, references, visitedFragmentNames);
+        }
+    }
+
+    private void addFragmentReference(String fragmentName,
+                                      AstSignatureInputReferences references,
+                                      Set<String> visitedFragmentNames) {
+        if (!visitedFragmentNames.add(fragmentName)) {
+            return;
+        }
+
+        AstSignatureInputReferences fragmentReferences = fragmentReferencesByName.get(fragmentName);
+        if (fragmentReferences != null) {
+            references.addAll(fragmentReferences);
+        }
+
+        Set<String> fragmentSpreads = fragmentSpreadsByName.get(fragmentName);
+        if (fragmentSpreads != null) {
+            addFragmentReferences(fragmentSpreads, references, visitedFragmentNames);
+        }
+    }
+}

--- a/src/main/java/graphql/language/AstSignatureWithInputResult.java
+++ b/src/main/java/graphql/language/AstSignatureWithInputResult.java
@@ -1,0 +1,137 @@
+package graphql.language;
+
+import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.NullUnmarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import static graphql.Assert.assertNotNull;
+
+/**
+ * The result of creating an input-aware AST signature.
+ */
+@PublicApi
+@NullMarked
+public class AstSignatureWithInputResult {
+
+    private final Document document;
+    private final List<String> fieldCoordinates;
+    private final List<String> usedDirectives;
+    private final List<String> fieldArgumentCoordinates;
+    private final List<String> directiveArgumentCoordinates;
+    private final List<String> inputObjectFieldCoordinates;
+
+    public AstSignatureWithInputResult(
+            Document document,
+            List<String> fieldCoordinates,
+            List<String> usedDirectives,
+            List<String> fieldArgumentCoordinates,
+            List<String> directiveArgumentCoordinates,
+            List<String> inputObjectFieldCoordinates
+    ) {
+        this.document = assertNotNull(document);
+        this.fieldCoordinates = ImmutableKit.nonNullCopyOf(fieldCoordinates);
+        this.usedDirectives = ImmutableKit.nonNullCopyOf(usedDirectives);
+        this.fieldArgumentCoordinates = ImmutableKit.nonNullCopyOf(fieldArgumentCoordinates);
+        this.directiveArgumentCoordinates = ImmutableKit.nonNullCopyOf(directiveArgumentCoordinates);
+        this.inputObjectFieldCoordinates = ImmutableKit.nonNullCopyOf(inputObjectFieldCoordinates);
+    }
+
+    public Document getDocument() {
+        return document;
+    }
+
+    public List<String> getFieldCoordinates() {
+        return fieldCoordinates;
+    }
+
+    public List<String> getUsedDirectives() {
+        return usedDirectives;
+    }
+
+    public List<String> getFieldArgumentCoordinates() {
+        return fieldArgumentCoordinates;
+    }
+
+    public List<String> getDirectiveArgumentCoordinates() {
+        return directiveArgumentCoordinates;
+    }
+
+    public List<String> getInputObjectFieldCoordinates() {
+        return inputObjectFieldCoordinates;
+    }
+
+    public AstSignatureWithInputResult transform(Consumer<Builder> builderConsumer) {
+        Builder builder = newAstSignatureWithInputResult().from(this);
+        builderConsumer.accept(builder);
+        return builder.build();
+    }
+
+    public static Builder newAstSignatureWithInputResult() {
+        return new Builder();
+    }
+
+    @NullUnmarked
+    public static class Builder {
+        private @Nullable Document document;
+        private List<String> fieldCoordinates = ImmutableKit.emptyList();
+        private List<String> usedDirectives = ImmutableKit.emptyList();
+        private List<String> fieldArgumentCoordinates = ImmutableKit.emptyList();
+        private List<String> directiveArgumentCoordinates = ImmutableKit.emptyList();
+        private List<String> inputObjectFieldCoordinates = ImmutableKit.emptyList();
+
+        public Builder document(Document document) {
+            this.document = document;
+            return this;
+        }
+
+        public Builder fieldCoordinates(List<String> fieldCoordinates) {
+            this.fieldCoordinates = fieldCoordinates;
+            return this;
+        }
+
+        public Builder usedDirectives(List<String> usedDirectives) {
+            this.usedDirectives = usedDirectives;
+            return this;
+        }
+
+        public Builder fieldArgumentCoordinates(List<String> fieldArgumentCoordinates) {
+            this.fieldArgumentCoordinates = fieldArgumentCoordinates;
+            return this;
+        }
+
+        public Builder directiveArgumentCoordinates(List<String> directiveArgumentCoordinates) {
+            this.directiveArgumentCoordinates = directiveArgumentCoordinates;
+            return this;
+        }
+
+        public Builder inputObjectFieldCoordinates(List<String> inputObjectFieldCoordinates) {
+            this.inputObjectFieldCoordinates = inputObjectFieldCoordinates;
+            return this;
+        }
+
+        public Builder from(AstSignatureWithInputResult result) {
+            return document(result.getDocument())
+                    .fieldCoordinates(result.getFieldCoordinates())
+                    .usedDirectives(result.getUsedDirectives())
+                    .fieldArgumentCoordinates(result.getFieldArgumentCoordinates())
+                    .directiveArgumentCoordinates(result.getDirectiveArgumentCoordinates())
+                    .inputObjectFieldCoordinates(result.getInputObjectFieldCoordinates());
+        }
+
+        public AstSignatureWithInputResult build() {
+            return new AstSignatureWithInputResult(
+                    assertNotNull(document),
+                    fieldCoordinates,
+                    usedDirectives,
+                    fieldArgumentCoordinates,
+                    directiveArgumentCoordinates,
+                    inputObjectFieldCoordinates
+            );
+        }
+    }
+}

--- a/src/test/groovy/graphql/language/AstSignatureTest.groovy
+++ b/src/test/groovy/graphql/language/AstSignatureTest.groovy
@@ -574,19 +574,308 @@ fragment ResultFields on SearchResult {
 '''
     }
 
+    def "signature with input result collects field and input coordinates"() {
+        when:
+        def result = signatureWithInputResult('''
+            query Test($filter: FilterInput) {
+                search(filter: $filter, term: "secret") {
+                    id
+                }
+            }
+        ''', [
+                filter: [term: "variable", nested: [min: 1]]
+        ])
+
+        then:
+        result.fieldCoordinates == ["Query.search", "SearchResult.id"]
+        result.fieldArgumentCoordinates == ["Query.search(filter:)", "Query.search(term:)"]
+        result.inputObjectFieldCoordinates == ["FilterInput.nested", "FilterInput.term", "NestedInput.min"]
+        result.usedDirectives == []
+        result.directiveArgumentCoordinates == []
+    }
+
+    def "signature with input result collects used directives and directive arguments"() {
+        when:
+        def result = signatureWithInputResult('''
+            query Test($include: Boolean!, $meta: FilterInput) @searchMeta(meta: { term: "operation" }, enabled: true) {
+                search(term: "secret") @include(if: $include) @searchMeta(meta: $meta) {
+                    id
+                }
+            }
+        ''', [
+                include: true,
+                meta   : [nested: [min: 1]]
+        ])
+
+        then:
+        result.usedDirectives == ["@include", "@searchMeta"]
+        result.directiveArgumentCoordinates == ["@include(if:)", "@searchMeta(enabled:)", "@searchMeta(meta:)"]
+        result.inputObjectFieldCoordinates == ["FilterInput.nested", "FilterInput.term", "NestedInput.min"]
+    }
+
+    def "signature with input result collects variable definition directives"() {
+        when:
+        def result = signatureWithInputResult('''
+            query Test($term: String @searchMeta(meta: { term: "variable" })) {
+                search(term: $term) {
+                    id
+                }
+            }
+        ''')
+
+        then:
+        result.fieldCoordinates == ["Query.search", "SearchResult.id"]
+        result.usedDirectives == ["@searchMeta"]
+        result.directiveArgumentCoordinates == ["@searchMeta(meta:)"]
+        result.fieldArgumentCoordinates == []
+        result.inputObjectFieldCoordinates == ["FilterInput.term"]
+    }
+
+    def "signature with input result collects used fragment references once"() {
+        when:
+        def result = signatureWithInputResult('''
+            query Test {
+                node(filter: { term: "root" }) {
+                    ...ResultFields
+                    ...ResultFields
+                }
+            }
+
+            fragment ResultFields on SearchResult @searchMeta(meta: { term: "fragment" }) {
+                child(filter: { nested: { flag: true } }) @skip(if: false) {
+                    id
+                }
+            }
+        ''')
+
+        then:
+        result.fieldCoordinates == ["Query.node", "SearchResult.child", "SearchResult.id"]
+        result.usedDirectives == ["@searchMeta", "@skip"]
+        result.fieldArgumentCoordinates == ["Query.node(filter:)", "SearchResult.child(filter:)"]
+        result.directiveArgumentCoordinates == ["@searchMeta(meta:)", "@skip(if:)"]
+        result.inputObjectFieldCoordinates == ["FilterInput.nested", "FilterInput.term", "NestedInput.flag"]
+    }
+
+    def "signature with input result does not collect unreferenced fragment references"() {
+        when:
+        def result = signatureWithInputResult('''
+            query Test {
+                search {
+                    id
+                }
+            }
+
+            fragment UnusedFields on SearchResult @searchMeta(meta: { nested: { max: 1 } }) {
+                child(filter: { nested: { flag: true } }) {
+                    id
+                }
+            }
+        ''')
+
+        then:
+        result.fieldCoordinates == ["Query.search", "SearchResult.id"]
+        result.usedDirectives == []
+        result.fieldArgumentCoordinates == []
+        result.directiveArgumentCoordinates == []
+        result.inputObjectFieldCoordinates == []
+    }
+
+    def "signature with input result ignores unknown reference definitions"() {
+        when:
+        def result = signatureWithInputResult('''
+            query Test {
+                search(unknownArg: { term: "secret" }) @unknown(meta: { term: "secret" }) {
+                    id
+                }
+            }
+        ''')
+
+        then:
+        result.fieldCoordinates == ["Query.search", "SearchResult.id"]
+        result.fieldArgumentCoordinates == []
+        result.usedDirectives == []
+        result.directiveArgumentCoordinates == []
+        result.inputObjectFieldCoordinates == []
+    }
+
+    def "signature with input result omits absent variable reference coordinates"() {
+        when:
+        def result = signatureWithInputResult('''
+            query Test($term: String) {
+                search(count: 1, term: $term) {
+                    id
+                }
+            }
+        ''')
+
+        then:
+        result.fieldCoordinates == ["Query.search", "SearchResult.id"]
+        result.fieldArgumentCoordinates == ["Query.search(count:)"]
+        result.inputObjectFieldCoordinates == []
+    }
+
+    def "signature with input result ignores introspection fields but collects their directives"() {
+        when:
+        def result = signatureWithInputResult('''
+            query Test($include: Boolean!) {
+                search {
+                    __typename @include(if: $include)
+                    id
+                }
+            }
+        ''', [
+                include: true
+        ])
+
+        then:
+        result.fieldCoordinates == ["Query.search", "SearchResult.id"]
+        result.usedDirectives == ["@include"]
+        result.directiveArgumentCoordinates == ["@include(if:)"]
+    }
+
+    def "signature with input result collects known directives but ignores unknown directive arguments"() {
+        when:
+        def result = signatureWithInputResult('''
+            query Test {
+                search @searchMeta(meta: { term: "secret" }, unknown: "secret") {
+                    id
+                }
+            }
+        ''')
+
+        then:
+        result.usedDirectives == ["@searchMeta"]
+        result.directiveArgumentCoordinates == ["@searchMeta(meta:)"]
+        result.inputObjectFieldCoordinates == ["FilterInput.term"]
+    }
+
+    def "signature with input result ignores missing and recursive fragment references"() {
+        when:
+        def result = signatureWithInputResult('''
+            query Test {
+                search {
+                    ...Missing @include(if: true)
+                    ...MissingTypeFields
+                    ...A
+                }
+            }
+
+            fragment A on SearchResult {
+                id
+                ...B
+            }
+
+            fragment B on SearchResult {
+                child {
+                    ...A
+                }
+            }
+
+            fragment MissingTypeFields on MissingType {
+                id
+            }
+        ''')
+
+        then:
+        result.fieldCoordinates == ["Query.search", "SearchResult.child", "SearchResult.id"]
+        result.usedDirectives == ["@include"]
+        result.directiveArgumentCoordinates == ["@include(if:)"]
+    }
+
+    def "signature with input result ignores non selectable type conditions"() {
+        when:
+        def result = signatureWithInputResult('''
+            query Test {
+                search {
+                    ...InputFields
+                    ... on FilterInput {
+                        term
+                    }
+                    id
+                }
+            }
+
+            fragment InputFields on FilterInput {
+                term
+            }
+        ''')
+
+        then:
+        result.fieldCoordinates == ["Query.search", "SearchResult.id"]
+        result.fieldArgumentCoordinates == []
+        result.inputObjectFieldCoordinates == []
+    }
+
+    def "signature with input result collects interface and union field references"() {
+        when:
+        def result = signatureWithInputResult('''
+            query Test {
+                lookup {
+                    ... on SearchUnion {
+                        ... on SearchResult {
+                            id
+                        }
+                    }
+                }
+                node(filter: { term: "secret" }) {
+                    ... on Node {
+                        id
+                    }
+                }
+            }
+        ''')
+
+        then:
+        result.fieldCoordinates == ["Node.id", "Query.lookup", "Query.node", "SearchResult.id"]
+        result.fieldArgumentCoordinates == ["Query.node(filter:)"]
+        result.inputObjectFieldCoordinates == ["FilterInput.term"]
+    }
+
+    def "signature with input result can be transformed"() {
+        given:
+        def result = signatureWithInputResult('''
+            query Test {
+                search {
+                    id
+                }
+            }
+        ''')
+
+        when:
+        def transformed = result.transform { builder ->
+            builder.usedDirectives(["@custom"])
+        }
+
+        then:
+        transformed.document == result.document
+        transformed.fieldCoordinates == result.fieldCoordinates
+        transformed.usedDirectives == ["@custom"]
+        transformed.fieldArgumentCoordinates == result.fieldArgumentCoordinates
+        transformed.directiveArgumentCoordinates == result.directiveArgumentCoordinates
+        transformed.inputObjectFieldCoordinates == result.inputObjectFieldCoordinates
+    }
+
     def signatureWithInput(String query, Map<String, Object> variables = [:], String operationName = "Test") {
         signatureWithInput(query, variables, operationName, inputSignatureSchema())
     }
 
     def signatureWithInput(String query, Map<String, Object> variables, String operationName, def schema) {
+        def result = signatureWithInputResult(query, variables, operationName, schema)
+        printAst(result.document)
+    }
+
+    def signatureWithInputResult(String query, Map<String, Object> variables = [:], String operationName = "Test") {
+        signatureWithInputResult(query, variables, operationName, inputSignatureSchema())
+    }
+
+    def signatureWithInputResult(String query, Map<String, Object> variables, String operationName, def schema) {
         def doc = TestUtil.parseQuery(query)
-        def newDoc = new AstSignature().signatureWithInput(doc, operationName, schema, CoercedVariables.of(variables))
-        printAst(newDoc)
+        new AstSignature().signatureWithInput(doc, operationName, schema, CoercedVariables.of(variables))
     }
 
     def inputSignatureSchema() {
         TestUtil.schema('''
-            directive @searchMeta(meta: FilterInput, enabled: Boolean) on FIELD | QUERY | FRAGMENT_SPREAD | INLINE_FRAGMENT
+            directive @searchMeta(meta: FilterInput, enabled: Boolean) on FIELD | QUERY | VARIABLE_DEFINITION | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
             scalar JSON
 
@@ -603,6 +892,8 @@ fragment ResultFields on SearchResult {
                 id: ID
                 child(filter: FilterInput): SearchResult
             }
+
+            union SearchUnion = SearchResult
 
             type Query {
                 search(
@@ -621,6 +912,7 @@ fragment ResultFields on SearchResult {
                     requiredFilter: FilterInput!
                 ): SearchResult
                 node(filter: FilterInput): Node
+                lookup: SearchUnion
             }
 
             type Mutation {


### PR DESCRIPTION
## Summary
- Change AstSignature.signatureWithInput to return a result object containing the signature document plus referenced fields, used directives, field arguments, directive arguments, and input object fields.
- Collect references during the existing input-redaction pass instead of walking the redacted/sorted document a second time.
- Record per-fragment references during fragment redaction and merge only fragments reachable from the selected operation's fragment-spread graph.
- Add focused AstSignature tests for omitted variables, directive arguments, used directives, variable-definition directives, fragments, recursive/unreferenced fragments, interfaces/unions, and result transform coverage.

## Test
- ./gradlew test --tests graphql.language.AstSignatureTest jacocoTestReport --rerun-tasks

## Coverage
- Focused JaCoCo source report shows no missed lines or branches for AstSignatureInputReferences, AstSignatureReferenceCollector, and AstSignatureWithInputResult.
- AstSignature has 100% line coverage in the focused run; remaining branch misses are pre-existing branches outside this change.