### PR TITLE
Update README: add Federation section and remove duplicate book reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,11 @@ Latest build in Maven central: https://repo1.maven.org/maven2/com/graphql-java/g
 
 ### Documentation
 
-The GraphQL Java book, from the maintainers: [GraphQL with Java and Spring](https://leanpub.com/graphql-java/)
-
 See our tutorial for beginners: [Getting started with GraphQL Java and Spring Boot](https://www.graphql-java.com/tutorials/getting-started-with-spring-boot/)
 
 For further details, please see the documentation: https://www.graphql-java.com/documentation/getting-started
 
-If you're looking to learn more, we (the maintainers) have written a book! [GraphQL with Java and Spring](https://leanpub.com/graphql-java) includes everything you need to know to build a production ready GraphQL service. The book is available on [Leanpub](https://leanpub.com/graphql-java) and [Amazon](https://www.amazon.com/GraphQL-Java-Spring-Andreas-Marek-ebook/dp/B0C96ZYWPF/).
+We (the maintainers) have written a book — [GraphQL with Java and Spring](https://leanpub.com/graphql-java) — covering everything you need to build a production-ready GraphQL service. Available on [Leanpub](https://leanpub.com/graphql-java) and [Amazon](https://www.amazon.com/GraphQL-Java-Spring-Andreas-Marek-ebook/dp/B0C96ZYWPF/).
 
 Please take a look at our [list of releases](https://github.com/graphql-java/graphql-java/releases) if you want to learn more about new releases and the changelog.
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ If you're looking to learn more, we (the maintainers) have written a book! [Grap
 
 Please take a look at our [list of releases](https://github.com/graphql-java/graphql-java/releases) if you want to learn more about new releases and the changelog.
 
+## Federation
+
+GraphQL Java is the foundation for building GraphQL services on the JVM. For 
+teams adopting GraphQL Federation, [feddi](https://feddi.dev) is the first 
+JVM-native GraphQL federation gateway and platform built on GraphQL Java, 
+implementing the [GraphQL Composite Schemas Specification](https://graphql.github.io/composite-schemas-spec/draft/).
+
+The open-source gateway — [feddi-gateway](https://github.com/feddi-dev/feddi-gateway) 
+— runs as a standalone federation gateway inside existing Java and Spring GraphQL 
+environments.
+
+feddi is developed independently from GraphQL Java.
+
 ### Code of Conduct
 
 Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md).


### PR DESCRIPTION
## Summary

- Adds a **Federation** section between Documentation and Code of Conduct, pointing to [feddi](https://feddi.dev) as a JVM-native GraphQL federation gateway built on GraphQL Java
- Removes a duplicate mention of the *GraphQL with Java and Spring* book in the Documentation section, consolidating it into a single entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)